### PR TITLE
use correct libcurl.4.dylib name for macOS

### DIFF
--- a/config/user-libfetch.m4
+++ b/config/user-libfetch.m4
@@ -45,8 +45,13 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBFETCH], [
 			LIBFETCH_IS_LIBCURL=1
 			if test "$(curl-config --built-shared)" = "yes"; then
 				LIBFETCH_DYNAMIC=1
-				LIBFETCH_SONAME='"libcurl.so.4"'
-				LIBFETCH_LIBS="-ldl"
+				AM_COND_IF([BUILD_MACOS], [
+					LIBFETCH_SONAME='"libcurl.4.dylib"'
+					LIBFETCH_LIBS=""
+				], [
+					LIBFETCH_SONAME='"libcurl.so.4"'
+					LIBFETCH_LIBS="-ldl"
+				])
 				AC_MSG_RESULT([libcurl])
 			else
 				LIBFETCH_LIBS="$(curl-config --libs)"


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

Use the .dylib extension on macOS.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Linux uses libcurl.so.4, and macOS libcurl.4.dylib. 
Possibly there is a better way to handle this rather
than a static string based on platform. Searching for
library name? env var for platform library extension?

### Description
<!--- Describe your changes in detail -->

This is the first autoconf change for macOS, it is a change to common files
(as opposed to future macOS-only files) in a "test the water" sort of way,
and to discuss better solutions for autoconf work.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
