### PR TITLE
ZTS: Avoid unset $tmpdir in redacted_panic

### DIFF
--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_panic.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_panic.ksh
@@ -28,9 +28,15 @@ typeset ds_name="panic"
 typeset sendfs="$POOL/$ds_name"
 typeset recvfs="$POOL2/$ds_name"
 typeset clone="$POOL/${ds_name}_clone"
-typeset stream=$(mktemp $tmpdir/stream.XXXX)
+typeset stream=$(mktemp $TEST_BASE_DIR/stream.XXXX)
 
-log_onexit redacted_cleanup $sendfs $recvfs
+function cleanup
+{
+	redacted_cleanup $sendfs $recvfs
+	rm -f $stream
+}
+
+log_onexit cleanup
 
 log_must zfs create -o recsize=8k $sendfs
 log_must dd if=/dev/urandom of=/$sendfs/file bs=1024k count=2048


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The redacted_send tests make use of a $tmpdir variable, except in
redacted_send/redacted_panic the variable is never defined.

### Description
<!--- Describe your changes in detail -->
Use $TEST_BASE_DIR instead of $tmpdir.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
