### PR TITLE
vdev_id: Fix enclosure_symlinks feature

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -622,8 +622,8 @@ enclosure_handler () {
 	PCI_ID=$(echo "$PCI_ID_LONG" | sed -r 's/^[0-9]+://g')
 
 	# Name our device according to vdev_id.conf (like "L0" or "U1").
-	NAME=$(awk '/channel/{if ($1 == "channel" && $2 == "$PCI_ID" && \
-		$3 == "$PORT_ID") {print ${4}int(count[$4])}; count[$4]++}' $CONFIG)
+	NAME=$(awk "/channel/{if (\$1 == \"channel\" && \$2 == \"$PCI_ID\" && \
+		\$3 == \"$PORT_ID\") {print \$4\$3}}" $CONFIG)
 
 	echo "${NAME}"
 }


### PR DESCRIPTION

### Motivation and Context
Fix broken `enclosure_symlinks` feature in `vdev_id`

### Description
The vdev_id.conf `enclosure_symlinks` option persistently creates and maps `/dev/by-enclosure` symlinks to dynamic `/dev/sg*` devices.

This patch fixes two issues:

1. The enclosure_symlinks feature was accidentally broken in:
```
   vdev_id: Support daisy-chained JBODs in multipath mode
```
2. Even when working, the feature numbered the enclosure sequentially rather than by HBA port number.  That meant that if a port was down or didn't appear in sysfs, then the enclosure_sumlinks numbers would be numbered wrong.

### How Has This Been Tested?
Ran `udevadm trigger /dev/<sg_device>` on a node with a storage enclosure, and verified that this correctly created the symlinks in `/dev/by-enclosure`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
