### PR TITLE
Add explicit error for device_rebuild being disabled

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -3364,9 +3364,20 @@ zpool_vdev_attach(zpool_handle_t *zhp, const char *old_disk,
 				    "cannot replace a replacing device"));
 			}
 		} else {
-			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "can only attach to mirrors and top-level "
-			    "disks"));
+			char status[64] = {0};
+			zpool_prop_get_feature(zhp,
+			    "feature@device_rebuild", status, 63);
+			if (rebuild &&
+			    strncmp(status, ZFS_FEATURE_DISABLED, 64) == 0) {
+				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+				    "device_rebuild feature must be enabled "
+				    "in order to use sequential "
+				    "reconstruction"));
+			} else {
+				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+				    "can only attach to mirrors and top-level "
+				    "disks"));
+			}
 		}
 		(void) zfs_error(hdl, EZFS_BADTARGET, msg);
 		break;


### PR DESCRIPTION
### Motivation and Context
(I ran into #11414, that's really all.)

Currently, you get back "can only attach to mirrors and top-level disks"
unconditionally if zpool attach returns ENOTSUP, but that also happens
if, say, feature@device_rebuild=disabled and you tried attach -s.

### Description
Adds an error case for ENOTSUP and feature@device_rebuild=disabled.

(I don't check for unsupported explicitly because it's checked earlier in the function; I considered adding this error check right below that one, but opted to put it with the ENOTSUP return handling rather than another special case early on. If people disagree strongly, I can move it.)

### How Has This Been Tested?
```
$ sudo zpool attach -s ephemeral ata-HGST_HUH728080ALE604_1234 /badideatest
cannot attach /badideatest to ata-HGST_HUH728080ALE604_1234: can only attach to mirrors and top-level disks
$ sudo cmd/zpool/zpool attach -s ephemeral ata-HGST_HUH728080ALE604_2EGTR1JX /badideatest
cannot attach /badideatest to ata-HGST_HUH728080ALE604_1234: device_rebuild feature must be enabled in order to use sequential reconstruction
$ sudo zpool get feature@device_rebuild ephemeral
NAME       PROPERTY                VALUE                   SOURCE
ephemeral  feature@device_rebuild  disabled                local
$
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
