### PR TITLE
ZTS: Explicitly wait for some zvols

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies.kshlib
@@ -87,7 +87,7 @@ function do_vol_test
 
 	log_must zfs create -V $VOLSIZE -o copies=$copies $vol
 	log_must zfs set refreservation=none $vol
-	block_device_wait
+	block_device_wait $vol_b_path
 
 	case "$type" in
 	"ext2")

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_007_pos.ksh
@@ -117,7 +117,7 @@ log_must diff $SRC_FILE $obj
 if is_global_zone; then
 	vol=$TESTPOOL/$TESTFS/vol.$$ ;	volclone=$TESTPOOL/$TESTFS/volclone.$$
 	log_must zfs create -V 100M $vol
-	block_device_wait
+	block_device_wait $DEV_DSKDIR/$vol
 
 	obj=$(target_obj $vol)
 	log_must dd if=$SRC_FILE of=$obj bs=$BS count=$CNT
@@ -125,12 +125,12 @@ if is_global_zone; then
 	snap=${vol}@snap.$$
 	log_must zfs snapshot $snap
 	log_must zfs clone $snap $volclone
-	block_device_wait
+	block_device_wait $DEV_DSKDIR/$volclone
 
 	# Rename dataset & clone
 	log_must zfs rename $vol ${vol}-new
 	log_must zfs rename $volclone ${volclone}-new
-	block_device_wait
+	block_device_wait $DEV_DSKDIR/${volclone}-new
 
 	# Compare source file and target file
 	obj=$(target_obj ${vol}-new)
@@ -144,7 +144,7 @@ if is_global_zone; then
 	log_must zfs rename ${vol}-new $vol
 	log_must zfs rename $snap ${snap}-new
 	log_must zfs clone ${snap}-new $volclone
-	block_device_wait
+	block_device_wait $DEV_DSKDIR/$volclone
 
 	# Compare source file and target file
 	obj=$(target_obj $volclone)

--- a/tests/zfs-tests/tests/functional/rsend/recv_dedup_encrypted_zvol.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/recv_dedup_encrypted_zvol.ksh
@@ -52,7 +52,7 @@ log_must eval "bzcat <$sendfile_compressed >$sendfile"
 log_must eval "zstream redup $sendfile | zfs recv $TESTPOOL/recv"
 
 log_must zfs load-key $TESTPOOL/recv
-block_device_wait
+block_device_wait $recvdev
 
 log_must eval "bzcat <$volfile_compressed >$volfile"
 log_must diff $volfile $recvdev

--- a/tests/zfs-tests/tests/functional/rsend/send-c_stream_size_estimate.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_stream_size_estimate.ksh
@@ -65,7 +65,7 @@ for compress in "${compress_prop_vals[@]}"; do
 	datasetexists $send_vol && log_must_busy zfs destroy -r $send_vol
 	log_must zfs create -o compress=$compress $send_ds
 	log_must zfs create -V 1g -o compress=$compress $send_vol
-	block_device_wait
+	block_device_wait $DEV_DSKDIR/$send_vol
 
 	typeset dir=$(get_prop mountpoint $send_ds)
 	log_must cp $file $dir

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_volmode.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_volmode.ksh
@@ -107,6 +107,7 @@ log_must zfs create -o mountpoint=none $VOLFS
 log_must zfs create -V $VOLSIZE -s $SUBZVOL
 log_must zfs create -V $VOLSIZE -s $ZVOL
 udev_wait
+block_device_wait $ZDEV $SUBZDEV
 test_io $ZDEV
 test_io $SUBZDEV
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_004_pos.ksh
@@ -62,7 +62,7 @@ for vbs in 8192 16384 32768 65536 131072; do
 
 		# Create a sparse volume to test larger sizes
 		log_must zfs create -s -b $vbs -V $volsize $vol
-		block_device_wait
+		block_device_wait $swapname
 		log_must swap_setup $swapname
 
 		new_volsize=$(get_prop volsize $vol)


### PR DESCRIPTION
### Motivation and Context
My test results in #12516 made me notice that some tests were failing rather often.

### Description
It seems like udevadm settle is returning before the zvol devices populate, at least on the RH platforms. (I'll look at the FBSD ones once my testbed updates...)

So this mostly just turns the existing block_device_wait calls into block_device_wait [the zvol we're waiting on]. (It also adds one block_device_wait after a udev_wait.)

### How Has This Been Tested?
I stopped being able to reproduce 5 of the 6 tests that kept failing on Fedora/CentOS. (I could never reproduce the sixth one in the first place.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
