### PR TITLE
zpool-remove.8: describe top-level vdev sector size limitation

### DIFF
--- a/man/man8/zpool-remove.8
+++ b/man/man8/zpool-remove.8
@@ -52,10 +52,10 @@
 Removes the specified device from the pool.
 This command supports removing hot spare, cache, log, and both mirrored and
 non-redundant primary top-level vdevs, including dedup and special vdevs.
-When the primary pool storage includes a top-level raidz vdev only hot spare,
-cache, and log devices can be removed.
-Note that keys for all encrypted datasets must be loaded for top-level vdevs
-to be removed.
+.Pp
+Top-level vdevs can only be removed if the primary pool storage does not contain
+a top-level raidz vdev, all top-level vdevs have the same sector size, and the
+keys for all encrypted datasets are loaded.
 .Pp
 Removing a top-level vdev reduces the total amount of space in the storage pool.
 The specified device will be evacuated by copying all allocated space from it to


### PR DESCRIPTION
Document that top-level vdevs cannot be removed unless all top-level vdevs have the same sector size.

Signed-off-by: Sam Hathaway <sam@sam-hathaway.com>
Closes: openzfs#11339

### Motivation and Context

It is currently undocumented that top-level vdevs cannot be removed unless all top-level vdevs have the same sector size. This patch adds this fact to zpool-remove.8.

### Description

This patch adds text to zpool-remove.8 to explain that top-level vdevs cannot be removed unless all top-level vdevs have the same sector size.

### How Has This Been Tested?

I compiled the manpage to ensure that I hadn't broken anything.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
