### PR TITLE
[2.1] FreeBSD: fix compilation of FreeBSD world after 29274c9f6

### DIFF
--- a/include/os/freebsd/spl/sys/random.h
+++ b/include/os/freebsd/spl/sys/random.h
@@ -51,7 +51,7 @@ random_get_pseudo_bytes(uint8_t *p, size_t s)
 static inline uint32_t
 random_in_range(uint32_t range)
 {
-#if  __FreeBSD_version >= 1300108
+#if defined(_KERNEL) && __FreeBSD_version >= 1300108
 	return (prng32_bounded(range));
 #else
 	uint32_t r;
@@ -61,7 +61,7 @@ random_in_range(uint32_t range)
 	if (range == 1)
 		return (0);
 
-	(void) random_get_pseudo_bytes((void *)&r, sizeof (r));
+	(void) random_get_pseudo_bytes((uint8_t *)&r, sizeof (r));
 
 	return (r % range);
 #endif

--- a/include/os/linux/spl/sys/random.h
+++ b/include/os/linux/spl/sys/random.h
@@ -46,7 +46,7 @@ random_in_range(uint32_t range)
 	if (range == 1)
 		return (0);
 
-	(void) random_get_pseudo_bytes((void *)&r, sizeof (r));
+	(void) random_get_pseudo_bytes((uint8_t *)&r, sizeof (r));
 
 	return (r % range);
 }

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -650,7 +650,7 @@ random_in_range(uint32_t range)
 	if (range == 1)
 		return (0);
 
-	(void) random_get_pseudo_bytes((void *)&r, sizeof (r));
+	(void) random_get_pseudo_bytes((uint8_t *)&r, sizeof (r));
 
 	return (r % range);
 }


### PR DESCRIPTION
prng32_bounded() is available to kernel only on FreeBSD 13+.

Call inline random_get_pseudo_bytes() with correct pointer type.
To be consistent, apply to Linux as well.

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed-by: Alexander Motin <mav@FreeBSD.org>
Signed-off-by: Martin Matuska <mm@FreeBSD.org>
Closes #12282

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Cherry-pick of 14d2841b5318f92bc443d24ed65f29ccc4b9f2bd required for OpenZFS 2.1.1 in FreeBSD 13

### Description

### How Has This Been Tested?
Import of OpenZFS 2.1.1 into FreeBSD 13

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).