### PR TITLE
Remove basename(1). Clean up/shorten/eliminate some pipelines

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -596,7 +596,9 @@ enclosure_handler () {
 	# DEVPATH=/sys/devices/pci0000:00/0000:00:03.0/0000:05:00.0/host0/subsystem/devices/0:0:0:0/scsi_generic/sg0
 
 	# Get the enclosure ID ("0:0:0:0")
-	ENC=$(basename $(readlink -m "/sys/$DEVPATH/../.."))
+	ENC="${DEVPATH%/*}"
+	ENC="${ENC%/*}"
+	ENC="${ENC##*/}"
 	if [ ! -d "/sys/class/enclosure/$ENC" ] ; then
 		# Not an enclosure, bail out
 		return
@@ -616,10 +618,11 @@ enclosure_handler () {
 
 	# The PCI directory is two directories up from the port directory
 	# /sys/devices/pci0000:00/0000:00:03.0/0000:05:00.0
-	PCI_ID_LONG=$(basename $(readlink -m "/sys/$PORT_DIR/../.."))
+	PCI_ID_LONG="$(readlink -m "/sys/$PORT_DIR/../..")"
+	PCI_ID_LONG="${PCI_ID_LONG##*/}"
 
 	# Strip down the PCI address from 0000:05:00.0 to 05:00.0
-	PCI_ID=$(echo "$PCI_ID_LONG" | sed -r 's/^[0-9]+://g')
+	PCI_ID="${PCI_ID_LONG#[0-9]*:}"
 
 	# Name our device according to vdev_id.conf (like "L0" or "U1").
 	NAME=$(awk "/channel/{if (\$1 == \"channel\" && \$2 == \"$PCI_ID\" && \
@@ -674,7 +677,7 @@ alias_handler () {
 			link=$(echo "$link" | sed 's/p[0-9][0-9]*$//')
 		fi
 		# Check both the fully qualified and the base name of link.
-		for l in $link $(basename "$link") ; do
+		for l in $link ${link##*/} ; do
 			if [ ! -z "$l" ]; then
 				alias=$(awk -v var="$l" '($1 == "alias") && \
 					($3 == var) \

--- a/cmd/zed/zed.d/all-syslog.sh
+++ b/cmd/zed/zed.d/all-syslog.sh
@@ -21,7 +21,7 @@ if [ "${ZED_SYSLOG_DISPLAY_GUIDS}" = "1" ]; then
     [ -n "${ZEVENT_VDEV_GUID}" ] && msg="${msg} vdev_guid=${ZEVENT_VDEV_GUID}"
 else
     [ -n "${ZEVENT_POOL}" ] && msg="${msg} pool='${ZEVENT_POOL}'"
-    [ -n "${ZEVENT_VDEV_PATH}" ] && msg="${msg} vdev=$(basename "${ZEVENT_VDEV_PATH}")"
+    [ -n "${ZEVENT_VDEV_PATH}" ] && msg="${msg} vdev=${ZEVENT_VDEV_PATH##*/}"
 fi
 
 # log pool state if state is anything other than 'ACTIVE'

--- a/cmd/zed/zed.d/generic-notify.sh
+++ b/cmd/zed/zed.d/generic-notify.sh
@@ -23,7 +23,7 @@
 
 # Rate-limit the notification based in part on the filename.
 #
-rate_limit_tag="${ZEVENT_POOL};${ZEVENT_SUBCLASS};$(basename -- "$0")"
+rate_limit_tag="${ZEVENT_POOL};${ZEVENT_SUBCLASS};${0##*/}"
 rate_limit_interval="${ZED_NOTIFY_INTERVAL_SECS}"
 zed_rate_limit "${rate_limit_tag}" "${rate_limit_interval}" || exit 3
 

--- a/cmd/zed/zed.d/zed-functions.sh
+++ b/cmd/zed/zed.d/zed-functions.sh
@@ -77,7 +77,7 @@ zed_log_msg()
 zed_log_err()
 {
     logger -p "${ZED_SYSLOG_PRIORITY}" -t "${ZED_SYSLOG_TAG}" -- "error:" \
-        "$(basename -- "$0"):""${ZEVENT_EID:+" eid=${ZEVENT_EID}:"}" "$@"
+        "${0##*/}:""${ZEVENT_EID:+" eid=${ZEVENT_EID}:"}" "$@"
 }
 
 
@@ -258,7 +258,7 @@ zed_notify_email()
     [ -n "${subject}" ] || return 1
     if [ ! -r "${pathname}" ]; then
         zed_log_err \
-                "$(basename "${ZED_EMAIL_PROG}") cannot read \"${pathname}\""
+                "${ZED_EMAIL_PROG##*/} cannot read \"${pathname}\""
         return 1
     fi
 
@@ -270,7 +270,7 @@ zed_notify_email()
     eval ${ZED_EMAIL_PROG} ${ZED_EMAIL_OPTS} < "${pathname}" >/dev/null 2>&1
     rv=$?
     if [ "${rv}" -ne 0 ]; then
-        zed_log_err "$(basename "${ZED_EMAIL_PROG}") exit=${rv}"
+        zed_log_err "${ZED_EMAIL_PROG##*/} exit=${rv}"
         return 1
     fi
     return 0

--- a/cmd/zpool/zpool.d/dm-deps
+++ b/cmd/zpool/zpool.d/dm-deps
@@ -16,14 +16,12 @@ if [ -L "$dev" ] ; then
 	dev=$(readlink "$dev")
 fi
 
-dev=$(basename "$dev")
+dev="${dev##*/}"
 val=""
 if [ -d "/sys/class/block/$dev/slaves" ] ; then
-	# ls -C: output in columns, no newlines
-	val=$(ls -C "/sys/class/block/$dev/slaves")
-
-	# ls -C will print two spaces between files; change to one space.
-	val=$(echo "$val" | sed -r 's/[[:blank:]]+/ /g')
+	# ls -C: output in columns, no newlines, two spaces (change to one)
+	# shellcheck disable=SC2012
+	val=$(ls -C "/sys/class/block/$dev/slaves" | tr -s '[:space:]' ' ')
 fi
 
 echo "dm-deps=$val"

--- a/cmd/zpool/zpool.d/iostat
+++ b/cmd/zpool/zpool.d/iostat
@@ -9,7 +9,7 @@ iostat:		Show iostat values since boot (summary page).
 iostat-1s:	Do a single 1-second iostat sample and show values.
 iostat-10s:	Do a single 10-second iostat sample and show values."
 
-script=$(basename "$0")
+script="${0##*/}"
 if [ "$1" = "-h" ] ; then
 	echo "$helpstr" | grep "$script:" | tr -s '\t' | cut -f 2-
 	exit
@@ -42,7 +42,7 @@ else
 		${brief:+"-y"} \
 		${interval:+"$interval"} \
 		${interval:+"1"} \
-		"$VDEV_UPATH" | awk NF | tail -n 2)
+		"$VDEV_UPATH" | grep -v '^$' | tail -n 2)
 fi
 
 
@@ -61,7 +61,7 @@ fi
 cols=$(echo "$out" | head -n 1)
 
 # Get the values and tab separate them to make them cut-able.
-vals=$(echo "$out" | tail -n 1 | sed -r 's/[[:blank:]]+/\t/g')
+vals=$(echo "$out" | tail -n 1 | tr -s '[:space:]' '\t')
 
 i=0
 for col in $cols ; do

--- a/cmd/zpool/zpool.d/lsblk
+++ b/cmd/zpool/zpool.d/lsblk
@@ -48,7 +48,7 @@ size:	Show the disk capacity.
 vendor:	Show the disk vendor.
 lsblk:	Show the disk size, vendor, and model number."
 
-script=$(basename "$0")
+script="${0##*/}"
 
 if [ "$1" = "-h" ] ; then
         echo "$helpstr" | grep "$script:" | tr -s '\t' | cut -f 2-

--- a/cmd/zpool/zpool.d/media
+++ b/cmd/zpool/zpool.d/media
@@ -9,15 +9,12 @@ if [ "$1" = "-h" ] ; then
 fi
 
 if [ -b "$VDEV_UPATH" ]; then
-	device=$(basename "$VDEV_UPATH")
-	val=$(cat "/sys/block/$device/queue/rotational" 2>/dev/null)
-	if [ "$val" = "0" ]; then
-		MEDIA="ssd"
-	fi
-
-	if [ "$val" = "1" ]; then
-		MEDIA="hdd"
-	fi
+	device="${VDEV_UPATH##*/}"
+	read -r val 2>/dev/null < "/sys/block/$device/queue/rotational"
+	case "$val" in
+		0) MEDIA="ssd" ;;
+		1) MEDIA="hdd" ;;
+	esac
 
 	vpd_pg83="/sys/block/$device/device/vpd_pg83"
 	if [ -f "$vpd_pg83" ]; then

--- a/cmd/zpool/zpool.d/ses
+++ b/cmd/zpool/zpool.d/ses
@@ -11,7 +11,7 @@ fault_led:	Show value of the disk enclosure slot fault LED.
 locate_led:	Show value of the disk enclosure slot locate LED.
 ses:		Show disk's enc, enc device, slot, and fault/locate LED values."
 
-script=$(basename "$0")
+script="${0##*/}"
 if [ "$1" = "-h" ] ; then
 	echo "$helpstr" | grep "$script:" | tr -s '\t' | cut -f 2-
 	exit

--- a/config/always-python.m4
+++ b/config/always-python.m4
@@ -28,7 +28,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYTHON], [
 	dnl #
 	AM_PATH_PYTHON([], [], [:])
 	AS_IF([test -z "$PYTHON_VERSION"], [
-		PYTHON_VERSION=$(basename $PYTHON | tr -cd 0-9.)
+		PYTHON_VERSION=$(echo ${PYTHON##*/} | tr -cd 0-9.)
 	])
 	PYTHON_MINOR=${PYTHON_VERSION#*\.}
 

--- a/config/always-pyzfs.m4
+++ b/config/always-pyzfs.m4
@@ -6,7 +6,7 @@ dnl # https://www.gnu.org/software/autoconf-archive/ax_python_module.html
 dnl # Required by ZFS_AC_CONFIG_ALWAYS_PYZFS.
 dnl #
 AC_DEFUN([ZFS_AC_PYTHON_MODULE], [
-	PYTHON_NAME=$(basename $PYTHON)
+	PYTHON_NAME=${PYTHON##*/}
 	AC_MSG_CHECKING([for $PYTHON_NAME module: $1])
 	AS_IF([$PYTHON -c "import $1" 2>/dev/null], [
 		AC_MSG_RESULT(yes)

--- a/config/zfs-meta.m4
+++ b/config/zfs-meta.m4
@@ -73,14 +73,14 @@ AC_DEFUN([ZFS_AC_META], [
 		if test ! -f ".nogitrelease" && git rev-parse --git-dir > /dev/null 2>&1; then
 			_match="${ZFS_META_NAME}-${ZFS_META_VERSION}"
 			_alias=$(git describe --match=${_match} 2>/dev/null)
-			_release=$(echo ${_alias}|sed "s/${ZFS_META_NAME}//"|cut -f3- -d'-'|sed 's/-/_/g')
+			_release=$(echo ${_alias}|sed "s/${ZFS_META_NAME}//"|cut -f3- -d'-'|tr - _)
 			if test -n "${_release}"; then
 				ZFS_META_RELEASE=${_release}
 				_zfs_ac_meta_type="git describe"
 			else
 				_match="${ZFS_META_NAME}-${ZFS_META_VERSION}-${ZFS_META_RELEASE}"
 	                        _alias=$(git describe --match=${_match} 2>/dev/null)
-				_release=$(echo ${_alias}|sed 's/${ZFS_META_NAME}//'|cut -f3- -d'-'|sed 's/-/_/g')
+				_release=$(echo ${_alias}|sed 's/${ZFS_META_NAME}//'|cut -f3- -d'-'|tr - _)
 				if test -n "${_release}"; then
 					ZFS_META_RELEASE=${_release}
 					_zfs_ac_meta_type="git describe"

--- a/contrib/bpftrace/zfs-trace.sh
+++ b/contrib/bpftrace/zfs-trace.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-ZVER=$(cut -f 1 -d '-' /sys/module/zfs/version)
+read -r ZVER < /sys/module/zfs/version
+ZVER="${ZVER%%-*}"
 KVER=$(uname -r)
 
 exec bpftrace \

--- a/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
+++ b/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
@@ -2,8 +2,8 @@
 
 get_devtype() {
   local typ
-  typ=$(udevadm info --query=property --name="$1" | grep "^ID_FS_TYPE=" | sed 's|^ID_FS_TYPE=||')
-  if [ "$typ" = "" ] ; then
+  typ=$(udevadm info --query=property --name="$1" | sed -n 's|^ID_FS_TYPE=||p')
+  if [ -z "$typ" ] ; then
      typ=$(blkid -c /dev/null "$1" -o value -s TYPE)
   fi
   echo "$typ"
@@ -36,7 +36,6 @@ find_zfs_block_devices() {
     local dev
     local mp
     local fstype
-    local pool
     local _
     numfields="$(awk '{print NF; exit}' /proc/self/mountinfo)"
     if [ "$numfields" = "10" ] ; then
@@ -47,10 +46,7 @@ find_zfs_block_devices() {
     # shellcheck disable=SC2086
     while read -r ${fields?} ; do
        [ "$fstype" = "zfs" ] || continue
-       if [ "$mp" = "$1" ]; then
-           pool=$(echo "$dev" | cut -d / -f 1)
-           get_pool_devices "$pool"
-       fi
+       [ "$mp" = "$1" ] && get_pool_devices "${dev%%/*}"
     done < /proc/self/mountinfo
 }
 
@@ -100,9 +96,9 @@ if [ -n "$hostonly" ]; then
             majmin=$(get_maj_min "$dev")
             if [ -d "/sys/dev/block/$majmin/slaves" ] ; then
                 for _depdev in "/sys/dev/block/$majmin/slaves"/*; do
-                    [[ -f $_depdev/dev ]] || continue
-                    _depdev=/dev/$(basename "$_depdev")
-                    _depdevname=$(udevadm info --query=property --name="$_depdev" | grep "^DEVNAME=" | sed 's|^DEVNAME=||')
+                    [ -f "$_depdev/dev" ] || continue
+                    _depdev="/dev/${_depdev##*/}"
+                    _depdevname=$(udevadm info --query=property --name="$_depdev" | sed -n 's|^DEVNAME=||p')
                     _depdevtype=$(get_devtype "$_depdevname")
                     dinfo "zfsexpandknowledge: underlying block device backing ZFS dataset $mp: ${_depdevname//$'\n'/ }"
                     array_contains "$_depdevname" "${host_devs[@]}" || host_devs+=("$_depdevname")

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -69,8 +69,8 @@ install() {
 	dracut_install @mounthelperdir@/mount.zfs
 	dracut_install @udevdir@/vdev_id
 	dracut_install awk
-	dracut_install basename
 	dracut_install cut
+	dracut_install tr
 	dracut_install head
 	dracut_install @udevdir@/zvol_id
 	inst_hook cmdline 95 "${moddir}/parse-zfs.sh"

--- a/contrib/dracut/90zfs/parse-zfs.sh.in
+++ b/contrib/dracut/90zfs/parse-zfs.sh.in
@@ -43,7 +43,7 @@ case "${root}" in
 		root="${root#FILESYSTEM=}"
 		root="zfs:${root#ZFS=}"
 		# switch + with spaces because kernel cmdline does not allow us to quote parameters
-		root=$(printf '%s\n' "$root" | sed "s/+/ /g")
+		root=$(echo "$root" | tr '+' ' ')
 		rootok=1
 		wait_for_zfs=1
 

--- a/contrib/dracut/90zfs/zfs-generator.sh.in
+++ b/contrib/dracut/90zfs/zfs-generator.sh.in
@@ -89,7 +89,7 @@ else
   _zfs_generator_cb() {
       dset="${1}"
       mpnt="${2}"
-      unit="sysroot$(echo "$mpnt" | sed 's;/;-;g').mount"
+      unit="sysroot$(echo "$mpnt" | tr '/' '-').mount"
 
       {
           echo "[Unit]"

--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -105,8 +105,7 @@ find_rootfs()
 find_pools()
 {
 	pools=$("$@" 2> /dev/null | \
-		grep -E "pool:|^[a-zA-Z0-9]" | \
-		sed 's@.*: @@' | \
+		sed -Ee '/pool:|^[a-zA-Z0-9]/!d' -e 's@.*: @@' | \
 		tr '\n' ';')
 
 	echo "${pools%%;}" # Return without the last ';'.
@@ -428,7 +427,7 @@ decrypt_fs()
 			else
 				# Temporarily setting "printk" to "7" allows the prompt to appear even when the "quiet" kernel option has been used
 				echo "load-key" > /run/zfs_console_askpwd_cmd
-				storeprintk="$(awk '{print $1}' /proc/sys/kernel/printk)"
+				read -r storeprintk _ < /proc/sys/kernel/printk
 				echo 7 > /proc/sys/kernel/printk
 				$ZFS load-key "${ENCRYPTIONROOT}"
 				echo "$storeprintk" > /proc/sys/kernel/printk

--- a/etc/init.d/zfs-import.in
+++ b/etc/init.d/zfs-import.in
@@ -57,8 +57,7 @@ find_pools()
 	local pools
 
 	pools=$("$@" 2> /dev/null | \
-		grep -E "pool:|^[a-zA-Z0-9]" | \
-		sed 's@.*: @@' | \
+		sed -Ee '/pool:|^[a-zA-Z0-9]/!d' -e 's@.*: @@' | \
 		sort | \
 		tr '\n' ';')
 

--- a/etc/zfs/zfs-functions.in
+++ b/etc/zfs/zfs-functions.in
@@ -345,7 +345,7 @@ read_mtab()
 
 	# Unset all MTAB_* variables
 	# shellcheck disable=SC2046
-	unset $(env | grep ^MTAB_ | sed 's,=.*,,')
+	unset $(env | sed -e '/^MTAB_/!d' -e 's,=.*,,')
 
 	while read -r fs mntpnt fstype opts rest; do
 		if echo "$fs $mntpnt $fstype $opts" | grep -qE "$match"; then
@@ -360,9 +360,8 @@ read_mtab()
 			fs=$(/bin/echo "$fs" | sed 's,\\0,\\00,')
 
 			# Remove 'unwanted' characters.
-			mntpnt=$(printf '%b\n' "$mntpnt" | sed -e 's,/,,g' \
-			    -e 's,-,,g' -e 's,\.,,g' -e 's, ,,g')
-			fs=$(printf '%b\n' "$fs")
+			mntpnt=$(printf '%b' "$mntpnt" | tr -d '/. -')
+			fs=$(printf '%b' "$fs")
 
 			# Set the variable.
 			eval export "MTAB_$mntpnt=\"$fs\""
@@ -374,8 +373,7 @@ in_mtab()
 {
 	local mntpnt="$1"
 	# Remove 'unwanted' characters.
-	mntpnt=$(printf '%b\n' "$mntpnt" | sed -e 's,/,,g' \
-	    -e 's,-,,g' -e 's,\.,,g' -e 's, ,,g')
+	mntpnt=$(printf '%b' "$mntpnt" | tr -d '/. -')
 	local var
 
 	var="$(eval echo "MTAB_$mntpnt")"
@@ -391,7 +389,7 @@ read_fstab()
 
 	# Unset all FSTAB_* variables
 	# shellcheck disable=SC2046
-	unset $(env | grep ^FSTAB_ | sed 's,=.*,,')
+	unset $(env | sed -e '/^FSTAB_/!d' -e 's,=.*,,')
 
 	i=0
 	while read -r fs mntpnt fstype opts; do
@@ -401,7 +399,7 @@ read_fstab()
 
 		if echo "$fs $mntpnt $fstype $opts" | grep -qE "$match"; then
 			eval export "FSTAB_dev_$i=$fs"
-			fs=$(printf '%b\n' "$fs" | sed 's,/,_,g')
+			fs=$(printf '%b' "$fs" | tr '/' '_')
 			eval export "FSTAB_$i=$mntpnt"
 
 			i=$((i + 1))

--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -82,7 +82,7 @@ exit 1
 # Are we doing an upgrade?
 if [ "$1" = "1" -o "$1" = "upgrade" ] ; then
 	# Yes we are.  Are we upgrading to a new ZFS version?
-	NEWEST_VER=$(dkms status zfs | sed 's/,//g' | sort -r -V | awk '/installed/{print $2; exit}')
+	NEWEST_VER=$(dkms status zfs | tr -d , | sort -r -V | awk '/installed/{print $2; exit}')
 	if [ "$NEWEST_VER" != "%{version}" ] ; then
 		# Yes, it's a new ZFS version.  We'll uninstall the old module
 		# later on in this script.

--- a/scripts/kmodtool
+++ b/scripts/kmodtool
@@ -446,7 +446,7 @@ print_rpmtemplate ()
 
 myprog_help ()
 {
-	echo "Usage: $(basename ${0}) [OPTIONS]"
+	echo "Usage: ${0##*/} [OPTIONS]"
 	echo $'\n'"Creates a template to be used during kmod building"
 	echo $'\n'"Available options:"
 	echo " --filterfile <file>  -- filter the results with grep --file <file>"

--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -90,7 +90,7 @@ cleanup_freebsd_loopback() {
 
 cleanup_linux_loopback() {
 	for TEST_LOOPBACK in ${LOOPBACKS}; do
-		LOOP_DEV=$(basename "$TEST_LOOPBACK")
+		LOOP_DEV="${TEST_LOOPBACK##*/}"
 		DM_DEV=$(sudo "${DMSETUP}" ls 2>/dev/null | \
 		    grep "${LOOP_DEV}" | cut -f1)
 
@@ -606,7 +606,7 @@ if [ -z "${DISKS}" ]; then
 				TEST_LOOPBACK=$(sudo "${LOSETUP}" -f)
 				sudo "${LOSETUP}" "${TEST_LOOPBACK}" "${TEST_FILE}" ||
 				    fail "Failed: ${TEST_FILE} -> ${TEST_LOOPBACK}"
-				BASELOOPBACK=$(basename "$TEST_LOOPBACK")
+				BASELOOPBACK="${TEST_LOOPBACK##*/}"
 				DISKS="$DISKS $BASELOOPBACK"
 				LOOPBACKS="$LOOPBACKS $TEST_LOOPBACK"
 			fi

--- a/scripts/zfs.sh
+++ b/scripts/zfs.sh
@@ -91,7 +91,8 @@ check_modules_linux() {
 
 	for KMOD in $KMOD_SPL $KMOD_ZAVL $KMOD_ZNVPAIR $KMOD_ZUNICODE $KMOD_ZCOMMON \
 	    $KMOD_ZLUA $KMOD_ZZSTD $KMOD_ICP $KMOD_ZFS; do
-		NAME=$(basename "$KMOD" .ko)
+		NAME="${KMOD##*/}"
+		NAME="${NAME%.ko}"
 
 		if lsmod | grep -E -q "^${NAME}"; then
 			LOADED_MODULES="$LOADED_MODULES\t$NAME\n"
@@ -172,7 +173,8 @@ load_modules_linux() {
 unload_module_linux() {
 	KMOD=$1
 
-	NAME=$(basename "$KMOD" .ko)
+	NAME="${KMOD##*/}"
+	NAME="${NAME%.ko}"
 	FILE=$(modinfo "$KMOD" | awk '/^filename:/ {print $2}')
 	VERSION=$(modinfo "$KMOD" | awk '/^version:/ {print $2}')
 
@@ -198,8 +200,9 @@ unload_modules_freebsd() {
 unload_modules_linux() {
 	for KMOD in $KMOD_ZFS $KMOD_ICP $KMOD_ZZSTD $KMOD_ZLUA $KMOD_ZCOMMON \
 	    $KMOD_ZUNICODE $KMOD_ZNVPAIR  $KMOD_ZAVL $KMOD_SPL; do
-		NAME=$(basename "$KMOD" .ko)
-		USE_COUNT=$(lsmod | grep -E "^${NAME} " | awk '{print $3}')
+		NAME="${KMOD##*/}"
+		NAME="${NAME%.ko}"
+		USE_COUNT=$(lsmod | awk '/^'"${NAME}"'/ {print $3}')
 
 		if [ "$USE_COUNT" = "0" ] ; then
 			unload_module_linux "$KMOD" || return 1

--- a/scripts/zimport.sh
+++ b/scripts/zimport.sh
@@ -486,7 +486,7 @@ for TAG in $POOL_TAGS; do
 		    "$POOL_DIR_COPY" || \
 		    fail "Failed to copy $POOL_DIR_PRISTINE to $POOL_DIR_COPY"
 		POOL_NAME=$($ZPOOL_CMD import -d "$POOL_DIR_COPY" | \
-		    awk '/pool:/ { print $2; exit 0 }')
+		    awk '/pool:/ { print $2; exit }')
 
 		if ! $ZPOOL_CMD import -N -d "$POOL_DIR_COPY"
 		    "$POOL_NAME" &>/dev/null; then

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -252,7 +252,7 @@ function unmounted
 
 function splitline
 {
-	echo $1 | sed "s/,/ /g"
+	echo $1 | tr ',' ' '
 }
 
 function default_setup
@@ -1092,9 +1092,7 @@ function get_endslice #<disk> <slice>
 	case "$(uname)" in
 	Linux)
 		endcyl=$(parted -s $DEV_DSKDIR/$disk -- unit cyl print | \
-			grep "part${slice}" | \
-			awk '{print $3}' | \
-			sed 's,cyl,,')
+			awk "/part${slice}/"' {sub(/cyl/, "", $3); print $3}')
 		((endcyl = (endcyl + 1)))
 		;;
 	FreeBSD)
@@ -1461,7 +1459,7 @@ function is_shared_smb
 	if datasetnonexists "$fs" ; then
 		return 1
 	else
-		fs=$(echo $fs | sed 's@/@_@g')
+		fs=$(echo $fs | tr / _)
 	fi
 
 	if is_linux; then

--- a/tests/zfs-tests/tests/functional/reservation/reservation_021_neg.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_021_neg.ksh
@@ -34,7 +34,7 @@
 
 verify_runnable "both"
 
-fs=$TESTPOOL/$TESTFS/$(basename $0).$$
+fs=$TESTPOOL/$TESTFS/${0##*/}.$$
 
 function cleanup
 {


### PR DESCRIPTION
### Motivation and Context
Basename has a very narrow window of usefulness. For the others, well, they're smaller, and faster.

Basenames that remain:
```
cmd/zed/zed.d/statechange-led.sh:		dev=$(basename "$(echo "$therest" | awk '{print $(NF-1)}')")
cmd/zed/zed.d/statechange-led.sh:	vdev=$(basename "$ZEVENT_VDEV_PATH")
```
I don't wanna interfere with #11988

```
scripts/zfs-tests.sh:	SINGLETESTFILE=$(basename "$SINGLETEST")
tests/zfs-tests/tests/functional/cli_user/zfs_list/zfs_list.kshlib:		ACTUAL=$(basename $dataset)
tests/zfs-tests/tests/functional/cli_user/zfs_list/zfs_list.kshlib:		ACTUAL=$(basename $dataset)
tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_-c_homedir.ksh:typeset USER_SCRIPT=$(basename "$USER_SCRIPT_FULL")
tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_-c_searchpath.ksh:typeset CMD_1=$(basename "$SCRIPT_1")
tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_-c_searchpath.ksh:typeset CMD_2=$(basename "$SCRIPT_2")
tests/zfs-tests/tests/functional/cli_user/zpool_status/zpool_status_-c_homedir.ksh:typeset USER_SCRIPT=$(basename "$USER_SCRIPT_FULL")
tests/zfs-tests/tests/functional/cli_user/zpool_status/zpool_status_-c_searchpath.ksh:typeset CMD_1=$(basename "$SCRIPT_1")
tests/zfs-tests/tests/functional/cli_user/zpool_status/zpool_status_-c_searchpath.ksh:typeset CMD_2=$(basename "$SCRIPT_2")
tests/zfs-tests/tests/functional/migration/migration.cfg:export BNAME=`basename $TESTFILE`
tests/zfs-tests/tests/perf/perf.shlib:	typeset logbase="$(get_perf_output_dir)/$(basename \
tests/zfs-tests/tests/perf/perf.shlib:		typeset logbase="$(get_perf_output_dir)/$(basename \
```
These are potentially Of Directories, where basename is actually useful

### Description
Case-by-case basis, I grepped for cut, awk, and sed.

### How Has This Been Tested?
Ex situ.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. ‒ none should apply
- [ ] I have run the ZFS Test Suite with this change applied. ‒ CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
