### PR TITLE
Avoid panic in case of pool errors and missing L2ARC

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3775,8 +3775,13 @@ arc_hdr_destroy(arc_buf_hdr_t *hdr)
 		 * to acquire the l2ad_mtx. If that happens, we don't
 		 * want to re-destroy the header's L2 portion.
 		 */
-		if (HDR_HAS_L2HDR(hdr))
+		if (HDR_HAS_L2HDR(hdr)) {
+
+			if (!HDR_EMPTY(hdr))
+				buf_discard_identity(hdr);
+
 			arc_hdr_l2hdr_destroy(hdr);
+		}
 
 		if (!buflist_held)
 			mutex_exit(&dev->l2ad_mtx);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Local testing hitting the panic:
```
VERIFY(HDR_EMPTY_OR_LOCKED(hdr)) failed
PANIC at arc.c:1628:arc_hdr_clear_flags()
Showing stack for process 1084883
CPU: 8 PID: 1084883 Comm: z_rd_int_0 Tainted: P           OE     5.12.15-arch1-1 #1
Call Trace:
 dump_stack+0x76/0x94
 spl_panic+0xef/0x117 [spl]
 ? abd_fletcher_4_impl+0x50/0x50 [zfs]
 ? _raw_spin_unlock+0xa/0x20
 ? _raw_spin_unlock+0xa/0x20
 arc_hdr_clear_flags+0x7b/0x80 [zfs]
 arc_hdr_destroy+0x393/0x3a0 [zfs]
 zio_done+0x416/0x18b0 [zfs]
 zio_execute+0xea/0x220 [zfs]
 taskq_thread+0x239/0x4a0 [spl]
 ? wake_up_q+0xa0/0xa0
 ? zio_execute_stack_check.constprop.0+0x10/0x10 [zfs]
 ? taskq_thread_spawn+0x50/0x50 [spl]
 kthread+0x133/0x150
 ? kthread_associate_blkcg+0xc0/0xc0
 ret_from_fork+0x22/0x30
```

### Description
<!--- Describe your changes in detail -->
In case an ARC buffer is allocated only on L2ARC, and there are
underlying errors in a pool with the cache device in faulty state, a
panic can occur in arc_read_done()->arc_hdr_destroy()->
arc_hdr_l2arc_destroy()->arc_hdr_clear_flags() when trying to free
the ARC buffer.

Fix this by checking in arc_read_done() if the ARC buffer to be freed
is stored on L2ARC and not empty, and acquiring its hash_lock in this
case.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Without this patch the following code panics:
```
echo 0 | tee /sys/module/zfs/parameters/l2arc_noprefetch
zpool create test /dev/sda cache /dev/sdb

# Fill L2ARC
fio --name=test --size=100M --nrfiles=1 --readwrite=read --directory=/test --time_based --runtime=1000

# Simulate missing device, this leaves the L2ARC buffers intact in ARC
zpool offline test /dev/sdb

# Simulate error on pool
zinject -t data -e checksum -f 100 -am /test/test.0.0 

# Panic
fio --name=test --size=100M --nrfiles=1 --readwrite=read --directory=/test
```


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
