### PR TITLE
ZTS: Waiting for zvols to be available

### DIFF
--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -93,7 +93,7 @@ function block_device_wait
 		typeset missing=false
 		typeset dev
 		for dev in "${@}"; do
-			if ! [[ -f $dev ]]; then
+			if ! [[ -e $dev ]]; then
 				missing=true
 				break
 			fi

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies.kshlib
@@ -87,7 +87,7 @@ function do_vol_test
 
 	log_must zfs create -V $VOLSIZE -o copies=$copies $vol
 	log_must zfs set refreservation=none $vol
-	block_device_wait
+	block_device_wait $vol_r_path
 
 	case "$type" in
 	"ext2")

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_007_pos.ksh
@@ -117,26 +117,26 @@ log_must diff $SRC_FILE $obj
 if is_global_zone; then
 	vol=$TESTPOOL/$TESTFS/vol.$$ ;	volclone=$TESTPOOL/$TESTFS/volclone.$$
 	log_must zfs create -V 100M $vol
-	block_device_wait
 
 	obj=$(target_obj $vol)
+	block_device_wait $obj
 	log_must dd if=$SRC_FILE of=$obj bs=$BS count=$CNT
 
 	snap=${vol}@snap.$$
 	log_must zfs snapshot $snap
 	log_must zfs clone $snap $volclone
-	block_device_wait
 
 	# Rename dataset & clone
 	log_must zfs rename $vol ${vol}-new
 	log_must zfs rename $volclone ${volclone}-new
-	block_device_wait
 
 	# Compare source file and target file
 	obj=$(target_obj ${vol}-new)
+	block_device_wait $obj
 	log_must dd if=$obj of=$DST_FILE bs=$BS count=$CNT
 	log_must diff $SRC_FILE $DST_FILE
 	obj=$(target_obj ${volclone}-new)
+	block_device_wait $obj
 	log_must dd if=$obj of=$DST_FILE bs=$BS count=$CNT
 	log_must diff $SRC_FILE $DST_FILE
 
@@ -144,10 +144,10 @@ if is_global_zone; then
 	log_must zfs rename ${vol}-new $vol
 	log_must zfs rename $snap ${snap}-new
 	log_must zfs clone ${snap}-new $volclone
-	block_device_wait
 
 	# Compare source file and target file
 	obj=$(target_obj $volclone)
+	block_device_wait $obj
 	log_must dd if=$obj of=$DST_FILE bs=$BS count=$CNT
 	log_must diff $SRC_FILE $DST_FILE
 fi

--- a/tests/zfs-tests/tests/functional/rsend/recv_dedup_encrypted_zvol.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/recv_dedup_encrypted_zvol.ksh
@@ -52,7 +52,7 @@ log_must eval "bzcat <$sendfile_compressed >$sendfile"
 log_must eval "zstream redup $sendfile | zfs recv $TESTPOOL/recv"
 
 log_must zfs load-key $TESTPOOL/recv
-block_device_wait
+block_device_wait $volfile
 
 log_must eval "bzcat <$volfile_compressed >$volfile"
 log_must diff $volfile $recvdev

--- a/tests/zfs-tests/tests/functional/rsend/send-c_stream_size_estimate.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_stream_size_estimate.ksh
@@ -65,7 +65,7 @@ for compress in "${compress_prop_vals[@]}"; do
 	datasetexists $send_vol && log_must_busy zfs destroy -r $send_vol
 	log_must zfs create -o compress=$compress $send_ds
 	log_must zfs create -V 1g -o compress=$compress $send_vol
-	block_device_wait
+	block_device_wait $send_voldev
 
 	typeset dir=$(get_prop mountpoint $send_ds)
 	log_must cp $file $dir

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_004_pos.ksh
@@ -62,7 +62,7 @@ for vbs in 8192 16384 32768 65536 131072; do
 
 		# Create a sparse volume to test larger sizes
 		log_must zfs create -s -b $vbs -V $volsize $vol
-		block_device_wait
+		block_device_wait $swapname
 		log_must swap_setup $swapname
 
 		new_volsize=$(get_prop volsize $vol)


### PR DESCRIPTION
### Motivation and Context

The Fedora CI builder appears to almost always hit at least one false
positive when running the ZTS because a test didn't wait long enough
for a zvol to be available.  Try and make this less likely so the Fedora
builder doesn't always fail the CI.

### Description

The ZTS `block_device_wait` helper function should use `-e` when waiting
for a file to appear since it will be either a block special device
or a symlink.  This didn't cause any failures but when a device path
was specified the function would wait longer than needed.

Additionally update the most flaky test cases to pass the file path
to `block_device_wait` to try and improve the test reliability.  The
udev behavior on Fedora in particular can result in frequent false
positives.

### How Has This Been Tested?

Locally by running the failing tests in a loop on Fedora 34.  This
change does improve their reliability, however at least one other
scenario was observed where for some reason udev on Fedora
would fail entirely to create the needed links.  That issue is not
understood or addressed here.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
