### PR TITLE
Add zfskeys script from and for FreeBSD

### DIFF
--- a/contrib/freebsd/zfskeys
+++ b/contrib/freebsd/zfskeys
@@ -1,0 +1,119 @@
+#!/bin/sh
+
+# PROVIDE: zfskeys
+# REQUIRE: zpool
+# BEFORE: zfs zvol
+
+. /etc/rc.subr
+
+name="zfskeys"
+desc="Load dataset keys"
+rcvar="zfskeys_enable"
+extra_commands="status"
+start_cmd="load_zfs_keys"
+stop_cmd="unload_zfs_keys"
+status_cmd="status_zfs_keys"
+required_modules="zfs"
+
+# Note that zfskeys_datasets must have any character found in IFS escaped.
+# Forcibly unmounting/unloading only applies to filesystems; ignored for zvols.
+: ${zfskeys_datasets:=''}
+: ${zfskeys_timeout:=10}
+: ${zfskeys_unload_force:='NO'}
+
+encode_args()
+{
+    shift && [ $# -gt 0 ] && printf "%s\0" "$@" | b64encode -r -
+}
+
+list_datasets()
+{
+    if [ "$zfskeys_args" ]; then
+        echo "$zfskeys_args" | b64decode -r |
+            xargs -0 zfs get -H -s local -o value,name keylocation
+    elif [ ! "$zfskeys_datasets" ]; then
+        zfs get -H -t filesystem,volume -s local -o value,name keylocation
+    else
+        echo "$zfskeys_datasets" | xargs -n 1 zfs get -H -s local \
+            -o value,name keylocation
+    fi
+}
+
+unlock_fs()
+{
+    local fs="$1"
+    local kl="$2"
+    local k="${kl##file://}"
+
+    if [ "$k" ] && [ -f "$k" ] && [ -s "$k" ] && [ -r "$k" ]; then
+        if [ "$(zfs get -Ho value keystatus "$fs")" = 'available' ]; then
+            echo "Key already loaded for $fs."
+        elif keytest=$(zfs load-key -n -L "$kl" "$fs" 2>&1); then
+            echo "Loading key for $fs from $kl.."
+            if ! keyload=$(timeout $zfskeys_timeout zfs load-key -L "$kl" "$fs" 2>&1) ; then
+                if [ $? -eq 124 ]; then
+                    echo "Timed out loading key from $kl for $fs"
+                else
+                    echo "Failed to load key from $kl for $fs:"
+                    echo "$keyload"
+                fi
+            fi
+        else
+            echo "Could not verify key from $kl for $fs:"
+            echo "$keytest"
+        fi
+    else
+        echo "Key file $k not found, empty or unreadable. Skipping $fs.."
+    fi
+}
+
+lock_fs()
+{
+    local fs=$1
+
+    if [ "$(zfs get -Ho value mounted "$fs")" = 'yes' ]; then
+        if checkyesno zfskeys_unload_force ; then
+            zfs unmount -f "$fs" && echo "Forcibly unmounted $fs."
+        else
+            zfs unmount "$fs" && echo "Unmounted $fs."
+        fi
+    fi
+    if [ "$?" -ne 0 ]; then
+        echo "Unmount failed for $fs"
+    elif [ "$(zfs get -Ho value keystatus "$fs")" = 'available' ]; then
+        zfs unload-key "$fs" && echo "Unloaded key for $fs."
+    else
+        echo "No key loaded for $fs."
+    fi
+}
+
+status_zfs_keys()
+{
+    local IFS=$(printf "\t")
+
+    list_datasets | while read kl fs ; do
+        echo "$fs: $(zfs get -Ho value keystatus "$fs")"
+    done
+}
+
+load_zfs_keys()
+{
+    local IFS=$(printf "\t")
+
+    list_datasets | while read kl fs ; do
+        unlock_fs "$fs" "$kl"
+    done
+}
+
+unload_zfs_keys()
+{
+    local IFS=$(printf "\t")
+
+    list_datasets | while read kl fs ; do
+        lock_fs "$fs"
+    done
+}
+
+zfskeys_args=$(encode_args "$@")
+load_rc_config $name
+run_rc_command "$1"


### PR DESCRIPTION
Note: The below is mostly CCed from the FreeBSD commit at [cgit.freebsd.org](https://cgit.freebsd.org/src/commit/?id=33ff39796ffe469a764e485ac49c31700a51fd6f)

### Motivation and Context
ZFS in FreeBSD 13 supports encryption, but for the use case where keys are available in plaintext on disk there is no mechanism for automatically loading keys on startup.

### Description
This script will, by default, look for any dataset with encryption and keylocation prefixed with file://. It will attempt to unlock, timing
out after 10 seconds for each dataset found. User can optionally specify explicitly which datasets to attempt to unlock.

Also supports (optionally by force) unmounting filesystems and unloading associated keys.

### How Has This Been Tested?
This has been tested in various in-house environments, preproduction and production, with a mix of non-encrypted, plaintext-key-on-disk-encrypted and offline-key-encrypted datasets. Has also been tested in combination with GELI-encrypted pools, making sure the startup sequence is correct.

Script itself has been subjected to shellcheck, and is already accepted upstream in FreeBSD.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
- [x] Platform-specific supporting scripts

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
