### PR TITLE
Add missing properties to zfs allow manpage

### DIFF
--- a/man/man8/zfs-allow.8
+++ b/man/man8/zfs-allow.8
@@ -203,8 +203,8 @@ create	subcommand	Must also have the \fBmount\fR ability. Must also have the \fB
 destroy	subcommand	Must also have the \fBmount\fR ability
 diff	subcommand	Allows lookup of paths within a dataset given an object number, and the ability to create snapshots necessary to \fBzfs diff\fR.
 hold	subcommand	Allows adding a user hold to a snapshot
-load	subcommand	Allows loading and unloading of encryption key (see \fBzfs load-key\fR and \fBzfs unload-key\fR).
-change	subcommand	Allows changing an encryption key via \fBzfs change-key\fR.
+load-key	subcommand	Allows loading and unloading of encryption key (see \fBzfs load-key\fR and \fBzfs unload-key\fR).
+change-key	subcommand	Allows changing an encryption key via \fBzfs change-key\fR.
 mount	subcommand	Allows mounting/umounting ZFS datasets
 promote	subcommand	Must also have the \fBmount\fR and \fBpromote\fR ability in the origin file system
 receive	subcommand	Must also have the \fBmount\fR and \fBcreate\fR ability
@@ -216,45 +216,69 @@ share	subcommand	Allows sharing file systems over NFS or SMB protocols
 snapshot	subcommand	Must also have the \fBmount\fR ability
 
 groupquota	other	Allows accessing any \fBgroupquota@\fI...\fR property
+groupobjquota	other   Allows accessing any \fBgroupobjquota@\fI...\fR property
 groupused	other	Allows reading any \fBgroupused@\fI...\fR property
+groupobjused	other   Allows reading any \fBgroupobjused@\fI...\fR property
 userprop	other	Allows changing any user property
 userquota	other	Allows accessing any \fBuserquota@\fI...\fR property
+userobjquota	other   Allows accessing any \fBuserobjquota@\fI...\fR property
 userused	other	Allows reading any \fBuserused@\fI...\fR property
+userobjused	other   Allows reading any \fBuserobjused@\fI...\fR property
 projectobjquota	other	Allows accessing any \fBprojectobjquota@\fI...\fR property
 projectquota	other	Allows accessing any \fBprojectquota@\fI...\fR property
 projectobjused	other	Allows reading any \fBprojectobjused@\fI...\fR property
 projectused	other	Allows reading any \fBprojectused@\fI...\fR property
 
 aclinherit	property
+aclmode	property
 acltype	property
 atime	property
 canmount	property
 casesensitivity	property
 checksum	property
 compression	property
+context	property
 copies	property
+dedup	property
+defcontext	property
 devices	property
+dnodesize	property
+encryption	property
 exec	property
 filesystem_limit	property
+fscontext	property
+keyformat	property
+keylocation	property
+logbias	property
+mlslabel	property
 mountpoint	property
 nbmand	property
 normalization	property
+overlay	property
+pbkdf2iters	property
 primarycache	property
 quota	property
 readonly	property
 recordsize	property
+redundant_metadata	property
 refquota	property
 refreservation	property
+relatime	property
 reservation	property
+rootcontext	property
 secondarycache	property
 setuid	property
 sharenfs	property
 sharesmb	property
+snapdev	property
 snapdir	property
 snapshot_limit	property
+special_small_blocks	property
+sync	property
 utf8only	property
 version	property
 volblocksize	property
+volmode	property
 volsize	property
 vscan	property
 xattr	property


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Make zfs allow manpage and zfs allow error output consistent.

### Description
Add to manpage properties mentioned only in zfs allow error output (output of zfs allow command without any parameters).
Also changed in manpage nonexistent subcommands "load" and "change" to real subcommands "load-key" and "change-key". 


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
