### PR TITLE
ZFS: Remove a redundant if condition

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -968,9 +968,7 @@ dmu_free_long_object(objset_t *os, uint64_t object)
 	dmu_tx_mark_netfree(tx);
 	err = dmu_tx_assign(tx, TXG_WAIT);
 	if (err == 0) {
-		if (err == 0)
-			err = dmu_object_free(os, object, tx);
-
+		err = dmu_object_free(os, object, tx);
 		dmu_tx_commit(tx);
 	} else {
 		dmu_tx_abort(tx);


### PR DESCRIPTION

### Motivation and Context

Just a tiny code cleanup, I stumbled across this while reading the code.

### Description

Commit 0c03d21ac99ebdbe left in a redundant if condition while removing some code. It's quite obvious if you look at the [diff](https://github.com/openzfs/zfs/commit/0c03d21ac99ebdbefe65c319fc3712928c40af78#diff-ca90fbcec3d06757e86842bcb516688997f5203c3501fc40845bb7ae8f74468dL940-L944).

### How Has This Been Tested?

Visual inspection, relying on CI testing.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
