### PR TITLE
zfsprops.7: Add note about comma-separation

### DIFF
--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1643,7 +1643,7 @@ the dataset is shared using the default options:
 Please note that the options are comma-separated, unlike those found in
 .Xr exports 5 .
 This is done to negate the need for quoting, as well as to make parsing
-with with scripts easier.
+with scripts easier.
 .Pp
 See
 .Xr exports 5

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1640,6 +1640,11 @@ If the property is set to
 the dataset is shared using the default options:
 .Dl sec=sys,rw,crossmnt,no_subtree_check
 .Pp
+Please note that the options are comma-separated, unlike those found in
+.Xr exports 5 .
+This is done to negate the need for quoting, as well as to make parsing
+with with scripts easier.
+.Pp
 See
 .Xr exports 5
 for the meaning of the default options.


### PR DESCRIPTION
This change primarily seeks to make implicit documentation explicit, as
it is not outright stated that options should be comma-separated, nor is
there a reason given for it.

### Motivation and Context
Having implicit documentation can lead to important details being lost,
and makes it harder to point to anything specific.

### Description
An extra paragraph has been added to make it clear that the options are
comma-separated, and that this is different from what's expected in
exports(5). Additionally, the reason for the choice is expanded upon,
and although I wasn't able to find a commit to back this up, I think it
might be nice to have something to refer to in the commit message.

### How Has This Been Tested?
It has been tested using mandoc on FreeBSD 13, rendered to both less(1)
and as a HTML using -Thtml

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style
requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing**
document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain
[`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
