### PR TITLE
zvol: Support blk-mq for better performance

### DIFF
--- a/config/kernel-blk-queue.m4
+++ b/config/kernel-blk-queue.m4
@@ -315,6 +315,36 @@ AC_DEFUN([ZFS_AC_KERNEL_BLK_QUEUE_MAX_SEGMENTS], [
 	])
 ])
 
+dnl #
+dnl # See if kernel supports block multi-queue and blk_status_t.
+dnl # blk_status_t represents the new status codes introduced in the 4.13
+dnl # kernel patch:
+dnl #
+dnl #  block: introduce new block status code type
+dnl #
+dnl # We do not currently support the "old" block multi-queue interfaces from
+dnl # prior kernels.
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_BLK_MQ], [
+	ZFS_LINUX_TEST_SRC([blk_mq], [
+		#include <linux/blk-mq.h>
+	], [
+		struct blk_mq_tag_set tag_set = {0};
+		(void) blk_mq_alloc_tag_set(&tag_set);
+		return BLK_STS_OK;
+	], [$NO_UNUSED_BUT_SET_VARIABLE])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_BLK_MQ], [
+	AC_MSG_CHECKING([whether block multiqueue with blk_status_t is available])
+	ZFS_LINUX_TEST_RESULT([blk_mq], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_BLK_MQ, 1, [block multiqueue is available])
+	], [
+		AC_MSG_RESULT(no)
+	])
+])
+
 AC_DEFUN([ZFS_AC_KERNEL_SRC_BLK_QUEUE], [
 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_PLUG
 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_BDI
@@ -326,6 +356,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLK_QUEUE], [
 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_FLUSH
 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_MAX_HW_SECTORS
 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_MAX_SEGMENTS
+	ZFS_AC_KERNEL_SRC_BLK_MQ
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_BLK_QUEUE], [
@@ -339,4 +370,5 @@ AC_DEFUN([ZFS_AC_KERNEL_BLK_QUEUE], [
 	ZFS_AC_KERNEL_BLK_QUEUE_FLUSH
 	ZFS_AC_KERNEL_BLK_QUEUE_MAX_HW_SECTORS
 	ZFS_AC_KERNEL_BLK_QUEUE_MAX_SEGMENTS
+	ZFS_AC_KERNEL_BLK_MQ
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -403,6 +403,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/zpool_influxdb/Makefile
 	tests/zfs-tests/tests/functional/zvol/Makefile
 	tests/zfs-tests/tests/functional/zvol/zvol_ENOSPC/Makefile
+	tests/zfs-tests/tests/functional/zvol/zvol_stress/Makefile
 	tests/zfs-tests/tests/functional/zvol/zvol_cli/Makefile
 	tests/zfs-tests/tests/functional/zvol/zvol_misc/Makefile
 	tests/zfs-tests/tests/functional/zvol/zvol_swap/Makefile

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2207,9 +2207,55 @@ for each I/O submitter.
 When unset, requests are handled asynchronously by a thread pool.
 The number of requests which can be handled concurrently is controlled by
 .Sy zvol_threads .
+.Sy zvol_request_sync
+is ignored when running on a kernel that supports block multiqueue
+.Pq Li blk-mq .
 .
-.It Sy zvol_threads Ns = Ns Sy 32 Pq uint
-Max number of threads which can handle zvol I/O requests concurrently.
+.It Sy zvol_threads Ns = Ns Sy 0 Pq uint
+The number of threads to use for processing zvol block IOs.
+On older
+.No non- Ns Li blk-mq
+kernels,
+.Sy zvol_threads
+is the total number of threads to use for all zvols.
+On kernels that support
+.Li blk-mq
+.Sy zvol_threads
+is the total number of threads per zvol.
+If
+.Sy 0
+(the default) then internally set
+.Sy zvol_threads
+to the number of CPUs present.
+.It Sy zvol_use_blk_mq Ns = Ns Sy 0 Ns | Ns 1 Pq uint
+Set to
+.Sy 1
+to use the
+.Li blk-mq
+API for zvols.
+Set to
+.Sy 0
+(the default) to use the legacy zvol APIs.
+This setting can give better or worse zvol performance depending on
+the workload.
+This parameter will only appear if your kernel supports
+.Li blk-mq
+and is only read and assigned to a zvol at zvol load time.
+.
+.It Sy zvol_blk_mq_queue_depth Ns = Ns Sy 0 Pq uint
+The queue_depth value for the zvol
+.Li blk-mq
+interface.
+This parameter will only appear if your kernel supports
+.Li blk-mq
+and is only read at zvol load time.
+If
+.Sy 0
+(the default) then use the kernel's default queue depth.
+If you set
+.Sy zvol_blk_mq_queue_depth
+lower than the kernel's minimum queue depth, it will be internally
+capped to the kernel's minimum queue depth (currently 4 on 5.15 kernels).
 .
 .It Sy zvol_volmode Ns = Ns Sy 1 Pq uint
 Defines zvol block devices behaviour when

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -941,6 +941,10 @@ tests = ['zvol_misc_002_pos', 'zvol_misc_hierarchy', 'zvol_misc_rename_inuse',
     'zvol_misc_snapdev', 'zvol_misc_volmode', 'zvol_misc_zil']
 tags = ['functional', 'zvol', 'zvol_misc']
 
+[tests/functional/zvol/zvol_stress]
+tests = ['zvol_stress']
+tags = ['functional', 'zvol', 'zvol_stress']
+
 [tests/functional/zvol/zvol_swap]
 tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_004_pos']
 tags = ['functional', 'zvol', 'zvol_swap']

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3334,18 +3334,22 @@ function is_te_enabled
 	fi
 }
 
-# Utility function to determine if a system has multiple cpus.
-function is_mp
+# Return the number of CPUs (cross-platform)
+function get_num_cpus
 {
-	if is_linux; then
-		(($(nproc) > 1))
+	if is_linux ; then
+		nproc
 	elif is_freebsd; then
 		sysctl -n kern.smp.cpus
 	else
-		(($(psrinfo | wc -l) > 1))
+		psrinfo | wc -l
 	fi
+}
 
-	return $?
+# Utility function to determine if a system has multiple cpus.
+function is_mp
+{
+	[[ $(get_num_cpus) -gt 1 ]]
 }
 
 function get_cpu_freq
@@ -3888,14 +3892,23 @@ function get_tunable_impl
 {
 	typeset name="$1"
 	typeset module="${2:-zfs}"
+	typeset check_only="$3"
 
 	eval "typeset tunable=\$$name"
 	case "$tunable" in
 	UNSUPPORTED)
-		log_unsupported "Tunable '$name' is unsupported on $(uname)"
+		if [ -z "$check_only" ] ; then
+			log_unsupported "Tunable '$name' is unsupported on $(uname)"
+		else
+			return 1
+		fi
 		;;
 	"")
-		log_fail "Tunable '$name' must be added to tunables.cfg"
+		if [ -z "$check_only" ] ; then
+			log_fail "Tunable '$name' must be added to tunables.cfg"
+		else
+			return 1
+		fi
 		;;
 	*)
 		;;
@@ -3917,6 +3930,14 @@ function get_tunable_impl
 	esac
 
 	return 1
+}
+
+# Does a tunable exist?
+#
+# $1: Tunable name
+function tunable_exists
+{
+	get_tunable_impl $1 "zfs" 1
 }
 
 #

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -88,6 +88,7 @@ VOL_INHIBIT_DEV			UNSUPPORTED			zvol_inhibit_dev
 VOL_MODE			vol.mode			zvol_volmode
 VOL_RECURSIVE			vol.recursive			UNSUPPORTED
 XATTR_COMPAT			xattr_compat			zfs_xattr_compat
+VOL_USE_BLK_MQ			UNSUPPORTED			zvol_use_blk_mq
 ZEVENT_LEN_MAX			zevent.len_max			zfs_zevent_len_max
 ZEVENT_RETAIN_MAX		zevent.retain_max		zfs_zevent_retain_max
 ZIO_SLOW_IO_MS			zio.slow_io_ms			zio_slow_io_ms

--- a/tests/zfs-tests/tests/functional/zvol/Makefile.am
+++ b/tests/zfs-tests/tests/functional/zvol/Makefile.am
@@ -5,6 +5,7 @@ dist_pkgdata_DATA = \
 
 SUBDIRS = \
 	zvol_ENOSPC \
+	zvol_stress \
 	zvol_cli \
 	zvol_misc \
 	zvol_swap

--- a/tests/zfs-tests/tests/functional/zvol/zvol_stress/Makefile.am
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_stress/Makefile.am
@@ -1,0 +1,5 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/zvol/zvol_stress
+dist_pkgdata_SCRIPTS = \
+	cleanup.ksh \
+	setup.ksh \
+	zvol_stress.ksh

--- a/tests/zfs-tests/tests/functional/zvol/zvol_stress/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_stress/cleanup.ksh
@@ -1,0 +1,36 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_stress/setup.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_stress/setup.ksh
@@ -1,0 +1,38 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+default_setup "$DISKS"
+
+log_pass

--- a/tests/zfs-tests/tests/functional/zvol/zvol_stress/zvol_stress.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_stress/zvol_stress.ksh
@@ -1,0 +1,167 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2021 by Lawrence Livermore National Security, LLC.
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/reservation/reservation.shlib
+
+#
+# DESCRIPTION:
+# Stress test multithreaded transfers to multiple zvols.  Also verify
+# zvol errors show up in zpool status.
+#
+# STRATEGY:
+# 1. Create one zvol per CPU
+# 2. In parallel, spawn an fio "write and verify" for each zvol
+# 3. Inject write errors
+# 4. Write to one of the zvols with dd and verify the errors
+#
+
+verify_runnable "global"
+
+num_zvols=$(get_num_cpus)
+
+# If we were making one big zvol from all the pool space, it would
+# be this big:
+biggest_zvol_size_possible=$(largest_volsize_from_pool $TESTPOOL)
+
+# Crude calculation: take the biggest zvol size we could possibly
+# create, knock 10% off it (for overhead) and divide by the number
+# of ZVOLs we want to make.
+each_zvol_size=$(( floor($biggest_zvol_size_possible * 0.9) / $num_zvols ))
+
+typeset tmpdir="$(mktemp -d zvol_stress_fio_state.XXXXXX)"
+
+function create_zvols
+{
+	log_note "Creating $num_zvols zvols that are ${each_zvol_size}B each"
+	for i in $(seq $num_zvols) ; do
+		log_must zfs create -V $each_zvol_size $TESTPOOL/testvol$i
+		block_device_wait "$ZVOL_DEVDIR/$TESTPOOL/testvol$i"
+	done
+}
+
+function destroy_zvols
+{
+	for i in $(seq $num_zvols) ; do
+		log_must_busy zfs destroy $TESTPOOL/testvol$i
+	done
+}
+
+# enable/disable blk-mq (if available)
+#
+# $1: 1 = enable, 0 = disable
+function set_blk_mq
+{
+	# Not all kernels support blk-mq
+	if tunable_exists VOL_USE_BLK_MQ ; then
+		log_must set_tunable32 VOL_USE_BLK_MQ $1
+	fi
+}
+
+function do_zvol_stress
+{
+	# Write 10% of each zvol, or 50MB, whichever is less
+	zvol_write_size=$((each_zvol_size / 10))
+	if [ $zvol_write_size -gt $((50 * 1048576)) ] ; then
+		zvol_write_size=$((50 * 1048576))
+	fi
+	zvol_write_size_mb=$(($zvol_write_size / 1048576))
+
+	if is_linux ; then
+		engine=libaio
+	else
+		engine=psync
+	fi
+
+	# Spawn off one fio per zvol in parallel
+	pids=""
+	for i in $(seq $num_zvols) ; do
+		# Spawn one fio per zvol as its own process
+		fio --ioengine=$engine --name=zvol_stress$i --direct=0 \
+			--filename="$ZVOL_DEVDIR/$TESTPOOL/testvol$i" --bs=1048576 \
+			--iodepth=10 --readwrite=randwrite --size=${zvol_write_size} \
+			--verify_async=2 --numjobs=1 --verify=sha1 \
+			--verify_fatal=1 \
+			--continue_on_error=none \
+			--error_dump=1 \
+			--exitall_on_error \
+			--aux-path="$tmpdir" --do_verify=1 &
+		pids="$pids $!"
+	done
+
+	# Wait for all the spawned fios to finish and look for errors
+	fail=""
+	i=0
+	for pid in $pids ; do
+		log_note "$s waiting on $pid"
+		if ! wait $pid ; then
+			log_fail "fio error on $TESTPOOL/testvol$i"
+		fi
+		i=$(($i + 1))
+	done
+}
+
+function cleanup
+{
+	log_must zinject -c all
+	log_must zpool clear $TESTPOOL
+	destroy_zvols
+	set_blk_mq 0
+
+	# Remove all fio's leftover state files
+	if [ -n "$tmpdir" ] ; then
+		rm -f "$tmpdir"/*.state
+		rmdir "$tmpdir"
+	fi
+}
+
+log_onexit cleanup
+
+log_assert "Stress test zvols"
+
+set_blk_mq 0
+create_zvols
+# Do some fio write/verifies in parallel
+do_zvol_stress
+destroy_zvols
+
+# Enable blk-mq (block multi-queue), and re-run the same test
+set_blk_mq 1
+create_zvols
+do_zvol_stress
+
+# Inject some errors, and verify we see some IO errors in zpool status
+for DISK in $DISKS ; do
+	log_must zinject -d $DISK -f 10 -e io -T write $TESTPOOL
+done
+log_must dd if=/dev/zero of=$ZVOL_DEVDIR/$TESTPOOL/testvol1 bs=512 count=50
+log_must zinject -c all
+
+log_must zpool status
+write_errors=$(zpool status -pv | grep $DISK | awk '{print $4}')
+if [ $write_errors -le 0 ] ; then
+	log_fail "Expected to see some write errors (saw $write_errors)"
+else
+	log_note "Correctly saw $write_errors write errors"
+fi
+log_pass "Done with zvol_stress"


### PR DESCRIPTION
### Motivation and Context
Increase multi-threaded performance on zvols (Issue #12483)

### Description
Add support for the kernel's block multiqueue (blk-mq) interface in the zvol block driver.  blk-mq creates multiple request queues on different CPUs rather than having a single request queue.  This can improve zvol performance with multithreaded reads/writes.

This implementation uses the blk-mq interfaces on 4.13 or newer kernels.  Building against older kernels will fall back to the
older BIO interfaces.

### How Has This Been Tested?
Test case added.  Also ran benchmarks (results to follow)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
