### PR TITLE
Set DEFAULT_INIT_SHELL to /sbin/openrc-run for Gentoo and Alpine

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -564,15 +564,11 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		*)          DEFAULT_INIT_SCRIPT=lsb    ;;
 	esac
 
-	# On gentoo, it's possible that OpenRC isn't installed.  Check if
-	# /sbin/openrc-run exists, and if not, fall back to generic defaults.
-
-	DEFAULT_INIT_SHELL="/bin/sh"
-	AS_IF([test "$DEFAULT_INIT_SCRIPT" = "openrc"], [
-		AS_IF([test -x "/sbin/openrc-run"],
-			[DEFAULT_INIT_SHELL="/sbin/openrc-run"],
-			[DEFAULT_INIT_SCRIPT=lsb])
-	])
+	case "$VENDOR" in
+		gentoo)     DEFAULT_INIT_SHELL="/sbin/openrc-run";;
+		alpine)     DEFAULT_INIT_SHELL="/sbin/openrc-run";;
+		*)          DEFAULT_INIT_SHELL="/bin/sh"         ;;
+	esac
 
 	AC_MSG_RESULT([$DEFAULT_INIT_SCRIPT:$DEFAULT_INIT_SHELL])
 	AC_SUBST(DEFAULT_INIT_SCRIPT)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Gentoo and Alpine always set the rc init scripts' shebang to `#!/sbin/openrc-run`, whether or not openrc is installed.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/openzfs/zfs/issues/12683
### Description
<!--- Describe your changes in detail -->
Unconditionally sets `DEFAULT_INIT_SHELL="/sbin/openrc-run"` for Gentoo and Alpine to ensure the correct shebang is always used regardless of build-time availability of openrc-run.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

`mv /sbin/openrc-run /sbin/openrc-run.old`
`ebuild /var/db/repos/gentoo/sys-fs/zfs/zfs-2.1.1-r2.ebuild unpack`.
Edited _/var/tmp/portage/sys-fs/zfs-2.1.1-r2/work/zfs-2.1.1/config/zfs-build.m4_ to reflect changes in this PR.
`ebuild /var/db/repos/gentoo/sys-fs/zfs/zfs-2.1.1-r2.ebuild merge`.
Confirmed correct shebang.
`mv /sbin/openrc-run.old /sbin/openrc-run`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
