### PR TITLE
Run arc_evict thread at higher priority

### DIFF
--- a/include/sys/zthr.h
+++ b/include/sys/zthr.h
@@ -25,10 +25,11 @@ typedef void (zthr_func_t)(void *, zthr_t *);
 typedef boolean_t (zthr_checkfunc_t)(void *, zthr_t *);
 
 extern zthr_t *zthr_create(const char *zthr_name,
-    zthr_checkfunc_t checkfunc, zthr_func_t *func, void *arg);
+    zthr_checkfunc_t checkfunc, zthr_func_t *func, void *arg,
+	pri_t pri);
 extern zthr_t *zthr_create_timer(const char *zthr_name,
     zthr_checkfunc_t *checkfunc, zthr_func_t *func, void *arg,
-	hrtime_t nano_wait);
+	hrtime_t nano_wait, pri_t pri);
 extern void zthr_destroy(zthr_t *t);
 
 extern void zthr_wakeup(zthr_t *t);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7972,9 +7972,9 @@ arc_init(void)
 	}
 
 	arc_evict_zthr = zthr_create("arc_evict",
-	    arc_evict_cb_check, arc_evict_cb, NULL);
+	    arc_evict_cb_check, arc_evict_cb, NULL, defclsyspri);
 	arc_reap_zthr = zthr_create_timer("arc_reap",
-	    arc_reap_cb_check, arc_reap_cb, NULL, SEC2NSEC(1));
+	    arc_reap_cb_check, arc_reap_cb, NULL, SEC2NSEC(1), minclsyspri);
 
 	arc_warm = B_FALSE;
 

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2610,7 +2610,8 @@ spa_start_livelist_destroy_thread(spa_t *spa)
 	ASSERT3P(spa->spa_livelist_delete_zthr, ==, NULL);
 	spa->spa_livelist_delete_zthr =
 	    zthr_create("z_livelist_destroy",
-	    spa_livelist_delete_cb_check, spa_livelist_delete_cb, spa);
+	    spa_livelist_delete_cb_check, spa_livelist_delete_cb, spa,
+	    minclsyspri);
 }
 
 typedef struct livelist_new_arg {
@@ -2820,7 +2821,7 @@ spa_start_livelist_condensing_thread(spa_t *spa)
 	spa->spa_livelist_condense_zthr =
 	    zthr_create("z_livelist_condense",
 	    spa_livelist_condense_cb_check,
-	    spa_livelist_condense_cb, spa);
+	    spa_livelist_condense_cb, spa, minclsyspri);
 }
 
 static void
@@ -2838,7 +2839,7 @@ spa_spawn_aux_threads(spa_t *spa)
 	spa->spa_checkpoint_discard_zthr =
 	    zthr_create("z_checkpoint_discard",
 	    spa_checkpoint_discard_thread_check,
-	    spa_checkpoint_discard_thread, spa);
+	    spa_checkpoint_discard_thread, spa, minclsyspri);
 }
 
 /*

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -885,7 +885,7 @@ spa_start_indirect_condensing_thread(spa_t *spa)
 	ASSERT3P(spa->spa_condense_zthr, ==, NULL);
 	spa->spa_condense_zthr = zthr_create("z_indirect_condense",
 	    spa_condense_indirect_thread_check,
-	    spa_condense_indirect_thread, spa);
+	    spa_condense_indirect_thread, spa, minclsyspri);
 }
 
 /*


### PR DESCRIPTION
This was https://github.com/openzfs/zfs/pull/12151. I have a new repo and couldn't update
that PR.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Run arc_evict thread at higher priority, nice=0, to give it more CPU
time which can improve performance for workload with high ARC evict
activities.

On mixed read/write and sequential read workloads, I've seen between
10-40% better performance.

### Description
<!--- Describe your changes in detail -->
Extending zthr_create() and zthr_create_timer() to take a new priority_t
argument and arc_evict_zthr is created with defclsyspri (nice=0) priority
value rather than the current minimum priority (nice=19).

Observed performance gains with nice=0 and nice=-20 comparing to current nice=19

VM config: 16 vCPU, 32 GB RAM, 4 x 200 GB disks
Workload: 32 threads x 1M sequential reads
minclsyspri (nice 19) current value: 1301 IOPS, 1365 MB/s, 37-45% idle
defclsyspri (nice 0): 1860 IOPS, 1951 MB/s, 22-25% idle
maxclsyspri (nice -20): 1929 IOPS, 2023 MB/s, 20-22% idle

====================
VM config: 8 vCPU, 32 GB RAM, 4 x 200 GB disks
Workload: 32 threads x 1M sequential reads
minclsyspri (nice 19) current value: 915 IOPS, 960 MB/s, 8-12% idle
defclsyspri (nice 0): 1135 IOPS, 1191 MB/s, 6-10% idle
maxclsyspri (nice -20): 1455 IOPS, 1527 MB/s, % idle 1-1.5% idle

====================
VM config: 1 vCPU, 24 GB RAM, 4 x 200 GB disks
Workload: 16 threads x 1M sequential reads
minclsyspri (nice 19) current value: 251 IOPS, 251 MB/s, 0% idle
defclsyspri (nice 0): 251 IOPS, 251 MB/s, 0% idle
maxclsyspri (nice -20): 240 IOPS, 240 MB/s, 0% idle

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Manual tests with sequential reads and mixed read/writes with larger pool size.

ZFS performance test suite also show better though smaller gains for
sequential read and sequential writes, up to 8% and 3%, respectively.
Test setup: 8 vCPU, 32 GB memory, and 4 x 100 SSD disks

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
