### PR TITLE
ABI: add no-corpus-path flag + Update ABI files with generated in CI worker

### DIFF
--- a/config/Abigail.am
+++ b/config/Abigail.am
@@ -25,5 +25,7 @@ checkabi:
 storeabi:
 	cd .libs ; \
 	for lib in $(lib_LTLIBRARIES) ; do \
-		abidw --no-show-locs $${lib%.la}.so > ../$${lib%.la}.abi ; \
+		abidw --no-show-locs \
+		--no-corpus-path \
+		$${lib%.la}.so > ../$${lib%.la}.abi ; \
 	done

--- a/lib/libnvpair/libnvpair.abi
+++ b/lib/libnvpair/libnvpair.abi
@@ -1,8 +1,10 @@
-<abi-corpus path='libnvpair.so' architecture='elf-amd-x86_64' soname='libnvpair.so.3'>
+<abi-corpus architecture='elf-amd-x86_64' soname='libnvpair.so.3'>
   <elf-needed>
     <dependency name='libc.so.6'/>
   </elf-needed>
   <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='dump_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fnvlist_add_boolean' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fnvlist_add_boolean_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -234,814 +236,33 @@
     <elf-symbol name='nv_alloc_nosleep' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nv_fixed_ops' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='libnvpair.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libnvpair' language='LANG_C99'>
-    <type-decl name='void' id='type-id-1'/>
-    <class-decl name='nvlist_prtctl' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-2'>
+  <abi-instr version='1.0' address-size='64' path='libnvpair.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libnvpair' language='LANG_C99'>
+    <type-decl name='int' size-in-bits='32' id='type-id-1'/>
+    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-2'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvprt_fp' type-id='type-id-3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvprt_indent_mode' type-id='type-id-4' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='nvprt_indent' type-id='type-id-5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvprt_indentinc' type-id='type-id-5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='nvprt_nmfmt' type-id='type-id-6' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='nvprt_eomfmt' type-id='type-id-6' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='nvprt_btwnarrfmt' type-id='type-id-6' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='nvprt_btwnarrfmt_nl' type-id='type-id-5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='nvprt_dfltops' type-id='type-id-7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='nvprt_custops' type-id='type-id-7' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='type-id-8'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_flags' type-id='type-id-5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-10' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-11' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='_fileno' type-id='type-id-5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='_flags2' type-id='type-id-5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-12' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-13' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-14' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-15' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-18' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-11' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-19' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-20' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='_mode' type-id='type-id-5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-21' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <type-decl name='int' size-in-bits='32' id='type-id-5'/>
-    <type-decl name='char' size-in-bits='8' id='type-id-22'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-9'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-23'/>
-    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-10'/>
-    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-11'/>
-    <type-decl name='long int' size-in-bits='64' id='type-id-24'/>
-    <typedef-decl name='__off_t' type-id='type-id-24' id='type-id-12'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-13'/>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-14'/>
-    <type-decl name='__ARRAY_SIZE_TYPE__' size-in-bits='64' id='type-id-25'/>
-
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='8' id='type-id-15'>
-      <subrange length='1' type-id='type-id-25' id='type-id-26'/>
-
-    </array-type-def>
-    <typedef-decl name='__off64_t' type-id='type-id-24' id='type-id-16'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
-    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-17'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-28'/>
-    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-18'/>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-19'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-29'/>
-    <typedef-decl name='size_t' type-id='type-id-29' id='type-id-20'/>
-
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='160' id='type-id-21'>
-      <subrange length='20' type-id='type-id-25' id='type-id-30'/>
-
-    </array-type-def>
-    <typedef-decl name='FILE' type-id='type-id-8' id='type-id-31'/>
-    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-3'/>
-    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-32'/>
-    <enum-decl name='nvlist_indent_mode' id='type-id-4'>
-      <underlying-type type-id='type-id-32'/>
-      <enumerator name='NVLIST_INDENT_ABS' value='0'/>
-      <enumerator name='NVLIST_INDENT_TABBED' value='1'/>
-    </enum-decl>
-    <qualified-type-def type-id='type-id-22' const='yes' id='type-id-33'/>
-    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-6'/>
-    <class-decl name='nvlist_printops' size-in-bits='3456' is-struct='yes' visibility='default' id='type-id-34'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='print_boolean' type-id='type-id-35' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='print_boolean_value' type-id='type-id-36' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='print_byte' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='print_int8' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='print_uint8' type-id='type-id-39' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='print_int16' type-id='type-id-40' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='print_uint16' type-id='type-id-41' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='print_int32' type-id='type-id-42' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='print_uint32' type-id='type-id-43' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='print_int64' type-id='type-id-44' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='print_uint64' type-id='type-id-45' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='print_double' type-id='type-id-46' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='print_string' type-id='type-id-47' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='print_hrtime' type-id='type-id-48' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1792'>
-        <var-decl name='print_nvlist' type-id='type-id-49' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1920'>
-        <var-decl name='print_boolean_array' type-id='type-id-50' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2048'>
-        <var-decl name='print_byte_array' type-id='type-id-51' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='print_int8_array' type-id='type-id-52' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2304'>
-        <var-decl name='print_uint8_array' type-id='type-id-53' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='print_int16_array' type-id='type-id-54' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='print_uint16_array' type-id='type-id-55' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2688'>
-        <var-decl name='print_int32_array' type-id='type-id-56' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2816'>
-        <var-decl name='print_uint32_array' type-id='type-id-57' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2944'>
-        <var-decl name='print_int64_array' type-id='type-id-58' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='3072'>
-        <var-decl name='print_uint64_array' type-id='type-id-59' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='3200'>
-        <var-decl name='print_string_array' type-id='type-id-60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='3328'>
-        <var-decl name='print_nvlist_array' type-id='type-id-61' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-35'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-62' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-63'/>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-64'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='type-id-65' visibility='default'/>
+        <var-decl name='nvp_size' type-id='type-id-3' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='type-id-66' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvl_priv' type-id='type-id-67' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='type-id-66' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='type-id-65' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__int32_t' type-id='type-id-5' id='type-id-68'/>
-    <typedef-decl name='int32_t' type-id='type-id-68' id='type-id-65'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-69'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-69' id='type-id-70'/>
-    <typedef-decl name='uint32_t' type-id='type-id-70' id='type-id-66'/>
-    <typedef-decl name='__uint64_t' type-id='type-id-29' id='type-id-71'/>
-    <typedef-decl name='uint64_t' type-id='type-id-71' id='type-id-67'/>
-    <typedef-decl name='nvlist_t' type-id='type-id-64' id='type-id-72'/>
-    <pointer-type-def type-id='type-id-72' size-in-bits='64' id='type-id-73'/>
-    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-62'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-36'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-75' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-76'>
-      <underlying-type type-id='type-id-32'/>
-      <enumerator name='B_FALSE' value='0'/>
-      <enumerator name='B_TRUE' value='1'/>
-    </enum-decl>
-    <typedef-decl name='boolean_t' type-id='type-id-76' id='type-id-77'/>
-    <pointer-type-def type-id='type-id-78' size-in-bits='64' id='type-id-75'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-37'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-80'/>
-    <typedef-decl name='uchar_t' type-id='type-id-80' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-79'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-38'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-83' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__int8_t' type-id='type-id-14' id='type-id-84'/>
-    <typedef-decl name='int8_t' type-id='type-id-84' id='type-id-85'/>
-    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-83'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-39'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-87' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__uint8_t' type-id='type-id-80' id='type-id-88'/>
-    <typedef-decl name='uint8_t' type-id='type-id-88' id='type-id-89'/>
-    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-87'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-40'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-91' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <type-decl name='short int' size-in-bits='16' id='type-id-92'/>
-    <typedef-decl name='__int16_t' type-id='type-id-92' id='type-id-93'/>
-    <typedef-decl name='int16_t' type-id='type-id-93' id='type-id-94'/>
-    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-91'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-41'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-96' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__uint16_t' type-id='type-id-13' id='type-id-97'/>
-    <typedef-decl name='uint16_t' type-id='type-id-97' id='type-id-98'/>
-    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-96'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-42'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-100' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-100'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-43'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-102' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-102'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-44'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-104' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__int64_t' type-id='type-id-24' id='type-id-105'/>
-    <typedef-decl name='int64_t' type-id='type-id-105' id='type-id-106'/>
-    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-104'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-45'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-108' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-108'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-46'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-110' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <type-decl name='double' size-in-bits='64' id='type-id-111'/>
-    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-110'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-47'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-113' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-113'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-48'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-115' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-116'/>
-    <typedef-decl name='hrtime_t' type-id='type-id-116' id='type-id-117'/>
-    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-115'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-49'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-119' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-120' size-in-bits='64' id='type-id-119'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-50'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-121' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-122'/>
-    <typedef-decl name='uint_t' type-id='type-id-69' id='type-id-123'/>
-    <pointer-type-def type-id='type-id-124' size-in-bits='64' id='type-id-121'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-51'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-125' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-126'/>
-    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-125'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-52'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-128' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-129'/>
-    <pointer-type-def type-id='type-id-130' size-in-bits='64' id='type-id-128'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-53'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-131' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-132'/>
-    <pointer-type-def type-id='type-id-133' size-in-bits='64' id='type-id-131'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-54'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-134' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-135'/>
-    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-134'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-55'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-137' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-138'/>
-    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-137'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-56'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-140' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-141'/>
-    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-140'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-57'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-143' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-144'/>
-    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-143'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-58'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-146' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-147'/>
-    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-146'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-59'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-149' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-67' size-in-bits='64' id='type-id-150'/>
-    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-149'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-60'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-152' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-153'/>
-    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-152'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-61'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-155' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-156'/>
-    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-155'/>
-    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-7'/>
-    <typedef-decl name='nvlist_prtctl_t' type-id='type-id-63' id='type-id-158'/>
-    <function-decl name='nvlist_prtctl_setdest' mangled-name='nvlist_prtctl_setdest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setdest'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-3' name='fp'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_getdest' mangled-name='nvlist_prtctl_getdest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_getdest'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <return type-id='type-id-3'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_setindent' mangled-name='nvlist_prtctl_setindent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setindent'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-4' name='mode'/>
-      <parameter type-id='type-id-5' name='start'/>
-      <parameter type-id='type-id-5' name='inc'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_doindent' mangled-name='nvlist_prtctl_doindent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_doindent'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-5' name='onemore'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <enum-decl name='nvlist_prtctl_fmt' id='type-id-159'>
-      <underlying-type type-id='type-id-32'/>
-      <enumerator name='NVLIST_FMT_MEMBER_NAME' value='0'/>
-      <enumerator name='NVLIST_FMT_MEMBER_POSTAMBLE' value='1'/>
-      <enumerator name='NVLIST_FMT_BTWN_ARRAY' value='2'/>
-    </enum-decl>
-    <function-decl name='nvlist_prtctl_setfmt' mangled-name='nvlist_prtctl_setfmt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setfmt'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-159' name='which'/>
-      <parameter type-id='type-id-6' name='fmt'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_dofmt' mangled-name='nvlist_prtctl_dofmt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_dofmt'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-159' name='which'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-160' size-in-bits='64' id='type-id-161'/>
-    <function-decl name='nvlist_prtctlop_boolean' mangled-name='nvlist_prtctlop_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-161' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-162' size-in-bits='64' id='type-id-163'/>
-    <function-decl name='nvlist_prtctlop_boolean_value' mangled-name='nvlist_prtctlop_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_value'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-163' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-165'/>
-    <function-decl name='nvlist_prtctlop_byte' mangled-name='nvlist_prtctlop_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-165' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-167'/>
-    <function-decl name='nvlist_prtctlop_int8' mangled-name='nvlist_prtctlop_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-167' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-169'/>
-    <function-decl name='nvlist_prtctlop_uint8' mangled-name='nvlist_prtctlop_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-169' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-171'/>
-    <function-decl name='nvlist_prtctlop_int16' mangled-name='nvlist_prtctlop_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-171' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-173'/>
-    <function-decl name='nvlist_prtctlop_uint16' mangled-name='nvlist_prtctlop_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-173' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-175'/>
-    <function-decl name='nvlist_prtctlop_int32' mangled-name='nvlist_prtctlop_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-175' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-177'/>
-    <function-decl name='nvlist_prtctlop_uint32' mangled-name='nvlist_prtctlop_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-177' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-179'/>
-    <function-decl name='nvlist_prtctlop_int64' mangled-name='nvlist_prtctlop_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-179' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-181'/>
-    <function-decl name='nvlist_prtctlop_uint64' mangled-name='nvlist_prtctlop_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-181' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-182' size-in-bits='64' id='type-id-183'/>
-    <function-decl name='nvlist_prtctlop_double' mangled-name='nvlist_prtctlop_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_double'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-183' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-184' size-in-bits='64' id='type-id-185'/>
-    <function-decl name='nvlist_prtctlop_string' mangled-name='nvlist_prtctlop_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-185' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-186' size-in-bits='64' id='type-id-187'/>
-    <function-decl name='nvlist_prtctlop_hrtime' mangled-name='nvlist_prtctlop_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_hrtime'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-187' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-188' size-in-bits='64' id='type-id-189'/>
-    <function-decl name='nvlist_prtctlop_nvlist' mangled-name='nvlist_prtctlop_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-189' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-190' size-in-bits='64' id='type-id-191'/>
-    <function-decl name='nvlist_prtctlop_boolean_array' mangled-name='nvlist_prtctlop_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-191' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-192' size-in-bits='64' id='type-id-193'/>
-    <function-decl name='nvlist_prtctlop_byte_array' mangled-name='nvlist_prtctlop_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-193' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-194' size-in-bits='64' id='type-id-195'/>
-    <function-decl name='nvlist_prtctlop_int8_array' mangled-name='nvlist_prtctlop_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-195' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-196' size-in-bits='64' id='type-id-197'/>
-    <function-decl name='nvlist_prtctlop_uint8_array' mangled-name='nvlist_prtctlop_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-197' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-198' size-in-bits='64' id='type-id-199'/>
-    <function-decl name='nvlist_prtctlop_int16_array' mangled-name='nvlist_prtctlop_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-199' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-200' size-in-bits='64' id='type-id-201'/>
-    <function-decl name='nvlist_prtctlop_uint16_array' mangled-name='nvlist_prtctlop_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-201' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-202' size-in-bits='64' id='type-id-203'/>
-    <function-decl name='nvlist_prtctlop_int32_array' mangled-name='nvlist_prtctlop_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-203' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-204' size-in-bits='64' id='type-id-205'/>
-    <function-decl name='nvlist_prtctlop_uint32_array' mangled-name='nvlist_prtctlop_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-205' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-206' size-in-bits='64' id='type-id-207'/>
-    <function-decl name='nvlist_prtctlop_int64_array' mangled-name='nvlist_prtctlop_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-207' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-208' size-in-bits='64' id='type-id-209'/>
-    <function-decl name='nvlist_prtctlop_uint64_array' mangled-name='nvlist_prtctlop_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-209' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-210' size-in-bits='64' id='type-id-211'/>
-    <function-decl name='nvlist_prtctlop_string_array' mangled-name='nvlist_prtctlop_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-211' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-212' size-in-bits='64' id='type-id-213'/>
-    <function-decl name='nvlist_prtctlop_nvlist_array' mangled-name='nvlist_prtctlop_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist_array'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <parameter type-id='type-id-213' name='func'/>
-      <parameter type-id='type-id-19' name='private'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_alloc' mangled-name='nvlist_prtctl_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_alloc'>
-      <return type-id='type-id-158'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctl_free' mangled-name='nvlist_prtctl_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_free'>
-      <parameter type-id='type-id-158' name='pctl'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_print' mangled-name='nvlist_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print'>
-      <parameter type-id='type-id-3' name='fp'/>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-214'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvp_size' type-id='type-id-65' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvp_name_sz' type-id='type-id-94' visibility='default'/>
+        <var-decl name='nvp_name_sz' type-id='type-id-4' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='nvp_reserve' type-id='type-id-94' visibility='default'/>
+        <var-decl name='nvp_reserve' type-id='type-id-4' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvp_value_elem' type-id='type-id-65' visibility='default'/>
+        <var-decl name='nvp_value_elem' type-id='type-id-3' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='nvp_type' type-id='type-id-215' visibility='default'/>
+        <var-decl name='nvp_type' type-id='type-id-5' visibility='default'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-216'>
-      <underlying-type type-id='type-id-32'/>
+    <typedef-decl name='__int32_t' type-id='type-id-1' id='type-id-6'/>
+    <typedef-decl name='int32_t' type-id='type-id-6' id='type-id-3'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-7'/>
+    <typedef-decl name='__int16_t' type-id='type-id-7' id='type-id-8'/>
+    <typedef-decl name='int16_t' type-id='type-id-8' id='type-id-4'/>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-9'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-10'>
+      <underlying-type type-id='type-id-9'/>
       <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
       <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
       <enumerator name='DATA_TYPE_BOOLEAN' value='1'/>
@@ -1072,2565 +293,2899 @@
       <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
       <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
     </enum-decl>
-    <typedef-decl name='data_type_t' type-id='type-id-216' id='type-id-215'/>
-    <pointer-type-def type-id='type-id-214' size-in-bits='64' id='type-id-217'/>
-    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-218'/>
-    <function-decl name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-217'/>
-    </function-decl>
-    <function-decl name='nvpair_type' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-216'/>
-    </function-decl>
-    <function-decl name='nvpair_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-80' size-in-bits='64' id='type-id-219'/>
-    <function-decl name='nvpair_value_byte' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-219'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-220'/>
-    <function-decl name='nvpair_value_int16' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-220'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-221'/>
-    <function-decl name='nvpair_value_uint16' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-221'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-222'/>
-    <function-decl name='nvpair_value_int32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-222'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-223'/>
-    <function-decl name='nvpair_value_uint32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-224'/>
-    <function-decl name='nvpair_value_int64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-224'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-225'/>
-    <function-decl name='nvpair_value_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-225'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-153'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-219' size-in-bits='64' id='type-id-226'/>
-    <function-decl name='nvpair_value_byte_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-226'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-220' size-in-bits='64' id='type-id-227'/>
-    <function-decl name='nvpair_value_int16_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-227'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-221' size-in-bits='64' id='type-id-228'/>
-    <function-decl name='nvpair_value_uint16_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-228'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-222' size-in-bits='64' id='type-id-229'/>
-    <function-decl name='nvpair_value_int32_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-229'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-223' size-in-bits='64' id='type-id-230'/>
-    <function-decl name='nvpair_value_uint32_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-230'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-224' size-in-bits='64' id='type-id-231'/>
-    <function-decl name='nvpair_value_int64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-231'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-225' size-in-bits='64' id='type-id-232'/>
-    <function-decl name='nvpair_value_uint64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-232'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-233'/>
-    <function-decl name='nvpair_value_string_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-233'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-116' size-in-bits='64' id='type-id-234'/>
-    <function-decl name='nvpair_value_hrtime' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-234'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-218' size-in-bits='64' id='type-id-235'/>
-    <function-decl name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-235'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-236'/>
-    <function-decl name='nvpair_value_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-236'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-237'/>
-    <function-decl name='nvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-237'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-238'/>
-    <function-decl name='nvpair_value_int8' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-238'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint8' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-219'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-237' size-in-bits='64' id='type-id-239'/>
-    <function-decl name='nvpair_value_boolean_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-239'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-238' size-in-bits='64' id='type-id-240'/>
-    <function-decl name='nvpair_value_int8_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-240'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint8_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-226'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-241'/>
-    <function-decl name='nvpair_value_double' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <parameter type-id='type-id-241'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_prt' mangled-name='nvlist_prt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prt'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-158' name='pctl'/>
+    <typedef-decl name='data_type_t' type-id='type-id-10' id='type-id-5'/>
+    <typedef-decl name='nvpair_t' type-id='type-id-2' id='type-id-11'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-12'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-13'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-14'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-15'/>
+    <function-decl name='nvpair_value_match' mangled-name='nvpair_value_match' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-1' name='ai'/>
+      <parameter type-id='type-id-14' name='value'/>
+      <parameter type-id='type-id-15' name='ep'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='dump_nvlist' mangled-name='dump_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dump_nvlist'>
-      <parameter type-id='type-id-73' name='list'/>
-      <parameter type-id='type-id-5' name='indent'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='dcgettext' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <typedef-decl name='nvpair_t' type-id='type-id-214' id='type-id-242'/>
-    <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-243'/>
-    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-244'>
+    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-16'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='buffer' type-id='type-id-245' visibility='default'/>
+        <var-decl name='buffer' type-id='type-id-17' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='allocated' type-id='type-id-246' visibility='default'/>
+        <var-decl name='allocated' type-id='type-id-18' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='used' type-id='type-id-246' visibility='default'/>
+        <var-decl name='used' type-id='type-id-18' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='syntax' type-id='type-id-247' visibility='default'/>
+        <var-decl name='syntax' type-id='type-id-19' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fastmap' type-id='type-id-9' visibility='default'/>
+        <var-decl name='fastmap' type-id='type-id-14' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='translate' type-id='type-id-219' visibility='default'/>
+        <var-decl name='translate' type-id='type-id-17' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
         <var-decl name='re_nsub' type-id='type-id-20' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='can_be_null' type-id='type-id-69' visibility='default'/>
+        <var-decl name='can_be_null' type-id='type-id-21' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='29'>
-        <var-decl name='regs_allocated' type-id='type-id-69' visibility='default'/>
+        <var-decl name='regs_allocated' type-id='type-id-21' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='28'>
-        <var-decl name='fastmap_accurate' type-id='type-id-69' visibility='default'/>
+        <var-decl name='fastmap_accurate' type-id='type-id-21' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='27'>
-        <var-decl name='no_sub' type-id='type-id-69' visibility='default'/>
+        <var-decl name='no_sub' type-id='type-id-21' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='26'>
-        <var-decl name='not_bol' type-id='type-id-69' visibility='default'/>
+        <var-decl name='not_bol' type-id='type-id-21' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='25'>
-        <var-decl name='not_eol' type-id='type-id-69' visibility='default'/>
+        <var-decl name='not_eol' type-id='type-id-21' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24'>
-        <var-decl name='newline_anchor' type-id='type-id-69' visibility='default'/>
+        <var-decl name='newline_anchor' type-id='type-id-21' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-248'/>
-    <pointer-type-def type-id='type-id-248' size-in-bits='64' id='type-id-245'/>
-    <typedef-decl name='__re_long_size_t' type-id='type-id-29' id='type-id-246'/>
-    <typedef-decl name='reg_syntax_t' type-id='type-id-29' id='type-id-247'/>
-    <typedef-decl name='regex_t' type-id='type-id-244' id='type-id-249'/>
-    <pointer-type-def type-id='type-id-249' size-in-bits='64' id='type-id-250'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-17'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-18'/>
+    <typedef-decl name='reg_syntax_t' type-id='type-id-18' id='type-id-19'/>
+    <typedef-decl name='size_t' type-id='type-id-18' id='type-id-20'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-21'/>
+    <typedef-decl name='regex_t' type-id='type-id-16' id='type-id-23'/>
+    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-24'/>
     <function-decl name='nvpair_value_match_regex' mangled-name='nvpair_value_match_regex' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match_regex'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-5' name='ai'/>
-      <parameter type-id='type-id-9' name='value'/>
-      <parameter type-id='type-id-250' name='value_regex'/>
-      <parameter type-id='type-id-153' name='ep'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_type_is_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-244' const='yes' id='type-id-251'/>
-    <pointer-type-def type-id='type-id-251' size-in-bits='64' id='type-id-252'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-253'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='rm_so' type-id='type-id-254' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='rm_eo' type-id='type-id-254' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='regoff_t' type-id='type-id-5' id='type-id-254'/>
-    <pointer-type-def type-id='type-id-253' size-in-bits='64' id='type-id-255'/>
-    <function-decl name='regexec' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-252'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-29'/>
-      <parameter type-id='type-id-255'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_match' mangled-name='nvpair_value_match' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-5' name='ai'/>
-      <parameter type-id='type-id-9' name='value'/>
-      <parameter type-id='type-id-153' name='ep'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-124'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-122'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-114'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-9'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-154'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-153'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-112'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-111'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-74'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-136'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-135'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-142'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-141'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-148'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-147'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-130'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-129'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-120'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-73'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-157'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-156'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-78'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-77'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-118'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-117'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-95'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-94'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-101'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-65'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-107'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-106'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-86'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-85'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-82'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-81'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-99'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-98'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-103'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-66'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-109'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-67'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-90'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-127'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-139'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-138'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-145'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-144'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-151'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-150'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-133'>
-      <parameter type-id='type-id-63'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-132'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-190'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-122'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-184'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-9'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-210'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-153'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-182'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-111'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-160'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-198'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-135'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-202'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-141'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-206'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-147'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-194'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-129'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-188'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-73'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-212'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-156'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-162'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-77'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-186'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-117'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-170'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-94'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-174'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-65'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-178'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-106'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-166'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-85'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-164'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-81'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-172'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-98'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-176'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-66'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-180'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-67'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-168'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-192'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-200'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-138'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-204'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-144'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-208'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-150'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-196'>
-      <parameter type-id='type-id-158'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-132'/>
-      <parameter type-id='type-id-123'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libnvpair_json.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libnvpair' language='LANG_C99'>
-    <function-decl name='nvlist_print_json' mangled-name='nvlist_print_json' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print_json'>
-      <parameter type-id='type-id-3' name='fp'/>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_byte' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-80'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int16' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-92'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint16' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-13'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-24'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-29'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <function-decl name='libspl_assertf' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-6'/>
-      <parameter is-variadic='yes'/>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-1' name='ai'/>
+      <parameter type-id='type-id-14' name='value'/>
+      <parameter type-id='type-id-24' name='value_regex'/>
+      <parameter type-id='type-id-15' name='ep'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-218'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-76'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int8' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-14'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint8' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-80'/>
-    </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-256'>
+    <type-decl name='void' id='type-id-25'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-26'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__count' type-id='type-id-5' visibility='default'/>
+        <var-decl name='nvl_version' type-id='type-id-3' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__value' type-id='type-id-257' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-257'>
-      <data-member access='private'>
-        <var-decl name='__wch' type-id='type-id-69' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__wchb' type-id='type-id-258' visibility='default'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='32' id='type-id-258'>
-      <subrange length='4' type-id='type-id-25' id='type-id-259'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-256' size-in-bits='64' id='type-id-260'/>
-    <function-decl name='mbrtowc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-222'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-29'/>
-      <parameter type-id='type-id-260'/>
-      <return type-id='type-id-29'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='nvpair_alloc_system.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libnvpair' language='LANG_C99'>
-    <class-decl name='nv_alloc' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-261'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nva_ops' type-id='type-id-262' visibility='default'/>
+        <var-decl name='nvl_nvflag' type-id='type-id-27' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nva_arg' type-id='type-id-19' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='nv_alloc_ops' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-263'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nv_ao_init' type-id='type-id-264' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nv_ao_fini' type-id='type-id-265' visibility='default'/>
+        <var-decl name='nvl_priv' type-id='type-id-28' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nv_ao_alloc' type-id='type-id-266' visibility='default'/>
+        <var-decl name='nvl_flag' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='nvl_pad' type-id='type-id-3' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__uint32_t' type-id='type-id-21' id='type-id-29'/>
+    <typedef-decl name='uint32_t' type-id='type-id-29' id='type-id-27'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-18' id='type-id-30'/>
+    <typedef-decl name='uint64_t' type-id='type-id-30' id='type-id-28'/>
+    <typedef-decl name='nvlist_t' type-id='type-id-26' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-32'/>
+    <function-decl name='dump_nvlist' mangled-name='dump_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dump_nvlist'>
+      <parameter type-id='type-id-32' name='list'/>
+      <parameter type-id='type-id-1' name='indent'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <class-decl name='nvlist_prtctl' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-33'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvprt_fp' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvprt_indent_mode' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='nvprt_indent' type-id='type-id-1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvprt_indentinc' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='nv_ao_free' type-id='type-id-267' visibility='default'/>
+        <var-decl name='nvprt_nmfmt' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='nv_ao_reset' type-id='type-id-265' visibility='default'/>
+        <var-decl name='nvprt_eomfmt' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='nvprt_btwnarrfmt' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='nvprt_btwnarrfmt_nl' type-id='type-id-1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='nvprt_dfltops' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='nvprt_custops' type-id='type-id-37' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='nv_alloc_t' type-id='type-id-261' id='type-id-268'/>
-    <pointer-type-def type-id='type-id-268' size-in-bits='64' id='type-id-269'/>
-    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-270'>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='type-id-38'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='gp_offset' type-id='type-id-69' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='fp_offset' type-id='type-id-69' visibility='default'/>
+        <var-decl name='_flags' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='overflow_arg_area' type-id='type-id-19' visibility='default'/>
+        <var-decl name='_IO_read_ptr' type-id='type-id-14' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='reg_save_area' type-id='type-id-19' visibility='default'/>
+        <var-decl name='_IO_read_end' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='__pad1' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='__pad2' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='__pad3' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='__pad4' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-47' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-270' size-in-bits='64' id='type-id-271'/>
-    <pointer-type-def type-id='type-id-272' size-in-bits='64' id='type-id-264'/>
-    <pointer-type-def type-id='type-id-273' size-in-bits='64' id='type-id-265'/>
-    <pointer-type-def type-id='type-id-274' size-in-bits='64' id='type-id-266'/>
-    <pointer-type-def type-id='type-id-275' size-in-bits='64' id='type-id-267'/>
-    <typedef-decl name='nv_alloc_ops_t' type-id='type-id-263' id='type-id-276'/>
-    <qualified-type-def type-id='type-id-276' const='yes' id='type-id-277'/>
-    <pointer-type-def type-id='type-id-277' size-in-bits='64' id='type-id-262'/>
-    <var-decl name='nv_alloc_nosleep' type-id='type-id-269' mangled-name='nv_alloc_nosleep' visibility='default' elf-symbol-id='nv_alloc_nosleep'/>
-    <function-type size-in-bits='64' id='type-id-272'>
-      <parameter type-id='type-id-269'/>
-      <parameter type-id='type-id-271'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-273'>
-      <parameter type-id='type-id-269'/>
-      <return type-id='type-id-1'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-275'>
-      <parameter type-id='type-id-269'/>
-      <parameter type-id='type-id-19'/>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-1'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-274'>
-      <parameter type-id='type-id-269'/>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-19'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair_alloc_fixed.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libnvpair' language='LANG_C99'>
-    <var-decl name='nv_fixed_ops' type-id='type-id-262' mangled-name='nv_fixed_ops' visibility='default' elf-symbol-id='nv_fixed_ops'/>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libnvpair' language='LANG_C99'>
-    <function-decl name='nv_alloc_init' mangled-name='nv_alloc_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_init'>
-      <parameter type-id='type-id-269' name='nva'/>
-      <parameter type-id='type-id-262' name='nvo'/>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-48'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_next' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_sbuf' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_pos' type-id='type-id-1' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-39'/>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-40'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-49'/>
+    <typedef-decl name='__off_t' type-id='type-id-49' id='type-id-41'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-42'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-43'/>
+
+    <array-type-def dimensions='1' type-id='type-id-13' size-in-bits='8' id='type-id-44'>
+      <subrange length='1' type-id='type-id-18' id='type-id-50'/>
+
+    </array-type-def>
+    <typedef-decl name='__off64_t' type-id='type-id-49' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-46'/>
+
+    <array-type-def dimensions='1' type-id='type-id-13' size-in-bits='160' id='type-id-47'>
+      <subrange length='20' type-id='type-id-18' id='type-id-51'/>
+
+    </array-type-def>
+    <typedef-decl name='FILE' type-id='type-id-38' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-34'/>
+    <enum-decl name='nvlist_indent_mode' id='type-id-35'>
+      <underlying-type type-id='type-id-9'/>
+      <enumerator name='NVLIST_INDENT_ABS' value='0'/>
+      <enumerator name='NVLIST_INDENT_TABBED' value='1'/>
+    </enum-decl>
+    <qualified-type-def type-id='type-id-13' const='yes' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-53' size-in-bits='64' id='type-id-36'/>
+    <class-decl name='nvlist_printops' size-in-bits='3456' is-struct='yes' visibility='default' id='type-id-54'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='print_boolean' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='print_boolean_value' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='print_byte' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='print_int8' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='print_uint8' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='print_int16' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='print_uint16' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='print_int32' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='print_uint32' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='print_int64' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='print_uint64' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='print_double' type-id='type-id-66' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='print_string' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='print_hrtime' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1792'>
+        <var-decl name='print_nvlist' type-id='type-id-69' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1920'>
+        <var-decl name='print_boolean_array' type-id='type-id-70' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='print_byte_array' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='print_int8_array' type-id='type-id-72' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='print_uint8_array' type-id='type-id-73' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='print_int16_array' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='print_uint16_array' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='print_int32_array' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='print_uint32_array' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2944'>
+        <var-decl name='print_int64_array' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3072'>
+        <var-decl name='print_uint64_array' type-id='type-id-79' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3200'>
+        <var-decl name='print_string_array' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3328'>
+        <var-decl name='print_nvlist_array' type-id='type-id-81' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-55'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-82'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-85' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-86'>
+      <underlying-type type-id='type-id-9'/>
+      <enumerator name='B_FALSE' value='0'/>
+      <enumerator name='B_TRUE' value='1'/>
+    </enum-decl>
+    <typedef-decl name='boolean_t' type-id='type-id-86' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-85'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uchar_t' type-id='type-id-22' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-89'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-58'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-92' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int8_t' type-id='type-id-43' id='type-id-93'/>
+    <typedef-decl name='int8_t' type-id='type-id-93' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-92'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-59'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-96' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__uint8_t' type-id='type-id-22' id='type-id-97'/>
+    <typedef-decl name='uint8_t' type-id='type-id-97' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-96'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-60'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-100' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-100'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-61'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__uint16_t' type-id='type-id-42' id='type-id-103'/>
+    <typedef-decl name='uint16_t' type-id='type-id-103' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-102'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-62'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-106'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-63'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-108' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-108'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-110' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int64_t' type-id='type-id-49' id='type-id-111'/>
+    <typedef-decl name='int64_t' type-id='type-id-111' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-110'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-65'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-115' size-in-bits='64' id='type-id-114'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-66'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <type-decl name='double' size-in-bits='64' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-116'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-120' size-in-bits='64' id='type-id-119'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-68'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-122'/>
+    <typedef-decl name='hrtime_t' type-id='type-id-122' id='type-id-123'/>
+    <pointer-type-def type-id='type-id-124' size-in-bits='64' id='type-id-121'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-69'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-126' size-in-bits='64' id='type-id-125'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-128'/>
+    <typedef-decl name='uint_t' type-id='type-id-21' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-130' size-in-bits='64' id='type-id-127'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-71'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-133' size-in-bits='64' id='type-id-131'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-134'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-138'/>
+    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-137'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-74'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-141'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-140'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-75'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-144'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-143'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-147'/>
+    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-146'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-77'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-150'/>
+    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-149'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-78'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-153'/>
+    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-152'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-155' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-156'/>
+    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-155'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-80'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-158' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-158'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-81'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-161'/>
+    <pointer-type-def type-id='type-id-162' size-in-bits='64' id='type-id-160'/>
+    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-37'/>
+    <typedef-decl name='nvlist_prtctl_t' type-id='type-id-83' id='type-id-163'/>
+    <function-decl name='nvlist_prt' mangled-name='nvlist_prt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prt'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_print' mangled-name='nvlist_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print'>
+      <parameter type-id='type-id-34' name='fp'/>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_free' mangled-name='nvlist_prtctl_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_free'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_alloc' mangled-name='nvlist_prtctl_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_alloc'>
+      <return type-id='type-id-163'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-165'/>
+    <function-decl name='nvlist_prtctlop_nvlist_array' mangled-name='nvlist_prtctlop_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-165' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-167'/>
+    <function-decl name='nvlist_prtctlop_string_array' mangled-name='nvlist_prtctlop_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-167' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-169'/>
+    <function-decl name='nvlist_prtctlop_uint64_array' mangled-name='nvlist_prtctlop_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-169' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-171'/>
+    <function-decl name='nvlist_prtctlop_int64_array' mangled-name='nvlist_prtctlop_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-171' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-173'/>
+    <function-decl name='nvlist_prtctlop_uint32_array' mangled-name='nvlist_prtctlop_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-173' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-175'/>
+    <function-decl name='nvlist_prtctlop_int32_array' mangled-name='nvlist_prtctlop_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-175' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-177'/>
+    <function-decl name='nvlist_prtctlop_uint16_array' mangled-name='nvlist_prtctlop_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-177' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-179'/>
+    <function-decl name='nvlist_prtctlop_int16_array' mangled-name='nvlist_prtctlop_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-179' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-181'/>
+    <function-decl name='nvlist_prtctlop_uint8_array' mangled-name='nvlist_prtctlop_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-181' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-182' size-in-bits='64' id='type-id-183'/>
+    <function-decl name='nvlist_prtctlop_int8_array' mangled-name='nvlist_prtctlop_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-183' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-184' size-in-bits='64' id='type-id-185'/>
+    <function-decl name='nvlist_prtctlop_byte_array' mangled-name='nvlist_prtctlop_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-185' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-186' size-in-bits='64' id='type-id-187'/>
+    <function-decl name='nvlist_prtctlop_boolean_array' mangled-name='nvlist_prtctlop_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_array'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-187' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-188' size-in-bits='64' id='type-id-189'/>
+    <function-decl name='nvlist_prtctlop_nvlist' mangled-name='nvlist_prtctlop_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-189' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-190' size-in-bits='64' id='type-id-191'/>
+    <function-decl name='nvlist_prtctlop_hrtime' mangled-name='nvlist_prtctlop_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_hrtime'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-191' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-192' size-in-bits='64' id='type-id-193'/>
+    <function-decl name='nvlist_prtctlop_string' mangled-name='nvlist_prtctlop_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-193' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-194' size-in-bits='64' id='type-id-195'/>
+    <function-decl name='nvlist_prtctlop_double' mangled-name='nvlist_prtctlop_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_double'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-195' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-196' size-in-bits='64' id='type-id-197'/>
+    <function-decl name='nvlist_prtctlop_uint64' mangled-name='nvlist_prtctlop_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-197' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-198' size-in-bits='64' id='type-id-199'/>
+    <function-decl name='nvlist_prtctlop_int64' mangled-name='nvlist_prtctlop_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-199' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-200' size-in-bits='64' id='type-id-201'/>
+    <function-decl name='nvlist_prtctlop_uint32' mangled-name='nvlist_prtctlop_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-201' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-202' size-in-bits='64' id='type-id-203'/>
+    <function-decl name='nvlist_prtctlop_int32' mangled-name='nvlist_prtctlop_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-203' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-204' size-in-bits='64' id='type-id-205'/>
+    <function-decl name='nvlist_prtctlop_uint16' mangled-name='nvlist_prtctlop_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-205' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-206' size-in-bits='64' id='type-id-207'/>
+    <function-decl name='nvlist_prtctlop_int16' mangled-name='nvlist_prtctlop_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-207' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-208' size-in-bits='64' id='type-id-209'/>
+    <function-decl name='nvlist_prtctlop_uint8' mangled-name='nvlist_prtctlop_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-209' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-210' size-in-bits='64' id='type-id-211'/>
+    <function-decl name='nvlist_prtctlop_int8' mangled-name='nvlist_prtctlop_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-211' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-212' size-in-bits='64' id='type-id-213'/>
+    <function-decl name='nvlist_prtctlop_byte' mangled-name='nvlist_prtctlop_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-213' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-214' size-in-bits='64' id='type-id-215'/>
+    <function-decl name='nvlist_prtctlop_boolean_value' mangled-name='nvlist_prtctlop_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_value'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-215' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-216' size-in-bits='64' id='type-id-217'/>
+    <function-decl name='nvlist_prtctlop_boolean' mangled-name='nvlist_prtctlop_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-217' name='func'/>
+      <parameter type-id='type-id-46' name='private'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <enum-decl name='nvlist_prtctl_fmt' id='type-id-218'>
+      <underlying-type type-id='type-id-9'/>
+      <enumerator name='NVLIST_FMT_MEMBER_NAME' value='0'/>
+      <enumerator name='NVLIST_FMT_MEMBER_POSTAMBLE' value='1'/>
+      <enumerator name='NVLIST_FMT_BTWN_ARRAY' value='2'/>
+    </enum-decl>
+    <function-decl name='nvlist_prtctl_dofmt' mangled-name='nvlist_prtctl_dofmt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_dofmt'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-218' name='which'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-5'/>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='nv_alloc_reset' mangled-name='nv_alloc_reset' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_reset'>
-      <parameter type-id='type-id-269' name='nva'/>
+    <function-decl name='nvlist_prtctl_setfmt' mangled-name='nvlist_prtctl_setfmt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setfmt'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-218' name='which'/>
+      <parameter type-id='type-id-36' name='fmt'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_doindent' mangled-name='nvlist_prtctl_doindent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_doindent'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-1' name='onemore'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_setindent' mangled-name='nvlist_prtctl_setindent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setindent'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-35' name='mode'/>
+      <parameter type-id='type-id-1' name='start'/>
+      <parameter type-id='type-id-1' name='inc'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_getdest' mangled-name='nvlist_prtctl_getdest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_getdest'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_setdest' mangled-name='nvlist_prtctl_setdest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setdest'>
+      <parameter type-id='type-id-163' name='pctl'/>
+      <parameter type-id='type-id-34' name='fp'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_string_array' mangled-name='nvpair_value_string_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='regexec' mangled-name='regexec' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='strcmp' mangled-name='strcmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='sscanf' mangled-name='sscanf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_byte' mangled-name='nvpair_value_byte' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_byte_array' mangled-name='nvpair_value_byte_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int8' mangled-name='nvpair_value_int8' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int8_array' mangled-name='nvpair_value_int8_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8' mangled-name='nvpair_value_uint8' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8_array' mangled-name='nvpair_value_uint8_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int16' mangled-name='nvpair_value_int16' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int16_array' mangled-name='nvpair_value_int16_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint16' mangled-name='nvpair_value_uint16' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint16_array' mangled-name='nvpair_value_uint16_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int32_array' mangled-name='nvpair_value_int32_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint32_array' mangled-name='nvpair_value_uint32_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int64' mangled-name='nvpair_value_int64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int64_array' mangled-name='nvpair_value_int64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint64_array' mangled-name='nvpair_value_uint64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_boolean_value' mangled-name='nvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_boolean_array' mangled-name='nvpair_value_boolean_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_type_is_array' mangled-name='nvpair_type_is_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_type' mangled-name='nvpair_type' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='strspn' mangled-name='strspn' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='strcspn' mangled-name='strcspn' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='__stack_chk_fail' mangled-name='__stack_chk_fail' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='__printf_chk' mangled-name='__printf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_name' mangled-name='nvpair_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist_array' mangled-name='nvpair_value_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='dcgettext' mangled-name='dcgettext' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_double' mangled-name='nvpair_value_double' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvpair_value_hrtime' mangled-name='nvpair_value_hrtime' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='__builtin_fputs' mangled-name='fputs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='__fprintf_chk' mangled-name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='free' mangled-name='free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='malloc' mangled-name='malloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='calloc' mangled-name='calloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='__builtin_strchr' mangled-name='strchr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='__builtin_fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-130'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-128'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-120'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-159'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-118'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-117'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-84'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-142'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-141'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-148'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-147'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-154'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-153'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-136'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-135'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-126'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-32'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-162'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-161'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-88'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-87'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-124'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-101'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-113'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-95'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-94'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-91'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-90'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-104'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-115'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-28'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-99'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-98'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-133'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-145'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-144'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-151'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-150'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-157'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-156'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-139'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-138'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-186'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-128'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-192'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-166'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-194'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-117'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-216'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-178'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-141'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-174'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-147'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-170'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-153'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-182'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-135'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-188'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-32'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-164'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-161'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-214'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-87'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-190'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-123'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-206'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-202'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-198'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-112'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-210'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-94'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-212'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-90'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-204'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-104'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-200'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-27'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-196'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-28'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-208'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-98'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-184'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-176'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-144'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-172'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-150'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-168'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-156'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-180'>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-138'/>
+      <parameter type-id='type-id-129'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libnvpair_json.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libnvpair' language='LANG_C99'>
+    <function-decl name='nvlist_print_json' mangled-name='nvlist_print_json' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print_json'>
+      <parameter type-id='type-id-34' name='fp'/>
+      <parameter type-id='type-id-32' name='nvl'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nv_alloc_fini' mangled-name='nv_alloc_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_fini'>
-      <parameter type-id='type-id-269' name='nva'/>
+    <function-decl name='fnvpair_value_string' mangled-name='fnvpair_value_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_byte' mangled-name='fnvpair_value_byte' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int16' mangled-name='fnvpair_value_int16' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint16' mangled-name='fnvpair_value_uint16' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint32' mangled-name='fnvpair_value_uint32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_boolean_value' mangled-name='fnvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int8' mangled-name='fnvpair_value_int8' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint8' mangled-name='fnvpair_value_uint8' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='__ctype_get_mb_cur_max' mangled-name='__ctype_get_mb_cur_max' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='mbrtowc' mangled-name='mbrtowc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='nvpair_alloc_system.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libnvpair' language='LANG_C99'>
+    <class-decl name='nv_alloc' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-219'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nva_ops' type-id='type-id-220' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nva_arg' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='nv_alloc_ops' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-221'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nv_ao_init' type-id='type-id-222' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nv_ao_fini' type-id='type-id-223' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nv_ao_alloc' type-id='type-id-224' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='nv_ao_free' type-id='type-id-225' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='nv_ao_reset' type-id='type-id-223' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='nv_alloc_t' type-id='type-id-219' id='type-id-226'/>
+    <pointer-type-def type-id='type-id-226' size-in-bits='64' id='type-id-227'/>
+    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-228'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gp_offset' type-id='type-id-21' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fp_offset' type-id='type-id-21' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='overflow_arg_area' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='reg_save_area' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-228' size-in-bits='64' id='type-id-229'/>
+    <pointer-type-def type-id='type-id-230' size-in-bits='64' id='type-id-222'/>
+    <pointer-type-def type-id='type-id-231' size-in-bits='64' id='type-id-223'/>
+    <pointer-type-def type-id='type-id-232' size-in-bits='64' id='type-id-224'/>
+    <pointer-type-def type-id='type-id-233' size-in-bits='64' id='type-id-225'/>
+    <typedef-decl name='nv_alloc_ops_t' type-id='type-id-221' id='type-id-234'/>
+    <qualified-type-def type-id='type-id-234' const='yes' id='type-id-235'/>
+    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-220'/>
+    <var-decl name='nv_alloc_nosleep' type-id='type-id-227' mangled-name='nv_alloc_nosleep' visibility='default' elf-symbol-id='nv_alloc_nosleep'/>
+    <function-type size-in-bits='64' id='type-id-230'>
+      <parameter type-id='type-id-227'/>
+      <parameter type-id='type-id-229'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-231'>
+      <parameter type-id='type-id-227'/>
+      <return type-id='type-id-25'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-233'>
+      <parameter type-id='type-id-227'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-25'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-232'>
+      <parameter type-id='type-id-227'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-46'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair_alloc_fixed.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libnvpair' language='LANG_C99'>
+    <var-decl name='nv_fixed_ops' type-id='type-id-220' mangled-name='nv_fixed_ops' visibility='default' elf-symbol-id='nv_fixed_ops'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libnvpair' language='LANG_C99'>
+    <function-decl name='nvlist_xunpack' mangled-name='nvlist_xunpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xunpack'>
+      <parameter type-id='type-id-14' name='buf'/>
+      <parameter type-id='type-id-20' name='buflen'/>
+      <parameter type-id='type-id-161' name='nvlp'/>
+      <parameter type-id='type-id-227' name='nva'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_nv_alloc' mangled-name='nvlist_lookup_nv_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nv_alloc'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <return type-id='type-id-269'/>
+    <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_unpack'>
+      <parameter type-id='type-id-14' name='buf'/>
+      <parameter type-id='type-id-20' name='buflen'/>
+      <parameter type-id='type-id-161' name='nvlp'/>
+      <parameter type-id='type-id-1' name='kmflag'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_nvflag' mangled-name='nvlist_nvflag' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_nvflag'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <return type-id='type-id-123'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-236'/>
+    <function-decl name='nvlist_pack' mangled-name='nvlist_pack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_pack'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-15' name='bufp'/>
+      <parameter type-id='type-id-236' name='buflen'/>
+      <parameter type-id='type-id-1' name='encoding'/>
+      <parameter type-id='type-id-1' name='kmflag'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_alloc'>
-      <parameter type-id='type-id-156' name='nvlp'/>
-      <parameter type-id='type-id-123' name='nvflag'/>
-      <parameter type-id='type-id-5' name='kmflag'/>
+    <function-decl name='nvlist_merge' mangled-name='nvlist_merge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_merge'>
+      <parameter type-id='type-id-32' name='dst'/>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-1' name='flag'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvpair' mangled-name='nvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvpair'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-237'/>
+    <function-decl name='nvpair_value_hrtime' mangled-name='nvpair_value_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_hrtime'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-237' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-238'/>
+    <pointer-type-def type-id='type-id-129' size-in-bits='64' id='type-id-239'/>
+    <function-decl name='nvpair_value_nvlist_array' mangled-name='nvpair_value_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-238' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-240'/>
+    <function-decl name='nvpair_value_string_array' mangled-name='nvpair_value_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-240' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-156' size-in-bits='64' id='type-id-241'/>
+    <function-decl name='nvpair_value_uint64_array' mangled-name='nvpair_value_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-241' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-242'/>
+    <function-decl name='nvpair_value_int64_array' mangled-name='nvpair_value_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-242' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-150' size-in-bits='64' id='type-id-243'/>
+    <function-decl name='nvpair_value_uint32_array' mangled-name='nvpair_value_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-243' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-244'/>
+    <function-decl name='nvpair_value_int32_array' mangled-name='nvpair_value_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-244' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-245'/>
+    <function-decl name='nvpair_value_uint16_array' mangled-name='nvpair_value_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-245' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-246'/>
+    <function-decl name='nvpair_value_int16_array' mangled-name='nvpair_value_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-246' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-247'/>
+    <function-decl name='nvpair_value_uint8_array' mangled-name='nvpair_value_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-247' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-248'/>
+    <function-decl name='nvpair_value_int8_array' mangled-name='nvpair_value_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-248' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-132' size-in-bits='64' id='type-id-249'/>
+    <function-decl name='nvpair_value_byte_array' mangled-name='nvpair_value_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-249' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-128' size-in-bits='64' id='type-id-250'/>
+    <function-decl name='nvpair_value_boolean_array' mangled-name='nvpair_value_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-250' name='val'/>
+      <parameter type-id='type-id-239' name='nelem'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-161' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-15' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-251'/>
+    <function-decl name='nvpair_value_double' mangled-name='nvpair_value_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_double'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-251' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-156' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int64' mangled-name='nvpair_value_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-153' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-150' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-147' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint16' mangled-name='nvpair_value_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-144' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int16' mangled-name='nvpair_value_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-141' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8' mangled-name='nvpair_value_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-138' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int8' mangled-name='nvpair_value_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-135' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_byte' mangled-name='nvpair_value_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-132' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_boolean_value' mangled-name='nvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_value'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <parameter type-id='type-id-128' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_exists' mangled-name='nvlist_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_exists'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-252'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-253'/>
+    <function-decl name='nvlist_lookup_nvpair_embedded_index' mangled-name='nvlist_lookup_nvpair_embedded_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair_embedded_index'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-252' name='ret'/>
+      <parameter type-id='type-id-253' name='ip'/>
+      <parameter type-id='type-id-15' name='ep'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvpair' mangled-name='nvlist_lookup_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-252' name='ret'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_pairs' mangled-name='nvlist_lookup_pairs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_pairs'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-1' name='flag'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_hrtime' mangled-name='nvlist_lookup_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_hrtime'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-237' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-238' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string_array' mangled-name='nvlist_lookup_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-240' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-241' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64_array' mangled-name='nvlist_lookup_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-242' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32_array' mangled-name='nvlist_lookup_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-243' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32_array' mangled-name='nvlist_lookup_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-244' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16_array' mangled-name='nvlist_lookup_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-245' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16_array' mangled-name='nvlist_lookup_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-246' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8_array' mangled-name='nvlist_lookup_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-247' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8_array' mangled-name='nvlist_lookup_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-248' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte_array' mangled-name='nvlist_lookup_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-249' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_array' mangled-name='nvlist_lookup_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-250' name='a'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-161' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-15' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_double' mangled-name='nvlist_lookup_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_double'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-251' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-156' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-153' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32' mangled-name='nvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-150' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32' mangled-name='nvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-147' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16' mangled-name='nvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-144' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16' mangled-name='nvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-141' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8' mangled-name='nvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-138' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8' mangled-name='nvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-135' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte' mangled-name='nvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-132' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_value' mangled-name='nvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_value'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-128' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_type_is_array' mangled-name='nvpair_type_is_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type_is_array'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_type' mangled-name='nvpair_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type'>
+      <parameter type-id='type-id-12' name='nvp'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='nvlist_xalloc' mangled-name='nvlist_xalloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xalloc'>
-      <parameter type-id='type-id-156' name='nvlp'/>
-      <parameter type-id='type-id-123' name='nvflag'/>
-      <parameter type-id='type-id-269' name='nva'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='nvpair_name' mangled-name='nvpair_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_name'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-14'/>
     </function-decl>
-    <function-decl name='nvlist_free' mangled-name='nvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_free'>
-      <parameter type-id='type-id-73' name='nvl'/>
+    <function-decl name='nvlist_empty' mangled-name='nvlist_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_empty'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='nvlist_prev_nvpair' mangled-name='nvlist_prev_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prev_nvpair'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_next_nvpair'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-161' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-32' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_hrtime' mangled-name='nvlist_add_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_hrtime'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-123' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-14' const='yes' id='type-id-254'/>
+    <pointer-type-def type-id='type-id-254' size-in-bits='64' id='type-id-255'/>
+    <function-decl name='nvlist_add_string_array' mangled-name='nvlist_add_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-255' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-156' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64_array' mangled-name='nvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-153' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32_array' mangled-name='nvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-150' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32_array' mangled-name='nvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-147' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16_array' mangled-name='nvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-144' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16_array' mangled-name='nvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-141' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-138' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8_array' mangled-name='nvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-135' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte_array' mangled-name='nvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-132' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_array' mangled-name='nvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-128' name='a'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-36' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_double' mangled-name='nvlist_add_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_double'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-117' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-28' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64' mangled-name='nvlist_add_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-112' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32' mangled-name='nvlist_add_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-27' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32' mangled-name='nvlist_add_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-3' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16' mangled-name='nvlist_add_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-104' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16' mangled-name='nvlist_add_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-4' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8' mangled-name='nvlist_add_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-98' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8' mangled-name='nvlist_add_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-94' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte' mangled-name='nvlist_add_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-90' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_value' mangled-name='nvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_value'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-87' name='val'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='nvlist_dup' mangled-name='nvlist_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_dup'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-156' name='nvlp'/>
-      <parameter type-id='type-id-5' name='kmflag'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_xdup' mangled-name='nvlist_xdup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xdup'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-156' name='nvlp'/>
-      <parameter type-id='type-id-269' name='nva'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_all'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_remove_nvpair' mangled-name='nvlist_remove_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_nvpair'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_remove' mangled-name='nvlist_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-215' name='type'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean_value' mangled-name='nvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_value'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-77' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_byte' mangled-name='nvlist_add_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-81' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int8' mangled-name='nvlist_add_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-85' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint8' mangled-name='nvlist_add_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-89' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int16' mangled-name='nvlist_add_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-94' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint16' mangled-name='nvlist_add_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-98' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int32' mangled-name='nvlist_add_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-65' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint32' mangled-name='nvlist_add_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-66' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int64' mangled-name='nvlist_add_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-106' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-67' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_double' mangled-name='nvlist_add_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_double'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-111' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-6' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean_array' mangled-name='nvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-122' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_byte_array' mangled-name='nvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-126' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int8_array' mangled-name='nvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-129' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-132' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int16_array' mangled-name='nvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-135' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint16_array' mangled-name='nvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-138' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int32_array' mangled-name='nvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-141' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint32_array' mangled-name='nvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-144' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int64_array' mangled-name='nvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-147' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-150' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-9' const='yes' id='type-id-278'/>
-    <pointer-type-def type-id='type-id-278' size-in-bits='64' id='type-id-279'/>
-    <function-decl name='nvlist_add_string_array' mangled-name='nvlist_add_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-279' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_hrtime' mangled-name='nvlist_add_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_hrtime'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-117' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-73' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-156' name='a'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_next_nvpair'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-243'/>
-    </function-decl>
-    <function-decl name='nvlist_prev_nvpair' mangled-name='nvlist_prev_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prev_nvpair'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-243'/>
-    </function-decl>
-    <function-decl name='nvlist_empty' mangled-name='nvlist_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_empty'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <return type-id='type-id-77'/>
-    </function-decl>
-    <function-decl name='nvpair_name' mangled-name='nvpair_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_name'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <function-decl name='nvpair_type' mangled-name='nvpair_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-215'/>
-    </function-decl>
-    <function-decl name='nvpair_type_is_array' mangled-name='nvpair_type_is_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type_is_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean_value' mangled-name='nvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_value'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-122' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_byte' mangled-name='nvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-126' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int8' mangled-name='nvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-129' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint8' mangled-name='nvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-132' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int16' mangled-name='nvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-135' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint16' mangled-name='nvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-138' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int32' mangled-name='nvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-141' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint32' mangled-name='nvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-144' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-147' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-150' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_double' mangled-name='nvlist_lookup_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_double'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-241' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-153' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-156' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-122' size-in-bits='64' id='type-id-280'/>
-    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-281'/>
-    <function-decl name='nvlist_lookup_boolean_array' mangled-name='nvlist_lookup_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-280' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-126' size-in-bits='64' id='type-id-282'/>
-    <function-decl name='nvlist_lookup_byte_array' mangled-name='nvlist_lookup_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-282' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-129' size-in-bits='64' id='type-id-283'/>
-    <function-decl name='nvlist_lookup_int8_array' mangled-name='nvlist_lookup_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-283' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-132' size-in-bits='64' id='type-id-284'/>
-    <function-decl name='nvlist_lookup_uint8_array' mangled-name='nvlist_lookup_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-284' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-285'/>
-    <function-decl name='nvlist_lookup_int16_array' mangled-name='nvlist_lookup_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-285' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-286'/>
-    <function-decl name='nvlist_lookup_uint16_array' mangled-name='nvlist_lookup_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-286' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-287'/>
-    <function-decl name='nvlist_lookup_int32_array' mangled-name='nvlist_lookup_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-287' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-288'/>
-    <function-decl name='nvlist_lookup_uint32_array' mangled-name='nvlist_lookup_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-288' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-289'/>
-    <function-decl name='nvlist_lookup_int64_array' mangled-name='nvlist_lookup_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-289' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-150' size-in-bits='64' id='type-id-290'/>
-    <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-290' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_string_array' mangled-name='nvlist_lookup_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-233' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-156' size-in-bits='64' id='type-id-291'/>
-    <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-291' name='a'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-292'/>
-    <function-decl name='nvlist_lookup_hrtime' mangled-name='nvlist_lookup_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_hrtime'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-292' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_pairs' mangled-name='nvlist_lookup_pairs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_pairs'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-5' name='flag'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-243' size-in-bits='64' id='type-id-293'/>
-    <function-decl name='nvlist_lookup_nvpair' mangled-name='nvlist_lookup_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-293' name='ret'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvpair_embedded_index' mangled-name='nvlist_lookup_nvpair_embedded_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair_embedded_index'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-293' name='ret'/>
-      <parameter type-id='type-id-222' name='ip'/>
-      <parameter type-id='type-id-153' name='ep'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_exists' mangled-name='nvlist_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_exists'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-77'/>
-    </function-decl>
-    <function-decl name='nvpair_value_boolean_value' mangled-name='nvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_value'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-122' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_byte' mangled-name='nvpair_value_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-126' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int8' mangled-name='nvpair_value_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-129' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint8' mangled-name='nvpair_value_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-132' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int16' mangled-name='nvpair_value_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-135' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint16' mangled-name='nvpair_value_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-138' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-141' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-144' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int64' mangled-name='nvpair_value_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-147' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-150' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_double' mangled-name='nvpair_value_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_double'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-241' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-153' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-156' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_boolean_array' mangled-name='nvpair_value_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-280' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_byte_array' mangled-name='nvpair_value_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-282' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int8_array' mangled-name='nvpair_value_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-283' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint8_array' mangled-name='nvpair_value_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-284' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int16_array' mangled-name='nvpair_value_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-285' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint16_array' mangled-name='nvpair_value_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-286' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int32_array' mangled-name='nvpair_value_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-287' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint32_array' mangled-name='nvpair_value_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-288' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int64_array' mangled-name='nvpair_value_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-289' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint64_array' mangled-name='nvpair_value_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-290' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_string_array' mangled-name='nvpair_value_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-233' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_nvlist_array' mangled-name='nvpair_value_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist_array'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-291' name='val'/>
-      <parameter type-id='type-id-281' name='nelem'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvpair_value_hrtime' mangled-name='nvpair_value_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_hrtime'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <parameter type-id='type-id-292' name='val'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvpair' mangled-name='nvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvpair'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_merge' mangled-name='nvlist_merge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_merge'>
-      <parameter type-id='type-id-73' name='dst'/>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-5' name='flag'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-294'/>
-    <function-decl name='nvlist_size' mangled-name='nvlist_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_size'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-294' name='size'/>
-      <parameter type-id='type-id-5' name='encoding'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <class-decl name='XDR' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-295'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='x_op' type-id='type-id-296' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='x_ops' type-id='type-id-297' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='x_public' type-id='type-id-298' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='x_private' type-id='type-id-298' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='x_base' type-id='type-id-298' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='x_handy' type-id='type-id-299' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='xdr_op' id='type-id-296'>
-      <underlying-type type-id='type-id-32'/>
-      <enumerator name='XDR_ENCODE' value='0'/>
-      <enumerator name='XDR_DECODE' value='1'/>
-      <enumerator name='XDR_FREE' value='2'/>
-    </enum-decl>
-    <class-decl name='xdr_ops' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-300'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='x_getlong' type-id='type-id-301' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='x_putlong' type-id='type-id-302' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='x_getbytes' type-id='type-id-303' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='x_putbytes' type-id='type-id-304' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='x_getpostn' type-id='type-id-305' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='x_setpostn' type-id='type-id-306' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='x_inline' type-id='type-id-307' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='x_destroy' type-id='type-id-308' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='x_getint32' type-id='type-id-309' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='x_putint32' type-id='type-id-310' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='bool_t' type-id='type-id-5' id='type-id-311'/>
-    <typedef-decl name='XDR' type-id='type-id-295' id='type-id-312'/>
-    <pointer-type-def type-id='type-id-312' size-in-bits='64' id='type-id-313'/>
-    <pointer-type-def type-id='type-id-314' size-in-bits='64' id='type-id-301'/>
-    <qualified-type-def type-id='type-id-24' const='yes' id='type-id-315'/>
-    <pointer-type-def type-id='type-id-315' size-in-bits='64' id='type-id-316'/>
-    <pointer-type-def type-id='type-id-317' size-in-bits='64' id='type-id-302'/>
-    <typedef-decl name='__caddr_t' type-id='type-id-9' id='type-id-318'/>
-    <typedef-decl name='caddr_t' type-id='type-id-318' id='type-id-298'/>
-    <typedef-decl name='__u_int' type-id='type-id-69' id='type-id-319'/>
-    <typedef-decl name='u_int' type-id='type-id-319' id='type-id-299'/>
-    <pointer-type-def type-id='type-id-320' size-in-bits='64' id='type-id-303'/>
-    <pointer-type-def type-id='type-id-321' size-in-bits='64' id='type-id-304'/>
-    <qualified-type-def type-id='type-id-312' const='yes' id='type-id-322'/>
-    <pointer-type-def type-id='type-id-322' size-in-bits='64' id='type-id-323'/>
-    <pointer-type-def type-id='type-id-324' size-in-bits='64' id='type-id-305'/>
-    <pointer-type-def type-id='type-id-325' size-in-bits='64' id='type-id-306'/>
-    <pointer-type-def type-id='type-id-326' size-in-bits='64' id='type-id-307'/>
-    <pointer-type-def type-id='type-id-327' size-in-bits='64' id='type-id-308'/>
-    <pointer-type-def type-id='type-id-328' size-in-bits='64' id='type-id-309'/>
-    <qualified-type-def type-id='type-id-65' const='yes' id='type-id-329'/>
-    <pointer-type-def type-id='type-id-329' size-in-bits='64' id='type-id-330'/>
-    <pointer-type-def type-id='type-id-331' size-in-bits='64' id='type-id-310'/>
-    <pointer-type-def type-id='type-id-300' size-in-bits='64' id='type-id-297'/>
-    <function-decl name='xdrmem_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-69'/>
-      <parameter type-id='type-id-296'/>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-161' name='nvlp'/>
+      <parameter type-id='type-id-1' name='kmflag'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_pack' mangled-name='nvlist_pack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_pack'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-153' name='bufp'/>
-      <parameter type-id='type-id-294' name='buflen'/>
-      <parameter type-id='type-id-5' name='encoding'/>
-      <parameter type-id='type-id-5' name='kmflag'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='nvlist_free' mangled-name='nvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_free'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='nvlist_xpack' mangled-name='nvlist_xpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xpack'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-153' name='bufp'/>
-      <parameter type-id='type-id-294' name='buflen'/>
-      <parameter type-id='type-id-5' name='encoding'/>
-      <parameter type-id='type-id-269' name='nva'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_unpack'>
-      <parameter type-id='type-id-9' name='buf'/>
-      <parameter type-id='type-id-20' name='buflen'/>
-      <parameter type-id='type-id-156' name='nvlp'/>
-      <parameter type-id='type-id-5' name='kmflag'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='nvlist_xunpack' mangled-name='nvlist_xunpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xunpack'>
-      <parameter type-id='type-id-9' name='buf'/>
-      <parameter type-id='type-id-20' name='buflen'/>
-      <parameter type-id='type-id-156' name='nvlp'/>
-      <parameter type-id='type-id-269' name='nva'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='xdr_int' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-222'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='xdr_u_int' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='xdr_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-153'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='xdr_char' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-9'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='xdr_longlong_t' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-224'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-332' size-in-bits='64' id='type-id-333'/>
-    <function-decl name='xdr_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-153'/>
-      <parameter type-id='type-id-223'/>
-      <parameter type-id='type-id-69'/>
-      <parameter type-id='type-id-69'/>
-      <parameter type-id='type-id-333'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='xdr_short' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-220'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='xdr_u_short' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-221'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='xdr_u_longlong_t' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-225'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='xdr_opaque' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='xdr_double' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-241'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-332'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-19'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-5'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-326'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-299'/>
-      <return type-id='type-id-141'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-321'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-299'/>
-      <return type-id='type-id-311'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-331'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-330'/>
-      <return type-id='type-id-311'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-317'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-316'/>
-      <return type-id='type-id-311'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-328'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-141'/>
-      <return type-id='type-id-311'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-314'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-224'/>
-      <return type-id='type-id-311'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-320'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-298'/>
-      <parameter type-id='type-id-299'/>
-      <return type-id='type-id-311'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-325'>
-      <parameter type-id='type-id-313'/>
-      <parameter type-id='type-id-299'/>
-      <return type-id='type-id-311'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-324'>
-      <parameter type-id='type-id-323'/>
-      <return type-id='type-id-299'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-327'>
-      <parameter type-id='type-id-313'/>
-      <return type-id='type-id-1'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/fnvpair.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libnvpair' language='LANG_C99'>
-    <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_alloc'>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-235'/>
-      <parameter type-id='type-id-69'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_free' mangled-name='fnvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_free'>
-      <parameter type-id='type-id-73' name='nvl'/>
+    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_alloc'>
+      <parameter type-id='type-id-161' name='nvlp'/>
+      <parameter type-id='type-id-129' name='nvflag'/>
+      <parameter type-id='type-id-1' name='kmflag'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_free' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fnvlist_size' mangled-name='fnvlist_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_size'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='nvlist_size' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-225'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_pack' mangled-name='fnvlist_pack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-294' name='sizep'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <function-decl name='nvlist_pack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-153'/>
-      <parameter type-id='type-id-225'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_pack_free' mangled-name='fnvlist_pack_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack_free'>
-      <parameter type-id='type-id-9' name='pack'/>
-      <parameter type-id='type-id-20' name='size'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fnvlist_unpack' mangled-name='fnvlist_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_unpack'>
-      <parameter type-id='type-id-9' name='buf'/>
-      <parameter type-id='type-id-20' name='buflen'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='nvlist_unpack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-29'/>
-      <parameter type-id='type-id-235'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_dup' mangled-name='fnvlist_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_dup'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='nvlist_dup' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-235'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_merge'>
-      <parameter type-id='type-id-73' name='dst'/>
-      <parameter type-id='type-id-73' name='src'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_merge' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_num_pairs' mangled-name='fnvlist_num_pairs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_num_pairs'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_value'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-77' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_byte' mangled-name='fnvlist_add_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-81' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_byte' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int8' mangled-name='fnvlist_add_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-85' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int8' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-14'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint8' mangled-name='fnvlist_add_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-89' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint8' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int16' mangled-name='fnvlist_add_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-94' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int16' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-92'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint16' mangled-name='fnvlist_add_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-98' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint16' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-13'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int32' mangled-name='fnvlist_add_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-65' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint32' mangled-name='fnvlist_add_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-66' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int64' mangled-name='fnvlist_add_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-106' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-24'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-67' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-29'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-6' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-73' name='val'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-218'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_nvpair' mangled-name='fnvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvpair'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-243' name='pair'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_boolean_array' mangled-name='fnvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-122' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-237'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_byte_array' mangled-name='fnvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-126' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int8_array' mangled-name='fnvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-129' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-238'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint8_array' mangled-name='fnvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-132' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-219'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int16_array' mangled-name='fnvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-135' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-220'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint16_array' mangled-name='fnvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-138' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-221'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int32_array' mangled-name='fnvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-141' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-222'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint32_array' mangled-name='fnvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-144' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-223'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int64_array' mangled-name='fnvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-147' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-224'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint64_array' mangled-name='fnvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-150' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-225'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_string_array' mangled-name='fnvlist_add_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-279' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_string_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-279'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_nvlist_array' mangled-name='fnvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-156' name='val'/>
-      <parameter type-id='type-id-123' name='n'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-235'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_remove_all' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_remove_nvpair' mangled-name='fnvlist_remove_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove_nvpair'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-243' name='pair'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_remove_nvpair' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-217'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_nvpair' mangled-name='fnvlist_lookup_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvpair'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-243'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-334'/>
-    <function-decl name='nvlist_lookup_nvpair' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-334'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_boolean' mangled-name='fnvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-77'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_value'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-77'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-237'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_byte' mangled-name='fnvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-81'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-219'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int8' mangled-name='fnvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-85'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-238'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int16' mangled-name='fnvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-94'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-220'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int32' mangled-name='fnvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-65'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-222'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int64' mangled-name='fnvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-106'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-224'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint8' mangled-name='fnvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-89'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-219'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint16' mangled-name='fnvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-98'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-221'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint32' mangled-name='fnvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-66'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-67'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-225'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_string'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-153'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvlist'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-235'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_boolean_array' mangled-name='fnvlist_lookup_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-122'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-239'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_byte_array' mangled-name='fnvlist_lookup_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_byte_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-226'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int8_array' mangled-name='fnvlist_lookup_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-281' name='n'/>
+    <function-decl name='nvlist_nvflag' mangled-name='nvlist_nvflag' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_nvflag'>
+      <parameter type-id='type-id-32' name='nvl'/>
       <return type-id='type-id-129'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_int8_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-240'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='nvlist_lookup_nv_alloc' mangled-name='nvlist_lookup_nv_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nv_alloc'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <return type-id='type-id-227'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint8_array' mangled-name='fnvlist_lookup_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-132'/>
+    <function-decl name='nv_alloc_fini' mangled-name='nv_alloc_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_fini'>
+      <parameter type-id='type-id-227' name='nva'/>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_uint8_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-226'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='nv_alloc_reset' mangled-name='nv_alloc_reset' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_reset'>
+      <parameter type-id='type-id-227' name='nva'/>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int16_array' mangled-name='fnvlist_lookup_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-135'/>
+    <function-decl name='nv_alloc_init' mangled-name='nv_alloc_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_init'>
+      <parameter type-id='type-id-227' name='nva'/>
+      <parameter type-id='type-id-220' name='nvo'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_int16_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-227'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='nvlist_xalloc' mangled-name='nvlist_xalloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xalloc'>
+      <parameter type-id='type-id-161' name='nvlp'/>
+      <parameter type-id='type-id-129' name='nvflag'/>
+      <parameter type-id='type-id-227' name='nva'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint16_array' mangled-name='fnvlist_lookup_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-138'/>
+    <function-decl name='nvlist_remove_nvpair' mangled-name='nvlist_remove_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_nvpair'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_uint16_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-228'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_all'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int32_array' mangled-name='fnvlist_lookup_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-141'/>
+    <function-decl name='nvlist_remove' mangled-name='nvlist_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-5' name='type'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_int32_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-229'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='nvlist_xdup' mangled-name='nvlist_xdup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xdup'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-161' name='nvlp'/>
+      <parameter type-id='type-id-227' name='nva'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint32_array' mangled-name='fnvlist_lookup_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-144'/>
+    <function-decl name='nvlist_size' mangled-name='nvlist_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_size'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-236' name='size'/>
+      <parameter type-id='type-id-1' name='encoding'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_uint32_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-230'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='nvlist_xpack' mangled-name='nvlist_xpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xpack'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-15' name='bufp'/>
+      <parameter type-id='type-id-236' name='buflen'/>
+      <parameter type-id='type-id-1' name='encoding'/>
+      <parameter type-id='type-id-227' name='nva'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int64_array' mangled-name='fnvlist_lookup_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-147'/>
+    <function-decl name='xdr_int' mangled-name='xdr_int' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_int64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-231'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='strlen' mangled-name='strlen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint64_array' mangled-name='fnvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64_array'>
-      <parameter type-id='type-id-73' name='nvl'/>
-      <parameter type-id='type-id-6' name='name'/>
-      <parameter type-id='type-id-281' name='n'/>
-      <return type-id='type-id-150'/>
+    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-218'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-232'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='xdr_string' mangled-name='xdr_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_boolean_value' mangled-name='fnvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_boolean_value'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-77'/>
+    <function-decl name='xdr_longlong_t' mangled-name='xdr_longlong_t' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_byte' mangled-name='fnvpair_value_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_byte'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-81'/>
+    <function-decl name='xdr_array' mangled-name='xdr_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_int8' mangled-name='fnvpair_value_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int8'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-85'/>
+    <function-decl name='xdr_opaque' mangled-name='xdr_opaque' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_int16' mangled-name='fnvpair_value_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int16'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-94'/>
+    <function-decl name='xdr_u_longlong_t' mangled-name='xdr_u_longlong_t' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int32'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-65'/>
+    <function-decl name='xdr_double' mangled-name='xdr_double' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int64'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-106'/>
+    <function-decl name='xdr_u_int' mangled-name='xdr_u_int' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_uint8' mangled-name='fnvpair_value_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint8'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-89'/>
+    <function-decl name='xdr_u_short' mangled-name='xdr_u_short' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_uint16' mangled-name='fnvpair_value_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint16'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-98'/>
+    <function-decl name='xdr_short' mangled-name='xdr_short' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_uint32' mangled-name='fnvpair_value_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint32'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-66'/>
+    <function-decl name='xdr_char' mangled-name='xdr_char' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint64'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-67'/>
+    <function-decl name='__builtin_memmove' mangled-name='memmove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_string' mangled-name='fnvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_string'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-9'/>
+    <function-decl name='xdrmem_create' mangled-name='xdrmem_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_nvlist'>
-      <parameter type-id='type-id-243' name='nvp'/>
-      <return type-id='type-id-73'/>
+    <function-decl name='strncmp' mangled-name='strncmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='strtol' mangled-name='strtol' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
-    <var-decl name='libspl_assert_ok' type-id='type-id-5' mangled-name='libspl_assert_ok' visibility='default' elf-symbol-id='libspl_assert_ok'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/fnvpair.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libnvpair' language='LANG_C99'>
+    <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_nvlist'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_string' mangled-name='fnvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_string'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint64'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint32' mangled-name='fnvpair_value_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint32'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint16' mangled-name='fnvpair_value_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint16'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-104'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint8' mangled-name='fnvpair_value_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint8'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-98'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int64'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-112'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int32'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int16' mangled-name='fnvpair_value_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int16'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int8' mangled-name='fnvpair_value_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int8'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-94'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_byte' mangled-name='fnvpair_value_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_byte'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-90'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_boolean_value' mangled-name='fnvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_boolean_value'>
+      <parameter type-id='type-id-12' name='nvp'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64_array' mangled-name='fnvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-156'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int64_array' mangled-name='fnvlist_lookup_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-153'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint32_array' mangled-name='fnvlist_lookup_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-150'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int32_array' mangled-name='fnvlist_lookup_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-147'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint16_array' mangled-name='fnvlist_lookup_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-144'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int16_array' mangled-name='fnvlist_lookup_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-141'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint8_array' mangled-name='fnvlist_lookup_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-138'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int8_array' mangled-name='fnvlist_lookup_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-135'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_byte_array' mangled-name='fnvlist_lookup_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-132'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean_array' mangled-name='fnvlist_lookup_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-239' name='n'/>
+      <return type-id='type-id-128'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvlist'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_string'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint32' mangled-name='fnvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint16' mangled-name='fnvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-104'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint8' mangled-name='fnvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-98'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int64' mangled-name='fnvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-112'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int32' mangled-name='fnvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int16' mangled-name='fnvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int8' mangled-name='fnvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-94'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_byte' mangled-name='fnvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-90'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_value'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean' mangled-name='fnvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_nvpair' mangled-name='fnvlist_lookup_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvpair'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='fnvlist_remove_nvpair' mangled-name='fnvlist_remove_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove_nvpair'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-12' name='pair'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvlist_array' mangled-name='fnvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-161' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_string_array' mangled-name='fnvlist_add_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-255' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint64_array' mangled-name='fnvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-156' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int64_array' mangled-name='fnvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-153' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint32_array' mangled-name='fnvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-150' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int32_array' mangled-name='fnvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-147' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint16_array' mangled-name='fnvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-144' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int16_array' mangled-name='fnvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-141' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint8_array' mangled-name='fnvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-138' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int8_array' mangled-name='fnvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-135' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_byte_array' mangled-name='fnvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-132' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean_array' mangled-name='fnvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_array'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-128' name='val'/>
+      <parameter type-id='type-id-129' name='n'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvpair' mangled-name='fnvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvpair'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-12' name='pair'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-32' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-36' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-28' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int64' mangled-name='fnvlist_add_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-112' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint32' mangled-name='fnvlist_add_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-27' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int32' mangled-name='fnvlist_add_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-3' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint16' mangled-name='fnvlist_add_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-104' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int16' mangled-name='fnvlist_add_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-4' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint8' mangled-name='fnvlist_add_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-98' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int8' mangled-name='fnvlist_add_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-94' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_byte' mangled-name='fnvlist_add_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-90' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_value'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <parameter type-id='type-id-87' name='val'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-36' name='name'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_num_pairs' mangled-name='fnvlist_num_pairs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_num_pairs'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_merge'>
+      <parameter type-id='type-id-32' name='dst'/>
+      <parameter type-id='type-id-32' name='src'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_dup' mangled-name='fnvlist_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_dup'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='fnvlist_unpack' mangled-name='fnvlist_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_unpack'>
+      <parameter type-id='type-id-14' name='buf'/>
+      <parameter type-id='type-id-20' name='buflen'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='fnvlist_pack_free' mangled-name='fnvlist_pack_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack_free'>
+      <parameter type-id='type-id-14' name='pack'/>
+      <parameter type-id='type-id-20' name='size'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_pack' mangled-name='fnvlist_pack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <parameter type-id='type-id-236' name='sizep'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='fnvlist_size' mangled-name='fnvlist_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_size'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='fnvlist_free' mangled-name='fnvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_free'>
+      <parameter type-id='type-id-32' name='nvl'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_alloc'>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64_array' mangled-name='nvlist_lookup_int64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32_array' mangled-name='nvlist_lookup_uint32_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32_array' mangled-name='nvlist_lookup_int32_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16_array' mangled-name='nvlist_lookup_uint16_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16_array' mangled-name='nvlist_lookup_int16_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8_array' mangled-name='nvlist_lookup_uint8_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8_array' mangled-name='nvlist_lookup_int8_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte_array' mangled-name='nvlist_lookup_byte_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_array' mangled-name='nvlist_lookup_boolean_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32' mangled-name='nvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16' mangled-name='nvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8' mangled-name='nvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32' mangled-name='nvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16' mangled-name='nvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8' mangled-name='nvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte' mangled-name='nvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_value' mangled-name='nvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvpair' mangled-name='nvlist_lookup_nvpair' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_nvpair' mangled-name='nvlist_remove_nvpair' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string_array' mangled-name='nvlist_add_string_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64_array' mangled-name='nvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32_array' mangled-name='nvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32_array' mangled-name='nvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16_array' mangled-name='nvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16_array' mangled-name='nvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8_array' mangled-name='nvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte_array' mangled-name='nvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_array' mangled-name='nvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvpair' mangled-name='nvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64' mangled-name='nvlist_add_int64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32' mangled-name='nvlist_add_uint32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32' mangled-name='nvlist_add_int32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16' mangled-name='nvlist_add_uint16' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16' mangled-name='nvlist_add_int16' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8' mangled-name='nvlist_add_uint8' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8' mangled-name='nvlist_add_int8' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte' mangled-name='nvlist_add_byte' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_value' mangled-name='nvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_merge' mangled-name='nvlist_merge' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_dup' mangled-name='nvlist_dup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_pack' mangled-name='nvlist_pack' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_size' mangled-name='nvlist_size' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_free' mangled-name='nvlist_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <var-decl name='libspl_assert_ok' type-id='type-id-1' mangled-name='libspl_assert_ok' visibility='default' elf-symbol-id='libspl_assert_ok'/>
+    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
+      <parameter type-id='type-id-36' name='file'/>
+      <parameter type-id='type-id-36' name='func'/>
+      <parameter type-id='type-id-1' name='line'/>
+      <parameter type-id='type-id-36' name='format'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='__vfprintf_chk' mangled-name='__vfprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='abort' mangled-name='abort' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-25'/>
+    </function-decl>
   </abi-instr>
 </abi-corpus>

--- a/lib/libuutil/libuutil.abi
+++ b/lib/libuutil/libuutil.abi
@@ -1,11 +1,12 @@
-<abi-corpus path='libuutil.so' architecture='elf-amd-x86_64' soname='libuutil.so.3'>
+<abi-corpus architecture='elf-amd-x86_64' soname='libuutil.so.3'>
   <elf-needed>
-    <dependency name='libatomic.so.1'/>
     <dependency name='libpthread.so.0'/>
     <dependency name='libc.so.6'/>
     <dependency name='ld-linux-x86-64.so.2'/>
   </elf-needed>
   <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -259,2190 +260,1828 @@
     <elf-symbol name='uu_exit_ok_value' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='uu_exit_usage_value' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='uu_alloc.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
-    <type-decl name='void' id='type-id-1'/>
+  <abi-instr version='1.0' address-size='64' path='uu_alloc.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libuutil' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
     <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-2'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
-    <typedef-decl name='size_t' type-id='type-id-3' filepath='/usr/lib/llvm-13/lib/clang/13.0.0/include/stddef.h' line='46' column='1' id='type-id-4'/>
-    <function-decl name='uu_zalloc' mangled-name='uu_zalloc' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='33' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_zalloc'>
-      <parameter type-id='type-id-4' name='n' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='33' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-5'/>
-    <function-decl name='uu_set_error' filepath='../../include/libuutil_impl.h' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='uu_free' mangled-name='uu_free' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='48' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_free'>
-      <parameter type-id='type-id-2' name='p' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='48' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <type-decl name='char' size-in-bits='8' id='type-id-6'/>
-    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-7'/>
-    <qualified-type-def type-id='type-id-6' const='yes' id='type-id-8'/>
-    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-9'/>
-    <function-decl name='uu_strdup' mangled-name='uu_strdup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strdup'>
-      <parameter type-id='type-id-9' name='str' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='54' column='1'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='uu_strndup' mangled-name='uu_strndup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strndup'>
-      <parameter type-id='type-id-9' name='s' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='74' column='1'/>
-      <parameter type-id='type-id-4' name='n' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='74' column='1'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='strnlen' filepath='/usr/include/string.h' line='390' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-3'/>
-    </function-decl>
-    <function-decl name='uu_memdup' mangled-name='uu_memdup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_memdup'>
-      <parameter type-id='type-id-2' name='buf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='96' column='1'/>
-      <parameter type-id='type-id-4' name='sz' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='96' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='uu_msprintf' mangled-name='uu_msprintf' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_msprintf'>
-      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_alloc.c' line='108' column='1'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-3'/>
+    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-4'/>
+    <function-decl name='uu_msprintf' mangled-name='uu_msprintf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_msprintf'>
+      <parameter type-id='type-id-4' name='format'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-7'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-6'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-7'/>
+    <typedef-decl name='size_t' type-id='type-id-7' id='type-id-8'/>
+    <function-decl name='uu_memdup' mangled-name='uu_memdup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_memdup'>
+      <parameter type-id='type-id-6' name='buf'/>
+      <parameter type-id='type-id-8' name='sz'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='uu_strndup' mangled-name='uu_strndup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strndup'>
+      <parameter type-id='type-id-4' name='s'/>
+      <parameter type-id='type-id-8' name='n'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='uu_strdup' mangled-name='uu_strdup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strdup'>
+      <parameter type-id='type-id-4' name='str'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='uu_free' mangled-name='uu_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_free'>
+      <parameter type-id='type-id-6' name='p'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_zalloc' mangled-name='uu_zalloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_zalloc'>
+      <parameter type-id='type-id-8' name='n'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='__builtin___vsnprintf_chk' mangled-name='__vsnprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__stack_chk_fail' mangled-name='__stack_chk_fail' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='strnlen' mangled-name='strnlen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='strlen' mangled-name='strlen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='free' mangled-name='free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__builtin_calloc' mangled-name='calloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_set_error' mangled-name='uu_set_error' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_avl.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
-    <class-decl name='uu_avl_pool' size-in-bits='2176' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='148' column='1' id='type-id-10'>
+  <abi-instr version='1.0' address-size='64' path='uu_avl.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libuutil' language='LANG_C99'>
+    <function-decl name='uu_avl_release' mangled-name='uu_avl_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_release'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_avl_lockup' mangled-name='uu_avl_lockup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_lockup'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <class-decl name='uu_avl' size-in-bits='960' is-struct='yes' visibility='default' id='type-id-9'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='uap_next' type-id='type-id-11' visibility='default' filepath='../../include/libuutil_impl.h' line='149' column='1'/>
+        <var-decl name='ua_next_enc' type-id='type-id-10' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uap_prev' type-id='type-id-11' visibility='default' filepath='../../include/libuutil_impl.h' line='150' column='1'/>
+        <var-decl name='ua_prev_enc' type-id='type-id-10' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='uap_name' type-id='type-id-12' visibility='default' filepath='../../include/libuutil_impl.h' line='152' column='1'/>
+        <var-decl name='ua_pool' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='ua_parent_enc' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ua_debug' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='264'>
+        <var-decl name='ua_index' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='ua_tree' type-id='type-id-13' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='uap_nodeoffset' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='153' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='uap_objsize' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='154' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='uap_cmp' type-id='type-id-13' visibility='default' filepath='../../include/libuutil_impl.h' line='155' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='uap_debug' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='156' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='840'>
-        <var-decl name='uap_last_index' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='157' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='uap_lock' type-id='type-id-15' visibility='default' filepath='../../include/libuutil_impl.h' line='158' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='uap_null_avl' type-id='type-id-16' visibility='default' filepath='../../include/libuutil_impl.h' line='159' column='1'/>
+        <var-decl name='ua_null_walk' type-id='type-id-14' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='uu_avl_pool_t' type-id='type-id-10' filepath='../../include/libuutil.h' line='259' column='1' id='type-id-17'/>
-    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-11'/>
-    <type-decl name='__ARRAY_SIZE_TYPE__' size-in-bits='64' id='type-id-18'/>
-
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='512' id='type-id-12'>
-      <subrange length='64' type-id='type-id-18' id='type-id-19'/>
-
-    </array-type-def>
-    <type-decl name='int' size-in-bits='32' id='type-id-20'/>
-    <typedef-decl name='uu_compare_fn_t' type-id='type-id-21' filepath='../../include/libuutil.h' line='131' column='1' id='type-id-22'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-13'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-23'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-23' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='37' column='1' id='type-id-24'/>
-    <typedef-decl name='uint8_t' type-id='type-id-24' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-14'/>
-    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='67' column='1' id='type-id-25'>
-      <data-member access='private'>
-        <var-decl name='__data' type-id='type-id-26' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='69' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-27' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-28' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='118' column='1' id='type-id-26'>
+    <typedef-decl name='uintptr_t' type-id='type-id-7' id='type-id-10'/>
+    <class-decl name='uu_avl_pool' size-in-bits='2176' is-struct='yes' visibility='default' id='type-id-15'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__lock' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='120' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__count' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='121' column='1'/>
+        <var-decl name='uap_next' type-id='type-id-11' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__owner' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='122' column='1'/>
+        <var-decl name='uap_prev' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uap_name' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='uap_nodeoffset' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='uap_objsize' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='uap_cmp' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='uap_debug' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='840'>
+        <var-decl name='uap_last_index' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='uap_lock' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='uap_null_avl' type-id='type-id-19' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_avl_pool_t' type-id='type-id-15' id='type-id-20'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-11'/>
+
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='512' id='type-id-16'>
+      <subrange length='64' type-id='type-id-7' id='type-id-21'/>
+
+    </array-type-def>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <typedef-decl name='uu_compare_fn_t' type-id='type-id-23' id='type-id-24'/>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-17'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-25'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-25' id='type-id-26'/>
+    <typedef-decl name='uint8_t' type-id='type-id-26' id='type-id-12'/>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' id='type-id-27'>
+      <data-member access='private'>
+        <var-decl name='__data' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-30' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-28'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-22' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__nusers' type-id='type-id-5' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='124' column='1'/>
+        <var-decl name='__nusers' type-id='type-id-31' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__kind' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='148' column='1'/>
+        <var-decl name='__kind' type-id='type-id-22' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='__spins' type-id='type-id-29' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
+        <var-decl name='__spins' type-id='type-id-32' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='__elision' type-id='type-id-29' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='154' column='1'/>
+        <var-decl name='__elision' type-id='type-id-32' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='type-id-30' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='155' column='1'/>
+        <var-decl name='__list' type-id='type-id-33' visibility='default'/>
       </data-member>
     </class-decl>
-    <type-decl name='short int' size-in-bits='16' id='type-id-29'/>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='82' column='1' id='type-id-31'>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-31'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-32'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-34'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='type-id-32' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='84' column='1'/>
+        <var-decl name='__prev' type-id='type-id-35' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='type-id-32' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='85' column='1'/>
+        <var-decl name='__next' type-id='type-id-35' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-32'/>
-    <typedef-decl name='__pthread_list_t' type-id='type-id-31' filepath='/usr/include/x86_64-linux-gnu/bits/thread-shared-types.h' line='86' column='1' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-35'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-34' id='type-id-33'/>
 
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='320' id='type-id-27'>
-      <subrange length='40' type-id='type-id-18' id='type-id-33'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='320' id='type-id-29'>
+      <subrange length='40' type-id='type-id-7' id='type-id-36'/>
 
     </array-type-def>
-    <type-decl name='long int' size-in-bits='64' id='type-id-28'/>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-25' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='72' column='1' id='type-id-15'/>
-    <class-decl name='uu_avl' size-in-bits='960' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='131' column='1' id='type-id-34'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-30'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-27' id='type-id-18'/>
+    <typedef-decl name='uu_avl_t' type-id='type-id-9' id='type-id-19'/>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-13'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ua_next_enc' type-id='type-id-35' visibility='default' filepath='../../include/libuutil_impl.h' line='132' column='1'/>
+        <var-decl name='avl_root' type-id='type-id-37' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='ua_prev_enc' type-id='type-id-35' visibility='default' filepath='../../include/libuutil_impl.h' line='133' column='1'/>
+        <var-decl name='avl_compar' type-id='type-id-38' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ua_pool' type-id='type-id-11' visibility='default' filepath='../../include/libuutil_impl.h' line='135' column='1'/>
+        <var-decl name='avl_offset' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='ua_parent_enc' type-id='type-id-35' visibility='default' filepath='../../include/libuutil_impl.h' line='136' column='1'/>
+        <var-decl name='avl_numnodes' type-id='type-id-39' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='ua_debug' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='137' column='1'/>
+        <var-decl name='avl_pad' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_child' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_pcb' type-id='type-id-10' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-37'/>
+
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='128' id='type-id-41'>
+      <subrange length='2' type-id='type-id-7' id='type-id-42'/>
+
+    </array-type-def>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-38'/>
+    <typedef-decl name='ulong_t' type-id='type-id-7' id='type-id-39'/>
+    <class-decl name='uu_avl_walk' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-44'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uaw_next' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uaw_prev' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uaw_avl' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='uaw_next_result' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='uaw_dir' type-id='type-id-47' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='264'>
-        <var-decl name='ua_index' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='138' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='ua_tree' type-id='type-id-36' visibility='default' filepath='../../include/libuutil_impl.h' line='140' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='ua_null_walk' type-id='type-id-37' visibility='default' filepath='../../include/libuutil_impl.h' line='141' column='1'/>
+        <var-decl name='uaw_robust' type-id='type-id-12' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='uintptr_t' type-id='type-id-3' filepath='/usr/include/stdint.h' line='90' column='1' id='type-id-35'/>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='146' column='1' id='type-id-36'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='type-id-38' visibility='default' filepath='../../include/sys/avl_impl.h' line='147' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='type-id-39' visibility='default' filepath='../../include/sys/avl_impl.h' line='148' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='type-id-4' visibility='default' filepath='../../include/sys/avl_impl.h' line='149' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='type-id-40' visibility='default' filepath='../../include/sys/avl_impl.h' line='150' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_size' type-id='type-id-4' visibility='default' filepath='../../include/sys/avl_impl.h' line='151' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/sys/avl_impl.h' line='90' column='1' id='type-id-41'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='type-id-42' visibility='default' filepath='../../include/sys/avl_impl.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='type-id-35' visibility='default' filepath='../../include/sys/avl_impl.h' line='92' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-41' size-in-bits='64' id='type-id-38'/>
-
-    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='128' id='type-id-42'>
-      <subrange length='2' type-id='type-id-18' id='type-id-43'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-44' size-in-bits='64' id='type-id-39'/>
-    <typedef-decl name='ulong_t' type-id='type-id-3' filepath='../../lib/libspl/include/sys/stdtypes.h' line='34' column='1' id='type-id-40'/>
-    <class-decl name='uu_avl_walk' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='121' column='1' id='type-id-45'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='uaw_next' type-id='type-id-46' visibility='default' filepath='../../include/libuutil_impl.h' line='122' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uaw_prev' type-id='type-id-46' visibility='default' filepath='../../include/libuutil_impl.h' line='123' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='uaw_avl' type-id='type-id-47' visibility='default' filepath='../../include/libuutil_impl.h' line='125' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='uaw_next_result' type-id='type-id-2' visibility='default' filepath='../../include/libuutil_impl.h' line='126' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='uaw_dir' type-id='type-id-48' visibility='default' filepath='../../include/libuutil_impl.h' line='127' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='264'>
-        <var-decl name='uaw_robust' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='128' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uu_avl_walk_t' type-id='type-id-45' filepath='../../include/libuutil.h' line='270' column='1' id='type-id-37'/>
-    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-46'/>
-    <typedef-decl name='uu_avl_t' type-id='type-id-34' filepath='../../include/libuutil.h' line='260' column='1' id='type-id-16'/>
-    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-47'/>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-49'/>
-    <typedef-decl name='__int8_t' type-id='type-id-49' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='36' column='1' id='type-id-50'/>
-    <typedef-decl name='int8_t' type-id='type-id-50' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='24' column='1' id='type-id-48'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-51'/>
-    <typedef-decl name='uint32_t' type-id='type-id-51' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-52'/>
-    <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='66' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_create'>
-      <parameter type-id='type-id-9' name='name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
-      <parameter type-id='type-id-4' name='objsize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
-      <parameter type-id='type-id-4' name='nodeoffset' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='66' column='1'/>
-      <parameter type-id='type-id-13' name='compare_func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='67' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='67' column='1'/>
-      <return type-id='type-id-11'/>
+    <typedef-decl name='uu_avl_walk_t' type-id='type-id-44' id='type-id-14'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-46'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-48'/>
+    <typedef-decl name='__int8_t' type-id='type-id-48' id='type-id-49'/>
+    <typedef-decl name='int8_t' type-id='type-id-49' id='type-id-47'/>
+    <typedef-decl name='uu_avl_index_t' type-id='type-id-10' id='type-id-50'/>
+    <function-decl name='uu_avl_nearest_prev' mangled-name='uu_avl_nearest_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_prev'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <parameter type-id='type-id-50' name='idx'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='uu_check_name' filepath='../../include/libuutil.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-20'/>
+    <function-decl name='uu_avl_nearest_next' mangled-name='uu_avl_nearest_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_next'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <parameter type-id='type-id-50' name='idx'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='uu_zalloc' filepath='../../include/libuutil.h' line='116' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_insert'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <parameter type-id='type-id-6' name='elem'/>
+      <parameter type-id='type-id-50' name='idx'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='strlcpy' filepath='../../lib/libspl/include/string.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-3'/>
+    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-51'/>
+    <function-decl name='uu_avl_find' mangled-name='uu_avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_find'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <parameter type-id='type-id-6' name='elem'/>
+      <parameter type-id='type-id-6' name='private'/>
+      <parameter type-id='type-id-51' name='out'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-53'/>
-    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='32' column='1' id='type-id-54'>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-55' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='34' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h' line='35' column='1'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='32' id='type-id-55'>
-      <subrange length='4' type-id='type-id-18' id='type-id-56'/>
-
-    </array-type-def>
-    <qualified-type-def type-id='type-id-54' const='yes' id='type-id-57'/>
-    <pointer-type-def type-id='type-id-57' size-in-bits='64' id='type-id-58'/>
-    <function-decl name='pthread_mutex_init' filepath='/usr/include/pthread.h' line='750' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
-      <parameter type-id='type-id-58'/>
-      <return type-id='type-id-20'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-52'/>
+    <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_teardown'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <parameter type-id='type-id-52' name='cookie'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='pthread_mutex_lock' filepath='/usr/include/pthread.h' line='763' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
-      <return type-id='type-id-20'/>
+    <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_remove'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <parameter type-id='type-id-6' name='elem'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='pthread_mutex_unlock' filepath='/usr/include/pthread.h' line='774' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
-      <return type-id='type-id-20'/>
+    <typedef-decl name='uu_walk_fn_t' type-id='type-id-43' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-53' size-in-bits='64' id='type-id-54'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-31' id='type-id-55'/>
+    <typedef-decl name='uint32_t' type-id='type-id-55' id='type-id-56'/>
+    <function-decl name='uu_avl_walk' mangled-name='uu_avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <parameter type-id='type-id-54' name='func'/>
+      <parameter type-id='type-id-6' name='private'/>
+      <parameter type-id='type-id-56' name='flags'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_destroy'>
-      <parameter type-id='type-id-11' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='114' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_end'>
+      <parameter type-id='type-id-45' name='wp'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_panic' filepath='../../include/libuutil_impl.h' line='46' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_next'>
+      <parameter type-id='type-id-45' name='wp'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='pthread_mutex_destroy' filepath='/usr/include/pthread.h' line='755' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-53'/>
-      <return type-id='type-id-20'/>
+    <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_start'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <parameter type-id='type-id-56' name='flags'/>
+      <return type-id='type-id-45'/>
     </function-decl>
-    <class-decl name='uu_avl_node' size-in-bits='192' is-struct='yes' visibility='default' filepath='../../include/libuutil.h' line='262' column='1' id='type-id-59'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='uan_opaque' type-id='type-id-60' visibility='default' filepath='../../include/libuutil.h' line='264' column='1'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-35' size-in-bits='192' id='type-id-60'>
-      <subrange length='3' type-id='type-id-18' id='type-id-61'/>
-
-    </array-type-def>
-    <typedef-decl name='uu_avl_node_t' type-id='type-id-59' filepath='../../include/libuutil.h' line='268' column='1' id='type-id-62'/>
-    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-63'/>
-    <function-decl name='uu_avl_node_init' mangled-name='uu_avl_node_init' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='138' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_init'>
-      <parameter type-id='type-id-2' name='base' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='138' column='1'/>
-      <parameter type-id='type-id-63' name='np' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='138' column='1'/>
-      <parameter type-id='type-id-11' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='138' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_avl_prev' mangled-name='uu_avl_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_prev'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <parameter type-id='type-id-6' name='node'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='uu_avl_node_fini' mangled-name='uu_avl_node_fini' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_fini'>
-      <parameter type-id='type-id-2' name='base' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='163' column='1'/>
-      <parameter type-id='type-id-63' name='np' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='163' column='1'/>
-      <parameter type-id='type-id-11' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='163' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_avl_next' mangled-name='uu_avl_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_next'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <parameter type-id='type-id-6' name='node'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='uu_avl_create' mangled-name='uu_avl_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_create'>
-      <parameter type-id='type-id-11' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='211' column='1'/>
-      <parameter type-id='type-id-2' name='parent' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='211' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='211' column='1'/>
-      <return type-id='type-id-47'/>
+    <function-decl name='uu_avl_last' mangled-name='uu_avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_last'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-64'/>
-    <function-decl name='avl_create' filepath='../../include/sys/avl.h' line='163' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <parameter type-id='type-id-39'/>
-      <parameter type-id='type-id-3'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_avl_first' mangled-name='uu_avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_first'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_destroy'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='250' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_avl_numnodes' mangled-name='uu_avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_numnodes'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='avl_numnodes' filepath='../../include/sys/avl.h' line='281' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <return type-id='type-id-3'/>
+    <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_destroy'>
+      <parameter type-id='type-id-46' name='ap'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='avl_destroy' filepath='../../include/sys/avl.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='uu_avl_numnodes' mangled-name='uu_avl_numnodes' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='279' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_numnodes'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='279' column='1'/>
-      <return type-id='type-id-4'/>
-    </function-decl>
-    <function-decl name='uu_avl_first' mangled-name='uu_avl_first' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='285' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_first'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='285' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='avl_first' filepath='../../include/sys/avl.h' line='205' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='uu_avl_last' mangled-name='uu_avl_last' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='291' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_last'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='285' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='avl_last' filepath='../../include/sys/avl.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='uu_avl_next' mangled-name='uu_avl_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='297' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_next'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
-      <parameter type-id='type-id-2' name='node' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='avl_walk' filepath='../../include/sys/avl_impl.h' line='158' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='uu_avl_prev' mangled-name='uu_avl_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_prev'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
-      <parameter type-id='type-id-2' name='node' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='297' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='364' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_start'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='364' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='364' column='1'/>
+    <function-decl name='uu_avl_create' mangled-name='uu_avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_create'>
+      <parameter type-id='type-id-11' name='pp'/>
+      <parameter type-id='type-id-6' name='parent'/>
+      <parameter type-id='type-id-56' name='flags'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='384' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_next'>
-      <parameter type-id='type-id-46' name='wp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='384' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='390' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_end'>
-      <parameter type-id='type-id-46' name='wp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='390' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <typedef-decl name='uu_walk_fn_t' type-id='type-id-44' filepath='../../include/libuutil.h' line='155' column='1' id='type-id-65'/>
-    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-66'/>
-    <function-decl name='uu_avl_walk' mangled-name='uu_avl_walk' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='397' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
-      <parameter type-id='type-id-66' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
-      <parameter type-id='type-id-2' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='397' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='422' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_remove'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='422' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='422' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_remove' filepath='../../include/sys/avl.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-67'/>
-    <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='458' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_teardown'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='458' column='1'/>
-      <parameter type-id='type-id-67' name='cookie' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='458' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='avl_destroy_nodes' filepath='../../include/sys/avl.h' line='309' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <parameter type-id='type-id-67'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <typedef-decl name='uu_avl_index_t' type-id='type-id-35' filepath='../../include/libuutil.h' line='272' column='1' id='type-id-68'/>
-    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-69'/>
-    <function-decl name='uu_avl_find' mangled-name='uu_avl_find' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='473' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_find'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
-      <parameter type-id='type-id-2' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
-      <parameter type-id='type-id-69' name='out' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='473' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-70'/>
-    <function-decl name='avl_find' filepath='../../include/sys/avl.h' line='175' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-70'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='494' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_insert'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='494' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='494' column='1'/>
-      <parameter type-id='type-id-68' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='494' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_insert' filepath='../../include/sys/avl.h' line='183' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='uu_avl_nearest_next' mangled-name='uu_avl_nearest_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='528' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_next'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
-      <parameter type-id='type-id-68' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='avl_nearest' filepath='../../include/sys/avl.h' line='242' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-64'/>
-      <parameter type-id='type-id-3'/>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='uu_avl_nearest_prev' mangled-name='uu_avl_nearest_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='538' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_prev'>
-      <parameter type-id='type-id-47' name='ap' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
-      <parameter type-id='type-id-68' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='528' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='uu_avl_lockup' mangled-name='uu_avl_lockup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='551' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_lockup'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='uu_avl_release' mangled-name='uu_avl_release' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_avl.c' line='562' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_release'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-44'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-20'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-21'>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-20'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_ident.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
-    <typedef-decl name='uint_t' type-id='type-id-5' filepath='../../lib/libspl/include/sys/stdtypes.h' line='33' column='1' id='type-id-71'/>
-    <function-decl name='uu_check_name' mangled-name='uu_check_name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_ident.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_check_name'>
-      <parameter type-id='type-id-9' name='name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_ident.c' line='93' column='1'/>
-      <parameter type-id='type-id-71' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_ident.c' line='93' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_list.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
-    <class-decl name='uu_list_pool' size-in-bits='2112' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='102' column='1' id='type-id-72'>
+    <class-decl name='uu_avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-57'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ulp_next' type-id='type-id-73' visibility='default' filepath='../../include/libuutil_impl.h' line='103' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='ulp_prev' type-id='type-id-73' visibility='default' filepath='../../include/libuutil_impl.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ulp_name' type-id='type-id-12' visibility='default' filepath='../../include/libuutil_impl.h' line='106' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='ulp_nodeoffset' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='107' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='ulp_objsize' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='108' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='ulp_cmp' type-id='type-id-13' visibility='default' filepath='../../include/libuutil_impl.h' line='109' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='ulp_debug' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='110' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='840'>
-        <var-decl name='ulp_last_index' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='111' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='ulp_lock' type-id='type-id-15' visibility='default' filepath='../../include/libuutil_impl.h' line='112' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='ulp_null_list' type-id='type-id-74' visibility='default' filepath='../../include/libuutil_impl.h' line='113' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uu_list_pool_t' type-id='type-id-72' filepath='../../include/libuutil.h' line='160' column='1' id='type-id-75'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-73'/>
-    <class-decl name='uu_list' size-in-bits='896' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='82' column='1' id='type-id-76'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ul_next_enc' type-id='type-id-35' visibility='default' filepath='../../include/libuutil_impl.h' line='83' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='ul_prev_enc' type-id='type-id-35' visibility='default' filepath='../../include/libuutil_impl.h' line='84' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ul_pool' type-id='type-id-73' visibility='default' filepath='../../include/libuutil_impl.h' line='86' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='ul_parent_enc' type-id='type-id-35' visibility='default' filepath='../../include/libuutil_impl.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='ul_offset' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='ul_numnodes' type-id='type-id-4' visibility='default' filepath='../../include/libuutil_impl.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='ul_debug' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='90' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='392'>
-        <var-decl name='ul_sorted' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='400'>
-        <var-decl name='ul_index' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='ul_null_node' type-id='type-id-77' visibility='default' filepath='../../include/libuutil_impl.h' line='94' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='ul_null_walk' type-id='type-id-78' visibility='default' filepath='../../include/libuutil_impl.h' line='95' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='uu_list_node_impl' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='67' column='1' id='type-id-79'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='uln_next' type-id='type-id-80' visibility='default' filepath='../../include/libuutil_impl.h' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uln_prev' type-id='type-id-80' visibility='default' filepath='../../include/libuutil_impl.h' line='69' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-80'/>
-    <typedef-decl name='uu_list_node_impl_t' type-id='type-id-79' filepath='../../include/libuutil_impl.h' line='70' column='1' id='type-id-77'/>
-    <class-decl name='uu_list_walk' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../include/libuutil_impl.h' line='72' column='1' id='type-id-81'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ulw_next' type-id='type-id-82' visibility='default' filepath='../../include/libuutil_impl.h' line='73' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='ulw_prev' type-id='type-id-82' visibility='default' filepath='../../include/libuutil_impl.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ulw_list' type-id='type-id-83' visibility='default' filepath='../../include/libuutil_impl.h' line='76' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='ulw_dir' type-id='type-id-48' visibility='default' filepath='../../include/libuutil_impl.h' line='77' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='200'>
-        <var-decl name='ulw_robust' type-id='type-id-14' visibility='default' filepath='../../include/libuutil_impl.h' line='78' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='ulw_next_result' type-id='type-id-84' visibility='default' filepath='../../include/libuutil_impl.h' line='79' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uu_list_walk_t' type-id='type-id-81' filepath='../../include/libuutil.h' line='167' column='1' id='type-id-78'/>
-    <pointer-type-def type-id='type-id-78' size-in-bits='64' id='type-id-82'/>
-    <typedef-decl name='uu_list_t' type-id='type-id-76' filepath='../../include/libuutil.h' line='161' column='1' id='type-id-74'/>
-    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-83'/>
-    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-84'/>
-    <function-decl name='uu_list_pool_create' mangled-name='uu_list_pool_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_create'>
-      <parameter type-id='type-id-9' name='name' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='63' column='1'/>
-      <parameter type-id='type-id-4' name='objsize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='63' column='1'/>
-      <parameter type-id='type-id-4' name='nodeoffset' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
-      <parameter type-id='type-id-13' name='compare_func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='64' column='1'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='uu_list_pool_destroy' mangled-name='uu_list_pool_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_destroy'>
-      <parameter type-id='type-id-73' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='110' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='uu_list_node' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../include/libuutil.h' line='163' column='1' id='type-id-85'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='uln_opaque' type-id='type-id-86' visibility='default' filepath='../../include/libuutil.h' line='164' column='1'/>
+        <var-decl name='uan_opaque' type-id='type-id-58' visibility='default'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-35' size-in-bits='128' id='type-id-86'>
-      <subrange length='2' type-id='type-id-18' id='type-id-43'/>
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='192' id='type-id-58'>
+      <subrange length='3' type-id='type-id-7' id='type-id-59'/>
 
     </array-type-def>
-    <typedef-decl name='uu_list_node_t' type-id='type-id-85' filepath='../../include/libuutil.h' line='165' column='1' id='type-id-87'/>
-    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-88'/>
-    <function-decl name='uu_list_node_init' mangled-name='uu_list_node_init' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_init'>
-      <parameter type-id='type-id-2' name='base' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
-      <parameter type-id='type-id-88' name='np_arg' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
-      <parameter type-id='type-id-73' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='133' column='1'/>
-      <return type-id='type-id-1'/>
+    <typedef-decl name='uu_avl_node_t' type-id='type-id-57' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='64' id='type-id-61'/>
+    <function-decl name='uu_avl_node_fini' mangled-name='uu_avl_node_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_fini'>
+      <parameter type-id='type-id-6' name='base'/>
+      <parameter type-id='type-id-61' name='np'/>
+      <parameter type-id='type-id-11' name='pp'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_node_fini' mangled-name='uu_list_node_fini' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_fini'>
-      <parameter type-id='type-id-2' name='base' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
-      <parameter type-id='type-id-88' name='np_arg' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
-      <parameter type-id='type-id-73' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='157' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_avl_node_init' mangled-name='uu_avl_node_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_init'>
+      <parameter type-id='type-id-6' name='base'/>
+      <parameter type-id='type-id-61' name='np'/>
+      <parameter type-id='type-id-11' name='pp'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_create' mangled-name='uu_list_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_create'>
-      <parameter type-id='type-id-73' name='pp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
-      <parameter type-id='type-id-2' name='parent' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='180' column='1'/>
-      <return type-id='type-id-83'/>
+    <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_destroy'>
+      <parameter type-id='type-id-11' name='pp'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_destroy' mangled-name='uu_list_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_destroy'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='231' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_create'>
+      <parameter type-id='type-id-4' name='name'/>
+      <parameter type-id='type-id-8' name='objsize'/>
+      <parameter type-id='type-id-8' name='nodeoffset'/>
+      <parameter type-id='type-id-17' name='compare_func'/>
+      <parameter type-id='type-id-56' name='flags'/>
+      <return type-id='type-id-11'/>
     </function-decl>
-    <typedef-decl name='uu_list_index_t' type-id='type-id-35' filepath='../../include/libuutil.h' line='169' column='1' id='type-id-89'/>
-    <function-decl name='uu_list_insert' mangled-name='uu_list_insert' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='292' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
-      <parameter type-id='type-id-89' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='292' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='pthread_mutex_unlock' mangled-name='pthread_mutex_unlock' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-90'/>
-    <function-decl name='uu_list_find' mangled-name='uu_list_find' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_find'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
-      <parameter type-id='type-id-2' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
-      <parameter type-id='type-id-90' name='out' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='315' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='pthread_mutex_lock' mangled-name='pthread_mutex_lock' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_nearest_next' mangled-name='uu_list_nearest_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='348' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_next'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
-      <parameter type-id='type-id-89' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='uu_panic' mangled-name='uu_panic' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_nearest_prev' mangled-name='uu_list_nearest_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_prev'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
-      <parameter type-id='type-id-89' name='idx' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='348' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='avl_nearest' mangled-name='avl_nearest' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_walk_start' mangled-name='uu_list_walk_start' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='456' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_start'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='456' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='456' column='1'/>
-      <return type-id='type-id-82'/>
+    <function-decl name='avl_insert' mangled-name='avl_insert' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_walk_next' mangled-name='uu_list_walk_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='476' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_next'>
-      <parameter type-id='type-id-82' name='wp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='476' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_walk_end' mangled-name='uu_list_walk_end' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='488' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_end'>
-      <parameter type-id='type-id-82' name='wp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='488' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_walk' mangled-name='uu_list_walk' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
-      <parameter type-id='type-id-66' name='func' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
-      <parameter type-id='type-id-2' name='private' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
-      <parameter type-id='type-id-52' name='flags' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='495' column='1'/>
-      <return type-id='type-id-20'/>
+    <function-decl name='avl_remove' mangled-name='avl_remove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_remove' mangled-name='uu_list_remove' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='540' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_remove'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='540' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='540' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_free' mangled-name='uu_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_teardown' mangled-name='uu_list_teardown' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='580' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_teardown'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='580' column='1'/>
-      <parameter type-id='type-id-67' name='cookie' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='580' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='uu_zalloc' mangled-name='uu_zalloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_first' mangled-name='uu_list_first' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='656' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_first'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='656' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='avl_last' mangled-name='avl_last' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_insert_before' mangled-name='uu_list_insert_before' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_before'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
-      <parameter type-id='type-id-2' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
-      <return type-id='type-id-20'/>
+    <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_insert_after' mangled-name='uu_list_insert_after' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_after'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
-      <parameter type-id='type-id-2' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='598' column='1'/>
-      <return type-id='type-id-20'/>
+    <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_numnodes' mangled-name='uu_list_numnodes' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='650' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_numnodes'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='650' column='1'/>
-      <return type-id='type-id-4'/>
+    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_last' mangled-name='uu_list_last' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='665' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_last'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='656' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_next' mangled-name='uu_list_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='674' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_next'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_prev' mangled-name='uu_list_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_prev'>
-      <parameter type-id='type-id-83' name='lp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
-      <parameter type-id='type-id-2' name='elem' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='674' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='pthread_mutex_destroy' mangled-name='pthread_mutex_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_lockup' mangled-name='uu_list_lockup' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_lockup'>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_check_name' mangled-name='uu_check_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_list_release' mangled-name='uu_list_release' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_list.c' line='710' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_release'>
-      <return type-id='type-id-1'/>
+    <function-decl name='strlcpy' mangled-name='strlcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_misc.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
-    <function-decl name='uu_set_error' mangled-name='uu_set_error' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_misc.c' line='73' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_set_error'>
-      <parameter type-id='type-id-71' name='code' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_misc.c' line='73' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='pthread_mutex_init' mangled-name='pthread_mutex_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-91'/>
-    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-93'/>
-    <function-decl name='pthread_key_create' filepath='/usr/include/pthread.h' line='1112' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-93'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='pthread_setspecific' filepath='/usr/include/pthread.h' line='1123' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='uu_error' mangled-name='uu_error' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_misc.c' line='102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_error'>
-      <return type-id='type-id-52'/>
-    </function-decl>
-    <function-decl name='pthread_getspecific' filepath='/usr/include/pthread.h' line='1120' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='uu_strerror' mangled-name='uu_strerror' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_misc.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strerror'>
-      <parameter type-id='type-id-52' name='code' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_misc.c' line='118' column='1'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <function-decl name='dcgettext' filepath='/usr/include/libintl.h' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='pthread_self' filepath='/usr/include/pthread.h' line='276' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-3'/>
-    </function-decl>
-    <function-decl name='pause' filepath='/usr/include/unistd.h' line='469' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-95'/>
-    <function-decl name='pthread_atfork' filepath='/usr/include/pthread.h' line='1146' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-95'/>
-      <parameter type-id='type-id-95'/>
-      <parameter type-id='type-id-95'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-94'>
-      <return type-id='type-id-1'/>
+    <function-type size-in-bits='64' id='type-id-43'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-22'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-92'>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-1'/>
+    <function-type size-in-bits='64' id='type-id-23'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-22'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_pname.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
-    <var-decl name='uu_exit_ok_value' type-id='type-id-20' mangled-name='uu_exit_ok_value' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='49' column='1' elf-symbol-id='uu_exit_ok_value'/>
-    <var-decl name='uu_exit_fatal_value' type-id='type-id-20' mangled-name='uu_exit_fatal_value' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='50' column='1' elf-symbol-id='uu_exit_fatal_value'/>
-    <var-decl name='uu_exit_usage_value' type-id='type-id-20' mangled-name='uu_exit_usage_value' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='51' column='1' elf-symbol-id='uu_exit_usage_value'/>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-96'/>
-    <function-decl name='uu_exit_ok' mangled-name='uu_exit_ok' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_ok'>
-      <return type-id='type-id-96'/>
+  <abi-instr version='1.0' address-size='64' path='uu_ident.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libuutil' language='LANG_C99'>
+    <typedef-decl name='uint_t' type-id='type-id-31' id='type-id-62'/>
+    <function-decl name='uu_check_name' mangled-name='uu_check_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_check_name'>
+      <parameter type-id='type-id-4' name='name'/>
+      <parameter type-id='type-id-62' name='flags'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='uu_exit_fatal' mangled-name='uu_exit_fatal' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='60' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_fatal'>
-      <return type-id='type-id-96'/>
+    <function-decl name='strchr' mangled-name='strchr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_exit_usage' mangled-name='uu_exit_usage' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='66' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_usage'>
-      <return type-id='type-id-96'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_list.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libuutil' language='LANG_C99'>
+    <function-decl name='uu_list_release' mangled-name='uu_list_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_release'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='uu_alt_exit' mangled-name='uu_alt_exit' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_alt_exit'>
-      <parameter type-id='type-id-20' name='profile' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='72' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_list_lockup' mangled-name='uu_list_lockup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_lockup'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-97'>
+    <class-decl name='uu_list' size-in-bits='896' is-struct='yes' visibility='default' id='type-id-63'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='gp_offset' type-id='type-id-5' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='fp_offset' type-id='type-id-5' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
+        <var-decl name='ul_next_enc' type-id='type-id-10' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='overflow_arg_area' type-id='type-id-2' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
+        <var-decl name='ul_prev_enc' type-id='type-id-10' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='reg_save_area' type-id='type-id-2' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='86' column='1'/>
+        <var-decl name='ul_pool' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='ul_parent_enc' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ul_offset' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='ul_numnodes' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='ul_debug' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='392'>
+        <var-decl name='ul_sorted' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='400'>
+        <var-decl name='ul_index' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='ul_null_node' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='ul_null_walk' type-id='type-id-66' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-98'/>
-    <function-decl name='uu_vwarn' mangled-name='uu_vwarn' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vwarn'>
-      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='101' column='1'/>
-      <parameter type-id='type-id-98' name='alist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='101' column='1'/>
-      <return type-id='type-id-1'/>
+    <class-decl name='uu_list_pool' size-in-bits='2112' is-struct='yes' visibility='default' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ulp_next' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ulp_prev' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ulp_name' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ulp_nodeoffset' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='ulp_objsize' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='ulp_cmp' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='ulp_debug' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='840'>
+        <var-decl name='ulp_last_index' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='ulp_lock' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='ulp_null_list' type-id='type-id-68' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_list_pool_t' type-id='type-id-67' id='type-id-69'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-64'/>
+    <typedef-decl name='uu_list_t' type-id='type-id-63' id='type-id-68'/>
+    <class-decl name='uu_list_node_impl' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uln_next' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uln_prev' type-id='type-id-71' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
+    <typedef-decl name='uu_list_node_impl_t' type-id='type-id-70' id='type-id-65'/>
+    <class-decl name='uu_list_walk' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ulw_next' type-id='type-id-73' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ulw_prev' type-id='type-id-73' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ulw_list' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='ulw_dir' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='200'>
+        <var-decl name='ulw_robust' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ulw_next_result' type-id='type-id-75' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_list_walk_t' type-id='type-id-72' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-73'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-74'/>
+    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-75'/>
+    <function-decl name='uu_list_prev' mangled-name='uu_list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_prev'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-6' name='elem'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='uu_warn' mangled-name='uu_warn' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_warn'>
-      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='108' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_list_next' mangled-name='uu_list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_next'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-6' name='elem'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='uu_vdie' mangled-name='uu_vdie' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vdie'>
-      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='135' column='1'/>
-      <parameter type-id='type-id-98' name='alist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='135' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_list_last' mangled-name='uu_list_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_last'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='uu_die' mangled-name='uu_die' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='142' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_die'>
-      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='142' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_list_first' mangled-name='uu_list_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_first'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='uu_vxdie' mangled-name='uu_vxdie' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vxdie'>
-      <parameter type-id='type-id-20' name='status' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
-      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
-      <parameter type-id='type-id-98' name='alist' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='151' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_list_numnodes' mangled-name='uu_list_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_numnodes'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='uu_xdie' mangled-name='uu_xdie' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_xdie'>
-      <parameter type-id='type-id-20' name='status' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='158' column='1'/>
-      <parameter type-id='type-id-9' name='format' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='158' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='uu_list_insert_after' mangled-name='uu_list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_after'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-6' name='target'/>
+      <parameter type-id='type-id-6' name='elem'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='uu_setpname' mangled-name='uu_setpname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_setpname'>
-      <parameter type-id='type-id-7' name='arg0' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='167' column='1'/>
-      <return type-id='type-id-9'/>
+    <function-decl name='uu_list_insert_before' mangled-name='uu_list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_before'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-6' name='target'/>
+      <parameter type-id='type-id-6' name='elem'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='getexecname' filepath='../../lib/libspl/include/stdlib.h' line='32' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-9'/>
+    <function-decl name='uu_list_teardown' mangled-name='uu_list_teardown' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_teardown'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-52' name='cookie'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='uu_getpname' mangled-name='uu_getpname' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_pname.c' line='204' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_getpname'>
-      <return type-id='type-id-9'/>
+    <function-decl name='uu_list_remove' mangled-name='uu_list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_remove'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-6' name='elem'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_list_walk' mangled-name='uu_list_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-54' name='func'/>
+      <parameter type-id='type-id-6' name='private'/>
+      <parameter type-id='type-id-56' name='flags'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='uu_list_walk_end' mangled-name='uu_list_walk_end' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_end'>
+      <parameter type-id='type-id-73' name='wp'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_list_walk_next' mangled-name='uu_list_walk_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_next'>
+      <parameter type-id='type-id-73' name='wp'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='uu_list_walk_start' mangled-name='uu_list_walk_start' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_start'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-56' name='flags'/>
+      <return type-id='type-id-73'/>
+    </function-decl>
+    <typedef-decl name='uu_list_index_t' type-id='type-id-10' id='type-id-76'/>
+    <function-decl name='uu_list_nearest_prev' mangled-name='uu_list_nearest_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_prev'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-76' name='idx'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='uu_list_nearest_next' mangled-name='uu_list_nearest_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_next'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-76' name='idx'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-77'/>
+    <function-decl name='uu_list_find' mangled-name='uu_list_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_find'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-6' name='elem'/>
+      <parameter type-id='type-id-6' name='private'/>
+      <parameter type-id='type-id-77' name='out'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='uu_list_insert' mangled-name='uu_list_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <parameter type-id='type-id-6' name='elem'/>
+      <parameter type-id='type-id-76' name='idx'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_list_destroy' mangled-name='uu_list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_destroy'>
+      <parameter type-id='type-id-74' name='lp'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_list_create' mangled-name='uu_list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_create'>
+      <parameter type-id='type-id-64' name='pp'/>
+      <parameter type-id='type-id-6' name='parent'/>
+      <parameter type-id='type-id-56' name='flags'/>
+      <return type-id='type-id-74'/>
+    </function-decl>
+    <class-decl name='uu_list_node' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-78'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uln_opaque' type-id='type-id-79' visibility='default'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='128' id='type-id-79'>
+      <subrange length='2' type-id='type-id-7' id='type-id-42'/>
+
+    </array-type-def>
+    <typedef-decl name='uu_list_node_t' type-id='type-id-78' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-80' size-in-bits='64' id='type-id-81'/>
+    <function-decl name='uu_list_node_fini' mangled-name='uu_list_node_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_fini'>
+      <parameter type-id='type-id-6' name='base'/>
+      <parameter type-id='type-id-81' name='np_arg'/>
+      <parameter type-id='type-id-64' name='pp'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_list_node_init' mangled-name='uu_list_node_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_init'>
+      <parameter type-id='type-id-6' name='base'/>
+      <parameter type-id='type-id-81' name='np_arg'/>
+      <parameter type-id='type-id-64' name='pp'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_list_pool_destroy' mangled-name='uu_list_pool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_destroy'>
+      <parameter type-id='type-id-64' name='pp'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_list_pool_create' mangled-name='uu_list_pool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_create'>
+      <parameter type-id='type-id-4' name='name'/>
+      <parameter type-id='type-id-8' name='objsize'/>
+      <parameter type-id='type-id-8' name='nodeoffset'/>
+      <parameter type-id='type-id-17' name='compare_func'/>
+      <parameter type-id='type-id-56' name='flags'/>
+      <return type-id='type-id-64'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_string.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil' language='LANG_C99'>
-    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-99'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='../../lib/libspl/include/sys/stdtypes.h' line='26' column='1' id='type-id-100'>
-      <underlying-type type-id='type-id-99'/>
+  <abi-instr version='1.0' address-size='64' path='uu_misc.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libuutil' language='LANG_C99'>
+    <function-decl name='uu_panic' mangled-name='uu_panic' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_panic'>
+      <parameter type-id='type-id-4' name='format'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_strerror' mangled-name='uu_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strerror'>
+      <parameter type-id='type-id-56' name='code'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='uu_error' mangled-name='uu_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_error'>
+      <return type-id='type-id-56'/>
+    </function-decl>
+    <function-decl name='uu_set_error' mangled-name='uu_set_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_set_error'>
+      <parameter type-id='type-id-62' name='code'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_atfork' mangled-name='pthread_atfork' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__vfprintf_chk' mangled-name='__vfprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_self' mangled-name='pthread_self' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pause' mangled-name='pause' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='abort' mangled-name='abort' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='dcgettext' mangled-name='dcgettext' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__errno_location' mangled-name='__errno_location' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_getspecific' mangled-name='pthread_getspecific' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_setspecific' mangled-name='pthread_setspecific' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='pthread_key_create' mangled-name='pthread_key_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_pname.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libuutil' language='LANG_C99'>
+    <var-decl name='uu_exit_ok_value' type-id='type-id-22' mangled-name='uu_exit_ok_value' visibility='default' elf-symbol-id='uu_exit_ok_value'/>
+    <var-decl name='uu_exit_fatal_value' type-id='type-id-22' mangled-name='uu_exit_fatal_value' visibility='default' elf-symbol-id='uu_exit_fatal_value'/>
+    <var-decl name='uu_exit_usage_value' type-id='type-id-22' mangled-name='uu_exit_usage_value' visibility='default' elf-symbol-id='uu_exit_usage_value'/>
+    <function-decl name='uu_getpname' mangled-name='uu_getpname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_getpname'>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='uu_setpname' mangled-name='uu_setpname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_setpname'>
+      <parameter type-id='type-id-2' name='arg0'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='uu_xdie' mangled-name='uu_xdie' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_xdie'>
+      <parameter type-id='type-id-22' name='status'/>
+      <parameter type-id='type-id-4' name='format'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-82'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gp_offset' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fp_offset' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='overflow_arg_area' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='reg_save_area' type-id='type-id-6' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-83'/>
+    <function-decl name='uu_vxdie' mangled-name='uu_vxdie' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vxdie'>
+      <parameter type-id='type-id-22' name='status'/>
+      <parameter type-id='type-id-4' name='format'/>
+      <parameter type-id='type-id-83' name='alist'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_die' mangled-name='uu_die' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_die'>
+      <parameter type-id='type-id-4' name='format'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_vdie' mangled-name='uu_vdie' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vdie'>
+      <parameter type-id='type-id-4' name='format'/>
+      <parameter type-id='type-id-83' name='alist'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_warn' mangled-name='uu_warn' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_warn'>
+      <parameter type-id='type-id-4' name='format'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_vwarn' mangled-name='uu_vwarn' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vwarn'>
+      <parameter type-id='type-id-4' name='format'/>
+      <parameter type-id='type-id-83' name='alist'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='uu_alt_exit' mangled-name='uu_alt_exit' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_alt_exit'>
+      <parameter type-id='type-id-22' name='profile'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-84'/>
+    <function-decl name='uu_exit_usage' mangled-name='uu_exit_usage' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_usage'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='uu_exit_fatal' mangled-name='uu_exit_fatal' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_fatal'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='uu_exit_ok' mangled-name='uu_exit_ok' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_ok'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strrchr' mangled-name='strrchr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='getexecname' mangled-name='getexecname' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='exit' mangled-name='exit' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__fprintf_chk' mangled-name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='strerror' mangled-name='strerror' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='uu_string.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libuutil' language='LANG_C99'>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-85'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-86'>
+      <underlying-type type-id='type-id-85'/>
       <enumerator name='B_FALSE' value='0'/>
       <enumerator name='B_TRUE' value='1'/>
     </enum-decl>
-    <typedef-decl name='boolean_t' type-id='type-id-100' filepath='../../lib/libspl/include/sys/stdtypes.h' line='29' column='1' id='type-id-101'/>
-    <function-decl name='uu_streq' mangled-name='uu_streq' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_streq'>
-      <parameter type-id='type-id-9' name='a' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
-      <parameter type-id='type-id-9' name='b' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
-      <return type-id='type-id-101'/>
+    <typedef-decl name='boolean_t' type-id='type-id-86' id='type-id-87'/>
+    <function-decl name='uu_strbw' mangled-name='uu_strbw' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strbw'>
+      <parameter type-id='type-id-4' name='a'/>
+      <parameter type-id='type-id-4' name='b'/>
+      <return type-id='type-id-87'/>
     </function-decl>
-    <function-decl name='uu_strcaseeq' mangled-name='uu_strcaseeq' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strcaseeq'>
-      <parameter type-id='type-id-9' name='a' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
-      <parameter type-id='type-id-9' name='b' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
-      <return type-id='type-id-101'/>
+    <function-decl name='uu_strcaseeq' mangled-name='uu_strcaseeq' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strcaseeq'>
+      <parameter type-id='type-id-4' name='a'/>
+      <parameter type-id='type-id-4' name='b'/>
+      <return type-id='type-id-87'/>
     </function-decl>
-    <function-decl name='uu_strbw' mangled-name='uu_strbw' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strbw'>
-      <parameter type-id='type-id-9' name='a' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
-      <parameter type-id='type-id-9' name='b' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libuutil/uu_string.c' line='37' column='1'/>
-      <return type-id='type-id-101'/>
+    <function-decl name='uu_streq' mangled-name='uu_streq' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_streq'>
+      <parameter type-id='type-id-4' name='a'/>
+      <parameter type-id='type-id-4' name='b'/>
+      <return type-id='type-id-87'/>
     </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libavl' language='LANG_C99'>
-    <typedef-decl name='avl_tree_t' type-id='type-id-36' filepath='../../include/sys/avl.h' line='119' column='1' id='type-id-102'/>
-    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-103'/>
-    <function-decl name='avl_walk' mangled-name='avl_walk' filepath='../../module/avl/avl.c' line='140' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='140' column='1'/>
-      <parameter type-id='type-id-2' name='oldnode' filepath='../../module/avl/avl.c' line='140' column='1'/>
-      <parameter type-id='type-id-20' name='left' filepath='../../module/avl/avl.c' line='140' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='strncmp' mangled-name='strncmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='avl_first' mangled-name='avl_first' filepath='../../module/avl/avl.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='187' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='strcasecmp' mangled-name='strcasecmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='avl_last' mangled-name='avl_last' filepath='../../module/avl/avl.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='187' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <typedef-decl name='avl_index_t' type-id='type-id-35' filepath='../../include/sys/avl.h' line='130' column='1' id='type-id-104'/>
-    <function-decl name='avl_nearest' mangled-name='avl_nearest' filepath='../../module/avl/avl.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='230' column='1'/>
-      <parameter type-id='type-id-104' name='where' filepath='../../module/avl/avl.c' line='230' column='1'/>
-      <parameter type-id='type-id-20' name='direction' filepath='../../module/avl/avl.c' line='230' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-105'/>
-    <function-decl name='avl_find' mangled-name='avl_find' filepath='../../module/avl/avl.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='259' column='1'/>
-      <parameter type-id='type-id-2' name='value' filepath='../../module/avl/avl.c' line='259' column='1'/>
-      <parameter type-id='type-id-105' name='where' filepath='../../module/avl/avl.c' line='259' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='avl_insert' mangled-name='avl_insert' filepath='../../module/avl/avl.c' line='486' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='486' column='1'/>
-      <parameter type-id='type-id-2' name='new_data' filepath='../../module/avl/avl.c' line='486' column='1'/>
-      <parameter type-id='type-id-104' name='where' filepath='../../module/avl/avl.c' line='486' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_insert_here' mangled-name='avl_insert_here' filepath='../../module/avl/avl.c' line='575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='576' column='1'/>
-      <parameter type-id='type-id-2' name='new_data' filepath='../../module/avl/avl.c' line='577' column='1'/>
-      <parameter type-id='type-id-2' name='here' filepath='../../module/avl/avl.c' line='578' column='1'/>
-      <parameter type-id='type-id-20' name='direction' filepath='../../module/avl/avl.c' line='579' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_add' mangled-name='avl_add' filepath='../../module/avl/avl.c' line='636' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='636' column='1'/>
-      <parameter type-id='type-id-2' name='new_node' filepath='../../module/avl/avl.c' line='636' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='libspl_assertf' filepath='../../lib/libspl/include/assert.h' line='40' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-9'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_remove' mangled-name='avl_remove' filepath='../../module/avl/avl.c' line='669' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='669' column='1'/>
-      <parameter type-id='type-id-2' name='data' filepath='../../module/avl/avl.c' line='669' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' filepath='../../module/avl/avl.c' line='817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
-      <parameter type-id='type-id-103' name='t' filepath='../../module/avl/avl.c' line='817' column='1'/>
-      <parameter type-id='type-id-2' name='obj' filepath='../../module/avl/avl.c' line='817' column='1'/>
-      <return type-id='type-id-101'/>
-    </function-decl>
-    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' filepath='../../module/avl/avl.c' line='834' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
-      <parameter type-id='type-id-103' name='t' filepath='../../module/avl/avl.c' line='817' column='1'/>
-      <parameter type-id='type-id-2' name='obj' filepath='../../module/avl/avl.c' line='817' column='1'/>
-      <return type-id='type-id-101'/>
-    </function-decl>
-    <function-decl name='avl_update' mangled-name='avl_update' filepath='../../module/avl/avl.c' line='851' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
-      <parameter type-id='type-id-103' name='t' filepath='../../module/avl/avl.c' line='851' column='1'/>
-      <parameter type-id='type-id-2' name='obj' filepath='../../module/avl/avl.c' line='851' column='1'/>
-      <return type-id='type-id-101'/>
-    </function-decl>
-    <function-decl name='avl_swap' mangled-name='avl_swap' filepath='../../module/avl/avl.c' line='871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
-      <parameter type-id='type-id-103' name='tree1' filepath='../../module/avl/avl.c' line='871' column='1'/>
-      <parameter type-id='type-id-103' name='tree2' filepath='../../module/avl/avl.c' line='871' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_create' mangled-name='avl_create' filepath='../../module/avl/avl.c' line='892' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='892' column='1'/>
-      <parameter type-id='type-id-39' name='compar' filepath='../../module/avl/avl.c' line='892' column='1'/>
-      <parameter type-id='type-id-4' name='size' filepath='../../module/avl/avl.c' line='893' column='1'/>
-      <parameter type-id='type-id-4' name='offset' filepath='../../module/avl/avl.c' line='893' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_destroy' mangled-name='avl_destroy' filepath='../../module/avl/avl.c' line='915' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='915' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' filepath='../../module/avl/avl.c' line='927' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='927' column='1'/>
-      <return type-id='type-id-40'/>
-    </function-decl>
-    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' filepath='../../module/avl/avl.c' line='934' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='934' column='1'/>
-      <return type-id='type-id-101'/>
-    </function-decl>
-    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' filepath='../../module/avl/avl.c' line='962' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
-      <parameter type-id='type-id-103' name='tree' filepath='../../module/avl/avl.c' line='962' column='1'/>
-      <parameter type-id='type-id-67' name='cookie' filepath='../../module/avl/avl.c' line='962' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='strcmp' mangled-name='strcmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='atomic.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <qualified-type-def type-id='type-id-14' volatile='yes' id='type-id-106'/>
-    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-107'/>
-    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='39' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <typedef-decl name='uchar_t' type-id='type-id-23' filepath='../../lib/libspl/include/sys/stdtypes.h' line='31' column='1' id='type-id-108'/>
-    <qualified-type-def type-id='type-id-108' volatile='yes' id='type-id-109'/>
-    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-110'/>
-    <function-decl name='atomic_inc_uchar' mangled-name='atomic_inc_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='40' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uchar'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='40' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-111'/>
-    <typedef-decl name='__uint16_t' type-id='type-id-111' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='39' column='1' id='type-id-112'/>
-    <typedef-decl name='uint16_t' type-id='type-id-112' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='25' column='1' id='type-id-113'/>
-    <qualified-type-def type-id='type-id-113' volatile='yes' id='type-id-114'/>
-    <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-115'/>
-    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='41' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='41' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <typedef-decl name='ushort_t' type-id='type-id-111' filepath='../../lib/libspl/include/sys/stdtypes.h' line='32' column='1' id='type-id-116'/>
-    <qualified-type-def type-id='type-id-116' volatile='yes' id='type-id-117'/>
-    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-118'/>
-    <function-decl name='atomic_inc_ushort' mangled-name='atomic_inc_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='42' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ushort'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='42' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-52' volatile='yes' id='type-id-119'/>
-    <pointer-type-def type-id='type-id-119' size-in-bits='64' id='type-id-120'/>
-    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='43' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='43' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-71' volatile='yes' id='type-id-121'/>
-    <pointer-type-def type-id='type-id-121' size-in-bits='64' id='type-id-122'/>
-    <function-decl name='atomic_inc_uint' mangled-name='atomic_inc_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uint'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='44' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-40' volatile='yes' id='type-id-123'/>
-    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-124'/>
-    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='45' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='45' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <typedef-decl name='__uint64_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='44' column='1' id='type-id-125'/>
-    <typedef-decl name='uint64_t' type-id='type-id-125' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-126'/>
-    <qualified-type-def type-id='type-id-126' volatile='yes' id='type-id-127'/>
-    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-128'/>
-    <function-decl name='atomic_inc_64' mangled-name='atomic_inc_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='46' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_64'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='46' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='55' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='39' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_dec_uchar' mangled-name='atomic_dec_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='56' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uchar'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='40' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='57' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='41' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ushort' mangled-name='atomic_dec_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='58' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ushort'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='42' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='43' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_dec_uint' mangled-name='atomic_dec_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='60' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uint'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='44' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='45' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_dec_64' mangled-name='atomic_dec_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_64'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='46' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_add_8' mangled-name='atomic_add_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
-      <parameter type-id='type-id-48' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_add_char' mangled-name='atomic_add_char' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_char'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
-      <parameter type-id='type-id-49' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <typedef-decl name='__int16_t' type-id='type-id-29' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-129'/>
-    <typedef-decl name='int16_t' type-id='type-id-129' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='25' column='1' id='type-id-130'/>
-    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
-      <parameter type-id='type-id-130' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_add_short' mangled-name='atomic_add_short' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_short'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
-      <parameter type-id='type-id-29' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <typedef-decl name='__int32_t' type-id='type-id-20' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-131'/>
-    <typedef-decl name='int32_t' type-id='type-id-131' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-132'/>
-    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
-      <parameter type-id='type-id-132' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_add_int' mangled-name='atomic_add_int' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_int'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
-      <parameter type-id='type-id-20' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
-      <parameter type-id='type-id-28' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <typedef-decl name='__int64_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='43' column='1' id='type-id-133'/>
-    <typedef-decl name='int64_t' type-id='type-id-133' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='27' column='1' id='type-id-134'/>
-    <function-decl name='atomic_add_64' mangled-name='atomic_add_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_64'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
-      <parameter type-id='type-id-134' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-1' volatile='yes' id='type-id-135'/>
-    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-136'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='191' column='1' id='type-id-137'/>
-    <typedef-decl name='ssize_t' type-id='type-id-137' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='108' column='1' id='type-id-138'/>
-    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
-      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
-      <parameter type-id='type-id-138' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
-      <parameter type-id='type-id-48' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='71' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_sub_char' mangled-name='atomic_sub_char' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='94' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_char'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
-      <parameter type-id='type-id-49' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='72' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='95' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
-      <parameter type-id='type-id-130' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='73' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_sub_short' mangled-name='atomic_sub_short' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_short'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
-      <parameter type-id='type-id-29' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='74' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
-      <parameter type-id='type-id-132' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='75' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_sub_int' mangled-name='atomic_sub_int' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_int'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
-      <parameter type-id='type-id-20' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='76' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
-      <parameter type-id='type-id-28' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='77' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_sub_64' mangled-name='atomic_sub_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='100' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_64'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
-      <parameter type-id='type-id-134' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='78' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
-      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
-      <parameter type-id='type-id-138' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='81' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
-      <parameter type-id='type-id-14' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_or_uchar' mangled-name='atomic_or_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uchar'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
-      <parameter type-id='type-id-108' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
-      <parameter type-id='type-id-113' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_or_ushort' mangled-name='atomic_or_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ushort'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
-      <parameter type-id='type-id-116' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
-      <parameter type-id='type-id-52' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_or_uint' mangled-name='atomic_or_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uint'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
-      <parameter type-id='type-id-71' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
-      <parameter type-id='type-id-40' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_or_64' mangled-name='atomic_or_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_64'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
-      <parameter type-id='type-id-126' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
-      <parameter type-id='type-id-14' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='115' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_and_uchar' mangled-name='atomic_and_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='132' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uchar'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
-      <parameter type-id='type-id-108' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='116' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
-      <parameter type-id='type-id-113' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='117' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_and_ushort' mangled-name='atomic_and_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ushort'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
-      <parameter type-id='type-id-116' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='118' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
-      <parameter type-id='type-id-52' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='119' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_and_uint' mangled-name='atomic_and_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='136' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uint'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
-      <parameter type-id='type-id-71' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='120' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
-      <parameter type-id='type-id-40' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='121' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_and_64' mangled-name='atomic_and_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='138' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_64'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
-      <parameter type-id='type-id-126' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='122' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='151' column='1'/>
-      <return type-id='type-id-14'/>
-    </function-decl>
-    <function-decl name='atomic_inc_uchar_nv' mangled-name='atomic_inc_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='152' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uchar_nv'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='152' column='1'/>
-      <return type-id='type-id-108'/>
-    </function-decl>
-    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='153' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='153' column='1'/>
-      <return type-id='type-id-113'/>
-    </function-decl>
-    <function-decl name='atomic_inc_ushort_nv' mangled-name='atomic_inc_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='154' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ushort_nv'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='154' column='1'/>
-      <return type-id='type-id-116'/>
-    </function-decl>
-    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='155' column='1'/>
-      <return type-id='type-id-52'/>
-    </function-decl>
-    <function-decl name='atomic_inc_uint_nv' mangled-name='atomic_inc_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uint_nv'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='156' column='1'/>
-      <return type-id='type-id-71'/>
-    </function-decl>
-    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='157' column='1'/>
-      <return type-id='type-id-40'/>
-    </function-decl>
-    <function-decl name='atomic_inc_64_nv' mangled-name='atomic_inc_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_64_nv'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='158' column='1'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='151' column='1'/>
-      <return type-id='type-id-14'/>
-    </function-decl>
-    <function-decl name='atomic_dec_uchar_nv' mangled-name='atomic_dec_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='168' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uchar_nv'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='152' column='1'/>
-      <return type-id='type-id-108'/>
-    </function-decl>
-    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='153' column='1'/>
-      <return type-id='type-id-113'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ushort_nv' mangled-name='atomic_dec_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ushort_nv'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='154' column='1'/>
-      <return type-id='type-id-116'/>
-    </function-decl>
-    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='171' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='155' column='1'/>
-      <return type-id='type-id-52'/>
-    </function-decl>
-    <function-decl name='atomic_dec_uint_nv' mangled-name='atomic_dec_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uint_nv'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='156' column='1'/>
-      <return type-id='type-id-71'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='157' column='1'/>
-      <return type-id='type-id-40'/>
-    </function-decl>
-    <function-decl name='atomic_dec_64_nv' mangled-name='atomic_dec_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_64_nv'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='158' column='1'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
-      <parameter type-id='type-id-48' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
-      <return type-id='type-id-14'/>
-    </function-decl>
-    <function-decl name='atomic_add_char_nv' mangled-name='atomic_add_char_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_char_nv'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
-      <parameter type-id='type-id-49' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
-      <return type-id='type-id-108'/>
-    </function-decl>
-    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
-      <parameter type-id='type-id-130' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
-      <return type-id='type-id-113'/>
-    </function-decl>
-    <function-decl name='atomic_add_short_nv' mangled-name='atomic_add_short_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_short_nv'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
-      <parameter type-id='type-id-29' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
-      <return type-id='type-id-116'/>
-    </function-decl>
-    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
-      <parameter type-id='type-id-132' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
-      <return type-id='type-id-52'/>
-    </function-decl>
-    <function-decl name='atomic_add_int_nv' mangled-name='atomic_add_int_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_int_nv'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
-      <parameter type-id='type-id-20' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
-      <return type-id='type-id-71'/>
-    </function-decl>
-    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
-      <parameter type-id='type-id-28' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
-      <return type-id='type-id-40'/>
-    </function-decl>
-    <function-decl name='atomic_add_64_nv' mangled-name='atomic_add_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_64_nv'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
-      <parameter type-id='type-id-134' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
-      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
-      <parameter type-id='type-id-138' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='205' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
-      <parameter type-id='type-id-48' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='183' column='1'/>
-      <return type-id='type-id-14'/>
-    </function-decl>
-    <function-decl name='atomic_sub_char_nv' mangled-name='atomic_sub_char_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_char_nv'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
-      <parameter type-id='type-id-49' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='184' column='1'/>
-      <return type-id='type-id-108'/>
-    </function-decl>
-    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='207' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
-      <parameter type-id='type-id-130' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='185' column='1'/>
-      <return type-id='type-id-113'/>
-    </function-decl>
-    <function-decl name='atomic_sub_short_nv' mangled-name='atomic_sub_short_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='208' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_short_nv'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
-      <parameter type-id='type-id-29' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='186' column='1'/>
-      <return type-id='type-id-116'/>
-    </function-decl>
-    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
-      <parameter type-id='type-id-132' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='187' column='1'/>
-      <return type-id='type-id-52'/>
-    </function-decl>
-    <function-decl name='atomic_sub_int_nv' mangled-name='atomic_sub_int_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='210' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_int_nv'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
-      <parameter type-id='type-id-20' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='188' column='1'/>
-      <return type-id='type-id-71'/>
-    </function-decl>
-    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
-      <parameter type-id='type-id-28' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='189' column='1'/>
-      <return type-id='type-id-40'/>
-    </function-decl>
-    <function-decl name='atomic_sub_64_nv' mangled-name='atomic_sub_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='212' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_64_nv'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
-      <parameter type-id='type-id-134' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='190' column='1'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
-      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
-      <parameter type-id='type-id-138' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='193' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
-      <parameter type-id='type-id-14' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
-      <return type-id='type-id-14'/>
-    </function-decl>
-    <function-decl name='atomic_or_uchar_nv' mangled-name='atomic_or_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uchar_nv'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
-      <parameter type-id='type-id-108' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
-      <return type-id='type-id-108'/>
-    </function-decl>
-    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
-      <parameter type-id='type-id-113' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
-      <return type-id='type-id-113'/>
-    </function-decl>
-    <function-decl name='atomic_or_ushort_nv' mangled-name='atomic_or_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ushort_nv'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
-      <parameter type-id='type-id-116' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
-      <return type-id='type-id-116'/>
-    </function-decl>
-    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
-      <parameter type-id='type-id-52' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
-      <return type-id='type-id-52'/>
-    </function-decl>
-    <function-decl name='atomic_or_uint_nv' mangled-name='atomic_or_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uint_nv'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
-      <parameter type-id='type-id-71' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
-      <return type-id='type-id-71'/>
-    </function-decl>
-    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
-      <parameter type-id='type-id-40' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
-      <return type-id='type-id-40'/>
-    </function-decl>
-    <function-decl name='atomic_or_64_nv' mangled-name='atomic_or_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_64_nv'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
-      <parameter type-id='type-id-126' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='243' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
-      <parameter type-id='type-id-14' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
-      <return type-id='type-id-14'/>
-    </function-decl>
-    <function-decl name='atomic_and_uchar_nv' mangled-name='atomic_and_uchar_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='244' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uchar_nv'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
-      <parameter type-id='type-id-108' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
-      <return type-id='type-id-108'/>
-    </function-decl>
-    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
-      <parameter type-id='type-id-113' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
-      <return type-id='type-id-113'/>
-    </function-decl>
-    <function-decl name='atomic_and_ushort_nv' mangled-name='atomic_and_ushort_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ushort_nv'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
-      <parameter type-id='type-id-116' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
-      <return type-id='type-id-116'/>
-    </function-decl>
-    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
-      <parameter type-id='type-id-52' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
-      <return type-id='type-id-52'/>
-    </function-decl>
-    <function-decl name='atomic_and_uint_nv' mangled-name='atomic_and_uint_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uint_nv'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
-      <parameter type-id='type-id-71' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
-      <return type-id='type-id-71'/>
-    </function-decl>
-    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='249' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
-      <parameter type-id='type-id-40' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
-      <return type-id='type-id-40'/>
-    </function-decl>
-    <function-decl name='atomic_and_64_nv' mangled-name='atomic_and_64_nv' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_64_nv'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
-      <parameter type-id='type-id-126' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1'/>
-      <parameter type-id='type-id-14' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1'/>
-      <parameter type-id='type-id-14' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='271' column='1'/>
-      <return type-id='type-id-14'/>
-    </function-decl>
-    <function-decl name='atomic_cas_uchar' mangled-name='atomic_cas_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_uchar'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1'/>
-      <parameter type-id='type-id-108' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1'/>
-      <parameter type-id='type-id-108' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='272' column='1'/>
-      <return type-id='type-id-108'/>
-    </function-decl>
-    <function-decl name='atomic_cas_16' mangled-name='atomic_cas_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_16'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1'/>
-      <parameter type-id='type-id-113' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1'/>
-      <parameter type-id='type-id-113' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='273' column='1'/>
-      <return type-id='type-id-113'/>
-    </function-decl>
-    <function-decl name='atomic_cas_ushort' mangled-name='atomic_cas_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ushort'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1'/>
-      <parameter type-id='type-id-116' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1'/>
-      <parameter type-id='type-id-116' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='274' column='1'/>
-      <return type-id='type-id-116'/>
-    </function-decl>
-    <function-decl name='atomic_cas_32' mangled-name='atomic_cas_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_32'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1'/>
-      <parameter type-id='type-id-52' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1'/>
-      <parameter type-id='type-id-52' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='275' column='1'/>
-      <return type-id='type-id-52'/>
-    </function-decl>
-    <function-decl name='atomic_cas_uint' mangled-name='atomic_cas_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_uint'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1'/>
-      <parameter type-id='type-id-71' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1'/>
-      <parameter type-id='type-id-71' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='276' column='1'/>
-      <return type-id='type-id-71'/>
-    </function-decl>
-    <function-decl name='atomic_cas_ulong' mangled-name='atomic_cas_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ulong'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1'/>
-      <parameter type-id='type-id-40' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1'/>
-      <parameter type-id='type-id-40' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='277' column='1'/>
-      <return type-id='type-id-40'/>
-    </function-decl>
-    <function-decl name='atomic_cas_64' mangled-name='atomic_cas_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_64'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1'/>
-      <parameter type-id='type-id-126' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1'/>
-      <parameter type-id='type-id-126' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='278' column='1'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
-      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1'/>
-      <parameter type-id='type-id-2' name='exp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1'/>
-      <parameter type-id='type-id-2' name='des' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='281' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
-      <parameter type-id='type-id-107' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
-      <parameter type-id='type-id-14' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='227' column='1'/>
-      <return type-id='type-id-14'/>
-    </function-decl>
-    <function-decl name='atomic_swap_uchar' mangled-name='atomic_swap_uchar' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='301' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_uchar'>
-      <parameter type-id='type-id-110' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
-      <parameter type-id='type-id-108' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='228' column='1'/>
-      <return type-id='type-id-108'/>
-    </function-decl>
-    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='302' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
-      <parameter type-id='type-id-115' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
-      <parameter type-id='type-id-113' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='229' column='1'/>
-      <return type-id='type-id-113'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ushort' mangled-name='atomic_swap_ushort' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ushort'>
-      <parameter type-id='type-id-118' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
-      <parameter type-id='type-id-116' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='230' column='1'/>
-      <return type-id='type-id-116'/>
-    </function-decl>
-    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
-      <parameter type-id='type-id-120' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
-      <parameter type-id='type-id-52' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='231' column='1'/>
-      <return type-id='type-id-52'/>
-    </function-decl>
-    <function-decl name='atomic_swap_uint' mangled-name='atomic_swap_uint' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='305' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_uint'>
-      <parameter type-id='type-id-122' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
-      <parameter type-id='type-id-71' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='232' column='1'/>
-      <return type-id='type-id-71'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
-      <parameter type-id='type-id-40' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='233' column='1'/>
-      <return type-id='type-id-40'/>
-    </function-decl>
-    <function-decl name='atomic_swap_64' mangled-name='atomic_swap_64' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='307' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_64'>
-      <parameter type-id='type-id-128' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
-      <parameter type-id='type-id-126' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='234' column='1'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
-      <parameter type-id='type-id-136' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='311' column='1'/>
-      <parameter type-id='type-id-2' name='bits' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='311' column='1'/>
-      <return type-id='type-id-2'/>
-    </function-decl>
-    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
-      <parameter type-id='type-id-71' name='value' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='326' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
-      <parameter type-id='type-id-124' name='target' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
-      <parameter type-id='type-id-71' name='value' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='318' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='membar_enter' mangled-name='membar_enter' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='334' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='membar_exit' mangled-name='membar_exit' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='340' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_exit'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='membar_producer' mangled-name='membar_producer' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='346' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='membar_consumer' mangled-name='membar_consumer' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/atomic.c' line='352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
-      <return type-id='type-id-1'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libavl' language='LANG_C99'>
+    <typedef-decl name='avl_tree_t' type-id='type-id-13' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-89'/>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <parameter type-id='type-id-52' name='cookie'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <parameter type-id='type-id-38' name='compar'/>
+      <parameter type-id='type-id-8' name='size'/>
+      <parameter type-id='type-id-8' name='offset'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='avl_swap' mangled-name='avl_swap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
+      <parameter type-id='type-id-89' name='tree1'/>
+      <parameter type-id='type-id-89' name='tree2'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='avl_update' mangled-name='avl_update' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
+      <parameter type-id='type-id-89' name='t'/>
+      <parameter type-id='type-id-6' name='obj'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
+      <parameter type-id='type-id-89' name='t'/>
+      <parameter type-id='type-id-6' name='obj'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
+      <parameter type-id='type-id-89' name='t'/>
+      <parameter type-id='type-id-6' name='obj'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='avl_remove' mangled-name='avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <parameter type-id='type-id-6' name='data'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='avl_add' mangled-name='avl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <parameter type-id='type-id-6' name='new_node'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='avl_insert_here' mangled-name='avl_insert_here' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <parameter type-id='type-id-6' name='new_data'/>
+      <parameter type-id='type-id-6' name='here'/>
+      <parameter type-id='type-id-22' name='direction'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <typedef-decl name='avl_index_t' type-id='type-id-10' id='type-id-90'/>
+    <function-decl name='avl_insert' mangled-name='avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <parameter type-id='type-id-6' name='new_data'/>
+      <parameter type-id='type-id-90' name='where'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-91'/>
+    <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <parameter type-id='type-id-6' name='value'/>
+      <parameter type-id='type-id-91' name='where'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='avl_nearest' mangled-name='avl_nearest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <parameter type-id='type-id-90' name='where'/>
+      <parameter type-id='type-id-22' name='direction'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='avl_last' mangled-name='avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
+      <parameter type-id='type-id-89' name='tree'/>
+      <parameter type-id='type-id-6' name='oldnode'/>
+      <parameter type-id='type-id-22' name='left'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='getexecname.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='getexecname_impl' filepath='./libspl_impl.h' line='24' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-28'/>
+  <abi-instr version='1.0' address-size='64' path='atomic.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='membar_consumer' mangled-name='membar_consumer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='membar_producer' mangled-name='membar_producer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='membar_enter' mangled-name='membar_enter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-39' volatile='yes' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-93'/>
+    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-62' name='value'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-62' name='value'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-5' volatile='yes' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-95'/>
+    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
+      <parameter type-id='type-id-95' name='target'/>
+      <parameter type-id='type-id-6' name='bits'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-39' name='bits'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-56' volatile='yes' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-97'/>
+    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
+      <parameter type-id='type-id-97' name='target'/>
+      <parameter type-id='type-id-56' name='bits'/>
+      <return type-id='type-id-56'/>
+    </function-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-98'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-98' id='type-id-99'/>
+    <typedef-decl name='uint16_t' type-id='type-id-99' id='type-id-100'/>
+    <qualified-type-def type-id='type-id-100' volatile='yes' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-102'/>
+    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
+      <parameter type-id='type-id-102' name='target'/>
+      <parameter type-id='type-id-100' name='bits'/>
+      <return type-id='type-id-100'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-12' volatile='yes' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-104'/>
+    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
+      <parameter type-id='type-id-104' name='target'/>
+      <parameter type-id='type-id-12' name='bits'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
+      <parameter type-id='type-id-95' name='target'/>
+      <parameter type-id='type-id-6' name='exp'/>
+      <parameter type-id='type-id-6' name='des'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-39' name='bits'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
+      <parameter type-id='type-id-97' name='target'/>
+      <parameter type-id='type-id-56' name='bits'/>
+      <return type-id='type-id-56'/>
+    </function-decl>
+    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
+      <parameter type-id='type-id-102' name='target'/>
+      <parameter type-id='type-id-100' name='bits'/>
+      <return type-id='type-id-100'/>
+    </function-decl>
+    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
+      <parameter type-id='type-id-104' name='target'/>
+      <parameter type-id='type-id-12' name='bits'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-39' name='bits'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
+      <parameter type-id='type-id-97' name='target'/>
+      <parameter type-id='type-id-56' name='bits'/>
+      <return type-id='type-id-56'/>
+    </function-decl>
+    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
+      <parameter type-id='type-id-102' name='target'/>
+      <parameter type-id='type-id-100' name='bits'/>
+      <return type-id='type-id-100'/>
+    </function-decl>
+    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
+      <parameter type-id='type-id-104' name='target'/>
+      <parameter type-id='type-id-12' name='bits'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <typedef-decl name='__ssize_t' type-id='type-id-30' id='type-id-105'/>
+    <typedef-decl name='ssize_t' type-id='type-id-105' id='type-id-106'/>
+    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
+      <parameter type-id='type-id-95' name='target'/>
+      <parameter type-id='type-id-106' name='bits'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-30' name='bits'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <typedef-decl name='__int32_t' type-id='type-id-22' id='type-id-107'/>
+    <typedef-decl name='int32_t' type-id='type-id-107' id='type-id-108'/>
+    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
+      <parameter type-id='type-id-97' name='target'/>
+      <parameter type-id='type-id-108' name='bits'/>
+      <return type-id='type-id-56'/>
+    </function-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-32' id='type-id-109'/>
+    <typedef-decl name='int16_t' type-id='type-id-109' id='type-id-110'/>
+    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
+      <parameter type-id='type-id-102' name='target'/>
+      <parameter type-id='type-id-110' name='bits'/>
+      <return type-id='type-id-100'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
+      <parameter type-id='type-id-104' name='target'/>
+      <parameter type-id='type-id-47' name='bits'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
+      <parameter type-id='type-id-95' name='target'/>
+      <parameter type-id='type-id-106' name='bits'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-30' name='bits'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
+      <parameter type-id='type-id-97' name='target'/>
+      <parameter type-id='type-id-108' name='bits'/>
+      <return type-id='type-id-56'/>
+    </function-decl>
+    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
+      <parameter type-id='type-id-102' name='target'/>
+      <parameter type-id='type-id-110' name='bits'/>
+      <return type-id='type-id-100'/>
+    </function-decl>
+    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
+      <parameter type-id='type-id-104' name='target'/>
+      <parameter type-id='type-id-47' name='bits'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
+      <parameter type-id='type-id-93' name='target'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
+      <parameter type-id='type-id-97' name='target'/>
+      <return type-id='type-id-56'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
+      <parameter type-id='type-id-102' name='target'/>
+      <return type-id='type-id-100'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
+      <parameter type-id='type-id-104' name='target'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
+      <parameter type-id='type-id-93' name='target'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
+      <parameter type-id='type-id-97' name='target'/>
+      <return type-id='type-id-56'/>
+    </function-decl>
+    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
+      <parameter type-id='type-id-102' name='target'/>
+      <return type-id='type-id-100'/>
+    </function-decl>
+    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
+      <parameter type-id='type-id-104' name='target'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-39' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
+      <parameter type-id='type-id-97' name='target'/>
+      <parameter type-id='type-id-56' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
+      <parameter type-id='type-id-102' name='target'/>
+      <parameter type-id='type-id-100' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
+      <parameter type-id='type-id-104' name='target'/>
+      <parameter type-id='type-id-12' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-39' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
+      <parameter type-id='type-id-97' name='target'/>
+      <parameter type-id='type-id-56' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
+      <parameter type-id='type-id-102' name='target'/>
+      <parameter type-id='type-id-100' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
+      <parameter type-id='type-id-104' name='target'/>
+      <parameter type-id='type-id-12' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
+      <parameter type-id='type-id-95' name='target'/>
+      <parameter type-id='type-id-106' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-30' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
+      <parameter type-id='type-id-97' name='target'/>
+      <parameter type-id='type-id-108' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
+      <parameter type-id='type-id-102' name='target'/>
+      <parameter type-id='type-id-110' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
+      <parameter type-id='type-id-104' name='target'/>
+      <parameter type-id='type-id-47' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
+      <parameter type-id='type-id-95' name='target'/>
+      <parameter type-id='type-id-106' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-30' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
+      <parameter type-id='type-id-97' name='target'/>
+      <parameter type-id='type-id-108' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
+      <parameter type-id='type-id-102' name='target'/>
+      <parameter type-id='type-id-110' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_add_8' mangled-name='atomic_add_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
+      <parameter type-id='type-id-104' name='target'/>
+      <parameter type-id='type-id-47' name='bits'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
+      <parameter type-id='type-id-93' name='target'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
+      <parameter type-id='type-id-97' name='target'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
+      <parameter type-id='type-id-102' name='target'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
+      <parameter type-id='type-id-104' name='target'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
+      <parameter type-id='type-id-93' name='target'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
+      <parameter type-id='type-id-97' name='target'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
+      <parameter type-id='type-id-102' name='target'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
+      <parameter type-id='type-id-104' name='target'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
+      <parameter type-id='type-id-104' name='target'/>
+      <parameter type-id='type-id-12' name='exp'/>
+      <parameter type-id='type-id-12' name='des'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='atomic_cas_16' mangled-name='atomic_cas_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_16'>
+      <parameter type-id='type-id-102' name='target'/>
+      <parameter type-id='type-id-100' name='exp'/>
+      <parameter type-id='type-id-100' name='des'/>
+      <return type-id='type-id-100'/>
+    </function-decl>
+    <function-decl name='atomic_cas_32' mangled-name='atomic_cas_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_32'>
+      <parameter type-id='type-id-97' name='target'/>
+      <parameter type-id='type-id-56' name='exp'/>
+      <parameter type-id='type-id-56' name='des'/>
+      <return type-id='type-id-56'/>
+    </function-decl>
+    <function-decl name='atomic_cas_ulong' mangled-name='atomic_cas_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ulong'>
+      <parameter type-id='type-id-93' name='target'/>
+      <parameter type-id='type-id-39' name='exp'/>
+      <parameter type-id='type-id-39' name='des'/>
+      <return type-id='type-id-39'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='41' column='1' id='type-id-139'>
+  <abi-instr version='1.0' address-size='64' path='getexecname.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='getexecname' mangled-name='getexecname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getexecname'>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='getexecname_impl' mangled-name='getexecname_impl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-111'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='list_size' type-id='type-id-4' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='42' column='1'/>
+        <var-decl name='list_size' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='list_offset' type-id='type-id-4' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='43' column='1'/>
+        <var-decl name='list_offset' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='list_head' type-id='type-id-140' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='44' column='1'/>
+        <var-decl name='list_head' type-id='type-id-112' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='36' column='1' id='type-id-140'>
+    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-112'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='type-id-141' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='37' column='1'/>
+        <var-decl name='next' type-id='type-id-113' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='prev' type-id='type-id-141' visibility='default' filepath='../../lib/libspl/include/sys/list_impl.h' line='38' column='1'/>
+        <var-decl name='prev' type-id='type-id-113' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-141'/>
-    <typedef-decl name='list_t' type-id='type-id-139' filepath='../../lib/libspl/include/sys/list.h' line='36' column='1' id='type-id-142'/>
-    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-143'/>
-    <function-decl name='list_create' mangled-name='list_create' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1'/>
-      <parameter type-id='type-id-4' name='size' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1'/>
-      <parameter type-id='type-id-4' name='offset' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='62' column='1'/>
-      <return type-id='type-id-1'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-113'/>
+    <typedef-decl name='list_t' type-id='type-id-111' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-115'/>
+    <function-decl name='list_is_empty' mangled-name='list_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+      <parameter type-id='type-id-115' name='list'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='list_destroy' mangled-name='list_destroy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='74' column='1'/>
-      <return type-id='type-id-1'/>
+    <typedef-decl name='list_node_t' type-id='type-id-112' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-116' size-in-bits='64' id='type-id-117'/>
+    <function-decl name='list_link_active' mangled-name='list_link_active' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
+      <parameter type-id='type-id-117' name='ln'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='list_insert_after' mangled-name='list_insert_after' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
-      <parameter type-id='type-id-2' name='nobject' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='list_link_init' mangled-name='list_link_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
+      <parameter type-id='type-id-117' name='ln'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='list_insert_head' mangled-name='list_insert_head' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='list_link_replace' mangled-name='list_link_replace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
+      <parameter type-id='type-id-117' name='lold'/>
+      <parameter type-id='type-id-117' name='lnew'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='list_insert_before' mangled-name='list_insert_before' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='97' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
-      <parameter type-id='type-id-2' name='nobject' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='86' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='list_move_tail' mangled-name='list_move_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
+      <parameter type-id='type-id-115' name='dst'/>
+      <parameter type-id='type-id-115' name='src'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='list_insert_tail' mangled-name='list_insert_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_tail'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='108' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='list_prev' mangled-name='list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
+      <parameter type-id='type-id-115' name='list'/>
+      <parameter type-id='type-id-6' name='object'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='list_remove' mangled-name='list_remove' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='122' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='122' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='list_next' mangled-name='list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
+      <parameter type-id='type-id-115' name='list'/>
+      <parameter type-id='type-id-6' name='object'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='list_remove_head' mangled-name='list_remove_head' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='131' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='list_tail' mangled-name='list_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
+      <parameter type-id='type-id-115' name='list'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='131' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='list_head' mangled-name='list_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
+      <parameter type-id='type-id-115' name='list'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='list_head' mangled-name='list_head' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='151' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='151' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
+      <parameter type-id='type-id-115' name='list'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='list_tail' mangled-name='list_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='151' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='list_remove_head' mangled-name='list_remove_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
+      <parameter type-id='type-id-115' name='list'/>
+      <return type-id='type-id-6'/>
     </function-decl>
-    <function-decl name='list_next' mangled-name='list_next' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='list_remove' mangled-name='list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
+      <parameter type-id='type-id-115' name='list'/>
+      <parameter type-id='type-id-6' name='object'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='list_prev' mangled-name='list_prev' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
-      <parameter type-id='type-id-2' name='object' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='167' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='list_insert_tail' mangled-name='list_insert_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_tail'>
+      <parameter type-id='type-id-115' name='list'/>
+      <parameter type-id='type-id-6' name='object'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='list_move_tail' mangled-name='list_move_tail' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
-      <parameter type-id='type-id-143' name='dst' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='192' column='1'/>
-      <parameter type-id='type-id-143' name='src' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='192' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='list_insert_head' mangled-name='list_insert_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
+      <parameter type-id='type-id-115' name='list'/>
+      <parameter type-id='type-id-6' name='object'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <typedef-decl name='list_node_t' type-id='type-id-140' filepath='../../lib/libspl/include/sys/list.h' line='35' column='1' id='type-id-144'/>
-    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-145'/>
-    <function-decl name='list_link_replace' mangled-name='list_link_replace' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='213' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
-      <parameter type-id='type-id-145' name='lold' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='213' column='1'/>
-      <parameter type-id='type-id-145' name='lnew' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='213' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='list_insert_before' mangled-name='list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
+      <parameter type-id='type-id-115' name='list'/>
+      <parameter type-id='type-id-6' name='object'/>
+      <parameter type-id='type-id-6' name='nobject'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='list_link_init' mangled-name='list_link_init' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='226' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
-      <parameter type-id='type-id-145' name='ln' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='226' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='list_insert_after' mangled-name='list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
+      <parameter type-id='type-id-115' name='list'/>
+      <parameter type-id='type-id-6' name='object'/>
+      <parameter type-id='type-id-6' name='nobject'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='list_link_active' mangled-name='list_link_active' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='233' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
-      <parameter type-id='type-id-145' name='ln' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='233' column='1'/>
-      <return type-id='type-id-20'/>
+    <function-decl name='list_destroy' mangled-name='list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
+      <parameter type-id='type-id-115' name='list'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='list_is_empty' mangled-name='list_is_empty' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
-      <parameter type-id='type-id-143' name='list' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/list.c' line='240' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='mkdirp.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='__mode_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='148' column='1' id='type-id-146'/>
-    <typedef-decl name='mode_t' type-id='type-id-146' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='69' column='1' id='type-id-147'/>
-    <function-decl name='mkdirp' mangled-name='mkdirp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/mkdirp.c' line='50' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
-      <parameter type-id='type-id-9' name='d' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
-      <parameter type-id='type-id-147' name='mode' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/mkdirp.c' line='50' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='mbstowcs' filepath='/usr/include/stdlib.h' line='930' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-96'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-3'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-20' const='yes' id='type-id-148'/>
-    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-149'/>
-    <function-decl name='wcstombs' filepath='/usr/include/stdlib.h' line='933' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-149'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-3'/>
-    </function-decl>
-    <function-decl name='mkdir' filepath='/usr/include/x86_64-linux-gnu/sys/stat.h' line='317' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='access' filepath='/usr/include/unistd.h' line='287' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-20'/>
+    <function-decl name='list_create' mangled-name='list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
+      <parameter type-id='type-id-115' name='list'/>
+      <parameter type-id='type-id-8' name='size'/>
+      <parameter type-id='type-id-8' name='offset'/>
+      <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='spl_pagesize' mangled-name='spl_pagesize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/page.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
-      <return type-id='type-id-4'/>
+  <abi-instr version='1.0' address-size='64' path='mkdirp.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='__mode_t' type-id='type-id-31' id='type-id-118'/>
+    <typedef-decl name='mode_t' type-id='type-id-118' id='type-id-119'/>
+    <function-decl name='mkdirp' mangled-name='mkdirp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
+      <parameter type-id='type-id-4' name='d'/>
+      <parameter type-id='type-id-119' name='mode'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='sysconf' filepath='/usr/include/unistd.h' line='619' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-28'/>
+    <function-decl name='__mbstowcs_alias' mangled-name='mbstowcs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__wcstombs_alias' mangled-name='wcstombs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='strdup' mangled-name='strdup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='mkdir' mangled-name='mkdir' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='access' mangled-name='access' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='strlcat' mangled-name='strlcat' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
-      <parameter type-id='type-id-7' name='dst' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
-      <parameter type-id='type-id-9' name='src' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
-      <parameter type-id='type-id-4' name='dstsize' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcat.c' line='39' column='1'/>
-      <return type-id='type-id-4'/>
+  <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='spl_pagesize' mangled-name='spl_pagesize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='sysconf' mangled-name='sysconf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='strlcpy' mangled-name='strlcpy' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
-      <parameter type-id='type-id-7' name='dst' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
-      <parameter type-id='type-id-9' name='src' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/strlcpy.c' line='39' column='1'/>
-      <return type-id='type-id-4'/>
+  <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='strlcat' mangled-name='strlcat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
+      <parameter type-id='type-id-2' name='dst'/>
+      <parameter type-id='type-id-4' name='src'/>
+      <parameter type-id='type-id-8' name='dstsize'/>
+      <return type-id='type-id-8'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='print_timestamp' mangled-name='print_timestamp' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/timestamp.c' line='44' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
-      <parameter type-id='type-id-71' name='timestamp_fmt' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/timestamp.c' line='44' column='1'/>
-      <return type-id='type-id-1'/>
+  <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='strlcpy' mangled-name='strlcpy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
+      <parameter type-id='type-id-2' name='dst'/>
+      <parameter type-id='type-id-4' name='src'/>
+      <parameter type-id='type-id-8' name='len'/>
+      <return type-id='type-id-8'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-150'/>
-    <function-decl name='time' filepath='/usr/include/time.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-150'/>
-      <return type-id='type-id-28'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='print_timestamp' mangled-name='print_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
+      <parameter type-id='type-id-62' name='timestamp_fmt'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='nl_langinfo' filepath='/usr/include/langinfo.h' line='661' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-20'/>
+    <function-decl name='__builtin_puts' mangled-name='puts' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='localtime' mangled-name='localtime' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='strftime' mangled-name='strftime' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__printf_chk' mangled-name='__printf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='time' mangled-name='time' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='nl_langinfo' mangled-name='nl_langinfo' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/getexecname.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='__readlink_alias' mangled-name='readlink' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='get_system_hostid' mangled-name='get_system_hostid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
       <return type-id='type-id-7'/>
     </function-decl>
-    <class-decl name='tm' size-in-bits='448' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='7' column='1' id='type-id-151'>
+    <function-decl name='__open_alias' mangled-name='open64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__read_alias' mangled-name='read' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='close' mangled-name='close' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='getenv' mangled-name='getenv' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='strtoull' mangled-name='strtoull' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fopen' mangled-name='fopen64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fscanf' mangled-name='fscanf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='fclose' mangled-name='fclose' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-120'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tm_sec' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='9' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='tm_min' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='10' column='1'/>
+        <var-decl name='mnt_special' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tm_hour' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='11' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='tm_mday' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='12' column='1'/>
+        <var-decl name='mnt_mountp' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tm_mon' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='13' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='tm_year' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='14' column='1'/>
+        <var-decl name='mnt_fstype' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='tm_wday' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='15' column='1'/>
+        <var-decl name='mnt_mntopts' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='mnt_major' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='mnt_minor' type-id='type-id-62' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-120' size-in-bits='64' id='type-id-121'/>
+    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' id='type-id-122'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='st_dev' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='st_ino' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='st_nlink' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='st_mode' type-id='type-id-118' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='tm_yday' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='16' column='1'/>
+        <var-decl name='st_uid' type-id='type-id-126' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='tm_isdst' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='17' column='1'/>
+        <var-decl name='st_gid' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__pad0' type-id='type-id-22' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='tm_gmtoff' type-id='type-id-28' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='20' column='1'/>
+        <var-decl name='st_rdev' type-id='type-id-123' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='tm_zone' type-id='type-id-9' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='21' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-152'/>
-    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-153'/>
-    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-154'/>
-    <function-decl name='localtime' filepath='/usr/include/time.h' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-154'/>
-      <return type-id='type-id-152'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-151' const='yes' id='type-id-155'/>
-    <pointer-type-def type-id='type-id-155' size-in-bits='64' id='type-id-156'/>
-    <function-decl name='strftime' filepath='/usr/include/time.h' line='88' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-3'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-156'/>
-      <return type-id='type-id-3'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/getexecname.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='readlink' filepath='/usr/include/unistd.h' line='808' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-28'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <function-decl name='get_system_hostid' mangled-name='get_system_hostid' filepath='os/linux/gethostid.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
-      <return type-id='type-id-3'/>
-    </function-decl>
-    <function-decl name='getenv' filepath='/usr/include/stdlib.h' line='631' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='49' column='1' id='type-id-157'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_flags' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='51' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='54' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='55' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='56' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='57' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='58' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='59' column='1'/>
+        <var-decl name='st_size' type-id='type-id-128' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='60' column='1'/>
+        <var-decl name='st_blksize' type-id='type-id-129' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='61' column='1'/>
+        <var-decl name='st_blocks' type-id='type-id-130' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='64' column='1'/>
+        <var-decl name='st_atim' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='st_mtim' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='st_ctim' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='__glibc_reserved' type-id='type-id-132' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__dev_t' type-id='type-id-7' id='type-id-123'/>
+    <typedef-decl name='__ino64_t' type-id='type-id-7' id='type-id-124'/>
+    <typedef-decl name='__nlink_t' type-id='type-id-7' id='type-id-125'/>
+    <typedef-decl name='__uid_t' type-id='type-id-31' id='type-id-126'/>
+    <typedef-decl name='__gid_t' type-id='type-id-31' id='type-id-127'/>
+    <typedef-decl name='__off_t' type-id='type-id-30' id='type-id-128'/>
+    <typedef-decl name='__blksize_t' type-id='type-id-30' id='type-id-129'/>
+    <typedef-decl name='__blkcnt64_t' type-id='type-id-30' id='type-id-130'/>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-131'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_nsec' type-id='type-id-134' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__time_t' type-id='type-id-30' id='type-id-133'/>
+    <typedef-decl name='__syscall_slong_t' type-id='type-id-30' id='type-id-134'/>
+
+    <array-type-def dimensions='1' type-id='type-id-134' size-in-bits='192' id='type-id-132'>
+      <subrange length='3' type-id='type-id-7' id='type-id-59'/>
+
+    </array-type-def>
+    <pointer-type-def type-id='type-id-122' size-in-bits='64' id='type-id-135'/>
+    <function-decl name='getextmntent' mangled-name='getextmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
+      <parameter type-id='type-id-4' name='path'/>
+      <parameter type-id='type-id-121' name='entry'/>
+      <parameter type-id='type-id-135' name='statbuf'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='type-id-136'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='65' column='1'/>
+        <var-decl name='_IO_backup_base' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-7' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='66' column='1'/>
+        <var-decl name='_IO_save_end' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-158' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='68' column='1'/>
+        <var-decl name='_markers' type-id='type-id-137' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-159' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='70' column='1'/>
+        <var-decl name='_chain' type-id='type-id-138' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='_fileno' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='72' column='1'/>
+        <var-decl name='_fileno' type-id='type-id-22' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='_flags2' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='73' column='1'/>
+        <var-decl name='_flags2' type-id='type-id-22' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-160' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='74' column='1'/>
+        <var-decl name='_old_offset' type-id='type-id-128' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-111' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='77' column='1'/>
+        <var-decl name='_cur_column' type-id='type-id-98' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-49' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='78' column='1'/>
+        <var-decl name='_vtable_offset' type-id='type-id-48' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-161' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='79' column='1'/>
+        <var-decl name='_shortbuf' type-id='type-id-139' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-162' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='89' column='1'/>
+        <var-decl name='_offset' type-id='type-id-140' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-163' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='91' column='1'/>
+        <var-decl name='__pad1' type-id='type-id-6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-164' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='92' column='1'/>
+        <var-decl name='__pad2' type-id='type-id-6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-159' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='93' column='1'/>
+        <var-decl name='__pad3' type-id='type-id-6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-2' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='94' column='1'/>
+        <var-decl name='__pad4' type-id='type-id-6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-4' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='95' column='1'/>
+        <var-decl name='__pad5' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='_mode' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='96' column='1'/>
+        <var-decl name='_mode' type-id='type-id-22' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-165' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_FILE.h' line='98' column='1'/>
+        <var-decl name='_unused2' type-id='type-id-141' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-166'/>
-    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-158'/>
-    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-159'/>
-    <typedef-decl name='__off_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='150' column='1' id='type-id-160'/>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-142'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_next' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_sbuf' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_pos' type-id='type-id-22' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-138'/>
 
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='8' id='type-id-161'>
-      <subrange length='1' type-id='type-id-18' id='type-id-167'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='8' id='type-id-139'>
+      <subrange length='1' type-id='type-id-7' id='type-id-143'/>
 
     </array-type-def>
-    <typedef-decl name='__off64_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='151' column='1' id='type-id-162'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-168'/>
-    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-163'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-169'/>
-    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-164'/>
+    <typedef-decl name='__off64_t' type-id='type-id-30' id='type-id-140'/>
 
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='160' id='type-id-165'>
-      <subrange length='20' type-id='type-id-18' id='type-id-170'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='160' id='type-id-141'>
+      <subrange length='20' type-id='type-id-7' id='type-id-144'/>
 
     </array-type-def>
-    <function-decl name='fclose' filepath='/usr/include/stdio.h' line='213' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-159'/>
-      <return type-id='type-id-20'/>
+    <typedef-decl name='FILE' type-id='type-id-136' id='type-id-145'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-146'/>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-147'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-148'/>
+    <function-decl name='getmntany' mangled-name='getmntany' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
+      <parameter type-id='type-id-146' name='fp'/>
+      <parameter type-id='type-id-148' name='mgetp'/>
+      <parameter type-id='type-id-148' name='mrefp'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='open' mangled-name='open64' filepath='/usr/include/fcntl.h' line='171' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-20'/>
+    <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_sol_getmntent'>
+      <parameter type-id='type-id-146' name='fp'/>
+      <parameter type-id='type-id-148' name='mgetp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='__xstat64' mangled-name='__xstat64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='__builtin_fwrite' mangled-name='fwrite' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='feof' mangled-name='feof' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='getmntent_r' mangled-name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='zoneid_t' type-id='type-id-22' id='type-id-149'/>
+    <function-decl name='getzoneid' mangled-name='getzoneid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
+      <return type-id='type-id-149'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <var-decl name='libspl_assert_ok' type-id='type-id-22' mangled-name='libspl_assert_ok' visibility='default' elf-symbol-id='libspl_assert_ok'/>
+    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
+      <parameter type-id='type-id-4' name='file'/>
+      <parameter type-id='type-id-4' name='func'/>
+      <parameter type-id='type-id-22' name='line'/>
+      <parameter type-id='type-id-4' name='format'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-20'/>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='read' filepath='/usr/include/unistd.h' line='360' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-2'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-28'/>
-    </function-decl>
-    <function-decl name='close' filepath='/usr/include/unistd.h' line='353' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-20'/>
+    <function-decl name='__builtin_fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='FILE' type-id='type-id-157' filepath='/usr/include/x86_64-linux-gnu/bits/types/FILE.h' line='7' column='1' id='type-id-171'/>
-    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-172'/>
-    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='49' column='1' id='type-id-173'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='50' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='51' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='52' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='53' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-174'/>
-    <function-decl name='getmntany' mangled-name='getmntany' filepath='os/linux/getmntany.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
-      <parameter type-id='type-id-172' name='fp' filepath='os/linux/getmntany.c' line='51' column='1'/>
-      <parameter type-id='type-id-174' name='mgetp' filepath='os/linux/getmntany.c' line='51' column='1'/>
-      <parameter type-id='type-id-174' name='mrefp' filepath='os/linux/getmntany.c' line='51' column='1'/>
-      <return type-id='type-id-20'/>
+  <abi-instr version='1.0' address-size='64' path='pthread_atfork.c' comp-dir-path='/build/glibc-S9d2JN/glibc-2.27/nptl' language='LANG_C99'>
+    <function-decl name='__register_atfork' mangled-name='__register_atfork' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-5'/>
     </function-decl>
-    <class-decl name='mntent' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/mntent.h' line='51' column='1' id='type-id-175'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_fsname' type-id='type-id-7' visibility='default' filepath='/usr/include/mntent.h' line='53' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_dir' type-id='type-id-7' visibility='default' filepath='/usr/include/mntent.h' line='54' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_type' type-id='type-id-7' visibility='default' filepath='/usr/include/mntent.h' line='55' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_opts' type-id='type-id-7' visibility='default' filepath='/usr/include/mntent.h' line='56' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='mnt_freq' type-id='type-id-20' visibility='default' filepath='/usr/include/mntent.h' line='57' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='mnt_passno' type-id='type-id-20' visibility='default' filepath='/usr/include/mntent.h' line='58' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-176'/>
-    <function-decl name='getmntent_r' filepath='/usr/include/mntent.h' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-159'/>
-      <parameter type-id='type-id-176'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-176'/>
-    </function-decl>
-    <function-decl name='feof' filepath='/usr/include/stdio.h' line='765' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-159'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' filepath='os/linux/getmntany.c' line='64' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_sol_getmntent'>
-      <parameter type-id='type-id-172' name='fp' filepath='os/linux/getmntany.c' line='64' column='1'/>
-      <parameter type-id='type-id-174' name='mgetp' filepath='os/linux/getmntany.c' line='64' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='62' column='1' id='type-id-177'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='63' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='64' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='type-id-7' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='mnt_major' type-id='type-id-71' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='67' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='mnt_minor' type-id='type-id-71' visibility='default' filepath='../../lib/libspl/include/os/linux/sys/mnttab.h' line='68' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-178'/>
-    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='119' column='1' id='type-id-179'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='st_dev' type-id='type-id-180' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='121' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='type-id-181' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='123' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_nlink' type-id='type-id-182' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='124' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='st_mode' type-id='type-id-146' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='125' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='st_uid' type-id='type-id-183' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='132' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='st_gid' type-id='type-id-184' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='133' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__pad0' type-id='type-id-20' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='135' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='st_rdev' type-id='type-id-180' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='136' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='st_size' type-id='type-id-160' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='137' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='st_blksize' type-id='type-id-185' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='143' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_blocks' type-id='type-id-186' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='144' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='type-id-187' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='152' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='type-id-187' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='153' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='type-id-187' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='154' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__glibc_reserved' type-id='type-id-188' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='164' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__dev_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='143' column='1' id='type-id-180'/>
-    <typedef-decl name='__ino64_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='147' column='1' id='type-id-181'/>
-    <typedef-decl name='__nlink_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='149' column='1' id='type-id-182'/>
-    <typedef-decl name='__uid_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='144' column='1' id='type-id-183'/>
-    <typedef-decl name='__gid_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='145' column='1' id='type-id-184'/>
-    <typedef-decl name='__blksize_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='172' column='1' id='type-id-185'/>
-    <typedef-decl name='__blkcnt64_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='178' column='1' id='type-id-186'/>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='9' column='1' id='type-id-187'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='type-id-189' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='11' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='type-id-190' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='12' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__time_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='158' column='1' id='type-id-189'/>
-    <typedef-decl name='__syscall_slong_t' type-id='type-id-28' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-190'/>
-
-    <array-type-def dimensions='1' type-id='type-id-190' size-in-bits='192' id='type-id-188'>
-      <subrange length='3' type-id='type-id-18' id='type-id-61'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-191'/>
-    <function-decl name='getextmntent' mangled-name='getextmntent' filepath='os/linux/getmntany.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
-      <parameter type-id='type-id-9' name='path' filepath='os/linux/getmntany.c' line='106' column='1'/>
-      <parameter type-id='type-id-178' name='entry' filepath='os/linux/getmntany.c' line='106' column='1'/>
-      <parameter type-id='type-id-191' name='statbuf' filepath='os/linux/getmntany.c' line='106' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='zoneid_t' type-id='type-id-20' filepath='../../lib/libspl/include/sys/types.h' line='47' column='1' id='type-id-192'/>
-    <function-decl name='getzoneid' mangled-name='getzoneid' filepath='os/linux/zone.c' line='29' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
-      <return type-id='type-id-192'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl' language='LANG_C99'>
-    <var-decl name='libspl_assert_ok' type-id='type-id-20' mangled-name='libspl_assert_ok' visibility='default' filepath='/mnt/filling/store/nabijaczleweli/code/zfs/lib/libspl/assert.c' line='28' column='1' elf-symbol-id='libspl_assert_ok'/>
   </abi-instr>
 </abi-corpus>

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -1,4 +1,4 @@
-<abi-corpus path='libzfs.so' architecture='elf-amd-x86_64' soname='libzfs.so.4'>
+<abi-corpus architecture='elf-amd-x86_64' soname='libzfs.so.4'>
   <elf-needed>
     <dependency name='libzfs_core.so.3'/>
     <dependency name='libnvpair.so.3'/>
@@ -6,11 +6,12 @@
     <dependency name='libm.so.6'/>
     <dependency name='libcrypto.so.1.1'/>
     <dependency name='libz.so.1'/>
-    <dependency name='libdl.so.2'/>
     <dependency name='libpthread.so.0'/>
     <dependency name='libc.so.6'/>
   </elf-needed>
   <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='bookmark_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='cityhash4' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='color_end' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -354,390 +355,508 @@
     <elf-symbol name='zfs_max_dataset_nesting' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_userquota_prop_prefixes' size='96' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='libzfs_changelist.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='uu_avl_walk' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-1'/>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-2'/>
-    <class-decl name='uu_avl' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-3'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-4'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-5'/>
-    <function-decl name='uu_avl_walk_start' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-2'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_changelist.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <type-decl name='void' id='type-id-1'/>
+    <function-decl name='zfs_alloc' mangled-name='zfs_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <type-decl name='void' id='type-id-6'/>
-    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-7'/>
-    <function-decl name='uu_avl_walk_next' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-7'/>
+    <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <type-decl name='int' size-in-bits='32' id='type-id-8'/>
-    <function-decl name='getzoneid' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-8'/>
+    <function-decl name='uu_avl_create' mangled-name='uu_avl_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='zfs_handle' size-in-bits='4928' is-struct='yes' visibility='default' id='type-id-9'>
+    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_open' mangled-name='zfs_open' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_node_init' mangled-name='uu_avl_node_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_find' mangled-name='uu_avl_find' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='free' mangled-name='free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_close' mangled-name='zfs_close' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_error' mangled-name='zfs_error' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__stack_chk_fail' mangled-name='__stack_chk_fail' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strcmp' mangled-name='strcmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='getzoneid' mangled-name='getzoneid' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_unshare_proto' mangled-name='zfs_unshare_proto' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_commit_proto' mangled-name='zfs_commit_proto' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strlen' mangled-name='strlen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strncmp' mangled-name='strncmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='remove_mountpoint' mangled-name='remove_mountpoint' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strlcpy' mangled-name='strlcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strlcat' mangled-name='strlcat' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_mount' mangled-name='zfs_mount' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_last' mangled-name='uu_avl_last' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_commit_smb_shares' mangled-name='zfs_commit_smb_shares' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_commit_nfs_shares' mangled-name='zfs_commit_nfs_shares' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_config.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <type-decl name='int' size-in-bits='32' id='type-id-2'/>
+    <class-decl name='libzfs_handle' size-in-bits='18240' is-struct='yes' visibility='default' id='type-id-3'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zfs_hdl' type-id='type-id-10' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zpool_hdl' type-id='type-id-11' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zfs_name' type-id='type-id-12' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='zfs_type' type-id='type-id-13' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2208'>
-        <var-decl name='zfs_head_type' type-id='type-id-13' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='zfs_dmustats' type-id='type-id-14' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='4544'>
-        <var-decl name='zfs_props' type-id='type-id-15' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='4608'>
-        <var-decl name='zfs_user_props' type-id='type-id-15' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='4672'>
-        <var-decl name='zfs_recvd_props' type-id='type-id-15' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='4736'>
-        <var-decl name='zfs_mntcheck' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='4800'>
-        <var-decl name='zfs_mntopts' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='4864'>
-        <var-decl name='zfs_props_table' type-id='type-id-18' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='libzfs_handle' size-in-bits='18240' is-struct='yes' visibility='default' id='type-id-19'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='libzfs_error' type-id='type-id-8' visibility='default'/>
+        <var-decl name='libzfs_error' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='libzfs_fd' type-id='type-id-8' visibility='default'/>
+        <var-decl name='libzfs_fd' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='libzfs_pool_handles' type-id='type-id-11' visibility='default'/>
+        <var-decl name='libzfs_pool_handles' type-id='type-id-4' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='libzfs_ns_avlpool' type-id='type-id-20' visibility='default'/>
+        <var-decl name='libzfs_ns_avlpool' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='libzfs_ns_avl' type-id='type-id-21' visibility='default'/>
+        <var-decl name='libzfs_ns_avl' type-id='type-id-6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='libzfs_ns_gen' type-id='type-id-22' visibility='default'/>
+        <var-decl name='libzfs_ns_gen' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='libzfs_desc_active' type-id='type-id-8' visibility='default'/>
+        <var-decl name='libzfs_desc_active' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='libzfs_action' type-id='type-id-23' visibility='default'/>
+        <var-decl name='libzfs_action' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8544'>
-        <var-decl name='libzfs_desc' type-id='type-id-23' visibility='default'/>
+        <var-decl name='libzfs_desc' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16736'>
-        <var-decl name='libzfs_printerr' type-id='type-id-8' visibility='default'/>
+        <var-decl name='libzfs_printerr' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16768'>
-        <var-decl name='libzfs_mnttab_enable' type-id='type-id-16' visibility='default'/>
+        <var-decl name='libzfs_mnttab_enable' type-id='type-id-9' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16832'>
-        <var-decl name='libzfs_mnttab_cache_lock' type-id='type-id-24' visibility='default'/>
+        <var-decl name='libzfs_mnttab_cache_lock' type-id='type-id-10' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='17152'>
-        <var-decl name='libzfs_mnttab_cache' type-id='type-id-25' visibility='default'/>
+        <var-decl name='libzfs_mnttab_cache' type-id='type-id-11' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='17472'>
-        <var-decl name='libzfs_pool_iter' type-id='type-id-8' visibility='default'/>
+        <var-decl name='libzfs_pool_iter' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='17504'>
-        <var-decl name='libzfs_prop_debug' type-id='type-id-16' visibility='default'/>
+        <var-decl name='libzfs_prop_debug' type-id='type-id-9' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='17536'>
-        <var-decl name='libzfs_urire' type-id='type-id-26' visibility='default'/>
+        <var-decl name='libzfs_urire' type-id='type-id-12' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='18048'>
-        <var-decl name='libzfs_max_nvlist' type-id='type-id-22' visibility='default'/>
+        <var-decl name='libzfs_max_nvlist' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='18112'>
-        <var-decl name='libfetch' type-id='type-id-7' visibility='default'/>
+        <var-decl name='libfetch' type-id='type-id-13' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='18176'>
-        <var-decl name='libfetch_load_error' type-id='type-id-17' visibility='default'/>
+        <var-decl name='libfetch_load_error' type-id='type-id-14' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' id='type-id-27'>
+    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' id='type-id-15'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zpool_hdl' type-id='type-id-10' visibility='default'/>
+        <var-decl name='zpool_hdl' type-id='type-id-16' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zpool_next' type-id='type-id-11' visibility='default'/>
+        <var-decl name='zpool_next' type-id='type-id-4' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zpool_name' type-id='type-id-12' visibility='default'/>
+        <var-decl name='zpool_name' type-id='type-id-17' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='zpool_state' type-id='type-id-8' visibility='default'/>
+        <var-decl name='zpool_state' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='zpool_config_size' type-id='type-id-28' visibility='default'/>
+        <var-decl name='zpool_config_size' type-id='type-id-18' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2304'>
-        <var-decl name='zpool_config' type-id='type-id-15' visibility='default'/>
+        <var-decl name='zpool_config' type-id='type-id-19' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2368'>
-        <var-decl name='zpool_old_config' type-id='type-id-15' visibility='default'/>
+        <var-decl name='zpool_old_config' type-id='type-id-19' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='zpool_props' type-id='type-id-15' visibility='default'/>
+        <var-decl name='zpool_props' type-id='type-id-19' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2496'>
-        <var-decl name='zpool_start_block' type-id='type-id-29' visibility='default'/>
+        <var-decl name='zpool_start_block' type-id='type-id-20' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='libzfs_handle_t' type-id='type-id-19' id='type-id-30'/>
-    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-10'/>
-    <typedef-decl name='zpool_handle_t' type-id='type-id-27' id='type-id-31'/>
-    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-11'/>
-    <type-decl name='char' size-in-bits='8' id='type-id-32'/>
-    <type-decl name='__ARRAY_SIZE_TYPE__' size-in-bits='64' id='type-id-33'/>
+    <typedef-decl name='libzfs_handle_t' type-id='type-id-3' id='type-id-21'/>
+    <pointer-type-def type-id='type-id-21' size-in-bits='64' id='type-id-16'/>
+    <typedef-decl name='zpool_handle_t' type-id='type-id-15' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-4'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-23'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-24'/>
 
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='2048' id='type-id-12'>
-      <subrange length='256' type-id='type-id-33' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='2048' id='type-id-17'>
+      <subrange length='256' type-id='type-id-24' id='type-id-25'/>
 
     </array-type-def>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-35'/>
-    <typedef-decl name='size_t' type-id='type-id-35' id='type-id-28'/>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-36'>
+    <typedef-decl name='size_t' type-id='type-id-24' id='type-id-18'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-26'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='type-id-37' visibility='default'/>
+        <var-decl name='nvl_version' type-id='type-id-27' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='type-id-38' visibility='default'/>
+        <var-decl name='nvl_nvflag' type-id='type-id-28' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvl_priv' type-id='type-id-22' visibility='default'/>
+        <var-decl name='nvl_priv' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='type-id-38' visibility='default'/>
+        <var-decl name='nvl_flag' type-id='type-id-28' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='type-id-37' visibility='default'/>
+        <var-decl name='nvl_pad' type-id='type-id-27' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__int32_t' type-id='type-id-8' id='type-id-39'/>
-    <typedef-decl name='int32_t' type-id='type-id-39' id='type-id-37'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-5' id='type-id-40'/>
-    <typedef-decl name='uint32_t' type-id='type-id-40' id='type-id-38'/>
-    <typedef-decl name='__uint64_t' type-id='type-id-35' id='type-id-41'/>
-    <typedef-decl name='uint64_t' type-id='type-id-41' id='type-id-22'/>
-    <typedef-decl name='nvlist_t' type-id='type-id-36' id='type-id-42'/>
-    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-15'/>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-43'/>
-    <typedef-decl name='longlong_t' type-id='type-id-43' id='type-id-44'/>
-    <typedef-decl name='diskaddr_t' type-id='type-id-44' id='type-id-29'/>
-    <class-decl name='uu_avl_pool' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-45'/>
-    <typedef-decl name='uu_avl_pool_t' type-id='type-id-45' id='type-id-46'/>
-    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-20'/>
-    <typedef-decl name='uu_avl_t' type-id='type-id-3' id='type-id-47'/>
-    <pointer-type-def type-id='type-id-47' size-in-bits='64' id='type-id-21'/>
+    <typedef-decl name='__int32_t' type-id='type-id-2' id='type-id-29'/>
+    <typedef-decl name='int32_t' type-id='type-id-29' id='type-id-27'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-30'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-30' id='type-id-31'/>
+    <typedef-decl name='uint32_t' type-id='type-id-31' id='type-id-28'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-24' id='type-id-32'/>
+    <typedef-decl name='uint64_t' type-id='type-id-32' id='type-id-7'/>
+    <typedef-decl name='nvlist_t' type-id='type-id-26' id='type-id-33'/>
+    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-19'/>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-34'/>
+    <typedef-decl name='longlong_t' type-id='type-id-34' id='type-id-35'/>
+    <typedef-decl name='diskaddr_t' type-id='type-id-35' id='type-id-20'/>
+    <class-decl name='uu_avl_pool' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-36'/>
+    <typedef-decl name='uu_avl_pool_t' type-id='type-id-36' id='type-id-37'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-5'/>
+    <class-decl name='uu_avl' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-38'/>
+    <typedef-decl name='uu_avl_t' type-id='type-id-38' id='type-id-39'/>
+    <pointer-type-def type-id='type-id-39' size-in-bits='64' id='type-id-6'/>
 
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='8192' id='type-id-23'>
-      <subrange length='1024' type-id='type-id-33' id='type-id-48'/>
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='8192' id='type-id-8'>
+      <subrange length='1024' type-id='type-id-24' id='type-id-40'/>
 
     </array-type-def>
-    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-49'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-50'>
-      <underlying-type type-id='type-id-49'/>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-41'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-42'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='B_FALSE' value='0'/>
       <enumerator name='B_TRUE' value='1'/>
     </enum-decl>
-    <typedef-decl name='boolean_t' type-id='type-id-50' id='type-id-16'/>
-    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' id='type-id-51'>
+    <typedef-decl name='boolean_t' type-id='type-id-42' id='type-id-9'/>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' id='type-id-43'>
       <data-member access='private'>
-        <var-decl name='__data' type-id='type-id-52' visibility='default'/>
+        <var-decl name='__data' type-id='type-id-44' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-53' visibility='default'/>
+        <var-decl name='__size' type-id='type-id-45' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-54' visibility='default'/>
+        <var-decl name='__align' type-id='type-id-46' visibility='default'/>
       </data-member>
     </union-decl>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-52'>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-44'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__lock' type-id='type-id-8' visibility='default'/>
+        <var-decl name='__lock' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__count' type-id='type-id-5' visibility='default'/>
+        <var-decl name='__count' type-id='type-id-30' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__owner' type-id='type-id-8' visibility='default'/>
+        <var-decl name='__owner' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__nusers' type-id='type-id-5' visibility='default'/>
+        <var-decl name='__nusers' type-id='type-id-30' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__kind' type-id='type-id-8' visibility='default'/>
+        <var-decl name='__kind' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='__spins' type-id='type-id-55' visibility='default'/>
+        <var-decl name='__spins' type-id='type-id-47' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='__elision' type-id='type-id-55' visibility='default'/>
+        <var-decl name='__elision' type-id='type-id-47' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='type-id-56' visibility='default'/>
+        <var-decl name='__list' type-id='type-id-48' visibility='default'/>
       </data-member>
     </class-decl>
-    <type-decl name='short int' size-in-bits='16' id='type-id-55'/>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-57'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-47'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-49'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='type-id-58' visibility='default'/>
+        <var-decl name='__prev' type-id='type-id-50' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='type-id-58' visibility='default'/>
+        <var-decl name='__next' type-id='type-id-50' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-57' size-in-bits='64' id='type-id-58'/>
-    <typedef-decl name='__pthread_list_t' type-id='type-id-57' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-50'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-49' id='type-id-48'/>
 
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='320' id='type-id-53'>
-      <subrange length='40' type-id='type-id-33' id='type-id-59'/>
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='320' id='type-id-45'>
+      <subrange length='40' type-id='type-id-24' id='type-id-51'/>
 
     </array-type-def>
-    <type-decl name='long int' size-in-bits='64' id='type-id-54'/>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-51' id='type-id-24'/>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-60'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-46'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-43' id='type-id-10'/>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-52'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='type-id-61' visibility='default'/>
+        <var-decl name='avl_root' type-id='type-id-53' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='type-id-62' visibility='default'/>
+        <var-decl name='avl_compar' type-id='type-id-54' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='type-id-28' visibility='default'/>
+        <var-decl name='avl_offset' type-id='type-id-18' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='type-id-63' visibility='default'/>
+        <var-decl name='avl_numnodes' type-id='type-id-55' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_size' type-id='type-id-28' visibility='default'/>
+        <var-decl name='avl_pad' type-id='type-id-18' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-64'>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-56'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='type-id-65' visibility='default'/>
+        <var-decl name='avl_child' type-id='type-id-57' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='type-id-66' visibility='default'/>
+        <var-decl name='avl_pcb' type-id='type-id-58' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-53'/>
 
-    <array-type-def dimensions='1' type-id='type-id-61' size-in-bits='128' id='type-id-65'>
-      <subrange length='2' type-id='type-id-33' id='type-id-67'/>
+    <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='128' id='type-id-57'>
+      <subrange length='2' type-id='type-id-24' id='type-id-59'/>
 
     </array-type-def>
-    <typedef-decl name='uintptr_t' type-id='type-id-35' id='type-id-66'/>
-    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-62'/>
-    <typedef-decl name='ulong_t' type-id='type-id-35' id='type-id-63'/>
-    <typedef-decl name='avl_tree_t' type-id='type-id-60' id='type-id-25'/>
-    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-69'>
+    <typedef-decl name='uintptr_t' type-id='type-id-24' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-13'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='64' id='type-id-54'/>
+    <typedef-decl name='ulong_t' type-id='type-id-24' id='type-id-55'/>
+    <typedef-decl name='avl_tree_t' type-id='type-id-52' id='type-id-11'/>
+    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-61'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='buffer' type-id='type-id-70' visibility='default'/>
+        <var-decl name='buffer' type-id='type-id-62' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='allocated' type-id='type-id-71' visibility='default'/>
+        <var-decl name='allocated' type-id='type-id-24' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='used' type-id='type-id-71' visibility='default'/>
+        <var-decl name='used' type-id='type-id-24' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='syntax' type-id='type-id-72' visibility='default'/>
+        <var-decl name='syntax' type-id='type-id-63' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fastmap' type-id='type-id-17' visibility='default'/>
+        <var-decl name='fastmap' type-id='type-id-14' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='translate' type-id='type-id-73' visibility='default'/>
+        <var-decl name='translate' type-id='type-id-62' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='re_nsub' type-id='type-id-28' visibility='default'/>
+        <var-decl name='re_nsub' type-id='type-id-18' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='can_be_null' type-id='type-id-5' visibility='default'/>
+        <var-decl name='can_be_null' type-id='type-id-30' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='29'>
-        <var-decl name='regs_allocated' type-id='type-id-5' visibility='default'/>
+        <var-decl name='regs_allocated' type-id='type-id-30' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='28'>
-        <var-decl name='fastmap_accurate' type-id='type-id-5' visibility='default'/>
+        <var-decl name='fastmap_accurate' type-id='type-id-30' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='27'>
-        <var-decl name='no_sub' type-id='type-id-5' visibility='default'/>
+        <var-decl name='no_sub' type-id='type-id-30' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='26'>
-        <var-decl name='not_bol' type-id='type-id-5' visibility='default'/>
+        <var-decl name='not_bol' type-id='type-id-30' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='25'>
-        <var-decl name='not_eol' type-id='type-id-5' visibility='default'/>
+        <var-decl name='not_eol' type-id='type-id-30' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='24'>
-        <var-decl name='newline_anchor' type-id='type-id-5' visibility='default'/>
+        <var-decl name='newline_anchor' type-id='type-id-30' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-74'/>
-    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-70'/>
-    <typedef-decl name='__re_long_size_t' type-id='type-id-35' id='type-id-71'/>
-    <typedef-decl name='reg_syntax_t' type-id='type-id-35' id='type-id-72'/>
-    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-17'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-75'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-73'/>
-    <typedef-decl name='regex_t' type-id='type-id-69' id='type-id-26'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-76'>
-      <underlying-type type-id='type-id-49'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-62'/>
+    <typedef-decl name='reg_syntax_t' type-id='type-id-24' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-14'/>
+    <typedef-decl name='regex_t' type-id='type-id-61' id='type-id-12'/>
+    <class-decl name='zfs_handle' size-in-bits='4928' is-struct='yes' visibility='default' id='type-id-65'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zfs_hdl' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zpool_hdl' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zfs_name' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='zfs_type' type-id='type-id-66' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2208'>
+        <var-decl name='zfs_head_type' type-id='type-id-66' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='zfs_dmustats' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4544'>
+        <var-decl name='zfs_props' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4608'>
+        <var-decl name='zfs_user_props' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4672'>
+        <var-decl name='zfs_recvd_props' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='zfs_mntcheck' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4800'>
+        <var-decl name='zfs_mntopts' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4864'>
+        <var-decl name='zfs_props_table' type-id='type-id-68' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-69'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZFS_TYPE_FILESYSTEM' value='1'/>
       <enumerator name='ZFS_TYPE_SNAPSHOT' value='2'/>
       <enumerator name='ZFS_TYPE_VOLUME' value='4'/>
       <enumerator name='ZFS_TYPE_POOL' value='8'/>
       <enumerator name='ZFS_TYPE_BOOKMARK' value='16'/>
     </enum-decl>
-    <typedef-decl name='zfs_type_t' type-id='type-id-76' id='type-id-13'/>
-    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' id='type-id-77'>
+    <typedef-decl name='zfs_type_t' type-id='type-id-69' id='type-id-66'/>
+    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' id='type-id-70'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dds_num_clones' type-id='type-id-22' visibility='default'/>
+        <var-decl name='dds_num_clones' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='dds_creation_txg' type-id='type-id-22' visibility='default'/>
+        <var-decl name='dds_creation_txg' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='dds_guid' type-id='type-id-22' visibility='default'/>
+        <var-decl name='dds_guid' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='dds_type' type-id='type-id-78' visibility='default'/>
+        <var-decl name='dds_type' type-id='type-id-71' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dds_is_snapshot' type-id='type-id-79' visibility='default'/>
+        <var-decl name='dds_is_snapshot' type-id='type-id-72' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='232'>
-        <var-decl name='dds_inconsistent' type-id='type-id-79' visibility='default'/>
+        <var-decl name='dds_inconsistent' type-id='type-id-72' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='240'>
-        <var-decl name='dds_redacted' type-id='type-id-79' visibility='default'/>
+        <var-decl name='dds_redacted' type-id='type-id-72' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='248'>
-        <var-decl name='dds_origin' type-id='type-id-12' visibility='default'/>
+        <var-decl name='dds_origin' type-id='type-id-17' visibility='default'/>
       </data-member>
     </class-decl>
-    <enum-decl name='dmu_objset_type' id='type-id-80'>
-      <underlying-type type-id='type-id-49'/>
+    <enum-decl name='dmu_objset_type' id='type-id-73'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='DMU_OST_NONE' value='0'/>
       <enumerator name='DMU_OST_META' value='1'/>
       <enumerator name='DMU_OST_ZFS' value='2'/>
@@ -746,50 +865,633 @@
       <enumerator name='DMU_OST_ANY' value='5'/>
       <enumerator name='DMU_OST_NUMTYPES' value='6'/>
     </enum-decl>
-    <typedef-decl name='dmu_objset_type_t' type-id='type-id-80' id='type-id-78'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-75' id='type-id-81'/>
-    <typedef-decl name='uint8_t' type-id='type-id-81' id='type-id-79'/>
-    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-77' id='type-id-14'/>
-    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-18'/>
-    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-82'/>
-    <qualified-type-def type-id='type-id-32' const='yes' id='type-id-83'/>
+    <typedef-decl name='dmu_objset_type_t' type-id='type-id-73' id='type-id-71'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-64' id='type-id-74'/>
+    <typedef-decl name='uint8_t' type-id='type-id-74' id='type-id-72'/>
+    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-70' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-72' size-in-bits='64' id='type-id-68'/>
+    <typedef-decl name='zfs_handle_t' type-id='type-id-65' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-78'/>
+    <typedef-decl name='zfs_iter_f' type-id='type-id-78' id='type-id-79'/>
+    <function-decl name='zfs_iter_root' mangled-name='zfs_iter_root' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_root'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-79' name='func'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-80' size-in-bits='64' id='type-id-81'/>
+    <typedef-decl name='zpool_iter_f' type-id='type-id-81' id='type-id-82'/>
+    <function-decl name='zpool_iter' mangled-name='zpool_iter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_iter'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-82' name='func'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-83'/>
     <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-84'/>
-    <function-decl name='zfs_unmount' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zpool_skip_pool' mangled-name='zpool_skip_pool' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_skip_pool'>
+      <parameter type-id='type-id-84' name='poolname'/>
+      <return type-id='type-id-9'/>
     </function-decl>
-    <function-decl name='zfs_unshare_smb' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-85'/>
+    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_refresh_stats'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-85' name='missing'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zfs_commit_smb_shares' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
+    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_features'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <return type-id='type-id-19'/>
     </function-decl>
-    <function-decl name='uu_avl_walk_end' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-2'/>
-      <return type-id='type-id-6'/>
+    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-86'/>
+    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_config'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-86' name='oldconfig'/>
+      <return type-id='type-id-19'/>
     </function-decl>
-    <function-decl name='uu_avl_last' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='uu_avl_first' mangled-name='uu_avl_first' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='make_dataset_handle' mangled-name='make_dataset_handle' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_next' mangled-name='uu_avl_next' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_open_silent' mangled-name='zpool_open_silent' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strchr' mangled-name='strchr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='getenv' mangled-name='getenv' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin___strcpy_chk' mangled-name='__strcpy_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zcmd_alloc_dst_nvlist' mangled-name='zcmd_alloc_dst_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__errno_location' mangled-name='__errno_location' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zcmd_expand_dst_nvlist' mangled-name='zcmd_expand_dst_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zcmd_read_dst_nvlist' mangled-name='zcmd_read_dst_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zcmd_free_nvlists' mangled-name='zcmd_free_nvlists' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_free' mangled-name='nvlist_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_exists' mangled-name='nvlist_exists' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='no_memory' mangled-name='no_memory' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_dup' mangled-name='nvlist_dup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_name' mangled-name='nvpair_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_strdup' mangled-name='zfs_strdup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='dcgettext' mangled-name='dcgettext' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-60'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-13'/>
+      <return type-id='type-id-2'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-77'>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-13'/>
+      <return type-id='type-id-2'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-80'>
       <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-13'/>
+      <return type-id='type-id-2'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_crypto.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-19' name='raw_props'/>
+      <parameter type-id='type-id-9' name='inheritkey'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-9' name='noop'/>
+      <parameter type-id='type-id-14' name='alt_keylocation'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-14' name='fsname'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-76' name='origin_zhp'/>
+      <parameter type-id='type-id-14' name='parent_name'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-87'/>
+    <typedef-decl name='uint_t' type-id='type-id-30' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-89'/>
+    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_create'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-14' name='parent_name'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <parameter type-id='type-id-19' name='pool_props'/>
+      <parameter type-id='type-id-9' name='stdin_available'/>
+      <parameter type-id='type-id-87' name='wkeydata_out'/>
+      <parameter type-id='type-id-89' name='wkeylen_out'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-85' name='is_encroot'/>
+      <parameter type-id='type-id-14' name='buf'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='__builtin___snprintf_chk' mangled-name='__snprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_error_aux' mangled-name='zfs_error_aux' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_change_key' mangled-name='lzc_change_key' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_unload_key' mangled-name='lzc_unload_key' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_load_key' mangled-name='lzc_load_key' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__printf_chk' mangled-name='__printf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='calloc' mangled-name='calloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='regexec' mangled-name='regexec' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fileno' mangled-name='fileno' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='isatty' mangled-name='isatty' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin_putchar' mangled-name='putchar' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__getdelim' mangled-name='__getdelim' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sigemptyset' mangled-name='sigemptyset' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sigaction' mangled-name='sigaction' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fflush' mangled-name='fflush' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='tcgetattr' mangled-name='tcgetattr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='tcsetattr' mangled-name='tcsetattr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='getpid' mangled-name='getpid' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='kill' mangled-name='kill' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__ctype_b_loc' mangled-name='__ctype_b_loc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__fread_alias' mangled-name='fread' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='malloc' mangled-name='malloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='ferror' mangled-name='ferror' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fopen' mangled-name='fopen64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fclose' mangled-name='fclose' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin_memmove' mangled-name='memmove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sscanf' mangled-name='sscanf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='PKCS5_PBKDF2_HMAC_SHA1' mangled-name='PKCS5_PBKDF2_HMAC_SHA1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__open_alias' mangled-name='open64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__read_alias' mangled-name='read' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='close' mangled-name='close' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin_strcpy' mangled-name='strcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_dataset.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-90'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
+      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
+    </enum-decl>
+    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-90' id='type-id-91'/>
+    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-91' name='activity'/>
+      <parameter type-id='type-id-85' name='missing'/>
+      <parameter type-id='type-id-85' name='waited'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
+      <parameter type-id='type-id-4' name='zph'/>
+      <parameter type-id='type-id-7' name='volsize'/>
+      <parameter type-id='type-id-19' name='props'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='remove_mountpoint' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-6'/>
+    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-86' name='nvl'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zfs_share_smb' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-9' name='un'/>
+      <parameter type-id='type-id-19' name='nvl'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zfs_refresh_properties' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-6'/>
+    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-86' name='nvl'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-85'>
-      <underlying-type type-id='type-id-49'/>
+    <function-decl name='zfs_release' mangled-name='zfs_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='snapname'/>
+      <parameter type-id='type-id-84' name='tag'/>
+      <parameter type-id='type-id-9' name='recursive'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-2' name='cleanup_fd'/>
+      <parameter type-id='type-id-19' name='holds'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_hold' mangled-name='zfs_hold' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='snapname'/>
+      <parameter type-id='type-id-84' name='tag'/>
+      <parameter type-id='type-id-9' name='recursive'/>
+      <parameter type-id='type-id-2' name='cleanup_fd'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-92'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='ZFS_PROP_USERUSED' value='0'/>
+      <enumerator name='ZFS_PROP_USERQUOTA' value='1'/>
+      <enumerator name='ZFS_PROP_GROUPUSED' value='2'/>
+      <enumerator name='ZFS_PROP_GROUPQUOTA' value='3'/>
+      <enumerator name='ZFS_PROP_USEROBJUSED' value='4'/>
+      <enumerator name='ZFS_PROP_USEROBJQUOTA' value='5'/>
+      <enumerator name='ZFS_PROP_GROUPOBJUSED' value='6'/>
+      <enumerator name='ZFS_PROP_GROUPOBJQUOTA' value='7'/>
+      <enumerator name='ZFS_PROP_PROJECTUSED' value='8'/>
+      <enumerator name='ZFS_PROP_PROJECTQUOTA' value='9'/>
+      <enumerator name='ZFS_PROP_PROJECTOBJUSED' value='10'/>
+      <enumerator name='ZFS_PROP_PROJECTOBJQUOTA' value='11'/>
+      <enumerator name='ZFS_NUM_USERQUOTA_PROPS' value='12'/>
+    </enum-decl>
+    <typedef-decl name='zfs_userquota_prop_t' type-id='type-id-92' id='type-id-93'/>
+    <typedef-decl name='__uid_t' type-id='type-id-30' id='type-id-94'/>
+    <typedef-decl name='uid_t' type-id='type-id-94' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-97'/>
+    <typedef-decl name='zfs_userspace_cb_t' type-id='type-id-97' id='type-id-98'/>
+    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-93' name='type'/>
+      <parameter type-id='type-id-98' name='func'/>
+      <parameter type-id='type-id-13' name='arg'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-14' name='dataset'/>
+      <parameter type-id='type-id-14' name='path'/>
+      <parameter type-id='type-id-14' name='oldname'/>
+      <parameter type-id='type-id-14' name='newname'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-14' name='dataset'/>
+      <parameter type-id='type-id-14' name='path'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-14' name='dataset'/>
+      <parameter type-id='type-id-14' name='path'/>
+      <parameter type-id='type-id-14' name='resource'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-14' name='dataset'/>
+      <parameter type-id='type-id-14' name='path'/>
+      <parameter type-id='type-id-14' name='resource'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-68' name='props'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='zprop_list' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-99'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pl_prop' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pl_user_prop' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pl_next' type-id='type-id-100' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pl_all' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pl_width' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pl_recvd_width' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='pl_fixed' type-id='type-id-9' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-100'/>
+    <typedef-decl name='zprop_list_t' type-id='type-id-99' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-103'/>
+    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-103' name='plp'/>
+      <parameter type-id='type-id-9' name='received'/>
+      <parameter type-id='type-id-9' name='literal'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-19'/>
+    </function-decl>
+    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-19'/>
+    </function-decl>
+    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-19'/>
+    </function-decl>
+    <class-decl name='renameflags' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-104'>
+      <data-member access='public' layout-offset-in-bits='31'>
+        <var-decl name='recursive' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='30'>
+        <var-decl name='nounmount' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='29'>
+        <var-decl name='forceunmount' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='renameflags_t' type-id='type-id-104' id='type-id-105'/>
+    <function-decl name='zfs_rename' mangled-name='zfs_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='target'/>
+      <parameter type-id='type-id-105' name='flags'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-76' name='snap'/>
+      <parameter type-id='type-id-9' name='force'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-9' name='recursive'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-19' name='snaps'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_promote' mangled-name='zfs_promote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_clone' mangled-name='zfs_clone' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='target'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-19' name='snaps'/>
+      <parameter type-id='type-id-9' name='defer'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-14' name='snapname'/>
+      <parameter type-id='type-id-9' name='defer'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-9' name='defer'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_create' mangled-name='zfs_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-14' name='buf'/>
+      <parameter type-id='type-id-18' name='buflen'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-75' const='yes' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-107'/>
+    <function-decl name='zfs_get_underlying_type' mangled-name='zfs_get_underlying_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_type'>
+      <parameter type-id='type-id-107' name='zhp'/>
+      <return type-id='type-id-66'/>
+    </function-decl>
+    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_type'>
+      <parameter type-id='type-id-107' name='zhp'/>
+      <return type-id='type-id-66'/>
+    </function-decl>
+    <function-decl name='zfs_get_pool_name' mangled-name='zfs_get_pool_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_name'>
+      <parameter type-id='type-id-107' name='zhp'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_name'>
+      <parameter type-id='type-id-107' name='zhp'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_written' mangled-name='zfs_prop_get_written' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='propname'/>
+      <parameter type-id='type-id-14' name='propbuf'/>
+      <parameter type-id='type-id-2' name='proplen'/>
+      <parameter type-id='type-id-9' name='literal'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-7' size-in-bits='64' id='type-id-108'/>
+    <function-decl name='zfs_prop_get_written_int' mangled-name='zfs_prop_get_written_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written_int'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='propname'/>
+      <parameter type-id='type-id-108' name='propvalue'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_userquota' mangled-name='zfs_prop_get_userquota' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='propname'/>
+      <parameter type-id='type-id-14' name='propbuf'/>
+      <parameter type-id='type-id-2' name='proplen'/>
+      <parameter type-id='type-id-9' name='literal'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_userquota_int' mangled-name='zfs_prop_get_userquota_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota_int'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='propname'/>
+      <parameter type-id='type-id-108' name='propvalue'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-109'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZPROP_CONT' value='-2'/>
       <enumerator name='ZPROP_INVAL' value='-1'/>
       <enumerator name='ZFS_PROP_TYPE' value='0'/>
@@ -889,8 +1591,9 @@
       <enumerator name='ZFS_PROP_REDACT_SNAPS' value='94'/>
       <enumerator name='ZFS_NUM_PROPS' value='95'/>
     </enum-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-86'>
-      <underlying-type type-id='type-id-49'/>
+    <typedef-decl name='zfs_prop_t' type-id='type-id-109' id='type-id-110'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-111'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZPROP_SRC_NONE' value='1'/>
       <enumerator name='ZPROP_SRC_DEFAULT' value='2'/>
       <enumerator name='ZPROP_SRC_TEMPORARY' value='4'/>
@@ -898,712 +1601,1452 @@
       <enumerator name='ZPROP_SRC_INHERITED' value='16'/>
       <enumerator name='ZPROP_SRC_RECEIVED' value='32'/>
     </enum-decl>
-    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-87'/>
-    <function-decl name='zfs_prop_get' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-85'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-87'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-50'/>
-      <return type-id='type-id-8'/>
+    <typedef-decl name='zprop_source_t' type-id='type-id-111' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-113'/>
+    <function-decl name='zfs_prop_get_numeric' mangled-name='zfs_prop_get_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_numeric'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-110' name='prop'/>
+      <parameter type-id='type-id-108' name='value'/>
+      <parameter type-id='type-id-113' name='src'/>
+      <parameter type-id='type-id-14' name='statbuf'/>
+      <parameter type-id='type-id-18' name='statlen'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zfs_prop_get_int' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-85'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-88'/>
-    <function-decl name='zfs_is_mounted' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-88'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zfs_mount' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unshare_nfs' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_share_nfs' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_commit_nfs_shares' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='strlcpy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='strlcat' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-89'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='PROTO_NFS' value='0'/>
-      <enumerator name='PROTO_SMB' value='1'/>
-      <enumerator name='PROTO_END' value='2'/>
-    </enum-decl>
-    <function-decl name='zfs_unshare_proto' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-87'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_commit_proto' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-87'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='uu_avl_remove' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_close' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='uu_avl_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-90'/>
-    <function-decl name='uu_avl_pool_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-90'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-91'/>
-    <function-decl name='zfs_alloc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-35'/>
+    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_int'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-110' name='prop'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-93'/>
-    <function-decl name='uu_avl_pool_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-93'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-90'/>
+    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-110' name='prop'/>
+      <parameter type-id='type-id-14' name='propbuf'/>
+      <parameter type-id='type-id-18' name='proplen'/>
+      <parameter type-id='type-id-113' name='src'/>
+      <parameter type-id='type-id-14' name='statbuf'/>
+      <parameter type-id='type-id-18' name='statlen'/>
+      <parameter type-id='type-id-9' name='literal'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='uu_avl_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-90'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-4'/>
+    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_clones_nvl'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-19'/>
     </function-decl>
-    <function-decl name='zfs_error' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zfs_prop_get_recvd' mangled-name='zfs_prop_get_recvd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_recvd'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='propname'/>
+      <parameter type-id='type-id-14' name='propbuf'/>
+      <parameter type-id='type-id-18' name='proplen'/>
+      <parameter type-id='type-id-9' name='literal'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-95'/>
-    <function-decl name='zfs_iter_dependents' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-95'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zfs_prop_inherit' mangled-name='zfs_prop_inherit' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inherit'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='propname'/>
+      <parameter type-id='type-id-9' name='received'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zfs_iter_mounted' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-95'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zfs_prop_set_list' mangled-name='zfs_prop_set_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zfs_iter_children' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-95'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='propname'/>
+      <parameter type-id='type-id-84' name='propval'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-9' const='yes' id='type-id-96'/>
-    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-97'/>
-    <function-decl name='zfs_get_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-97'/>
+    <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valid_proplist'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <parameter type-id='type-id-19' name='nvl'/>
+      <parameter type-id='type-id-7' name='zoned'/>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-4' name='zpool_hdl'/>
+      <parameter type-id='type-id-9' name='key_params_ok'/>
+      <parameter type-id='type-id-84' name='errbuf'/>
+      <return type-id='type-id-19'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-114'/>
+    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-114' name='spa_version'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_remove'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='fsname'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_add'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='special'/>
+      <parameter type-id='type-id-84' name='mountp'/>
+      <parameter type-id='type-id-84' name='mntopts'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_cache' mangled-name='libzfs_mnttab_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_cache'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-9' name='enable'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_fini'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_init'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_close' mangled-name='zfs_close' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_close'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_open' mangled-name='zfs_open' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_open'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-2' name='types'/>
+      <return type-id='type-id-76'/>
+    </function-decl>
+    <function-decl name='zfs_bookmark_exists' mangled-name='zfs_bookmark_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_bookmark_exists'>
+      <parameter type-id='type-id-84' name='path'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_handle_dup'>
+      <parameter type-id='type-id-76' name='zhp_orig'/>
+      <return type-id='type-id-76'/>
+    </function-decl>
+    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_refresh_properties'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_free_handles'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_valid'>
+      <parameter type-id='type-id-84' name='name'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_type_to_name' mangled-name='zfs_type_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_type_to_name'>
+      <parameter type-id='type-id-66' name='type'/>
       <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zfs_open' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-82'/>
-    </function-decl>
-    <function-decl name='zfs_is_shared' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <class-decl name='uu_avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-98'>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-115'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='uan_opaque' type-id='type-id-99' visibility='default'/>
+        <var-decl name='mnt_special' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-14' visibility='default'/>
       </data-member>
     </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-66' size-in-bits='192' id='type-id-99'>
-      <subrange length='3' type-id='type-id-33' id='type-id-100'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-101'/>
-    <function-decl name='uu_avl_node_init' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-101'/>
-      <parameter type-id='type-id-90'/>
-      <return type-id='type-id-6'/>
+    <pointer-type-def type-id='type-id-115' size-in-bits='64' id='type-id-116'/>
+    <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_find'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='fsname'/>
+      <parameter type-id='type-id-116' name='entry'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-102'/>
-    <function-decl name='uu_avl_find' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-102'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-117'/>
+    <function-decl name='getprop_uint64' mangled-name='getprop_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getprop_uint64'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-110' name='prop'/>
+      <parameter type-id='type-id-117' name='source'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='uu_avl_insert' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-6'/>
+    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_exists'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-66' name='types'/>
+      <return type-id='type-id-9'/>
     </function-decl>
-    <function-decl name='zfs_get_handle' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-91'/>
+    <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-68'>
+    <function-decl name='zfs_standard_error_fmt' mangled-name='zfs_standard_error_fmt' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strtol' mangled-name='strtol' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_get_holds' mangled-name='lzc_get_holds' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_size' mangled-name='nvlist_size' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_pack' mangled-name='nvlist_pack' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strerror' mangled-name='strerror' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_empty' mangled-name='nvlist_empty' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_free' mangled-name='fnvlist_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_release' mangled-name='lzc_release' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_hold' mangled-name='lzc_hold' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='ioctl' mangled-name='ioctl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zcmd_write_src_nvlist' mangled-name='zcmd_write_src_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_type' mangled-name='nvpair_type' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_remove' mangled-name='nvlist_remove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_expand_list' mangled-name='zprop_expand_list' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='changelist_gather' mangled-name='changelist_gather' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='changelist_haszonedchild' mangled-name='changelist_haszonedchild' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='changelist_free' mangled-name='changelist_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='changelist_rename' mangled-name='changelist_rename' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='changelist_postfix' mangled-name='changelist_postfix' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='changelist_prefix' mangled-name='changelist_prefix' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='changelist_remove' mangled-name='changelist_remove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strcspn' mangled-name='strcspn' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_open' mangled-name='zpool_open' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_close' mangled-name='zpool_close' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_snapshot' mangled-name='lzc_snapshot' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_promote' mangled-name='lzc_promote' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_clone' mangled-name='lzc_clone' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_snaps' mangled-name='lzc_destroy_snaps' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_destroy' mangled-name='lzc_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='dataset_nestcheck' mangled-name='dataset_nestcheck' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_create' mangled-name='lzc_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strdup' mangled-name='strdup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_share' mangled-name='zfs_share' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_commit_all_shares' mangled-name='zfs_commit_all_shares' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin___strncpy_chk' mangled-name='__strncpy_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strrchr' mangled-name='strrchr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_error_fmt' mangled-name='zfs_error_fmt' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='localtime_r' mangled-name='localtime_r' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strftime' mangled-name='strftime' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin_snprintf' mangled-name='snprintf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_type' mangled-name='zfs_prop_get_type' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_index_to_string' mangled-name='zfs_prop_index_to_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_readonly' mangled-name='zfs_prop_readonly' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='abort' mangled-name='abort' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__fprintf_chk' mangled-name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_channel_program_nosync' mangled-name='lzc_channel_program_nosync' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strsep' mangled-name='strsep' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='hasmntopt' mangled-name='hasmntopt' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_setonce' mangled-name='zfs_prop_setonce' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_inheritable' mangled-name='zfs_prop_inheritable' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_setprop_error' mangled-name='zfs_setprop_error' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__asprintf_chk' mangled-name='__asprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='mountpoint_namecheck' mangled-name='mountpoint_namecheck' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_parse_options' mangled-name='zfs_parse_options' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_encryption_key_param' mangled-name='zfs_prop_encryption_key_param' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_parse_value' mangled-name='zprop_parse_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_userquota' mangled-name='zfs_prop_userquota' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_written' mangled-name='zfs_prop_written' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_valid_keylocation' mangled-name='zfs_prop_valid_keylocation' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_lock' mangled-name='pthread_mutex_lock' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_remove' mangled-name='avl_remove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_unlock' mangled-name='pthread_mutex_unlock' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_add' mangled-name='avl_add' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_destroy' mangled-name='pthread_mutex_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_init' mangled-name='pthread_mutex_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_get_bookmarks' mangled-name='lzc_get_bookmarks' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_name_valid' mangled-name='zpool_name_valid' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strtoul' mangled-name='strtoul' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='getgrnam' mangled-name='getgrnam' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='getpwnam' mangled-name='getpwnam' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strstr' mangled-name='strstr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='entity_namecheck' mangled-name='entity_namecheck' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_exists' mangled-name='lzc_exists' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='getmntany' mangled-name='getmntany' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-96'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-95'/>
       <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-92'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-94'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
+      <return type-id='type-id-2'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_config.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zpool_skip_pool' mangled-name='zpool_skip_pool' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_skip_pool'>
-      <parameter type-id='type-id-84' name='poolname'/>
-      <return type-id='type-id-16'/>
+  <abi-instr version='1.0' address-size='64' path='libzfs_diff.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_show_diffs' mangled-name='zfs_show_diffs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_show_diffs'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-2' name='outfd'/>
+      <parameter type-id='type-id-84' name='fromsnap'/>
+      <parameter type-id='type-id-84' name='tosnap'/>
+      <parameter type-id='type-id-2' name='flags'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-7' size-in-bits='64' id='type-id-103'/>
-    <function-decl name='uu_avl_teardown' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-103'/>
-      <return type-id='type-id-7'/>
+    <function-decl name='__builtin_strncpy' mangled-name='strncpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-104'/>
-    <function-decl name='nvlist_free' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-6'/>
+    <function-decl name='zfs_asprintf' mangled-name='zfs_asprintf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-105'/>
-    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_config'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-105' name='oldconfig'/>
-      <return type-id='type-id-15'/>
+    <function-decl name='zfs_validate_name' mangled-name='zfs_validate_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_features'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-15'/>
+    <function-decl name='find_shares_object' mangled-name='find_shares_object' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_exists' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
+    <function-decl name='pipe2' mangled-name='pipe2' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_create' mangled-name='pthread_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_cancel' mangled-name='pthread_cancel' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pthread_join' mangled-name='pthread_join' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fdopen' mangled-name='fdopen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin_fwrite' mangled-name='fwrite' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='is_mounted' mangled-name='is_mounted' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_import.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-118'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pco_refresh_config' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pco_pool_active' type-id='type-id-120' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='refresh_config_func_t' type-id='type-id-121' id='type-id-122'/>
+    <pointer-type-def type-id='type-id-122' size-in-bits='64' id='type-id-119'/>
+    <typedef-decl name='pool_active_func_t' type-id='type-id-123' id='type-id-124'/>
+    <pointer-type-def type-id='type-id-124' size-in-bits='64' id='type-id-120'/>
+    <qualified-type-def type-id='type-id-118' const='yes' id='type-id-125'/>
+    <typedef-decl name='pool_config_ops_t' type-id='type-id-125' id='type-id-126'/>
+    <var-decl name='libzfs_config_ops' type-id='type-id-126' mangled-name='libzfs_config_ops' visibility='default' elf-symbol-id='libzfs_config_ops'/>
+    <enum-decl name='pool_state' id='type-id-127'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='POOL_STATE_ACTIVE' value='0'/>
+      <enumerator name='POOL_STATE_EXPORTED' value='1'/>
+      <enumerator name='POOL_STATE_DESTROYED' value='2'/>
+      <enumerator name='POOL_STATE_SPARE' value='3'/>
+      <enumerator name='POOL_STATE_L2CACHE' value='4'/>
+      <enumerator name='POOL_STATE_UNINITIALIZED' value='5'/>
+      <enumerator name='POOL_STATE_UNAVAIL' value='6'/>
+      <enumerator name='POOL_STATE_POTENTIALLY_ACTIVE' value='7'/>
+    </enum-decl>
+    <typedef-decl name='pool_state_t' type-id='type-id-127' id='type-id-128'/>
+    <pointer-type-def type-id='type-id-128' size-in-bits='64' id='type-id-129'/>
+    <function-decl name='zpool_in_use' mangled-name='zpool_in_use' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_in_use'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-2' name='fd'/>
+      <parameter type-id='type-id-129' name='state'/>
+      <parameter type-id='type-id-117' name='namestr'/>
+      <parameter type-id='type-id-85' name='inuse'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_clear_label' mangled-name='zpool_clear_label' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear_label'>
+      <parameter type-id='type-id-2' name='fd'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_read_label' mangled-name='zpool_read_label' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_iter' mangled-name='zpool_iter' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__pread64_alias' mangled-name='pread64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pwrite64' mangled-name='pwrite64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__fxstat64' mangled-name='__fxstat64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zcmd_write_conf_nvlist' mangled-name='zcmd_write_conf_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-123'>
+      <parameter type-id='type-id-13'/>
       <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-106'/>
-    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_refresh_stats'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-106' name='missing'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-107'/>
-    <function-decl name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='type-id-108'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_name' type-id='type-id-109' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32768'>
-        <var-decl name='zc_nvlist_src' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32832'>
-        <var-decl name='zc_nvlist_src_size' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32896'>
-        <var-decl name='zc_nvlist_dst' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32960'>
-        <var-decl name='zc_nvlist_dst_size' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33024'>
-        <var-decl name='zc_nvlist_dst_filled' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33056'>
-        <var-decl name='zc_pad2' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33088'>
-        <var-decl name='zc_history' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33152'>
-        <var-decl name='zc_value' type-id='type-id-110' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='98688'>
-        <var-decl name='zc_string' type-id='type-id-12' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100736'>
-        <var-decl name='zc_guid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100800'>
-        <var-decl name='zc_nvlist_conf' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100864'>
-        <var-decl name='zc_nvlist_conf_size' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100928'>
-        <var-decl name='zc_cookie' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100992'>
-        <var-decl name='zc_objset_type' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101056'>
-        <var-decl name='zc_perm_action' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101120'>
-        <var-decl name='zc_history_len' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101184'>
-        <var-decl name='zc_history_offset' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101248'>
-        <var-decl name='zc_obj' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101312'>
-        <var-decl name='zc_iflags' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101376'>
-        <var-decl name='zc_share' type-id='type-id-111' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101632'>
-        <var-decl name='zc_objset_stats' type-id='type-id-14' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='103936'>
-        <var-decl name='zc_begin_record' type-id='type-id-112' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='106368'>
-        <var-decl name='zc_inject_record' type-id='type-id-113' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109184'>
-        <var-decl name='zc_defer_destroy' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109216'>
-        <var-decl name='zc_flags' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109248'>
-        <var-decl name='zc_action_handle' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109312'>
-        <var-decl name='zc_cleanup_fd' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109344'>
-        <var-decl name='zc_simple' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109352'>
-        <var-decl name='zc_pad' type-id='type-id-114' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109376'>
-        <var-decl name='zc_sendobj' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109440'>
-        <var-decl name='zc_fromobj' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109504'>
-        <var-decl name='zc_createtxg' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109568'>
-        <var-decl name='zc_stat' type-id='type-id-115' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109888'>
-        <var-decl name='zc_zoneid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='32768' id='type-id-109'>
-      <subrange length='4096' type-id='type-id-33' id='type-id-116'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='65536' id='type-id-110'>
-      <subrange length='8192' type-id='type-id-33' id='type-id-117'/>
-
-    </array-type-def>
-    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-118'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='z_exportdata' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='z_sharedata' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='z_sharetype' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='z_sharemax' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zfs_share_t' type-id='type-id-118' id='type-id-111'/>
-    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' id='type-id-112'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_magic' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_versioninfo' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_creation_time' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_type' type-id='type-id-78' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_flags' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_fromguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_toname' type-id='type-id-12' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='type-id-119'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zi_objset' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zi_object' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zi_start' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zi_end' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zi_guid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='zi_level' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='zi_error' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='zi_type' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='zi_freq' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='zi_failfast' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='zi_func' type-id='type-id-12' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='zi_iotype' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2592'>
-        <var-decl name='zi_duration' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2624'>
-        <var-decl name='zi_timer' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2688'>
-        <var-decl name='zi_nlanes' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2752'>
-        <var-decl name='zi_cmd' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2784'>
-        <var-decl name='zi_dvas' type-id='type-id-38' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zinject_record_t' type-id='type-id-119' id='type-id-113'/>
-
-    <array-type-def dimensions='1' type-id='type-id-79' size-in-bits='24' id='type-id-114'>
-      <subrange length='3' type-id='type-id-33' id='type-id-100'/>
-
-    </array-type-def>
-    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-120'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zs_gen' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zs_mode' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zs_links' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zs_ctime' type-id='type-id-121' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='128' id='type-id-121'>
-      <subrange length='2' type-id='type-id-33' id='type-id-67'/>
-
-    </array-type-def>
-    <typedef-decl name='zfs_stat_t' type-id='type-id-120' id='type-id-115'/>
-    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-122'/>
-    <function-decl name='zcmd_alloc_dst_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-122'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_ioctl' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-122'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zcmd_expand_dst_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-122'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zcmd_free_nvlists' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-122'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zcmd_read_dst_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-122'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='getenv' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-124'/>
-    <typedef-decl name='zpool_iter_f' type-id='type-id-124' id='type-id-125'/>
-    <function-decl name='zpool_iter' mangled-name='zpool_iter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_iter'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-125' name='func'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='uu_avl_first' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='uu_avl_next' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-4'/>
       <parameter type-id='type-id-7'/>
-      <return type-id='type-id-7'/>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-2'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-121'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-19'/>
+      <return type-id='type-id-19'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_iter.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-79' name='func'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-126'/>
-    <pointer-type-def type-id='type-id-126' size-in-bits='64' id='type-id-127'/>
-    <function-decl name='zpool_open_silent' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-127'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-9' name='allowrecursion'/>
+      <parameter type-id='type-id-79' name='func'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='no_memory' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-79' name='func'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-128'>
+    <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
+      <parameter type-id='type-id-76' name='fs_zhp'/>
+      <parameter type-id='type-id-84' name='spec_orig'/>
+      <parameter type-id='type-id-79' name='func'/>
+      <parameter type-id='type-id-13' name='arg'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-79' name='callback'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <parameter type-id='type-id-7' name='min_txg'/>
+      <parameter type-id='type-id-7' name='max_txg'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-79' name='func'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-9' name='simple'/>
+      <parameter type-id='type-id-79' name='func'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <parameter type-id='type-id-7' name='min_txg'/>
+      <parameter type-id='type-id-7' name='max_txg'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-79' name='func'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='make_bookmark_handle' mangled-name='make_bookmark_handle' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='make_dataset_simple_handle_zc' mangled-name='make_dataset_simple_handle_zc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='make_dataset_handle_zc' mangled-name='make_dataset_handle_zc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_mount.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-130' visibility='default' id='type-id-131'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvp_size' type-id='type-id-37' visibility='default'/>
+        <var-decl name='p_prop' type-id='type-id-110' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_name' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_share_err' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='p_unshare_err' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='proto_table_t' type-id='type-id-131' id='type-id-130'/>
+
+    <array-type-def dimensions='1' type-id='type-id-130' size-in-bits='384' id='type-id-132'>
+      <subrange length='2' type-id='type-id-24' id='type-id-59'/>
+
+    </array-type-def>
+    <var-decl name='proto_table' type-id='type-id-132' visibility='default'/>
+    <function-decl name='zpool_disable_datasets' mangled-name='zpool_disable_datasets' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_disable_datasets'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-9' name='force'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='mntopts'/>
+      <parameter type-id='type-id-2' name='flags'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-133'/>
+    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-133' name='handles'/>
+      <parameter type-id='type-id-18' name='num_handles'/>
+      <parameter type-id='type-id-79' name='func'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <parameter type-id='type-id-9' name='parallel'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-134'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cb_handles' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='cb_alloc' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='cb_used' type-id='type-id-18' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='get_all_cb_t' type-id='type-id-134' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-136'/>
+    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
+      <parameter type-id='type-id-136' name='cbp'/>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='mountpoint'/>
+      <parameter type-id='type-id-84' name='proto'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='mountpoint'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='mountpoint'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='mountpoint'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
+      <parameter type-id='type-id-84' name='proto'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-117' name='where'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-117' name='where'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_share' mangled-name='zfs_share' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-2' name='flags'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='mountpoint'/>
+      <parameter type-id='type-id-2' name='flags'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_mount_at' mangled-name='zfs_mount_at' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_at'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='options'/>
+      <parameter type-id='type-id-2' name='flags'/>
+      <parameter type-id='type-id-84' name='mountpoint'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_mount' mangled-name='zfs_mount' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='options'/>
+      <parameter type-id='type-id-2' name='flags'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mounted'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-117' name='where'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='is_mounted' mangled-name='is_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mounted'>
+      <parameter type-id='type-id-16' name='zfs_hdl'/>
+      <parameter type-id='type-id-84' name='special'/>
+      <parameter type-id='type-id-117' name='where'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_realloc' mangled-name='zfs_realloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='qsort' mangled-name='qsort' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='tpool_create' mangled-name='tpool_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='tpool_wait' mangled-name='tpool_wait' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='tpool_destroy' mangled-name='tpool_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='rmdir' mangled-name='rmdir' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='changelist_unshare' mangled-name='changelist_unshare' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sa_enable_share' mangled-name='sa_enable_share' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sa_errorstr' mangled-name='sa_errorstr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sa_disable_share' mangled-name='sa_disable_share' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='do_unmount' mangled-name='do_unmount' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__lxstat' mangled-name='__lxstat64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__openat_alias' mangled-name='openat64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fdopendir' mangled-name='fdopendir' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='readdir64' mangled-name='readdir64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='closedir' mangled-name='closedir' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__xstat' mangled-name='__xstat64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='statfs64' mangled-name='statfs64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='do_mount' mangled-name='do_mount' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='mkdirp' mangled-name='mkdirp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='getprop_uint64' mangled-name='getprop_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sa_is_shared' mangled-name='sa_is_shared' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_pool.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-86' name='nvlp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-33' const='yes' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-138'/>
+    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-138' name='envmap'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-139'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
+      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
+      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
+      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
+      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
+      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
+      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
+      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
+      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
+    </enum-decl>
+    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-139' id='type-id-140'/>
+    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-140' name='activity'/>
+      <parameter type-id='type-id-85' name='missing'/>
+      <parameter type-id='type-id-85' name='waited'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_wait' mangled-name='zpool_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-140' name='activity'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-7' name='dsobj'/>
+      <parameter type-id='type-id-7' name='obj'/>
+      <parameter type-id='type-id-14' name='pathname'/>
+      <parameter type-id='type-id-18' name='len'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-7' name='dsobj'/>
+      <parameter type-id='type-id-7' name='obj'/>
+      <parameter type-id='type-id-14' name='pathname'/>
+      <parameter type-id='type-id-18' name='len'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-7' name='eid'/>
+      <parameter type-id='type-id-2' name='zevent_fd'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-114' name='count'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-86' name='nvp'/>
+      <parameter type-id='type-id-114' name='dropped'/>
+      <parameter type-id='type-id-30' name='flags'/>
+      <parameter type-id='type-id-2' name='zevent_fd'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-86' name='nvhisp'/>
+      <parameter type-id='type-id-108' name='off'/>
+      <parameter type-id='type-id-85' name='eof'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='message'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
+      <parameter type-id='type-id-2' name='argc'/>
+      <parameter type-id='type-id-117' name='argv'/>
+      <parameter type-id='type-id-14' name='string'/>
+      <parameter type-id='type-id-2' name='len'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-7' name='new_version'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-86' name='nverrlistp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-19' name='nv'/>
+      <parameter type-id='type-id-2' name='name_flags'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-7' name='guid'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_clear' mangled-name='zpool_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-19' name='rewindnvl'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-108' name='sizep'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <class-decl name='splitflags' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-141'>
+      <data-member access='public' layout-offset-in-bits='31'>
+        <var-decl name='dryrun' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='30'>
+        <var-decl name='import' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvp_name_sz' type-id='type-id-129' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='nvp_reserve' type-id='type-id-129' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvp_value_elem' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='nvp_type' type-id='type-id-130' visibility='default'/>
+        <var-decl name='name_flags' type-id='type-id-2' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__int16_t' type-id='type-id-55' id='type-id-131'/>
-    <typedef-decl name='int16_t' type-id='type-id-131' id='type-id-129'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-132'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
-      <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
-      <enumerator name='DATA_TYPE_BOOLEAN' value='1'/>
-      <enumerator name='DATA_TYPE_BYTE' value='2'/>
-      <enumerator name='DATA_TYPE_INT16' value='3'/>
-      <enumerator name='DATA_TYPE_UINT16' value='4'/>
-      <enumerator name='DATA_TYPE_INT32' value='5'/>
-      <enumerator name='DATA_TYPE_UINT32' value='6'/>
-      <enumerator name='DATA_TYPE_INT64' value='7'/>
-      <enumerator name='DATA_TYPE_UINT64' value='8'/>
-      <enumerator name='DATA_TYPE_STRING' value='9'/>
-      <enumerator name='DATA_TYPE_BYTE_ARRAY' value='10'/>
-      <enumerator name='DATA_TYPE_INT16_ARRAY' value='11'/>
-      <enumerator name='DATA_TYPE_UINT16_ARRAY' value='12'/>
-      <enumerator name='DATA_TYPE_INT32_ARRAY' value='13'/>
-      <enumerator name='DATA_TYPE_UINT32_ARRAY' value='14'/>
-      <enumerator name='DATA_TYPE_INT64_ARRAY' value='15'/>
-      <enumerator name='DATA_TYPE_UINT64_ARRAY' value='16'/>
-      <enumerator name='DATA_TYPE_STRING_ARRAY' value='17'/>
-      <enumerator name='DATA_TYPE_HRTIME' value='18'/>
-      <enumerator name='DATA_TYPE_NVLIST' value='19'/>
-      <enumerator name='DATA_TYPE_NVLIST_ARRAY' value='20'/>
-      <enumerator name='DATA_TYPE_BOOLEAN_VALUE' value='21'/>
-      <enumerator name='DATA_TYPE_INT8' value='22'/>
-      <enumerator name='DATA_TYPE_UINT8' value='23'/>
-      <enumerator name='DATA_TYPE_BOOLEAN_ARRAY' value='24'/>
-      <enumerator name='DATA_TYPE_INT8_ARRAY' value='25'/>
-      <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
-      <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
+    <typedef-decl name='splitflags_t' type-id='type-id-141' id='type-id-142'/>
+    <function-decl name='zpool_vdev_split' mangled-name='zpool_vdev_split' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_split'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-14' name='newname'/>
+      <parameter type-id='type-id-86' name='newroot'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <parameter type-id='type-id-142' name='flags'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='old_disk'/>
+      <parameter type-id='type-id-84' name='new_disk'/>
+      <parameter type-id='type-id-19' name='nvroot'/>
+      <parameter type-id='type-id-2' name='replacing'/>
+      <parameter type-id='type-id-9' name='rebuild'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <enum-decl name='vdev_aux' id='type-id-143'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='VDEV_AUX_NONE' value='0'/>
+      <enumerator name='VDEV_AUX_OPEN_FAILED' value='1'/>
+      <enumerator name='VDEV_AUX_CORRUPT_DATA' value='2'/>
+      <enumerator name='VDEV_AUX_NO_REPLICAS' value='3'/>
+      <enumerator name='VDEV_AUX_BAD_GUID_SUM' value='4'/>
+      <enumerator name='VDEV_AUX_TOO_SMALL' value='5'/>
+      <enumerator name='VDEV_AUX_BAD_LABEL' value='6'/>
+      <enumerator name='VDEV_AUX_VERSION_NEWER' value='7'/>
+      <enumerator name='VDEV_AUX_VERSION_OLDER' value='8'/>
+      <enumerator name='VDEV_AUX_UNSUP_FEAT' value='9'/>
+      <enumerator name='VDEV_AUX_SPARED' value='10'/>
+      <enumerator name='VDEV_AUX_ERR_EXCEEDED' value='11'/>
+      <enumerator name='VDEV_AUX_IO_FAILURE' value='12'/>
+      <enumerator name='VDEV_AUX_BAD_LOG' value='13'/>
+      <enumerator name='VDEV_AUX_EXTERNAL' value='14'/>
+      <enumerator name='VDEV_AUX_SPLIT_POOL' value='15'/>
+      <enumerator name='VDEV_AUX_BAD_ASHIFT' value='16'/>
+      <enumerator name='VDEV_AUX_EXTERNAL_PERSIST' value='17'/>
+      <enumerator name='VDEV_AUX_ACTIVE' value='18'/>
+      <enumerator name='VDEV_AUX_CHILDREN_OFFLINE' value='19'/>
+      <enumerator name='VDEV_AUX_ASHIFT_TOO_BIG' value='20'/>
     </enum-decl>
-    <typedef-decl name='data_type_t' type-id='type-id-132' id='type-id-130'/>
-    <pointer-type-def type-id='type-id-128' size-in-bits='64' id='type-id-133'/>
-    <function-decl name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-133'/>
-      <return type-id='type-id-133'/>
+    <typedef-decl name='vdev_aux_t' type-id='type-id-143' id='type-id-144'/>
+    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-7' name='guid'/>
+      <parameter type-id='type-id-144' name='aux'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='nvpair_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-7' name='guid'/>
+      <parameter type-id='type-id-144' name='aux'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zfs_strdup' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-9' name='istmp'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
+    <enum-decl name='vdev_state' id='type-id-145'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='VDEV_STATE_UNKNOWN' value='0'/>
+      <enumerator name='VDEV_STATE_CLOSED' value='1'/>
+      <enumerator name='VDEV_STATE_OFFLINE' value='2'/>
+      <enumerator name='VDEV_STATE_REMOVED' value='3'/>
+      <enumerator name='VDEV_STATE_CANT_OPEN' value='4'/>
+      <enumerator name='VDEV_STATE_FAULTED' value='5'/>
+      <enumerator name='VDEV_STATE_DEGRADED' value='6'/>
+      <enumerator name='VDEV_STATE_HEALTHY' value='7'/>
+    </enum-decl>
+    <typedef-decl name='vdev_state_t' type-id='type-id-145' id='type-id-146'/>
+    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-147'/>
+    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-2' name='flags'/>
+      <parameter type-id='type-id-147' name='newstate'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='libspl_assertf' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-6'/>
+    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='nvlist_dup' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-107'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-14' name='physpath'/>
+      <parameter type-id='type-id-18' name='phypath_size'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='dcgettext' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-85' name='avail_spare'/>
+      <parameter type-id='type-id-85' name='l2cache'/>
+      <parameter type-id='type-id-85' name='log'/>
+      <return type-id='type-id-19'/>
     </function-decl>
-    <function-decl name='zfs_standard_error' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='ppath'/>
+      <parameter type-id='type-id-85' name='avail_spare'/>
+      <parameter type-id='type-id-85' name='l2cache'/>
+      <parameter type-id='type-id-85' name='log'/>
+      <return type-id='type-id-19'/>
     </function-decl>
-    <typedef-decl name='zfs_handle_t' type-id='type-id-9' id='type-id-134'/>
-    <pointer-type-def type-id='type-id-134' size-in-bits='64' id='type-id-135'/>
-    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-137'/>
-    <typedef-decl name='zfs_iter_f' type-id='type-id-137' id='type-id-138'/>
-    <function-decl name='zfs_iter_root' mangled-name='zfs_iter_root' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_root'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-138' name='func'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
+    <enum-decl name='pool_scan_func' id='type-id-148'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='POOL_SCAN_NONE' value='0'/>
+      <enumerator name='POOL_SCAN_SCRUB' value='1'/>
+      <enumerator name='POOL_SCAN_RESILVER' value='2'/>
+      <enumerator name='POOL_SCAN_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_scan_func_t' type-id='type-id-148' id='type-id-149'/>
+    <enum-decl name='pool_scrub_cmd' id='type-id-150'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='POOL_SCRUB_NORMAL' value='0'/>
+      <enumerator name='POOL_SCRUB_PAUSE' value='1'/>
+      <enumerator name='POOL_SCRUB_FLAGS_END' value='2'/>
+    </enum-decl>
+    <typedef-decl name='pool_scrub_cmd_t' type-id='type-id-150' id='type-id-151'/>
+    <function-decl name='zpool_scan' mangled-name='zpool_scan' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-149' name='func'/>
+      <parameter type-id='type-id-151' name='cmd'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='make_dataset_handle' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-82'/>
+    <enum-decl name='pool_trim_func' id='type-id-152'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='POOL_TRIM_START' value='0'/>
+      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
+      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
+      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_trim_func_t' type-id='type-id-152' id='type-id-153'/>
+    <class-decl name='trimflags' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-154'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fullpool' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='secure' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='wait' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='rate' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='trimflags_t' type-id='type-id-154' id='type-id-155'/>
+    <pointer-type-def type-id='type-id-155' size-in-bits='64' id='type-id-156'/>
+    <function-decl name='zpool_trim' mangled-name='zpool_trim' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-153' name='cmd_type'/>
+      <parameter type-id='type-id-19' name='vds'/>
+      <parameter type-id='type-id-156' name='trim_flags'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-136'>
-      <parameter type-id='type-id-135'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-123'>
-      <parameter type-id='type-id-11'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_crypto.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-106' name='is_encroot'/>
-      <parameter type-id='type-id-17' name='buf'/>
-      <return type-id='type-id-8'/>
+    <enum-decl name='pool_initialize_func' id='type-id-157'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='POOL_INITIALIZE_START' value='0'/>
+      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
+      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
+      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_initialize_func_t' type-id='type-id-157' id='type-id-158'/>
+    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-158' name='cmd_type'/>
+      <parameter type-id='type-id-19' name='vds'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-139'/>
-    <typedef-decl name='uint_t' type-id='type-id-5' id='type-id-140'/>
-    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-141'/>
-    <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_create'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-17' name='parent_name'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <parameter type-id='type-id-15' name='pool_props'/>
-      <parameter type-id='type-id-16' name='stdin_available'/>
-      <parameter type-id='type-id-139' name='wkeydata_out'/>
-      <parameter type-id='type-id-141' name='wkeylen_out'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-158' name='cmd_type'/>
+      <parameter type-id='type-id-19' name='vds'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zfs_prop_to_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-85'/>
+    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-19' name='config'/>
+      <parameter type-id='type-id-84' name='newname'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <parameter type-id='type-id-2' name='flags'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
+      <parameter type-id='type-id-19' name='config'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_import' mangled-name='zpool_import' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-19' name='config'/>
+      <parameter type-id='type-id-84' name='newname'/>
+      <parameter type-id='type-id-14' name='altroot'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='name'/>
+      <parameter type-id='type-id-2' name='reason'/>
+      <parameter type-id='type-id-19' name='config'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='log_str'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_export' mangled-name='zpool_export' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-9' name='force'/>
+      <parameter type-id='type-id-84' name='log_str'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_add' mangled-name='zpool_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-19' name='nvroot'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='log_str'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_create' mangled-name='zpool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='pool'/>
+      <parameter type-id='type-id-19' name='nvroot'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <parameter type-id='type-id-19' name='fsprops'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
+      <parameter type-id='type-id-84' name='name'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
+      <parameter type-id='type-id-4' name='zhp'/>
       <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-102'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zpool_close' mangled-name='zpool_close' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-88'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zpool_open' mangled-name='zpool_open' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='pool'/>
+      <return type-id='type-id-4'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-142'>
-      <underlying-type type-id='type-id-49'/>
+    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='pool'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='propname'/>
+      <parameter type-id='type-id-14' name='buf'/>
+      <parameter type-id='type-id-18' name='len'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-103' name='plp'/>
+      <parameter type-id='type-id-9' name='literal'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='propname'/>
+      <parameter type-id='type-id-84' name='propval'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-159'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZPOOL_PROP_INVAL' value='-1'/>
       <enumerator name='ZPOOL_PROP_NAME' value='0'/>
       <enumerator name='ZPOOL_PROP_SIZE' value='1'/>
@@ -1640,2617 +3083,479 @@
       <enumerator name='ZPOOL_PROP_COMPATIBILITY' value='32'/>
       <enumerator name='ZPOOL_NUM_PROPS' value='33'/>
     </enum-decl>
-    <function-decl name='zpool_get_prop_int' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-142'/>
-      <parameter type-id='type-id-87'/>
-      <return type-id='type-id-35'/>
+    <typedef-decl name='zpool_prop_t' type-id='type-id-159' id='type-id-160'/>
+    <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-160' name='prop'/>
+      <parameter type-id='type-id-14' name='buf'/>
+      <parameter type-id='type-id-18' name='len'/>
+      <parameter type-id='type-id-113' name='srctype'/>
+      <parameter type-id='type-id-9' name='literal'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zpool_get_features' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
-      <return type-id='type-id-104'/>
-    </function-decl>
-    <function-decl name='zfs_error_aux' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='open' mangled-name='open64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='read' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-54'/>
-    </function-decl>
-    <function-decl name='close' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-135' name='origin_zhp'/>
-      <parameter type-id='type-id-17' name='parent_name'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-17' name='fsname'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_handle_dup' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-82'/>
-    </function-decl>
-    <function-decl name='zfs_iter_filesystems' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-95'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-16' name='noop'/>
-      <parameter type-id='type-id-17' name='alt_keylocation'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_load_key' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-69' const='yes' id='type-id-143'/>
-    <pointer-type-def type-id='type-id-143' size-in-bits='64' id='type-id-144'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-145'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='rm_so' type-id='type-id-146' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='rm_eo' type-id='type-id-146' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='regoff_t' type-id='type-id-8' id='type-id-146'/>
-    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-147'/>
-    <function-decl name='regexec' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-144'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-147'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='type-id-148'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_flags' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-149' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-150' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='_fileno' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='_flags2' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-151' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-152' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-153' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-154' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-155' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-156' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-157' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-150' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-28' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='_mode' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-158' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-159'/>
-    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-149'/>
-    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-150'/>
-    <typedef-decl name='__off_t' type-id='type-id-54' id='type-id-151'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-152'/>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-153'/>
-
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='8' id='type-id-154'>
-      <subrange length='1' type-id='type-id-33' id='type-id-160'/>
-
-    </array-type-def>
-    <typedef-decl name='__off64_t' type-id='type-id-54' id='type-id-155'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-161'/>
-    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-156'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-162'/>
-    <pointer-type-def type-id='type-id-162' size-in-bits='64' id='type-id-157'/>
-
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='160' id='type-id-158'>
-      <subrange length='20' type-id='type-id-33' id='type-id-163'/>
-
-    </array-type-def>
-    <function-decl name='fileno' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-150'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='isatty' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-75' const='yes' id='type-id-164'/>
-    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-165'/>
-    <function-decl name='PKCS5_PBKDF2_HMAC_SHA1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-165'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-73'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_unload_key' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-15' name='raw_props'/>
-      <parameter type-id='type-id-16' name='inheritkey'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_parent_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-104'/>
-    </function-decl>
-    <function-decl name='zfs_name_to_prop' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-85'/>
-    </function-decl>
-    <function-decl name='zfs_valid_proplist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-104'/>
-    </function-decl>
-    <function-decl name='lzc_change_key' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='ferror' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-150'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='1024' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-166' visibility='default' id='type-id-167'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__val' type-id='type-id-168' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-35' size-in-bits='1024' id='type-id-168'>
-      <subrange length='16' type-id='type-id-33' id='type-id-169'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-170'/>
-    <function-decl name='sigemptyset' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-170'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='sigaction' size-in-bits='1216' is-struct='yes' visibility='default' id='type-id-171'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__sigaction_handler' type-id='type-id-172' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='sa_mask' type-id='type-id-166' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='sa_flags' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='sa_restorer' type-id='type-id-173' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-172'>
-      <data-member access='private'>
-        <var-decl name='sa_handler' type-id='type-id-174' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='sa_sigaction' type-id='type-id-175' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-177'/>
-    <typedef-decl name='__sighandler_t' type-id='type-id-177' id='type-id-174'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='1024' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-178' visibility='default' id='type-id-179'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='si_signo' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='si_errno' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='si_code' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__pad0' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_sifields' type-id='type-id-180' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='896' is-anonymous='yes' visibility='default' id='type-id-180'>
-      <data-member access='private'>
-        <var-decl name='_pad' type-id='type-id-181' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='_kill' type-id='type-id-182' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='_timer' type-id='type-id-183' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='_rt' type-id='type-id-184' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='_sigchld' type-id='type-id-185' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='_sigfault' type-id='type-id-186' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='_sigpoll' type-id='type-id-187' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='_sigsys' type-id='type-id-188' visibility='default'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='896' id='type-id-181'>
-      <subrange length='28' type-id='type-id-33' id='type-id-189'/>
-
-    </array-type-def>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-182'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='si_pid' type-id='type-id-190' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='si_uid' type-id='type-id-191' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__pid_t' type-id='type-id-8' id='type-id-190'/>
-    <typedef-decl name='__uid_t' type-id='type-id-5' id='type-id-191'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-183'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='si_tid' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='si_overrun' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='si_sigval' type-id='type-id-192' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <union-decl name='sigval' size-in-bits='64' visibility='default' id='type-id-193'>
-      <data-member access='private'>
-        <var-decl name='sival_int' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='sival_ptr' type-id='type-id-7' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='__sigval_t' type-id='type-id-193' id='type-id-192'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-184'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='si_pid' type-id='type-id-190' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='si_uid' type-id='type-id-191' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='si_sigval' type-id='type-id-192' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-185'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='si_pid' type-id='type-id-190' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='si_uid' type-id='type-id-191' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='si_status' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='si_utime' type-id='type-id-194' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='si_stime' type-id='type-id-194' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__clock_t' type-id='type-id-54' id='type-id-194'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-186'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='si_addr' type-id='type-id-7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='si_addr_lsb' type-id='type-id-55' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_bounds' type-id='type-id-195' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' id='type-id-195'>
-      <data-member access='private'>
-        <var-decl name='_addr_bnd' type-id='type-id-196' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='_pkey' type-id='type-id-40' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-196'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_lower' type-id='type-id-7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_upper' type-id='type-id-7' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-187'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='si_band' type-id='type-id-54' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='si_fd' type-id='type-id-8' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-188'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_call_addr' type-id='type-id-7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_syscall' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='_arch' type-id='type-id-5' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='siginfo_t' type-id='type-id-179' id='type-id-178'/>
-    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-197'/>
-    <pointer-type-def type-id='type-id-198' size-in-bits='64' id='type-id-175'/>
-    <typedef-decl name='__sigset_t' type-id='type-id-167' id='type-id-166'/>
-    <pointer-type-def type-id='type-id-199' size-in-bits='64' id='type-id-173'/>
-    <qualified-type-def type-id='type-id-171' const='yes' id='type-id-200'/>
-    <pointer-type-def type-id='type-id-200' size-in-bits='64' id='type-id-201'/>
-    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-202'/>
-    <function-decl name='sigaction' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-201'/>
-      <parameter type-id='type-id-202'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fputc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-150'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fflush' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-150'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='termios' size-in-bits='480' is-struct='yes' visibility='default' id='type-id-203'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='c_iflag' type-id='type-id-204' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='c_oflag' type-id='type-id-204' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='c_cflag' type-id='type-id-204' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='c_lflag' type-id='type-id-204' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='c_line' type-id='type-id-205' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='136'>
-        <var-decl name='c_cc' type-id='type-id-206' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='c_ispeed' type-id='type-id-207' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='c_ospeed' type-id='type-id-207' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='tcflag_t' type-id='type-id-5' id='type-id-204'/>
-    <typedef-decl name='cc_t' type-id='type-id-75' id='type-id-205'/>
-
-    <array-type-def dimensions='1' type-id='type-id-205' size-in-bits='256' id='type-id-206'>
-      <subrange length='32' type-id='type-id-33' id='type-id-208'/>
-
-    </array-type-def>
-    <typedef-decl name='speed_t' type-id='type-id-5' id='type-id-207'/>
-    <pointer-type-def type-id='type-id-203' size-in-bits='64' id='type-id-209'/>
-    <function-decl name='tcgetattr' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-209'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-203' const='yes' id='type-id-210'/>
-    <pointer-type-def type-id='type-id-210' size-in-bits='64' id='type-id-211'/>
-    <function-decl name='tcsetattr' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-211'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='getpid' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='kill' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fclose' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-150'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='dlopen' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='dlsym' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='fdopen' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-150'/>
-    </function-decl>
-    <function-decl name='dlerror' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='asprintf' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-88'/>
-      <parameter type-id='type-id-84'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='mkostemps' mangled-name='mkostemps64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='unlink' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='rewind' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-150'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-199'>
-      <return type-id='type-id-6'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-176'>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-6'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-198'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-197'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-6'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_dataset.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_type_to_name' mangled-name='zfs_type_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_type_to_name'>
-      <parameter type-id='type-id-13' name='type'/>
+    <function-decl name='zpool_pool_state_to_name' mangled-name='zpool_pool_state_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_pool_state_to_name'>
+      <parameter type-id='type-id-128' name='state'/>
       <return type-id='type-id-84'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-212'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='NAME_ERR_LEADING_SLASH' value='0'/>
-      <enumerator name='NAME_ERR_EMPTY_COMPONENT' value='1'/>
-      <enumerator name='NAME_ERR_TRAILING_SLASH' value='2'/>
-      <enumerator name='NAME_ERR_INVALCHAR' value='3'/>
-      <enumerator name='NAME_ERR_MULTIPLE_DELIMITERS' value='4'/>
-      <enumerator name='NAME_ERR_NOLETTER' value='5'/>
-      <enumerator name='NAME_ERR_RESERVED' value='6'/>
-      <enumerator name='NAME_ERR_DISKLIKE' value='7'/>
-      <enumerator name='NAME_ERR_TOOLONG' value='8'/>
-      <enumerator name='NAME_ERR_SELF_REF' value='9'/>
-      <enumerator name='NAME_ERR_PARENT_REF' value='10'/>
-      <enumerator name='NAME_ERR_NO_AT' value='11'/>
-      <enumerator name='NAME_ERR_NO_POUND' value='12'/>
-    </enum-decl>
-    <pointer-type-def type-id='type-id-212' size-in-bits='64' id='type-id-213'/>
-    <function-decl name='entity_namecheck' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-213'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_valid'>
-      <parameter type-id='type-id-84' name='name'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_name_valid' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_free_handles'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_close' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_refresh_properties'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_get_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
+    <function-decl name='zpool_state_to_name' mangled-name='zpool_state_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_state_to_name'>
+      <parameter type-id='type-id-146' name='state'/>
+      <parameter type-id='type-id-144' name='aux'/>
       <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zpool_open_canfail' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_handle_dup'>
-      <parameter type-id='type-id-135' name='zhp_orig'/>
-      <return type-id='type-id-135'/>
-    </function-decl>
-    <function-decl name='zfs_close' mangled-name='zfs_close' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_close'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_bookmark_exists' mangled-name='zfs_bookmark_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_bookmark_exists'>
-      <parameter type-id='type-id-84' name='path'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='lzc_get_bookmarks' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_open' mangled-name='zfs_open' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_open'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-8' name='types'/>
-      <return type-id='type-id-135'/>
-    </function-decl>
-    <function-decl name='zfs_iter_bookmarks' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-95'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_init'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-51' size-in-bits='64' id='type-id-214'/>
-    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-215'>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-216' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-8' visibility='default'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='32' id='type-id-216'>
-      <subrange length='4' type-id='type-id-33' id='type-id-217'/>
-
-    </array-type-def>
-    <qualified-type-def type-id='type-id-215' const='yes' id='type-id-218'/>
-    <pointer-type-def type-id='type-id-218' size-in-bits='64' id='type-id-219'/>
-    <function-decl name='pthread_mutex_init' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-214'/>
-      <parameter type-id='type-id-219'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-60' size-in-bits='64' id='type-id-220'/>
-    <function-decl name='avl_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-220'/>
-      <parameter type-id='type-id-62'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_fini'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-220'/>
-      <parameter type-id='type-id-103'/>
+    <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-160' name='prop'/>
+      <parameter type-id='type-id-113' name='src'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='avl_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-220'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-214'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_cache' mangled-name='libzfs_mnttab_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_cache'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-16' name='enable'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-221'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='type-id-17' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-221' size-in-bits='64' id='type-id-222'/>
-    <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_find'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='fsname'/>
-      <parameter type-id='type-id-222' name='entry'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_lock' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-214'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='avl_numnodes' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-220'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='avl_find' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-220'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-102'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='getmntany' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-150'/>
-      <parameter type-id='type-id-222'/>
-      <parameter type-id='type-id-222'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_unlock' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-214'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='avl_add' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-220'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_add'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='special'/>
-      <parameter type-id='type-id-84' name='mountp'/>
-      <parameter type-id='type-id-84' name='mntopts'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_remove'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='fsname'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='avl_remove' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-220'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-223'/>
-    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-223' name='spa_version'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valid_proplist'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <parameter type-id='type-id-15' name='nvl'/>
-      <parameter type-id='type-id-22' name='zoned'/>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-11' name='zpool_hdl'/>
-      <parameter type-id='type-id-16' name='key_params_ok'/>
-      <parameter type-id='type-id-84' name='errbuf'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-107'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_valid_for_type' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-50'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zfs_prop_readonly' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-85'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zfs_prop_setonce' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-85'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zfs_prop_encryption_key_param' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-85'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zprop_parse_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-133'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-88'/>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_user' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='nvpair_type' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <return type-id='type-id-132'/>
-    </function-decl>
-    <function-decl name='nvpair_value_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <parameter type-id='type-id-88'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_userquota' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zfs_nicestrtonum' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-102'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <parameter type-id='type-id-102'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='mountpoint_namecheck' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-213'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_valid_keylocation' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-50'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zpool_prop_get_feature' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_parse_options' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_written' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zfs_nicebytes' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <class-decl name='passwd' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-224'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pw_name' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pw_passwd' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pw_uid' type-id='type-id-191' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='pw_gid' type-id='type-id-225' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pw_gecos' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pw_dir' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pw_shell' type-id='type-id-17' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__gid_t' type-id='type-id-5' id='type-id-225'/>
-    <pointer-type-def type-id='type-id-224' size-in-bits='64' id='type-id-226'/>
-    <function-decl name='getpwnam' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-226'/>
-    </function-decl>
-    <class-decl name='group' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-227'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='gr_name' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='gr_passwd' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='gr_gid' type-id='type-id-225' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='gr_mem' type-id='type-id-88' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-227' size-in-bits='64' id='type-id-228'/>
-    <function-decl name='getgrnam' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-228'/>
-    </function-decl>
-    <typedef-decl name='zfs_prop_t' type-id='type-id-85' id='type-id-229'/>
-    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_int'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-84' name='propval'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_set_list' mangled-name='zfs_prop_set_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvlist_free' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
-      <parameter type-id='type-id-11' name='zph'/>
-      <parameter type-id='type-id-22' name='volsize'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <class-decl name='prop_changelist' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-230'/>
-    <pointer-type-def type-id='type-id-230' size-in-bits='64' id='type-id-231'/>
-    <function-decl name='changelist_gather' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-85'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-231'/>
-    </function-decl>
-    <function-decl name='changelist_haszonedchild' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-231'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='changelist_prefix' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-231'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zcmd_write_src_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-122'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='changelist_free' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-231'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='changelist_postfix' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-231'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_setprop_error' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-85'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='nvlist_remove_all' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_inherit' mangled-name='zfs_prop_inherit' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inherit'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-16' name='received'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_inheritable' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-85'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='getprop_uint64' mangled-name='getprop_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getprop_uint64'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-229' name='prop'/>
-      <parameter type-id='type-id-88' name='source'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='zfs_prop_default_numeric' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-85'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_recvd' mangled-name='zfs_prop_get_recvd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_recvd'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-17' name='propbuf'/>
-      <parameter type-id='type-id-28' name='proplen'/>
-      <parameter type-id='type-id-16' name='literal'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <typedef-decl name='zprop_source_t' type-id='type-id-86' id='type-id-232'/>
-    <pointer-type-def type-id='type-id-232' size-in-bits='64' id='type-id-233'/>
-    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-229' name='prop'/>
-      <parameter type-id='type-id-17' name='propbuf'/>
-      <parameter type-id='type-id-28' name='proplen'/>
-      <parameter type-id='type-id-233' name='src'/>
-      <parameter type-id='type-id-17' name='statbuf'/>
-      <parameter type-id='type-id-28' name='statlen'/>
-      <parameter type-id='type-id-16' name='literal'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-234'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='PROP_TYPE_NUMBER' value='0'/>
-      <enumerator name='PROP_TYPE_STRING' value='1'/>
-      <enumerator name='PROP_TYPE_INDEX' value='2'/>
-    </enum-decl>
-    <function-decl name='zfs_prop_get_type' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-85'/>
-      <return type-id='type-id-234'/>
-    </function-decl>
-    <function-decl name='zfs_nicenum' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <class-decl name='tm' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-235'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tm_sec' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='tm_min' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tm_hour' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='tm_mday' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tm_mon' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='tm_year' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='tm_wday' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='tm_yday' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='tm_isdst' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='tm_gmtoff' type-id='type-id-54' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='tm_zone' type-id='type-id-84' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-236'/>
-    <qualified-type-def type-id='type-id-54' const='yes' id='type-id-237'/>
-    <pointer-type-def type-id='type-id-237' size-in-bits='64' id='type-id-238'/>
-    <function-decl name='localtime_r' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-238'/>
-      <parameter type-id='type-id-236'/>
-      <return type-id='type-id-236'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-235' const='yes' id='type-id-239'/>
-    <pointer-type-def type-id='type-id-239' size-in-bits='64' id='type-id-240'/>
-    <function-decl name='strftime' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-240'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='zpool_get_prop' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-142'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-87'/>
-      <parameter type-id='type-id-50'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-241'/>
-    <function-decl name='zfs_prop_index_to_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-85'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-241'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_clones_nvl'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='strsep' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-88'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_boolean' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='lzc_channel_program_nosync' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-104'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-242'/>
-    <function-decl name='nvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-242'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_default_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-85'/>
+    <function-decl name='zpool_props_refresh' mangled-name='zpool_props_refresh' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_props_refresh'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_get_state_str' mangled-name='zpool_get_state_str' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state_str'>
+      <parameter type-id='type-id-4' name='zhp'/>
       <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-243'/>
-    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-244'/>
-    <function-decl name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-243'/>
-      <parameter type-id='type-id-244'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvlist_empty' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <class-decl name='mntent' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-245'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_fsname' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_dir' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_type' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_opts' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='mnt_freq' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='mnt_passno' type-id='type-id-8' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <qualified-type-def type-id='type-id-245' const='yes' id='type-id-246'/>
-    <pointer-type-def type-id='type-id-246' size-in-bits='64' id='type-id-247'/>
-    <function-decl name='hasmntopt' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-247'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-248'/>
-    <function-decl name='zfs_prop_get_numeric' mangled-name='zfs_prop_get_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_numeric'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-229' name='prop'/>
-      <parameter type-id='type-id-248' name='value'/>
-      <parameter type-id='type-id-233' name='src'/>
-      <parameter type-id='type-id-17' name='statbuf'/>
-      <parameter type-id='type-id-28' name='statlen'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_error_fmt' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_userquota_int' mangled-name='zfs_prop_get_userquota_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota_int'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-248' name='propvalue'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_userquota' mangled-name='zfs_prop_get_userquota' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-17' name='propbuf'/>
-      <parameter type-id='type-id-8' name='proplen'/>
-      <parameter type-id='type-id-16' name='literal'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_written_int' mangled-name='zfs_prop_get_written_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written_int'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-248' name='propvalue'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_written' mangled-name='zfs_prop_get_written' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-17' name='propbuf'/>
-      <parameter type-id='type-id-8' name='proplen'/>
-      <parameter type-id='type-id-16' name='literal'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-134' const='yes' id='type-id-249'/>
-    <pointer-type-def type-id='type-id-249' size-in-bits='64' id='type-id-250'/>
-    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_name'>
-      <parameter type-id='type-id-250' name='zhp'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zfs_get_pool_name' mangled-name='zfs_get_pool_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_name'>
-      <parameter type-id='type-id-250' name='zhp'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_type'>
-      <parameter type-id='type-id-250' name='zhp'/>
-      <return type-id='type-id-13'/>
-    </function-decl>
-    <function-decl name='zfs_get_underlying_type' mangled-name='zfs_get_underlying_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_type'>
-      <parameter type-id='type-id-250' name='zhp'/>
-      <return type-id='type-id-13'/>
-    </function-decl>
-    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-17' name='buf'/>
-      <parameter type-id='type-id-28' name='buflen'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_exists'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-13' name='types'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_create' mangled-name='zfs_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_share' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_commit_all_shares' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='dataset_nestcheck' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_open' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-251'/>
-    <function-decl name='zfs_crypto_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-251'/>
-      <parameter type-id='type-id-244'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <enum-decl name='lzc_dataset_type' id='type-id-252'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='LZC_DATSET_TYPE_ZFS' value='2'/>
-      <enumerator name='LZC_DATSET_TYPE_ZVOL' value='3'/>
-    </enum-decl>
-    <function-decl name='lzc_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-252'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-16' name='defer'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_destroy_bookmarks' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_destroy_snaps' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_standard_error_fmt' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-17' name='snapname'/>
-      <parameter type-id='type-id-16' name='defer'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-15' name='snaps'/>
-      <parameter type-id='type-id-16' name='defer'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_exists' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_clone' mangled-name='zfs_clone' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='target'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_clone_check' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_clone' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_promote' mangled-name='zfs_promote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_promote' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-15' name='snaps'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_snapshot' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-16' name='recursive'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-135' name='snap'/>
-      <parameter type-id='type-id-16' name='force'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_iter_snapshots' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-95'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_rollback_to' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='renameflags' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-253'>
-      <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='recursive' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='30'>
-        <var-decl name='nounmount' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='29'>
-        <var-decl name='forceunmount' type-id='type-id-8' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='renameflags_t' type-id='type-id-253' id='type-id-254'/>
-    <function-decl name='zfs_rename' mangled-name='zfs_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='target'/>
-      <parameter type-id='type-id-254' name='flags'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='changelist_rename' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-231'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <class-decl name='zprop_list' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-255'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pl_prop' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pl_user_prop' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pl_next' type-id='type-id-256' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pl_all' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pl_width' type-id='type-id-28' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pl_recvd_width' type-id='type-id-28' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='pl_fixed' type-id='type-id-16' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-255' size-in-bits='64' id='type-id-256'/>
-    <typedef-decl name='zprop_list_t' type-id='type-id-255' id='type-id-257'/>
-    <pointer-type-def type-id='type-id-257' size-in-bits='64' id='type-id-258'/>
-    <pointer-type-def type-id='type-id-258' size-in-bits='64' id='type-id-259'/>
-    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-259' name='plp'/>
-      <parameter type-id='type-id-16' name='received'/>
-      <parameter type-id='type-id-16' name='literal'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-256' size-in-bits='64' id='type-id-260'/>
-    <function-decl name='zprop_expand_list' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-260'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-18' name='props'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='nvlist_remove' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-132'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-17' name='dataset'/>
-      <parameter type-id='type-id-17' name='path'/>
-      <parameter type-id='type-id-17' name='resource'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='ioctl' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-35'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-17' name='dataset'/>
-      <parameter type-id='type-id-17' name='path'/>
-      <parameter type-id='type-id-17' name='resource'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-17' name='dataset'/>
-      <parameter type-id='type-id-17' name='path'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-17' name='dataset'/>
-      <parameter type-id='type-id-17' name='path'/>
-      <parameter type-id='type-id-17' name='oldname'/>
-      <parameter type-id='type-id-17' name='newname'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-261'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='ZFS_PROP_USERUSED' value='0'/>
-      <enumerator name='ZFS_PROP_USERQUOTA' value='1'/>
-      <enumerator name='ZFS_PROP_GROUPUSED' value='2'/>
-      <enumerator name='ZFS_PROP_GROUPQUOTA' value='3'/>
-      <enumerator name='ZFS_PROP_USEROBJUSED' value='4'/>
-      <enumerator name='ZFS_PROP_USEROBJQUOTA' value='5'/>
-      <enumerator name='ZFS_PROP_GROUPOBJUSED' value='6'/>
-      <enumerator name='ZFS_PROP_GROUPOBJQUOTA' value='7'/>
-      <enumerator name='ZFS_PROP_PROJECTUSED' value='8'/>
-      <enumerator name='ZFS_PROP_PROJECTQUOTA' value='9'/>
-      <enumerator name='ZFS_PROP_PROJECTOBJUSED' value='10'/>
-      <enumerator name='ZFS_PROP_PROJECTOBJQUOTA' value='11'/>
-      <enumerator name='ZFS_NUM_USERQUOTA_PROPS' value='12'/>
-    </enum-decl>
-    <typedef-decl name='zfs_userquota_prop_t' type-id='type-id-261' id='type-id-262'/>
-    <typedef-decl name='uid_t' type-id='type-id-191' id='type-id-263'/>
-    <pointer-type-def type-id='type-id-264' size-in-bits='64' id='type-id-265'/>
-    <typedef-decl name='zfs_userspace_cb_t' type-id='type-id-265' id='type-id-266'/>
-    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-262' name='type'/>
-      <parameter type-id='type-id-266' name='func'/>
-      <parameter type-id='type-id-7' name='arg'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_hold' mangled-name='zfs_hold' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='snapname'/>
-      <parameter type-id='type-id-84' name='tag'/>
-      <parameter type-id='type-id-16' name='recursive'/>
-      <parameter type-id='type-id-8' name='cleanup_fd'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-8' name='cleanup_fd'/>
-      <parameter type-id='type-id-15' name='holds'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_hold' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_release' mangled-name='zfs_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='snapname'/>
-      <parameter type-id='type-id-84' name='tag'/>
-      <parameter type-id='type-id-16' name='recursive'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_release' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_get_holds' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-105' name='nvl'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvlist_unpack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-107'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-16' name='un'/>
-      <parameter type-id='type-id-15' name='nvl'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvlist_size' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvlist_pack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-88'/>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-105' name='nvl'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_get_config' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-104'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-267'/>
-    <function-decl name='nvlist_lookup_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-267'/>
-      <parameter type-id='type-id-244'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-268'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
-      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
-    </enum-decl>
-    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-268' id='type-id-269'/>
-    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-269' name='activity'/>
-      <parameter type-id='type-id-106' name='missing'/>
-      <parameter type-id='type-id-106' name='waited'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_wait_fs' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-268'/>
-      <parameter type-id='type-id-213'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='changelist_remove' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-231'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-264'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-263'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_diff.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_show_diffs' mangled-name='zfs_show_diffs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_show_diffs'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-8' name='outfd'/>
-      <parameter type-id='type-id-84' name='fromsnap'/>
-      <parameter type-id='type-id-84' name='tosnap'/>
-      <parameter type-id='type-id-8' name='flags'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_validate_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-50'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_asprintf' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='is_mounted' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-88'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <class-decl name='differ_info' size-in-bits='9024' is-struct='yes' visibility='default' id='type-id-270'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zhp' type-id='type-id-135' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='fromsnap' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='frommnt' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='tosnap' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='tomnt' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='ds' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='dsmnt' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='tmpsnap' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='errbuf' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8704'>
-        <var-decl name='isclone' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8736'>
-        <var-decl name='scripted' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8768'>
-        <var-decl name='classify' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8800'>
-        <var-decl name='timestamped' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8832'>
-        <var-decl name='shares' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8896'>
-        <var-decl name='zerr' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8928'>
-        <var-decl name='cleanupfd' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8960'>
-        <var-decl name='outputfd' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8992'>
-        <var-decl name='datafd' type-id='type-id-8' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-270' size-in-bits='64' id='type-id-271'/>
-    <function-decl name='find_shares_object' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-271'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='pipe2' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-223'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' id='type-id-272'>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-273' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-54' visibility='default'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='448' id='type-id-273'>
-      <subrange length='56' type-id='type-id-33' id='type-id-274'/>
-
-    </array-type-def>
-    <qualified-type-def type-id='type-id-272' const='yes' id='type-id-275'/>
-    <pointer-type-def type-id='type-id-275' size-in-bits='64' id='type-id-276'/>
-    <pointer-type-def type-id='type-id-277' size-in-bits='64' id='type-id-278'/>
-    <function-decl name='pthread_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-276'/>
-      <parameter type-id='type-id-278'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='pthread_join' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-103'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='pthread_cancel' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-277'>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-7'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_import.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-279'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pco_refresh_config' type-id='type-id-280' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pco_pool_active' type-id='type-id-281' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='refresh_config_func_t' type-id='type-id-282' id='type-id-283'/>
-    <pointer-type-def type-id='type-id-283' size-in-bits='64' id='type-id-280'/>
-    <typedef-decl name='pool_active_func_t' type-id='type-id-284' id='type-id-285'/>
-    <pointer-type-def type-id='type-id-285' size-in-bits='64' id='type-id-281'/>
-    <qualified-type-def type-id='type-id-279' const='yes' id='type-id-286'/>
-    <typedef-decl name='pool_config_ops_t' type-id='type-id-286' id='type-id-287'/>
-    <var-decl name='libzfs_config_ops' type-id='type-id-287' mangled-name='libzfs_config_ops' visibility='default' elf-symbol-id='libzfs_config_ops'/>
-    <function-decl name='zcmd_write_conf_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-122'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_clear_label' mangled-name='zpool_clear_label' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear_label'>
-      <parameter type-id='type-id-8' name='fd'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='pread64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-54'/>
-      <return type-id='type-id-54'/>
-    </function-decl>
-    <function-decl name='pwrite64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-54'/>
-      <return type-id='type-id-54'/>
-    </function-decl>
-    <enum-decl name='pool_state' id='type-id-289'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='POOL_STATE_ACTIVE' value='0'/>
-      <enumerator name='POOL_STATE_EXPORTED' value='1'/>
-      <enumerator name='POOL_STATE_DESTROYED' value='2'/>
-      <enumerator name='POOL_STATE_SPARE' value='3'/>
-      <enumerator name='POOL_STATE_L2CACHE' value='4'/>
-      <enumerator name='POOL_STATE_UNINITIALIZED' value='5'/>
-      <enumerator name='POOL_STATE_UNAVAIL' value='6'/>
-      <enumerator name='POOL_STATE_POTENTIALLY_ACTIVE' value='7'/>
-    </enum-decl>
-    <typedef-decl name='pool_state_t' type-id='type-id-289' id='type-id-290'/>
-    <pointer-type-def type-id='type-id-290' size-in-bits='64' id='type-id-291'/>
-    <function-decl name='zpool_in_use' mangled-name='zpool_in_use' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_in_use'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-8' name='fd'/>
-      <parameter type-id='type-id-291' name='state'/>
-      <parameter type-id='type-id-88' name='namestr'/>
-      <parameter type-id='type-id-106' name='inuse'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_read_label' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-107'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-292' size-in-bits='64' id='type-id-293'/>
-    <function-decl name='zpool_iter' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-293'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-284'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-106'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-292'>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-282'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-15'/>
-      <return type-id='type-id-15'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_iter.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-138' name='func'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='make_dataset_handle_zc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-122'/>
-      <return type-id='type-id-82'/>
-    </function-decl>
-    <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-16' name='simple'/>
-      <parameter type-id='type-id-138' name='func'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <parameter type-id='type-id-22' name='min_txg'/>
-      <parameter type-id='type-id-22' name='max_txg'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='make_dataset_simple_handle_zc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-122'/>
-      <return type-id='type-id-82'/>
-    </function-decl>
-    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-138' name='func'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_get_type' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-97'/>
-      <return type-id='type-id-76'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <return type-id='type-id-104'/>
-    </function-decl>
-    <function-decl name='make_bookmark_handle' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-82'/>
-    </function-decl>
-    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-138' name='callback'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <parameter type-id='type-id-22' name='min_txg'/>
-      <parameter type-id='type-id-22' name='max_txg'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='avl_first' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-220'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='avl_walk' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-220'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
-      <parameter type-id='type-id-135' name='fs_zhp'/>
-      <parameter type-id='type-id-84' name='spec_orig'/>
-      <parameter type-id='type-id-138' name='func'/>
-      <parameter type-id='type-id-7' name='arg'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_dataset_exists' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-138' name='func'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-16' name='allowrecursion'/>
-      <parameter type-id='type-id-138' name='func'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_get_clones_nvl' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-104'/>
-    </function-decl>
-    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-138' name='func'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_mount.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='is_mounted' mangled-name='is_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mounted'>
-      <parameter type-id='type-id-10' name='zfs_hdl'/>
-      <parameter type-id='type-id-84' name='special'/>
-      <parameter type-id='type-id-88' name='where'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_find' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-222'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mounted'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-88' name='where'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_mount' mangled-name='zfs_mount' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='options'/>
-      <parameter type-id='type-id-8' name='flags'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_mount_at' mangled-name='zfs_mount_at' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_at'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='options'/>
-      <parameter type-id='type-id-8' name='flags'/>
-      <parameter type-id='type-id-84' name='mountpoint'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='getprop_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-85'/>
-      <parameter type-id='type-id-88'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-294'/>
-    <function-decl name='zfs_crypto_get_encryption_root' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-294'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_load_key' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='mkdirp' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='statfs64' size-in-bits='960' is-struct='yes' visibility='default' id='type-id-295'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='f_type' type-id='type-id-296' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='f_bsize' type-id='type-id-296' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='f_blocks' type-id='type-id-297' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='f_bfree' type-id='type-id-297' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='f_bavail' type-id='type-id-297' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='f_files' type-id='type-id-298' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='f_ffree' type-id='type-id-298' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='f_fsid' type-id='type-id-299' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='f_namelen' type-id='type-id-296' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='f_frsize' type-id='type-id-296' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='f_flags' type-id='type-id-296' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='f_spare' type-id='type-id-300' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__fsword_t' type-id='type-id-54' id='type-id-296'/>
-    <typedef-decl name='__fsblkcnt64_t' type-id='type-id-35' id='type-id-297'/>
-    <typedef-decl name='__fsfilcnt64_t' type-id='type-id-35' id='type-id-298'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-299' visibility='default' id='type-id-301'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__val' type-id='type-id-302' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='64' id='type-id-302'>
-      <subrange length='2' type-id='type-id-33' id='type-id-67'/>
-
-    </array-type-def>
-    <typedef-decl name='__fsid_t' type-id='type-id-301' id='type-id-299'/>
-
-    <array-type-def dimensions='1' type-id='type-id-296' size-in-bits='256' id='type-id-300'>
-      <subrange length='4' type-id='type-id-33' id='type-id-217'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-295' size-in-bits='64' id='type-id-303'/>
-    <function-decl name='statfs64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-303'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='openat' mangled-name='openat64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='__dirstream' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-304'/>
-    <pointer-type-def type-id='type-id-304' size-in-bits='64' id='type-id-305'/>
-    <function-decl name='fdopendir' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-305'/>
-    </function-decl>
-    <class-decl name='dirent64' size-in-bits='2240' is-struct='yes' visibility='default' id='type-id-306'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='d_ino' type-id='type-id-307' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='d_off' type-id='type-id-155' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='d_reclen' type-id='type-id-152' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='d_type' type-id='type-id-75' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='152'>
-        <var-decl name='d_name' type-id='type-id-12' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__ino64_t' type-id='type-id-35' id='type-id-307'/>
-    <pointer-type-def type-id='type-id-306' size-in-bits='64' id='type-id-308'/>
-    <function-decl name='readdir64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-305'/>
-      <return type-id='type-id-308'/>
-    </function-decl>
-    <function-decl name='closedir' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-305'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='do_mount' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_remove' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_add' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_spa_version' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='mountpoint'/>
-      <parameter type-id='type-id-8' name='flags'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='sa_commit_shares' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='do_unmount' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_unload_key' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='sa_is_shared' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='sa_disable_share' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='sa_errorstr' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='zfs_shareall' mangled-name='zfs_shareall' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_shareall'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-8' name='flags'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='sa_enable_share' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_share' mangled-name='zfs_share' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='changelist_unshare' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-231'/>
-      <parameter type-id='type-id-294'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-88' name='where'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-88' name='where'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='sa_validate_shareopts' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
-      <parameter type-id='type-id-84' name='proto'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='mountpoint'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='mountpoint'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='mountpoint'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='mountpoint'/>
-      <parameter type-id='type-id-84' name='proto'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='rmdir' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-309'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cb_handles' type-id='type-id-310' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='cb_alloc' type-id='type-id-28' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='cb_used' type-id='type-id-28' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-310'/>
-    <typedef-decl name='get_all_cb_t' type-id='type-id-309' id='type-id-311'/>
-    <pointer-type-def type-id='type-id-311' size-in-bits='64' id='type-id-312'/>
-    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
-      <parameter type-id='type-id-312' name='cbp'/>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_realloc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-310' name='handles'/>
-      <parameter type-id='type-id-28' name='num_handles'/>
-      <parameter type-id='type-id-138' name='func'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <parameter type-id='type-id-16' name='parallel'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='qsort' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-62'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <class-decl name='tpool' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-313'/>
-    <pointer-type-def type-id='type-id-313' size-in-bits='64' id='type-id-314'/>
-    <pointer-type-def type-id='type-id-272' size-in-bits='64' id='type-id-315'/>
-    <function-decl name='tpool_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-315'/>
-      <return type-id='type-id-314'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-316' size-in-bits='64' id='type-id-317'/>
-    <function-decl name='tpool_dispatch' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-314'/>
-      <parameter type-id='type-id-317'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='tpool_wait' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-314'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='tpool_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-314'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='mntopts'/>
-      <parameter type-id='type-id-8' name='flags'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_disable_datasets' mangled-name='zpool_disable_datasets' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_disable_datasets'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-16' name='force'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-316'>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-6'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_pool.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-318'>
-      <underlying-type type-id='type-id-49'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-161'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZPOOL_COMPATIBILITY_OK' value='0'/>
       <enumerator name='ZPOOL_COMPATIBILITY_WARNTOKEN' value='1'/>
       <enumerator name='ZPOOL_COMPATIBILITY_BADTOKEN' value='2'/>
       <enumerator name='ZPOOL_COMPATIBILITY_BADFILE' value='3'/>
       <enumerator name='ZPOOL_COMPATIBILITY_NOFILES' value='4'/>
     </enum-decl>
-    <typedef-decl name='zpool_compat_status_t' type-id='type-id-318' id='type-id-319'/>
+    <typedef-decl name='zpool_compat_status_t' type-id='type-id-161' id='type-id-162'/>
     <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_load_compat'>
       <parameter type-id='type-id-84' name='compat'/>
-      <parameter type-id='type-id-106' name='features'/>
-      <parameter type-id='type-id-17' name='report'/>
-      <parameter type-id='type-id-28' name='rlen'/>
-      <return type-id='type-id-319'/>
+      <parameter type-id='type-id-85' name='features'/>
+      <parameter type-id='type-id-14' name='report'/>
+      <parameter type-id='type-id-18' name='rlen'/>
+      <return type-id='type-id-162'/>
     </function-decl>
-    <function-decl name='zpool_props_refresh' mangled-name='zpool_props_refresh' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_props_refresh'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <typedef-decl name='zpool_prop_t' type-id='type-id-142' id='type-id-320'/>
-    <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-320' name='prop'/>
-      <parameter type-id='type-id-233' name='src'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='zpool_standard_error_fmt' mangled-name='zpool_standard_error_fmt' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_prop_to_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-142'/>
-      <return type-id='type-id-84'/>
+    <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_prop_default_numeric' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-142'/>
-      <return type-id='type-id-35'/>
+    <function-decl name='lzc_wait' mangled-name='lzc_wait' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <enum-decl name='vdev_state' id='type-id-321'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='VDEV_STATE_UNKNOWN' value='0'/>
-      <enumerator name='VDEV_STATE_CLOSED' value='1'/>
-      <enumerator name='VDEV_STATE_OFFLINE' value='2'/>
-      <enumerator name='VDEV_STATE_REMOVED' value='3'/>
-      <enumerator name='VDEV_STATE_CANT_OPEN' value='4'/>
-      <enumerator name='VDEV_STATE_FAULTED' value='5'/>
-      <enumerator name='VDEV_STATE_DEGRADED' value='6'/>
-      <enumerator name='VDEV_STATE_HEALTHY' value='7'/>
-    </enum-decl>
-    <typedef-decl name='vdev_state_t' type-id='type-id-321' id='type-id-322'/>
-    <enum-decl name='vdev_aux' id='type-id-323'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='VDEV_AUX_NONE' value='0'/>
-      <enumerator name='VDEV_AUX_OPEN_FAILED' value='1'/>
-      <enumerator name='VDEV_AUX_CORRUPT_DATA' value='2'/>
-      <enumerator name='VDEV_AUX_NO_REPLICAS' value='3'/>
-      <enumerator name='VDEV_AUX_BAD_GUID_SUM' value='4'/>
-      <enumerator name='VDEV_AUX_TOO_SMALL' value='5'/>
-      <enumerator name='VDEV_AUX_BAD_LABEL' value='6'/>
-      <enumerator name='VDEV_AUX_VERSION_NEWER' value='7'/>
-      <enumerator name='VDEV_AUX_VERSION_OLDER' value='8'/>
-      <enumerator name='VDEV_AUX_UNSUP_FEAT' value='9'/>
-      <enumerator name='VDEV_AUX_SPARED' value='10'/>
-      <enumerator name='VDEV_AUX_ERR_EXCEEDED' value='11'/>
-      <enumerator name='VDEV_AUX_IO_FAILURE' value='12'/>
-      <enumerator name='VDEV_AUX_BAD_LOG' value='13'/>
-      <enumerator name='VDEV_AUX_EXTERNAL' value='14'/>
-      <enumerator name='VDEV_AUX_SPLIT_POOL' value='15'/>
-      <enumerator name='VDEV_AUX_BAD_ASHIFT' value='16'/>
-      <enumerator name='VDEV_AUX_EXTERNAL_PERSIST' value='17'/>
-      <enumerator name='VDEV_AUX_ACTIVE' value='18'/>
-      <enumerator name='VDEV_AUX_CHILDREN_OFFLINE' value='19'/>
-      <enumerator name='VDEV_AUX_ASHIFT_TOO_BIG' value='20'/>
-    </enum-decl>
-    <typedef-decl name='vdev_aux_t' type-id='type-id-323' id='type-id-324'/>
-    <function-decl name='zpool_state_to_name' mangled-name='zpool_state_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_state_to_name'>
-      <parameter type-id='type-id-322' name='state'/>
-      <parameter type-id='type-id-324' name='aux'/>
-      <return type-id='type-id-84'/>
+    <function-decl name='zpool_standard_error' mangled-name='zpool_standard_error' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_pool_state_to_name' mangled-name='zpool_pool_state_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_pool_state_to_name'>
-      <parameter type-id='type-id-290' name='state'/>
-      <return type-id='type-id-84'/>
+    <function-decl name='zpool_history_unpack' mangled-name='zpool_history_unpack' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_get_state_str' mangled-name='zpool_get_state_str' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state_str'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-84'/>
+    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-325'>
-      <underlying-type type-id='type-id-49'/>
+    <function-decl name='zfs_basename' mangled-name='zfs_basename' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='memcmp' mangled-name='memcmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__realpath_alias' mangled-name='realpath' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strncasecmp' mangled-name='strncasecmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_strip_path' mangled-name='zfs_strip_path' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_sync' mangled-name='lzc_sync' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_reopen' mangled-name='lzc_reopen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_to_name' mangled-name='zpool_prop_to_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfeature_lookup_guid' mangled-name='zfeature_lookup_guid' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_relabel_disk' mangled-name='zpool_relabel_disk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strtoull' mangled-name='strtoull' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_strcmp_pathname' mangled-name='zfs_strcmp_pathname' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_wait_tag' mangled-name='lzc_wait_tag' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_trim' mangled-name='lzc_trim' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_initialize' mangled-name='lzc_initialize' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfeature_lookup_name' mangled-name='zfeature_lookup_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_pool_checkpoint_discard' mangled-name='lzc_pool_checkpoint_discard' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_pool_checkpoint' mangled-name='lzc_pool_checkpoint' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pool_namecheck' mangled-name='pool_namecheck' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_feature' mangled-name='zpool_prop_feature' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfeature_is_supported' mangled-name='zfeature_is_supported' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_name_to_prop' mangled-name='zpool_name_to_prop' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_readonly' mangled-name='zpool_prop_readonly' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_setonce' mangled-name='zpool_prop_setonce' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='get_system_hostid' mangled-name='get_system_hostid' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_get_type' mangled-name='zpool_prop_get_type' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_index_to_string' mangled-name='zpool_prop_index_to_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strtok_r' mangled-name='strtok_r' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='mmap' mangled-name='mmap64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='munmap' mangled-name='munmap' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_get_status' mangled-name='zpool_get_status' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int64' mangled-name='fnvlist_add_int64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_sendrecv.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' id='type-id-163'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='verbose' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='isprefix' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='istail' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='dryrun' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='force' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='canmountoff' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='resumable' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='byteswap' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='nomount' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='holds' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='skipholds' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='domount' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='forceunmount' type-id='type-id-9' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='recvflags_t' type-id='type-id-163' id='type-id-164'/>
+    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-165'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-166'/>
+    <function-decl name='zfs_receive' mangled-name='zfs_receive' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='tosnap'/>
+      <parameter type-id='type-id-19' name='props'/>
+      <parameter type-id='type-id-165' name='flags'/>
+      <parameter type-id='type-id-2' name='infd'/>
+      <parameter type-id='type-id-166' name='stream_avl'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <class-decl name='sendflags' size-in-bits='544' is-struct='yes' visibility='default' id='type-id-167'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='verbosity' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='replicate' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='skipmissing' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='doall' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fromorigin' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='props' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='dryrun' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='parsable' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='progress' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='largeblock' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='embed_data' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='compress' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='raw' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='backup' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='holds' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='saved' type-id='type-id-9' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='sendflags_t' type-id='type-id-167' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-169'/>
+    <function-decl name='zfs_send_one' mangled-name='zfs_send_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_one'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='from'/>
+      <parameter type-id='type-id-2' name='fd'/>
+      <parameter type-id='type-id-169' name='flags'/>
+      <parameter type-id='type-id-84' name='redactbook'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <typedef-decl name='snapfilter_cb_t' type-id='type-id-170' id='type-id-171'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-172'/>
+    <function-decl name='zfs_send' mangled-name='zfs_send' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='fromsnap'/>
+      <parameter type-id='type-id-84' name='tosnap'/>
+      <parameter type-id='type-id-169' name='flags'/>
+      <parameter type-id='type-id-2' name='outfd'/>
+      <parameter type-id='type-id-172' name='filter_func'/>
+      <parameter type-id='type-id-13' name='cb_arg'/>
+      <parameter type-id='type-id-86' name='debugnvp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_send_saved' mangled-name='zfs_send_saved' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_saved'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-169' name='flags'/>
+      <parameter type-id='type-id-2' name='outfd'/>
+      <parameter type-id='type-id-84' name='resume_token'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_send_resume' mangled-name='zfs_send_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-169' name='flags'/>
+      <parameter type-id='type-id-2' name='outfd'/>
+      <parameter type-id='type-id-84' name='resume_token'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_send_resume_token_to_nvlist' mangled-name='zfs_send_resume_token_to_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume_token_to_nvlist'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='token'/>
+      <return type-id='type-id-19'/>
+    </function-decl>
+    <function-decl name='zfs_send_progress' mangled-name='zfs_send_progress' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_progress'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-2' name='fd'/>
+      <parameter type-id='type-id-108' name='bytes_written'/>
+      <parameter type-id='type-id-108' name='blocks_visited'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='libzfs_set_pipe_max' mangled-name='libzfs_set_pipe_max' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='perror' mangled-name='perror' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fletcher_4_incremental_byteswap' mangled-name='fletcher_4_incremental_byteswap' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin___strcat_chk' mangled-name='__strcat_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='create_parents' mangled-name='create_parents' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='time' mangled-name='time' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvpair' mangled-name='fnvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_receive_with_cmdprops' mangled-name='lzc_receive_with_cmdprops' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin___sprintf_chk' mangled-name='__sprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin_puts' mangled-name='puts' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64_array' mangled-name='fnvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fletcher_4_incremental_native' mangled-name='fletcher_4_incremental_native' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_redacted' mangled-name='lzc_send_redacted' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_size' mangled-name='fnvlist_size' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='write' mangled-name='write' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strndup' mangled-name='strndup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_resume_redacted' mangled-name='lzc_send_resume_redacted' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_print' mangled-name='nvlist_print' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_space_resume_redacted' mangled-name='lzc_send_space_resume_redacted' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fletcher_4_native_varsize' mangled-name='fletcher_4_native_varsize' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uncompress' mangled-name='uncompress' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_space' mangled-name='lzc_send_space' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sleep' mangled-name='sleep' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='localtime' mangled-name='localtime' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_rename' mangled-name='lzc_rename' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-170'>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-13'/>
+      <return type-id='type-id-9'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_status.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-173'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZPOOL_STATUS_CORRUPT_CACHE' value='0'/>
       <enumerator name='ZPOOL_STATUS_MISSING_DEV_R' value='1'/>
       <enumerator name='ZPOOL_STATUS_MISSING_DEV_NR' value='2'/>
@@ -4285,82 +3590,747 @@
       <enumerator name='ZPOOL_STATUS_INCOMPATIBLE_FEAT' value='31'/>
       <enumerator name='ZPOOL_STATUS_OK' value='32'/>
     </enum-decl>
-    <enum-decl name='zpool_errata' id='type-id-326'>
-      <underlying-type type-id='type-id-49'/>
+    <typedef-decl name='zpool_status_t' type-id='type-id-173' id='type-id-174'/>
+    <enum-decl name='zpool_errata' id='type-id-175'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZPOOL_ERRATA_NONE' value='0'/>
       <enumerator name='ZPOOL_ERRATA_ZOL_2094_SCRUB' value='1'/>
       <enumerator name='ZPOOL_ERRATA_ZOL_2094_ASYNC_DESTROY' value='2'/>
       <enumerator name='ZPOOL_ERRATA_ZOL_6845_ENCRYPTION' value='3'/>
       <enumerator name='ZPOOL_ERRATA_ZOL_8308_ENCRYPTION' value='4'/>
     </enum-decl>
-    <pointer-type-def type-id='type-id-326' size-in-bits='64' id='type-id-327'/>
-    <function-decl name='zpool_get_status' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-88'/>
-      <parameter type-id='type-id-327'/>
-      <return type-id='type-id-325'/>
+    <typedef-decl name='zpool_errata_t' type-id='type-id-175' id='type-id-176'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-177'/>
+    <function-decl name='zpool_import_status' mangled-name='zpool_import_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_status'>
+      <parameter type-id='type-id-19' name='config'/>
+      <parameter type-id='type-id-117' name='msgid'/>
+      <parameter type-id='type-id-177' name='errata'/>
+      <return type-id='type-id-174'/>
     </function-decl>
-    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zpool_get_status' mangled-name='zpool_get_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_status'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-117' name='msgid'/>
+      <parameter type-id='type-id-177' name='errata'/>
+      <return type-id='type-id-174'/>
     </function-decl>
-    <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-320' name='prop'/>
-      <parameter type-id='type-id-17' name='buf'/>
-      <parameter type-id='type-id-28' name='len'/>
-      <parameter type-id='type-id-233' name='srctype'/>
-      <parameter type-id='type-id-16' name='literal'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_prop_get_type' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-142'/>
-      <return type-id='type-id-234'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='libzfs_util.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='printf_color' mangled-name='printf_color' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
+      <parameter type-id='type-id-14' name='color'/>
+      <parameter type-id='type-id-14' name='format'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zpool_prop_index_to_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-142'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-241'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zfs_version_print' mangled-name='zfs_version_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-84'/>
+    <function-decl name='zfs_version_userland' mangled-name='zfs_version_userland' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_userland'>
+      <parameter type-id='type-id-14' name='version'/>
+      <parameter type-id='type-id-2' name='len'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_prop_default_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-142'/>
-      <return type-id='type-id-84'/>
+    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-179'/>
+    <typedef-decl name='zprop_func' type-id='type-id-179' id='type-id-180'/>
+    <function-decl name='zprop_iter' mangled-name='zprop_iter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter'>
+      <parameter type-id='type-id-180' name='func'/>
+      <parameter type-id='type-id-13' name='cb'/>
+      <parameter type-id='type-id-9' name='show_all'/>
+      <parameter type-id='type-id-9' name='ordered'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
-      <parameter type-id='type-id-11' name='zhp'/>
+    <function-decl name='zprop_free_list' mangled-name='zprop_free_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_free_list'>
+      <parameter type-id='type-id-102' name='pl'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_get_list' mangled-name='zprop_get_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_get_list'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-14' name='props'/>
+      <parameter type-id='type-id-103' name='listp'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <class-decl name='zprop_get_cbdata' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-181'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cb_sources' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='cb_columns' type-id='type-id-182' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='cb_colwidths' type-id='type-id-183' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='cb_scripted' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='cb_literal' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='cb_first' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='cb_proplist' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='cb_type' type-id='type-id-66' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-184'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='GET_COL_NONE' value='0'/>
+      <enumerator name='GET_COL_NAME' value='1'/>
+      <enumerator name='GET_COL_PROPERTY' value='2'/>
+      <enumerator name='GET_COL_VALUE' value='3'/>
+      <enumerator name='GET_COL_RECVD' value='4'/>
+      <enumerator name='GET_COL_SOURCE' value='5'/>
+    </enum-decl>
+    <typedef-decl name='zfs_get_column_t' type-id='type-id-184' id='type-id-185'/>
+
+    <array-type-def dimensions='1' type-id='type-id-185' size-in-bits='160' alignment-in-bits='32' id='type-id-182'>
+      <subrange length='5' type-id='type-id-24' id='type-id-186'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='192' id='type-id-183'>
+      <subrange length='6' type-id='type-id-24' id='type-id-187'/>
+
+    </array-type-def>
+    <typedef-decl name='zprop_get_cbdata_t' type-id='type-id-181' id='type-id-188'/>
+    <pointer-type-def type-id='type-id-188' size-in-bits='64' id='type-id-189'/>
+    <function-decl name='zprop_print_one_property' mangled-name='zprop_print_one_property' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_print_one_property'>
+      <parameter type-id='type-id-84' name='name'/>
+      <parameter type-id='type-id-189' name='cbp'/>
       <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-84' name='propval'/>
-      <return type-id='type-id-8'/>
+      <parameter type-id='type-id-84' name='value'/>
+      <parameter type-id='type-id-112' name='sourcetype'/>
+      <parameter type-id='type-id-84' name='source'/>
+      <parameter type-id='type-id-84' name='recvd_value'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zpool_standard_error' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zfs_path_to_zhandle' mangled-name='zfs_path_to_zhandle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_path_to_zhandle'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-66' name='argtype'/>
+      <return type-id='type-id-76'/>
     </function-decl>
-    <function-decl name='zpool_name_to_prop' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-142'/>
+    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_handle'>
+      <parameter type-id='type-id-107' name='zhp'/>
+      <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='zpool_prop_readonly' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-142'/>
-      <return type-id='type-id-50'/>
+    <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_handle'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <return type-id='type-id-16'/>
     </function-decl>
-    <function-decl name='zpool_prop_setonce' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-142'/>
-      <return type-id='type-id-50'/>
+    <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_handle'>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <return type-id='type-id-16'/>
     </function-decl>
-    <function-decl name='zpool_prop_feature' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
+    <function-decl name='libzfs_fini' mangled-name='libzfs_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_fini'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <enum-decl name='spa_feature' id='type-id-328'>
-      <underlying-type type-id='type-id-49'/>
+    <function-decl name='libzfs_init' mangled-name='libzfs_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_envvar_is_set'>
+      <parameter type-id='type-id-14' name='envvar'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='libzfs_free_str_array' mangled-name='libzfs_free_str_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_free_str_array'>
+      <parameter type-id='type-id-117' name='strs'/>
+      <parameter type-id='type-id-2' name='count'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-190'/>
+    <function-decl name='libzfs_run_process_get_stdout_nopath' mangled-name='libzfs_run_process_get_stdout_nopath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout_nopath'>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-117' name='argv'/>
+      <parameter type-id='type-id-117' name='env'/>
+      <parameter type-id='type-id-190' name='lines'/>
+      <parameter type-id='type-id-114' name='lines_cnt'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='libzfs_run_process_get_stdout' mangled-name='libzfs_run_process_get_stdout' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout'>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-117' name='argv'/>
+      <parameter type-id='type-id-117' name='env'/>
+      <parameter type-id='type-id-190' name='lines'/>
+      <parameter type-id='type-id-114' name='lines_cnt'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process'>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-117' name='argv'/>
+      <parameter type-id='type-id-2' name='flags'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='libzfs_print_on_error' mangled-name='libzfs_print_on_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_print_on_error'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-9' name='enable'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-2' name='error'/>
+      <parameter type-id='type-id-84' name='msg'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='libzfs_error_action' mangled-name='libzfs_error_action' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_action'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='libzfs_errno' mangled-name='libzfs_errno' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_errno'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='libzfs_error_description' mangled-name='libzfs_error_description' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_description'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicestrtonum'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-84' name='value'/>
+      <parameter type-id='type-id-108' name='num'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='color_start' mangled-name='color_start' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_start'>
+      <parameter type-id='type-id-14' name='color'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='color_end' mangled-name='color_end' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_end'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__vfprintf_chk' mangled-name='__vfprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_iter_common' mangled-name='zprop_iter_common' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_width' mangled-name='zprop_width' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_name_to_prop' mangled-name='zprop_name_to_prop' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_valid_for_type' mangled-name='zprop_valid_for_type' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_unsupported' mangled-name='zpool_prop_unsupported' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_string_to_index' mangled-name='zprop_string_to_index' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_values' mangled-name='zprop_values' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__ctype_toupper_loc' mangled-name='__ctype_toupper_loc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='getextmntent' mangled-name='getextmntent' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='namespace_clear' mangled-name='namespace_clear' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='regfree' mangled-name='regfree' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fletcher_4_fini' mangled-name='fletcher_4_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_fini'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_get_table' mangled-name='zpool_prop_get_table' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_load_module' mangled-name='libzfs_load_module' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='regcomp' mangled-name='regcomp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_core_init' mangled-name='libzfs_core_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_init' mangled-name='zfs_prop_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_prop_init' mangled-name='zpool_prop_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_feature_init' mangled-name='zpool_feature_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fletcher_4_init' mangled-name='fletcher_4_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strnlen' mangled-name='strnlen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='realloc' mangled-name='realloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='waitpid' mangled-name='waitpid' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fork' mangled-name='fork' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='dup2' mangled-name='dup2' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='execve' mangled-name='execve' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='_exit' mangled-name='_exit' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='execvpe' mangled-name='execvpe' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='execv' mangled-name='execv' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='execvp' mangled-name='execvp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__vasprintf_chk' mangled-name='__vasprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__builtin___vsnprintf_chk' mangled-name='__vsnprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='exit' mangled-name='exit' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='strtod' mangled-name='strtod' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='pow' mangled-name='pow' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-178'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-13'/>
+      <return type-id='type-id-2'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_mount_os.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_mount_delegation_check' mangled-name='zfs_mount_delegation_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_delegation_check'>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_adjust_mount_options' mangled-name='zfs_adjust_mount_options' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_adjust_mount_options'>
+      <parameter type-id='type-id-76' name='zhp'/>
+      <parameter type-id='type-id-84' name='mntpoint'/>
+      <parameter type-id='type-id-14' name='mntopts'/>
+      <parameter type-id='type-id-14' name='mtabopt'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-191'/>
+    <function-decl name='zfs_parse_mount_options' mangled-name='zfs_parse_mount_options' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_mount_options'>
+      <parameter type-id='type-id-14' name='mntopts'/>
+      <parameter type-id='type-id-191' name='mntflags'/>
+      <parameter type-id='type-id-191' name='zfsflags'/>
+      <parameter type-id='type-id-2' name='sloppy'/>
+      <parameter type-id='type-id-14' name='badopt'/>
+      <parameter type-id='type-id-14' name='mtabopt'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='geteuid' mangled-name='geteuid' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='umount2' mangled-name='umount2' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='mount' mangled-name='mount' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_pool_os.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zpool_label_disk' mangled-name='zpool_label_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-4' name='zhp'/>
+      <parameter type-id='type-id-84' name='name'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='rand' mangled-name='rand' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_alloc_and_read' mangled-name='efi_alloc_and_read' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_free' mangled-name='efi_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_write' mangled-name='efi_write' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fsync' mangled-name='fsync' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_rescan' mangled-name='efi_rescan' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_use_whole_disk' mangled-name='efi_use_whole_disk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_sendrecv_os.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='fscanf' mangled-name='fscanf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fcntl' mangled-name='fcntl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_util_os.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_kernel'>
+      <parameter type-id='type-id-14' name='version'/>
+      <parameter type-id='type-id-2' name='len'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='libzfs_error_init' mangled-name='libzfs_error_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_init'>
+      <parameter type-id='type-id-2' name='error'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='type-id-192'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zc_name' type-id='type-id-193' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32768'>
+        <var-decl name='zc_nvlist_src' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32832'>
+        <var-decl name='zc_nvlist_src_size' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32896'>
+        <var-decl name='zc_nvlist_dst' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32960'>
+        <var-decl name='zc_nvlist_dst_size' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33024'>
+        <var-decl name='zc_nvlist_dst_filled' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33056'>
+        <var-decl name='zc_pad2' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33088'>
+        <var-decl name='zc_history' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33152'>
+        <var-decl name='zc_value' type-id='type-id-194' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='98688'>
+        <var-decl name='zc_string' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100736'>
+        <var-decl name='zc_guid' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100800'>
+        <var-decl name='zc_nvlist_conf' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100864'>
+        <var-decl name='zc_nvlist_conf_size' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100928'>
+        <var-decl name='zc_cookie' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100992'>
+        <var-decl name='zc_objset_type' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101056'>
+        <var-decl name='zc_perm_action' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101120'>
+        <var-decl name='zc_history_len' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101184'>
+        <var-decl name='zc_history_offset' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101248'>
+        <var-decl name='zc_obj' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101312'>
+        <var-decl name='zc_iflags' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101376'>
+        <var-decl name='zc_share' type-id='type-id-195' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101632'>
+        <var-decl name='zc_objset_stats' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='103936'>
+        <var-decl name='zc_begin_record' type-id='type-id-196' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='106368'>
+        <var-decl name='zc_inject_record' type-id='type-id-197' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109184'>
+        <var-decl name='zc_defer_destroy' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109216'>
+        <var-decl name='zc_flags' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109248'>
+        <var-decl name='zc_action_handle' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109312'>
+        <var-decl name='zc_cleanup_fd' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109344'>
+        <var-decl name='zc_simple' type-id='type-id-72' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109352'>
+        <var-decl name='zc_pad' type-id='type-id-198' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109376'>
+        <var-decl name='zc_sendobj' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109440'>
+        <var-decl name='zc_fromobj' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109504'>
+        <var-decl name='zc_createtxg' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109568'>
+        <var-decl name='zc_stat' type-id='type-id-199' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109888'>
+        <var-decl name='zc_zoneid' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='32768' id='type-id-193'>
+      <subrange length='4096' type-id='type-id-24' id='type-id-200'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='65536' id='type-id-194'>
+      <subrange length='8192' type-id='type-id-24' id='type-id-201'/>
+
+    </array-type-def>
+    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-202'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='z_exportdata' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='z_sharedata' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='z_sharetype' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='z_sharemax' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_share_t' type-id='type-id-202' id='type-id-195'/>
+    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' id='type-id-196'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_magic' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_versioninfo' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_creation_time' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_type' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='drr_flags' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_fromguid' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_toname' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='type-id-203'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zi_objset' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zi_object' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zi_start' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zi_end' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='zi_guid' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='zi_level' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='zi_error' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='zi_type' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='zi_freq' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='zi_failfast' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zi_func' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='zi_iotype' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2592'>
+        <var-decl name='zi_duration' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2624'>
+        <var-decl name='zi_timer' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='zi_nlanes' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2752'>
+        <var-decl name='zi_cmd' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2784'>
+        <var-decl name='zi_dvas' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zinject_record_t' type-id='type-id-203' id='type-id-197'/>
+
+    <array-type-def dimensions='1' type-id='type-id-72' size-in-bits='24' id='type-id-198'>
+      <subrange length='3' type-id='type-id-24' id='type-id-204'/>
+
+    </array-type-def>
+    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-205'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zs_gen' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zs_mode' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zs_links' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zs_ctime' type-id='type-id-206' visibility='default'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='128' id='type-id-206'>
+      <subrange length='2' type-id='type-id-24' id='type-id-59'/>
+
+    </array-type-def>
+    <typedef-decl name='zfs_stat_t' type-id='type-id-205' id='type-id-199'/>
+    <typedef-decl name='zfs_cmd_t' type-id='type-id-192' id='type-id-207'/>
+    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-208'/>
+    <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl'>
+      <parameter type-id='type-id-16' name='hdl'/>
+      <parameter type-id='type-id-2' name='request'/>
+      <parameter type-id='type-id-208' name='zc'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='clock_gettime' mangled-name='clock_gettime' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='sched_yield' mangled-name='sched_yield' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='usleep' mangled-name='usleep' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='access' mangled-name='access' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/icp/algs/sha2/sha2.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='htonl' mangled-name='htonl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/cityhash.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='cityhash4' mangled-name='cityhash4' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='cityhash4'>
+      <parameter type-id='type-id-7' name='w1'/>
+      <parameter type-id='type-id-7' name='w2'/>
+      <parameter type-id='type-id-7' name='w3'/>
+      <parameter type-id='type-id-7' name='w4'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfeature_common.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='zfeature_checks_disable' type-id='type-id-9' mangled-name='zfeature_checks_disable' visibility='default' elf-symbol-id='zfeature_checks_disable'/>
+    <class-decl name='zfeature_info' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-209'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fi_feature' type-id='type-id-210' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fi_uname' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fi_guid' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='fi_desc' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='fi_flags' type-id='type-id-211' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='fi_zfs_mod_supported' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='fi_type' type-id='type-id-212' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='fi_depends' type-id='type-id-213' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='spa_feature' id='type-id-214'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='SPA_FEATURE_NONE' value='-1'/>
       <enumerator name='SPA_FEATURE_ASYNC_DESTROY' value='0'/>
       <enumerator name='SPA_FEATURE_EMPTY_BPOBJ' value='1'/>
@@ -4398,2407 +4368,125 @@
       <enumerator name='SPA_FEATURE_DRAID' value='33'/>
       <enumerator name='SPA_FEATURES' value='34'/>
     </enum-decl>
-    <pointer-type-def type-id='type-id-328' size-in-bits='64' id='type-id-329'/>
-    <function-decl name='zfeature_lookup_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-329'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='pool'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zpool_close' mangled-name='zpool_close' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='get_system_hostid' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-259' name='plp'/>
-      <parameter type-id='type-id-16' name='literal'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfeature_is_supported' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-17' name='buf'/>
-      <parameter type-id='type-id-28' name='len'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='pool_namecheck' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-213'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_refresh_stats' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-294'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_open' mangled-name='zpool_open' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='pool'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
-      <parameter type-id='type-id-84' name='name'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zpool_create' mangled-name='zpool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='pool'/>
-      <parameter type-id='type-id-15' name='nvroot'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <parameter type-id='type-id-15' name='fsprops'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='log_str'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_pool_checkpoint' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_pool_checkpoint_discard' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_add' mangled-name='zpool_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-15' name='nvroot'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_export' mangled-name='zpool_export' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-16' name='force'/>
-      <parameter type-id='type-id-84' name='log_str'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_standard_error_fmt' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='log_str'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='name'/>
-      <parameter type-id='type-id-8' name='reason'/>
-      <parameter type-id='type-id-15' name='config'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_import' mangled-name='zpool_import' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-15' name='config'/>
-      <parameter type-id='type-id-84' name='newname'/>
-      <parameter type-id='type-id-17' name='altroot'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-15' name='config'/>
-      <parameter type-id='type-id-84' name='newname'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <parameter type-id='type-id-8' name='flags'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='zpool_load_policy' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-330'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zlp_rewind' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zlp_maxmeta' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zlp_maxdata' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zlp_txg' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-330' size-in-bits='64' id='type-id-331'/>
-    <function-decl name='zpool_get_load_policy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-331'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
-      <parameter type-id='type-id-15' name='config'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-15' name='nv'/>
-      <parameter type-id='type-id-8' name='name_flags'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <enum-decl name='pool_initialize_func' id='type-id-332'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='POOL_INITIALIZE_START' value='0'/>
-      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
-      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
-      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
-    </enum-decl>
-    <typedef-decl name='pool_initialize_func_t' type-id='type-id-332' id='type-id-333'/>
-    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-333' name='cmd_type'/>
-      <parameter type-id='type-id-15' name='vds'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_initialize' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-332'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <return type-id='type-id-54'/>
-    </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-334'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
-      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
-      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
-      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
-      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
-      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
-      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
-      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
-      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
-    </enum-decl>
-    <function-decl name='lzc_wait_tag' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-334'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-294'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-333' name='cmd_type'/>
-      <parameter type-id='type-id-15' name='vds'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <enum-decl name='pool_trim_func' id='type-id-335'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='POOL_TRIM_START' value='0'/>
-      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
-      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
-      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
-    </enum-decl>
-    <typedef-decl name='pool_trim_func_t' type-id='type-id-335' id='type-id-336'/>
-    <class-decl name='trimflags' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-337'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fullpool' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='secure' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='wait' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='rate' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='trimflags_t' type-id='type-id-337' id='type-id-338'/>
-    <pointer-type-def type-id='type-id-338' size-in-bits='64' id='type-id-339'/>
-    <function-decl name='zpool_trim' mangled-name='zpool_trim' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-336' name='cmd_type'/>
-      <parameter type-id='type-id-15' name='vds'/>
-      <parameter type-id='type-id-339' name='trim_flags'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_trim' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-335'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-54'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-106' name='avail_spare'/>
-      <parameter type-id='type-id-106' name='l2cache'/>
-      <parameter type-id='type-id-106' name='log'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <enum-decl name='pool_scan_func' id='type-id-340'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='POOL_SCAN_NONE' value='0'/>
-      <enumerator name='POOL_SCAN_SCRUB' value='1'/>
-      <enumerator name='POOL_SCAN_RESILVER' value='2'/>
-      <enumerator name='POOL_SCAN_FUNCS' value='3'/>
-    </enum-decl>
-    <typedef-decl name='pool_scan_func_t' type-id='type-id-340' id='type-id-341'/>
-    <enum-decl name='pool_scrub_cmd' id='type-id-342'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='POOL_SCRUB_NORMAL' value='0'/>
-      <enumerator name='POOL_SCRUB_PAUSE' value='1'/>
-      <enumerator name='POOL_SCRUB_FLAGS_END' value='2'/>
-    </enum-decl>
-    <typedef-decl name='pool_scrub_cmd_t' type-id='type-id-342' id='type-id-343'/>
-    <function-decl name='zpool_scan' mangled-name='zpool_scan' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-341' name='func'/>
-      <parameter type-id='type-id-343' name='cmd'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='ppath'/>
-      <parameter type-id='type-id-106' name='avail_spare'/>
-      <parameter type-id='type-id-106' name='l2cache'/>
-      <parameter type-id='type-id-106' name='log'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='zfs_strcmp_pathname' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-17' name='physpath'/>
-      <parameter type-id='type-id-28' name='phypath_size'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-322' size-in-bits='64' id='type-id-344'/>
-    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-8' name='flags'/>
-      <parameter type-id='type-id-344' name='newstate'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_resolve_shortname' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_relabel_disk' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-16' name='istmp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-22' name='guid'/>
-      <parameter type-id='type-id-324' name='aux'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-22' name='guid'/>
-      <parameter type-id='type-id-324' name='aux'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='old_disk'/>
-      <parameter type-id='type-id-84' name='new_disk'/>
-      <parameter type-id='type-id-15' name='nvroot'/>
-      <parameter type-id='type-id-8' name='replacing'/>
-      <parameter type-id='type-id-16' name='rebuild'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfeature_lookup_guid' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-329'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='realpath' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='zfs_strip_path' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='zfs_strip_partition' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='splitflags' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-345'>
-      <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='dryrun' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='30'>
-        <var-decl name='import' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='name_flags' type-id='type-id-8' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='splitflags_t' type-id='type-id-345' id='type-id-346'/>
-    <function-decl name='zpool_vdev_split' mangled-name='zpool_vdev_split' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_split'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-17' name='newname'/>
-      <parameter type-id='type-id-105' name='newroot'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <parameter type-id='type-id-346' name='flags'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-107'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-248' name='sizep'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_clear' mangled-name='zpool_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-15' name='rewindnvl'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-22' name='guid'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_get_handle' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
-      <return type-id='type-id-91'/>
-    </function-decl>
-    <function-decl name='lzc_reopen' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-50'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-50'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='lzc_sync' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-105' name='nverrlistp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-22' name='new_version'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
-      <parameter type-id='type-id-8' name='argc'/>
-      <parameter type-id='type-id-88' name='argv'/>
-      <parameter type-id='type-id-17' name='string'/>
-      <parameter type-id='type-id-8' name='len'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='message'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-105' name='nvhisp'/>
-      <parameter type-id='type-id-248' name='off'/>
-      <parameter type-id='type-id-106' name='eof'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_history_unpack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-267'/>
-      <parameter type-id='type-id-244'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-105' name='nvp'/>
-      <parameter type-id='type-id-223' name='dropped'/>
-      <parameter type-id='type-id-5' name='flags'/>
-      <parameter type-id='type-id-8' name='zevent_fd'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-223' name='count'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-22' name='eid'/>
-      <parameter type-id='type-id-8' name='zevent_fd'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-22' name='dsobj'/>
-      <parameter type-id='type-id-22' name='obj'/>
-      <parameter type-id='type-id-17' name='pathname'/>
-      <parameter type-id='type-id-28' name='len'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-22' name='dsobj'/>
-      <parameter type-id='type-id-22' name='obj'/>
-      <parameter type-id='type-id-17' name='pathname'/>
-      <parameter type-id='type-id-28' name='len'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-334' id='type-id-347'/>
-    <function-decl name='zpool_wait' mangled-name='zpool_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-347' name='activity'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_wait' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-334'/>
-      <parameter type-id='type-id-294'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-347' name='activity'/>
-      <parameter type-id='type-id-106' name='missing'/>
-      <parameter type-id='type-id-106' name='waited'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-42' const='yes' id='type-id-348'/>
-    <pointer-type-def type-id='type-id-348' size-in-bits='64' id='type-id-349'/>
-    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-349' name='envmap'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-36' const='yes' id='type-id-350'/>
-    <pointer-type-def type-id='type-id-350' size-in-bits='64' id='type-id-351'/>
-    <function-decl name='lzc_set_bootenv' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-351'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-105' name='nvlp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_get_bootenv' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='strtok_r' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-88'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='mmap' mangled-name='mmap64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-54'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='strchrnul' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='munmap' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_name_valid' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_sendrecv.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='sendflags' size-in-bits='544' is-struct='yes' visibility='default' id='type-id-352'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='verbosity' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='replicate' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='skipmissing' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='doall' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='fromorigin' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='pad' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='props' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dryrun' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='parsable' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='progress' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='largeblock' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='embed_data' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='compress' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='raw' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='backup' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='holds' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='saved' type-id='type-id-16' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='sendflags_t' type-id='type-id-352' id='type-id-353'/>
-    <pointer-type-def type-id='type-id-353' size-in-bits='64' id='type-id-354'/>
-    <typedef-decl name='snapfilter_cb_t' type-id='type-id-355' id='type-id-356'/>
-    <pointer-type-def type-id='type-id-356' size-in-bits='64' id='type-id-357'/>
-    <function-decl name='zfs_send' mangled-name='zfs_send' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='fromsnap'/>
-      <parameter type-id='type-id-84' name='tosnap'/>
-      <parameter type-id='type-id-354' name='flags'/>
-      <parameter type-id='type-id-8' name='outfd'/>
-      <parameter type-id='type-id-357' name='filter_func'/>
-      <parameter type-id='type-id-7' name='cb_arg'/>
-      <parameter type-id='type-id-105' name='debugnvp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_send_progress' mangled-name='zfs_send_progress' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_progress'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-8' name='fd'/>
-      <parameter type-id='type-id-248' name='bytes_written'/>
-      <parameter type-id='type-id-248' name='blocks_visited'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_send_resume_token_to_nvlist' mangled-name='zfs_send_resume_token_to_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume_token_to_nvlist'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='token'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-358'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_word' type-id='type-id-359' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='256' id='type-id-359'>
-      <subrange length='4' type-id='type-id-33' id='type-id-217'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-358' size-in-bits='64' id='type-id-360'/>
-    <function-decl name='fletcher_4_native_varsize' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-360'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='uncompress' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-165'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_send_resume' mangled-name='zfs_send_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-354' name='flags'/>
-      <parameter type-id='type-id-8' name='outfd'/>
-      <parameter type-id='type-id-84' name='resume_token'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvlist_print' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-150'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <enum-decl name='lzc_send_flags' id='type-id-361'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='LZC_SEND_FLAG_EMBED_DATA' value='1'/>
-      <enumerator name='LZC_SEND_FLAG_LARGE_BLOCK' value='2'/>
-      <enumerator name='LZC_SEND_FLAG_COMPRESS' value='4'/>
-      <enumerator name='LZC_SEND_FLAG_RAW' value='8'/>
-      <enumerator name='LZC_SEND_FLAG_SAVED' value='16'/>
-    </enum-decl>
-    <function-decl name='lzc_send_resume_redacted' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-361'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_send_saved' mangled-name='zfs_send_saved' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_saved'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-354' name='flags'/>
-      <parameter type-id='type-id-8' name='outfd'/>
-      <parameter type-id='type-id-84' name='resume_token'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_get_pool_handle' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-97'/>
-      <return type-id='type-id-126'/>
-    </function-decl>
-    <function-decl name='zfs_hold_nvl' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fletcher_4_incremental_native' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='write' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-54'/>
-    </function-decl>
-    <function-decl name='fnvlist_size' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_send_one' mangled-name='zfs_send_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_one'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='from'/>
-      <parameter type-id='type-id-8' name='fd'/>
-      <parameter type-id='type-id-354' name='flags'/>
-      <parameter type-id='type-id-84' name='redactbook'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_send_redacted' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-361'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_send_space_resume_redacted' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-361'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-102'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='sleep' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='time' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-242'/>
-      <return type-id='type-id-54'/>
-    </function-decl>
-    <function-decl name='localtime' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-238'/>
-      <return type-id='type-id-236'/>
-    </function-decl>
-    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' id='type-id-362'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='verbose' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='isprefix' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='istail' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='dryrun' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='force' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='canmountoff' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='resumable' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='byteswap' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='nomount' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='holds' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='skipholds' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='domount' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='forceunmount' type-id='type-id-16' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='recvflags_t' type-id='type-id-362' id='type-id-363'/>
-    <pointer-type-def type-id='type-id-363' size-in-bits='64' id='type-id-364'/>
-    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-365'/>
-    <function-decl name='zfs_receive' mangled-name='zfs_receive' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='tosnap'/>
-      <parameter type-id='type-id-15' name='props'/>
-      <parameter type-id='type-id-364' name='flags'/>
-      <parameter type-id='type-id-8' name='infd'/>
-      <parameter type-id='type-id-365' name='stream_avl'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_set_pipe_max' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='perror' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='fletcher_4_incremental_byteswap' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-244'/>
-      <return type-id='type-id-102'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zfs_iter_snapshots_sorted' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-95'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_get_recvd_props' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-104'/>
-    </function-decl>
-    <function-decl name='lzc_send_space' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-361'/>
-      <parameter type-id='type-id-102'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvlist_merge' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-104'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <class-decl name='dmu_replay_record' size-in-bits='2496' is-struct='yes' visibility='default' id='type-id-366'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_type' type-id='type-id-367' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='drr_payloadlen' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_u' type-id='type-id-368' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-367'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='DRR_BEGIN' value='0'/>
-      <enumerator name='DRR_OBJECT' value='1'/>
-      <enumerator name='DRR_FREEOBJECTS' value='2'/>
-      <enumerator name='DRR_WRITE' value='3'/>
-      <enumerator name='DRR_FREE' value='4'/>
-      <enumerator name='DRR_END' value='5'/>
-      <enumerator name='DRR_WRITE_BYREF' value='6'/>
-      <enumerator name='DRR_SPILL' value='7'/>
-      <enumerator name='DRR_WRITE_EMBEDDED' value='8'/>
-      <enumerator name='DRR_OBJECT_RANGE' value='9'/>
-      <enumerator name='DRR_REDACT' value='10'/>
-      <enumerator name='DRR_NUMTYPES' value='11'/>
-    </enum-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' id='type-id-368'>
-      <data-member access='private'>
-        <var-decl name='drr_begin' type-id='type-id-112' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_end' type-id='type-id-369' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_object' type-id='type-id-370' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_freeobjects' type-id='type-id-371' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_write' type-id='type-id-372' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_free' type-id='type-id-373' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_write_byref' type-id='type-id-374' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_spill' type-id='type-id-375' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_write_embedded' type-id='type-id-376' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_object_range' type-id='type-id-377' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_redact' type-id='type-id-378' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_checksum' type-id='type-id-379' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='drr_end' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-369'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_checksum' type-id='type-id-380' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zio_cksum_t' type-id='type-id-358' id='type-id-380'/>
-    <class-decl name='drr_object' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-370'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_type' type-id='type-id-381' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='drr_bonustype' type-id='type-id-381' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_blksz' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='drr_bonuslen' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_checksumtype' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='200'>
-        <var-decl name='drr_compress' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='208'>
-        <var-decl name='drr_dn_slots' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='216'>
-        <var-decl name='drr_flags' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_raw_bonuslen' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_indblkshift' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drr_nlevels' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='drr_nblkptr' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='drr_pad' type-id='type-id-382' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_maxblkid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='dmu_object_type' id='type-id-383'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='DMU_OT_NONE' value='0'/>
-      <enumerator name='DMU_OT_OBJECT_DIRECTORY' value='1'/>
-      <enumerator name='DMU_OT_OBJECT_ARRAY' value='2'/>
-      <enumerator name='DMU_OT_PACKED_NVLIST' value='3'/>
-      <enumerator name='DMU_OT_PACKED_NVLIST_SIZE' value='4'/>
-      <enumerator name='DMU_OT_BPOBJ' value='5'/>
-      <enumerator name='DMU_OT_BPOBJ_HDR' value='6'/>
-      <enumerator name='DMU_OT_SPACE_MAP_HEADER' value='7'/>
-      <enumerator name='DMU_OT_SPACE_MAP' value='8'/>
-      <enumerator name='DMU_OT_INTENT_LOG' value='9'/>
-      <enumerator name='DMU_OT_DNODE' value='10'/>
-      <enumerator name='DMU_OT_OBJSET' value='11'/>
-      <enumerator name='DMU_OT_DSL_DIR' value='12'/>
-      <enumerator name='DMU_OT_DSL_DIR_CHILD_MAP' value='13'/>
-      <enumerator name='DMU_OT_DSL_DS_SNAP_MAP' value='14'/>
-      <enumerator name='DMU_OT_DSL_PROPS' value='15'/>
-      <enumerator name='DMU_OT_DSL_DATASET' value='16'/>
-      <enumerator name='DMU_OT_ZNODE' value='17'/>
-      <enumerator name='DMU_OT_OLDACL' value='18'/>
-      <enumerator name='DMU_OT_PLAIN_FILE_CONTENTS' value='19'/>
-      <enumerator name='DMU_OT_DIRECTORY_CONTENTS' value='20'/>
-      <enumerator name='DMU_OT_MASTER_NODE' value='21'/>
-      <enumerator name='DMU_OT_UNLINKED_SET' value='22'/>
-      <enumerator name='DMU_OT_ZVOL' value='23'/>
-      <enumerator name='DMU_OT_ZVOL_PROP' value='24'/>
-      <enumerator name='DMU_OT_PLAIN_OTHER' value='25'/>
-      <enumerator name='DMU_OT_UINT64_OTHER' value='26'/>
-      <enumerator name='DMU_OT_ZAP_OTHER' value='27'/>
-      <enumerator name='DMU_OT_ERROR_LOG' value='28'/>
-      <enumerator name='DMU_OT_SPA_HISTORY' value='29'/>
-      <enumerator name='DMU_OT_SPA_HISTORY_OFFSETS' value='30'/>
-      <enumerator name='DMU_OT_POOL_PROPS' value='31'/>
-      <enumerator name='DMU_OT_DSL_PERMS' value='32'/>
-      <enumerator name='DMU_OT_ACL' value='33'/>
-      <enumerator name='DMU_OT_SYSACL' value='34'/>
-      <enumerator name='DMU_OT_FUID' value='35'/>
-      <enumerator name='DMU_OT_FUID_SIZE' value='36'/>
-      <enumerator name='DMU_OT_NEXT_CLONES' value='37'/>
-      <enumerator name='DMU_OT_SCAN_QUEUE' value='38'/>
-      <enumerator name='DMU_OT_USERGROUP_USED' value='39'/>
-      <enumerator name='DMU_OT_USERGROUP_QUOTA' value='40'/>
-      <enumerator name='DMU_OT_USERREFS' value='41'/>
-      <enumerator name='DMU_OT_DDT_ZAP' value='42'/>
-      <enumerator name='DMU_OT_DDT_STATS' value='43'/>
-      <enumerator name='DMU_OT_SA' value='44'/>
-      <enumerator name='DMU_OT_SA_MASTER_NODE' value='45'/>
-      <enumerator name='DMU_OT_SA_ATTR_REGISTRATION' value='46'/>
-      <enumerator name='DMU_OT_SA_ATTR_LAYOUTS' value='47'/>
-      <enumerator name='DMU_OT_SCAN_XLATE' value='48'/>
-      <enumerator name='DMU_OT_DEDUP' value='49'/>
-      <enumerator name='DMU_OT_DEADLIST' value='50'/>
-      <enumerator name='DMU_OT_DEADLIST_HDR' value='51'/>
-      <enumerator name='DMU_OT_DSL_CLONES' value='52'/>
-      <enumerator name='DMU_OT_BPOBJ_SUBOBJ' value='53'/>
-      <enumerator name='DMU_OT_NUMTYPES' value='54'/>
-      <enumerator name='DMU_OTN_UINT8_DATA' value='128'/>
-      <enumerator name='DMU_OTN_UINT8_METADATA' value='192'/>
-      <enumerator name='DMU_OTN_UINT16_DATA' value='129'/>
-      <enumerator name='DMU_OTN_UINT16_METADATA' value='193'/>
-      <enumerator name='DMU_OTN_UINT32_DATA' value='130'/>
-      <enumerator name='DMU_OTN_UINT32_METADATA' value='194'/>
-      <enumerator name='DMU_OTN_UINT64_DATA' value='131'/>
-      <enumerator name='DMU_OTN_UINT64_METADATA' value='195'/>
-      <enumerator name='DMU_OTN_ZAP_DATA' value='132'/>
-      <enumerator name='DMU_OTN_ZAP_METADATA' value='196'/>
-      <enumerator name='DMU_OTN_UINT8_ENC_DATA' value='160'/>
-      <enumerator name='DMU_OTN_UINT8_ENC_METADATA' value='224'/>
-      <enumerator name='DMU_OTN_UINT16_ENC_DATA' value='161'/>
-      <enumerator name='DMU_OTN_UINT16_ENC_METADATA' value='225'/>
-      <enumerator name='DMU_OTN_UINT32_ENC_DATA' value='162'/>
-      <enumerator name='DMU_OTN_UINT32_ENC_METADATA' value='226'/>
-      <enumerator name='DMU_OTN_UINT64_ENC_DATA' value='163'/>
-      <enumerator name='DMU_OTN_UINT64_ENC_METADATA' value='227'/>
-      <enumerator name='DMU_OTN_ZAP_ENC_DATA' value='164'/>
-      <enumerator name='DMU_OTN_ZAP_ENC_METADATA' value='228'/>
-    </enum-decl>
-    <typedef-decl name='dmu_object_type_t' type-id='type-id-383' id='type-id-381'/>
-
-    <array-type-def dimensions='1' type-id='type-id-79' size-in-bits='40' id='type-id-382'>
-      <subrange length='5' type-id='type-id-33' id='type-id-384'/>
-
-    </array-type-def>
-    <class-decl name='drr_freeobjects' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-371'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_firstobj' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_numobjs' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_write' size-in-bits='1088' is-struct='yes' visibility='default' id='type-id-372'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_type' type-id='type-id-381' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='drr_pad' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_offset' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_logical_size' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_checksumtype' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drr_flags' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='drr_compressiontype' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='drr_pad2' type-id='type-id-382' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_key' type-id='type-id-385' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='drr_compressed_size' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='drr_salt' type-id='type-id-386' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='drr_iv' type-id='type-id-387' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='drr_mac' type-id='type-id-388' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='ddt_key' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-389'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ddk_cksum' type-id='type-id-380' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='ddk_prop' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='ddt_key_t' type-id='type-id-389' id='type-id-385'/>
-
-    <array-type-def dimensions='1' type-id='type-id-79' size-in-bits='64' id='type-id-386'>
-      <subrange length='8' type-id='type-id-33' id='type-id-390'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-79' size-in-bits='96' id='type-id-387'>
-      <subrange length='12' type-id='type-id-33' id='type-id-391'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-79' size-in-bits='128' id='type-id-388'>
-      <subrange length='16' type-id='type-id-33' id='type-id-169'/>
-
-    </array-type-def>
-    <class-decl name='drr_free' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-373'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_write_byref' size-in-bits='832' is-struct='yes' visibility='default' id='type-id-374'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_refguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_refobject' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_refoffset' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='drr_checksumtype' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='456'>
-        <var-decl name='drr_flags' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='464'>
-        <var-decl name='drr_pad2' type-id='type-id-392' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='drr_key' type-id='type-id-385' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-79' size-in-bits='48' id='type-id-392'>
-      <subrange length='6' type-id='type-id-33' id='type-id-393'/>
-
-    </array-type-def>
-    <class-decl name='drr_spill' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-375'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_length' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_flags' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='200'>
-        <var-decl name='drr_compressiontype' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='208'>
-        <var-decl name='drr_pad' type-id='type-id-392' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_compressed_size' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_salt' type-id='type-id-386' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_iv' type-id='type-id-387' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='drr_mac' type-id='type-id-388' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='drr_type' type-id='type-id-381' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_write_embedded' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-376'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_compression' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='264'>
-        <var-decl name='drr_etype' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='272'>
-        <var-decl name='drr_pad' type-id='type-id-392' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_lsize' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='drr_psize' type-id='type-id-38' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_object_range' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-377'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_firstobj' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_numslots' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_salt' type-id='type-id-386' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_iv' type-id='type-id-387' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='drr_mac' type-id='type-id-388' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='drr_flags' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='488'>
-        <var-decl name='drr_pad' type-id='type-id-114' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_redact' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-378'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_checksum' size-in-bits='2432' is-struct='yes' visibility='default' id='type-id-379'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_pad' type-id='type-id-394' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='drr_checksum' type-id='type-id-380' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='2176' id='type-id-394'>
-      <subrange length='34' type-id='type-id-33' id='type-id-395'/>
-
-    </array-type-def>
-    <qualified-type-def type-id='type-id-366' const='yes' id='type-id-396'/>
-    <pointer-type-def type-id='type-id-396' size-in-bits='64' id='type-id-397'/>
-    <function-decl name='lzc_receive_with_cmdprops' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-397'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-107'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <parameter type-id='type-id-223'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='create_parents' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-133'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='fnvlist_remove' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_prop_set' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='lzc_rename' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-355'>
-      <parameter type-id='type-id-135'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-16'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_status.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <typedef-decl name='zpool_status_t' type-id='type-id-325' id='type-id-398'/>
-    <typedef-decl name='zpool_errata_t' type-id='type-id-326' id='type-id-399'/>
-    <pointer-type-def type-id='type-id-399' size-in-bits='64' id='type-id-400'/>
-    <function-decl name='zpool_get_status' mangled-name='zpool_get_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_status'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-88' name='msgid'/>
-      <parameter type-id='type-id-400' name='errata'/>
-      <return type-id='type-id-398'/>
-    </function-decl>
-    <function-decl name='zpool_load_compat' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-294'/>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-318'/>
-    </function-decl>
-    <function-decl name='zpool_import_status' mangled-name='zpool_import_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_status'>
-      <parameter type-id='type-id-15' name='config'/>
-      <parameter type-id='type-id-88' name='msgid'/>
-      <parameter type-id='type-id-400' name='errata'/>
-      <return type-id='type-id-398'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_util.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zprop_get_list' mangled-name='zprop_get_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_get_list'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-17' name='props'/>
-      <parameter type-id='type-id-259' name='listp'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_errno' mangled-name='libzfs_errno' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_errno'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_error_action' mangled-name='libzfs_error_action' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_action'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='libzfs_error_description' mangled-name='libzfs_error_description' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_description'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-8' name='error'/>
-      <parameter type-id='type-id-84' name='msg'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-401'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='gp_offset' type-id='type-id-5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='fp_offset' type-id='type-id-5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='overflow_arg_area' type-id='type-id-7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='reg_save_area' type-id='type-id-7' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-401' size-in-bits='64' id='type-id-402'/>
-    <function-decl name='vasprintf' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-88'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-402'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_print_on_error' mangled-name='libzfs_print_on_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_print_on_error'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-16' name='enable'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process'>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-88' name='argv'/>
-      <parameter type-id='type-id-8' name='flags'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fork' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='waitpid' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-223'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='dup2' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-17' const='yes' id='type-id-403'/>
-    <pointer-type-def type-id='type-id-403' size-in-bits='64' id='type-id-404'/>
-    <function-decl name='execv' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-404'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='execvp' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-404'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='execve' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-404'/>
-      <parameter type-id='type-id-404'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='execvpe' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-404'/>
-      <parameter type-id='type-id-404'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-405'/>
-    <function-decl name='libzfs_run_process_get_stdout' mangled-name='libzfs_run_process_get_stdout' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout'>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-88' name='argv'/>
-      <parameter type-id='type-id-88' name='env'/>
-      <parameter type-id='type-id-405' name='lines'/>
-      <parameter type-id='type-id-223' name='lines_cnt'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_run_process_get_stdout_nopath' mangled-name='libzfs_run_process_get_stdout_nopath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout_nopath'>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-88' name='argv'/>
-      <parameter type-id='type-id-88' name='env'/>
-      <parameter type-id='type-id-405' name='lines'/>
-      <parameter type-id='type-id-223' name='lines_cnt'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_free_str_array' mangled-name='libzfs_free_str_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_free_str_array'>
-      <parameter type-id='type-id-88' name='strs'/>
-      <parameter type-id='type-id-8' name='count'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_envvar_is_set'>
-      <parameter type-id='type-id-17' name='envvar'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='strnlen' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='libzfs_init' mangled-name='libzfs_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
-      <return type-id='type-id-10'/>
-    </function-decl>
-    <function-decl name='libzfs_load_module' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-406'/>
-    <function-decl name='regcomp' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-406'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_core_init' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_init' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_prop_init' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_feature_init' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_init' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='fletcher_4_init' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicestrtonum'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='value'/>
-      <parameter type-id='type-id-248' name='num'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='704' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-407' visibility='default' id='type-id-408'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pd_name' type-id='type-id-84' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pd_propnum' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='pd_proptype' type-id='type-id-409' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pd_strdefault' type-id='type-id-84' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pd_numdefault' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pd_attr' type-id='type-id-410' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='pd_types' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pd_values' type-id='type-id-84' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='pd_colname' type-id='type-id-84' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='pd_rightalign' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='pd_visible' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='pd_zfs_mod_supported' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='pd_table' type-id='type-id-411' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='pd_table_size' type-id='type-id-28' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zprop_type_t' type-id='type-id-234' id='type-id-409'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-412'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='PROP_DEFAULT' value='0'/>
-      <enumerator name='PROP_READONLY' value='1'/>
-      <enumerator name='PROP_INHERIT' value='2'/>
-      <enumerator name='PROP_ONETIME' value='3'/>
-      <enumerator name='PROP_ONETIME_DEFAULT' value='4'/>
-    </enum-decl>
-    <typedef-decl name='zprop_attr_t' type-id='type-id-412' id='type-id-410'/>
-    <class-decl name='zfs_index' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-413'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pi_name' type-id='type-id-84' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pi_value' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zprop_index_t' type-id='type-id-413' id='type-id-414'/>
-    <qualified-type-def type-id='type-id-414' const='yes' id='type-id-415'/>
-    <pointer-type-def type-id='type-id-415' size-in-bits='64' id='type-id-411'/>
-    <pointer-type-def type-id='type-id-408' size-in-bits='64' id='type-id-416'/>
-    <function-decl name='zpool_prop_get_table' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-416'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_table' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-416'/>
-    </function-decl>
-    <function-decl name='libzfs_fini' mangled-name='libzfs_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_fini'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zpool_free_handles' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='namespace_clear' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_fini' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-91'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='libzfs_core_fini' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='regfree' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-406'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='fletcher_4_fini' mangled-name='fletcher_4_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_fini'>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='dlclose' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_handle'>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <return type-id='type-id-10'/>
-    </function-decl>
-    <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_handle'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <return type-id='type-id-10'/>
-    </function-decl>
-    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_handle'>
-      <parameter type-id='type-id-250' name='zhp'/>
-      <return type-id='type-id-11'/>
-    </function-decl>
-    <function-decl name='zfs_path_to_zhandle' mangled-name='zfs_path_to_zhandle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_path_to_zhandle'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-13' name='argtype'/>
-      <return type-id='type-id-135'/>
-    </function-decl>
-    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-417'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='mnt_major' type-id='type-id-140' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='mnt_minor' type-id='type-id-140' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-417' size-in-bits='64' id='type-id-418'/>
-    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' id='type-id-419'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='st_dev' type-id='type-id-420' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='type-id-307' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_nlink' type-id='type-id-421' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='st_mode' type-id='type-id-422' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='st_uid' type-id='type-id-191' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='st_gid' type-id='type-id-225' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__pad0' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='st_rdev' type-id='type-id-420' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='st_size' type-id='type-id-151' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='st_blksize' type-id='type-id-423' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_blocks' type-id='type-id-424' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='type-id-425' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='type-id-425' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='type-id-425' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__glibc_reserved' type-id='type-id-426' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__dev_t' type-id='type-id-35' id='type-id-420'/>
-    <typedef-decl name='__nlink_t' type-id='type-id-35' id='type-id-421'/>
-    <typedef-decl name='__mode_t' type-id='type-id-5' id='type-id-422'/>
-    <typedef-decl name='__blksize_t' type-id='type-id-54' id='type-id-423'/>
-    <typedef-decl name='__blkcnt64_t' type-id='type-id-54' id='type-id-424'/>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-425'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='type-id-427' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='type-id-428' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__time_t' type-id='type-id-54' id='type-id-427'/>
-    <typedef-decl name='__syscall_slong_t' type-id='type-id-54' id='type-id-428'/>
-
-    <array-type-def dimensions='1' type-id='type-id-428' size-in-bits='192' id='type-id-426'>
-      <subrange length='3' type-id='type-id-33' id='type-id-100'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-419' size-in-bits='64' id='type-id-429'/>
-    <function-decl name='getextmntent' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-418'/>
-      <parameter type-id='type-id-429'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='zprop_get_cbdata' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-430'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cb_sources' type-id='type-id-8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='cb_columns' type-id='type-id-431' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='cb_colwidths' type-id='type-id-432' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='cb_scripted' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='cb_literal' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='cb_first' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='cb_proplist' type-id='type-id-258' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='cb_type' type-id='type-id-13' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-433'>
-      <underlying-type type-id='type-id-49'/>
-      <enumerator name='GET_COL_NONE' value='0'/>
-      <enumerator name='GET_COL_NAME' value='1'/>
-      <enumerator name='GET_COL_PROPERTY' value='2'/>
-      <enumerator name='GET_COL_VALUE' value='3'/>
-      <enumerator name='GET_COL_RECVD' value='4'/>
-      <enumerator name='GET_COL_SOURCE' value='5'/>
-    </enum-decl>
-    <typedef-decl name='zfs_get_column_t' type-id='type-id-433' id='type-id-434'/>
-
-    <array-type-def dimensions='1' type-id='type-id-434' size-in-bits='160' alignment-in-bits='32' id='type-id-431'>
-      <subrange length='5' type-id='type-id-33' id='type-id-384'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='192' id='type-id-432'>
-      <subrange length='6' type-id='type-id-33' id='type-id-393'/>
-
-    </array-type-def>
-    <typedef-decl name='zprop_get_cbdata_t' type-id='type-id-430' id='type-id-435'/>
-    <pointer-type-def type-id='type-id-435' size-in-bits='64' id='type-id-436'/>
-    <function-decl name='zprop_print_one_property' mangled-name='zprop_print_one_property' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_print_one_property'>
-      <parameter type-id='type-id-84' name='name'/>
-      <parameter type-id='type-id-436' name='cbp'/>
-      <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-84' name='value'/>
-      <parameter type-id='type-id-232' name='sourcetype'/>
-      <parameter type-id='type-id-84' name='source'/>
-      <parameter type-id='type-id-84' name='recvd_value'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zprop_string_to_index' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-102'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zprop_values' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zprop_name_to_prop' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zprop_valid_for_type' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-50'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zprop_width' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-294'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='zpool_prop_unsupported' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zprop_free_list' mangled-name='zprop_free_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_free_list'>
-      <parameter type-id='type-id-258' name='pl'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-437' size-in-bits='64' id='type-id-438'/>
-    <function-decl name='zprop_iter_common' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-438'/>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <typedef-decl name='zprop_func' type-id='type-id-438' id='type-id-439'/>
-    <function-decl name='zprop_iter' mangled-name='zprop_iter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter'>
-      <parameter type-id='type-id-439' name='func'/>
-      <parameter type-id='type-id-7' name='cb'/>
-      <parameter type-id='type-id-16' name='show_all'/>
-      <parameter type-id='type-id-16' name='ordered'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_version_userland' mangled-name='zfs_version_userland' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_userland'>
-      <parameter type-id='type-id-17' name='version'/>
-      <parameter type-id='type-id-8' name='len'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_version_print' mangled-name='zfs_version_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_version_kernel' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='color_start' mangled-name='color_start' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_start'>
-      <parameter type-id='type-id-17' name='color'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='color_end' mangled-name='color_end' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_end'>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='printf_color' mangled-name='printf_color' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
-      <parameter type-id='type-id-17' name='color'/>
-      <parameter type-id='type-id-17' name='format'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-437'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_mount_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zfs_parse_mount_options' mangled-name='zfs_parse_mount_options' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_mount_options'>
-      <parameter type-id='type-id-17' name='mntopts'/>
-      <parameter type-id='type-id-102' name='mntflags'/>
-      <parameter type-id='type-id-102' name='zfsflags'/>
-      <parameter type-id='type-id-8' name='sloppy'/>
-      <parameter type-id='type-id-17' name='badopt'/>
-      <parameter type-id='type-id-17' name='mtabopt'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_adjust_mount_options' mangled-name='zfs_adjust_mount_options' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_adjust_mount_options'>
-      <parameter type-id='type-id-135' name='zhp'/>
-      <parameter type-id='type-id-84' name='mntpoint'/>
-      <parameter type-id='type-id-17' name='mntopts'/>
-      <parameter type-id='type-id-17' name='mtabopt'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='mount' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='umount2' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_mount_delegation_check' mangled-name='zfs_mount_delegation_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_delegation_check'>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='geteuid' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-5'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_pool_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='efi_use_whole_disk' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fsync' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_label_disk' mangled-name='zpool_label_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-11' name='zhp'/>
-      <parameter type-id='type-id-84' name='name'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='dk_gpt' size-in-bits='1920' is-struct='yes' visibility='default' id='type-id-440'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='efi_version' type-id='type-id-140' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='efi_nparts' type-id='type-id-140' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='efi_part_size' type-id='type-id-140' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='efi_lbasize' type-id='type-id-140' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='efi_last_lba' type-id='type-id-29' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='efi_first_u_lba' type-id='type-id-29' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='efi_last_u_lba' type-id='type-id-29' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='efi_disk_uguid' type-id='type-id-441' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='efi_flags' type-id='type-id-140' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='efi_reserved1' type-id='type-id-140' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='efi_altern_lba' type-id='type-id-29' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='efi_reserved' type-id='type-id-442' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='efi_parts' type-id='type-id-443' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='uuid' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-441'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='time_low' type-id='type-id-38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='time_mid' type-id='type-id-444' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='time_hi_and_version' type-id='type-id-444' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='clock_seq_hi_and_reserved' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='72'>
-        <var-decl name='clock_seq_low' type-id='type-id-79' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='node_addr' type-id='type-id-392' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__uint16_t' type-id='type-id-152' id='type-id-445'/>
-    <typedef-decl name='uint16_t' type-id='type-id-445' id='type-id-444'/>
-
-    <array-type-def dimensions='1' type-id='type-id-140' size-in-bits='384' id='type-id-442'>
-      <subrange length='12' type-id='type-id-33' id='type-id-391'/>
-
-    </array-type-def>
-    <class-decl name='dk_part' size-in-bits='960' is-struct='yes' visibility='default' id='type-id-446'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='p_start' type-id='type-id-29' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='p_size' type-id='type-id-29' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='p_guid' type-id='type-id-441' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='p_tag' type-id='type-id-447' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='272'>
-        <var-decl name='p_flag' type-id='type-id-447' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='p_name' type-id='type-id-448' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='p_uguid' type-id='type-id-441' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='p_resv' type-id='type-id-449' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='ushort_t' type-id='type-id-152' id='type-id-447'/>
-
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='288' id='type-id-448'>
-      <subrange length='36' type-id='type-id-33' id='type-id-450'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-140' size-in-bits='256' id='type-id-449'>
-      <subrange length='8' type-id='type-id-33' id='type-id-390'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-446' size-in-bits='960' id='type-id-443'>
-      <subrange length='1' type-id='type-id-33' id='type-id-160'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-440' size-in-bits='64' id='type-id-451'/>
-    <pointer-type-def type-id='type-id-451' size-in-bits='64' id='type-id-452'/>
-    <function-decl name='efi_alloc_and_init' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-452'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='rand' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='efi_write' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-451'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='efi_rescan' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='efi_free' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-451'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_append_partition' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_label_disk_wait' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='efi_alloc_and_read' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-452'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_sendrecv_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='fcntl' mangled-name='fcntl64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_util_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <typedef-decl name='zfs_cmd_t' type-id='type-id-108' id='type-id-453'/>
-    <pointer-type-def type-id='type-id-453' size-in-bits='64' id='type-id-454'/>
-    <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl'>
-      <parameter type-id='type-id-10' name='hdl'/>
-      <parameter type-id='type-id-8' name='request'/>
-      <parameter type-id='type-id-454' name='zc'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='libzfs_error_init' mangled-name='libzfs_error_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_init'>
-      <parameter type-id='type-id-8' name='error'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='access' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-425' size-in-bits='64' id='type-id-455'/>
-    <function-decl name='clock_gettime' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-455'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='usleep' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='sched_yield' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-8'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/icp/algs/sha2/sha2.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='htonl' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/cityhash.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='cityhash4' mangled-name='cityhash4' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='cityhash4'>
-      <parameter type-id='type-id-22' name='w1'/>
-      <parameter type-id='type-id-22' name='w2'/>
-      <parameter type-id='type-id-22' name='w3'/>
-      <parameter type-id='type-id-22' name='w4'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfeature_common.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='zfeature_checks_disable' type-id='type-id-16' mangled-name='zfeature_checks_disable' visibility='default' elf-symbol-id='zfeature_checks_disable'/>
-    <class-decl name='zfeature_info' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-456'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fi_feature' type-id='type-id-457' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='fi_uname' type-id='type-id-84' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='fi_guid' type-id='type-id-84' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='fi_desc' type-id='type-id-84' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fi_flags' type-id='type-id-458' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='fi_zfs_mod_supported' type-id='type-id-16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='fi_type' type-id='type-id-459' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='fi_depends' type-id='type-id-460' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='spa_feature_t' type-id='type-id-328' id='type-id-457'/>
-    <enum-decl name='zfeature_flags' id='type-id-461'>
-      <underlying-type type-id='type-id-49'/>
+    <typedef-decl name='spa_feature_t' type-id='type-id-214' id='type-id-210'/>
+    <enum-decl name='zfeature_flags' id='type-id-215'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZFEATURE_FLAG_READONLY_COMPAT' value='1'/>
       <enumerator name='ZFEATURE_FLAG_MOS' value='2'/>
       <enumerator name='ZFEATURE_FLAG_ACTIVATE_ON_ENABLE' value='4'/>
       <enumerator name='ZFEATURE_FLAG_PER_DATASET' value='8'/>
     </enum-decl>
-    <typedef-decl name='zfeature_flags_t' type-id='type-id-461' id='type-id-458'/>
-    <enum-decl name='zfeature_type' id='type-id-462'>
-      <underlying-type type-id='type-id-49'/>
+    <typedef-decl name='zfeature_flags_t' type-id='type-id-215' id='type-id-211'/>
+    <enum-decl name='zfeature_type' id='type-id-216'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZFEATURE_TYPE_BOOLEAN' value='0'/>
       <enumerator name='ZFEATURE_TYPE_UINT64_ARRAY' value='1'/>
       <enumerator name='ZFEATURE_NUM_TYPES' value='2'/>
     </enum-decl>
-    <typedef-decl name='zfeature_type_t' type-id='type-id-462' id='type-id-459'/>
-    <qualified-type-def type-id='type-id-457' const='yes' id='type-id-463'/>
-    <pointer-type-def type-id='type-id-463' size-in-bits='64' id='type-id-460'/>
-    <typedef-decl name='zfeature_info_t' type-id='type-id-456' id='type-id-464'/>
+    <typedef-decl name='zfeature_type_t' type-id='type-id-216' id='type-id-212'/>
+    <qualified-type-def type-id='type-id-210' const='yes' id='type-id-217'/>
+    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-213'/>
+    <typedef-decl name='zfeature_info_t' type-id='type-id-209' id='type-id-218'/>
 
-    <array-type-def dimensions='1' type-id='type-id-464' size-in-bits='15232' id='type-id-465'>
-      <subrange length='34' type-id='type-id-33' id='type-id-395'/>
+    <array-type-def dimensions='1' type-id='type-id-218' size-in-bits='15232' id='type-id-219'>
+      <subrange length='34' type-id='type-id-24' id='type-id-220'/>
 
     </array-type-def>
-    <var-decl name='spa_feature_table' type-id='type-id-465' mangled-name='spa_feature_table' visibility='default' elf-symbol-id='spa_feature_table'/>
-    <function-decl name='zfeature_is_valid_guid' mangled-name='zfeature_is_valid_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_valid_guid'>
+    <var-decl name='spa_feature_table' type-id='type-id-219' mangled-name='spa_feature_table' visibility='default' elf-symbol-id='spa_feature_table'/>
+    <function-decl name='zfeature_depends_on' mangled-name='zfeature_depends_on' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_depends_on'>
+      <parameter type-id='type-id-210' name='fid'/>
+      <parameter type-id='type-id-210' name='check'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-210' size-in-bits='64' id='type-id-221'/>
+    <function-decl name='zfeature_lookup_name' mangled-name='zfeature_lookup_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_name'>
       <parameter type-id='type-id-84' name='name'/>
-      <return type-id='type-id-16'/>
+      <parameter type-id='type-id-221' name='res'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfeature_lookup_guid' mangled-name='zfeature_lookup_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_guid'>
+      <parameter type-id='type-id-84' name='name'/>
+      <parameter type-id='type-id-221' name='res'/>
+      <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='zfeature_is_supported' mangled-name='zfeature_is_supported' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_supported'>
       <parameter type-id='type-id-84' name='guid'/>
-      <return type-id='type-id-16'/>
+      <return type-id='type-id-9'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-457' size-in-bits='64' id='type-id-466'/>
-    <function-decl name='zfeature_lookup_guid' mangled-name='zfeature_lookup_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_guid'>
-      <parameter type-id='type-id-84' name='guid'/>
-      <parameter type-id='type-id-466' name='res'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfeature_lookup_name' mangled-name='zfeature_lookup_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_name'>
-      <parameter type-id='type-id-84' name='guid'/>
-      <parameter type-id='type-id-466' name='res'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfeature_depends_on' mangled-name='zfeature_depends_on' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_depends_on'>
-      <parameter type-id='type-id-457' name='fid'/>
-      <parameter type-id='type-id-457' name='check'/>
-      <return type-id='type-id-16'/>
+    <function-decl name='zfeature_is_valid_guid' mangled-name='zfeature_is_valid_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_valid_guid'>
+      <parameter type-id='type-id-84' name='name'/>
+      <return type-id='type-id-9'/>
     </function-decl>
     <function-decl name='zfs_mod_supported' mangled-name='zfs_mod_supported' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mod_supported'>
       <parameter type-id='type-id-84' name='scope'/>
       <parameter type-id='type-id-84' name='name'/>
-      <return type-id='type-id-16'/>
+      <return type-id='type-id-9'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_comutil.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_comutil.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
 
-    <array-type-def dimensions='1' type-id='type-id-84' size-in-bits='2624' id='type-id-467'>
-      <subrange length='41' type-id='type-id-33' id='type-id-468'/>
+    <array-type-def dimensions='1' type-id='type-id-84' size-in-bits='2624' id='type-id-222'>
+      <subrange length='41' type-id='type-id-24' id='type-id-223'/>
 
     </array-type-def>
-    <var-decl name='zfs_history_event_names' type-id='type-id-467' mangled-name='zfs_history_event_names' visibility='default' elf-symbol-id='zfs_history_event_names'/>
-    <function-decl name='zfs_allocatable_devs' mangled-name='zfs_allocatable_devs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_allocatable_devs'>
-      <parameter type-id='type-id-15' name='nv'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_special_devs' mangled-name='zfs_special_devs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_special_devs'>
-      <parameter type-id='type-id-15' name='nv'/>
-      <parameter type-id='type-id-17' name='type'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <typedef-decl name='zpool_load_policy_t' type-id='type-id-330' id='type-id-469'/>
-    <pointer-type-def type-id='type-id-469' size-in-bits='64' id='type-id-470'/>
-    <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_load_policy'>
-      <parameter type-id='type-id-15' name='nvl'/>
-      <parameter type-id='type-id-470' name='zlpp'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-133'/>
-      <parameter type-id='type-id-244'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_zpl_version_map' mangled-name='zfs_zpl_version_map' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_zpl_version_map'>
-      <parameter type-id='type-id-8' name='spa_version'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_spa_version_map' mangled-name='zfs_spa_version_map' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version_map'>
-      <parameter type-id='type-id-8' name='spa_version'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
+    <var-decl name='zfs_history_event_names' type-id='type-id-222' mangled-name='zfs_history_event_names' visibility='default' elf-symbol-id='zfs_history_event_names'/>
     <function-decl name='zfs_dataset_name_hidden' mangled-name='zfs_dataset_name_hidden' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_name_hidden'>
       <parameter type-id='type-id-84' name='name'/>
-      <return type-id='type-id-16'/>
+      <return type-id='type-id-9'/>
     </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_deleg.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-471'>
+    <function-decl name='zfs_spa_version_map' mangled-name='zfs_spa_version_map' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version_map'>
+      <parameter type-id='type-id-2' name='zpl_version'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_zpl_version_map' mangled-name='zfs_zpl_version_map' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_zpl_version_map'>
+      <parameter type-id='type-id-2' name='zpl_version'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <class-decl name='zpool_load_policy' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-224'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='z_perm' type-id='type-id-17' visibility='default'/>
+        <var-decl name='zlp_rewind' type-id='type-id-28' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='z_note' type-id='type-id-472' visibility='default'/>
+        <var-decl name='zlp_maxmeta' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zlp_maxdata' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zlp_txg' type-id='type-id-7' visibility='default'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-473'>
-      <underlying-type type-id='type-id-49'/>
+    <typedef-decl name='zpool_load_policy_t' type-id='type-id-224' id='type-id-225'/>
+    <pointer-type-def type-id='type-id-225' size-in-bits='64' id='type-id-226'/>
+    <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_load_policy'>
+      <parameter type-id='type-id-19' name='nvl'/>
+      <parameter type-id='type-id-226' name='zlpp'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_special_devs' mangled-name='zfs_special_devs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_special_devs'>
+      <parameter type-id='type-id-19' name='nv'/>
+      <parameter type-id='type-id-14' name='type'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_allocatable_devs' mangled-name='zfs_allocatable_devs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_allocatable_devs'>
+      <parameter type-id='type-id-19' name='nv'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_deleg.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-227'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='z_perm' type-id='type-id-14' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='z_note' type-id='type-id-228' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-229'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZFS_DELEG_NOTE_CREATE' value='0'/>
       <enumerator name='ZFS_DELEG_NOTE_DESTROY' value='1'/>
       <enumerator name='ZFS_DELEG_NOTE_SNAPSHOT' value='2'/>
@@ -6832,34 +4520,16 @@
       <enumerator name='ZFS_DELEG_NOTE_PROJECTOBJQUOTA' value='30'/>
       <enumerator name='ZFS_DELEG_NOTE_NONE' value='31'/>
     </enum-decl>
-    <typedef-decl name='zfs_deleg_note_t' type-id='type-id-473' id='type-id-472'/>
-    <typedef-decl name='zfs_deleg_perm_tab_t' type-id='type-id-471' id='type-id-474'/>
+    <typedef-decl name='zfs_deleg_note_t' type-id='type-id-229' id='type-id-228'/>
+    <typedef-decl name='zfs_deleg_perm_tab_t' type-id='type-id-227' id='type-id-230'/>
 
-    <array-type-def dimensions='1' type-id='type-id-474' size-in-bits='4096' id='type-id-475'>
-      <subrange length='32' type-id='type-id-33' id='type-id-208'/>
+    <array-type-def dimensions='1' type-id='type-id-230' size-in-bits='128' id='type-id-231'>
+      <subrange length='1' id='type-id-232'/>
 
     </array-type-def>
-    <var-decl name='zfs_deleg_perm_tab' type-id='type-id-475' mangled-name='zfs_deleg_perm_tab' visibility='default' elf-symbol-id='zfs_deleg_perm_tab'/>
-    <function-decl name='zfs_deleg_canonicalize_perm' mangled-name='zfs_deleg_canonicalize_perm' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_canonicalize_perm'>
-      <parameter type-id='type-id-84' name='perm'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zfs_prop_delegatable' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-85'/>
-      <return type-id='type-id-50'/>
-    </function-decl>
-    <function-decl name='zfs_deleg_verify_nvlist' mangled-name='zfs_deleg_verify_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_verify_nvlist'>
-      <parameter type-id='type-id-15' name='nvp'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='permset_namecheck' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-213'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-476'>
-      <underlying-type type-id='type-id-49'/>
+    <var-decl name='zfs_deleg_perm_tab' type-id='type-id-231' mangled-name='zfs_deleg_perm_tab' visibility='default' elf-symbol-id='zfs_deleg_perm_tab'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-233'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZFS_DELEG_WHO_UNKNOWN' value='0'/>
       <enumerator name='ZFS_DELEG_USER' value='117'/>
       <enumerator name='ZFS_DELEG_USER_SETS' value='85'/>
@@ -6872,896 +4542,874 @@
       <enumerator name='ZFS_DELEG_NAMED_SET' value='115'/>
       <enumerator name='ZFS_DELEG_NAMED_SET_SETS' value='83'/>
     </enum-decl>
-    <typedef-decl name='zfs_deleg_who_type_t' type-id='type-id-476' id='type-id-477'/>
+    <typedef-decl name='zfs_deleg_who_type_t' type-id='type-id-233' id='type-id-234'/>
     <function-decl name='zfs_deleg_whokey' mangled-name='zfs_deleg_whokey' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_whokey'>
-      <parameter type-id='type-id-17' name='attr'/>
-      <parameter type-id='type-id-477' name='type'/>
-      <parameter type-id='type-id-32' name='inheritchr'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-14' name='attr'/>
+      <parameter type-id='type-id-234' name='type'/>
+      <parameter type-id='type-id-23' name='inheritchr'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_deleg_verify_nvlist' mangled-name='zfs_deleg_verify_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_verify_nvlist'>
+      <parameter type-id='type-id-19' name='nvp'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_deleg_canonicalize_perm' mangled-name='zfs_deleg_canonicalize_perm' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_canonicalize_perm'>
+      <parameter type-id='type-id-84' name='perm'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='permset_namecheck' mangled-name='permset_namecheck' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_prop_delegatable' mangled-name='zfs_prop_delegatable' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='zio_abd_checksum_func' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-478'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='zio_abd_checksum_func' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-235'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='acf_init' type-id='type-id-479' visibility='default'/>
+        <var-decl name='acf_init' type-id='type-id-236' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='acf_fini' type-id='type-id-480' visibility='default'/>
+        <var-decl name='acf_fini' type-id='type-id-237' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='acf_iter' type-id='type-id-481' visibility='default'/>
+        <var-decl name='acf_iter' type-id='type-id-238' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='zio_abd_checksum_data' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-482'>
+    <class-decl name='zio_abd_checksum_data' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-239'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='acd_byteorder' type-id='type-id-483' visibility='default'/>
+        <var-decl name='acd_byteorder' type-id='type-id-240' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='acd_ctx' type-id='type-id-484' visibility='default'/>
+        <var-decl name='acd_ctx' type-id='type-id-241' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='acd_zcp' type-id='type-id-485' visibility='default'/>
+        <var-decl name='acd_zcp' type-id='type-id-242' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='acd_private' type-id='type-id-7' visibility='default'/>
+        <var-decl name='acd_private' type-id='type-id-13' visibility='default'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-486'>
-      <underlying-type type-id='type-id-49'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-243'>
+      <underlying-type type-id='type-id-41'/>
       <enumerator name='ZIO_CHECKSUM_NATIVE' value='0'/>
       <enumerator name='ZIO_CHECKSUM_BYTESWAP' value='1'/>
     </enum-decl>
-    <typedef-decl name='zio_byteorder_t' type-id='type-id-486' id='type-id-483'/>
-    <union-decl name='fletcher_4_ctx' size-in-bits='2048' visibility='default' id='type-id-487'>
+    <typedef-decl name='zio_byteorder_t' type-id='type-id-243' id='type-id-240'/>
+    <union-decl name='fletcher_4_ctx' size-in-bits='2048' visibility='default' id='type-id-244'>
       <data-member access='private'>
-        <var-decl name='scalar' type-id='type-id-380' visibility='default'/>
+        <var-decl name='scalar' type-id='type-id-245' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='superscalar' type-id='type-id-488' visibility='default'/>
+        <var-decl name='superscalar' type-id='type-id-246' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sse' type-id='type-id-489' visibility='default'/>
+        <var-decl name='sse' type-id='type-id-247' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='avx' type-id='type-id-490' visibility='default'/>
+        <var-decl name='avx' type-id='type-id-248' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='avx512' type-id='type-id-491' visibility='default'/>
+        <var-decl name='avx512' type-id='type-id-249' visibility='default'/>
       </data-member>
     </union-decl>
-    <class-decl name='zfs_fletcher_superscalar' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-492'>
+    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-250'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-359' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zfs_fletcher_superscalar_t' type-id='type-id-492' id='type-id-493'/>
-
-    <array-type-def dimensions='1' type-id='type-id-493' size-in-bits='1024' id='type-id-488'>
-      <subrange length='4' type-id='type-id-33' id='type-id-217'/>
-
-    </array-type-def>
-    <class-decl name='zfs_fletcher_sse' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-494'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-121' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zfs_fletcher_sse_t' type-id='type-id-494' id='type-id-495'/>
-
-    <array-type-def dimensions='1' type-id='type-id-495' size-in-bits='512' id='type-id-489'>
-      <subrange length='4' type-id='type-id-33' id='type-id-217'/>
-
-    </array-type-def>
-    <class-decl name='zfs_fletcher_avx' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-496'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-359' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zfs_fletcher_avx_t' type-id='type-id-496' id='type-id-497'/>
-
-    <array-type-def dimensions='1' type-id='type-id-497' size-in-bits='1024' id='type-id-490'>
-      <subrange length='4' type-id='type-id-33' id='type-id-217'/>
-
-    </array-type-def>
-    <class-decl name='zfs_fletcher_avx512' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-498'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='v' type-id='type-id-499' visibility='default'/>
+        <var-decl name='zc_word' type-id='type-id-251' visibility='default'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='512' id='type-id-499'>
-      <subrange length='8' type-id='type-id-33' id='type-id-390'/>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='256' id='type-id-251'>
+      <subrange length='4' type-id='type-id-24' id='type-id-252'/>
 
     </array-type-def>
-    <typedef-decl name='zfs_fletcher_avx512_t' type-id='type-id-498' id='type-id-500'/>
+    <typedef-decl name='zio_cksum_t' type-id='type-id-250' id='type-id-245'/>
+    <class-decl name='zfs_fletcher_superscalar' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-253'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='v' type-id='type-id-251' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_fletcher_superscalar_t' type-id='type-id-253' id='type-id-254'/>
 
-    <array-type-def dimensions='1' type-id='type-id-500' size-in-bits='2048' id='type-id-491'>
-      <subrange length='4' type-id='type-id-33' id='type-id-217'/>
+    <array-type-def dimensions='1' type-id='type-id-254' size-in-bits='1024' id='type-id-246'>
+      <subrange length='4' type-id='type-id-24' id='type-id-252'/>
 
     </array-type-def>
-    <typedef-decl name='fletcher_4_ctx_t' type-id='type-id-487' id='type-id-501'/>
-    <pointer-type-def type-id='type-id-501' size-in-bits='64' id='type-id-484'/>
-    <pointer-type-def type-id='type-id-380' size-in-bits='64' id='type-id-485'/>
-    <typedef-decl name='zio_abd_checksum_data_t' type-id='type-id-482' id='type-id-502'/>
-    <pointer-type-def type-id='type-id-502' size-in-bits='64' id='type-id-503'/>
-    <typedef-decl name='zio_abd_checksum_init_t' type-id='type-id-504' id='type-id-505'/>
-    <pointer-type-def type-id='type-id-505' size-in-bits='64' id='type-id-479'/>
-    <typedef-decl name='zio_abd_checksum_fini_t' type-id='type-id-504' id='type-id-506'/>
-    <pointer-type-def type-id='type-id-506' size-in-bits='64' id='type-id-480'/>
-    <typedef-decl name='zio_abd_checksum_iter_t' type-id='type-id-507' id='type-id-508'/>
-    <pointer-type-def type-id='type-id-508' size-in-bits='64' id='type-id-481'/>
-    <qualified-type-def type-id='type-id-478' const='yes' id='type-id-509'/>
-    <typedef-decl name='zio_abd_checksum_func_t' type-id='type-id-509' id='type-id-510'/>
-    <var-decl name='fletcher_4_abd_ops' type-id='type-id-510' mangled-name='fletcher_4_abd_ops' visibility='default' elf-symbol-id='fletcher_4_abd_ops'/>
-    <function-decl name='fletcher_init' mangled-name='fletcher_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_init'>
-      <parameter type-id='type-id-485' name='zcp'/>
-      <return type-id='type-id-6'/>
+    <class-decl name='zfs_fletcher_sse' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-255'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='v' type-id='type-id-206' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_fletcher_sse_t' type-id='type-id-255' id='type-id-256'/>
+
+    <array-type-def dimensions='1' type-id='type-id-256' size-in-bits='512' id='type-id-247'>
+      <subrange length='4' type-id='type-id-24' id='type-id-252'/>
+
+    </array-type-def>
+    <class-decl name='zfs_fletcher_avx' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-257'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='v' type-id='type-id-251' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_fletcher_avx_t' type-id='type-id-257' id='type-id-258'/>
+
+    <array-type-def dimensions='1' type-id='type-id-258' size-in-bits='1024' id='type-id-248'>
+      <subrange length='4' type-id='type-id-24' id='type-id-252'/>
+
+    </array-type-def>
+    <class-decl name='zfs_fletcher_avx512' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-259'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='v' type-id='type-id-260' visibility='default'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='512' id='type-id-260'>
+      <subrange length='8' type-id='type-id-24' id='type-id-261'/>
+
+    </array-type-def>
+    <typedef-decl name='zfs_fletcher_avx512_t' type-id='type-id-259' id='type-id-262'/>
+
+    <array-type-def dimensions='1' type-id='type-id-262' size-in-bits='2048' id='type-id-249'>
+      <subrange length='4' type-id='type-id-24' id='type-id-252'/>
+
+    </array-type-def>
+    <typedef-decl name='fletcher_4_ctx_t' type-id='type-id-244' id='type-id-263'/>
+    <pointer-type-def type-id='type-id-263' size-in-bits='64' id='type-id-241'/>
+    <pointer-type-def type-id='type-id-245' size-in-bits='64' id='type-id-242'/>
+    <typedef-decl name='zio_abd_checksum_data_t' type-id='type-id-239' id='type-id-264'/>
+    <pointer-type-def type-id='type-id-264' size-in-bits='64' id='type-id-265'/>
+    <typedef-decl name='zio_abd_checksum_init_t' type-id='type-id-266' id='type-id-267'/>
+    <pointer-type-def type-id='type-id-267' size-in-bits='64' id='type-id-236'/>
+    <typedef-decl name='zio_abd_checksum_fini_t' type-id='type-id-266' id='type-id-268'/>
+    <pointer-type-def type-id='type-id-268' size-in-bits='64' id='type-id-237'/>
+    <typedef-decl name='zio_abd_checksum_iter_t' type-id='type-id-269' id='type-id-270'/>
+    <pointer-type-def type-id='type-id-270' size-in-bits='64' id='type-id-238'/>
+    <qualified-type-def type-id='type-id-235' const='yes' id='type-id-271'/>
+    <typedef-decl name='zio_abd_checksum_func_t' type-id='type-id-271' id='type-id-272'/>
+    <var-decl name='fletcher_4_abd_ops' type-id='type-id-272' mangled-name='fletcher_4_abd_ops' visibility='default' elf-symbol-id='fletcher_4_abd_ops'/>
+    <function-decl name='fletcher_4_incremental_byteswap' mangled-name='fletcher_4_incremental_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_byteswap'>
+      <parameter type-id='type-id-13' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='fletcher_2_incremental_native' mangled-name='fletcher_2_incremental_native' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_native'>
-      <parameter type-id='type-id-7' name='buf'/>
-      <parameter type-id='type-id-28' name='size'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fletcher_2_native' mangled-name='fletcher_2_native' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_native'>
-      <parameter type-id='type-id-7' name='buf'/>
-      <parameter type-id='type-id-22' name='size'/>
-      <parameter type-id='type-id-7' name='ctx_template'/>
-      <parameter type-id='type-id-485' name='zcp'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='fletcher_2_incremental_byteswap' mangled-name='fletcher_2_incremental_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_byteswap'>
-      <parameter type-id='type-id-7' name='buf'/>
-      <parameter type-id='type-id-28' name='size'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='fletcher_2_byteswap' mangled-name='fletcher_2_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_byteswap'>
-      <parameter type-id='type-id-7' name='buf'/>
-      <parameter type-id='type-id-22' name='size'/>
-      <parameter type-id='type-id-7' name='ctx_template'/>
-      <parameter type-id='type-id-485' name='zcp'/>
-      <return type-id='type-id-6'/>
+    <function-decl name='fletcher_4_native_varsize' mangled-name='fletcher_4_native_varsize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native_varsize'>
+      <parameter type-id='type-id-13' name='buf'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <parameter type-id='type-id-242' name='zcp'/>
+      <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='fletcher_4_impl_set' mangled-name='fletcher_4_impl_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_impl_set'>
       <parameter type-id='type-id-84' name='val'/>
-      <return type-id='type-id-8'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-5' volatile='yes' id='type-id-511'/>
-    <pointer-type-def type-id='type-id-511' size-in-bits='64' id='type-id-512'/>
-    <function-decl name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-512'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='fletcher_2_byteswap' mangled-name='fletcher_2_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_byteswap'>
+      <parameter type-id='type-id-13' name='buf'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <parameter type-id='type-id-13' name='ctx_template'/>
+      <parameter type-id='type-id-242' name='zcp'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='membar_producer' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
+    <function-decl name='fletcher_2_incremental_byteswap' mangled-name='fletcher_2_incremental_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_byteswap'>
+      <parameter type-id='type-id-13' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='fletcher_2_native' mangled-name='fletcher_2_native' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_native'>
+      <parameter type-id='type-id-13' name='buf'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <parameter type-id='type-id-13' name='ctx_template'/>
+      <parameter type-id='type-id-242' name='zcp'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='fletcher_2_incremental_native' mangled-name='fletcher_2_incremental_native' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_native'>
+      <parameter type-id='type-id-13' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='fletcher_init' mangled-name='fletcher_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_init'>
+      <parameter type-id='type-id-242' name='zcp'/>
+      <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='fletcher_4_native' mangled-name='fletcher_4_native' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native'>
-      <parameter type-id='type-id-7' name='buf'/>
-      <parameter type-id='type-id-22' name='size'/>
-      <parameter type-id='type-id-7' name='ctx_template'/>
-      <parameter type-id='type-id-485' name='zcp'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='fletcher_4_native_varsize' mangled-name='fletcher_4_native_varsize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native_varsize'>
-      <parameter type-id='type-id-7' name='buf'/>
-      <parameter type-id='type-id-22' name='size'/>
-      <parameter type-id='type-id-485' name='zcp'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-13' name='buf'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <parameter type-id='type-id-13' name='ctx_template'/>
+      <parameter type-id='type-id-242' name='zcp'/>
+      <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='fletcher_4_byteswap' mangled-name='fletcher_4_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_byteswap'>
-      <parameter type-id='type-id-7' name='buf'/>
-      <parameter type-id='type-id-22' name='size'/>
-      <parameter type-id='type-id-7' name='ctx_template'/>
-      <parameter type-id='type-id-485' name='zcp'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-13' name='buf'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <parameter type-id='type-id-13' name='ctx_template'/>
+      <parameter type-id='type-id-242' name='zcp'/>
+      <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='fletcher_4_incremental_native' mangled-name='fletcher_4_incremental_native' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_native'>
-      <parameter type-id='type-id-7' name='buf'/>
-      <parameter type-id='type-id-28' name='size'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
+      <parameter type-id='type-id-13' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-13' name='data'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='fletcher_4_incremental_byteswap' mangled-name='fletcher_4_incremental_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_byteswap'>
-      <parameter type-id='type-id-7' name='buf'/>
-      <parameter type-id='type-id-28' name='size'/>
-      <parameter type-id='type-id-7' name='data'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='membar_producer' mangled-name='membar_producer' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-507'>
-      <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-28'/>
-      <parameter type-id='type-id-7'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-269'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-18'/>
+      <parameter type-id='type-id-13'/>
+      <return type-id='type-id-2'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-504'>
-      <parameter type-id='type-id-503'/>
-      <return type-id='type-id-6'/>
+    <function-type size-in-bits='64' id='type-id-266'>
+      <parameter type-id='type-id-265'/>
+      <return type-id='type-id-1'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_avx512.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <class-decl name='fletcher_4_func' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-513'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_avx512.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <class-decl name='fletcher_4_func' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-273'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='init_native' type-id='type-id-514' visibility='default'/>
+        <var-decl name='init_native' type-id='type-id-274' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='fini_native' type-id='type-id-515' visibility='default'/>
+        <var-decl name='fini_native' type-id='type-id-275' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='compute_native' type-id='type-id-516' visibility='default'/>
+        <var-decl name='compute_native' type-id='type-id-276' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='init_byteswap' type-id='type-id-514' visibility='default'/>
+        <var-decl name='init_byteswap' type-id='type-id-274' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fini_byteswap' type-id='type-id-515' visibility='default'/>
+        <var-decl name='fini_byteswap' type-id='type-id-275' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='compute_byteswap' type-id='type-id-516' visibility='default'/>
+        <var-decl name='compute_byteswap' type-id='type-id-276' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='valid' type-id='type-id-517' visibility='default'/>
+        <var-decl name='valid' type-id='type-id-277' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='name' type-id='type-id-84' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-518' size-in-bits='64' id='type-id-519'/>
-    <typedef-decl name='fletcher_4_init_f' type-id='type-id-519' id='type-id-514'/>
-    <pointer-type-def type-id='type-id-520' size-in-bits='64' id='type-id-521'/>
-    <typedef-decl name='fletcher_4_fini_f' type-id='type-id-521' id='type-id-515'/>
-    <pointer-type-def type-id='type-id-522' size-in-bits='64' id='type-id-523'/>
-    <typedef-decl name='fletcher_4_compute_f' type-id='type-id-523' id='type-id-516'/>
-    <pointer-type-def type-id='type-id-524' size-in-bits='64' id='type-id-517'/>
-    <typedef-decl name='fletcher_4_ops_t' type-id='type-id-513' id='type-id-525'/>
-    <qualified-type-def type-id='type-id-525' const='yes' id='type-id-526'/>
-    <var-decl name='fletcher_4_avx512f_ops' type-id='type-id-526' mangled-name='fletcher_4_avx512f_ops' visibility='default' elf-symbol-id='fletcher_4_avx512f_ops'/>
-    <var-decl name='fletcher_4_avx512bw_ops' type-id='type-id-526' mangled-name='fletcher_4_avx512bw_ops' visibility='default' elf-symbol-id='fletcher_4_avx512bw_ops'/>
-    <function-type size-in-bits='64' id='type-id-524'>
-      <return type-id='type-id-16'/>
+    <pointer-type-def type-id='type-id-278' size-in-bits='64' id='type-id-279'/>
+    <typedef-decl name='fletcher_4_init_f' type-id='type-id-279' id='type-id-274'/>
+    <pointer-type-def type-id='type-id-280' size-in-bits='64' id='type-id-281'/>
+    <typedef-decl name='fletcher_4_fini_f' type-id='type-id-281' id='type-id-275'/>
+    <pointer-type-def type-id='type-id-282' size-in-bits='64' id='type-id-283'/>
+    <typedef-decl name='fletcher_4_compute_f' type-id='type-id-283' id='type-id-276'/>
+    <pointer-type-def type-id='type-id-284' size-in-bits='64' id='type-id-277'/>
+    <typedef-decl name='fletcher_4_ops_t' type-id='type-id-273' id='type-id-285'/>
+    <qualified-type-def type-id='type-id-285' const='yes' id='type-id-286'/>
+    <var-decl name='fletcher_4_avx512f_ops' type-id='type-id-286' mangled-name='fletcher_4_avx512f_ops' visibility='default' elf-symbol-id='fletcher_4_avx512f_ops'/>
+    <var-decl name='fletcher_4_avx512bw_ops' type-id='type-id-286' mangled-name='fletcher_4_avx512bw_ops' visibility='default' elf-symbol-id='fletcher_4_avx512bw_ops'/>
+    <function-type size-in-bits='64' id='type-id-284'>
+      <return type-id='type-id-9'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-518'>
-      <parameter type-id='type-id-484'/>
-      <return type-id='type-id-6'/>
+    <function-type size-in-bits='64' id='type-id-278'>
+      <parameter type-id='type-id-241'/>
+      <return type-id='type-id-1'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-522'>
-      <parameter type-id='type-id-484'/>
+    <function-type size-in-bits='64' id='type-id-282'>
+      <parameter type-id='type-id-241'/>
+      <parameter type-id='type-id-13'/>
       <parameter type-id='type-id-7'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-6'/>
+      <return type-id='type-id-1'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-520'>
-      <parameter type-id='type-id-484'/>
-      <parameter type-id='type-id-485'/>
-      <return type-id='type-id-6'/>
+    <function-type size-in-bits='64' id='type-id-280'>
+      <parameter type-id='type-id-241'/>
+      <parameter type-id='type-id-242'/>
+      <return type-id='type-id-1'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_intel.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_avx2_ops' type-id='type-id-526' mangled-name='fletcher_4_avx2_ops' visibility='default' elf-symbol-id='fletcher_4_avx2_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_intel.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_avx2_ops' type-id='type-id-286' mangled-name='fletcher_4_avx2_ops' visibility='default' elf-symbol-id='fletcher_4_avx2_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_sse.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_sse2_ops' type-id='type-id-526' mangled-name='fletcher_4_sse2_ops' visibility='default' elf-symbol-id='fletcher_4_sse2_ops'/>
-    <var-decl name='fletcher_4_ssse3_ops' type-id='type-id-526' mangled-name='fletcher_4_ssse3_ops' visibility='default' elf-symbol-id='fletcher_4_ssse3_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_sse.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_sse2_ops' type-id='type-id-286' mangled-name='fletcher_4_sse2_ops' visibility='default' elf-symbol-id='fletcher_4_sse2_ops'/>
+    <var-decl name='fletcher_4_ssse3_ops' type-id='type-id-286' mangled-name='fletcher_4_ssse3_ops' visibility='default' elf-symbol-id='fletcher_4_ssse3_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_superscalar_ops' type-id='type-id-526' mangled-name='fletcher_4_superscalar_ops' visibility='default' elf-symbol-id='fletcher_4_superscalar_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_superscalar_ops' type-id='type-id-286' mangled-name='fletcher_4_superscalar_ops' visibility='default' elf-symbol-id='fletcher_4_superscalar_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar4.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='fletcher_4_superscalar4_ops' type-id='type-id-526' mangled-name='fletcher_4_superscalar4_ops' visibility='default' elf-symbol-id='fletcher_4_superscalar4_ops'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar4.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='fletcher_4_superscalar4_ops' type-id='type-id-286' mangled-name='fletcher_4_superscalar4_ops' visibility='default' elf-symbol-id='fletcher_4_superscalar4_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_namecheck.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <var-decl name='zfs_max_dataset_nesting' type-id='type-id-8' mangled-name='zfs_max_dataset_nesting' visibility='default' elf-symbol-id='zfs_max_dataset_nesting'/>
-    <function-decl name='get_dataset_depth' mangled-name='get_dataset_depth' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_dataset_depth'>
-      <parameter type-id='type-id-84' name='path'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <typedef-decl name='namecheck_err_t' type-id='type-id-212' id='type-id-527'/>
-    <pointer-type-def type-id='type-id-527' size-in-bits='64' id='type-id-528'/>
-    <function-decl name='zfs_component_namecheck' mangled-name='zfs_component_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_component_namecheck'>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-528' name='why'/>
-      <parameter type-id='type-id-17' name='what'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='permset_namecheck' mangled-name='permset_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='permset_namecheck'>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-528' name='why'/>
-      <parameter type-id='type-id-17' name='what'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='entity_namecheck' mangled-name='entity_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='entity_namecheck'>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-528' name='why'/>
-      <parameter type-id='type-id-17' name='what'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='dataset_namecheck' mangled-name='dataset_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_namecheck'>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-528' name='why'/>
-      <parameter type-id='type-id-17' name='what'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='bookmark_namecheck' mangled-name='bookmark_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='bookmark_namecheck'>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-528' name='why'/>
-      <parameter type-id='type-id-17' name='what'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='snapshot_namecheck' mangled-name='snapshot_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='snapshot_namecheck'>
-      <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-528' name='why'/>
-      <parameter type-id='type-id-17' name='what'/>
-      <return type-id='type-id-8'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_namecheck.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <var-decl name='zfs_max_dataset_nesting' type-id='type-id-2' mangled-name='zfs_max_dataset_nesting' visibility='default' elf-symbol-id='zfs_max_dataset_nesting'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-287'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='NAME_ERR_LEADING_SLASH' value='0'/>
+      <enumerator name='NAME_ERR_EMPTY_COMPONENT' value='1'/>
+      <enumerator name='NAME_ERR_TRAILING_SLASH' value='2'/>
+      <enumerator name='NAME_ERR_INVALCHAR' value='3'/>
+      <enumerator name='NAME_ERR_MULTIPLE_DELIMITERS' value='4'/>
+      <enumerator name='NAME_ERR_NOLETTER' value='5'/>
+      <enumerator name='NAME_ERR_RESERVED' value='6'/>
+      <enumerator name='NAME_ERR_DISKLIKE' value='7'/>
+      <enumerator name='NAME_ERR_TOOLONG' value='8'/>
+      <enumerator name='NAME_ERR_SELF_REF' value='9'/>
+      <enumerator name='NAME_ERR_PARENT_REF' value='10'/>
+      <enumerator name='NAME_ERR_NO_AT' value='11'/>
+      <enumerator name='NAME_ERR_NO_POUND' value='12'/>
+    </enum-decl>
+    <typedef-decl name='namecheck_err_t' type-id='type-id-287' id='type-id-288'/>
+    <pointer-type-def type-id='type-id-288' size-in-bits='64' id='type-id-289'/>
+    <function-decl name='pool_namecheck' mangled-name='pool_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pool_namecheck'>
+      <parameter type-id='type-id-84' name='pool'/>
+      <parameter type-id='type-id-289' name='why'/>
+      <parameter type-id='type-id-14' name='what'/>
+      <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='mountpoint_namecheck' mangled-name='mountpoint_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mountpoint_namecheck'>
       <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-528' name='why'/>
-      <return type-id='type-id-8'/>
+      <parameter type-id='type-id-289' name='why'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='pool_namecheck' mangled-name='pool_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pool_namecheck'>
+    <function-decl name='snapshot_namecheck' mangled-name='snapshot_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='snapshot_namecheck'>
+      <parameter type-id='type-id-84' name='pool'/>
+      <parameter type-id='type-id-289' name='why'/>
+      <parameter type-id='type-id-14' name='what'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='bookmark_namecheck' mangled-name='bookmark_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='bookmark_namecheck'>
+      <parameter type-id='type-id-84' name='pool'/>
+      <parameter type-id='type-id-289' name='why'/>
+      <parameter type-id='type-id-14' name='what'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='dataset_namecheck' mangled-name='dataset_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_namecheck'>
+      <parameter type-id='type-id-84' name='pool'/>
+      <parameter type-id='type-id-289' name='why'/>
+      <parameter type-id='type-id-14' name='what'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='dataset_nestcheck' mangled-name='dataset_nestcheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_nestcheck'>
       <parameter type-id='type-id-84' name='path'/>
-      <parameter type-id='type-id-528' name='why'/>
-      <parameter type-id='type-id-17' name='what'/>
-      <return type-id='type-id-8'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='permset_namecheck' mangled-name='permset_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='permset_namecheck'>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-289' name='why'/>
+      <parameter type-id='type-id-14' name='what'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='get_dataset_depth' mangled-name='get_dataset_depth' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_dataset_depth'>
+      <parameter type-id='type-id-84' name='path'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_component_namecheck' mangled-name='zfs_component_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_component_namecheck'>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-289' name='why'/>
+      <parameter type-id='type-id-14' name='what'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='entity_namecheck' mangled-name='entity_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='entity_namecheck'>
+      <parameter type-id='type-id-84' name='path'/>
+      <parameter type-id='type-id-289' name='why'/>
+      <parameter type-id='type-id-14' name='what'/>
+      <return type-id='type-id-2'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_prop.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_prop.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
 
-    <array-type-def dimensions='1' type-id='type-id-84' size-in-bits='768' id='type-id-529'>
-      <subrange length='12' type-id='type-id-33' id='type-id-391'/>
+    <array-type-def dimensions='1' type-id='type-id-84' size-in-bits='768' id='type-id-290'>
+      <subrange length='12' type-id='type-id-24' id='type-id-291'/>
 
     </array-type-def>
-    <var-decl name='zfs_userquota_prop_prefixes' type-id='type-id-529' mangled-name='zfs_userquota_prop_prefixes' visibility='default' elf-symbol-id='zfs_userquota_prop_prefixes'/>
-    <function-decl name='zfs_prop_written' mangled-name='zfs_prop_written' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_written'>
-      <parameter type-id='type-id-84' name='name'/>
-      <return type-id='type-id-16'/>
+    <var-decl name='zfs_userquota_prop_prefixes' type-id='type-id-290' mangled-name='zfs_userquota_prop_prefixes' visibility='default' elf-symbol-id='zfs_userquota_prop_prefixes'/>
+    <function-decl name='zfs_prop_align_right' mangled-name='zfs_prop_align_right' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_align_right'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-9'/>
     </function-decl>
-    <typedef-decl name='zprop_desc_t' type-id='type-id-408' id='type-id-407'/>
-    <pointer-type-def type-id='type-id-407' size-in-bits='64' id='type-id-530'/>
-    <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_table'>
-      <return type-id='type-id-530'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-413' const='yes' id='type-id-531'/>
-    <pointer-type-def type-id='type-id-531' size-in-bits='64' id='type-id-532'/>
-    <function-decl name='zprop_register_index' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-412'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-532'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zprop_register_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-412'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zprop_register_number' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-412'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zprop_register_hidden' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-234'/>
-      <parameter type-id='type-id-412'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zprop_register_impl' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-234'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-412'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-50'/>
-      <parameter type-id='type-id-532'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zfs_prop_delegatable' mangled-name='zfs_prop_delegatable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_delegatable'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_to_prop'>
-      <parameter type-id='type-id-84' name='propname'/>
-      <return type-id='type-id-229'/>
-    </function-decl>
-    <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_user'>
-      <parameter type-id='type-id-84' name='name'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_prop_userquota' mangled-name='zfs_prop_userquota' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_userquota'>
-      <parameter type-id='type-id-84' name='name'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_prop_string_to_index' mangled-name='zfs_prop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_string_to_index'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <parameter type-id='type-id-84' name='string'/>
-      <parameter type-id='type-id-248' name='index'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_index_to_string' mangled-name='zfs_prop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_index_to_string'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <parameter type-id='type-id-22' name='index'/>
-      <parameter type-id='type-id-241' name='string'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zprop_index_to_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-241'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zfs_prop_random_value' mangled-name='zfs_prop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_random_value'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <parameter type-id='type-id-22' name='seed'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='zprop_random_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-76'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_for_type'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-13' name='types'/>
-      <parameter type-id='type-id-16' name='headcheck'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_type' mangled-name='zfs_prop_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_type'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-409'/>
-    </function-decl>
-    <function-decl name='zfs_prop_readonly' mangled-name='zfs_prop_readonly' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_readonly'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_prop_visible' mangled-name='zfs_prop_visible' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_visible'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_prop_setonce' mangled-name='zfs_prop_setonce' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_setonce'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_string'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_numeric'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_to_name'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zfs_prop_inheritable' mangled-name='zfs_prop_inheritable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inheritable'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_prop_encryption_key_param' mangled-name='zfs_prop_encryption_key_param' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_encryption_key_param'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_prop_valid_keylocation' mangled-name='zfs_prop_valid_keylocation' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_keylocation'>
-      <parameter type-id='type-id-84' name='str'/>
-      <parameter type-id='type-id-16' name='encrypted'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_prop_values' mangled-name='zfs_prop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_values'>
-      <parameter type-id='type-id-229' name='prop'/>
+    <function-decl name='zfs_prop_column_name' mangled-name='zfs_prop_column_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_column_name'>
+      <parameter type-id='type-id-110' name='prop'/>
       <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='zfs_prop_is_string' mangled-name='zfs_prop_is_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_is_string'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-8'/>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zfs_prop_column_name' mangled-name='zfs_prop_column_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_column_name'>
-      <parameter type-id='type-id-229' name='prop'/>
+    <function-decl name='zfs_prop_values' mangled-name='zfs_prop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_values'>
+      <parameter type-id='type-id-110' name='prop'/>
       <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zfs_prop_align_right' mangled-name='zfs_prop_align_right' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_align_right'>
-      <parameter type-id='type-id-229' name='prop'/>
-      <return type-id='type-id-16'/>
+    <function-decl name='zfs_prop_valid_keylocation' mangled-name='zfs_prop_valid_keylocation' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_keylocation'>
+      <parameter type-id='type-id-84' name='str'/>
+      <parameter type-id='type-id-9' name='encrypted'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_prop_encryption_key_param' mangled-name='zfs_prop_encryption_key_param' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_encryption_key_param'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_prop_inheritable' mangled-name='zfs_prop_inheritable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inheritable'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_to_name'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_numeric'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_string'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_prop_setonce' mangled-name='zfs_prop_setonce' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_setonce'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_prop_visible' mangled-name='zfs_prop_visible' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_visible'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_prop_readonly' mangled-name='zfs_prop_readonly' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_readonly'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-292'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='PROP_TYPE_NUMBER' value='0'/>
+      <enumerator name='PROP_TYPE_STRING' value='1'/>
+      <enumerator name='PROP_TYPE_INDEX' value='2'/>
+    </enum-decl>
+    <typedef-decl name='zprop_type_t' type-id='type-id-292' id='type-id-293'/>
+    <function-decl name='zfs_prop_get_type' mangled-name='zfs_prop_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_type'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-293'/>
+    </function-decl>
+    <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_for_type'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-66' name='types'/>
+      <parameter type-id='type-id-9' name='headcheck'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_prop_random_value' mangled-name='zfs_prop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_random_value'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <parameter type-id='type-id-7' name='seed'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-294'/>
+    <function-decl name='zfs_prop_index_to_string' mangled-name='zfs_prop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_index_to_string'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <parameter type-id='type-id-7' name='index'/>
+      <parameter type-id='type-id-294' name='string'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_prop_string_to_index' mangled-name='zfs_prop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_string_to_index'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <parameter type-id='type-id-84' name='string'/>
+      <parameter type-id='type-id-108' name='index'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zfs_prop_written' mangled-name='zfs_prop_written' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_written'>
+      <parameter type-id='type-id-84' name='name'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_prop_userquota' mangled-name='zfs_prop_userquota' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_userquota'>
+      <parameter type-id='type-id-84' name='name'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_user'>
+      <parameter type-id='type-id-84' name='name'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_to_prop'>
+      <parameter type-id='type-id-84' name='propname'/>
+      <return type-id='type-id-110'/>
+    </function-decl>
+    <function-decl name='zfs_prop_delegatable' mangled-name='zfs_prop_delegatable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_delegatable'>
+      <parameter type-id='type-id-110' name='prop'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='704' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-295' visibility='default' id='type-id-296'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pd_name' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pd_propnum' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pd_proptype' type-id='type-id-293' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pd_strdefault' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pd_numdefault' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pd_attr' type-id='type-id-297' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='pd_types' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pd_values' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='pd_colname' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='pd_rightalign' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='pd_visible' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='pd_zfs_mod_supported' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='pd_table' type-id='type-id-298' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='pd_table_size' type-id='type-id-18' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-299'>
+      <underlying-type type-id='type-id-41'/>
+      <enumerator name='PROP_DEFAULT' value='0'/>
+      <enumerator name='PROP_READONLY' value='1'/>
+      <enumerator name='PROP_INHERIT' value='2'/>
+      <enumerator name='PROP_ONETIME' value='3'/>
+      <enumerator name='PROP_ONETIME_DEFAULT' value='4'/>
+    </enum-decl>
+    <typedef-decl name='zprop_attr_t' type-id='type-id-299' id='type-id-297'/>
+    <class-decl name='zfs_index' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-300'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pi_name' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pi_value' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zprop_index_t' type-id='type-id-300' id='type-id-301'/>
+    <qualified-type-def type-id='type-id-301' const='yes' id='type-id-302'/>
+    <pointer-type-def type-id='type-id-302' size-in-bits='64' id='type-id-298'/>
+    <typedef-decl name='zprop_desc_t' type-id='type-id-296' id='type-id-295'/>
+    <pointer-type-def type-id='type-id-295' size-in-bits='64' id='type-id-303'/>
+    <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_table'>
+      <return type-id='type-id-303'/>
+    </function-decl>
+    <function-decl name='zprop_random_value' mangled-name='zprop_random_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_index_to_string' mangled-name='zprop_index_to_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_register_index' mangled-name='zprop_register_index' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_register_string' mangled-name='zprop_register_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_register_number' mangled-name='zprop_register_number' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_register_hidden' mangled-name='zprop_register_hidden' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zprop_register_impl' mangled-name='zprop_register_impl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zpool_prop.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zpool_prop_feature' mangled-name='zpool_prop_feature' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_feature'>
-      <parameter type-id='type-id-84' name='name'/>
-      <return type-id='type-id-16'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zpool_prop.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zpool_prop_align_right' mangled-name='zpool_prop_align_right' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_align_right'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zpool_prop_column_name' mangled-name='zpool_prop_column_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_column_name'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zpool_prop_values' mangled-name='zpool_prop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_values'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zpool_prop_random_value' mangled-name='zpool_prop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_random_value'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <parameter type-id='type-id-7' name='seed'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='zpool_prop_index_to_string' mangled-name='zpool_prop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_index_to_string'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <parameter type-id='type-id-7' name='index'/>
+      <parameter type-id='type-id-294' name='string'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zpool_prop_string_to_index' mangled-name='zpool_prop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_string_to_index'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <parameter type-id='type-id-84' name='string'/>
+      <parameter type-id='type-id-108' name='index'/>
+      <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='zpool_prop_unsupported' mangled-name='zpool_prop_unsupported' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_unsupported'>
       <parameter type-id='type-id-84' name='name'/>
-      <return type-id='type-id-16'/>
+      <return type-id='type-id-9'/>
     </function-decl>
-    <function-decl name='zpool_prop_get_table' mangled-name='zpool_prop_get_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_table'>
-      <return type-id='type-id-530'/>
+    <function-decl name='zpool_prop_feature' mangled-name='zpool_prop_feature' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_feature'>
+      <parameter type-id='type-id-84' name='name'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_numeric'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_string'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zpool_prop_setonce' mangled-name='zpool_prop_setonce' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_setonce'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zpool_prop_readonly' mangled-name='zpool_prop_readonly' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_readonly'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zpool_prop_get_type' mangled-name='zpool_prop_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_type'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <return type-id='type-id-293'/>
+    </function-decl>
+    <function-decl name='zpool_prop_to_name' mangled-name='zpool_prop_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_to_name'>
+      <parameter type-id='type-id-160' name='prop'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='zpool_name_to_prop' mangled-name='zpool_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_to_prop'>
       <parameter type-id='type-id-84' name='propname'/>
-      <return type-id='type-id-320'/>
+      <return type-id='type-id-160'/>
     </function-decl>
-    <function-decl name='zpool_prop_to_name' mangled-name='zpool_prop_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_to_name'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zpool_prop_get_type' mangled-name='zpool_prop_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_type'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <return type-id='type-id-409'/>
-    </function-decl>
-    <function-decl name='zpool_prop_readonly' mangled-name='zpool_prop_readonly' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_readonly'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zpool_prop_setonce' mangled-name='zpool_prop_setonce' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_setonce'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_string'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_numeric'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='zpool_prop_string_to_index' mangled-name='zpool_prop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_string_to_index'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <parameter type-id='type-id-84' name='string'/>
-      <parameter type-id='type-id-248' name='index'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_prop_index_to_string' mangled-name='zpool_prop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_index_to_string'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <parameter type-id='type-id-22' name='index'/>
-      <parameter type-id='type-id-241' name='string'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='zpool_prop_random_value' mangled-name='zpool_prop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_random_value'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <parameter type-id='type-id-22' name='seed'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='zpool_prop_values' mangled-name='zpool_prop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_values'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zpool_prop_column_name' mangled-name='zpool_prop_column_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_column_name'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <return type-id='type-id-84'/>
-    </function-decl>
-    <function-decl name='zpool_prop_align_right' mangled-name='zpool_prop_align_right' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_align_right'>
-      <parameter type-id='type-id-320' name='prop'/>
-      <return type-id='type-id-16'/>
+    <function-decl name='zpool_prop_get_table' mangled-name='zpool_prop_get_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_table'>
+      <return type-id='type-id-303'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zprop_common.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs' language='LANG_C99'>
-    <function-decl name='zprop_register_impl' mangled-name='zprop_register_impl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_impl'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-84' name='name'/>
-      <parameter type-id='type-id-409' name='type'/>
-      <parameter type-id='type-id-22' name='numdefault'/>
-      <parameter type-id='type-id-84' name='strdefault'/>
-      <parameter type-id='type-id-410' name='attr'/>
-      <parameter type-id='type-id-8' name='objset_types'/>
-      <parameter type-id='type-id-84' name='values'/>
-      <parameter type-id='type-id-84' name='colname'/>
-      <parameter type-id='type-id-16' name='rightalign'/>
-      <parameter type-id='type-id-16' name='visible'/>
-      <parameter type-id='type-id-411' name='idx_tbl'/>
-      <return type-id='type-id-6'/>
+  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zprop_common.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs' language='LANG_C99'>
+    <function-decl name='zprop_width' mangled-name='zprop_width' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_width'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-85' name='fixed'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='zfs_mod_supported' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-50'/>
+    <function-decl name='zprop_valid_for_type' mangled-name='zprop_valid_for_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_valid_for_type'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <parameter type-id='type-id-9' name='headcheck'/>
+      <return type-id='type-id-9'/>
     </function-decl>
-    <function-decl name='zprop_register_string' mangled-name='zprop_register_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_string'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-84' name='name'/>
-      <parameter type-id='type-id-84' name='def'/>
-      <parameter type-id='type-id-410' name='attr'/>
-      <parameter type-id='type-id-8' name='objset_types'/>
-      <parameter type-id='type-id-84' name='values'/>
-      <parameter type-id='type-id-84' name='colname'/>
-      <return type-id='type-id-6'/>
+    <function-decl name='zprop_values' mangled-name='zprop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_values'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zprop_register_number' mangled-name='zprop_register_number' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_number'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-84' name='name'/>
-      <parameter type-id='type-id-22' name='def'/>
-      <parameter type-id='type-id-410' name='attr'/>
-      <parameter type-id='type-id-8' name='objset_types'/>
-      <parameter type-id='type-id-84' name='values'/>
-      <parameter type-id='type-id-84' name='colname'/>
-      <return type-id='type-id-6'/>
+    <function-decl name='zprop_random_value' mangled-name='zprop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_random_value'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-7' name='seed'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='zprop_register_index' mangled-name='zprop_register_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_index'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-84' name='name'/>
-      <parameter type-id='type-id-22' name='def'/>
-      <parameter type-id='type-id-410' name='attr'/>
-      <parameter type-id='type-id-8' name='objset_types'/>
-      <parameter type-id='type-id-84' name='values'/>
-      <parameter type-id='type-id-84' name='colname'/>
-      <parameter type-id='type-id-411' name='idx_tbl'/>
-      <return type-id='type-id-6'/>
+    <function-decl name='zprop_index_to_string' mangled-name='zprop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_index_to_string'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-7' name='index'/>
+      <parameter type-id='type-id-294' name='string'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zprop_register_hidden' mangled-name='zprop_register_hidden' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_hidden'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-84' name='name'/>
-      <parameter type-id='type-id-409' name='type'/>
-      <parameter type-id='type-id-410' name='attr'/>
-      <parameter type-id='type-id-8' name='objset_types'/>
-      <parameter type-id='type-id-84' name='colname'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <function-decl name='zprop_iter_common' mangled-name='zprop_iter_common' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter_common'>
-      <parameter type-id='type-id-439' name='func'/>
-      <parameter type-id='type-id-7' name='cb'/>
-      <parameter type-id='type-id-16' name='show_all'/>
-      <parameter type-id='type-id-16' name='ordered'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zprop_string_to_index' mangled-name='zprop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_string_to_index'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-84' name='string'/>
+      <parameter type-id='type-id-108' name='index'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <return type-id='type-id-2'/>
     </function-decl>
     <function-decl name='zprop_name_to_prop' mangled-name='zprop_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_name_to_prop'>
       <parameter type-id='type-id-84' name='propname'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <return type-id='type-id-8'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zprop_string_to_index' mangled-name='zprop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_string_to_index'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-84' name='string'/>
-      <parameter type-id='type-id-248' name='index'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zprop_iter_common' mangled-name='zprop_iter_common' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter_common'>
+      <parameter type-id='type-id-180' name='func'/>
+      <parameter type-id='type-id-13' name='cb'/>
+      <parameter type-id='type-id-9' name='show_all'/>
+      <parameter type-id='type-id-9' name='ordered'/>
+      <parameter type-id='type-id-66' name='type'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='zprop_index_to_string' mangled-name='zprop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_index_to_string'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-22' name='index'/>
-      <parameter type-id='type-id-241' name='string'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='zprop_register_hidden' mangled-name='zprop_register_hidden' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_hidden'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-84' name='name'/>
+      <parameter type-id='type-id-293' name='type'/>
+      <parameter type-id='type-id-297' name='attr'/>
+      <parameter type-id='type-id-2' name='objset_types'/>
+      <parameter type-id='type-id-84' name='colname'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zprop_random_value' mangled-name='zprop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_random_value'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-22' name='seed'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='zprop_register_index' mangled-name='zprop_register_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_index'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-84' name='name'/>
+      <parameter type-id='type-id-7' name='def'/>
+      <parameter type-id='type-id-297' name='attr'/>
+      <parameter type-id='type-id-2' name='objset_types'/>
+      <parameter type-id='type-id-84' name='values'/>
+      <parameter type-id='type-id-84' name='colname'/>
+      <parameter type-id='type-id-298' name='idx_tbl'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zprop_values' mangled-name='zprop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_values'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <return type-id='type-id-84'/>
+    <function-decl name='zprop_register_number' mangled-name='zprop_register_number' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_number'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-84' name='name'/>
+      <parameter type-id='type-id-7' name='def'/>
+      <parameter type-id='type-id-297' name='attr'/>
+      <parameter type-id='type-id-2' name='objset_types'/>
+      <parameter type-id='type-id-84' name='values'/>
+      <parameter type-id='type-id-84' name='colname'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zprop_valid_for_type' mangled-name='zprop_valid_for_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_valid_for_type'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <parameter type-id='type-id-16' name='headcheck'/>
-      <return type-id='type-id-16'/>
+    <function-decl name='zprop_register_string' mangled-name='zprop_register_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_string'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-84' name='name'/>
+      <parameter type-id='type-id-84' name='def'/>
+      <parameter type-id='type-id-297' name='attr'/>
+      <parameter type-id='type-id-2' name='objset_types'/>
+      <parameter type-id='type-id-84' name='values'/>
+      <parameter type-id='type-id-84' name='colname'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zprop_width' mangled-name='zprop_width' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_width'>
-      <parameter type-id='type-id-8' name='prop'/>
-      <parameter type-id='type-id-106' name='fixed'/>
-      <parameter type-id='type-id-13' name='type'/>
-      <return type-id='type-id-28'/>
+    <function-decl name='zprop_register_impl' mangled-name='zprop_register_impl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_impl'>
+      <parameter type-id='type-id-2' name='prop'/>
+      <parameter type-id='type-id-84' name='name'/>
+      <parameter type-id='type-id-293' name='type'/>
+      <parameter type-id='type-id-7' name='numdefault'/>
+      <parameter type-id='type-id-84' name='strdefault'/>
+      <parameter type-id='type-id-297' name='attr'/>
+      <parameter type-id='type-id-2' name='objset_types'/>
+      <parameter type-id='type-id-84' name='values'/>
+      <parameter type-id='type-id-84' name='colname'/>
+      <parameter type-id='type-id-9' name='rightalign'/>
+      <parameter type-id='type-id-9' name='visible'/>
+      <parameter type-id='type-id-298' name='idx_tbl'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='__ctype_tolower_loc' mangled-name='__ctype_tolower_loc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zfs_mod_supported' mangled-name='zfs_mod_supported' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libshare.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libshare' language='LANG_C99'>
-    <function-decl name='libshare_nfs_init' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
+  <abi-instr version='1.0' address-size='64' path='libshare.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libshare' language='LANG_C99'>
+    <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_validate_shareopts'>
+      <parameter type-id='type-id-14' name='options'/>
+      <parameter type-id='type-id-14' name='proto'/>
+      <return type-id='type-id-2'/>
     </function-decl>
-    <function-decl name='libshare_smb_init' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
+    <function-decl name='sa_errorstr' mangled-name='sa_errorstr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_errorstr'>
+      <parameter type-id='type-id-2' name='err'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_commit_shares'>
+      <parameter type-id='type-id-84' name='protocol'/>
+      <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='sa_is_shared' mangled-name='sa_is_shared' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_is_shared'>
       <parameter type-id='type-id-84' name='mountpoint'/>
-      <parameter type-id='type-id-17' name='protocol'/>
-      <return type-id='type-id-16'/>
+      <parameter type-id='type-id-14' name='protocol'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='sa_disable_share' mangled-name='sa_disable_share' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_disable_share'>
+      <parameter type-id='type-id-84' name='mountpoint'/>
+      <parameter type-id='type-id-14' name='protocol'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='sa_enable_share' mangled-name='sa_enable_share' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_enable_share'>
+      <parameter type-id='type-id-84' name='zfsname'/>
+      <parameter type-id='type-id-84' name='mountpoint'/>
+      <parameter type-id='type-id-84' name='shareopts'/>
+      <parameter type-id='type-id-14' name='protocol'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='libshare_nfs_init' mangled-name='libshare_nfs_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='libshare_smb_init' mangled-name='libshare_smb_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='nfs.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libshare' language='LANG_C99'>
-    <function-decl name='mkdir' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
+  <abi-instr version='1.0' address-size='64' path='nfs.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libshare' language='LANG_C99'>
     <function-decl name='mkostemp' mangled-name='mkostemp64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='flock' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='mkdir' mangled-name='mkdir' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nfs_copy_entries' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='flock' mangled-name='flock' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='rename' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='rename' mangled-name='rename' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='unlink' mangled-name='unlink' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nfs_copy_entries' mangled-name='nfs_copy_entries' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/nfs.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libshare' language='LANG_C99'>
-    <function-decl name='fputs' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-150'/>
-      <return type-id='type-id-8'/>
+  <abi-instr version='1.0' address-size='64' path='os/linux/nfs.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libshare' language='LANG_C99'>
+    <function-decl name='register_fstype' mangled-name='register_fstype' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='sa_fstype' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-533'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='type-id-534' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='name' type-id='type-id-84' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ops' type-id='type-id-535' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='fsinfo_index' type-id='type-id-8' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-533' size-in-bits='64' id='type-id-534'/>
-    <class-decl name='sa_share_ops' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-536'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='enable_share' type-id='type-id-537' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='disable_share' type-id='type-id-537' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='is_shared' type-id='type-id-538' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='validate_shareopts' type-id='type-id-539' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='update_shareopts' type-id='type-id-540' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='clear_shareopts' type-id='type-id-541' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='commit_shares' type-id='type-id-542' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='sa_share_impl' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-543'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='sa_mountpoint' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='sa_zfsname' type-id='type-id-17' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='sa_fsinfo' type-id='type-id-544' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='sa_share_fsinfo' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-545'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='shareopts' type-id='type-id-17' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='sa_share_fsinfo_t' type-id='type-id-545' id='type-id-546'/>
-    <pointer-type-def type-id='type-id-546' size-in-bits='64' id='type-id-544'/>
-    <pointer-type-def type-id='type-id-543' size-in-bits='64' id='type-id-547'/>
-    <typedef-decl name='sa_share_impl_t' type-id='type-id-547' id='type-id-548'/>
-    <pointer-type-def type-id='type-id-549' size-in-bits='64' id='type-id-537'/>
-    <pointer-type-def type-id='type-id-550' size-in-bits='64' id='type-id-538'/>
-    <pointer-type-def type-id='type-id-551' size-in-bits='64' id='type-id-539'/>
-    <pointer-type-def type-id='type-id-552' size-in-bits='64' id='type-id-540'/>
-    <pointer-type-def type-id='type-id-553' size-in-bits='64' id='type-id-541'/>
-    <pointer-type-def type-id='type-id-554' size-in-bits='64' id='type-id-542'/>
-    <typedef-decl name='sa_share_ops_t' type-id='type-id-536' id='type-id-555'/>
-    <qualified-type-def type-id='type-id-555' const='yes' id='type-id-556'/>
-    <pointer-type-def type-id='type-id-556' size-in-bits='64' id='type-id-535'/>
-    <qualified-type-def type-id='type-id-536' const='yes' id='type-id-557'/>
-    <pointer-type-def type-id='type-id-557' size-in-bits='64' id='type-id-558'/>
-    <function-decl name='register_fstype' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-558'/>
-      <return type-id='type-id-534'/>
+    <function-decl name='nfs_toggle_share' mangled-name='nfs_toggle_share' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-559' size-in-bits='64' id='type-id-560'/>
-    <function-decl name='nfs_toggle_share' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-84'/>
-      <parameter type-id='type-id-547'/>
-      <parameter type-id='type-id-560'/>
-      <return type-id='type-id-8'/>
+    <function-decl name='fputs' mangled-name='fputs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-554'>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-551'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-559'>
-      <parameter type-id='type-id-547'/>
-      <parameter type-id='type-id-17'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-549'>
-      <parameter type-id='type-id-548'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-552'>
-      <parameter type-id='type-id-548'/>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-550'>
-      <parameter type-id='type-id-548'/>
-      <return type-id='type-id-16'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-553'>
-      <parameter type-id='type-id-548'/>
-      <return type-id='type-id-6'/>
-    </function-type>
+    <function-decl name='__builtin_stpcpy' mangled-name='stpcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/smb.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libshare' language='LANG_C99'>
-    <function-decl name='opendir' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-84'/>
-      <return type-id='type-id-305'/>
-    </function-decl>
-    <class-decl name='dirent' size-in-bits='2240' is-struct='yes' visibility='default' id='type-id-561'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/smb.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libshare' language='LANG_C99'>
+    <class-decl name='smb_share_s' size-in-bits='36992' is-struct='yes' visibility='default' id='type-id-304'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='d_ino' type-id='type-id-307' visibility='default'/>
+        <var-decl name='name' type-id='type-id-305' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='d_off' type-id='type-id-155' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='2040'>
+        <var-decl name='path' type-id='type-id-193' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='d_reclen' type-id='type-id-152' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='34808'>
+        <var-decl name='comment' type-id='type-id-305' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='d_type' type-id='type-id-75' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='36864'>
+        <var-decl name='guest_ok' type-id='type-id-9' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='152'>
-        <var-decl name='d_name' type-id='type-id-12' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='36928'>
+        <var-decl name='next' type-id='type-id-306' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-561' size-in-bits='64' id='type-id-562'/>
-    <function-decl name='readdir' mangled-name='readdir64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-305'/>
-      <return type-id='type-id-562'/>
+
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='2040' id='type-id-305'>
+      <subrange length='255' type-id='type-id-24' id='type-id-307'/>
+
+    </array-type-def>
+    <pointer-type-def type-id='type-id-304' size-in-bits='64' id='type-id-306'/>
+    <typedef-decl name='smb_share_t' type-id='type-id-304' id='type-id-308'/>
+    <pointer-type-def type-id='type-id-308' size-in-bits='64' id='type-id-309'/>
+    <var-decl name='smb_shares' type-id='type-id-309' visibility='default'/>
+    <function-decl name='__fgets_alias' mangled-name='fgets' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='fgets' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-17'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-150'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='opendir' mangled-name='opendir' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-1'/>
     </function-decl>
   </abi-instr>
 </abi-corpus>

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -1,6 +1,5 @@
-<abi-corpus path='libzfs_core.so' architecture='elf-amd-x86_64' soname='libzfs_core.so.3'>
+<abi-corpus architecture='elf-amd-x86_64' soname='libzfs_core.so.3'>
   <elf-needed>
-    <dependency name='libatomic.so.1'/>
     <dependency name='libuuid.so.1'/>
     <dependency name='libz.so.1'/>
     <dependency name='librt.so.1'/>
@@ -13,6 +12,8 @@
     <dependency name='ld-linux-x86-64.so.2'/>
   </elf-needed>
   <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -285,775 +286,236 @@
     <elf-symbol name='efi_debug' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='libspl_assert_ok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='libzfs_core.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzfs_core' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='libzfs_core.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfs_core' language='LANG_C99'>
     <type-decl name='int' size-in-bits='32' id='type-id-1'/>
-    <function-decl name='libzfs_core_init' mangled-name='libzfs_core_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_init'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' id='type-id-2'>
-      <data-member access='private'>
-        <var-decl name='__data' type-id='type-id-3' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-4' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-5' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-3'>
+    <type-decl name='char' size-in-bits='8' id='type-id-2'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-3'/>
+    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-4'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-5'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__lock' type-id='type-id-1' visibility='default'/>
+        <var-decl name='nvl_version' type-id='type-id-6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__count' type-id='type-id-6' visibility='default'/>
+        <var-decl name='nvl_nvflag' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__owner' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__nusers' type-id='type-id-6' visibility='default'/>
+        <var-decl name='nvl_priv' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__kind' type-id='type-id-1' visibility='default'/>
+        <var-decl name='nvl_flag' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='__spins' type-id='type-id-7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='__elision' type-id='type-id-7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='type-id-8' visibility='default'/>
+        <var-decl name='nvl_pad' type-id='type-id-6' visibility='default'/>
       </data-member>
     </class-decl>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-6'/>
-    <type-decl name='short int' size-in-bits='16' id='type-id-7'/>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-9'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='type-id-10' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='type-id-10' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-10'/>
-    <typedef-decl name='__pthread_list_t' type-id='type-id-9' id='type-id-8'/>
-    <type-decl name='char' size-in-bits='8' id='type-id-11'/>
-    <type-decl name='__ARRAY_SIZE_TYPE__' size-in-bits='64' id='type-id-12'/>
-
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='320' id='type-id-4'>
-      <subrange length='40' type-id='type-id-12' id='type-id-13'/>
-
-    </array-type-def>
-    <type-decl name='long int' size-in-bits='64' id='type-id-5'/>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-14'/>
-    <function-decl name='pthread_mutex_lock' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-14'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-15'/>
+    <typedef-decl name='__int32_t' type-id='type-id-1' id='type-id-9'/>
+    <typedef-decl name='int32_t' type-id='type-id-9' id='type-id-6'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-10'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-10' id='type-id-11'/>
+    <typedef-decl name='uint32_t' type-id='type-id-11' id='type-id-7'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-12'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-12' id='type-id-13'/>
+    <typedef-decl name='uint64_t' type-id='type-id-13' id='type-id-8'/>
+    <typedef-decl name='nvlist_t' type-id='type-id-5' id='type-id-14'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-15'/>
     <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-16'/>
-    <function-decl name='open' mangled-name='open64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-1'/>
-      <parameter is-variadic='yes'/>
+    <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bootenv'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-16' name='outnvl'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='pthread_mutex_unlock' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-14'/>
+    <qualified-type-def type-id='type-id-14' const='yes' id='type-id-17'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-18'/>
+    <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_set_bootenv'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-18' name='env'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <type-decl name='void' id='type-id-17'/>
-    <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_fini'>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='close' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-18'/>
-    <enum-decl name='lzc_dataset_type' id='type-id-19'>
-      <underlying-type type-id='type-id-18'/>
-      <enumerator name='LZC_DATSET_TYPE_ZFS' value='2'/>
-      <enumerator name='LZC_DATSET_TYPE_ZVOL' value='3'/>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-19'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-20'>
+      <underlying-type type-id='type-id-19'/>
+      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
+      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
     </enum-decl>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-20'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='type-id-21' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvl_priv' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='type-id-21' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__int32_t' type-id='type-id-1' id='type-id-24'/>
-    <typedef-decl name='int32_t' type-id='type-id-24' id='type-id-21'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-6' id='type-id-25'/>
-    <typedef-decl name='uint32_t' type-id='type-id-25' id='type-id-22'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-26'/>
-    <typedef-decl name='__uint64_t' type-id='type-id-26' id='type-id-27'/>
-    <typedef-decl name='uint64_t' type-id='type-id-27' id='type-id-23'/>
-    <typedef-decl name='nvlist_t' type-id='type-id-20' id='type-id-28'/>
-    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-29'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-30'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-30' id='type-id-31'/>
-    <typedef-decl name='uint8_t' type-id='type-id-31' id='type-id-32'/>
-    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-33'/>
-    <typedef-decl name='uint_t' type-id='type-id-6' id='type-id-34'/>
-    <function-decl name='lzc_create' mangled-name='lzc_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_create'>
-      <parameter type-id='type-id-16' name='fsname'/>
-      <parameter type-id='type-id-19' name='type'/>
-      <parameter type-id='type-id-29' name='props'/>
-      <parameter type-id='type-id-33' name='wkeydata'/>
-      <parameter type-id='type-id-34' name='wkeylen'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-35'/>
-    <function-decl name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-36'/>
-    <function-decl name='fnvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='nvlist_free' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='libspl_assertf' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-16'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-37'/>
-    <function-decl name='strlcpy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-26'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-38'/>
-    <function-decl name='fnvlist_pack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-38'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-26'/>
-    </function-decl>
-    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='type-id-39'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_name' type-id='type-id-40' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32768'>
-        <var-decl name='zc_nvlist_src' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32832'>
-        <var-decl name='zc_nvlist_src_size' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32896'>
-        <var-decl name='zc_nvlist_dst' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32960'>
-        <var-decl name='zc_nvlist_dst_size' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33024'>
-        <var-decl name='zc_nvlist_dst_filled' type-id='type-id-41' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33056'>
-        <var-decl name='zc_pad2' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33088'>
-        <var-decl name='zc_history' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='33152'>
-        <var-decl name='zc_value' type-id='type-id-42' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='98688'>
-        <var-decl name='zc_string' type-id='type-id-43' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100736'>
-        <var-decl name='zc_guid' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100800'>
-        <var-decl name='zc_nvlist_conf' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100864'>
-        <var-decl name='zc_nvlist_conf_size' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100928'>
-        <var-decl name='zc_cookie' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='100992'>
-        <var-decl name='zc_objset_type' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101056'>
-        <var-decl name='zc_perm_action' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101120'>
-        <var-decl name='zc_history_len' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101184'>
-        <var-decl name='zc_history_offset' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101248'>
-        <var-decl name='zc_obj' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101312'>
-        <var-decl name='zc_iflags' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101376'>
-        <var-decl name='zc_share' type-id='type-id-44' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='101632'>
-        <var-decl name='zc_objset_stats' type-id='type-id-45' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='103936'>
-        <var-decl name='zc_begin_record' type-id='type-id-46' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='106368'>
-        <var-decl name='zc_inject_record' type-id='type-id-47' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109184'>
-        <var-decl name='zc_defer_destroy' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109216'>
-        <var-decl name='zc_flags' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109248'>
-        <var-decl name='zc_action_handle' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109312'>
-        <var-decl name='zc_cleanup_fd' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109344'>
-        <var-decl name='zc_simple' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109352'>
-        <var-decl name='zc_pad' type-id='type-id-48' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109376'>
-        <var-decl name='zc_sendobj' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109440'>
-        <var-decl name='zc_fromobj' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109504'>
-        <var-decl name='zc_createtxg' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109568'>
-        <var-decl name='zc_stat' type-id='type-id-49' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109888'>
-        <var-decl name='zc_zoneid' type-id='type-id-23' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='32768' id='type-id-40'>
-      <subrange length='4096' type-id='type-id-12' id='type-id-50'/>
-
-    </array-type-def>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-51'>
-      <underlying-type type-id='type-id-18'/>
+    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-20' id='type-id-21'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-22'>
+      <underlying-type type-id='type-id-19'/>
       <enumerator name='B_FALSE' value='0'/>
       <enumerator name='B_TRUE' value='1'/>
     </enum-decl>
-    <typedef-decl name='boolean_t' type-id='type-id-51' id='type-id-41'/>
-
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='65536' id='type-id-42'>
-      <subrange length='8192' type-id='type-id-12' id='type-id-52'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='2048' id='type-id-43'>
-      <subrange length='256' type-id='type-id-12' id='type-id-53'/>
-
-    </array-type-def>
-    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-54'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='z_exportdata' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='z_sharedata' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='z_sharetype' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='z_sharemax' type-id='type-id-23' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zfs_share_t' type-id='type-id-54' id='type-id-44'/>
-    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' id='type-id-55'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dds_num_clones' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='dds_creation_txg' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='dds_guid' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='dds_type' type-id='type-id-56' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dds_is_snapshot' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='232'>
-        <var-decl name='dds_inconsistent' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='240'>
-        <var-decl name='dds_redacted' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='248'>
-        <var-decl name='dds_origin' type-id='type-id-43' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='dmu_objset_type' id='type-id-57'>
-      <underlying-type type-id='type-id-18'/>
-      <enumerator name='DMU_OST_NONE' value='0'/>
-      <enumerator name='DMU_OST_META' value='1'/>
-      <enumerator name='DMU_OST_ZFS' value='2'/>
-      <enumerator name='DMU_OST_ZVOL' value='3'/>
-      <enumerator name='DMU_OST_OTHER' value='4'/>
-      <enumerator name='DMU_OST_ANY' value='5'/>
-      <enumerator name='DMU_OST_NUMTYPES' value='6'/>
+    <typedef-decl name='boolean_t' type-id='type-id-22' id='type-id-23'/>
+    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-24'/>
+    <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_fs'>
+      <parameter type-id='type-id-4' name='fs'/>
+      <parameter type-id='type-id-21' name='activity'/>
+      <parameter type-id='type-id-24' name='waited'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-25'>
+      <underlying-type type-id='type-id-19'/>
+      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
+      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
+      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
+      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
+      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
+      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
+      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
+      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
+      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
     </enum-decl>
-    <typedef-decl name='dmu_objset_type_t' type-id='type-id-57' id='type-id-56'/>
-    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-55' id='type-id-45'/>
-    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' id='type-id-46'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_magic' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_versioninfo' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_creation_time' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_type' type-id='type-id-56' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_flags' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_fromguid' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_toname' type-id='type-id-43' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='type-id-58'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zi_objset' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zi_object' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zi_start' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zi_end' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zi_guid' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='zi_level' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='zi_error' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='zi_type' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='zi_freq' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='zi_failfast' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='zi_func' type-id='type-id-43' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='zi_iotype' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2592'>
-        <var-decl name='zi_duration' type-id='type-id-21' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2624'>
-        <var-decl name='zi_timer' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2688'>
-        <var-decl name='zi_nlanes' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2752'>
-        <var-decl name='zi_cmd' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2784'>
-        <var-decl name='zi_dvas' type-id='type-id-22' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zinject_record_t' type-id='type-id-58' id='type-id-47'/>
-
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='24' id='type-id-48'>
-      <subrange length='3' type-id='type-id-12' id='type-id-59'/>
-
-    </array-type-def>
-    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-60'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zs_gen' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zs_mode' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zs_links' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zs_ctime' type-id='type-id-61' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='128' id='type-id-61'>
-      <subrange length='2' type-id='type-id-12' id='type-id-62'/>
-
-    </array-type-def>
-    <typedef-decl name='zfs_stat_t' type-id='type-id-60' id='type-id-49'/>
-    <pointer-type-def type-id='type-id-39' size-in-bits='64' id='type-id-63'/>
-    <function-decl name='zfs_ioctl_fd' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-63'/>
+    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-25' id='type-id-26'/>
+    <function-decl name='lzc_wait_tag' mangled-name='lzc_wait_tag' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_tag'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-26' name='activity'/>
+      <parameter type-id='type-id-8' name='tag'/>
+      <parameter type-id='type-id-24' name='waited'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='fnvlist_unpack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='fnvlist_pack_free' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='lzc_clone' mangled-name='lzc_clone' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_clone'>
-      <parameter type-id='type-id-16' name='fsname'/>
-      <parameter type-id='type-id-16' name='origin'/>
-      <parameter type-id='type-id-29' name='props'/>
+    <function-decl name='lzc_wait' mangled-name='lzc_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-26' name='activity'/>
+      <parameter type-id='type-id-24' name='waited'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='fnvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='lzc_redact' mangled-name='lzc_redact' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_redact'>
+      <parameter type-id='type-id-4' name='snapshot'/>
+      <parameter type-id='type-id-4' name='bookname'/>
+      <parameter type-id='type-id-15' name='snapnv'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='lzc_promote' mangled-name='lzc_promote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_promote'>
-      <parameter type-id='type-id-16' name='fsname'/>
-      <parameter type-id='type-id-37' name='snapnamebuf'/>
+    <enum-decl name='pool_trim_func' id='type-id-27'>
+      <underlying-type type-id='type-id-19'/>
+      <enumerator name='POOL_TRIM_START' value='0'/>
+      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
+      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
+      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_trim_func_t' type-id='type-id-27' id='type-id-28'/>
+    <function-decl name='lzc_trim' mangled-name='lzc_trim' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_trim'>
+      <parameter type-id='type-id-4' name='poolname'/>
+      <parameter type-id='type-id-28' name='cmd_type'/>
+      <parameter type-id='type-id-8' name='rate'/>
+      <parameter type-id='type-id-23' name='secure'/>
+      <parameter type-id='type-id-15' name='vdevs'/>
+      <parameter type-id='type-id-16' name='errlist'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <enum-decl name='pool_initialize_func' id='type-id-29'>
+      <underlying-type type-id='type-id-19'/>
+      <enumerator name='POOL_INITIALIZE_START' value='0'/>
+      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
+      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
+      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_initialize_func_t' type-id='type-id-29' id='type-id-30'/>
+    <function-decl name='lzc_initialize' mangled-name='lzc_initialize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_initialize'>
+      <parameter type-id='type-id-4' name='poolname'/>
+      <parameter type-id='type-id-30' name='cmd_type'/>
+      <parameter type-id='type-id-15' name='vdevs'/>
+      <parameter type-id='type-id-16' name='errlist'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_reopen' mangled-name='lzc_reopen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_reopen'>
+      <parameter type-id='type-id-4' name='pool_name'/>
+      <parameter type-id='type-id-23' name='scrub_restart'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-31'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-31' id='type-id-32'/>
+    <typedef-decl name='uint8_t' type-id='type-id-32' id='type-id-33'/>
+    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-34'/>
+    <typedef-decl name='uint_t' type-id='type-id-10' id='type-id-35'/>
+    <function-decl name='lzc_change_key' mangled-name='lzc_change_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_change_key'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <parameter type-id='type-id-8' name='crypt_cmd'/>
+      <parameter type-id='type-id-15' name='props'/>
+      <parameter type-id='type-id-34' name='wkeydata'/>
+      <parameter type-id='type-id-35' name='wkeylen'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_unload_key' mangled-name='lzc_unload_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_unload_key'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_load_key' mangled-name='lzc_load_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_load_key'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <parameter type-id='type-id-23' name='noop'/>
+      <parameter type-id='type-id-34' name='wkeydata'/>
+      <parameter type-id='type-id-35' name='wkeylen'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_channel_program_nosync' mangled-name='lzc_channel_program_nosync' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program_nosync'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-4' name='program'/>
+      <parameter type-id='type-id-8' name='timeout'/>
+      <parameter type-id='type-id-8' name='memlimit'/>
+      <parameter type-id='type-id-15' name='argnvl'/>
+      <parameter type-id='type-id-16' name='outnvl'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_pool_checkpoint_discard' mangled-name='lzc_pool_checkpoint_discard' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint_discard'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_pool_checkpoint' mangled-name='lzc_pool_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_channel_program' mangled-name='lzc_channel_program' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-4' name='program'/>
+      <parameter type-id='type-id-8' name='timeout'/>
+      <parameter type-id='type-id-8' name='memlimit'/>
+      <parameter type-id='type-id-15' name='argnvl'/>
+      <parameter type-id='type-id-16' name='outnvl'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_bookmarks'>
+      <parameter type-id='type-id-15' name='bmarks'/>
+      <parameter type-id='type-id-16' name='errlist'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_get_bookmark_props' mangled-name='lzc_get_bookmark_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmark_props'>
+      <parameter type-id='type-id-4' name='bookmark'/>
+      <parameter type-id='type-id-16' name='props'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_get_bookmarks' mangled-name='lzc_get_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmarks'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <parameter type-id='type-id-15' name='props'/>
+      <parameter type-id='type-id-16' name='bmarks'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_bookmark' mangled-name='lzc_bookmark' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_bookmark'>
+      <parameter type-id='type-id-15' name='bmarks'/>
+      <parameter type-id='type-id-16' name='errlist'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback_to'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-36'/>
+    <function-decl name='lzc_rollback' mangled-name='lzc_rollback' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <parameter type-id='type-id-36' name='snapnamebuf'/>
       <parameter type-id='type-id-1' name='snapnamelen'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='lzc_rename' mangled-name='lzc_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rename'>
-      <parameter type-id='type-id-16' name='source'/>
-      <parameter type-id='type-id-16' name='target'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_destroy' mangled-name='lzc_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy'>
-      <parameter type-id='type-id-16' name='fsname'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-64'/>
-    <function-decl name='lzc_snapshot' mangled-name='lzc_snapshot' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snapshot'>
-      <parameter type-id='type-id-29' name='snaps'/>
-      <parameter type-id='type-id-29' name='props'/>
-      <parameter type-id='type-id-64' name='errlist'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-65'>
+    <class-decl name='dmu_replay_record' size-in-bits='2496' is-struct='yes' visibility='default' id='type-id-37'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvp_size' type-id='type-id-21' visibility='default'/>
+        <var-decl name='drr_type' type-id='type-id-38' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvp_name_sz' type-id='type-id-66' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='nvp_reserve' type-id='type-id-66' visibility='default'/>
+        <var-decl name='drr_payloadlen' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvp_value_elem' type-id='type-id-21' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='nvp_type' type-id='type-id-67' visibility='default'/>
+        <var-decl name='drr_u' type-id='type-id-39' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__int16_t' type-id='type-id-7' id='type-id-68'/>
-    <typedef-decl name='int16_t' type-id='type-id-68' id='type-id-66'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-69'>
-      <underlying-type type-id='type-id-18'/>
-      <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
-      <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
-      <enumerator name='DATA_TYPE_BOOLEAN' value='1'/>
-      <enumerator name='DATA_TYPE_BYTE' value='2'/>
-      <enumerator name='DATA_TYPE_INT16' value='3'/>
-      <enumerator name='DATA_TYPE_UINT16' value='4'/>
-      <enumerator name='DATA_TYPE_INT32' value='5'/>
-      <enumerator name='DATA_TYPE_UINT32' value='6'/>
-      <enumerator name='DATA_TYPE_INT64' value='7'/>
-      <enumerator name='DATA_TYPE_UINT64' value='8'/>
-      <enumerator name='DATA_TYPE_STRING' value='9'/>
-      <enumerator name='DATA_TYPE_BYTE_ARRAY' value='10'/>
-      <enumerator name='DATA_TYPE_INT16_ARRAY' value='11'/>
-      <enumerator name='DATA_TYPE_UINT16_ARRAY' value='12'/>
-      <enumerator name='DATA_TYPE_INT32_ARRAY' value='13'/>
-      <enumerator name='DATA_TYPE_UINT32_ARRAY' value='14'/>
-      <enumerator name='DATA_TYPE_INT64_ARRAY' value='15'/>
-      <enumerator name='DATA_TYPE_UINT64_ARRAY' value='16'/>
-      <enumerator name='DATA_TYPE_STRING_ARRAY' value='17'/>
-      <enumerator name='DATA_TYPE_HRTIME' value='18'/>
-      <enumerator name='DATA_TYPE_NVLIST' value='19'/>
-      <enumerator name='DATA_TYPE_NVLIST_ARRAY' value='20'/>
-      <enumerator name='DATA_TYPE_BOOLEAN_VALUE' value='21'/>
-      <enumerator name='DATA_TYPE_INT8' value='22'/>
-      <enumerator name='DATA_TYPE_UINT8' value='23'/>
-      <enumerator name='DATA_TYPE_BOOLEAN_ARRAY' value='24'/>
-      <enumerator name='DATA_TYPE_INT8_ARRAY' value='25'/>
-      <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
-      <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
-    </enum-decl>
-    <typedef-decl name='data_type_t' type-id='type-id-69' id='type-id-67'/>
-    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-70'/>
-    <function-decl name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-70'/>
-      <return type-id='type-id-70'/>
-    </function-decl>
-    <function-decl name='nvpair_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-70'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <function-decl name='lzc_destroy_snaps' mangled-name='lzc_destroy_snaps' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_snaps'>
-      <parameter type-id='type-id-29' name='snaps'/>
-      <parameter type-id='type-id-41' name='defer'/>
-      <parameter type-id='type-id-64' name='errlist'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_boolean' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-71'/>
-    <function-decl name='lzc_snaprange_space' mangled-name='lzc_snaprange_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snaprange_space'>
-      <parameter type-id='type-id-16' name='firstsnap'/>
-      <parameter type-id='type-id-16' name='lastsnap'/>
-      <parameter type-id='type-id-71' name='usedp'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fnvlist_free' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='lzc_exists' mangled-name='lzc_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_exists'>
-      <parameter type-id='type-id-16' name='dataset'/>
-      <return type-id='type-id-41'/>
-    </function-decl>
-    <function-decl name='lzc_sync' mangled-name='lzc_sync' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_sync'>
-      <parameter type-id='type-id-16' name='pool_name'/>
-      <parameter type-id='type-id-29' name='innvl'/>
-      <parameter type-id='type-id-64' name='outnvl'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_hold' mangled-name='lzc_hold' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_hold'>
-      <parameter type-id='type-id-29' name='holds'/>
-      <parameter type-id='type-id-1' name='cleanup_fd'/>
-      <parameter type-id='type-id-64' name='errlist'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_release' mangled-name='lzc_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_release'>
-      <parameter type-id='type-id-29' name='holds'/>
-      <parameter type-id='type-id-64' name='errlist'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_get_holds' mangled-name='lzc_get_holds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_holds'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-64' name='holdsp'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <enum-decl name='lzc_send_flags' id='type-id-72'>
-      <underlying-type type-id='type-id-18'/>
-      <enumerator name='LZC_SEND_FLAG_EMBED_DATA' value='1'/>
-      <enumerator name='LZC_SEND_FLAG_LARGE_BLOCK' value='2'/>
-      <enumerator name='LZC_SEND_FLAG_COMPRESS' value='4'/>
-      <enumerator name='LZC_SEND_FLAG_RAW' value='8'/>
-      <enumerator name='LZC_SEND_FLAG_SAVED' value='16'/>
-    </enum-decl>
-    <function-decl name='lzc_send' mangled-name='lzc_send' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-16' name='from'/>
-      <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-72' name='flags'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_send_resume_redacted' mangled-name='lzc_send_resume_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume_redacted'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-16' name='from'/>
-      <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-72' name='flags'/>
-      <parameter type-id='type-id-23' name='resumeobj'/>
-      <parameter type-id='type-id-23' name='resumeoff'/>
-      <parameter type-id='type-id-16' name='redactbook'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='lzc_send_redacted' mangled-name='lzc_send_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_redacted'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-16' name='from'/>
-      <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-72' name='flags'/>
-      <parameter type-id='type-id-16' name='redactbook'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_send_resume' mangled-name='lzc_send_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-16' name='from'/>
-      <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-72' name='flags'/>
-      <parameter type-id='type-id-23' name='resumeobj'/>
-      <parameter type-id='type-id-23' name='resumeoff'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_send_space_resume_redacted' mangled-name='lzc_send_space_resume_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space_resume_redacted'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-16' name='from'/>
-      <parameter type-id='type-id-72' name='flags'/>
-      <parameter type-id='type-id-23' name='resumeobj'/>
-      <parameter type-id='type-id-23' name='resumeoff'/>
-      <parameter type-id='type-id-23' name='resume_bytes'/>
-      <parameter type-id='type-id-16' name='redactbook'/>
-      <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-71' name='spacep'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_send_space' mangled-name='lzc_send_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-16' name='from'/>
-      <parameter type-id='type-id-72' name='flags'/>
-      <parameter type-id='type-id-71' name='spacep'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_receive' mangled-name='lzc_receive' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-29' name='props'/>
-      <parameter type-id='type-id-16' name='origin'/>
-      <parameter type-id='type-id-41' name='force'/>
-      <parameter type-id='type-id-41' name='raw'/>
-      <parameter type-id='type-id-1' name='fd'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-73'/>
-    <function-decl name='read' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-36'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-38'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-74'/>
-    <function-decl name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-74'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fnvlist_dup' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='nvlist_unpack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-74'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_receive_resumable' mangled-name='lzc_receive_resumable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_resumable'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-29' name='props'/>
-      <parameter type-id='type-id-16' name='origin'/>
-      <parameter type-id='type-id-41' name='force'/>
-      <parameter type-id='type-id-41' name='raw'/>
-      <parameter type-id='type-id-1' name='fd'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='dmu_replay_record' size-in-bits='2496' is-struct='yes' visibility='default' id='type-id-75'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_type' type-id='type-id-76' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='drr_payloadlen' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_u' type-id='type-id-77' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-76'>
-      <underlying-type type-id='type-id-18'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-38'>
+      <underlying-type type-id='type-id-19'/>
       <enumerator name='DRR_BEGIN' value='0'/>
       <enumerator name='DRR_OBJECT' value='1'/>
       <enumerator name='DRR_FREEOBJECTS' value='2'/>
@@ -1067,115 +529,157 @@
       <enumerator name='DRR_REDACT' value='10'/>
       <enumerator name='DRR_NUMTYPES' value='11'/>
     </enum-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' id='type-id-77'>
+    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' id='type-id-39'>
       <data-member access='private'>
-        <var-decl name='drr_begin' type-id='type-id-46' visibility='default'/>
+        <var-decl name='drr_begin' type-id='type-id-40' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_end' type-id='type-id-78' visibility='default'/>
+        <var-decl name='drr_end' type-id='type-id-41' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_object' type-id='type-id-79' visibility='default'/>
+        <var-decl name='drr_object' type-id='type-id-42' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_freeobjects' type-id='type-id-80' visibility='default'/>
+        <var-decl name='drr_freeobjects' type-id='type-id-43' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_write' type-id='type-id-81' visibility='default'/>
+        <var-decl name='drr_write' type-id='type-id-44' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_free' type-id='type-id-82' visibility='default'/>
+        <var-decl name='drr_free' type-id='type-id-45' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_write_byref' type-id='type-id-83' visibility='default'/>
+        <var-decl name='drr_write_byref' type-id='type-id-46' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_spill' type-id='type-id-84' visibility='default'/>
+        <var-decl name='drr_spill' type-id='type-id-47' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_write_embedded' type-id='type-id-85' visibility='default'/>
+        <var-decl name='drr_write_embedded' type-id='type-id-48' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_object_range' type-id='type-id-86' visibility='default'/>
+        <var-decl name='drr_object_range' type-id='type-id-49' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_redact' type-id='type-id-87' visibility='default'/>
+        <var-decl name='drr_redact' type-id='type-id-50' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='drr_checksum' type-id='type-id-88' visibility='default'/>
+        <var-decl name='drr_checksum' type-id='type-id-51' visibility='default'/>
       </data-member>
     </union-decl>
-    <class-decl name='drr_end' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-78'>
+    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' id='type-id-40'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_checksum' type-id='type-id-89' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-90'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_word' type-id='type-id-91' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='256' id='type-id-91'>
-      <subrange length='4' type-id='type-id-12' id='type-id-92'/>
-
-    </array-type-def>
-    <typedef-decl name='zio_cksum_t' type-id='type-id-90' id='type-id-89'/>
-    <class-decl name='drr_object' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-79'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_magic' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_type' type-id='type-id-93' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='drr_bonustype' type-id='type-id-93' visibility='default'/>
+        <var-decl name='drr_versioninfo' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_blksz' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='drr_bonuslen' type-id='type-id-22' visibility='default'/>
+        <var-decl name='drr_creation_time' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_checksumtype' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='200'>
-        <var-decl name='drr_compress' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='208'>
-        <var-decl name='drr_dn_slots' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='216'>
-        <var-decl name='drr_flags' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_type' type-id='type-id-52' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_raw_bonuslen' type-id='type-id-22' visibility='default'/>
+        <var-decl name='drr_flags' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_indblkshift' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drr_nlevels' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='drr_nblkptr' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='drr_pad' type-id='type-id-94' visibility='default'/>
+        <var-decl name='drr_fromguid' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_maxblkid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_toname' type-id='type-id-53' visibility='default'/>
       </data-member>
     </class-decl>
-    <enum-decl name='dmu_object_type' id='type-id-95'>
-      <underlying-type type-id='type-id-18'/>
+    <enum-decl name='dmu_objset_type' id='type-id-54'>
+      <underlying-type type-id='type-id-19'/>
+      <enumerator name='DMU_OST_NONE' value='0'/>
+      <enumerator name='DMU_OST_META' value='1'/>
+      <enumerator name='DMU_OST_ZFS' value='2'/>
+      <enumerator name='DMU_OST_ZVOL' value='3'/>
+      <enumerator name='DMU_OST_OTHER' value='4'/>
+      <enumerator name='DMU_OST_ANY' value='5'/>
+      <enumerator name='DMU_OST_NUMTYPES' value='6'/>
+    </enum-decl>
+    <typedef-decl name='dmu_objset_type_t' type-id='type-id-54' id='type-id-52'/>
+
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='2048' id='type-id-53'>
+      <subrange length='256' type-id='type-id-12' id='type-id-55'/>
+
+    </array-type-def>
+    <class-decl name='drr_end' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_checksum' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zc_word' type-id='type-id-58' visibility='default'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='256' id='type-id-58'>
+      <subrange length='4' type-id='type-id-12' id='type-id-59'/>
+
+    </array-type-def>
+    <typedef-decl name='zio_cksum_t' type-id='type-id-57' id='type-id-56'/>
+    <class-decl name='drr_object' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_type' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='drr_bonustype' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_blksz' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='drr_bonuslen' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_checksumtype' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='200'>
+        <var-decl name='drr_compress' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='208'>
+        <var-decl name='drr_dn_slots' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='216'>
+        <var-decl name='drr_flags' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='drr_raw_bonuslen' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_indblkshift' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='328'>
+        <var-decl name='drr_nlevels' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='drr_nblkptr' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='344'>
+        <var-decl name='drr_pad' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_maxblkid' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='dmu_object_type' id='type-id-62'>
+      <underlying-type type-id='type-id-19'/>
       <enumerator name='DMU_OT_NONE' value='0'/>
       <enumerator name='DMU_OT_OBJECT_DIRECTORY' value='1'/>
       <enumerator name='DMU_OT_OBJECT_ARRAY' value='2'/>
@@ -1252,1126 +756,939 @@
       <enumerator name='DMU_OTN_ZAP_ENC_DATA' value='164'/>
       <enumerator name='DMU_OTN_ZAP_ENC_METADATA' value='228'/>
     </enum-decl>
-    <typedef-decl name='dmu_object_type_t' type-id='type-id-95' id='type-id-93'/>
+    <typedef-decl name='dmu_object_type_t' type-id='type-id-62' id='type-id-60'/>
 
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='40' id='type-id-94'>
-      <subrange length='5' type-id='type-id-12' id='type-id-96'/>
+    <array-type-def dimensions='1' type-id='type-id-33' size-in-bits='40' id='type-id-61'>
+      <subrange length='5' type-id='type-id-12' id='type-id-63'/>
 
     </array-type-def>
-    <class-decl name='drr_freeobjects' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-80'>
+    <class-decl name='drr_freeobjects' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-43'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_firstobj' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_firstobj' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_numobjs' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_numobjs' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='drr_write' size-in-bits='1088' is-struct='yes' visibility='default' id='type-id-81'>
+    <class-decl name='drr_write' size-in-bits='1088' is-struct='yes' visibility='default' id='type-id-44'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_object' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_type' type-id='type-id-93' visibility='default'/>
+        <var-decl name='drr_type' type-id='type-id-60' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='drr_pad' type-id='type-id-22' visibility='default'/>
+        <var-decl name='drr_pad' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_offset' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_offset' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_logical_size' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_logical_size' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_checksumtype' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_checksumtype' type-id='type-id-33' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drr_flags' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_flags' type-id='type-id-33' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='drr_compressiontype' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_compressiontype' type-id='type-id-33' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='drr_pad2' type-id='type-id-94' visibility='default'/>
+        <var-decl name='drr_pad2' type-id='type-id-61' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_key' type-id='type-id-97' visibility='default'/>
+        <var-decl name='drr_key' type-id='type-id-64' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='drr_compressed_size' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_compressed_size' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='drr_salt' type-id='type-id-98' visibility='default'/>
+        <var-decl name='drr_salt' type-id='type-id-65' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='drr_iv' type-id='type-id-99' visibility='default'/>
+        <var-decl name='drr_iv' type-id='type-id-66' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='drr_mac' type-id='type-id-100' visibility='default'/>
+        <var-decl name='drr_mac' type-id='type-id-67' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='ddt_key' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-101'>
+    <class-decl name='ddt_key' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-68'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ddk_cksum' type-id='type-id-89' visibility='default'/>
+        <var-decl name='ddk_cksum' type-id='type-id-56' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='ddk_prop' type-id='type-id-23' visibility='default'/>
+        <var-decl name='ddk_prop' type-id='type-id-8' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='ddt_key_t' type-id='type-id-101' id='type-id-97'/>
+    <typedef-decl name='ddt_key_t' type-id='type-id-68' id='type-id-64'/>
 
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='64' id='type-id-98'>
-      <subrange length='8' type-id='type-id-12' id='type-id-102'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='96' id='type-id-99'>
-      <subrange length='12' type-id='type-id-12' id='type-id-103'/>
+    <array-type-def dimensions='1' type-id='type-id-33' size-in-bits='64' id='type-id-65'>
+      <subrange length='8' type-id='type-id-12' id='type-id-69'/>
 
     </array-type-def>
 
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='128' id='type-id-100'>
-      <subrange length='16' type-id='type-id-12' id='type-id-104'/>
+    <array-type-def dimensions='1' type-id='type-id-33' size-in-bits='96' id='type-id-66'>
+      <subrange length='12' type-id='type-id-12' id='type-id-70'/>
 
     </array-type-def>
-    <class-decl name='drr_free' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-82'>
+
+    <array-type-def dimensions='1' type-id='type-id-33' size-in-bits='128' id='type-id-67'>
+      <subrange length='16' type-id='type-id-12' id='type-id-71'/>
+
+    </array-type-def>
+    <class-decl name='drr_free' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-45'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_object' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_offset' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_length' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='drr_write_byref' size-in-bits='832' is-struct='yes' visibility='default' id='type-id-83'>
+    <class-decl name='drr_write_byref' size-in-bits='832' is-struct='yes' visibility='default' id='type-id-46'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_object' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_offset' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_length' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_refguid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_refguid' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_refobject' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_refobject' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_refoffset' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_refoffset' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='drr_checksumtype' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_checksumtype' type-id='type-id-33' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='456'>
-        <var-decl name='drr_flags' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_flags' type-id='type-id-33' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='464'>
-        <var-decl name='drr_pad2' type-id='type-id-105' visibility='default'/>
+        <var-decl name='drr_pad2' type-id='type-id-72' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='drr_key' type-id='type-id-97' visibility='default'/>
+        <var-decl name='drr_key' type-id='type-id-64' visibility='default'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-32' size-in-bits='48' id='type-id-105'>
-      <subrange length='6' type-id='type-id-12' id='type-id-106'/>
+    <array-type-def dimensions='1' type-id='type-id-33' size-in-bits='48' id='type-id-72'>
+      <subrange length='6' type-id='type-id-12' id='type-id-73'/>
 
     </array-type-def>
-    <class-decl name='drr_spill' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-84'>
+    <class-decl name='drr_spill' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-47'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_object' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_length' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_length' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_flags' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_flags' type-id='type-id-33' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='200'>
-        <var-decl name='drr_compressiontype' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_compressiontype' type-id='type-id-33' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='208'>
-        <var-decl name='drr_pad' type-id='type-id-105' visibility='default'/>
+        <var-decl name='drr_pad' type-id='type-id-72' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_compressed_size' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_compressed_size' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_salt' type-id='type-id-98' visibility='default'/>
+        <var-decl name='drr_salt' type-id='type-id-65' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_iv' type-id='type-id-99' visibility='default'/>
+        <var-decl name='drr_iv' type-id='type-id-66' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='drr_mac' type-id='type-id-100' visibility='default'/>
+        <var-decl name='drr_mac' type-id='type-id-67' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='drr_type' type-id='type-id-93' visibility='default'/>
+        <var-decl name='drr_type' type-id='type-id-60' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='drr_write_embedded' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-85'>
+    <class-decl name='drr_write_embedded' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-48'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_object' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_offset' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_length' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_compression' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_compression' type-id='type-id-33' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='264'>
-        <var-decl name='drr_etype' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_etype' type-id='type-id-33' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='272'>
-        <var-decl name='drr_pad' type-id='type-id-105' visibility='default'/>
+        <var-decl name='drr_pad' type-id='type-id-72' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_lsize' type-id='type-id-22' visibility='default'/>
+        <var-decl name='drr_lsize' type-id='type-id-7' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='drr_psize' type-id='type-id-22' visibility='default'/>
+        <var-decl name='drr_psize' type-id='type-id-7' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='drr_object_range' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-86'>
+    <class-decl name='drr_object_range' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-49'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_firstobj' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_firstobj' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_numslots' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_numslots' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_salt' type-id='type-id-98' visibility='default'/>
+        <var-decl name='drr_salt' type-id='type-id-65' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_iv' type-id='type-id-99' visibility='default'/>
+        <var-decl name='drr_iv' type-id='type-id-66' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='drr_mac' type-id='type-id-100' visibility='default'/>
+        <var-decl name='drr_mac' type-id='type-id-67' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='drr_flags' type-id='type-id-32' visibility='default'/>
+        <var-decl name='drr_flags' type-id='type-id-33' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='488'>
-        <var-decl name='drr_pad' type-id='type-id-48' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_redact' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-87'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_offset' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_length' type-id='type-id-23' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_toguid' type-id='type-id-23' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_checksum' size-in-bits='2432' is-struct='yes' visibility='default' id='type-id-88'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_pad' type-id='type-id-107' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='drr_checksum' type-id='type-id-89' visibility='default'/>
+        <var-decl name='drr_pad' type-id='type-id-74' visibility='default'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='2176' id='type-id-107'>
-      <subrange length='34' type-id='type-id-12' id='type-id-108'/>
+    <array-type-def dimensions='1' type-id='type-id-33' size-in-bits='24' id='type-id-74'>
+      <subrange length='3' type-id='type-id-12' id='type-id-75'/>
 
     </array-type-def>
-    <typedef-decl name='dmu_replay_record_t' type-id='type-id-75' id='type-id-109'/>
-    <qualified-type-def type-id='type-id-109' const='yes' id='type-id-110'/>
-    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
-    <function-decl name='lzc_receive_with_header' mangled-name='lzc_receive_with_header' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_header'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-29' name='props'/>
-      <parameter type-id='type-id-16' name='origin'/>
-      <parameter type-id='type-id-41' name='force'/>
-      <parameter type-id='type-id-41' name='resumable'/>
-      <parameter type-id='type-id-41' name='raw'/>
-      <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-111' name='begin_record'/>
+    <class-decl name='drr_redact' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_offset' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_length' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_toguid' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_checksum' size-in-bits='2432' is-struct='yes' visibility='default' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_pad' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='drr_checksum' type-id='type-id-56' visibility='default'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='2176' id='type-id-76'>
+      <subrange length='34' type-id='type-id-12' id='type-id-77'/>
+
+    </array-type-def>
+    <typedef-decl name='dmu_replay_record_t' type-id='type-id-37' id='type-id-78'/>
+    <qualified-type-def type-id='type-id-78' const='yes' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-81'/>
+    <function-decl name='lzc_receive_with_cmdprops' mangled-name='lzc_receive_with_cmdprops' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_cmdprops'>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-15' name='props'/>
+      <parameter type-id='type-id-15' name='cmdprops'/>
+      <parameter type-id='type-id-34' name='wkeydata'/>
+      <parameter type-id='type-id-35' name='wkeylen'/>
+      <parameter type-id='type-id-4' name='origin'/>
+      <parameter type-id='type-id-23' name='force'/>
+      <parameter type-id='type-id-23' name='resumable'/>
+      <parameter type-id='type-id-23' name='raw'/>
+      <parameter type-id='type-id-1' name='input_fd'/>
+      <parameter type-id='type-id-80' name='begin_record'/>
+      <parameter type-id='type-id-1' name='cleanup_fd'/>
+      <parameter type-id='type-id-81' name='read_bytes'/>
+      <parameter type-id='type-id-81' name='errflags'/>
+      <parameter type-id='type-id-81' name='action_handle'/>
+      <parameter type-id='type-id-16' name='errors'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='lzc_receive_one' mangled-name='lzc_receive_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_one'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-29' name='props'/>
-      <parameter type-id='type-id-16' name='origin'/>
-      <parameter type-id='type-id-41' name='force'/>
-      <parameter type-id='type-id-41' name='resumable'/>
-      <parameter type-id='type-id-41' name='raw'/>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-15' name='props'/>
+      <parameter type-id='type-id-4' name='origin'/>
+      <parameter type-id='type-id-23' name='force'/>
+      <parameter type-id='type-id-23' name='resumable'/>
+      <parameter type-id='type-id-23' name='raw'/>
       <parameter type-id='type-id-1' name='input_fd'/>
-      <parameter type-id='type-id-111' name='begin_record'/>
+      <parameter type-id='type-id-80' name='begin_record'/>
       <parameter type-id='type-id-1' name='cleanup_fd'/>
-      <parameter type-id='type-id-71' name='read_bytes'/>
-      <parameter type-id='type-id-71' name='errflags'/>
-      <parameter type-id='type-id-71' name='action_handle'/>
-      <parameter type-id='type-id-64' name='errors'/>
+      <parameter type-id='type-id-81' name='read_bytes'/>
+      <parameter type-id='type-id-81' name='errflags'/>
+      <parameter type-id='type-id-81' name='action_handle'/>
+      <parameter type-id='type-id-16' name='errors'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='lzc_receive_with_cmdprops' mangled-name='lzc_receive_with_cmdprops' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_cmdprops'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-29' name='props'/>
-      <parameter type-id='type-id-29' name='cmdprops'/>
-      <parameter type-id='type-id-33' name='wkeydata'/>
-      <parameter type-id='type-id-34' name='wkeylen'/>
-      <parameter type-id='type-id-16' name='origin'/>
-      <parameter type-id='type-id-41' name='force'/>
-      <parameter type-id='type-id-41' name='resumable'/>
-      <parameter type-id='type-id-41' name='raw'/>
-      <parameter type-id='type-id-1' name='input_fd'/>
-      <parameter type-id='type-id-111' name='begin_record'/>
-      <parameter type-id='type-id-1' name='cleanup_fd'/>
-      <parameter type-id='type-id-71' name='read_bytes'/>
-      <parameter type-id='type-id-71' name='errflags'/>
-      <parameter type-id='type-id-71' name='action_handle'/>
-      <parameter type-id='type-id-64' name='errors'/>
+    <function-decl name='lzc_receive_with_header' mangled-name='lzc_receive_with_header' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_header'>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-15' name='props'/>
+      <parameter type-id='type-id-4' name='origin'/>
+      <parameter type-id='type-id-23' name='force'/>
+      <parameter type-id='type-id-23' name='resumable'/>
+      <parameter type-id='type-id-23' name='raw'/>
+      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-80' name='begin_record'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='lzc_rollback' mangled-name='lzc_rollback' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback'>
-      <parameter type-id='type-id-16' name='fsname'/>
-      <parameter type-id='type-id-37' name='snapnamebuf'/>
+    <function-decl name='lzc_receive_resumable' mangled-name='lzc_receive_resumable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_resumable'>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-15' name='props'/>
+      <parameter type-id='type-id-4' name='origin'/>
+      <parameter type-id='type-id-23' name='force'/>
+      <parameter type-id='type-id-23' name='raw'/>
+      <parameter type-id='type-id-1' name='fd'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_receive' mangled-name='lzc_receive' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive'>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-15' name='props'/>
+      <parameter type-id='type-id-4' name='origin'/>
+      <parameter type-id='type-id-23' name='force'/>
+      <parameter type-id='type-id-23' name='raw'/>
+      <parameter type-id='type-id-1' name='fd'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <enum-decl name='lzc_send_flags' id='type-id-82'>
+      <underlying-type type-id='type-id-19'/>
+      <enumerator name='LZC_SEND_FLAG_EMBED_DATA' value='1'/>
+      <enumerator name='LZC_SEND_FLAG_LARGE_BLOCK' value='2'/>
+      <enumerator name='LZC_SEND_FLAG_COMPRESS' value='4'/>
+      <enumerator name='LZC_SEND_FLAG_RAW' value='8'/>
+      <enumerator name='LZC_SEND_FLAG_SAVED' value='16'/>
+    </enum-decl>
+    <function-decl name='lzc_send_space' mangled-name='lzc_send_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space'>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-4' name='from'/>
+      <parameter type-id='type-id-82' name='flags'/>
+      <parameter type-id='type-id-81' name='spacep'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_space_resume_redacted' mangled-name='lzc_send_space_resume_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space_resume_redacted'>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-4' name='from'/>
+      <parameter type-id='type-id-82' name='flags'/>
+      <parameter type-id='type-id-8' name='resumeobj'/>
+      <parameter type-id='type-id-8' name='resumeoff'/>
+      <parameter type-id='type-id-8' name='resume_bytes'/>
+      <parameter type-id='type-id-4' name='redactbook'/>
+      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-81' name='spacep'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_resume_redacted' mangled-name='lzc_send_resume_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume_redacted'>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-4' name='from'/>
+      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-82' name='flags'/>
+      <parameter type-id='type-id-8' name='resumeobj'/>
+      <parameter type-id='type-id-8' name='resumeoff'/>
+      <parameter type-id='type-id-4' name='redactbook'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_resume' mangled-name='lzc_send_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume'>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-4' name='from'/>
+      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-82' name='flags'/>
+      <parameter type-id='type-id-8' name='resumeobj'/>
+      <parameter type-id='type-id-8' name='resumeoff'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send_redacted' mangled-name='lzc_send_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_redacted'>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-4' name='from'/>
+      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-82' name='flags'/>
+      <parameter type-id='type-id-4' name='redactbook'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_send' mangled-name='lzc_send' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send'>
+      <parameter type-id='type-id-4' name='snapname'/>
+      <parameter type-id='type-id-4' name='from'/>
+      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-82' name='flags'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_get_holds' mangled-name='lzc_get_holds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_holds'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-16' name='outnvl'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_release' mangled-name='lzc_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_release'>
+      <parameter type-id='type-id-15' name='holds'/>
+      <parameter type-id='type-id-16' name='errlist'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_hold' mangled-name='lzc_hold' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_hold'>
+      <parameter type-id='type-id-15' name='holds'/>
+      <parameter type-id='type-id-1' name='cleanup_fd'/>
+      <parameter type-id='type-id-16' name='errlist'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_sync' mangled-name='lzc_sync' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_sync'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <parameter type-id='type-id-15' name='props'/>
+      <parameter type-id='type-id-16' name='bmarks'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_exists' mangled-name='lzc_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_exists'>
+      <parameter type-id='type-id-4' name='dataset'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='lzc_snaprange_space' mangled-name='lzc_snaprange_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snaprange_space'>
+      <parameter type-id='type-id-4' name='firstsnap'/>
+      <parameter type-id='type-id-4' name='lastsnap'/>
+      <parameter type-id='type-id-81' name='usedp'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_snaps' mangled-name='lzc_destroy_snaps' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_snaps'>
+      <parameter type-id='type-id-15' name='snaps'/>
+      <parameter type-id='type-id-23' name='defer'/>
+      <parameter type-id='type-id-16' name='errlist'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_snapshot' mangled-name='lzc_snapshot' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snapshot'>
+      <parameter type-id='type-id-15' name='snaps'/>
+      <parameter type-id='type-id-15' name='props'/>
+      <parameter type-id='type-id-16' name='errlist'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_destroy' mangled-name='lzc_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_rename' mangled-name='lzc_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rename'>
+      <parameter type-id='type-id-4' name='source'/>
+      <parameter type-id='type-id-4' name='target'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzc_promote' mangled-name='lzc_promote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_promote'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <parameter type-id='type-id-36' name='snapnamebuf'/>
       <parameter type-id='type-id-1' name='snapnamelen'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback_to'>
-      <parameter type-id='type-id-16' name='fsname'/>
-      <parameter type-id='type-id-16' name='snapname'/>
+    <function-decl name='lzc_clone' mangled-name='lzc_clone' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_clone'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <parameter type-id='type-id-4' name='origin'/>
+      <parameter type-id='type-id-15' name='props'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='lzc_bookmark' mangled-name='lzc_bookmark' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_bookmark'>
-      <parameter type-id='type-id-29' name='bookmarks'/>
-      <parameter type-id='type-id-64' name='errlist'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_get_bookmarks' mangled-name='lzc_get_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmarks'>
-      <parameter type-id='type-id-16' name='pool_name'/>
-      <parameter type-id='type-id-29' name='innvl'/>
-      <parameter type-id='type-id-64' name='outnvl'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_get_bookmark_props' mangled-name='lzc_get_bookmark_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmark_props'>
-      <parameter type-id='type-id-16' name='bookmark'/>
-      <parameter type-id='type-id-64' name='props'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_bookmarks'>
-      <parameter type-id='type-id-29' name='bookmarks'/>
-      <parameter type-id='type-id-64' name='errlist'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_channel_program' mangled-name='lzc_channel_program' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program'>
-      <parameter type-id='type-id-16' name='pool'/>
-      <parameter type-id='type-id-16' name='program'/>
-      <parameter type-id='type-id-23' name='instrlimit'/>
-      <parameter type-id='type-id-23' name='memlimit'/>
-      <parameter type-id='type-id-29' name='argnvl'/>
-      <parameter type-id='type-id-64' name='outnvl'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-51'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='lzc_pool_checkpoint' mangled-name='lzc_pool_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint'>
-      <parameter type-id='type-id-16' name='pool'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_pool_checkpoint_discard' mangled-name='lzc_pool_checkpoint_discard' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint_discard'>
-      <parameter type-id='type-id-16' name='pool'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_channel_program_nosync' mangled-name='lzc_channel_program_nosync' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program_nosync'>
-      <parameter type-id='type-id-16' name='pool'/>
-      <parameter type-id='type-id-16' name='program'/>
-      <parameter type-id='type-id-23' name='instrlimit'/>
-      <parameter type-id='type-id-23' name='memlimit'/>
-      <parameter type-id='type-id-29' name='argnvl'/>
-      <parameter type-id='type-id-64' name='outnvl'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_load_key' mangled-name='lzc_load_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_load_key'>
-      <parameter type-id='type-id-16' name='fsname'/>
-      <parameter type-id='type-id-41' name='noop'/>
-      <parameter type-id='type-id-33' name='wkeydata'/>
-      <parameter type-id='type-id-34' name='wkeylen'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_unload_key' mangled-name='lzc_unload_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_unload_key'>
-      <parameter type-id='type-id-16' name='fsname'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_change_key' mangled-name='lzc_change_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_change_key'>
-      <parameter type-id='type-id-16' name='fsname'/>
-      <parameter type-id='type-id-23' name='crypt_cmd'/>
-      <parameter type-id='type-id-29' name='props'/>
-      <parameter type-id='type-id-33' name='wkeydata'/>
-      <parameter type-id='type-id-34' name='wkeylen'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='lzc_reopen' mangled-name='lzc_reopen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_reopen'>
-      <parameter type-id='type-id-16' name='pool_name'/>
-      <parameter type-id='type-id-41' name='scrub_restart'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <enum-decl name='pool_initialize_func' id='type-id-112'>
-      <underlying-type type-id='type-id-18'/>
-      <enumerator name='POOL_INITIALIZE_START' value='0'/>
-      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
-      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
-      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
+    <enum-decl name='lzc_dataset_type' id='type-id-83'>
+      <underlying-type type-id='type-id-19'/>
+      <enumerator name='LZC_DATSET_TYPE_ZFS' value='2'/>
+      <enumerator name='LZC_DATSET_TYPE_ZVOL' value='3'/>
     </enum-decl>
-    <typedef-decl name='pool_initialize_func_t' type-id='type-id-112' id='type-id-113'/>
-    <function-decl name='lzc_initialize' mangled-name='lzc_initialize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_initialize'>
-      <parameter type-id='type-id-16' name='poolname'/>
-      <parameter type-id='type-id-113' name='cmd_type'/>
-      <parameter type-id='type-id-29' name='vdevs'/>
-      <parameter type-id='type-id-64' name='errlist'/>
+    <function-decl name='lzc_create' mangled-name='lzc_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_create'>
+      <parameter type-id='type-id-4' name='fsname'/>
+      <parameter type-id='type-id-83' name='type'/>
+      <parameter type-id='type-id-15' name='props'/>
+      <parameter type-id='type-id-34' name='wkeydata'/>
+      <parameter type-id='type-id-35' name='wkeylen'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <enum-decl name='pool_trim_func' id='type-id-114'>
-      <underlying-type type-id='type-id-18'/>
-      <enumerator name='POOL_TRIM_START' value='0'/>
-      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
-      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
-      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
-    </enum-decl>
-    <typedef-decl name='pool_trim_func_t' type-id='type-id-114' id='type-id-115'/>
-    <function-decl name='lzc_trim' mangled-name='lzc_trim' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_trim'>
-      <parameter type-id='type-id-16' name='poolname'/>
-      <parameter type-id='type-id-115' name='cmd_type'/>
-      <parameter type-id='type-id-23' name='rate'/>
-      <parameter type-id='type-id-41' name='secure'/>
-      <parameter type-id='type-id-29' name='vdevs'/>
-      <parameter type-id='type-id-64' name='errlist'/>
+    <type-decl name='void' id='type-id-84'/>
+    <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_fini'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='libzfs_core_init' mangled-name='libzfs_core_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_init'>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='lzc_redact' mangled-name='lzc_redact' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_redact'>
-      <parameter type-id='type-id-16' name='snapshot'/>
-      <parameter type-id='type-id-16' name='bookname'/>
-      <parameter type-id='type-id-29' name='snapnv'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-116'>
-      <underlying-type type-id='type-id-18'/>
-      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
-      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
-      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
-      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
-      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
-      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
-      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
-      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
-      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
-    </enum-decl>
-    <typedef-decl name='zpool_wait_activity_t' type-id='type-id-116' id='type-id-117'/>
-    <pointer-type-def type-id='type-id-41' size-in-bits='64' id='type-id-118'/>
-    <function-decl name='lzc_wait' mangled-name='lzc_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait'>
-      <parameter type-id='type-id-16' name='pool'/>
-      <parameter type-id='type-id-117' name='activity'/>
-      <parameter type-id='type-id-118' name='waited'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='fnvlist_add_int32' mangled-name='fnvlist_add_int32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-51'/>
+    <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='lzc_wait_tag' mangled-name='lzc_wait_tag' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_tag'>
-      <parameter type-id='type-id-16' name='pool'/>
-      <parameter type-id='type-id-117' name='activity'/>
-      <parameter type-id='type-id-23' name='tag'/>
-      <parameter type-id='type-id-118' name='waited'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='fnvlist_free' mangled-name='fnvlist_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='type-id-119'>
-      <underlying-type type-id='type-id-18'/>
-      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
-      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
-    </enum-decl>
-    <typedef-decl name='zfs_wait_activity_t' type-id='type-id-119' id='type-id-120'/>
-    <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_fs'>
-      <parameter type-id='type-id-16' name='fs'/>
-      <parameter type-id='type-id-120' name='activity'/>
-      <parameter type-id='type-id-118' name='waited'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='__stack_chk_fail' mangled-name='__stack_chk_fail' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-121'/>
-    <pointer-type-def type-id='type-id-121' size-in-bits='64' id='type-id-122'/>
-    <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_set_bootenv'>
-      <parameter type-id='type-id-16' name='pool'/>
-      <parameter type-id='type-id-122' name='env'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bootenv'>
-      <parameter type-id='type-id-16' name='snapname'/>
-      <parameter type-id='type-id-64' name='holdsp'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_free' mangled-name='nvlist_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint8_array' mangled-name='fnvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvpair_name' mangled-name='nvpair_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strlcpy' mangled-name='strlcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strcspn' mangled-name='strcspn' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strrchr' mangled-name='strrchr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_dup' mangled-name='fnvlist_dup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_byte_array' mangled-name='fnvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_pack' mangled-name='fnvlist_pack' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='malloc' mangled-name='malloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_ioctl_fd' mangled-name='zfs_ioctl_fd' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__errno_location' mangled-name='__errno_location' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_pack_free' mangled-name='fnvlist_pack_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='free' mangled-name='free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__read_alias' mangled-name='read' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strchr' mangled-name='strchr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fnvlist_unpack' mangled-name='fnvlist_unpack' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_lock' mangled-name='pthread_mutex_lock' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='close' mangled-name='close' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_unlock' mangled-name='pthread_mutex_unlock' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__open_alias' mangled-name='open64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_device_path.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
-    <function-decl name='zfs_basename' mangled-name='zfs_basename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_basename'>
-      <parameter type-id='type-id-16' name='path'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <typedef-decl name='__ssize_t' type-id='type-id-5' id='type-id-123'/>
-    <typedef-decl name='ssize_t' type-id='type-id-123' id='type-id-124'/>
-    <function-decl name='zfs_dirnamelen' mangled-name='zfs_dirnamelen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dirnamelen'>
-      <parameter type-id='type-id-16' name='path'/>
-      <return type-id='type-id-124'/>
-    </function-decl>
-    <typedef-decl name='size_t' type-id='type-id-26' id='type-id-125'/>
-    <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_resolve_shortname'>
-      <parameter type-id='type-id-16' name='name'/>
-      <parameter type-id='type-id-37' name='path'/>
-      <parameter type-id='type-id-125' name='len'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='getenv' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-126'/>
-    <function-decl name='strtok_r' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-126'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <function-decl name='access' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-16' const='yes' id='type-id-127'/>
-    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-128'/>
-    <function-decl name='zpool_default_search_paths' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-38'/>
-      <return type-id='type-id-128'/>
-    </function-decl>
+  <abi-instr version='1.0' address-size='64' path='zutil_device_path.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzutil' language='LANG_C99'>
     <function-decl name='zfs_strcmp_pathname' mangled-name='zfs_strcmp_pathname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strcmp_pathname'>
-      <parameter type-id='type-id-16' name='name'/>
-      <parameter type-id='type-id-16' name='cmp'/>
+      <parameter type-id='type-id-4' name='name'/>
+      <parameter type-id='type-id-4' name='cmp'/>
       <parameter type-id='type-id-1' name='wholedisk'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='strlcat' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-26'/>
-    </function-decl>
-    <function-decl name='zfs_append_partition' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-26'/>
+    <typedef-decl name='size_t' type-id='type-id-12' id='type-id-85'/>
+    <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_resolve_shortname'>
+      <parameter type-id='type-id-4' name='name'/>
+      <parameter type-id='type-id-36' name='path'/>
+      <parameter type-id='type-id-85' name='len'/>
       <return type-id='type-id-1'/>
+    </function-decl>
+    <type-decl name='long int' size-in-bits='64' id='type-id-86'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-86' id='type-id-87'/>
+    <typedef-decl name='ssize_t' type-id='type-id-87' id='type-id-88'/>
+    <function-decl name='zfs_dirnamelen' mangled-name='zfs_dirnamelen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dirnamelen'>
+      <parameter type-id='type-id-4' name='path'/>
+      <return type-id='type-id-88'/>
+    </function-decl>
+    <function-decl name='zfs_basename' mangled-name='zfs_basename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_basename'>
+      <parameter type-id='type-id-4' name='path'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='__builtin___snprintf_chk' mangled-name='__snprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='getenv' mangled-name='getenv' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strdup' mangled-name='strdup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strtok_r' mangled-name='strtok_r' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strlen' mangled-name='strlen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strcmp' mangled-name='strcmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zpool_default_search_paths' mangled-name='zpool_default_search_paths' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strlcat' mangled-name='strlcat' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='access' mangled-name='access' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_import.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-129'/>
-    <function-decl name='zpool_read_label' mangled-name='zpool_read_label' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_read_label'>
-      <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-64' name='config'/>
-      <parameter type-id='type-id-129' name='num_labels'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='ioctl' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-26'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='spl_pagesize' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-26'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-130'/>
-    <function-decl name='posix_memalign' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-130'/>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='aiocb' size-in-bits='1344' is-struct='yes' visibility='default' id='type-id-131'>
+  <abi-instr version='1.0' address-size='64' path='zutil_import.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzutil' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-89'/>
+    <class-decl name='importargs' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-90'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='aio_fildes' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='aio_lio_opcode' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='aio_reqprio' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='aio_buf' type-id='type-id-132' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='aio_nbytes' type-id='type-id-125' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='aio_sigevent' type-id='type-id-133' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='__next_prio' type-id='type-id-134' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='__abs_prio' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='864'>
-        <var-decl name='__policy' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='__error_code' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__return_value' type-id='type-id-123' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='aio_offset' type-id='type-id-135' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='__glibc_reserved' type-id='type-id-136' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <qualified-type-def type-id='type-id-17' volatile='yes' id='type-id-137'/>
-    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-132'/>
-    <class-decl name='sigevent' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-133'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='sigev_value' type-id='type-id-138' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='sigev_signo' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='sigev_notify' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_sigev_un' type-id='type-id-139' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <union-decl name='sigval' size-in-bits='64' visibility='default' id='type-id-140'>
-      <data-member access='private'>
-        <var-decl name='sival_int' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='sival_ptr' type-id='type-id-73' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='__sigval_t' type-id='type-id-140' id='type-id-138'/>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' id='type-id-139'>
-      <data-member access='private'>
-        <var-decl name='_pad' type-id='type-id-141' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='_tid' type-id='type-id-142' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='_sigev_thread' type-id='type-id-143' visibility='default'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='384' id='type-id-141'>
-      <subrange length='12' type-id='type-id-12' id='type-id-103'/>
-
-    </array-type-def>
-    <typedef-decl name='__pid_t' type-id='type-id-1' id='type-id-142'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-143'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_function' type-id='type-id-144' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_attribute' type-id='type-id-145' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-144'/>
-    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' id='type-id-147'>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-148' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-5' visibility='default'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='448' id='type-id-148'>
-      <subrange length='56' type-id='type-id-12' id='type-id-149'/>
-
-    </array-type-def>
-    <typedef-decl name='pthread_attr_t' type-id='type-id-147' id='type-id-150'/>
-    <pointer-type-def type-id='type-id-150' size-in-bits='64' id='type-id-145'/>
-    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-134'/>
-    <typedef-decl name='__off64_t' type-id='type-id-5' id='type-id-135'/>
-
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='256' id='type-id-136'>
-      <subrange length='32' type-id='type-id-12' id='type-id-151'/>
-
-    </array-type-def>
-    <qualified-type-def type-id='type-id-134' const='yes' id='type-id-152'/>
-    <pointer-type-def type-id='type-id-152' size-in-bits='64' id='type-id-153'/>
-    <pointer-type-def type-id='type-id-133' size-in-bits='64' id='type-id-154'/>
-    <function-decl name='lio_listio' mangled-name='lio_listio64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-153'/>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-154'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-131' const='yes' id='type-id-155'/>
-    <pointer-type-def type-id='type-id-155' size-in-bits='64' id='type-id-156'/>
-    <function-decl name='aio_error' mangled-name='aio_error64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-156'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='aio_return' mangled-name='aio_return64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-134'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='pread64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-157'/>
-    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-158'/>
-    <function-decl name='nvlist_lookup_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-157'/>
-      <parameter type-id='type-id-158'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-126'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='importargs' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-159'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='path' type-id='type-id-126' visibility='default'/>
+        <var-decl name='path' type-id='type-id-91' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='paths' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='poolname' type-id='type-id-16' visibility='default'/>
+        <var-decl name='poolname' type-id='type-id-4' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='guid' type-id='type-id-23' visibility='default'/>
+        <var-decl name='guid' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='cachefile' type-id='type-id-16' visibility='default'/>
+        <var-decl name='cachefile' type-id='type-id-4' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='can_be_active' type-id='type-id-41' visibility='default'/>
+        <var-decl name='can_be_active' type-id='type-id-23' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='scan' type-id='type-id-41' visibility='default'/>
+        <var-decl name='scan' type-id='type-id-23' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='policy' type-id='type-id-29' visibility='default'/>
+        <var-decl name='policy' type-id='type-id-15' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='importargs_t' type-id='type-id-159' id='type-id-160'/>
-    <pointer-type-def type-id='type-id-160' size-in-bits='64' id='type-id-161'/>
-    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-162'>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-91'/>
+    <typedef-decl name='importargs_t' type-id='type-id-90' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-93'/>
+    <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-94'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pco_refresh_config' type-id='type-id-163' visibility='default'/>
+        <var-decl name='pco_refresh_config' type-id='type-id-95' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pco_pool_active' type-id='type-id-164' visibility='default'/>
+        <var-decl name='pco_pool_active' type-id='type-id-96' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='refresh_config_func_t' type-id='type-id-165' id='type-id-166'/>
-    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-163'/>
-    <typedef-decl name='pool_active_func_t' type-id='type-id-167' id='type-id-168'/>
-    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-164'/>
-    <qualified-type-def type-id='type-id-162' const='yes' id='type-id-169'/>
-    <typedef-decl name='pool_config_ops_t' type-id='type-id-169' id='type-id-170'/>
-    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-172'/>
-    <function-decl name='zpool_search_import' mangled-name='zpool_search_import' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_search_import'>
-      <parameter type-id='type-id-73' name='hdl'/>
-      <parameter type-id='type-id-161' name='import'/>
-      <parameter type-id='type-id-172' name='pco'/>
-      <return type-id='type-id-29'/>
-    </function-decl>
-    <function-decl name='dcgettext' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-173'>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-174' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-1' visibility='default'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='32' id='type-id-174'>
-      <subrange length='4' type-id='type-id-12' id='type-id-92'/>
-
-    </array-type-def>
-    <qualified-type-def type-id='type-id-173' const='yes' id='type-id-175'/>
-    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-176'/>
-    <function-decl name='pthread_mutex_init' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-14'/>
-      <parameter type-id='type-id-176'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='libpc_handle' size-in-bits='8448' is-struct='yes' visibility='default' id='type-id-177'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='lpc_printerr' type-id='type-id-41' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='lpc_open_access_error' type-id='type-id-41' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='lpc_desc_active' type-id='type-id-41' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='lpc_desc' type-id='type-id-178' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8320'>
-        <var-decl name='lpc_ops' type-id='type-id-172' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8384'>
-        <var-decl name='lpc_lib_handle' type-id='type-id-73' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='8192' id='type-id-178'>
-      <subrange length='1024' type-id='type-id-12' id='type-id-179'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-180'/>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-181'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='type-id-182' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='type-id-183' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='type-id-125' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='type-id-184' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_size' type-id='type-id-125' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-185'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='type-id-186' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='type-id-187' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-182'/>
-
-    <array-type-def dimensions='1' type-id='type-id-182' size-in-bits='128' id='type-id-186'>
-      <subrange length='2' type-id='type-id-12' id='type-id-62'/>
-
-    </array-type-def>
-    <typedef-decl name='uintptr_t' type-id='type-id-26' id='type-id-187'/>
-    <pointer-type-def type-id='type-id-188' size-in-bits='64' id='type-id-183'/>
-    <typedef-decl name='ulong_t' type-id='type-id-26' id='type-id-184'/>
-    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-189'/>
-    <pointer-type-def type-id='type-id-189' size-in-bits='64' id='type-id-190'/>
-    <function-decl name='zpool_find_import_blkid' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-180'/>
-      <parameter type-id='type-id-14'/>
-      <parameter type-id='type-id-190'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-189'/>
-      <parameter type-id='type-id-183'/>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='dirname' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <function-decl name='realpath' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-37'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-14'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-74'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-70'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-35'/>
-    </function-decl>
-    <function-decl name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-189'/>
-      <parameter type-id='type-id-130'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='nvlist_empty' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-51'/>
-    </function-decl>
-    <function-decl name='geteuid' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-6'/>
-    </function-decl>
+    <typedef-decl name='refresh_config_func_t' type-id='type-id-97' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-95'/>
+    <typedef-decl name='pool_active_func_t' type-id='type-id-99' id='type-id-100'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-96'/>
+    <qualified-type-def type-id='type-id-94' const='yes' id='type-id-101'/>
+    <typedef-decl name='pool_config_ops_t' type-id='type-id-101' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-103'/>
     <function-decl name='zpool_find_config' mangled-name='zpool_find_config' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_config'>
-      <parameter type-id='type-id-73' name='hdl'/>
-      <parameter type-id='type-id-16' name='target'/>
-      <parameter type-id='type-id-64' name='configp'/>
-      <parameter type-id='type-id-161' name='args'/>
-      <parameter type-id='type-id-172' name='pco'/>
+      <parameter type-id='type-id-89' name='hdl'/>
+      <parameter type-id='type-id-4' name='target'/>
+      <parameter type-id='type-id-16' name='configp'/>
+      <parameter type-id='type-id-93' name='args'/>
+      <parameter type-id='type-id-103' name='pco'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-70'/>
-      <parameter type-id='type-id-74'/>
+    <function-decl name='zpool_search_import' mangled-name='zpool_search_import' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_search_import'>
+      <parameter type-id='type-id-89' name='hdl'/>
+      <parameter type-id='type-id-93' name='import'/>
+      <parameter type-id='type-id-103' name='pco'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-104'/>
+    <function-decl name='zpool_read_label' mangled-name='zpool_read_label' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_read_label'>
+      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-16' name='config'/>
+      <parameter type-id='type-id-104' name='num_labels'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='sysconf' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-191'/>
-    <pointer-type-def type-id='type-id-191' size-in-bits='64' id='type-id-192'/>
-    <function-decl name='tpool_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-145'/>
-      <return type-id='type-id-192'/>
+    <function-decl name='strtoull' mangled-name='strtoull' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='avl_first' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-189'/>
-      <return type-id='type-id-73'/>
+    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-193' size-in-bits='64' id='type-id-194'/>
-    <function-decl name='tpool_dispatch' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-192'/>
-      <parameter type-id='type-id-194'/>
-      <parameter type-id='type-id-73'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='strpbrk' mangled-name='strpbrk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='avl_walk' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-189'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-73'/>
+    <function-decl name='__fxstat64' mangled-name='__fxstat64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='tpool_wait' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-192'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='calloc' mangled-name='calloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='tpool_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-192'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='avl_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-189'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='nvlist_remove' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-69'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='pthread_mutex_init' mangled-name='pthread_mutex_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='pthread_mutex_destroy' mangled-name='pthread_mutex_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-195'/>
-    <function-decl name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-195'/>
-      <parameter type-id='type-id-158'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-38'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='nvlist_dup' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-74'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-74'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <class-decl name='__dirstream' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-196'/>
-    <pointer-type-def type-id='type-id-196' size-in-bits='64' id='type-id-197'/>
-    <function-decl name='opendir' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-197'/>
+    <function-decl name='dcgettext' mangled-name='dcgettext' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <class-decl name='dirent64' size-in-bits='2240' is-struct='yes' visibility='default' id='type-id-198'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='d_ino' type-id='type-id-199' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='d_off' type-id='type-id-135' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='d_reclen' type-id='type-id-200' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='d_type' type-id='type-id-30' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='152'>
-        <var-decl name='d_name' type-id='type-id-43' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__ino64_t' type-id='type-id-26' id='type-id-199'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-200'/>
-    <pointer-type-def type-id='type-id-198' size-in-bits='64' id='type-id-201'/>
-    <function-decl name='readdir64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-197'/>
-      <return type-id='type-id-201'/>
+    <function-decl name='strerror' mangled-name='strerror' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='closedir' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-197'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='__realpath_chk' mangled-name='__realpath_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='asprintf' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-16'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='strndup' mangled-name='strndup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='avl_find' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-189'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-38'/>
-      <return type-id='type-id-73'/>
+    <function-decl name='zfs_basename' mangled-name='zfs_basename' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='avl_insert' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-189'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='zfs_dirnamelen' mangled-name='zfs_dirnamelen' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='update_vdev_config_dev_strs' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='__xstat' mangled-name='__xstat64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-167'>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-23'/>
-      <parameter type-id='type-id-118'/>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zpool_find_import_blkid' mangled-name='zpool_find_import_blkid' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_empty' mangled-name='nvlist_empty' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='geteuid' mangled-name='geteuid' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='opendir' mangled-name='opendir' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='readdir64' mangled-name='readdir64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='closedir' mangled-name='closedir' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__asprintf_chk' mangled-name='__asprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='avl_insert' mangled-name='avl_insert' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='ioctl' mangled-name='ioctl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__pread64_alias' mangled-name='pread64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='spl_pagesize' mangled-name='spl_pagesize' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='posix_memalign' mangled-name='posix_memalign' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='aio_error' mangled-name='aio_error64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='aio_return' mangled-name='aio_return64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='lio_listio' mangled-name='lio_listio64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='exit' mangled-name='exit' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__builtin___vsnprintf_chk' mangled-name='__vsnprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__fprintf_chk' mangled-name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='update_vdev_config_dev_strs' mangled-name='update_vdev_config_dev_strs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strncmp' mangled-name='strncmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_dup' mangled-name='nvlist_dup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_remove' mangled-name='nvlist_remove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='sysconf' mangled-name='sysconf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='tpool_create' mangled-name='tpool_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='tpool_wait' mangled-name='tpool_wait' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='tpool_destroy' mangled-name='tpool_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-99'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-24'/>
       <return type-id='type-id-1'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-188'>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-73'/>
-      <return type-id='type-id-1'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-165'>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-29'/>
-      <return type-id='type-id-29'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-146'>
-      <parameter type-id='type-id-138'/>
-      <return type-id='type-id-17'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-193'>
-      <parameter type-id='type-id-73'/>
-      <return type-id='type-id-17'/>
+    <function-type size-in-bits='64' id='type-id-97'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-15'/>
+      <return type-id='type-id-15'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_nicenum.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
-    <function-decl name='zfs_isnumber' mangled-name='zfs_isnumber' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_isnumber'>
-      <parameter type-id='type-id-16' name='str'/>
-      <return type-id='type-id-41'/>
+  <abi-instr version='1.0' address-size='64' path='zutil_nicenum.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzutil' language='LANG_C99'>
+    <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicebytes'>
+      <parameter type-id='type-id-8' name='num'/>
+      <parameter type-id='type-id-36' name='buf'/>
+      <parameter type-id='type-id-85' name='buflen'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <enum-decl name='zfs_nicenum_format' id='type-id-202'>
-      <underlying-type type-id='type-id-18'/>
+    <function-decl name='zfs_niceraw' mangled-name='zfs_niceraw' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_niceraw'>
+      <parameter type-id='type-id-8' name='num'/>
+      <parameter type-id='type-id-36' name='buf'/>
+      <parameter type-id='type-id-85' name='buflen'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_nicetime' mangled-name='zfs_nicetime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicetime'>
+      <parameter type-id='type-id-8' name='num'/>
+      <parameter type-id='type-id-36' name='buf'/>
+      <parameter type-id='type-id-85' name='buflen'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum'>
+      <parameter type-id='type-id-8' name='num'/>
+      <parameter type-id='type-id-36' name='buf'/>
+      <parameter type-id='type-id-85' name='buflen'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <enum-decl name='zfs_nicenum_format' id='type-id-105'>
+      <underlying-type type-id='type-id-19'/>
       <enumerator name='ZFS_NICENUM_1024' value='0'/>
       <enumerator name='ZFS_NICENUM_BYTES' value='1'/>
       <enumerator name='ZFS_NICENUM_TIME' value='2'/>
@@ -2379,615 +1696,698 @@
       <enumerator name='ZFS_NICENUM_RAWTIME' value='4'/>
     </enum-decl>
     <function-decl name='zfs_nicenum_format' mangled-name='zfs_nicenum_format' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum_format'>
-      <parameter type-id='type-id-23' name='num'/>
-      <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-125' name='buflen'/>
-      <parameter type-id='type-id-202' name='format'/>
-      <return type-id='type-id-17'/>
+      <parameter type-id='type-id-8' name='num'/>
+      <parameter type-id='type-id-36' name='buf'/>
+      <parameter type-id='type-id-85' name='buflen'/>
+      <parameter type-id='type-id-105' name='format'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum'>
-      <parameter type-id='type-id-23' name='num'/>
-      <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-125' name='buflen'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='zfs_isnumber' mangled-name='zfs_isnumber' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_isnumber'>
+      <parameter type-id='type-id-4' name='str'/>
+      <return type-id='type-id-23'/>
     </function-decl>
-    <function-decl name='zfs_nicetime' mangled-name='zfs_nicetime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicetime'>
-      <parameter type-id='type-id-23' name='num'/>
-      <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-125' name='buflen'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='powl' mangled-name='powl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zfs_niceraw' mangled-name='zfs_niceraw' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_niceraw'>
-      <parameter type-id='type-id-23' name='num'/>
-      <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-125' name='buflen'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='__builtin_snprintf' mangled-name='snprintf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicebytes'>
-      <parameter type-id='type-id-23' name='num'/>
-      <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-125' name='buflen'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='__ctype_b_loc' mangled-name='__ctype_b_loc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_pool.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
-    <class-decl name='ddt_stat' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-203'>
+  <abi-instr version='1.0' address-size='64' path='zutil_pool.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzutil' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-107'/>
+    <function-decl name='zpool_history_unpack' mangled-name='zpool_history_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_history_unpack'>
+      <parameter type-id='type-id-36' name='buf'/>
+      <parameter type-id='type-id-8' name='bytes_read'/>
+      <parameter type-id='type-id-81' name='leftover'/>
+      <parameter type-id='type-id-106' name='records'/>
+      <parameter type-id='type-id-107' name='numrecords'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='ddt_stat' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-108'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dds_blocks' type-id='type-id-23' visibility='default'/>
+        <var-decl name='dds_blocks' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='dds_lsize' type-id='type-id-23' visibility='default'/>
+        <var-decl name='dds_lsize' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='dds_psize' type-id='type-id-23' visibility='default'/>
+        <var-decl name='dds_psize' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='dds_dsize' type-id='type-id-23' visibility='default'/>
+        <var-decl name='dds_dsize' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='dds_ref_blocks' type-id='type-id-23' visibility='default'/>
+        <var-decl name='dds_ref_blocks' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='dds_ref_lsize' type-id='type-id-23' visibility='default'/>
+        <var-decl name='dds_ref_lsize' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='dds_ref_psize' type-id='type-id-23' visibility='default'/>
+        <var-decl name='dds_ref_psize' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='dds_ref_dsize' type-id='type-id-23' visibility='default'/>
+        <var-decl name='dds_ref_dsize' type-id='type-id-8' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='ddt_stat_t' type-id='type-id-203' id='type-id-204'/>
-    <qualified-type-def type-id='type-id-204' const='yes' id='type-id-205'/>
-    <pointer-type-def type-id='type-id-205' size-in-bits='64' id='type-id-206'/>
-    <class-decl name='ddt_histogram' size-in-bits='32768' is-struct='yes' visibility='default' id='type-id-207'>
+    <typedef-decl name='ddt_stat_t' type-id='type-id-108' id='type-id-109'/>
+    <qualified-type-def type-id='type-id-109' const='yes' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
+    <class-decl name='ddt_histogram' size-in-bits='32768' is-struct='yes' visibility='default' id='type-id-112'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ddh_stat' type-id='type-id-208' visibility='default'/>
+        <var-decl name='ddh_stat' type-id='type-id-113' visibility='default'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-204' size-in-bits='32768' id='type-id-208'>
-      <subrange length='64' type-id='type-id-12' id='type-id-209'/>
+    <array-type-def dimensions='1' type-id='type-id-109' size-in-bits='32768' id='type-id-113'>
+      <subrange length='64' type-id='type-id-12' id='type-id-114'/>
 
     </array-type-def>
-    <typedef-decl name='ddt_histogram_t' type-id='type-id-207' id='type-id-210'/>
-    <qualified-type-def type-id='type-id-210' const='yes' id='type-id-211'/>
-    <pointer-type-def type-id='type-id-211' size-in-bits='64' id='type-id-212'/>
+    <typedef-decl name='ddt_histogram_t' type-id='type-id-112' id='type-id-115'/>
+    <qualified-type-def type-id='type-id-115' const='yes' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-116' size-in-bits='64' id='type-id-117'/>
     <function-decl name='zpool_dump_ddt' mangled-name='zpool_dump_ddt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_dump_ddt'>
-      <parameter type-id='type-id-206' name='dds_total'/>
-      <parameter type-id='type-id-212' name='ddh'/>
-      <return type-id='type-id-17'/>
+      <parameter type-id='type-id-111' name='dds_total'/>
+      <parameter type-id='type-id-117' name='ddh'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zfs_nicenum' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='realloc' mangled-name='realloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zfs_nicebytes' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='__builtin_putchar' mangled-name='putchar' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-213'/>
-    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-214'/>
-    <function-decl name='zpool_history_unpack' mangled-name='zpool_history_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_history_unpack'>
-      <parameter type-id='type-id-37' name='buf'/>
-      <parameter type-id='type-id-23' name='bytes_read'/>
-      <parameter type-id='type-id-71' name='leftover'/>
-      <parameter type-id='type-id-213' name='records'/>
-      <parameter type-id='type-id-214' name='numrecords'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='__builtin_puts' mangled-name='puts' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__printf_chk' mangled-name='__printf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_device_path_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
-    <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_append_partition'>
-      <parameter type-id='type-id-37' name='path'/>
-      <parameter type-id='type-id-125' name='max_len'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_partition'>
-      <parameter type-id='type-id-37' name='path'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <function-decl name='zfs_strip_path' mangled-name='zfs_strip_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_path'>
-      <parameter type-id='type-id-37'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <function-decl name='zfs_get_enclosure_sysfs_path' mangled-name='zfs_get_enclosure_sysfs_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_enclosure_sysfs_path'>
-      <parameter type-id='type-id-16' name='dev_name'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <class-decl name='dirent' size-in-bits='2240' is-struct='yes' visibility='default' id='type-id-215'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='d_ino' type-id='type-id-199' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='d_off' type-id='type-id-135' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='d_reclen' type-id='type-id-200' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='d_type' type-id='type-id-30' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='152'>
-        <var-decl name='d_name' type-id='type-id-43' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-215' size-in-bits='64' id='type-id-216'/>
-    <function-decl name='readdir' mangled-name='readdir64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-197'/>
-      <return type-id='type-id-216'/>
-    </function-decl>
-    <function-decl name='readlink' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='zfs_dev_is_dm' mangled-name='zfs_dev_is_dm' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_dm'>
-      <parameter type-id='type-id-16' name='dev_name'/>
-      <return type-id='type-id-41'/>
-    </function-decl>
-    <function-decl name='zfs_dev_is_whole_disk' mangled-name='zfs_dev_is_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_whole_disk'>
-      <parameter type-id='type-id-16' name='dev_name'/>
-      <return type-id='type-id-41'/>
-    </function-decl>
-    <class-decl name='dk_gpt' size-in-bits='1920' is-struct='yes' visibility='default' id='type-id-217'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='efi_version' type-id='type-id-34' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='efi_nparts' type-id='type-id-34' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='efi_part_size' type-id='type-id-34' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='efi_lbasize' type-id='type-id-34' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='efi_last_lba' type-id='type-id-218' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='efi_first_u_lba' type-id='type-id-218' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='efi_last_u_lba' type-id='type-id-218' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='efi_disk_uguid' type-id='type-id-219' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='efi_flags' type-id='type-id-34' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='efi_reserved1' type-id='type-id-34' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='efi_altern_lba' type-id='type-id-218' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='efi_reserved' type-id='type-id-220' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='efi_parts' type-id='type-id-221' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-222'/>
-    <typedef-decl name='longlong_t' type-id='type-id-222' id='type-id-223'/>
-    <typedef-decl name='diskaddr_t' type-id='type-id-223' id='type-id-218'/>
-    <class-decl name='uuid' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-219'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='time_low' type-id='type-id-22' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='time_mid' type-id='type-id-224' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='time_hi_and_version' type-id='type-id-224' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='clock_seq_hi_and_reserved' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='72'>
-        <var-decl name='clock_seq_low' type-id='type-id-32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='node_addr' type-id='type-id-105' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__uint16_t' type-id='type-id-200' id='type-id-225'/>
-    <typedef-decl name='uint16_t' type-id='type-id-225' id='type-id-224'/>
-
-    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='384' id='type-id-220'>
-      <subrange length='12' type-id='type-id-12' id='type-id-103'/>
-
-    </array-type-def>
-    <class-decl name='dk_part' size-in-bits='960' is-struct='yes' visibility='default' id='type-id-226'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='p_start' type-id='type-id-218' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='p_size' type-id='type-id-218' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='p_guid' type-id='type-id-219' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='p_tag' type-id='type-id-227' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='272'>
-        <var-decl name='p_flag' type-id='type-id-227' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='p_name' type-id='type-id-228' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='p_uguid' type-id='type-id-219' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='p_resv' type-id='type-id-229' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='ushort_t' type-id='type-id-200' id='type-id-227'/>
-
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='288' id='type-id-228'>
-      <subrange length='36' type-id='type-id-12' id='type-id-230'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='256' id='type-id-229'>
-      <subrange length='8' type-id='type-id-12' id='type-id-102'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-226' size-in-bits='960' id='type-id-221'>
-      <subrange length='1' type-id='type-id-12' id='type-id-231'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-232'/>
-    <pointer-type-def type-id='type-id-232' size-in-bits='64' id='type-id-233'/>
-    <function-decl name='efi_alloc_and_init' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-233'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='efi_free' mangled-name='efi_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_free'>
-      <parameter type-id='type-id-232'/>
-      <return type-id='type-id-17'/>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_device_path_os.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzutil' language='LANG_C99'>
+    <function-decl name='is_mpath_whole_disk' mangled-name='is_mpath_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mpath_whole_disk'>
+      <parameter type-id='type-id-4' name='path'/>
+      <return type-id='type-id-23'/>
     </function-decl>
     <function-decl name='zfs_get_underlying_path' mangled-name='zfs_get_underlying_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_path'>
-      <parameter type-id='type-id-16' name='dev_name'/>
-      <return type-id='type-id-37'/>
+      <parameter type-id='type-id-4' name='dev_name'/>
+      <return type-id='type-id-36'/>
     </function-decl>
-    <function-decl name='is_mpath_whole_disk' mangled-name='is_mpath_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mpath_whole_disk'>
-      <parameter type-id='type-id-16' name='path'/>
-      <return type-id='type-id-41'/>
+    <function-decl name='zfs_dev_is_whole_disk' mangled-name='zfs_dev_is_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_whole_disk'>
+      <parameter type-id='type-id-4' name='dev_name'/>
+      <return type-id='type-id-23'/>
     </function-decl>
-    <class-decl name='udev' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-234'/>
-    <pointer-type-def type-id='type-id-234' size-in-bits='64' id='type-id-235'/>
-    <function-decl name='udev_new' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-235'/>
+    <function-decl name='zfs_dev_is_dm' mangled-name='zfs_dev_is_dm' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_dm'>
+      <parameter type-id='type-id-4' name='dev_name'/>
+      <return type-id='type-id-23'/>
     </function-decl>
-    <class-decl name='udev_device' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-236'/>
-    <pointer-type-def type-id='type-id-236' size-in-bits='64' id='type-id-237'/>
-    <function-decl name='udev_device_new_from_subsystem_sysname' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-235'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-237'/>
+    <function-decl name='zfs_get_enclosure_sysfs_path' mangled-name='zfs_get_enclosure_sysfs_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_enclosure_sysfs_path'>
+      <parameter type-id='type-id-4' name='dev_name'/>
+      <return type-id='type-id-36'/>
     </function-decl>
-    <function-decl name='udev_device_get_property_value' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-237'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-16'/>
+    <function-decl name='zfs_strip_path' mangled-name='zfs_strip_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_path'>
+      <parameter type-id='type-id-36' name='path'/>
+      <return type-id='type-id-36'/>
     </function-decl>
-    <function-decl name='udev_device_unref' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-237'/>
-      <return type-id='type-id-237'/>
+    <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_partition'>
+      <parameter type-id='type-id-36' name='path'/>
+      <return type-id='type-id-36'/>
+    </function-decl>
+    <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_append_partition'>
+      <parameter type-id='type-id-36' name='path'/>
+      <parameter type-id='type-id-85' name='max_len'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='udev_device_get_property_value' mangled-name='udev_device_get_property_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='udev_new' mangled-name='udev_new' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='udev_device_new_from_subsystem_sysname' mangled-name='udev_device_new_from_subsystem_sysname' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='udev_device_unref' mangled-name='udev_device_unref' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__realpath_alias' mangled-name='realpath' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='efi_free' mangled-name='efi_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__readlink_alias' mangled-name='readlink' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='strstr' mangled-name='strstr' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_import_os.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_import_os.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzutil' language='LANG_C99'>
+    <function-decl name='update_vdev_config_dev_strs' mangled-name='update_vdev_config_dev_strs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='update_vdev_config_dev_strs'>
+      <parameter type-id='type-id-15' name='nv'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk_wait'>
+      <parameter type-id='type-id-4' name='path'/>
+      <parameter type-id='type-id-1' name='timeout_ms'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='udev_device' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-118'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-119'/>
+    <function-decl name='zfs_device_get_devid' mangled-name='zfs_device_get_devid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_devid'>
+      <parameter type-id='type-id-119' name='dev'/>
+      <parameter type-id='type-id-36' name='bufptr'/>
+      <parameter type-id='type-id-85' name='buflen'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-120'/>
+    <pointer-type-def type-id='type-id-120' size-in-bits='64' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-122'/>
+    <function-decl name='zpool_default_search_paths' mangled-name='zpool_default_search_paths' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_default_search_paths'>
+      <parameter type-id='type-id-122' name='count'/>
+      <return type-id='type-id-121'/>
+    </function-decl>
     <function-decl name='zfs_dev_flush' mangled-name='zfs_dev_flush' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_flush'>
       <parameter type-id='type-id-1' name='fd'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='zutil_strdup' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-180'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-37'/>
-    </function-decl>
-    <function-decl name='zpool_read_label' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-74'/>
-      <parameter type-id='type-id-129'/>
+    <function-decl name='zfs_device_get_physical' mangled-name='zfs_device_get_physical' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_physical'>
+      <parameter type-id='type-id-119' name='dev'/>
+      <parameter type-id='type-id-36' name='bufptr'/>
+      <parameter type-id='type-id-85' name='buflen'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='label_paths' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-180'/>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-126'/>
-      <parameter type-id='type-id-126'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='strtoul' mangled-name='strtoul' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk_wait'>
-      <parameter type-id='type-id-16' name='path'/>
-      <parameter type-id='type-id-1' name='timeout_ms'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='strncasecmp' mangled-name='strncasecmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='zutil_alloc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-180'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-73'/>
+    <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-238'>
+    <function-decl name='zfs_get_underlying_path' mangled-name='zfs_get_underlying_path' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zfs_get_enclosure_sysfs_path' mangled-name='zfs_get_enclosure_sysfs_path' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='clock_gettime' mangled-name='clock_gettime' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='sched_yield' mangled-name='sched_yield' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='usleep' mangled-name='usleep' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='udev_unref' mangled-name='udev_unref' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='udev_list_entry_get_name' mangled-name='udev_list_entry_get_name' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='udev_device_get_devlinks_list_entry' mangled-name='udev_device_get_devlinks_list_entry' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='udev_list_entry_get_next' mangled-name='udev_list_entry_get_next' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='udev_device_get_parent_with_subsystem_devtype' mangled-name='udev_device_get_parent_with_subsystem_devtype' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='blkid_get_cache' mangled-name='blkid_get_cache' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='blkid_probe_all_new' mangled-name='blkid_probe_all_new' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='blkid_dev_iterate_begin' mangled-name='blkid_dev_iterate_begin' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='blkid_dev_set_search' mangled-name='blkid_dev_set_search' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zutil_alloc' mangled-name='zutil_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='blkid_dev_next' mangled-name='blkid_dev_next' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='blkid_dev_devname' mangled-name='blkid_dev_devname' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zutil_strdup' mangled-name='zutil_strdup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='blkid_dev_iterate_end' mangled-name='blkid_dev_iterate_end' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='blkid_put_cache' mangled-name='blkid_put_cache' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='label_paths' mangled-name='label_paths' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='sscanf' mangled-name='sscanf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='zpool_read_label' mangled-name='zpool_read_label' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_compat.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzutil' language='LANG_C99'>
+    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='type-id-123'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='type-id-239' visibility='default'/>
+        <var-decl name='zc_name' type-id='type-id-124' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='type-id-240' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='32768'>
+        <var-decl name='zc_nvlist_src' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32832'>
+        <var-decl name='zc_nvlist_src_size' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32896'>
+        <var-decl name='zc_nvlist_dst' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32960'>
+        <var-decl name='zc_nvlist_dst_size' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33024'>
+        <var-decl name='zc_nvlist_dst_filled' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33056'>
+        <var-decl name='zc_pad2' type-id='type-id-1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33088'>
+        <var-decl name='zc_history' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='33152'>
+        <var-decl name='zc_value' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='98688'>
+        <var-decl name='zc_string' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100736'>
+        <var-decl name='zc_guid' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100800'>
+        <var-decl name='zc_nvlist_conf' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100864'>
+        <var-decl name='zc_nvlist_conf_size' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100928'>
+        <var-decl name='zc_cookie' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='100992'>
+        <var-decl name='zc_objset_type' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101056'>
+        <var-decl name='zc_perm_action' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101120'>
+        <var-decl name='zc_history_len' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101184'>
+        <var-decl name='zc_history_offset' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101248'>
+        <var-decl name='zc_obj' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101312'>
+        <var-decl name='zc_iflags' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101376'>
+        <var-decl name='zc_share' type-id='type-id-126' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='101632'>
+        <var-decl name='zc_objset_stats' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='103936'>
+        <var-decl name='zc_begin_record' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='106368'>
+        <var-decl name='zc_inject_record' type-id='type-id-128' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109184'>
+        <var-decl name='zc_defer_destroy' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109216'>
+        <var-decl name='zc_flags' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109248'>
+        <var-decl name='zc_action_handle' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109312'>
+        <var-decl name='zc_cleanup_fd' type-id='type-id-1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109344'>
+        <var-decl name='zc_simple' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109352'>
+        <var-decl name='zc_pad' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109376'>
+        <var-decl name='zc_sendobj' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109440'>
+        <var-decl name='zc_fromobj' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109504'>
+        <var-decl name='zc_createtxg' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109568'>
+        <var-decl name='zc_stat' type-id='type-id-129' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='109888'>
+        <var-decl name='zc_zoneid' type-id='type-id-8' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__time_t' type-id='type-id-5' id='type-id-239'/>
-    <typedef-decl name='__syscall_slong_t' type-id='type-id-5' id='type-id-240'/>
-    <pointer-type-def type-id='type-id-238' size-in-bits='64' id='type-id-241'/>
-    <function-decl name='clock_gettime' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-241'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='usleep' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='udev_list_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-242'/>
-    <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-243'/>
-    <function-decl name='udev_device_get_devlinks_list_entry' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-237'/>
-      <return type-id='type-id-243'/>
-    </function-decl>
-    <function-decl name='udev_list_entry_get_name' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-243'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='udev_list_entry_get_next' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-243'/>
-      <return type-id='type-id-243'/>
-    </function-decl>
-    <function-decl name='udev_unref' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-235'/>
-      <return type-id='type-id-235'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-125' size-in-bits='64' id='type-id-244'/>
-    <function-decl name='zpool_default_search_paths' mangled-name='zpool_default_search_paths' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_default_search_paths'>
-      <parameter type-id='type-id-244' name='count'/>
-      <return type-id='type-id-128'/>
-    </function-decl>
-    <class-decl name='blkid_struct_cache' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-245'/>
-    <pointer-type-def type-id='type-id-245' size-in-bits='64' id='type-id-246'/>
-    <pointer-type-def type-id='type-id-246' size-in-bits='64' id='type-id-247'/>
-    <function-decl name='blkid_get_cache' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-247'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='blkid_probe_all_new' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-246'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='blkid_struct_dev_iterate' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-248'/>
-    <pointer-type-def type-id='type-id-248' size-in-bits='64' id='type-id-249'/>
-    <function-decl name='blkid_dev_iterate_begin' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-246'/>
-      <return type-id='type-id-249'/>
-    </function-decl>
-    <function-decl name='blkid_dev_set_search' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-249'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='blkid_dev_iterate_end' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-249'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <class-decl name='blkid_struct_dev' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-250'/>
-    <pointer-type-def type-id='type-id-250' size-in-bits='64' id='type-id-251'/>
-    <pointer-type-def type-id='type-id-251' size-in-bits='64' id='type-id-252'/>
-    <function-decl name='blkid_dev_next' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-249'/>
-      <parameter type-id='type-id-252'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='blkid_put_cache' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-246'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='blkid_dev_devname' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-251'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='zfs_device_get_devid' mangled-name='zfs_device_get_devid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_devid'>
-      <parameter type-id='type-id-237' name='dev'/>
-      <parameter type-id='type-id-37' name='bufptr'/>
-      <parameter type-id='type-id-125' name='buflen'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='udev_device_get_parent_with_subsystem_devtype' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-237'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-237'/>
-    </function-decl>
-    <function-decl name='zfs_device_get_physical' mangled-name='zfs_device_get_physical' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_physical'>
-      <parameter type-id='type-id-237' name='dev'/>
-      <parameter type-id='type-id-37' name='bufptr'/>
-      <parameter type-id='type-id-125' name='buflen'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='update_vdev_config_dev_strs' mangled-name='update_vdev_config_dev_strs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='update_vdev_config_dev_strs'>
-      <parameter type-id='type-id-29' name='nv'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='nvlist_remove_all' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-35'/>
-      <parameter type-id='type-id-16'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='sched_yield' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_compat.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libzutil' language='LANG_C99'>
-    <typedef-decl name='zfs_cmd_t' type-id='type-id-39' id='type-id-253'/>
-    <pointer-type-def type-id='type-id-253' size-in-bits='64' id='type-id-254'/>
-    <function-decl name='zfs_ioctl_fd' mangled-name='zfs_ioctl_fd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl_fd'>
-      <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-26' name='request'/>
-      <parameter type-id='type-id-254' name='zc'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libavl' language='LANG_C99'>
-    <typedef-decl name='avl_tree_t' type-id='type-id-181' id='type-id-255'/>
-    <pointer-type-def type-id='type-id-255' size-in-bits='64' id='type-id-256'/>
-    <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <parameter type-id='type-id-73' name='oldnode'/>
-      <parameter type-id='type-id-1' name='left'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='avl_last' mangled-name='avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <typedef-decl name='avl_index_t' type-id='type-id-187' id='type-id-257'/>
-    <function-decl name='avl_nearest' mangled-name='avl_nearest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <parameter type-id='type-id-257' name='where'/>
-      <parameter type-id='type-id-1' name='direction'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-257' size-in-bits='64' id='type-id-258'/>
-    <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <parameter type-id='type-id-73' name='value'/>
-      <parameter type-id='type-id-258' name='where'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='avl_insert' mangled-name='avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <parameter type-id='type-id-73' name='new_data'/>
-      <parameter type-id='type-id-257' name='where'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='avl_insert_here' mangled-name='avl_insert_here' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <parameter type-id='type-id-73' name='new_data'/>
-      <parameter type-id='type-id-73' name='here'/>
-      <parameter type-id='type-id-1' name='direction'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='avl_add' mangled-name='avl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <parameter type-id='type-id-73' name='new_node'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='avl_remove' mangled-name='avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <parameter type-id='type-id-73' name='data'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
-      <parameter type-id='type-id-256' name='t'/>
-      <parameter type-id='type-id-73' name='obj'/>
-      <return type-id='type-id-41'/>
-    </function-decl>
-    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
-      <parameter type-id='type-id-256' name='t'/>
-      <parameter type-id='type-id-73' name='obj'/>
-      <return type-id='type-id-41'/>
-    </function-decl>
-    <function-decl name='avl_update' mangled-name='avl_update' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
-      <parameter type-id='type-id-256' name='t'/>
-      <parameter type-id='type-id-73' name='obj'/>
-      <return type-id='type-id-41'/>
-    </function-decl>
-    <function-decl name='avl_swap' mangled-name='avl_swap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
-      <parameter type-id='type-id-256' name='tree1'/>
-      <parameter type-id='type-id-256' name='tree2'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <parameter type-id='type-id-183' name='compar'/>
-      <parameter type-id='type-id-125' name='size'/>
-      <parameter type-id='type-id-125' name='offset'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <return type-id='type-id-184'/>
-    </function-decl>
-    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <return type-id='type-id-41'/>
-    </function-decl>
-    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
-      <parameter type-id='type-id-256' name='tree'/>
-      <parameter type-id='type-id-130' name='cookie'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='thread_pool.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libtpool' language='LANG_C99'>
-    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' id='type-id-191'>
+
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='32768' id='type-id-124'>
+      <subrange length='4096' type-id='type-id-12' id='type-id-130'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='65536' id='type-id-125'>
+      <subrange length='8192' type-id='type-id-12' id='type-id-131'/>
+
+    </array-type-def>
+    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-132'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tp_forw' type-id='type-id-259' visibility='default'/>
+        <var-decl name='z_exportdata' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tp_back' type-id='type-id-259' visibility='default'/>
+        <var-decl name='z_sharedata' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tp_mutex' type-id='type-id-260' visibility='default'/>
+        <var-decl name='z_sharetype' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='z_sharemax' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_share_t' type-id='type-id-132' id='type-id-126'/>
+    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' id='type-id-133'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dds_num_clones' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dds_creation_txg' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dds_guid' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dds_type' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='dds_is_snapshot' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='232'>
+        <var-decl name='dds_inconsistent' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='240'>
+        <var-decl name='dds_redacted' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='248'>
+        <var-decl name='dds_origin' type-id='type-id-53' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='dmu_objset_stats_t' type-id='type-id-133' id='type-id-127'/>
+    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='type-id-134'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zi_objset' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zi_object' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zi_start' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zi_end' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='zi_guid' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='zi_level' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='zi_error' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='zi_type' type-id='type-id-8' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='tp_busycv' type-id='type-id-261' visibility='default'/>
+        <var-decl name='zi_freq' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='zi_failfast' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zi_func' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='zi_iotype' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2592'>
+        <var-decl name='zi_duration' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2624'>
+        <var-decl name='zi_timer' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='zi_nlanes' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2752'>
+        <var-decl name='zi_cmd' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2784'>
+        <var-decl name='zi_dvas' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zinject_record_t' type-id='type-id-134' id='type-id-128'/>
+    <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-135'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zs_gen' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zs_mode' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zs_links' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zs_ctime' type-id='type-id-136' visibility='default'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='128' id='type-id-136'>
+      <subrange length='2' type-id='type-id-12' id='type-id-137'/>
+
+    </array-type-def>
+    <typedef-decl name='zfs_stat_t' type-id='type-id-135' id='type-id-129'/>
+    <typedef-decl name='zfs_cmd_t' type-id='type-id-123' id='type-id-138'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-139'/>
+    <function-decl name='zfs_ioctl_fd' mangled-name='zfs_ioctl_fd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl_fd'>
+      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-12' name='request'/>
+      <parameter type-id='type-id-139' name='zc'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libavl' language='LANG_C99'>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-140'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_root' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avl_compar' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_offset' type-id='type-id-85' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='avl_numnodes' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avl_pad' type-id='type-id-85' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-144'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_child' type-id='type-id-145' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_pcb' type-id='type-id-146' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-141'/>
+
+    <array-type-def dimensions='1' type-id='type-id-141' size-in-bits='128' id='type-id-145'>
+      <subrange length='2' type-id='type-id-12' id='type-id-137'/>
+
+    </array-type-def>
+    <typedef-decl name='uintptr_t' type-id='type-id-12' id='type-id-146'/>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-142'/>
+    <typedef-decl name='ulong_t' type-id='type-id-12' id='type-id-143'/>
+    <typedef-decl name='avl_tree_t' type-id='type-id-140' id='type-id-148'/>
+    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-149'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-150'/>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <parameter type-id='type-id-150' name='cookie'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <return type-id='type-id-143'/>
+    </function-decl>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <parameter type-id='type-id-142' name='compar'/>
+      <parameter type-id='type-id-85' name='size'/>
+      <parameter type-id='type-id-85' name='offset'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='avl_swap' mangled-name='avl_swap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
+      <parameter type-id='type-id-149' name='tree1'/>
+      <parameter type-id='type-id-149' name='tree2'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='avl_update' mangled-name='avl_update' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
+      <parameter type-id='type-id-149' name='t'/>
+      <parameter type-id='type-id-89' name='obj'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
+      <parameter type-id='type-id-149' name='t'/>
+      <parameter type-id='type-id-89' name='obj'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
+      <parameter type-id='type-id-149' name='t'/>
+      <parameter type-id='type-id-89' name='obj'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-decl name='avl_remove' mangled-name='avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <parameter type-id='type-id-89' name='data'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='avl_add' mangled-name='avl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <parameter type-id='type-id-89' name='new_node'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='avl_insert_here' mangled-name='avl_insert_here' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <parameter type-id='type-id-89' name='new_data'/>
+      <parameter type-id='type-id-89' name='here'/>
+      <parameter type-id='type-id-1' name='direction'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <typedef-decl name='avl_index_t' type-id='type-id-146' id='type-id-151'/>
+    <function-decl name='avl_insert' mangled-name='avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <parameter type-id='type-id-89' name='new_data'/>
+      <parameter type-id='type-id-151' name='where'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-152'/>
+    <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <parameter type-id='type-id-89' name='value'/>
+      <parameter type-id='type-id-152' name='where'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='avl_nearest' mangled-name='avl_nearest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <parameter type-id='type-id-151' name='where'/>
+      <parameter type-id='type-id-1' name='direction'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='avl_last' mangled-name='avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
+      <parameter type-id='type-id-149' name='tree'/>
+      <parameter type-id='type-id-89' name='oldnode'/>
+      <parameter type-id='type-id-1' name='left'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-147'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-89'/>
+      <return type-id='type-id-1'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='thread_pool.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libtpool' language='LANG_C99'>
+    <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' id='type-id-153'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tp_forw' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tp_back' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='tp_mutex' type-id='type-id-155' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='tp_busycv' type-id='type-id-156' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='tp_workcv' type-id='type-id-261' visibility='default'/>
+        <var-decl name='tp_workcv' type-id='type-id-156' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='tp_waitcv' type-id='type-id-261' visibility='default'/>
+        <var-decl name='tp_waitcv' type-id='type-id-156' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='tp_active' type-id='type-id-262' visibility='default'/>
+        <var-decl name='tp_active' type-id='type-id-157' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='tp_head' type-id='type-id-263' visibility='default'/>
+        <var-decl name='tp_head' type-id='type-id-158' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1728'>
-        <var-decl name='tp_tail' type-id='type-id-263' visibility='default'/>
+        <var-decl name='tp_tail' type-id='type-id-158' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1792'>
-        <var-decl name='tp_attr' type-id='type-id-150' visibility='default'/>
+        <var-decl name='tp_attr' type-id='type-id-159' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
         <var-decl name='tp_flags' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2272'>
-        <var-decl name='tp_linger' type-id='type-id-34' visibility='default'/>
+        <var-decl name='tp_linger' type-id='type-id-35' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2304'>
         <var-decl name='tp_njobs' type-id='type-id-1' visibility='default'/>
@@ -3005,1006 +2405,829 @@
         <var-decl name='tp_idle' type-id='type-id-1' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='tpool_t' type-id='type-id-191' id='type-id-264'/>
-    <pointer-type-def type-id='type-id-264' size-in-bits='64' id='type-id-259'/>
-    <typedef-decl name='pthread_mutex_t' type-id='type-id-2' id='type-id-260'/>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' id='type-id-265'>
+    <typedef-decl name='tpool_t' type-id='type-id-153' id='type-id-160'/>
+    <pointer-type-def type-id='type-id-160' size-in-bits='64' id='type-id-154'/>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' id='type-id-161'>
       <data-member access='private'>
-        <var-decl name='__data' type-id='type-id-266' visibility='default'/>
+        <var-decl name='__data' type-id='type-id-162' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__size' type-id='type-id-267' visibility='default'/>
+        <var-decl name='__size' type-id='type-id-163' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='__align' type-id='type-id-222' visibility='default'/>
+        <var-decl name='__align' type-id='type-id-86' visibility='default'/>
       </data-member>
     </union-decl>
-    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-266'>
-      <member-type access='public'>
-        <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-268'>
-          <data-member access='private'>
-            <var-decl name='__g1_start' type-id='type-id-269' visibility='default'/>
-          </data-member>
-          <data-member access='private'>
-            <var-decl name='__g1_start32' type-id='type-id-270' visibility='default'/>
-          </data-member>
-        </union-decl>
-      </member-type>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-162'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='' type-id='type-id-271' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__g_refs' type-id='type-id-272' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__g_size' type-id='type-id-272' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='__g1_orig_size' type-id='type-id-6' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__wrefs' type-id='type-id-6' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='__g_signals' type-id='type-id-272' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-271'>
-      <data-member access='private'>
-        <var-decl name='__wseq' type-id='type-id-269' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__wseq32' type-id='type-id-270' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <type-decl name='long long unsigned int' size-in-bits='64' id='type-id-269'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-270'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__low' type-id='type-id-6' visibility='default'/>
+        <var-decl name='__lock' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__high' type-id='type-id-6' visibility='default'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='64' id='type-id-272'>
-      <subrange length='2' type-id='type-id-12' id='type-id-62'/>
-
-    </array-type-def>
-
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='384' id='type-id-267'>
-      <subrange length='48' type-id='type-id-12' id='type-id-273'/>
-
-    </array-type-def>
-    <typedef-decl name='pthread_cond_t' type-id='type-id-265' id='type-id-261'/>
-    <class-decl name='tpool_active' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-274'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tpa_next' type-id='type-id-262' visibility='default'/>
+        <var-decl name='__count' type-id='type-id-10' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tpa_tid' type-id='type-id-275' visibility='default'/>
+        <var-decl name='__owner' type-id='type-id-1' visibility='default'/>
       </data-member>
-    </class-decl>
-    <typedef-decl name='tpool_active_t' type-id='type-id-274' id='type-id-276'/>
-    <pointer-type-def type-id='type-id-276' size-in-bits='64' id='type-id-262'/>
-    <typedef-decl name='pthread_t' type-id='type-id-26' id='type-id-275'/>
-    <class-decl name='tpool_job' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-277'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tpj_next' type-id='type-id-263' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tpj_func' type-id='type-id-194' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-10' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tpj_arg' type-id='type-id-73' visibility='default'/>
+        <var-decl name='__kind' type-id='type-id-1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-164' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-164' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-165' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='tpool_job_t' type-id='type-id-277' id='type-id-278'/>
-    <pointer-type-def type-id='type-id-278' size-in-bits='64' id='type-id-263'/>
-    <function-decl name='tpool_create' mangled-name='tpool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_create'>
-      <parameter type-id='type-id-34' name='min_threads'/>
-      <parameter type-id='type-id-34' name='max_threads'/>
-      <parameter type-id='type-id-34' name='linger'/>
-      <parameter type-id='type-id-145' name='attr'/>
-      <return type-id='type-id-259'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-147' const='yes' id='type-id-279'/>
-    <pointer-type-def type-id='type-id-279' size-in-bits='64' id='type-id-280'/>
-    <function-decl name='pthread_attr_getstack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
-      <parameter type-id='type-id-130'/>
-      <parameter type-id='type-id-38'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-265' size-in-bits='64' id='type-id-281'/>
-    <function-decl name='pthread_cond_init' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
-      <parameter type-id='type-id-176'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-282'/>
-    <function-decl name='pthread_attr_init' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-282'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='1024' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-283'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-164'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-166'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__bits' type-id='type-id-284' visibility='default'/>
+        <var-decl name='__prev' type-id='type-id-167' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-167' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__cpu_mask' type-id='type-id-26' id='type-id-285'/>
+    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-167'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-166' id='type-id-165'/>
 
-    <array-type-def dimensions='1' type-id='type-id-285' size-in-bits='1024' id='type-id-284'>
-      <subrange length='16' type-id='type-id-12' id='type-id-104'/>
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='320' id='type-id-163'>
+      <subrange length='40' type-id='type-id-12' id='type-id-168'/>
 
     </array-type-def>
-    <pointer-type-def type-id='type-id-283' size-in-bits='64' id='type-id-286'/>
-    <function-decl name='pthread_attr_getaffinity_np' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-286'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-283' const='yes' id='type-id-287'/>
-    <pointer-type-def type-id='type-id-287' size-in-bits='64' id='type-id-288'/>
-    <function-decl name='pthread_attr_setaffinity_np' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-282'/>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-288'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_getdetachstate' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
-      <parameter type-id='type-id-129'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_setdetachstate' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-282'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_getguardsize' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
-      <parameter type-id='type-id-38'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_setguardsize' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-282'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_getinheritsched' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
-      <parameter type-id='type-id-129'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_setinheritsched' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-282'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='sched_param' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-289'>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-161' id='type-id-155'/>
+    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' id='type-id-169'>
+      <data-member access='private'>
+        <var-decl name='__data' type-id='type-id-170' visibility='default'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-171' visibility='default'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-172' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-170'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='sched_priority' type-id='type-id-1' visibility='default'/>
+        <var-decl name='' type-id='type-id-173' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__g_refs' type-id='type-id-174' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__g_size' type-id='type-id-174' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='__g1_orig_size' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__wrefs' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='__g_signals' type-id='type-id-174' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-289' size-in-bits='64' id='type-id-290'/>
-    <function-decl name='pthread_attr_getschedparam' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
-      <parameter type-id='type-id-290'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-289' const='yes' id='type-id-291'/>
-    <pointer-type-def type-id='type-id-291' size-in-bits='64' id='type-id-292'/>
-    <function-decl name='pthread_attr_setschedparam' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-282'/>
-      <parameter type-id='type-id-292'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_getschedpolicy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
-      <parameter type-id='type-id-129'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_setschedpolicy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-282'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_getscope' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-280'/>
-      <parameter type-id='type-id-129'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_setscope' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-282'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_setstack' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-282'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_attr_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-282'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_dispatch'>
-      <parameter type-id='type-id-259' name='tpool'/>
-      <parameter type-id='type-id-194' name='func'/>
-      <parameter type-id='type-id-73' name='arg'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_cond_signal' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='1024' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-293'>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-173'>
+      <data-member access='private'>
+        <var-decl name='__wseq' type-id='type-id-175' visibility='default'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__wseq32' type-id='type-id-176' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='long long unsigned int' size-in-bits='64' id='type-id-175'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-176'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__val' type-id='type-id-294' visibility='default'/>
+        <var-decl name='__low' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__high' type-id='type-id-10' visibility='default'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='1024' id='type-id-294'>
-      <subrange length='16' type-id='type-id-12' id='type-id-104'/>
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='64' id='type-id-174'>
+      <subrange length='2' type-id='type-id-12' id='type-id-137'/>
 
     </array-type-def>
-    <qualified-type-def type-id='type-id-293' const='yes' id='type-id-295'/>
-    <pointer-type-def type-id='type-id-293' size-in-bits='64' id='type-id-296'/>
-    <function-decl name='pthread_sigmask' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-288'/>
-      <parameter type-id='type-id-296'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-297' size-in-bits='64' id='type-id-298'/>
-    <function-decl name='pthread_create' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-38'/>
-      <parameter type-id='type-id-280'/>
-      <parameter type-id='type-id-298'/>
-      <parameter type-id='type-id-73'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='tpool_destroy' mangled-name='tpool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_destroy'>
-      <parameter type-id='type-id-259' name='tpool'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='pthread_cond_broadcast' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_cancel' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='pthread_cond_wait' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
-      <parameter type-id='type-id-14'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='tpool_abandon' mangled-name='tpool_abandon' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_abandon'>
-      <parameter type-id='type-id-259' name='tpool'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='tpool_wait' mangled-name='tpool_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_wait'>
-      <parameter type-id='type-id-259' name='tpool'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='tpool_suspend' mangled-name='tpool_suspend' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspend'>
-      <parameter type-id='type-id-259' name='tpool'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='tpool_suspended' mangled-name='tpool_suspended' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspended'>
-      <parameter type-id='type-id-259' name='tpool'/>
+
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='384' id='type-id-171'>
+      <subrange length='48' type-id='type-id-12' id='type-id-177'/>
+
+    </array-type-def>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-172'/>
+    <typedef-decl name='pthread_cond_t' type-id='type-id-169' id='type-id-156'/>
+    <class-decl name='tpool_active' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-178'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tpa_next' type-id='type-id-157' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tpa_tid' type-id='type-id-179' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='tpool_active_t' type-id='type-id-178' id='type-id-180'/>
+    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-157'/>
+    <typedef-decl name='pthread_t' type-id='type-id-12' id='type-id-179'/>
+    <class-decl name='tpool_job' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-181'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tpj_next' type-id='type-id-158' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tpj_func' type-id='type-id-182' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='tpj_arg' type-id='type-id-89' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='tpool_job_t' type-id='type-id-181' id='type-id-183'/>
+    <pointer-type-def type-id='type-id-183' size-in-bits='64' id='type-id-158'/>
+    <pointer-type-def type-id='type-id-184' size-in-bits='64' id='type-id-182'/>
+    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' id='type-id-185'>
+      <data-member access='private'>
+        <var-decl name='__size' type-id='type-id-186' visibility='default'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='__align' type-id='type-id-86' visibility='default'/>
+      </data-member>
+    </union-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='448' id='type-id-186'>
+      <subrange length='56' type-id='type-id-12' id='type-id-187'/>
+
+    </array-type-def>
+    <typedef-decl name='pthread_attr_t' type-id='type-id-185' id='type-id-159'/>
+    <function-decl name='tpool_member' mangled-name='tpool_member' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_member'>
+      <parameter type-id='type-id-154' name='tpool'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='tpool_resume' mangled-name='tpool_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_resume'>
-      <parameter type-id='type-id-259' name='tpool'/>
-      <return type-id='type-id-17'/>
+      <parameter type-id='type-id-154' name='tpool'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='tpool_member' mangled-name='tpool_member' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_member'>
-      <parameter type-id='type-id-259' name='tpool'/>
+    <function-decl name='tpool_suspended' mangled-name='tpool_suspended' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspended'>
+      <parameter type-id='type-id-154' name='tpool'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='pthread_self' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-26'/>
+    <function-decl name='tpool_suspend' mangled-name='tpool_suspend' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspend'>
+      <parameter type-id='type-id-154' name='tpool'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-238' const='yes' id='type-id-299'/>
-    <pointer-type-def type-id='type-id-299' size-in-bits='64' id='type-id-300'/>
-    <function-decl name='pthread_cond_timedwait' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-281'/>
-      <parameter type-id='type-id-14'/>
-      <parameter type-id='type-id-300'/>
+    <function-decl name='tpool_wait' mangled-name='tpool_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_wait'>
+      <parameter type-id='type-id-154' name='tpool'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='tpool_abandon' mangled-name='tpool_abandon' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_abandon'>
+      <parameter type-id='type-id-154' name='tpool'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='tpool_destroy' mangled-name='tpool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_destroy'>
+      <parameter type-id='type-id-154' name='tpool'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_dispatch'>
+      <parameter type-id='type-id-154' name='tpool'/>
+      <parameter type-id='type-id-182' name='func'/>
+      <parameter type-id='type-id-89' name='arg'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='pthread_setcanceltype' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-129'/>
-      <return type-id='type-id-1'/>
+    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-188'/>
+    <function-decl name='tpool_create' mangled-name='tpool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_create'>
+      <parameter type-id='type-id-35' name='min_threads'/>
+      <parameter type-id='type-id-35' name='max_threads'/>
+      <parameter type-id='type-id-35' name='linger'/>
+      <parameter type-id='type-id-188' name='attr'/>
+      <return type-id='type-id-154'/>
     </function-decl>
-    <function-decl name='pthread_setcancelstate' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-129'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='pthread_self' mangled-name='pthread_self' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-297'>
-      <parameter type-id='type-id-73'/>
-      <return type-id='type-id-73'/>
+    <function-decl name='pthread_cond_broadcast' mangled-name='pthread_cond_broadcast' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__sigsetjmp' mangled-name='__sigsetjmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__pthread_register_cancel' mangled-name='__pthread_register_cancel' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_cond_wait' mangled-name='pthread_cond_wait' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__pthread_unregister_cancel' mangled-name='__pthread_unregister_cancel' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__pthread_unwind_next' mangled-name='__pthread_unwind_next' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_cancel' mangled-name='pthread_cancel' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_cond_signal' mangled-name='pthread_cond_signal' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_init' mangled-name='pthread_attr_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getaffinity_np' mangled-name='pthread_attr_getaffinity_np' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_destroy' mangled-name='pthread_attr_destroy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setaffinity_np' mangled-name='pthread_attr_setaffinity_np' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getdetachstate' mangled-name='pthread_attr_getdetachstate' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setdetachstate' mangled-name='pthread_attr_setdetachstate' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getguardsize' mangled-name='pthread_attr_getguardsize' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setguardsize' mangled-name='pthread_attr_setguardsize' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getinheritsched' mangled-name='pthread_attr_getinheritsched' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setinheritsched' mangled-name='pthread_attr_setinheritsched' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getschedparam' mangled-name='pthread_attr_getschedparam' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setschedparam' mangled-name='pthread_attr_setschedparam' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getschedpolicy' mangled-name='pthread_attr_getschedpolicy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setschedpolicy' mangled-name='pthread_attr_setschedpolicy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getscope' mangled-name='pthread_attr_getscope' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setscope' mangled-name='pthread_attr_setscope' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_getstack' mangled-name='pthread_attr_getstack' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_attr_setstack' mangled-name='pthread_attr_setstack' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_cond_init' mangled-name='pthread_cond_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_sigmask' mangled-name='pthread_sigmask' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_create' mangled-name='pthread_create' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_cond_timedwait' mangled-name='pthread_cond_timedwait' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_setcanceltype' mangled-name='pthread_setcanceltype' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='pthread_setcancelstate' mangled-name='pthread_setcancelstate' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-184'>
+      <parameter type-id='type-id-89'/>
+      <return type-id='type-id-84'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='assert.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
     <var-decl name='libspl_assert_ok' type-id='type-id-1' mangled-name='libspl_assert_ok' visibility='default' elf-symbol-id='libspl_assert_ok'/>
+    <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
+      <parameter type-id='type-id-4' name='file'/>
+      <parameter type-id='type-id-4' name='func'/>
+      <parameter type-id='type-id-1' name='line'/>
+      <parameter type-id='type-id-4' name='format'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__vfprintf_chk' mangled-name='__vfprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='__builtin_fputc' mangled-name='fputc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='abort' mangled-name='abort' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='atomic.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
-    <qualified-type-def type-id='type-id-32' volatile='yes' id='type-id-301'/>
-    <pointer-type-def type-id='type-id-301' size-in-bits='64' id='type-id-302'/>
-    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
-      <parameter type-id='type-id-302' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <typedef-decl name='uchar_t' type-id='type-id-30' id='type-id-303'/>
-    <qualified-type-def type-id='type-id-303' volatile='yes' id='type-id-304'/>
-    <pointer-type-def type-id='type-id-304' size-in-bits='64' id='type-id-305'/>
-    <function-decl name='atomic_inc_uchar' mangled-name='atomic_inc_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uchar'>
-      <parameter type-id='type-id-305' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-224' volatile='yes' id='type-id-306'/>
-    <pointer-type-def type-id='type-id-306' size-in-bits='64' id='type-id-307'/>
-    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
-      <parameter type-id='type-id-307' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-227' volatile='yes' id='type-id-308'/>
-    <pointer-type-def type-id='type-id-308' size-in-bits='64' id='type-id-309'/>
-    <function-decl name='atomic_inc_ushort' mangled-name='atomic_inc_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ushort'>
-      <parameter type-id='type-id-309' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-22' volatile='yes' id='type-id-310'/>
-    <pointer-type-def type-id='type-id-310' size-in-bits='64' id='type-id-311'/>
-    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
-      <parameter type-id='type-id-311' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-34' volatile='yes' id='type-id-312'/>
-    <pointer-type-def type-id='type-id-312' size-in-bits='64' id='type-id-313'/>
-    <function-decl name='atomic_inc_uint' mangled-name='atomic_inc_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uint'>
-      <parameter type-id='type-id-313' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-184' volatile='yes' id='type-id-314'/>
-    <pointer-type-def type-id='type-id-314' size-in-bits='64' id='type-id-315'/>
-    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
-      <parameter type-id='type-id-315' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-23' volatile='yes' id='type-id-316'/>
-    <pointer-type-def type-id='type-id-316' size-in-bits='64' id='type-id-317'/>
-    <function-decl name='atomic_inc_64' mangled-name='atomic_inc_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_64'>
-      <parameter type-id='type-id-317' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
-      <parameter type-id='type-id-302' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_dec_uchar' mangled-name='atomic_dec_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uchar'>
-      <parameter type-id='type-id-305' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
-      <parameter type-id='type-id-307' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ushort' mangled-name='atomic_dec_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ushort'>
-      <parameter type-id='type-id-309' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
-      <parameter type-id='type-id-311' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_dec_uint' mangled-name='atomic_dec_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uint'>
-      <parameter type-id='type-id-313' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
-      <parameter type-id='type-id-315' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_dec_64' mangled-name='atomic_dec_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_64'>
-      <parameter type-id='type-id-317' name='target'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-318'/>
-    <typedef-decl name='__int8_t' type-id='type-id-318' id='type-id-319'/>
-    <typedef-decl name='int8_t' type-id='type-id-319' id='type-id-320'/>
-    <function-decl name='atomic_add_8' mangled-name='atomic_add_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
-      <parameter type-id='type-id-302' name='target'/>
-      <parameter type-id='type-id-320' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_add_char' mangled-name='atomic_add_char' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_char'>
-      <parameter type-id='type-id-305' name='target'/>
-      <parameter type-id='type-id-318' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
-      <parameter type-id='type-id-307' name='target'/>
-      <parameter type-id='type-id-66' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_add_short' mangled-name='atomic_add_short' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_short'>
-      <parameter type-id='type-id-309' name='target'/>
-      <parameter type-id='type-id-7' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
-      <parameter type-id='type-id-311' name='target'/>
-      <parameter type-id='type-id-21' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_add_int' mangled-name='atomic_add_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_int'>
-      <parameter type-id='type-id-313' name='target'/>
-      <parameter type-id='type-id-1' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-5' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <typedef-decl name='__int64_t' type-id='type-id-5' id='type-id-321'/>
-    <typedef-decl name='int64_t' type-id='type-id-321' id='type-id-322'/>
-    <function-decl name='atomic_add_64' mangled-name='atomic_add_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_64'>
-      <parameter type-id='type-id-317' name='target'/>
-      <parameter type-id='type-id-322' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
-      <parameter type-id='type-id-132' name='target'/>
-      <parameter type-id='type-id-124' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
-      <parameter type-id='type-id-302' name='target'/>
-      <parameter type-id='type-id-320' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_sub_char' mangled-name='atomic_sub_char' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_char'>
-      <parameter type-id='type-id-305' name='target'/>
-      <parameter type-id='type-id-318' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
-      <parameter type-id='type-id-307' name='target'/>
-      <parameter type-id='type-id-66' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_sub_short' mangled-name='atomic_sub_short' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_short'>
-      <parameter type-id='type-id-309' name='target'/>
-      <parameter type-id='type-id-7' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
-      <parameter type-id='type-id-311' name='target'/>
-      <parameter type-id='type-id-21' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_sub_int' mangled-name='atomic_sub_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_int'>
-      <parameter type-id='type-id-313' name='target'/>
-      <parameter type-id='type-id-1' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-5' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_sub_64' mangled-name='atomic_sub_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_64'>
-      <parameter type-id='type-id-317' name='target'/>
-      <parameter type-id='type-id-322' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
-      <parameter type-id='type-id-132' name='target'/>
-      <parameter type-id='type-id-124' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
-      <parameter type-id='type-id-302' name='target'/>
-      <parameter type-id='type-id-32' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_or_uchar' mangled-name='atomic_or_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uchar'>
-      <parameter type-id='type-id-305' name='target'/>
-      <parameter type-id='type-id-303' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
-      <parameter type-id='type-id-307' name='target'/>
-      <parameter type-id='type-id-224' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_or_ushort' mangled-name='atomic_or_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ushort'>
-      <parameter type-id='type-id-309' name='target'/>
-      <parameter type-id='type-id-227' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
-      <parameter type-id='type-id-311' name='target'/>
-      <parameter type-id='type-id-22' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_or_uint' mangled-name='atomic_or_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uint'>
-      <parameter type-id='type-id-313' name='target'/>
-      <parameter type-id='type-id-34' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-184' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_or_64' mangled-name='atomic_or_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_64'>
-      <parameter type-id='type-id-317' name='target'/>
-      <parameter type-id='type-id-23' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
-      <parameter type-id='type-id-302' name='target'/>
-      <parameter type-id='type-id-32' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_and_uchar' mangled-name='atomic_and_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uchar'>
-      <parameter type-id='type-id-305' name='target'/>
-      <parameter type-id='type-id-303' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
-      <parameter type-id='type-id-307' name='target'/>
-      <parameter type-id='type-id-224' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_and_ushort' mangled-name='atomic_and_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ushort'>
-      <parameter type-id='type-id-309' name='target'/>
-      <parameter type-id='type-id-227' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
-      <parameter type-id='type-id-311' name='target'/>
-      <parameter type-id='type-id-22' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_and_uint' mangled-name='atomic_and_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uint'>
-      <parameter type-id='type-id-313' name='target'/>
-      <parameter type-id='type-id-34' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-184' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_and_64' mangled-name='atomic_and_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_64'>
-      <parameter type-id='type-id-317' name='target'/>
-      <parameter type-id='type-id-23' name='bits'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
-      <parameter type-id='type-id-302' name='target'/>
-      <return type-id='type-id-32'/>
-    </function-decl>
-    <function-decl name='atomic_inc_uchar_nv' mangled-name='atomic_inc_uchar_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uchar_nv'>
-      <parameter type-id='type-id-305' name='target'/>
-      <return type-id='type-id-303'/>
-    </function-decl>
-    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
-      <parameter type-id='type-id-307' name='target'/>
-      <return type-id='type-id-224'/>
-    </function-decl>
-    <function-decl name='atomic_inc_ushort_nv' mangled-name='atomic_inc_ushort_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ushort_nv'>
-      <parameter type-id='type-id-309' name='target'/>
-      <return type-id='type-id-227'/>
-    </function-decl>
-    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
-      <parameter type-id='type-id-311' name='target'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='atomic_inc_uint_nv' mangled-name='atomic_inc_uint_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_uint_nv'>
-      <parameter type-id='type-id-313' name='target'/>
-      <return type-id='type-id-34'/>
-    </function-decl>
-    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
-      <parameter type-id='type-id-315' name='target'/>
-      <return type-id='type-id-184'/>
-    </function-decl>
-    <function-decl name='atomic_inc_64_nv' mangled-name='atomic_inc_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_64_nv'>
-      <parameter type-id='type-id-317' name='target'/>
-      <return type-id='type-id-23'/>
-    </function-decl>
-    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
-      <parameter type-id='type-id-302' name='target'/>
-      <return type-id='type-id-32'/>
-    </function-decl>
-    <function-decl name='atomic_dec_uchar_nv' mangled-name='atomic_dec_uchar_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uchar_nv'>
-      <parameter type-id='type-id-305' name='target'/>
-      <return type-id='type-id-303'/>
-    </function-decl>
-    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
-      <parameter type-id='type-id-307' name='target'/>
-      <return type-id='type-id-224'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ushort_nv' mangled-name='atomic_dec_ushort_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ushort_nv'>
-      <parameter type-id='type-id-309' name='target'/>
-      <return type-id='type-id-227'/>
-    </function-decl>
-    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
-      <parameter type-id='type-id-311' name='target'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='atomic_dec_uint_nv' mangled-name='atomic_dec_uint_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_uint_nv'>
-      <parameter type-id='type-id-313' name='target'/>
-      <return type-id='type-id-34'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
-      <parameter type-id='type-id-315' name='target'/>
-      <return type-id='type-id-184'/>
-    </function-decl>
-    <function-decl name='atomic_dec_64_nv' mangled-name='atomic_dec_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_64_nv'>
-      <parameter type-id='type-id-317' name='target'/>
-      <return type-id='type-id-23'/>
-    </function-decl>
-    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
-      <parameter type-id='type-id-302' name='target'/>
-      <parameter type-id='type-id-320' name='bits'/>
-      <return type-id='type-id-32'/>
-    </function-decl>
-    <function-decl name='atomic_add_char_nv' mangled-name='atomic_add_char_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_char_nv'>
-      <parameter type-id='type-id-305' name='target'/>
-      <parameter type-id='type-id-318' name='bits'/>
-      <return type-id='type-id-303'/>
-    </function-decl>
-    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
-      <parameter type-id='type-id-307' name='target'/>
-      <parameter type-id='type-id-66' name='bits'/>
-      <return type-id='type-id-224'/>
-    </function-decl>
-    <function-decl name='atomic_add_short_nv' mangled-name='atomic_add_short_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_short_nv'>
-      <parameter type-id='type-id-309' name='target'/>
-      <parameter type-id='type-id-7' name='bits'/>
-      <return type-id='type-id-227'/>
-    </function-decl>
-    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
-      <parameter type-id='type-id-311' name='target'/>
-      <parameter type-id='type-id-21' name='bits'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='atomic_add_int_nv' mangled-name='atomic_add_int_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_int_nv'>
-      <parameter type-id='type-id-313' name='target'/>
-      <parameter type-id='type-id-1' name='bits'/>
-      <return type-id='type-id-34'/>
-    </function-decl>
-    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-5' name='bits'/>
-      <return type-id='type-id-184'/>
-    </function-decl>
-    <function-decl name='atomic_add_64_nv' mangled-name='atomic_add_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_64_nv'>
-      <parameter type-id='type-id-317' name='target'/>
-      <parameter type-id='type-id-322' name='bits'/>
-      <return type-id='type-id-23'/>
-    </function-decl>
-    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
-      <parameter type-id='type-id-132' name='target'/>
-      <parameter type-id='type-id-124' name='bits'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
-      <parameter type-id='type-id-302' name='target'/>
-      <parameter type-id='type-id-320' name='bits'/>
-      <return type-id='type-id-32'/>
-    </function-decl>
-    <function-decl name='atomic_sub_char_nv' mangled-name='atomic_sub_char_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_char_nv'>
-      <parameter type-id='type-id-305' name='target'/>
-      <parameter type-id='type-id-318' name='bits'/>
-      <return type-id='type-id-303'/>
-    </function-decl>
-    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
-      <parameter type-id='type-id-307' name='target'/>
-      <parameter type-id='type-id-66' name='bits'/>
-      <return type-id='type-id-224'/>
-    </function-decl>
-    <function-decl name='atomic_sub_short_nv' mangled-name='atomic_sub_short_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_short_nv'>
-      <parameter type-id='type-id-309' name='target'/>
-      <parameter type-id='type-id-7' name='bits'/>
-      <return type-id='type-id-227'/>
-    </function-decl>
-    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
-      <parameter type-id='type-id-311' name='target'/>
-      <parameter type-id='type-id-21' name='bits'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='atomic_sub_int_nv' mangled-name='atomic_sub_int_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_int_nv'>
-      <parameter type-id='type-id-313' name='target'/>
-      <parameter type-id='type-id-1' name='bits'/>
-      <return type-id='type-id-34'/>
-    </function-decl>
-    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-5' name='bits'/>
-      <return type-id='type-id-184'/>
-    </function-decl>
-    <function-decl name='atomic_sub_64_nv' mangled-name='atomic_sub_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_64_nv'>
-      <parameter type-id='type-id-317' name='target'/>
-      <parameter type-id='type-id-322' name='bits'/>
-      <return type-id='type-id-23'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
-      <parameter type-id='type-id-132' name='target'/>
-      <parameter type-id='type-id-124' name='bits'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
-      <parameter type-id='type-id-302' name='target'/>
-      <parameter type-id='type-id-32' name='bits'/>
-      <return type-id='type-id-32'/>
-    </function-decl>
-    <function-decl name='atomic_or_uchar_nv' mangled-name='atomic_or_uchar_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uchar_nv'>
-      <parameter type-id='type-id-305' name='target'/>
-      <parameter type-id='type-id-303' name='bits'/>
-      <return type-id='type-id-303'/>
-    </function-decl>
-    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
-      <parameter type-id='type-id-307' name='target'/>
-      <parameter type-id='type-id-224' name='bits'/>
-      <return type-id='type-id-224'/>
-    </function-decl>
-    <function-decl name='atomic_or_ushort_nv' mangled-name='atomic_or_ushort_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ushort_nv'>
-      <parameter type-id='type-id-309' name='target'/>
-      <parameter type-id='type-id-227' name='bits'/>
-      <return type-id='type-id-227'/>
-    </function-decl>
-    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
-      <parameter type-id='type-id-311' name='target'/>
-      <parameter type-id='type-id-22' name='bits'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='atomic_or_uint_nv' mangled-name='atomic_or_uint_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_uint_nv'>
-      <parameter type-id='type-id-313' name='target'/>
-      <parameter type-id='type-id-34' name='bits'/>
-      <return type-id='type-id-34'/>
-    </function-decl>
-    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-184' name='bits'/>
-      <return type-id='type-id-184'/>
-    </function-decl>
-    <function-decl name='atomic_or_64_nv' mangled-name='atomic_or_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_64_nv'>
-      <parameter type-id='type-id-317' name='target'/>
-      <parameter type-id='type-id-23' name='bits'/>
-      <return type-id='type-id-23'/>
-    </function-decl>
-    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
-      <parameter type-id='type-id-302' name='target'/>
-      <parameter type-id='type-id-32' name='bits'/>
-      <return type-id='type-id-32'/>
-    </function-decl>
-    <function-decl name='atomic_and_uchar_nv' mangled-name='atomic_and_uchar_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uchar_nv'>
-      <parameter type-id='type-id-305' name='target'/>
-      <parameter type-id='type-id-303' name='bits'/>
-      <return type-id='type-id-303'/>
-    </function-decl>
-    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
-      <parameter type-id='type-id-307' name='target'/>
-      <parameter type-id='type-id-224' name='bits'/>
-      <return type-id='type-id-224'/>
-    </function-decl>
-    <function-decl name='atomic_and_ushort_nv' mangled-name='atomic_and_ushort_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ushort_nv'>
-      <parameter type-id='type-id-309' name='target'/>
-      <parameter type-id='type-id-227' name='bits'/>
-      <return type-id='type-id-227'/>
-    </function-decl>
-    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
-      <parameter type-id='type-id-311' name='target'/>
-      <parameter type-id='type-id-22' name='bits'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='atomic_and_uint_nv' mangled-name='atomic_and_uint_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_uint_nv'>
-      <parameter type-id='type-id-313' name='target'/>
-      <parameter type-id='type-id-34' name='bits'/>
-      <return type-id='type-id-34'/>
-    </function-decl>
-    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-184' name='bits'/>
-      <return type-id='type-id-184'/>
-    </function-decl>
-    <function-decl name='atomic_and_64_nv' mangled-name='atomic_and_64_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_64_nv'>
-      <parameter type-id='type-id-317' name='target'/>
-      <parameter type-id='type-id-23' name='bits'/>
-      <return type-id='type-id-23'/>
-    </function-decl>
-    <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
-      <parameter type-id='type-id-302' name='target'/>
-      <parameter type-id='type-id-32' name='exp'/>
-      <parameter type-id='type-id-32' name='des'/>
-      <return type-id='type-id-32'/>
-    </function-decl>
-    <function-decl name='atomic_cas_uchar' mangled-name='atomic_cas_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_uchar'>
-      <parameter type-id='type-id-305' name='target'/>
-      <parameter type-id='type-id-303' name='exp'/>
-      <parameter type-id='type-id-303' name='des'/>
-      <return type-id='type-id-303'/>
-    </function-decl>
-    <function-decl name='atomic_cas_16' mangled-name='atomic_cas_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_16'>
-      <parameter type-id='type-id-307' name='target'/>
-      <parameter type-id='type-id-224' name='exp'/>
-      <parameter type-id='type-id-224' name='des'/>
-      <return type-id='type-id-224'/>
-    </function-decl>
-    <function-decl name='atomic_cas_ushort' mangled-name='atomic_cas_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ushort'>
-      <parameter type-id='type-id-309' name='target'/>
-      <parameter type-id='type-id-227' name='exp'/>
-      <parameter type-id='type-id-227' name='des'/>
-      <return type-id='type-id-227'/>
-    </function-decl>
-    <function-decl name='atomic_cas_32' mangled-name='atomic_cas_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_32'>
-      <parameter type-id='type-id-311' name='target'/>
-      <parameter type-id='type-id-22' name='exp'/>
-      <parameter type-id='type-id-22' name='des'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='atomic_cas_uint' mangled-name='atomic_cas_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_uint'>
-      <parameter type-id='type-id-313' name='target'/>
-      <parameter type-id='type-id-34' name='exp'/>
-      <parameter type-id='type-id-34' name='des'/>
-      <return type-id='type-id-34'/>
-    </function-decl>
-    <function-decl name='atomic_cas_ulong' mangled-name='atomic_cas_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ulong'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-184' name='exp'/>
-      <parameter type-id='type-id-184' name='des'/>
-      <return type-id='type-id-184'/>
-    </function-decl>
-    <function-decl name='atomic_cas_64' mangled-name='atomic_cas_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_64'>
-      <parameter type-id='type-id-317' name='target'/>
-      <parameter type-id='type-id-23' name='exp'/>
-      <parameter type-id='type-id-23' name='des'/>
-      <return type-id='type-id-23'/>
-    </function-decl>
-    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
-      <parameter type-id='type-id-132' name='target'/>
-      <parameter type-id='type-id-73' name='exp'/>
-      <parameter type-id='type-id-73' name='des'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
-      <parameter type-id='type-id-302' name='target'/>
-      <parameter type-id='type-id-32' name='bits'/>
-      <return type-id='type-id-32'/>
-    </function-decl>
-    <function-decl name='atomic_swap_uchar' mangled-name='atomic_swap_uchar' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_uchar'>
-      <parameter type-id='type-id-305' name='target'/>
-      <parameter type-id='type-id-303' name='bits'/>
-      <return type-id='type-id-303'/>
-    </function-decl>
-    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
-      <parameter type-id='type-id-307' name='target'/>
-      <parameter type-id='type-id-224' name='bits'/>
-      <return type-id='type-id-224'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ushort' mangled-name='atomic_swap_ushort' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ushort'>
-      <parameter type-id='type-id-309' name='target'/>
-      <parameter type-id='type-id-227' name='bits'/>
-      <return type-id='type-id-227'/>
-    </function-decl>
-    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
-      <parameter type-id='type-id-311' name='target'/>
-      <parameter type-id='type-id-22' name='bits'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='atomic_swap_uint' mangled-name='atomic_swap_uint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_uint'>
-      <parameter type-id='type-id-313' name='target'/>
-      <parameter type-id='type-id-34' name='bits'/>
-      <return type-id='type-id-34'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-184' name='bits'/>
-      <return type-id='type-id-184'/>
-    </function-decl>
-    <function-decl name='atomic_swap_64' mangled-name='atomic_swap_64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_64'>
-      <parameter type-id='type-id-317' name='target'/>
-      <parameter type-id='type-id-23' name='bits'/>
-      <return type-id='type-id-23'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
-      <parameter type-id='type-id-132' name='target'/>
-      <parameter type-id='type-id-73' name='bits'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-34' name='value'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
-      <parameter type-id='type-id-315' name='target'/>
-      <parameter type-id='type-id-34' name='value'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='membar_enter' mangled-name='membar_enter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='membar_exit' mangled-name='membar_exit' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_exit'>
-      <return type-id='type-id-17'/>
+  <abi-instr version='1.0' address-size='64' path='atomic.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <function-decl name='membar_consumer' mangled-name='membar_consumer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='membar_producer' mangled-name='membar_producer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
-      <return type-id='type-id-17'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='membar_consumer' mangled-name='membar_consumer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
-      <return type-id='type-id-17'/>
+    <function-decl name='membar_enter' mangled-name='membar_enter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-143' volatile='yes' id='type-id-189'/>
+    <pointer-type-def type-id='type-id-189' size-in-bits='64' id='type-id-190'/>
+    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-35' name='value'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-35' name='value'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-84' volatile='yes' id='type-id-191'/>
+    <pointer-type-def type-id='type-id-191' size-in-bits='64' id='type-id-192'/>
+    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
+      <parameter type-id='type-id-192' name='target'/>
+      <parameter type-id='type-id-89' name='bits'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-143' name='bits'/>
+      <return type-id='type-id-143'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-7' volatile='yes' id='type-id-193'/>
+    <pointer-type-def type-id='type-id-193' size-in-bits='64' id='type-id-194'/>
+    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
+      <parameter type-id='type-id-194' name='target'/>
+      <parameter type-id='type-id-7' name='bits'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-195'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-195' id='type-id-196'/>
+    <typedef-decl name='uint16_t' type-id='type-id-196' id='type-id-197'/>
+    <qualified-type-def type-id='type-id-197' volatile='yes' id='type-id-198'/>
+    <pointer-type-def type-id='type-id-198' size-in-bits='64' id='type-id-199'/>
+    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
+      <parameter type-id='type-id-199' name='target'/>
+      <parameter type-id='type-id-197' name='bits'/>
+      <return type-id='type-id-197'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-33' volatile='yes' id='type-id-200'/>
+    <pointer-type-def type-id='type-id-200' size-in-bits='64' id='type-id-201'/>
+    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
+      <parameter type-id='type-id-201' name='target'/>
+      <parameter type-id='type-id-33' name='bits'/>
+      <return type-id='type-id-33'/>
+    </function-decl>
+    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
+      <parameter type-id='type-id-192' name='target'/>
+      <parameter type-id='type-id-89' name='exp'/>
+      <parameter type-id='type-id-89' name='des'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-143' name='bits'/>
+      <return type-id='type-id-143'/>
+    </function-decl>
+    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
+      <parameter type-id='type-id-194' name='target'/>
+      <parameter type-id='type-id-7' name='bits'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
+      <parameter type-id='type-id-199' name='target'/>
+      <parameter type-id='type-id-197' name='bits'/>
+      <return type-id='type-id-197'/>
+    </function-decl>
+    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
+      <parameter type-id='type-id-201' name='target'/>
+      <parameter type-id='type-id-33' name='bits'/>
+      <return type-id='type-id-33'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-143' name='bits'/>
+      <return type-id='type-id-143'/>
+    </function-decl>
+    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
+      <parameter type-id='type-id-194' name='target'/>
+      <parameter type-id='type-id-7' name='bits'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
+      <parameter type-id='type-id-199' name='target'/>
+      <parameter type-id='type-id-197' name='bits'/>
+      <return type-id='type-id-197'/>
+    </function-decl>
+    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
+      <parameter type-id='type-id-201' name='target'/>
+      <parameter type-id='type-id-33' name='bits'/>
+      <return type-id='type-id-33'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
+      <parameter type-id='type-id-192' name='target'/>
+      <parameter type-id='type-id-88' name='bits'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-86' name='bits'/>
+      <return type-id='type-id-143'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
+      <parameter type-id='type-id-194' name='target'/>
+      <parameter type-id='type-id-6' name='bits'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-164' id='type-id-202'/>
+    <typedef-decl name='int16_t' type-id='type-id-202' id='type-id-203'/>
+    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
+      <parameter type-id='type-id-199' name='target'/>
+      <parameter type-id='type-id-203' name='bits'/>
+      <return type-id='type-id-197'/>
+    </function-decl>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-204'/>
+    <typedef-decl name='__int8_t' type-id='type-id-204' id='type-id-205'/>
+    <typedef-decl name='int8_t' type-id='type-id-205' id='type-id-206'/>
+    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
+      <parameter type-id='type-id-201' name='target'/>
+      <parameter type-id='type-id-206' name='bits'/>
+      <return type-id='type-id-33'/>
+    </function-decl>
+    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
+      <parameter type-id='type-id-192' name='target'/>
+      <parameter type-id='type-id-88' name='bits'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-86' name='bits'/>
+      <return type-id='type-id-143'/>
+    </function-decl>
+    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
+      <parameter type-id='type-id-194' name='target'/>
+      <parameter type-id='type-id-6' name='bits'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
+      <parameter type-id='type-id-199' name='target'/>
+      <parameter type-id='type-id-203' name='bits'/>
+      <return type-id='type-id-197'/>
+    </function-decl>
+    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
+      <parameter type-id='type-id-201' name='target'/>
+      <parameter type-id='type-id-206' name='bits'/>
+      <return type-id='type-id-33'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
+      <parameter type-id='type-id-190' name='target'/>
+      <return type-id='type-id-143'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
+      <parameter type-id='type-id-194' name='target'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
+      <parameter type-id='type-id-199' name='target'/>
+      <return type-id='type-id-197'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
+      <parameter type-id='type-id-201' name='target'/>
+      <return type-id='type-id-33'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
+      <parameter type-id='type-id-190' name='target'/>
+      <return type-id='type-id-143'/>
+    </function-decl>
+    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
+      <parameter type-id='type-id-194' name='target'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
+      <parameter type-id='type-id-199' name='target'/>
+      <return type-id='type-id-197'/>
+    </function-decl>
+    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
+      <parameter type-id='type-id-201' name='target'/>
+      <return type-id='type-id-33'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-143' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
+      <parameter type-id='type-id-194' name='target'/>
+      <parameter type-id='type-id-7' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
+      <parameter type-id='type-id-199' name='target'/>
+      <parameter type-id='type-id-197' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
+      <parameter type-id='type-id-201' name='target'/>
+      <parameter type-id='type-id-33' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-143' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
+      <parameter type-id='type-id-194' name='target'/>
+      <parameter type-id='type-id-7' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
+      <parameter type-id='type-id-199' name='target'/>
+      <parameter type-id='type-id-197' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
+      <parameter type-id='type-id-201' name='target'/>
+      <parameter type-id='type-id-33' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
+      <parameter type-id='type-id-192' name='target'/>
+      <parameter type-id='type-id-88' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-86' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
+      <parameter type-id='type-id-194' name='target'/>
+      <parameter type-id='type-id-6' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
+      <parameter type-id='type-id-199' name='target'/>
+      <parameter type-id='type-id-203' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
+      <parameter type-id='type-id-201' name='target'/>
+      <parameter type-id='type-id-206' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
+      <parameter type-id='type-id-192' name='target'/>
+      <parameter type-id='type-id-88' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-86' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
+      <parameter type-id='type-id-194' name='target'/>
+      <parameter type-id='type-id-6' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
+      <parameter type-id='type-id-199' name='target'/>
+      <parameter type-id='type-id-203' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_add_8' mangled-name='atomic_add_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
+      <parameter type-id='type-id-201' name='target'/>
+      <parameter type-id='type-id-206' name='bits'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
+      <parameter type-id='type-id-190' name='target'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
+      <parameter type-id='type-id-194' name='target'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
+      <parameter type-id='type-id-199' name='target'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
+      <parameter type-id='type-id-201' name='target'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
+      <parameter type-id='type-id-190' name='target'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
+      <parameter type-id='type-id-194' name='target'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
+      <parameter type-id='type-id-199' name='target'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
+      <parameter type-id='type-id-201' name='target'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
+      <parameter type-id='type-id-201' name='target'/>
+      <parameter type-id='type-id-33' name='exp'/>
+      <parameter type-id='type-id-33' name='des'/>
+      <return type-id='type-id-33'/>
+    </function-decl>
+    <function-decl name='atomic_cas_16' mangled-name='atomic_cas_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_16'>
+      <parameter type-id='type-id-199' name='target'/>
+      <parameter type-id='type-id-197' name='exp'/>
+      <parameter type-id='type-id-197' name='des'/>
+      <return type-id='type-id-197'/>
+    </function-decl>
+    <function-decl name='atomic_cas_32' mangled-name='atomic_cas_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_32'>
+      <parameter type-id='type-id-194' name='target'/>
+      <parameter type-id='type-id-7' name='exp'/>
+      <parameter type-id='type-id-7' name='des'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='atomic_cas_ulong' mangled-name='atomic_cas_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ulong'>
+      <parameter type-id='type-id-190' name='target'/>
+      <parameter type-id='type-id-143' name='exp'/>
+      <parameter type-id='type-id-143' name='des'/>
+      <return type-id='type-id-143'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='getexecname.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='getexecname.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
     <function-decl name='getexecname' mangled-name='getexecname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getexecname'>
-      <return type-id='type-id-16'/>
+      <return type-id='type-id-4'/>
     </function-decl>
-    <function-decl name='getexecname_impl' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='getexecname_impl' mangled-name='getexecname_impl' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
     <function-decl name='get_system_hostid' mangled-name='get_system_hostid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
-      <return type-id='type-id-26'/>
+      <return type-id='type-id-12'/>
     </function-decl>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='type-id-323'>
+    <function-decl name='fopen' mangled-name='fopen64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fscanf' mangled-name='fscanf' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='fclose' mangled-name='fclose' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-207'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='mnt_major' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='mnt_minor' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-208'/>
+    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' id='type-id-209'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='st_dev' type-id='type-id-210' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='st_ino' type-id='type-id-211' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='st_nlink' type-id='type-id-212' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='st_mode' type-id='type-id-213' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_uid' type-id='type-id-214' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_gid' type-id='type-id-215' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__pad0' type-id='type-id-1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='st_rdev' type-id='type-id-210' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='st_size' type-id='type-id-216' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='st_blksize' type-id='type-id-217' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='st_blocks' type-id='type-id-218' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='st_atim' type-id='type-id-219' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='st_mtim' type-id='type-id-219' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='st_ctim' type-id='type-id-219' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='__glibc_reserved' type-id='type-id-220' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__dev_t' type-id='type-id-12' id='type-id-210'/>
+    <typedef-decl name='__ino64_t' type-id='type-id-12' id='type-id-211'/>
+    <typedef-decl name='__nlink_t' type-id='type-id-12' id='type-id-212'/>
+    <typedef-decl name='__mode_t' type-id='type-id-10' id='type-id-213'/>
+    <typedef-decl name='__uid_t' type-id='type-id-10' id='type-id-214'/>
+    <typedef-decl name='__gid_t' type-id='type-id-10' id='type-id-215'/>
+    <typedef-decl name='__off_t' type-id='type-id-86' id='type-id-216'/>
+    <typedef-decl name='__blksize_t' type-id='type-id-86' id='type-id-217'/>
+    <typedef-decl name='__blkcnt64_t' type-id='type-id-86' id='type-id-218'/>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-219'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='type-id-221' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_nsec' type-id='type-id-222' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__time_t' type-id='type-id-86' id='type-id-221'/>
+    <typedef-decl name='__syscall_slong_t' type-id='type-id-86' id='type-id-222'/>
+
+    <array-type-def dimensions='1' type-id='type-id-222' size-in-bits='192' id='type-id-220'>
+      <subrange length='3' type-id='type-id-12' id='type-id-75'/>
+
+    </array-type-def>
+    <pointer-type-def type-id='type-id-209' size-in-bits='64' id='type-id-223'/>
+    <function-decl name='getextmntent' mangled-name='getextmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
+      <parameter type-id='type-id-4' name='path'/>
+      <parameter type-id='type-id-208' name='entry'/>
+      <parameter type-id='type-id-223' name='statbuf'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='type-id-224'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_read_ptr' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_read_end' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_read_base' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_write_base' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_write_ptr' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_write_end' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_buf_base' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_buf_end' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_save_base' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_backup_base' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-37' visibility='default'/>
+        <var-decl name='_IO_save_end' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-324' visibility='default'/>
+        <var-decl name='_markers' type-id='type-id-225' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-325' visibility='default'/>
+        <var-decl name='_chain' type-id='type-id-226' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
         <var-decl name='_fileno' type-id='type-id-1' visibility='default'/>
@@ -4013,510 +3236,450 @@
         <var-decl name='_flags2' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-326' visibility='default'/>
+        <var-decl name='_old_offset' type-id='type-id-216' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-200' visibility='default'/>
+        <var-decl name='_cur_column' type-id='type-id-195' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-318' visibility='default'/>
+        <var-decl name='_vtable_offset' type-id='type-id-204' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-327' visibility='default'/>
+        <var-decl name='_shortbuf' type-id='type-id-227' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-135' visibility='default'/>
+        <var-decl name='_offset' type-id='type-id-228' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-328' visibility='default'/>
+        <var-decl name='__pad1' type-id='type-id-89' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-329' visibility='default'/>
+        <var-decl name='__pad2' type-id='type-id-89' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-325' visibility='default'/>
+        <var-decl name='__pad3' type-id='type-id-89' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-73' visibility='default'/>
+        <var-decl name='__pad4' type-id='type-id-89' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-125' visibility='default'/>
+        <var-decl name='__pad5' type-id='type-id-85' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1536'>
         <var-decl name='_mode' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-330' visibility='default'/>
+        <var-decl name='_unused2' type-id='type-id-229' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-331'/>
-    <pointer-type-def type-id='type-id-331' size-in-bits='64' id='type-id-324'/>
-    <pointer-type-def type-id='type-id-323' size-in-bits='64' id='type-id-325'/>
-    <typedef-decl name='__off_t' type-id='type-id-5' id='type-id-326'/>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-230'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_next' type-id='type-id-225' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_sbuf' type-id='type-id-226' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_pos' type-id='type-id-1' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-230' size-in-bits='64' id='type-id-225'/>
+    <pointer-type-def type-id='type-id-224' size-in-bits='64' id='type-id-226'/>
 
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='8' id='type-id-327'>
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='8' id='type-id-227'>
       <subrange length='1' type-id='type-id-12' id='type-id-231'/>
 
     </array-type-def>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-332'/>
-    <pointer-type-def type-id='type-id-332' size-in-bits='64' id='type-id-328'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-333'/>
-    <pointer-type-def type-id='type-id-333' size-in-bits='64' id='type-id-329'/>
+    <typedef-decl name='__off64_t' type-id='type-id-86' id='type-id-228'/>
 
-    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='160' id='type-id-330'>
-      <subrange length='20' type-id='type-id-12' id='type-id-334'/>
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='160' id='type-id-229'>
+      <subrange length='20' type-id='type-id-12' id='type-id-232'/>
 
     </array-type-def>
-    <function-decl name='fclose' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-325'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='FILE' type-id='type-id-323' id='type-id-335'/>
-    <pointer-type-def type-id='type-id-335' size-in-bits='64' id='type-id-336'/>
-    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-337'>
+    <typedef-decl name='FILE' type-id='type-id-224' id='type-id-233'/>
+    <pointer-type-def type-id='type-id-233' size-in-bits='64' id='type-id-234'/>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-235'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='type-id-37' visibility='default'/>
+        <var-decl name='mnt_special' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='type-id-37' visibility='default'/>
+        <var-decl name='mnt_mountp' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='type-id-37' visibility='default'/>
+        <var-decl name='mnt_fstype' type-id='type-id-36' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='type-id-37' visibility='default'/>
+        <var-decl name='mnt_mntopts' type-id='type-id-36' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-337' size-in-bits='64' id='type-id-338'/>
+    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-236'/>
     <function-decl name='getmntany' mangled-name='getmntany' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
-      <parameter type-id='type-id-336' name='fp'/>
-      <parameter type-id='type-id-338' name='mgetp'/>
-      <parameter type-id='type-id-338' name='mrefp'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='mntent' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-339'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_fsname' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_dir' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_type' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_opts' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='mnt_freq' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='mnt_passno' type-id='type-id-1' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-339' size-in-bits='64' id='type-id-340'/>
-    <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-325'/>
-      <parameter type-id='type-id-340'/>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-340'/>
-    </function-decl>
-    <function-decl name='feof' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-325'/>
+      <parameter type-id='type-id-234' name='fp'/>
+      <parameter type-id='type-id-236' name='mgetp'/>
+      <parameter type-id='type-id-236' name='mrefp'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='_sol_getmntent' mangled-name='_sol_getmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_sol_getmntent'>
-      <parameter type-id='type-id-336' name='fp'/>
-      <parameter type-id='type-id-338' name='mgetp'/>
+      <parameter type-id='type-id-234' name='fp'/>
+      <parameter type-id='type-id-236' name='mgetp'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-341'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='type-id-37' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='mnt_major' type-id='type-id-34' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='mnt_minor' type-id='type-id-34' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-341' size-in-bits='64' id='type-id-342'/>
-    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' id='type-id-343'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='st_dev' type-id='type-id-344' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='type-id-199' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_nlink' type-id='type-id-345' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='st_mode' type-id='type-id-346' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='st_uid' type-id='type-id-347' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='st_gid' type-id='type-id-348' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__pad0' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='st_rdev' type-id='type-id-344' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='st_size' type-id='type-id-326' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='st_blksize' type-id='type-id-349' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_blocks' type-id='type-id-350' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='type-id-238' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='type-id-238' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='type-id-238' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__glibc_reserved' type-id='type-id-351' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__dev_t' type-id='type-id-26' id='type-id-344'/>
-    <typedef-decl name='__nlink_t' type-id='type-id-26' id='type-id-345'/>
-    <typedef-decl name='__mode_t' type-id='type-id-6' id='type-id-346'/>
-    <typedef-decl name='__uid_t' type-id='type-id-6' id='type-id-347'/>
-    <typedef-decl name='__gid_t' type-id='type-id-6' id='type-id-348'/>
-    <typedef-decl name='__blksize_t' type-id='type-id-5' id='type-id-349'/>
-    <typedef-decl name='__blkcnt64_t' type-id='type-id-5' id='type-id-350'/>
-
-    <array-type-def dimensions='1' type-id='type-id-240' size-in-bits='192' id='type-id-351'>
-      <subrange length='3' type-id='type-id-12' id='type-id-59'/>
-
-    </array-type-def>
-    <pointer-type-def type-id='type-id-343' size-in-bits='64' id='type-id-352'/>
-    <function-decl name='getextmntent' mangled-name='getextmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
-      <parameter type-id='type-id-16' name='path'/>
-      <parameter type-id='type-id-342' name='entry'/>
-      <parameter type-id='type-id-352' name='statbuf'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='__builtin_fwrite' mangled-name='fwrite' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='feof' mangled-name='feof' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='getmntent_r' mangled-name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
-    <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-353'>
+  <abi-instr version='1.0' address-size='64' path='list.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-237'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='list_size' type-id='type-id-125' visibility='default'/>
+        <var-decl name='list_size' type-id='type-id-85' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='list_offset' type-id='type-id-125' visibility='default'/>
+        <var-decl name='list_offset' type-id='type-id-85' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='list_head' type-id='type-id-354' visibility='default'/>
+        <var-decl name='list_head' type-id='type-id-238' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-354'>
+    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-238'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='type-id-355' visibility='default'/>
+        <var-decl name='next' type-id='type-id-239' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='prev' type-id='type-id-355' visibility='default'/>
+        <var-decl name='prev' type-id='type-id-239' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-354' size-in-bits='64' id='type-id-355'/>
-    <typedef-decl name='list_t' type-id='type-id-353' id='type-id-356'/>
-    <pointer-type-def type-id='type-id-356' size-in-bits='64' id='type-id-357'/>
-    <function-decl name='list_create' mangled-name='list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
-      <parameter type-id='type-id-357' name='list'/>
-      <parameter type-id='type-id-125' name='size'/>
-      <parameter type-id='type-id-125' name='offset'/>
-      <return type-id='type-id-17'/>
+    <pointer-type-def type-id='type-id-238' size-in-bits='64' id='type-id-239'/>
+    <typedef-decl name='list_t' type-id='type-id-237' id='type-id-240'/>
+    <pointer-type-def type-id='type-id-240' size-in-bits='64' id='type-id-241'/>
+    <function-decl name='list_is_empty' mangled-name='list_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+      <parameter type-id='type-id-241' name='list'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='list_destroy' mangled-name='list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
-      <parameter type-id='type-id-357' name='list'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='list_insert_after' mangled-name='list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
-      <parameter type-id='type-id-357' name='list'/>
-      <parameter type-id='type-id-73' name='object'/>
-      <parameter type-id='type-id-73' name='nobject'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='list_insert_head' mangled-name='list_insert_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
-      <parameter type-id='type-id-357' name='list'/>
-      <parameter type-id='type-id-73' name='object'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='list_insert_before' mangled-name='list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
-      <parameter type-id='type-id-357' name='list'/>
-      <parameter type-id='type-id-73' name='object'/>
-      <parameter type-id='type-id-73' name='nobject'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='list_insert_tail' mangled-name='list_insert_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_tail'>
-      <parameter type-id='type-id-357' name='list'/>
-      <parameter type-id='type-id-73' name='object'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='list_remove' mangled-name='list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
-      <parameter type-id='type-id-357' name='list'/>
-      <parameter type-id='type-id-73' name='object'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='list_remove_head' mangled-name='list_remove_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
-      <parameter type-id='type-id-357' name='list'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
-      <parameter type-id='type-id-357' name='list'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='list_head' mangled-name='list_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
-      <parameter type-id='type-id-357' name='list'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='list_tail' mangled-name='list_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
-      <parameter type-id='type-id-357' name='list'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='list_next' mangled-name='list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
-      <parameter type-id='type-id-357' name='list'/>
-      <parameter type-id='type-id-73' name='object'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='list_prev' mangled-name='list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
-      <parameter type-id='type-id-357' name='list'/>
-      <parameter type-id='type-id-73' name='object'/>
-      <return type-id='type-id-73'/>
-    </function-decl>
-    <function-decl name='list_move_tail' mangled-name='list_move_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
-      <parameter type-id='type-id-357' name='dst'/>
-      <parameter type-id='type-id-357' name='src'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <typedef-decl name='list_node_t' type-id='type-id-354' id='type-id-358'/>
-    <pointer-type-def type-id='type-id-358' size-in-bits='64' id='type-id-359'/>
-    <function-decl name='list_link_replace' mangled-name='list_link_replace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
-      <parameter type-id='type-id-359' name='lold'/>
-      <parameter type-id='type-id-359' name='lnew'/>
-      <return type-id='type-id-17'/>
+    <typedef-decl name='list_node_t' type-id='type-id-238' id='type-id-242'/>
+    <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-243'/>
+    <function-decl name='list_link_active' mangled-name='list_link_active' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
+      <parameter type-id='type-id-243' name='ln'/>
+      <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='list_link_init' mangled-name='list_link_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
-      <parameter type-id='type-id-359' name='ln'/>
-      <return type-id='type-id-17'/>
+      <parameter type-id='type-id-243' name='ln'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='list_link_active' mangled-name='list_link_active' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
-      <parameter type-id='type-id-359' name='ln'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='list_link_replace' mangled-name='list_link_replace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
+      <parameter type-id='type-id-243' name='lold'/>
+      <parameter type-id='type-id-243' name='lnew'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='list_is_empty' mangled-name='list_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
-      <parameter type-id='type-id-357' name='list'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='list_move_tail' mangled-name='list_move_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
+      <parameter type-id='type-id-241' name='dst'/>
+      <parameter type-id='type-id-241' name='src'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='list_prev' mangled-name='list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
+      <parameter type-id='type-id-241' name='list'/>
+      <parameter type-id='type-id-89' name='object'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='list_next' mangled-name='list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
+      <parameter type-id='type-id-241' name='list'/>
+      <parameter type-id='type-id-89' name='object'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='list_tail' mangled-name='list_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
+      <parameter type-id='type-id-241' name='list'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='list_head' mangled-name='list_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
+      <parameter type-id='type-id-241' name='list'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
+      <parameter type-id='type-id-241' name='list'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='list_remove_head' mangled-name='list_remove_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
+      <parameter type-id='type-id-241' name='list'/>
+      <return type-id='type-id-89'/>
+    </function-decl>
+    <function-decl name='list_remove' mangled-name='list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
+      <parameter type-id='type-id-241' name='list'/>
+      <parameter type-id='type-id-89' name='object'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='list_insert_tail' mangled-name='list_insert_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_tail'>
+      <parameter type-id='type-id-241' name='list'/>
+      <parameter type-id='type-id-89' name='object'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='list_insert_head' mangled-name='list_insert_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
+      <parameter type-id='type-id-241' name='list'/>
+      <parameter type-id='type-id-89' name='object'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='list_insert_before' mangled-name='list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
+      <parameter type-id='type-id-241' name='list'/>
+      <parameter type-id='type-id-89' name='object'/>
+      <parameter type-id='type-id-89' name='nobject'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='list_insert_after' mangled-name='list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
+      <parameter type-id='type-id-241' name='list'/>
+      <parameter type-id='type-id-89' name='object'/>
+      <parameter type-id='type-id-89' name='nobject'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='list_destroy' mangled-name='list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
+      <parameter type-id='type-id-241' name='list'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='list_create' mangled-name='list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
+      <parameter type-id='type-id-241' name='list'/>
+      <parameter type-id='type-id-85' name='size'/>
+      <parameter type-id='type-id-85' name='offset'/>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='mkdirp.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='mode_t' type-id='type-id-346' id='type-id-360'/>
+  <abi-instr version='1.0' address-size='64' path='mkdirp.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='mode_t' type-id='type-id-213' id='type-id-244'/>
     <function-decl name='mkdirp' mangled-name='mkdirp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
-      <parameter type-id='type-id-16' name='d'/>
-      <parameter type-id='type-id-360' name='mode'/>
+      <parameter type-id='type-id-4' name='d'/>
+      <parameter type-id='type-id-244' name='mode'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='mbstowcs' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-129'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-26'/>
+    <function-decl name='__mbstowcs_alias' mangled-name='mbstowcs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-361'/>
-    <pointer-type-def type-id='type-id-361' size-in-bits='64' id='type-id-362'/>
-    <function-decl name='wcstombs' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-362'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-26'/>
+    <function-decl name='__wcstombs_alias' mangled-name='wcstombs' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='mkdir' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='mkdir' mangled-name='mkdir' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='page.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
     <function-decl name='spl_pagesize' mangled-name='spl_pagesize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
-      <return type-id='type-id-125'/>
+      <return type-id='type-id-85'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='strlcat.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
     <function-decl name='strlcat' mangled-name='strlcat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
-      <parameter type-id='type-id-37' name='dst'/>
-      <parameter type-id='type-id-16' name='src'/>
-      <parameter type-id='type-id-125' name='dstsize'/>
-      <return type-id='type-id-125'/>
+      <parameter type-id='type-id-36' name='dst'/>
+      <parameter type-id='type-id-4' name='src'/>
+      <parameter type-id='type-id-85' name='dstsize'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='strlcpy.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
     <function-decl name='strlcpy' mangled-name='strlcpy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
-      <parameter type-id='type-id-37' name='dst'/>
-      <parameter type-id='type-id-16' name='src'/>
-      <parameter type-id='type-id-125' name='len'/>
-      <return type-id='type-id-125'/>
+      <parameter type-id='type-id-36' name='dst'/>
+      <parameter type-id='type-id-4' name='src'/>
+      <parameter type-id='type-id-85' name='len'/>
+      <return type-id='type-id-85'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='timestamp.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
     <function-decl name='print_timestamp' mangled-name='print_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
-      <parameter type-id='type-id-34' name='timestamp_fmt'/>
-      <return type-id='type-id-17'/>
+      <parameter type-id='type-id-35' name='timestamp_fmt'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-363'/>
-    <function-decl name='time' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-363'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='localtime' mangled-name='localtime' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='nl_langinfo' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-37'/>
+    <function-decl name='strftime' mangled-name='strftime' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <class-decl name='tm' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-364'>
+    <function-decl name='time' mangled-name='time' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='nl_langinfo' mangled-name='nl_langinfo' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libspl' language='LANG_C99'>
+    <typedef-decl name='zoneid_t' type-id='type-id-1' id='type-id-245'/>
+    <function-decl name='getzoneid' mangled-name='getzoneid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
+      <return type-id='type-id-245'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='rdwr_efi.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libefi' language='LANG_C99'>
+    <var-decl name='efi_debug' type-id='type-id-1' mangled-name='efi_debug' visibility='default' elf-symbol-id='efi_debug'/>
+    <class-decl name='dk_gpt' size-in-bits='1920' is-struct='yes' visibility='default' id='type-id-246'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tm_sec' type-id='type-id-1' visibility='default'/>
+        <var-decl name='efi_version' type-id='type-id-35' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='tm_min' type-id='type-id-1' visibility='default'/>
+        <var-decl name='efi_nparts' type-id='type-id-35' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tm_hour' type-id='type-id-1' visibility='default'/>
+        <var-decl name='efi_part_size' type-id='type-id-35' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='tm_mday' type-id='type-id-1' visibility='default'/>
+        <var-decl name='efi_lbasize' type-id='type-id-35' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tm_mon' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='tm_year' type-id='type-id-1' visibility='default'/>
+        <var-decl name='efi_last_lba' type-id='type-id-247' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='tm_wday' type-id='type-id-1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='tm_yday' type-id='type-id-1' visibility='default'/>
+        <var-decl name='efi_first_u_lba' type-id='type-id-247' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='tm_isdst' type-id='type-id-1' visibility='default'/>
+        <var-decl name='efi_last_u_lba' type-id='type-id-247' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='tm_gmtoff' type-id='type-id-5' visibility='default'/>
+        <var-decl name='efi_disk_uguid' type-id='type-id-248' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='tm_zone' type-id='type-id-16' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='efi_flags' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='efi_reserved1' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='efi_altern_lba' type-id='type-id-247' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='efi_reserved' type-id='type-id-249' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='efi_parts' type-id='type-id-250' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-364' size-in-bits='64' id='type-id-365'/>
-    <qualified-type-def type-id='type-id-5' const='yes' id='type-id-366'/>
-    <pointer-type-def type-id='type-id-366' size-in-bits='64' id='type-id-367'/>
-    <function-decl name='localtime' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-367'/>
-      <return type-id='type-id-365'/>
+    <typedef-decl name='longlong_t' type-id='type-id-172' id='type-id-251'/>
+    <typedef-decl name='diskaddr_t' type-id='type-id-251' id='type-id-247'/>
+    <class-decl name='uuid' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-248'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='time_low' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='time_mid' type-id='type-id-197' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='time_hi_and_version' type-id='type-id-197' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='clock_seq_hi_and_reserved' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='72'>
+        <var-decl name='clock_seq_low' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='node_addr' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-35' size-in-bits='384' id='type-id-249'>
+      <subrange length='12' type-id='type-id-12' id='type-id-70'/>
+
+    </array-type-def>
+    <class-decl name='dk_part' size-in-bits='960' is-struct='yes' visibility='default' id='type-id-252'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_start' type-id='type-id-247' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_size' type-id='type-id-247' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_guid' type-id='type-id-248' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_tag' type-id='type-id-253' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='272'>
+        <var-decl name='p_flag' type-id='type-id-253' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='p_name' type-id='type-id-254' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='p_uguid' type-id='type-id-248' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='p_resv' type-id='type-id-255' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='ushort_t' type-id='type-id-195' id='type-id-253'/>
+
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='288' id='type-id-254'>
+      <subrange length='36' type-id='type-id-12' id='type-id-256'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-35' size-in-bits='256' id='type-id-255'>
+      <subrange length='8' type-id='type-id-12' id='type-id-69'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-252' size-in-bits='960' id='type-id-250'>
+      <subrange length='1' type-id='type-id-12' id='type-id-231'/>
+
+    </array-type-def>
+    <pointer-type-def type-id='type-id-246' size-in-bits='64' id='type-id-257'/>
+    <function-decl name='efi_err_check' mangled-name='efi_err_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_err_check'>
+      <parameter type-id='type-id-257' name='vtoc'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-364' const='yes' id='type-id-368'/>
-    <pointer-type-def type-id='type-id-368' size-in-bits='64' id='type-id-369'/>
-    <function-decl name='strftime' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-37'/>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-16'/>
-      <parameter type-id='type-id-369'/>
-      <return type-id='type-id-26'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libspl' language='LANG_C99'>
-    <typedef-decl name='zoneid_t' type-id='type-id-1' id='type-id-370'/>
-    <function-decl name='getzoneid' mangled-name='getzoneid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
-      <return type-id='type-id-370'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='rdwr_efi.c' comp-dir-path='/home/nabijaczleweli/store/code/zfs/lib/libefi' language='LANG_C99'>
-    <var-decl name='efi_debug' type-id='type-id-1' mangled-name='efi_debug' visibility='default' elf-symbol-id='efi_debug'/>
-    <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_init'>
+    <function-decl name='efi_type' mangled-name='efi_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_type'>
       <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-22' name='nparts'/>
-      <parameter type-id='type-id-233' name='vtoc'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='uuid_generate' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-36'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='efi_free' mangled-name='efi_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_free'>
+      <parameter type-id='type-id-257' name='ptr'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='efi_alloc_and_read' mangled-name='efi_alloc_and_read' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_read'>
+    <function-decl name='efi_write' mangled-name='efi_write' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_write'>
       <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-233' name='vtoc'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='efi_rescan' mangled-name='efi_rescan' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_rescan'>
-      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-257' name='vtoc'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='efi_use_whole_disk' mangled-name='efi_use_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_use_whole_disk'>
       <parameter type-id='type-id-1' name='fd'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='efi_write' mangled-name='efi_write' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_write'>
+    <function-decl name='efi_rescan' mangled-name='efi_rescan' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_rescan'>
       <parameter type-id='type-id-1' name='fd'/>
-      <parameter type-id='type-id-232' name='vtoc'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-30' const='yes' id='type-id-371'/>
-    <pointer-type-def type-id='type-id-371' size-in-bits='64' id='type-id-372'/>
-    <function-decl name='uuid_is_null' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-372'/>
+    <pointer-type-def type-id='type-id-257' size-in-bits='64' id='type-id-258'/>
+    <function-decl name='efi_alloc_and_read' mangled-name='efi_alloc_and_read' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_read'>
+      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-258' name='vtoc'/>
       <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='crc32' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-26'/>
-      <parameter type-id='type-id-372'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-26'/>
+    <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_init'>
+      <parameter type-id='type-id-1' name='fd'/>
+      <parameter type-id='type-id-7' name='nparts'/>
+      <parameter type-id='type-id-258' name='vtoc'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='uuid_is_null' mangled-name='uuid_is_null' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='uuid_generate' mangled-name='uuid_generate' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='bcmp' mangled-name='bcmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='lseek' mangled-name='lseek64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-5'/>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='write' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <parameter type-id='type-id-73'/>
-      <parameter type-id='type-id-26'/>
-      <return type-id='type-id-5'/>
+    <function-decl name='write' mangled-name='write' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='fsync' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='fsync' mangled-name='fsync' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
-    <function-decl name='efi_type' mangled-name='efi_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_type'>
-      <parameter type-id='type-id-1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='efi_err_check' mangled-name='efi_err_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_err_check'>
-      <parameter type-id='type-id-232' name='vtoc'/>
-      <return type-id='type-id-17'/>
+    <function-decl name='crc32' mangled-name='crc32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-84'/>
     </function-decl>
   </abi-instr>
 </abi-corpus>

--- a/lib/libzfsbootenv/libzfsbootenv.abi
+++ b/lib/libzfsbootenv/libzfsbootenv.abi
@@ -1,20 +1,12 @@
-<abi-corpus path='libzfsbootenv.so' architecture='elf-amd-x86_64' soname='libzfsbootenv.so.1'>
+<abi-corpus architecture='elf-amd-x86_64' soname='libzfsbootenv.so.1'>
   <elf-needed>
     <dependency name='libzfs.so.4'/>
-    <dependency name='libzfs_core.so.3'/>
-    <dependency name='libuuid.so.1'/>
-    <dependency name='libblkid.so.1'/>
-    <dependency name='libudev.so.1'/>
-    <dependency name='libuutil.so.3'/>
-    <dependency name='libm.so.6'/>
-    <dependency name='libcrypto.so.1.1'/>
-    <dependency name='libz.so.1'/>
     <dependency name='libnvpair.so.3'/>
-    <dependency name='libtirpc.so.3'/>
-    <dependency name='libpthread.so.0'/>
     <dependency name='libc.so.6'/>
   </elf-needed>
   <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_add_pair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_bootenv_print' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_get_boot_device' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -24,189 +16,346 @@
     <elf-symbol name='lzbe_remove_pair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_set_boot_device' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
-  <abi-instr version='1.0' address-size='64' path='lzbe_device.c' comp-dir-path='/home/fedora/zfs/lib/libzfsbootenv' language='LANG_C99'>
-    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
-    <type-decl name='int' size-in-bits='32' id='type-id-2'/>
-    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-3'/>
-    <typedef-decl name='lzbe_flags_t' type-id='type-id-4' filepath='../../include/libzfsbootenv.h' line='26' column='1' id='type-id-5'/>
-    <enum-decl name='lzbe_flags' filepath='../../include/libzfsbootenv.h' line='23' column='1' id='type-id-4'>
-      <underlying-type type-id='type-id-3'/>
+  <abi-instr version='1.0' address-size='64' path='lzbe_device.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfsbootenv' language='LANG_C99'>
+    <type-decl name='int' size-in-bits='32' id='type-id-1'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-2'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-3'/>
+    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-4'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-6'/>
+    <function-decl name='lzbe_get_boot_device' mangled-name='lzbe_get_boot_device' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_get_boot_device'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-6' name='device'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-7'/>
+    <enum-decl name='lzbe_flags' id='type-id-8'>
+      <underlying-type type-id='type-id-7'/>
       <enumerator name='lzbe_add' value='0'/>
       <enumerator name='lzbe_replace' value='1'/>
     </enum-decl>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-6'/>
-    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-7'/>
-    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-8'/>
-    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-9'/>
-    <function-decl name='lzbe_get_boot_device' mangled-name='lzbe_get_boot_device' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_get_boot_device'>
-      <parameter type-id='type-id-9' name='pool' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='114' column='1'/>
-      <parameter type-id='type-id-7' name='device' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='114' column='1'/>
-      <return type-id='type-id-2'/>
+    <typedef-decl name='lzbe_flags_t' type-id='type-id-8' id='type-id-9'/>
+    <function-decl name='lzbe_set_boot_device' mangled-name='lzbe_set_boot_device' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_set_boot_device'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-9' name='flag'/>
+      <parameter type-id='type-id-4' name='device'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='lzbe_set_boot_device' mangled-name='lzbe_set_boot_device' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_set_boot_device'>
-      <parameter type-id='type-id-9' name='pool' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='28' column='1'/>
-      <parameter type-id='type-id-5' name='flag' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='28' column='1'/>
-      <parameter type-id='type-id-9' name='device' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_device.c' line='28' column='1'/>
-      <return type-id='type-id-2'/>
+    <type-decl name='void' id='type-id-10'/>
+    <function-decl name='libzfs_init' mangled-name='libzfs_init' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='zpool_open' mangled-name='zpool_open' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='zpool_close' mangled-name='zpool_close' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='libzfs_fini' mangled-name='libzfs_fini' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_free' mangled-name='nvlist_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='strdup' mangled-name='strdup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='__stack_chk_fail' mangled-name='__stack_chk_fail' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='__asprintf_chk' mangled-name='__asprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='__fprintf_chk' mangled-name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_exists' mangled-name='nvlist_exists' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='fnvlist_free' mangled-name='fnvlist_free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='free' mangled-name='free' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='libzfs_error_description' mangled-name='libzfs_error_description' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='lzbe_pair.c' comp-dir-path='/home/fedora/zfs/lib/libzfsbootenv' language='LANG_C99'>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-10'/>
-    <type-decl name='void' id='type-id-11'/>
-    <typedef-decl name='size_t' type-id='type-id-10' filepath='/usr/lib/gcc/x86_64-redhat-linux/10/include/stddef.h' line='209' column='1' id='type-id-12'/>
-    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-13'/>
-    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-14'/>
-    <function-decl name='lzbe_remove_pair' mangled-name='lzbe_remove_pair' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_remove_pair'>
-      <parameter type-id='type-id-13' name='ptr' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='343' column='1'/>
-      <parameter type-id='type-id-9' name='key' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='343' column='1'/>
-      <return type-id='type-id-2'/>
+  <abi-instr version='1.0' address-size='64' path='lzbe_pair.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfsbootenv' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-11'/>
+    <function-decl name='lzbe_remove_pair' mangled-name='lzbe_remove_pair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_remove_pair'>
+      <parameter type-id='type-id-11' name='ptr'/>
+      <parameter type-id='type-id-4' name='key'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='lzbe_add_pair' mangled-name='lzbe_add_pair' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='182' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_add_pair'>
-      <parameter type-id='type-id-13' name='ptr' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='182' column='1'/>
-      <parameter type-id='type-id-9' name='key' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='182' column='1'/>
-      <parameter type-id='type-id-9' name='type' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='182' column='1'/>
-      <parameter type-id='type-id-13' name='value' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='182' column='1'/>
-      <parameter type-id='type-id-12' name='size' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='183' column='1'/>
-      <return type-id='type-id-2'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-12'/>
+    <typedef-decl name='size_t' type-id='type-id-12' id='type-id-13'/>
+    <function-decl name='lzbe_add_pair' mangled-name='lzbe_add_pair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_add_pair'>
+      <parameter type-id='type-id-11' name='ptr'/>
+      <parameter type-id='type-id-4' name='key'/>
+      <parameter type-id='type-id-4' name='type'/>
+      <parameter type-id='type-id-11' name='value'/>
+      <parameter type-id='type-id-13' name='size'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='lzbe_nvlist_free' mangled-name='lzbe_nvlist_free' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_free'>
-      <parameter type-id='type-id-13' name='ptr' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='131' column='1'/>
-      <return type-id='type-id-11'/>
+    <function-decl name='lzbe_nvlist_free' mangled-name='lzbe_nvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_free'>
+      <parameter type-id='type-id-11' name='ptr'/>
+      <return type-id='type-id-10'/>
     </function-decl>
-    <function-decl name='lzbe_nvlist_set' mangled-name='lzbe_nvlist_set' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='74' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_set'>
-      <parameter type-id='type-id-9' name='pool' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='74' column='1'/>
-      <parameter type-id='type-id-9' name='key' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='74' column='1'/>
-      <parameter type-id='type-id-13' name='ptr' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='74' column='1'/>
-      <return type-id='type-id-2'/>
+    <function-decl name='lzbe_nvlist_set' mangled-name='lzbe_nvlist_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_set'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-4' name='key'/>
+      <parameter type-id='type-id-11' name='ptr'/>
+      <return type-id='type-id-1'/>
     </function-decl>
-    <function-decl name='lzbe_nvlist_get' mangled-name='lzbe_nvlist_get' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_get'>
-      <parameter type-id='type-id-9' name='pool' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='27' column='1'/>
-      <parameter type-id='type-id-9' name='key' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='27' column='1'/>
-      <parameter type-id='type-id-14' name='ptr' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_pair.c' line='27' column='1'/>
-      <return type-id='type-id-2'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-14'/>
+    <function-decl name='lzbe_nvlist_get' mangled-name='lzbe_nvlist_get' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_get'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-4' name='key'/>
+      <parameter type-id='type-id-14' name='ptr'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='strcmp' mangled-name='strcmp' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte' mangled-name='nvlist_add_byte' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16' mangled-name='nvlist_add_int16' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16' mangled-name='nvlist_add_uint16' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32' mangled-name='nvlist_add_int32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32' mangled-name='nvlist_add_uint32' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64' mangled-name='nvlist_add_int64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte_array' mangled-name='nvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16_array' mangled-name='nvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16_array' mangled-name='nvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32_array' mangled-name='nvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32_array' mangled-name='nvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64_array' mangled-name='nvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string_array' mangled-name='nvlist_add_string_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_value' mangled-name='nvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8' mangled-name='nvlist_add_int8' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8' mangled-name='nvlist_add_uint8' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_array' mangled-name='nvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8_array' mangled-name='nvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_dup' mangled-name='nvlist_dup' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='lzbe_util.c' comp-dir-path='/home/fedora/zfs/lib/libzfsbootenv' language='LANG_C99'>
-
-
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='8' id='type-id-15'>
-      <subrange length='1' type-id='type-id-10' id='type-id-16'/>
-
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='160' id='type-id-17'>
-      <subrange length='20' type-id='type-id-10' id='type-id-18'/>
-
-    </array-type-def>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-19'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-20'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-21'/>
-    <type-decl name='long int' size-in-bits='64' id='type-id-22'/>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-23'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-24'/>
-    <typedef-decl name='FILE' type-id='type-id-25' filepath='/usr/include/bits/types/FILE.h' line='7' column='1' id='type-id-26'/>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='49' column='1' id='type-id-25'>
+  <abi-instr version='1.0' address-size='64' path='lzbe_util.c' comp-dir-path='/home/runner/work/zfs/zfs/lib/libzfsbootenv' language='LANG_C99'>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='type-id-15'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_flags' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='51' column='1'/>
+        <var-decl name='_flags' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='54' column='1'/>
+        <var-decl name='_IO_read_ptr' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='55' column='1'/>
+        <var-decl name='_IO_read_end' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='56' column='1'/>
+        <var-decl name='_IO_read_base' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='57' column='1'/>
+        <var-decl name='_IO_write_base' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='58' column='1'/>
+        <var-decl name='_IO_write_ptr' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='59' column='1'/>
+        <var-decl name='_IO_write_end' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='60' column='1'/>
+        <var-decl name='_IO_buf_base' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='61' column='1'/>
+        <var-decl name='_IO_buf_end' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='64' column='1'/>
+        <var-decl name='_IO_save_base' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='65' column='1'/>
+        <var-decl name='_IO_backup_base' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-6' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='66' column='1'/>
+        <var-decl name='_IO_save_end' type-id='type-id-5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-27' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='68' column='1'/>
+        <var-decl name='_markers' type-id='type-id-16' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-28' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='70' column='1'/>
+        <var-decl name='_chain' type-id='type-id-17' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='_fileno' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='72' column='1'/>
+        <var-decl name='_fileno' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='_flags2' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='73' column='1'/>
+        <var-decl name='_flags2' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-29' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='74' column='1'/>
+        <var-decl name='_old_offset' type-id='type-id-18' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='77' column='1'/>
+        <var-decl name='_cur_column' type-id='type-id-19' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-23' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='78' column='1'/>
+        <var-decl name='_vtable_offset' type-id='type-id-20' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-15' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='79' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='_lock' type-id='type-id-30' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='81' column='1'/>
+        <var-decl name='_shortbuf' type-id='type-id-21' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-31' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='89' column='1'/>
+        <var-decl name='_offset' type-id='type-id-22' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='type-id-32' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='91' column='1'/>
+        <var-decl name='__pad1' type-id='type-id-11' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='type-id-33' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='92' column='1'/>
+        <var-decl name='__pad2' type-id='type-id-11' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='type-id-28' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='93' column='1'/>
+        <var-decl name='__pad3' type-id='type-id-11' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='type-id-13' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='94' column='1'/>
+        <var-decl name='__pad4' type-id='type-id-11' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-12' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='95' column='1'/>
+        <var-decl name='__pad5' type-id='type-id-13' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='_mode' type-id='type-id-2' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='96' column='1'/>
+        <var-decl name='_mode' type-id='type-id-1' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-17' visibility='default' filepath='/usr/include/bits/types/struct_FILE.h' line='98' column='1'/>
+        <var-decl name='_unused2' type-id='type-id-23' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__off_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='152' column='1' id='type-id-29'/>
-    <typedef-decl name='_IO_lock_t' type-id='type-id-11' filepath='/usr/include/bits/types/struct_FILE.h' line='43' column='1' id='type-id-34'/>
-    <typedef-decl name='__off64_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='153' column='1' id='type-id-31'/>
-    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-35'/>
-    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-28'/>
-    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-32'/>
-    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-30'/>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-27'/>
-    <pointer-type-def type-id='type-id-21' size-in-bits='64' id='type-id-33'/>
-    <function-decl name='lzbe_bootenv_print' mangled-name='lzbe_bootenv_print' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_util.c' line='24' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_bootenv_print'>
-      <parameter type-id='type-id-9' name='pool' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_util.c' line='24' column='1'/>
-      <parameter type-id='type-id-9' name='nvlist' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_util.c' line='24' column='1'/>
-      <parameter type-id='type-id-35' name='of' filepath='/home/fedora/zfs/lib/libzfsbootenv/lzbe_util.c' line='24' column='1'/>
-      <return type-id='type-id-2'/>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_next' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_sbuf' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_pos' type-id='type-id-1' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-16'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-17'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-25'/>
+    <typedef-decl name='__off_t' type-id='type-id-25' id='type-id-18'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-19'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-20'/>
+
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='8' id='type-id-21'>
+      <subrange length='1' type-id='type-id-12' id='type-id-26'/>
+
+    </array-type-def>
+    <typedef-decl name='__off64_t' type-id='type-id-25' id='type-id-22'/>
+
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='160' id='type-id-23'>
+      <subrange length='20' type-id='type-id-12' id='type-id-27'/>
+
+    </array-type-def>
+    <typedef-decl name='FILE' type-id='type-id-15' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-29'/>
+    <function-decl name='lzbe_bootenv_print' mangled-name='lzbe_bootenv_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_bootenv_print'>
+      <parameter type-id='type-id-4' name='pool'/>
+      <parameter type-id='type-id-4' name='nvlist'/>
+      <parameter type-id='type-id-29' name='of'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='lzbe_nvlist_get' mangled-name='lzbe_nvlist_get' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='nvlist_print' mangled-name='nvlist_print' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-10'/>
     </function-decl>
   </abi-instr>
 </abi-corpus>


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
-  storeabi: add no-corpus-path flag: just try to minimize diffs
- update ABI files with generated in CI worker: so next updates will have smaller diffs

### Description
<!--- Describe your changes in detail -->
ABI was generated on latest master via CI https://github.com/gmelikov/zfs/actions/runs/1042626752

#### Additional notes:
After https://github.com/openzfs/zfs/pull/12379 we can generate ABI description files with smaller diffs.

Unfortunately, further optimizations may be brought only with fresh libabigail, which is not in our CI and stable OS distros yet. For example, I 've found `--no-comp-dir-path`  was only introduced since 1.7, which is pretty new https://pkgs.org/download/abigail-tools . Good example of latest abigail usage: https://android.googlesource.com/kernel/build/+/c494508%5E%21/

Someone may prepare Docker image with needed abigail-tools, but it's not one-liner to get it work with CI and other machinery (it has to work on compiled binaries).

Let's wait a little, and ask everybody to commit .abi files from CI. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
CI will validate it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)