### PR TITLE
Add hole punching support on FreeBSD version 1400032

### DIFF
--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -5222,6 +5222,11 @@ zfs_freebsd_pathconf(struct vop_pathconf_args *ap)
 	case _PC_NAME_MAX:
 		*ap->a_retval = NAME_MAX;
 		return (0);
+#if __FreeBSD_version >= 1400032
+	case _PC_DEALLOC_PRESENT:
+		*ap->a_retval = 1;
+		return (0);
+#endif
 	case _PC_PIPE_BUF:
 		if (ap->a_vp->v_type == VDIR || ap->a_vp->v_type == VFIFO) {
 			*ap->a_retval = PIPE_BUF;
@@ -6057,6 +6062,55 @@ zfs_vptocnp(struct vop_vptocnp_args *ap)
 	return (error);
 }
 
+#if __FreeBSD_version >= 1400032
+static int
+zfs_deallocate(struct vop_deallocate_args *ap)
+{
+	znode_t *zp = VTOZ(ap->a_vp);
+	zfsvfs_t *zfsvfs = zp->z_zfsvfs;
+	zilog_t *zilog;
+	off_t off, len, file_sz;
+	int error;
+
+	ZFS_ENTER(zfsvfs);
+	ZFS_VERIFY_ZP(zp);
+
+	/*
+	 * Callers might not be able to detect properly that we are read-only,
+	 * so check it explicitly here.
+	 */
+	if (zfs_is_readonly(zfsvfs)) {
+		ZFS_EXIT(zfsvfs);
+		return (SET_ERROR(EROFS));
+	}
+
+	zilog = zfsvfs->z_log;
+	off = *ap->a_offset;
+	len = *ap->a_len;
+	file_sz = zp->z_size;
+	if (off + len > file_sz)
+		len = file_sz - off;
+	/* Fast path for out-of-range request. */
+	if (len <= 0) {
+		*ap->a_len = 0;
+		ZFS_EXIT(zfsvfs);
+		return (0);
+	}
+
+	error = zfs_freesp(zp, off, len, O_RDWR, TRUE);
+	if (error == 0) {
+		if (zfsvfs->z_os->os_sync == ZFS_SYNC_ALWAYS ||
+		    (ap->a_ioflag & IO_SYNC) != 0)
+			zil_commit(zilog, zp->z_id);
+		*ap->a_offset = off + len;
+		*ap->a_len = 0;
+	}
+
+	ZFS_EXIT(zfsvfs);
+	return (error);
+}
+#endif
+
 struct vop_vector zfs_vnodeops;
 struct vop_vector zfs_fifoops;
 struct vop_vector zfs_shareops;
@@ -6076,6 +6130,9 @@ struct vop_vector zfs_vnodeops = {
 #endif
 	.vop_access =		zfs_freebsd_access,
 	.vop_allocate =		VOP_EINVAL,
+#if __FreeBSD_version >= 1400032
+	.vop_deallocate =	zfs_deallocate,
+#endif
 	.vop_lookup =		zfs_cache_lookup,
 	.vop_cachedlookup =	zfs_freebsd_cachedlookup,
 	.vop_getattr =		zfs_freebsd_getattr,

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -603,6 +603,10 @@ tags = ['functional', 'delegate']
 tests = ['exec_001_pos', 'exec_002_neg']
 tags = ['functional', 'exec']
 
+[tests/functional/fallocate]
+tests = ['fallocate_punch-hole']
+tags = ['functional', 'fallocate']
+
 [tests/functional/features/async_destroy]
 tests = ['async_destroy_001_pos']
 tags = ['functional', 'features', 'async_destroy']

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -94,7 +94,7 @@ tests = ['events_001_pos', 'events_002_pos', 'zed_rc_filter', 'zed_fd_spill']
 tags = ['functional', 'events']
 
 [tests/functional/fallocate:Linux]
-tests = ['fallocate_prealloc', 'fallocate_punch-hole']
+tests = ['fallocate_prealloc']
 tags = ['functional', 'fallocate']
 
 [tests/functional/fault:Linux]

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -127,6 +127,13 @@ fio_reason = 'Fio v2.3 or newer required'
 trim_reason = 'DISKS must support discard (TRIM/UNMAP)'
 
 #
+# Some tests on FreeBSD require the fspacectl(2) system call and the
+# truncate(1) utility supporting the -d option.  The system call was first
+# introduced in FreeBSD version 1400032.
+#
+fspacectl_reason = 'fspacectl(2) and truncate -d support required'
+
+#
 # Some tests are not applicable to a platform or need to be updated to operate
 # in the manor required by the platform.  Any tests which are skipped for this
 # reason will be suppressed in the final analysis output.
@@ -224,6 +231,7 @@ maybe = {
     'cli_root/zpool_trim/setup': ['SKIP', trim_reason],
     'cli_root/zpool_upgrade/zpool_upgrade_004_pos': ['FAIL', '6141'],
     'delegate/setup': ['SKIP', exec_reason],
+    'fallocate/fallocate_punch-hole': ['SKIP', fspacectl_reason],
     'history/history_004_pos': ['FAIL', '7026'],
     'history/history_005_neg': ['FAIL', '6680'],
     'history/history_006_neg': ['FAIL', '5657'],

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -27,6 +27,7 @@
 # Copyright (c) 2017, Lawrence Livermore National Security LLC.
 # Copyright (c) 2017, Datto Inc. All rights reserved.
 # Copyright (c) 2017, Open-E Inc. All rights reserved.
+# Copyright (c) 2021, The FreeBSD Foundation.
 # Use is subject to license terms.
 #
 
@@ -4187,6 +4188,25 @@ function get_arcstat # stat
 		;;
 	Linux)
 		kstat arcstats | awk "/$stat/ { print \$3 }"
+		;;
+	*)
+		false
+		;;
+	esac
+}
+
+function punch_hole # offset length file
+{
+	typeset offset=$1
+	typeset length=$2
+	typeset file=$3
+
+	case $(uname) in
+	FreeBSD)
+		truncate -d -o $offset -l $length "$file"
+		;;
+	Linux)
+		fallocate --punch-hole --offset $offset --length $length "$file"
 		;;
 	*)
 		false

--- a/tests/zfs-tests/tests/functional/fallocate/fallocate_punch-hole.ksh
+++ b/tests/zfs-tests/tests/functional/fallocate/fallocate_punch-hole.ksh
@@ -22,13 +22,14 @@
 
 #
 # Copyright (c) 2020 by Lawrence Livermore National Security, LLC.
+# Copyright (c) 2021 by The FreeBSD Foundation.
 #
 
 . $STF_SUITE/include/libtest.shlib
 
 #
 # DESCRIPTION:
-# Test `fallocate --punch-hole`
+# Test hole-punching functionality
 #
 # STRATEGY:
 # 1. Create a dense file
@@ -36,6 +37,20 @@
 #
 
 verify_runnable "global"
+
+#
+# Prior to __FreeBSD_version 1400032 there are no mechanism to punch hole in a
+# file on FreeBSD.  truncate -d support is required to call fspacectl(2) on
+# behalf of the script.
+#
+if is_freebsd; then
+	if [[ $(uname -K) -lt 1400032 ]]; then
+		log_unsupported "Requires fspacectl(2) support on FreeBSD"
+	fi
+	if truncate -d 2>&1 | grep "illegal option" > /dev/null; then
+		log_unsupported "Requires truncate(1) -d support on FreeBSD"
+	fi
+fi
 
 FILE=$TESTDIR/$TESTFILE0
 BLKSZ=$(get_prop recordsize $TESTPOOL)
@@ -74,23 +89,21 @@ log_must file_write -o create -f $FILE -b $BLKSZ -c 8
 log_must check_disk_size  $((131072 * 8))
 
 # Punch a hole for the first full block.
-log_must fallocate --punch-hole --offset 0 --length $BLKSZ $FILE
+log_must punch_hole 0 $BLKSZ $FILE
 log_must check_disk_size  $((131072 * 7))
 
 # Partially punch a hole in the second block.
-log_must fallocate --punch-hole --offset $BLKSZ --length $((BLKSZ / 2)) $FILE
+log_must punch_hole $BLKSZ $((BLKSZ / 2)) $FILE
 log_must check_disk_size  $((131072 * 7))
 
 # Punch a hole which overlaps the third and forth block.
-log_must fallocate --punch-hole --offset $(((BLKSZ * 2) + (BLKSZ / 2))) \
-    --length $((BLKSZ)) $FILE
+log_must punch_hole $(((BLKSZ * 2) + (BLKSZ / 2))) $((BLKSZ)) $FILE
 log_must check_disk_size  $((131072 * 7))
 
 # Punch a hole from the fifth block past the end of file.  The apparent
 # file size should not change since --keep-size is implied.
 apparent_size=$(stat_size $FILE)
-log_must fallocate --punch-hole --offset $((BLKSZ * 4)) \
-    --length $((BLKSZ * 10)) $FILE
+log_must punch_hole $((BLKSZ * 4)) $((BLKSZ * 10)) $FILE
 log_must check_disk_size  $((131072 * 4))
 log_must check_apparent_size $apparent_size
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change introduces support for hole-punching facilities starting from __FreeBSD_version 1400032.

FreeBSD version 1400029 introduces hole-punching support. This comprises of a userland fspacectl(2) system call and the vn_deallocate(9) public KPI. The support was introduced at [https://cgit.freebsd.org/src/diff/share/man/man9/VOP_DEALLOCATE.9?id=0dc332bff200c940edc36c4715b629a2e1e9f9ae](https://cgit.freebsd.org/src/diff/share/man/man9/VOP_DEALLOCATE.9?id=0dc332bff200c940edc36c4715b629a2e1e9f9ae).
FreeBSD version 1400030 introduces O_*SYNC support. In case `ap->a_ioflag` includes IO_SYNC we do a zil_commit with respect to the given znode.  
The new semantic in 1400032 updates rmsr.r_offset to be rqsr.r_offset + number of bytes zeroed before EOF.

### Description
<!--- Describe your changes in detail -->
This revision comprises of a FreeBSD-specific implementation for vop_deallocate.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Run the setup on FreeBSD-current, and run all the test cases listed in `/usr/tests/sys/file/fspacectl_test -l` after changing working directory to a zfs mount. zts's fallocate-punch_hole has also been updated to include support for `truncate -d` on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
