### PR TITLE
Add zpool labelclear --unsafe option

### DIFF
--- a/man/man8/zpool-labelclear.8
+++ b/man/man8/zpool-labelclear.8
@@ -36,7 +36,7 @@
 .Sh SYNOPSIS
 .Nm zpool
 .Cm labelclear
-.Op Fl f
+.Op Fl f Op Fl -unsafe
 .Ar device
 .
 .Sh DESCRIPTION
@@ -51,6 +51,8 @@ must not be part of an active pool configuration.
 .Bl -tag -width Ds
 .It Fl f
 Treat exported or foreign devices as inactive.
+.It Fl -unsafe
+Perform no checks and clear the label unconditionally.
 .El
 .
 .Sh SEE ALSO


### PR DESCRIPTION
### Motivation and Context
Provide a way to delete a vdev label on an active pool.  There have been cases where this would have been useful during envelopment.  It could also be useful in cases where a disk is mistakenly replaced with a disk from the same pool, but you don't want to export the pool.  In that case you could do `zpool offline -f <pool> <disk> && zpool labelclear -f --unsafe <disk> && zpool replace <pool> <disk>` to get things going again.

### Description
Add an `--unsafe` option to `zpool labelclear` to preform no safety checks and unconditionally clear a label.  Note, `--unsafe` only modifies `-f`, so you must pass both flags to get the unsafe behavior (`zpool labelclear -f --unsafe <vdev>`).  This forces you to pass two flags before shooting yourself in the foot.

### How Has This Been Tested?
Force faulted a disk with `zpool offline -f`.  Ran `zpool labelclear <disk>` and `zpool labelclear -f <disk>` on an active pool and verified they correctly did not complete the operation.  Then ran `zpool labelclear -f --unsafe` and saw it complete.  Cleared the force fault with `zpool clear` and saw the vdev correctly report "invalid label".

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
