### PR TITLE
FreeBSD: Switch from MAXPHYS to maxphys on FreeBSD 13+ in zvol_os.c

### DIFF
--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -1241,7 +1241,11 @@ zvol_rename_minor(zvol_state_t *zv, const char *newname)
 		args.mda_si_drv2 = zv;
 		if (make_dev_s(&args, &dev, "%s/%s", ZVOL_DRIVER, newname)
 		    == 0) {
+#if __FreeBSD_version > 1300130
+			dev->si_iosize_max = maxphys;
+#else
 			dev->si_iosize_max = MAXPHYS;
+#endif
 			zsd->zsd_cdev = dev;
 		}
 	}
@@ -1382,7 +1386,11 @@ zvol_create_minor_impl(const char *name)
 			dmu_objset_disown(os, B_TRUE, FTAG);
 			goto out_doi;
 		}
+#if __FreeBSD_version > 1300130
+		dev->si_iosize_max = maxphys;
+#else
 		dev->si_iosize_max = MAXPHYS;
+#endif
 		zsd->zsd_cdev = dev;
 	}
 	(void) strlcpy(zv->zv_name, name, MAXPATHLEN);


### PR DESCRIPTION
### Motivation and Context
In FreeBSD 13, the loader tunable maxphys was introduced to replace MAXPHYS.
The commit eecceeae9feee7f7398c423e81b276a394c8ffae missed MAXPHYS in zvol_os.c

### Description
Analogous to the change in vdev_geom.c, use maxphys instead of MAXPHYS in zvol_os.c

### How Has This Been Tested?
The changed code is in FreeBSD base since freebsd/freebsd-src@cd8537910406e68d4719136a5b0cf6d23bb1b23b (Nov 28, 2020).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
