### PR TITLE
Increase default volblocksize from 8KB to 16KB.

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1225,7 +1225,7 @@ typedef struct ddt_histogram {
 #define	ZVOL_DEV_NAME		"zd"
 
 #define	ZVOL_PROP_NAME		"name"
-#define	ZVOL_DEFAULT_BLOCKSIZE	8192
+#define	ZVOL_DEFAULT_BLOCKSIZE	16384
 
 typedef enum {
 	VDEV_INITIALIZE_NONE,

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -527,7 +527,7 @@ cannot be changed once the volume has been written, so it should be set at
 volume creation time.
 The default
 .Sy blocksize
-for volumes is 8 Kbytes.
+for volumes is 16 Kbytes.
 Any power of 2 from 512 bytes to 128 Kbytes is valid.
 .Pp
 This property can also be referred to by its shortened column name,

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create.cfg
@@ -62,4 +62,4 @@ set -A size "8k" "8K" "35K" "1m" "1M" "1mb" "1mB" "1Mb" "1MB" "1g" "1G" \
 # explicitly check that its size has been rounded up to the nearest multiple
 # The volume with the exact size must exist in the "size" array above
 set -A explicit_size_check "35K"
-set -A expected_rounded_size "40960"
+set -A expected_rounded_size "49152"

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_volume.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_volume.ksh
@@ -45,14 +45,14 @@ log_assert "nopwrite works on volumes"
 
 log_must zfs set compress=on $origin
 log_must zfs set checksum=sha256 $origin
-dd if=/dev/urandom of=$vol bs=8192 count=4096 conv=notrunc >/dev/null \
+dd if=/dev/urandom of=$vol bs=16384 count=2048 conv=notrunc >/dev/null \
     2>&1 || log_fail "dd into $origin failed."
 zfs snapshot $origin@a || log_fail "zfs snap failed"
 log_must zfs clone $origin@a $clone
 log_must zfs set compress=on $clone
 log_must zfs set checksum=sha256 $clone
 block_device_wait
-dd if=$vol of=$volclone bs=8192 count=4096 conv=notrunc >/dev/null 2>&1 || \
+dd if=$vol of=$volclone bs=16384 count=2048 conv=notrunc >/dev/null 2>&1 || \
     log_fail "dd into $clone failed."
 log_must verify_nopwrite $origin $origin@a $clone
 

--- a/tests/zfs-tests/tests/functional/reservation/reservation.shlib
+++ b/tests/zfs-tests/tests/functional/reservation/reservation.shlib
@@ -108,7 +108,7 @@ function create_multiple_fs # num_fs base_fs_name base_mnt_name
 
 #
 # This function compute the largest volume size which is multiple of volume
-# block size (default 8K) and not greater than the largest expected volsize.
+# block size (default 16K) and not greater than the largest expected volsize.
 #
 # $1 The largest expected volume size.
 # $2 The volume block size
@@ -116,7 +116,7 @@ function create_multiple_fs # num_fs base_fs_name base_mnt_name
 function floor_volsize #<largest_volsize> [volblksize]
 {
 	typeset largest_volsize=$1
-	typeset volblksize=${2:-8192}
+	typeset volblksize=${2:-16384}
 
 	if ((largest_volsize < volblksize)); then
 		log_fail "The largest_volsize must be greater than volblksize."
@@ -157,7 +157,7 @@ function volsize_to_reservation
 		typeset volblocksize=$(get_prop volblocksize $vol)
 	else
 		typeset ncopies=1
-		typeset volblocksize=8192
+		typeset volblocksize=16384
 	fi
 	typeset nblocks=$((volsize / volblocksize))
 


### PR DESCRIPTION
Many things has changed since previous default was set many years ago.
Nowadays 8KB does not allow adequate compression or even decent space
efficiency on many of pools due to 4KB disk physical block rounding,
especially on RAIDZ and DRAID.  It effectively limits write throughput
to only 2-3GB/s (250-350K blocks/s) due to sync thread, allocation,
vdev queue and other block rate bottlenecks.  It keeps L2ARC expensive
despite many optimizations and dedup just unrealistic.

In FreeNAS/TrueNAS we for years default to at least 16KB volblocksize
for mirror pools and even bigger (32-64KB) for RAIDZ, and so far we
can find very few scenarios (not synthetic benchmarks) when smaller
blocks would show sufficient benefits.

It was discussed on today's OpenZFS meeting and got no objections.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
