### PR TITLE
Document additional -c caveat.

### DIFF
--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -198,6 +198,9 @@ will not have their data recompressed on the receiver side using
 .Fl o Sy compress Ns = Ar value .
 The data will stay compressed as it was from the sender.
 The new compression property will be set for future data.
+Note that uncompressed data from the sender will still attempt to
+compress on the receiver, unless you specify
+.Fl o Sy compress Ns = Em off .
 .It Fl w , -raw
 For encrypted datasets, send data exactly as it exists on disk.
 This allows backups to be taken even if encryption keys are not currently loaded.


### PR DESCRIPTION
### Motivation and Context
I personally found it very surprising when I used `zfs send -c` on a dataset containing some incompressible data and some quite compressible data, with `compress=zstd-3`, and found my poor Raspberry Pi bottlenecking badly on trying to compress all those uncompressed records on the receiver.

I also never would have guessed that `-o compress` might affect the behavior on uncompressed data but not compressed data received had @pcd1193182 not suggested it. So I documented it.

### Description
Not very complicated. Just notes that `recv -o compress` affects approximately the logical opposite of what I would want it to if you use `send -c` (that is, it controls behavior of uncompressed, and thus often incompressible, data received, but not compressed, and therefore compressible, data).

(Future plans include a flag to change this. But that's likely to be more controversial than just documentation.)

### How Has This Been Tested?
I ran a whole mancheck.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
