### PR TITLE
zhack: Add fix label option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/cli_root/zfs_unshare/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_wait/Makefile
+	tests/zfs-tests/tests/functional/cli_root/zhack/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_add/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_attach/Makefile

--- a/man/man1/zhack.1
+++ b/man/man1/zhack.1
@@ -94,6 +94,13 @@ The
 flag indicates that the
 .Ar guid
 feature is now required to read the pool MOS.
+.
+.It Xo
+.Nm zhack
+.Cm label repair
+.Ar device
+.Xc
+Repair corrupted labels by rewriting the checksum using the presumed valid contents of the label.
 .El
 .
 .Sh GLOBAL OPTIONS

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -315,6 +315,12 @@ tags = ['functional', 'cli_root', 'zfs_upgrade']
 tests = ['zfs_wait_deleteq']
 tags = ['functional', 'cli_root', 'zfs_wait']
 
+[tests/functional/cli_root/zhack]
+tests = ['zhack_label_checksum']
+pre =
+post =
+tags = ['functional', 'cli_root', 'zhack']
+
 [tests/functional/cli_root/zpool]
 tests = ['zpool_001_neg', 'zpool_002_pos', 'zpool_003_pos', 'zpool_colors']
 tags = ['functional', 'cli_root', 'zpool']

--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -652,3 +652,16 @@ function corrupt_blocks_at_level # input_file corrupt_level
 	# This is necessary for pools made of loop devices.
 	sync
 }
+
+function corrupt_label_checksum # label_number vdev_path
+{
+	typeset label_size=$((256*1024))
+	typeset vdev_size=$(stat_size ${2})
+	typeset -a offsets=("$((128*1024 - 32))" \
+	    "$(($label_size + (128*1024 - 32)))" \
+	    "$(($vdev_size - $label_size - (128*1024 + 32)))" \
+	    "$(($vdev_size - (128*1024 + 32)))")
+
+	dd if=/dev/urandom of=${2} seek=${offsets[$1]} bs=1 count=32 \
+	    conv=notrunc
+}

--- a/tests/zfs-tests/tests/functional/cli_root/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/Makefile.am
@@ -35,6 +35,7 @@ SUBDIRS = \
 	zfs_unshare \
 	zfs_upgrade \
 	zfs_wait \
+	zhack \
 	zpool \
 	zpool_add \
 	zpool_attach \

--- a/tests/zfs-tests/tests/functional/cli_root/zhack/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/Makefile.am
@@ -1,0 +1,3 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zhack
+dist_pkgdata_SCRIPTS = \
+	zhack_label_checksum.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_checksum.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_checksum.ksh
@@ -1,0 +1,64 @@
+#!/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2021 by vStack. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/blkdev.shlib
+
+#
+# Description:
+# zhack label repair <vdev> will calculate and rewrite label checksum if invalid
+#
+# Strategy:
+# 1. Create pool with some number of vdevs and export it
+# 2. Corrupt all labels checksums
+# 3. Check that pool cannot be imported
+# 4. Use zhack to repair labels checksums
+# 5. Check that pool can be imported
+#
+
+log_assert "Verify zhack label repair <vdev> will repair labels checksums"
+log_onexit cleanup
+
+VIRTUAL_DISK=$TEST_BASE_DIR/disk
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	[[ -f $VIRTUAL_DISK ]] && log_must rm $VIRTUAL_DISK
+}
+
+log_must truncate -s $(($MINVDEVSIZE * 8)) $VIRTUAL_DISK
+
+log_must zpool create $TESTPOOL $VIRTUAL_DISK
+log_must zpool export $TESTPOOL
+
+log_mustnot zhack label repair $VIRTUAL_DISK
+
+corrupt_label_checksum 0 $VIRTUAL_DISK
+corrupt_label_checksum 1 $VIRTUAL_DISK
+corrupt_label_checksum 2 $VIRTUAL_DISK
+corrupt_label_checksum 3 $VIRTUAL_DISK
+
+log_mustnot zpool import $TESTPOOL -d $TEST_BASE_DIR
+
+log_must zhack label repair $VIRTUAL_DISK
+
+log_must zpool import $TESTPOOL -d $TEST_BASE_DIR
+
+cleanup
+
+log_pass "zhack label repair works correctly."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Close issue #2510

In case if all label checksums will be invalid on any vdev, the pool
will become unimportable. The zhack with newly added cli options could
be used to restore label checksums and make pool importable again.

### Description
<!--- Describe your changes in detail -->
The label checksums could be restored, like:
% zhack label repair /path/to/vdev

The zhack will read labels and rewrite it, if checksums appear to be invalid.
It is not possible to repair label checksum if label nvlist is corrupted and cannot be unpacked.

The proposed functionality could be useful in case of manual label modifications, i. e.
pool_guid, vdev_tree moduification etc.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZFS test suite testcase for proposed functionality is here:
tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_checksum.ksh

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
