### PR TITLE
Correct a flaw in the Python 3 version checking (for 2.0)

### DIFF
--- a/.github/workflows/zfs-tests-functional.yml
+++ b/.github/workflows/zfs-tests-functional.yml
@@ -26,7 +26,7 @@ jobs:
           xfslibs-dev libattr1-dev libacl1-dev libudev-dev libdevmapper-dev \
           libssl-dev libffi-dev libaio-dev libelf-dev libmount-dev \
           libpam0g-dev pamtester python-dev python-setuptools python-cffi \
-          python3 python3-dev python3-setuptools python3-cffi
+          python3 python3-dev python3-setuptools python3-cffi python3-packaging
     - name: Autogen.sh
       run: |
         sh autogen.sh

--- a/.github/workflows/zfs-tests-sanity.yml
+++ b/.github/workflows/zfs-tests-sanity.yml
@@ -22,7 +22,7 @@ jobs:
           xfslibs-dev libattr1-dev libacl1-dev libudev-dev libdevmapper-dev \
           libssl-dev libffi-dev libaio-dev libelf-dev libmount-dev \
           libpam0g-dev pamtester python-dev python-setuptools python-cffi \
-          python3 python3-dev python3-setuptools python3-cffi
+          python3 python3-dev python3-setuptools python3-cffi python3-packaging
     - name: Autogen.sh
       run: |
         sh autogen.sh

--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -22,8 +22,8 @@ jobs:
           xfslibs-dev libattr1-dev libacl1-dev libudev-dev libdevmapper-dev \
           libssl-dev libffi-dev libaio-dev libelf-dev libmount-dev \
           libpam0g-dev \
-          python-dev python-setuptools python-cffi \
-          python3 python3-dev python3-setuptools python3-cffi
+          python-dev python-setuptools python-cffi python-packaging \
+          python3 python3-dev python3-setuptools python3-cffi python3-packaging
     - name: Autogen.sh
       run: |
         sh autogen.sh

--- a/config/always-pyzfs.m4
+++ b/config/always-pyzfs.m4
@@ -47,6 +47,21 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 	AC_SUBST(DEFINE_PYZFS)
 
 	dnl #
+	dnl # Python "packaging" (or, failing that, "distlib") module is required to build and install pyzfs
+	dnl #
+	AS_IF([test "x$enable_pyzfs" = xcheck -o "x$enable_pyzfs" = xyes], [
+		ZFS_AC_PYTHON_MODULE([packaging], [], [
+			ZFS_AC_PYTHON_MODULE([distlib], [], [
+				AS_IF([test "x$enable_pyzfs" = xyes], [
+					AC_MSG_ERROR("Python $PYTHON_VERSION packaging and distlib modules are not installed")
+				], [test "x$enable_pyzfs" != xno], [
+					enable_pyzfs=no
+				])
+			])
+		])
+	])
+
+	dnl #
 	dnl # Require python-devel libraries
 	dnl #
 	AS_IF([test "x$enable_pyzfs" = xcheck  -o "x$enable_pyzfs" = xyes], [

--- a/config/ax_python_devel.m4
+++ b/config/ax_python_devel.m4
@@ -97,9 +97,18 @@ AC_DEFUN([AX_PYTHON_DEVEL],[
 	# Check for a version of Python >= 2.1.0
 	#
 	AC_MSG_CHECKING([for a version of Python >= '2.1.0'])
-	ac_supports_python_ver=`$PYTHON -c "import sys; \
-		ver = sys.version.split ()[[0]]; \
-		print (ver >= '2.1.0')"`
+	ac_supports_python_ver=`cat<<EOD | $PYTHON -
+from __future__ import print_function;
+import sys;
+try:
+	from packaging import version;
+except ImportError:
+	from distlib import version;
+ver = sys.version.split ()[[0]];
+(tst_cmp, tst_ver) = ">= '2.1.0'".split ();
+tst_ver = tst_ver.strip ("'");
+eval ("print (version.LegacyVersion (ver)"+ tst_cmp +"version.LegacyVersion (tst_ver))")
+EOD`
 	if test "$ac_supports_python_ver" != "True"; then
 		if test -z "$PYTHON_NOVERSIONCHECK"; then
 			AC_MSG_RESULT([no])
@@ -126,9 +135,21 @@ to something else than an empty string.
 	#
 	if test -n "$1"; then
 		AC_MSG_CHECKING([for a version of Python $1])
-		ac_supports_python_ver=`$PYTHON -c "import sys; \
-			ver = sys.version.split ()[[0]]; \
-			print (ver $1)"`
+		# Why the strip ()?  Because if we don't, version.parse
+		# will, for example, report 3.10.0 >= '3.11.0'
+		ac_supports_python_ver=`cat<<EOD | $PYTHON -
+
+from __future__ import print_function;
+import sys;
+try:
+	from packaging import version;
+except ImportError:
+	from distlib import version;
+ver = sys.version.split ()[[0]];
+(tst_cmp, tst_ver) = "$1".split ();
+tst_ver = tst_ver.strip ("'");
+eval ("print (version.LegacyVersion (ver)"+ tst_cmp +"version.LegacyVersion (tst_ver))")
+EOD`
 		if test "$ac_supports_python_ver" = "True"; then
 		   AC_MSG_RESULT([yes])
 		else

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -284,6 +284,11 @@ Requires:       libffi
 Requires:       python%{__python_pkg_version}
 Requires:       %{__python_cffi_pkg}
 %if 0%{?rhel}%{?fedora}%{?suse_version}
+%if 0%{?rhel} >= 8 || 0%{?centos} >= 8 || 0%{?fedora} >= 28
+BuildRequires:  python3-packaging
+%else
+BuildRequires:  python-packaging
+%endif
 BuildRequires:  python%{__python_pkg_version}-devel
 BuildRequires:  %{__python_cffi_pkg}
 BuildRequires:  %{__python_setuptools_pkg}


### PR DESCRIPTION
### Motivation and Context
I sneezed, and somehow I got 08cd0717359b1a18693e3c8e6d6e5a2819b35a48 all over this branch too. What a mess I make.

### Description
#12636, but with an older vintage yet.

### How Has This Been Tested?
Same as #12636 - it configured and built on Fedora 34 and 35. (I updated my rawhide system in the interim and it installed a kernel with DEBUG_LOCK_ALLOC enabled again, so it's no longer useful for this, sadly.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
