### PR TITLE
Remove overlooked __sun_attr__ based macros

### DIFF
--- a/include/os/freebsd/spl/sys/ccompile.h
+++ b/include/os/freebsd/spl/sys/ccompile.h
@@ -36,12 +36,6 @@
 extern "C" {
 #endif
 
-#if	defined(_KERNEL) || defined(_STANDALONE)
-#define	__NORETURN		__sun_attr__((__noreturn__))
-#endif /* _KERNEL || _STANDALONE */
-#define	__CONST			__sun_attr__((__const__))
-#define	__PURE			__sun_attr__((__pure__))
-
 #if defined(INVARIANTS) && !defined(ZFS_DEBUG)
 #define	ZFS_DEBUG
 #undef 	NDEBUG

--- a/include/os/freebsd/spl/sys/cmn_err.h
+++ b/include/os/freebsd/spl/sys/cmn_err.h
@@ -71,7 +71,7 @@ extern void vuprintf(const char *, __va_list)
     __attribute__((format(printf, 1, 0)));
 
 extern void panic(const char *, ...)
-    __attribute__((format(printf, 1, 2))) __NORETURN;
+    __attribute__((format(printf, 1, 2)));
 
 #endif /* !_ASM */
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -8354,8 +8354,8 @@ l2arc_write_size(l2arc_dev_t *dev)
 		    "plus the overhead of log blocks (persistent L2ARC, "
 		    "%llu bytes) exceeds the size of the cache device "
 		    "(guid %llu), resetting them to the default (%d)",
-		    l2arc_log_blk_overhead(size, dev),
-		    dev->l2ad_vdev->vdev_guid, L2ARC_WRITE_SIZE);
+		    (u_longlong_t)l2arc_log_blk_overhead(size, dev),
+		    (u_longlong_t)dev->l2ad_vdev->vdev_guid, L2ARC_WRITE_SIZE);
 		size = l2arc_write_max = l2arc_write_boost = L2ARC_WRITE_SIZE;
 
 		if (arc_warm == B_FALSE)


### PR DESCRIPTION
### Motivation and Context

Fix accidentally introduced build failure on FreeBSD.

http://build.zfsonlinux.org/builders/FreeBSD%20stable%2F13%20amd64%20%28TEST%29/builds/1756/steps/shell_1/logs/make

### Description

The __NORETURN, __CONST, and __PURE macros in the FreeBSD platform
code were based on the `__sun_attr__` macro which was removed in
commit 5dbf6c5a6.  This caused a build failure because the
__NORETURN macro was still used in one place in kernel code.
The __CONST and __PURE macros were entirely unused.

### How Has This Been Tested?

Pending results from the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
