### PR TITLE
ZTS robustness - 2.0 edition

### DIFF
--- a/.github/workflows/zfs-tests-functional.yml
+++ b/.github/workflows/zfs-tests-functional.yml
@@ -44,6 +44,17 @@ jobs:
         sudo sed -i.bak 's/updates/extra updates/' /etc/depmod.d/ubuntu.conf
         sudo depmod
         sudo modprobe zfs
+        # Workaround for cloud-init bug
+        # see https://github.com/openzfs/zfs/issues/12644
+        FILE=/lib/udev/rules.d/10-cloud-init-hook-hotplug.rules
+        if [ -r "${FILE}" ]; then
+          HASH=$(md5sum "${FILE}" | awk '{ print $1 }')
+          if [ "${HASH}" = "121ff0ef1936cd2ef65aec0458a35772" ]; then
+            # Just shove a zd* exclusion right above the hotplug hook...
+            sudo sed -i -e s/'LABEL="cloudinit_hook"'/'KERNEL=="zd*", GOTO="cloudinit_end"\n&'/ "${FILE}"
+            sudo udevadm control --reload-rules
+          fi
+        fi
         # Workaround to provide additional free space for testing.
         #   https://github.com/actions/virtual-environments/issues/2840
         sudo rm -rf /usr/share/dotnet

--- a/.github/workflows/zfs-tests-sanity.yml
+++ b/.github/workflows/zfs-tests-sanity.yml
@@ -40,6 +40,17 @@ jobs:
         sudo sed -i.bak 's/updates/extra updates/' /etc/depmod.d/ubuntu.conf
         sudo depmod
         sudo modprobe zfs
+        # Workaround for cloud-init bug
+        # see https://github.com/openzfs/zfs/issues/12644
+        FILE=/lib/udev/rules.d/10-cloud-init-hook-hotplug.rules
+        if [ -r "${FILE}" ]; then
+          HASH=$(md5sum "${FILE}" | awk '{ print $1 }')
+          if [ "${HASH}" = "121ff0ef1936cd2ef65aec0458a35772" ]; then
+            # Just shove a zd* exclusion right above the hotplug hook...
+            sudo sed -i -e s/'LABEL="cloudinit_hook"'/'KERNEL=="zd*", GOTO="cloudinit_end"\n&'/ "${FILE}"
+            sudo udevadm control --reload-rules
+          fi
+        fi
         # Workaround to provide additional free space for testing.
         #   https://github.com/actions/virtual-environments/issues/2840
         sudo rm -rf /usr/share/dotnet

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -251,6 +251,8 @@ if sys.platform.startswith('freebsd'):
     maybe.update({
         'cli_root/zfs_copies/zfs_copies_002_pos': ['FAIL', known_reason],
         'cli_root/zfs_inherit/zfs_inherit_001_neg': ['FAIL', known_reason],
+        'cli_root/zfs_receive/receive-o-x_props_override':
+            ['FAIL', known_reason],
         'cli_root/zfs_share/zfs_share_011_pos': ['FAIL', known_reason],
         'cli_root/zfs_share/zfs_share_concurrent_shares':
             ['FAIL', known_reason],
@@ -272,6 +274,8 @@ elif sys.platform.startswith('linux'):
         'alloc_class/alloc_class_009_pos': ['FAIL', known_reason],
         'alloc_class/alloc_class_010_pos': ['FAIL', known_reason],
         'alloc_class/alloc_class_011_neg': ['FAIL', known_reason],
+        'alloc_class/alloc_class_012_pos': ['FAIL', known_reason],
+        'alloc_class/alloc_class_013_pos': ['FAIL', '11888'],
         'cli_root/zfs_rename/zfs_rename_002_pos': ['FAIL', known_reason],
         'cli_root/zpool_expand/zpool_expand_001_pos': ['FAIL', known_reason],
         'cli_root/zpool_expand/zpool_expand_005_pos': ['FAIL', known_reason],

--- a/tests/zfs-tests/tests/functional/bootfs/bootfs_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/bootfs/bootfs_002_neg.ksh
@@ -51,14 +51,9 @@
 verify_runnable "global"
 
 function cleanup {
-	if datasetexists $TESTPOOL/vol
-	then
-		log_must zfs destroy $TESTPOOL/vol
-	fi
-	if poolexists $TESTPOOL
-	then
-		log_must zpool destroy $TESTPOOL
-	fi
+	datasetexists $TESTPOOL/vol && destroy_dataset $TESTPOOL/vol
+	poolexists $TESTPOOL && log_must zpool destroy $TESTPOOL
+
 	if [[ -f $VDEV ]]; then
 		log_must rm -f $VDEV
 	fi

--- a/tests/zfs-tests/tests/functional/casenorm/casenorm.kshlib
+++ b/tests/zfs-tests/tests/functional/casenorm/casenorm.kshlib
@@ -34,7 +34,7 @@ function create_testfs
 function destroy_testfs
 {
 	if datasetexists $TESTPOOL/$TESTFS ; then
-		log_must zfs destroy -f $TESTPOOL/$TESTFS
+		destroy_dataset $TESTPOOL/$TESTFS -f
 		rm -rf $TESTDIR || log_unresolved Could not remove $TESTDIR
 	fi
 }

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.ksh
@@ -30,7 +30,7 @@ create_clone
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS@$TESTSNAP && \
-	    log_must zfs destroy -R $TESTPOOL/$TESTFS@$TESTSNAP
+	    destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP -R
 }
 
 log_must_program $TESTPOOL $ZCP_ROOT/lua_core/tst.exists.zcp \

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.return_large.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.return_large.ksh
@@ -27,7 +27,7 @@ fs=$TESTPOOL/$TESTFS/testchild
 
 function cleanup
 {
-	datasetexists $fs && log_must zfs destroy -R $fs
+	datasetexists $fs && destroy_dataset $fs -R
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_string_props.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_string_props.ksh
@@ -30,8 +30,8 @@ clone=$TESTPOOL/$TESTCLONE
 
 function cleanup
 {
-	datasetexists $clone && log_must zfs destroy $clone
-	datasetexists $fs && log_must zfs destroy -R $fs
+	datasetexists $clone && destroy_dataset $clone
+	datasetexists $fs && destroy_dataset $fs -R
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.terminate_by_signal.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.terminate_by_signal.ksh
@@ -28,7 +28,7 @@ limit=50000000
 
 function cleanup
 {
-	datasetexists $rootfs && log_must zfs destroy -R $rootfs
+	datasetexists $rootfs && destroy_dataset $rootfs -R
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs/zfs_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs/zfs_002_pos.ksh
@@ -56,9 +56,7 @@ function cleanup
 		rm -rf $corepath
 	fi
 	for ds in $fs1 $fs $ctr; do
-		if datasetexists $ds; then
-			log_must zfs destroy -rRf $ds
-		fi
+		datasetexists $ds && destroy_dataset $ds -rRf
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_bookmark/zfs_bookmark_cliargs.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_bookmark/zfs_bookmark_cliargs.ksh
@@ -54,15 +54,14 @@ verify_runnable "both"
 
 function cleanup
 {
-	if snapexists "$DATASET@$TESTSNAP"; then
-		log_must zfs destroy "$DATASET@$TESTSNAP"
-	fi
-	if bkmarkexists "$DATASET#$TESTBM"; then
-		log_must zfs destroy "$DATASET#$TESTBM"
-	fi
-	if bkmarkexists "$DATASET#$TESTBMCOPY"; then
-		log_must zfs destroy "$DATASET#$TESTBMCOPY"
-	fi
+	snapexists "$DATASET@$TESTSNAP" && \
+		destroy_dataset "$DATASET@$TESTSNAP"
+
+	bkmarkexists "$DATASET#$TESTBM" && \
+		destroy_dataset "$DATASET#$TESTBM"
+
+	bkmarkexists "$DATASET#$TESTBMCOPY" && \
+		destroy_dataset "$DATASET#$TESTBMCOPY"
 }
 
 log_assert "'zfs bookmark' should work only when passed valid arguments."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key.ksh
@@ -40,7 +40,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_child.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_child.ksh
@@ -44,7 +44,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_clones.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_clones.ksh
@@ -40,7 +40,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -Rf $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -Rf
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_format.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_format.ksh
@@ -43,7 +43,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_inherit.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_inherit.ksh
@@ -42,7 +42,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_load.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_load.ksh
@@ -38,7 +38,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_location.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_location.ksh
@@ -40,7 +40,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_pbkdf2iters.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_pbkdf2iters.ksh
@@ -52,7 +52,7 @@ function verify_pbkdf2iters
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_001_neg.ksh
@@ -100,11 +100,11 @@ function setup_all
 function cleanup_all
 {
 	for fs in $targets; do
-		datasetexists $fs && log_must zfs destroy -f $fs
+		datasetexists $fs && destroy_dataset $fs -f
 	done
 
 	for snap in $SNAPFS $SNAPFS1 ; do
-		snapexists $snap && log_must zfs destroy -Rf $snap
+		snapexists $snap && destroy_dataset $snap -Rf
 	done
 
 	return 0

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_002_pos.ksh
@@ -60,14 +60,10 @@ function setup_all
 function cleanup_all
 {
 
-	if datasetexists $TESTPOOL/notexist ; then
-		log_must zfs destroy -rRf $TESTPOOL/notexist
-	fi
+	datasetexists $TESTPOOL/notexist && destroy_dataset $TESTPOOL/notexist -rRf
 
 	for snap in $SNAPFS $SNAPFS1 ; do
-		if snapexists $snap ; then
-			log_must zfs destroy -Rf $snap
-		fi
+		snapexists $snap && destroy_dataset $snap -Rf
 	done
 
 	return 0

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_003_pos.ksh
@@ -48,9 +48,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	if snapexists $SNAPFS ; then
-		log_must zfs destroy -Rf $SNAPFS
-	fi
+	snapexists $SNAPFS && destroy_dataset $SNAPFS -Rf
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_004_pos.ksh
@@ -48,9 +48,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	if snapexists $SNAPFS ; then
-		log_must zfs destroy -Rf $SNAPFS
-	fi
+	snapexists $SNAPFS && destroy_dataset $SNAPFS -Rf
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_005_pos.ksh
@@ -48,9 +48,7 @@ verify_runnable "global"
 
 function cleanup
 {
-	if snapexists $SNAPFS1 ; then
-		log_must zfs destroy -Rf $SNAPFS1
-	fi
+	snapexists $SNAPFS1 && destroy_dataset $SNAPFS1 -Rf
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_006_pos.ksh
@@ -49,9 +49,7 @@ verify_runnable "global"
 
 function cleanup
 {
-	if snapexists $SNAPFS1 ; then
-		log_must_busy zfs destroy -Rf $SNAPFS1
-	fi
+	snapexists $SNAPFS1 && destroy_dataset $SNAPFS1 -Rf
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_007_pos.ksh
@@ -47,9 +47,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	if snapexists $SNAPFS ; then
-			log_must zfs destroy -Rf $SNAPFS
-	fi
+	snapexists $SNAPFS && destroy_dataset $SNAPFS -Rf
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_008_neg.ksh
@@ -48,9 +48,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	if snapexists $SNAPFS ; then
-		log_must zfs destroy -Rf $SNAPFS
-	fi
+	snapexists $SNAPFS && destroy_dataset $SNAPFS -Rf
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_009_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_009_neg.ksh
@@ -48,9 +48,7 @@ verify_runnable "global"
 
 function cleanup
 {
-	if snapexists $SNAPFS1 ; then
-		log_must zfs destroy -Rf $SNAPFS1
-	fi
+	snapexists $SNAPFS1 && destroy_dataset $SNAPFS1 -Rf
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_010_pos.ksh
@@ -39,8 +39,8 @@ function local_cleanup
 	typeset -i i=1
 	for ds in $datasets; do
                 datasetexists $ds/$TESTCLONE.$i && \
-		    log_must zfs destroy -rf $ds/$TESTCLONE.$i
-                datasetexists $ds && log_must zfs destroy -Rf $ds
+		    destroy_dataset $ds/$TESTCLONE.$i -rf
+                datasetexists $ds && destroy_dataset $ds -Rf
 		((i=i+1))
 	done
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_encrypted.ksh
@@ -44,9 +44,9 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -f
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_001_pos.ksh
@@ -49,9 +49,7 @@ function cleanup
 	typeset ds
 
 	for ds in $fs1 $fs2 $vol1 $vol2; do
-		if datasetexists $ds; then
-			log_must zfs destroy $ds
-		fi
+		datasetexists $ds && destroy_dataset $ds
 	done
 }
 
@@ -94,13 +92,13 @@ for val in 1 2 3; do
 		fi
 		for ds in $fs2 $vol2; do
 			cmp_prop $ds $val2
-			log_must zfs destroy $ds
+			destroy_dataset $ds
 			block_device_wait
 		done
 	done
 
 	for ds in $fs1 $vol1; do
-		log_must zfs destroy $ds
+		destroy_dataset $ds
 		block_device_wait
 	done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_002_pos.ksh
@@ -50,9 +50,8 @@ function cleanup
 	typeset val
 
 	for val in 1 2 3; do
-		if datasetexists $TESTPOOL/fs_$val; then
-			log_must zfs destroy $TESTPOOL/fs_$val
-		fi
+		datasetexists $TESTPOOL/fs_$val && \
+			destroy_dataset $TESTPOOL/fs_$val
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_003_pos.ksh
@@ -51,9 +51,7 @@ function cleanup
 		destroy_pool $TESTPOOL1
 	fi
 
-	if datasetexists $vol; then
-		log_must zfs destroy $vol
-	fi
+	datasetexists $vol && destroy_dataset $vol
 }
 
 log_assert "Verify that ZFS volume space used by multiple copies is charged correctly."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_006_pos.ksh
@@ -51,9 +51,7 @@ function cleanup
 		log_must umount $mntp
 	fi
 
-	if datasetexists $vol; then
-		log_must zfs destroy $vol
-	fi
+	datasetexists $vol && destroy_dataset $vol
 
 	if [[ -d $mntp ]]; then
                 rm -rf $mntp

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_001_pos.ksh
@@ -48,7 +48,7 @@ function cleanup
 	typeset -i i=0
 	while (( $i < ${#datasets[*]} )); do
 		datasetexists ${datasets[$i]} && \
-			log_must zfs destroy -f ${datasets[$i]}
+			destroy_dataset ${datasets[$i]} -f
 		((i = i + 1))
 	done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_003_pos.ksh
@@ -46,8 +46,7 @@ verify_runnable "global"
 
 function cleanup
 {
-	datasetexists $vol && \
-		log_must zfs destroy -f $vol
+	datasetexists $vol && destroy_dataset $vol -f
 }
 
 log_assert "Verify creating volume with specified blocksize works."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_004_pos.ksh
@@ -48,8 +48,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+	datasetexists $TESTPOOL/$TESTFS1 && destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 
 log_onexit cleanup
@@ -65,7 +64,7 @@ while (( $i < ${#RW_FS_PROP[*]} )); do
 		log_fail "zfs create $TESTPOOL/$TESTFS1 fail."
 	propertycheck $TESTPOOL/$TESTFS1 ${RW_FS_PROP[i]} || \
 		log_fail "${RW_FS_PROP[i]} is failed to set."
-	log_must zfs destroy -f $TESTPOOL/$TESTFS1
+	log_must_busy zfs destroy -f $TESTPOOL/$TESTFS1
 	(( i = i + 1 ))
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_005_pos.ksh
@@ -49,7 +49,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_006_pos.ksh
@@ -50,7 +50,7 @@ verify_runnable "global"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTVOL1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTVOL1
+		destroy_dataset $TESTPOOL/$TESTVOL1 -f
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_008_neg.ksh
@@ -46,9 +46,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $TESTPOOL/$TESTFS1 ; then
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
-	fi
+	datasetexists $TESTPOOL/$TESTFS1 && \
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_011_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_011_pos.ksh
@@ -48,9 +48,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $TESTPOOL/$TESTFS1 ; then
-		log_must zfs destroy -rf $TESTPOOL/$TESTFS1
-	fi
+	datasetexists $TESTPOOL/$TESTFS1 && \
+		destroy_dataset $TESTPOOL/$TESTFS1 -rf
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_012_pos.ksh
@@ -48,9 +48,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $TESTPOOL/$TESTFS1 ; then
-		log_must zfs destroy -rf $TESTPOOL/$TESTFS1
-	fi
+	datasetexists $TESTPOOL/$TESTFS1 && \
+		destroy_dataset $TESTPOOL/$TESTFS1 -rf
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_014_pos.ksh
@@ -43,8 +43,7 @@ TESTFS2=$(for i in $(seq $((255 - ${#TESTPOOL}))); do echo z ; done | tr -d '\n'
 
 function cleanup
 {
-	datasetexists $TESTPOOL/$TESTFS1 &&
-		log_must zfs destroy $TESTPOOL/$TESTFS1
+	datasetexists $TESTPOOL/$TESTFS1 && destroy_dataset $TESTPOOL/$TESTFS1
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_crypt_combos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_crypt_combos.ksh
@@ -38,7 +38,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 
 log_onexit cleanup
@@ -89,7 +89,7 @@ while (( i < ${#ENCRYPTION_ALGS[*]} )); do
 		propertycheck $TESTPOOL/$TESTFS1 ${KEYFORMATS[j]} || \
 			log_fail "failed to set ${KEYFORMATS[j]}"
 
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+		log_must_busy zfs destroy -f $TESTPOOL/$TESTFS1
 		(( j = j + 1 ))
 	done
 	(( i = i + 1 ))

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_dryrun.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_dryrun.ksh
@@ -126,9 +126,8 @@ function dry_create_parseable
 
 function cleanup
 {
-	if datasetexists "$TESTPOOL/$TESTFS1"; then
-		log_must zfs destroy -r "$TESTPOOL/$TESTFS1"
-	fi
+	datasetexists "$TESTPOOL/$TESTFS1" && \
+		destroy_dataset "$TESTPOOL/$TESTFS1" -r
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_encrypted.ksh
@@ -70,9 +70,9 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_verbose.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_verbose.ksh
@@ -131,9 +131,8 @@ function dry_create_parseable
 
 function cleanup
 {
-	if datasetexists "$TESTPOOL/$TESTFS1"; then
-		log_must_busy zfs destroy -r "$TESTPOOL/$TESTFS1"
-	fi
+	datasetexists "$TESTPOOL/$TESTFS1" && \
+		destroy_dataset "$TESTPOOL/$TESTFS1" -r
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
@@ -77,9 +77,7 @@ function test_n_check
 	fi
 
 	# Clean the test environment and make it clear.
-	if datasetexists $CTR; then
-		log_must zfs destroy -Rf $CTR
-	fi
+	datasetexists $CTR && destroy_dataset $CTR -Rf
 
 	# According to option create test compatible environment.
 	case $opt in

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_003_pos.ksh
@@ -50,8 +50,7 @@ verify_runnable "both"
 function cleanup
 {
 	for obj in $ctr2 $ctr1 $ctr; do
-		datasetexists $obj && \
-			log_must zfs destroy -Rf $obj
+		datasetexists $obj && destroy_dataset $obj -Rf
 	done
 
 	for mntp in $TESTDIR1 $TESTDIR2; do
@@ -142,14 +141,14 @@ done
 log_note "Verify that 'zfs destroy -R' succeeds to destroy dataset " \
 	"with dependent clone outside it."
 
-log_must zfs destroy -R $ctr1
+log_must_busy zfs destroy -R $ctr1
 datasetexists $ctr1 && \
 	log_fail "'zfs destroy -R' fails to destroy dataset with clone outside it."
 
 log_note "Verify that 'zfs destroy -r' succeeds to destroy dataset " \
 	"without dependent clone outside it."
 
-log_must zfs destroy -r $ctr
+log_must_busy zfs destroy -r $ctr
 datasetexists $ctr && \
 	log_fail "'zfs destroy -r' fails to destroy dataset with clone outside it."
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_004_pos.ksh
@@ -49,15 +49,11 @@ function cleanup
 {
 	cd $olddir
 
-	datasetexists $clone && \
-		log_must zfs destroy -f $clone
-
-	snapexists $snap && \
-		log_must zfs destroy -f $snap
+	datasetexists $clone && destroy_dataset $clone -f
+	snapexists $snap && destroy_dataset $snap -f
 
 	for fs in $fs1 $fs2; do
-		datasetexists $fs && \
-			log_must zfs destroy -f $fs
+		datasetexists $fs && destroy_dataset $fs -f
 	done
 
 	for dir in $TESTDIR1 $TESTDIR2; do

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_007_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_007_neg.ksh
@@ -51,8 +51,8 @@ function cleanup
 	if datasetexists $clonesnap; then
 		log_must zfs promote $fs
 	fi
-	datasetexists $clone && log_must zfs destroy $clone
-	datasetexists $fssnap && log_must zfs destroy $fssnap
+	datasetexists $clone && destroy_dataset $clone
+	datasetexists $fssnap && destroy_dataset $fssnap
 }
 
 log_assert "Destroy dataset which is namespace-parent of origin should failed."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_014_pos.ksh
@@ -45,7 +45,7 @@ datasets="$TESTPOOL/$TESTFS1 $TESTPOOL/$TESTFS1/$TESTFS2
 function cleanup
 {
 	for ds in $datasets; do
-		datasetexists $ds && zfs destroy -rf $ds
+		datasetexists $ds && destroy_dataset $ds -rf
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_015_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_015_pos.ksh
@@ -30,8 +30,8 @@
 
 function cleanup
 {
-	datasetexists $TESTPOOL/$TESTFS1 && zfs destroy -R $TESTPOOL/$TESTFS1
-	datasetexists $TESTPOOL/$TESTFS2 && zfs destroy -R $TESTPOOL/$TESTFS2
+	datasetexists $TESTPOOL/$TESTFS1 && destroy_dataset $TESTPOOL/$TESTFS1 -R
+	datasetexists $TESTPOOL/$TESTFS2 && destroy_dataset $TESTPOOL/$TESTFS2 -R
 	poolexists $TESTPOOL2 && zpool destroy $TESTPOOL2
 	rm -rf $VIRTUAL_DISK
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_016_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_016_pos.ksh
@@ -30,18 +30,18 @@
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-	    log_must zfs destroy -R $TESTPOOL/$TESTFS1
+	    destroy_dataset $TESTPOOL/$TESTFS1 -R
 	datasetexists $TESTPOOL/$TESTVOL && \
-	    log_must zfs destroy -Rf $TESTPOOL/$TESTVOL
+	    destroy_dataset $TESTPOOL/$TESTVOL -Rf
 }
 
 function setup_snapshots
 {
 	for i in $snaps; do
 		datasetexists $TESTPOOL/$TESTFS1@snap$i && \
-		    log_must zfs destroy $TESTPOOL/$TESTFS1@snap$i
+		    destroy_dataset $TESTPOOL/$TESTFS1@snap$i
 		datasetexists $TESTPOOL/$TESTVOL@snap$i && \
-		    log_must zfs destroy $TESTPOOL/$TESTVOL@snap$i
+		    destroy_dataset $TESTPOOL/$TESTVOL@snap$i
 		log_must zfs snapshot $TESTPOOL/$TESTFS1@snap$i
 		log_must zfs snapshot $TESTPOOL/$TESTVOL@snap$i
 	done

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_clone_livelist.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_clone_livelist.ksh
@@ -39,7 +39,7 @@
 
 function cleanup
 {
-	datasetexists $TESTPOOL/$TESTFS1 && zfs destroy -R $TESTPOOL/$TESTFS1
+	datasetexists $TESTPOOL/$TESTFS1 && destroy_dataset $TESTPOOL/$TESTFS1 -R
 	# reset the livelist sublist size to its original value
 	set_tunable64 LIVELIST_MAX_ENTRIES $ORIGINAL_MAX
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
@@ -102,9 +102,7 @@ function cleanup_testenv
 
 	pkill mkbusy
 
-	if datasetexists $CTR; then
-		log_must zfs destroy -Rf $CTR
-	fi
+	datasetexists $CTR && destroy_dataset $CTR -Rf
 }
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_cliargs.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_cliargs.ksh
@@ -32,9 +32,7 @@ verify_runnable "both"
 function cleanup
 {
 	for snap in $TESTSNAP1 $TESTSNAP2; do
-		if snapexists "$snap"; then
-			log_must zfs destroy "$snap"
-		fi
+		snapexists "$snap" && destroy_dataset "$snap"
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_timestamp.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_timestamp.ksh
@@ -31,9 +31,7 @@ verify_runnable "both"
 function cleanup
 {
 	for snap in $TESTSNAP1 $TESTSNAP2; do
-		if snapexists "$snap"; then
-			log_must zfs destroy "$snap"
-		fi
+		snapexists "$snap" && destroy_dataset "$snap"
 	done
 	find "$MNTPOINT" -type f -delete
 	rm -f "$FILEDIFF"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_004_pos.ksh
@@ -47,11 +47,9 @@ function cleanup
 {
 	[[ -e $propfile ]] && rm -f $propfile
 
-	datasetexists $clone  && \
-		log_must zfs destroy $clone
+	datasetexists $clone  && destroy_dataset $clone
 	for snap in $fssnap $volsnap ; do
-		snapexists $snap && \
-			log_must zfs destroy $snap
+		snapexists $snap && destroy_dataset $snap
 	done
 
 	if [[ -n $globalzone ]] ; then
@@ -64,8 +62,7 @@ function cleanup
 		done
 	else
 		for fs in $TESTPOOL/$TESTFS1 $TESTPOOL/$TESTFS2 $TESTPOOL/$TESTFS3; do
-			datasetexists $fs && \
-				log_must zfs destroy -rf $fs
+			datasetexists $fs && destroy_dataset $fs -rf
 		done
 	fi
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_list_d.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_list_d.kshlib
@@ -78,7 +78,5 @@ function depth_fs_setup
 #
 function depth_fs_cleanup
 {
-	log_must zfs destroy -rR $DEPTH_FS
+	datasetexists $DEPTH_FS && destroy_dataset $DEPTH_FS -rR
 }
-
-

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_inherit/zfs_inherit_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_inherit/zfs_inherit_002_neg.ksh
@@ -45,9 +45,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	if snapexists $TESTPOOL/$TESTFS@$TESTSNAP; then
-		log_must zfs destroy $TESTPOOL/$TESTFS@$TESTSNAP
-	fi
+	snapexists $TESTPOOL/$TESTFS@$TESTSNAP && \
+		destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP
 }
 
 log_assert "'zfs inherit' should return an error with bad parameters in" \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_inherit/zfs_inherit_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_inherit/zfs_inherit_003_pos.ksh
@@ -47,9 +47,7 @@ verify_runnable "both"
 function cleanup
 {
 	for ds in $TESTPOOL $TESTPOOL/$TESTFS $TESTPOOL/$TESTVOL ; do
-		if snapexists $ds@$TESTSNAP; then
-			log_must zfs destroy $ds@$TESTSNAP
-		fi
+		snapexists $ds@$TESTSNAP && destroy_dataset $ds@$TESTSNAP
 	done
 	cleanup_user_prop $TESTPOOL
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key.ksh
@@ -46,7 +46,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1
 	poolexists $TESTPOOL1 && log_must destroy_pool $TESTPOOL1
 }
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_all.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_all.ksh
@@ -37,9 +37,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy $TESTPOOL/$TESTFS1
-	datasetexists $TESTPOOL/zvol && log_must zfs destroy $TESTPOOL/zvol
+	datasetexists $TESTPOOL/$TESTFS1 && destroy_dataset $TESTPOOL/$TESTFS1
+	datasetexists $TESTPOOL/zvol && destroy_dataset $TESTPOOL/zvol
 	poolexists $TESTPOOL1 && log_must destroy_pool $TESTPOOL1
 }
 log_onexit cleanup
@@ -58,12 +57,12 @@ log_must zpool create -O encryption=on -O keyformat=passphrase \
 	-O keylocation=file:///$TESTPOOL/pkey $TESTPOOL1 $DISK2
 
 log_must zfs unmount $TESTPOOL/$TESTFS1
-log_must zfs unload-key $TESTPOOL/$TESTFS1
+log_must_busy zfs unload-key $TESTPOOL/$TESTFS1
 
-log_must zfs unload-key $TESTPOOL/zvol
+log_must_busy zfs unload-key $TESTPOOL/zvol
 
 log_must zfs unmount $TESTPOOL1
-log_must zfs unload-key $TESTPOOL1
+log_must_busy zfs unload-key $TESTPOOL1
 
 log_must zfs load-key -a
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_file.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_file.ksh
@@ -38,7 +38,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_location.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_location.ksh
@@ -44,7 +44,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_noop.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_noop.ksh
@@ -37,7 +37,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_recursive.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_recursive.ksh
@@ -39,7 +39,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_008_pos.ksh
@@ -47,9 +47,7 @@ function cleanup
 {
 	! ismounted $fs && log_must zfs mount $fs
 
-	if datasetexists $fs1; then
-		log_must zfs destroy $fs1
-	fi
+	datasetexists $fs1 && destroy_dataset $fs1
 
 	if [[ -f $testfile ]]; then
 		log_must rm -f $testfile

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_011_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_011_neg.ksh
@@ -45,12 +45,11 @@ verify_runnable "both"
 
 function cleanup
 {
-	if snapexists $TESTPOOL/$TESTFS@$TESTSNAP; then
-		log_must_busy zfs destroy $TESTPOOL/$TESTFS@$TESTSNAP
-	fi
+	snapexists $TESTPOOL/$TESTFS@$TESTSNAP && \
+		destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP
 
 	if is_global_zone && datasetexists $TESTPOOL/$TESTVOL; then
-		log_must_busy zfs destroy $TESTPOOL/$TESTVOL
+		destroy_dataset $TESTPOOL/$TESTVOL
 	fi
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_encrypted.ksh
@@ -42,7 +42,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_remount.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_remount.ksh
@@ -48,7 +48,7 @@ function cleanup
 {
 	log_must_busy zpool export $TESTPOOL
 	log_must zpool import $TESTPOOL
-	snapexists $TESTSNAP && log_must zfs destroy $TESTSNAP
+	snapexists $TESTSNAP && destroy_dataset $TESTSNAP
 	[[ -d $MNTPSNAP ]] && log_must rmdir $MNTPSNAP
 	return 0
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_001_pos.ksh
@@ -50,8 +50,7 @@ function cleanup
 	if snapexists $csnap; then
 		log_must zfs promote $fs
 	fi
-	snapexists $snap && \
-		log_must zfs destroy -rR $snap
+	snapexists $snap && destroy_dataset $snap -rR
 
 	typeset data
 	for data in $file0 $file1; do

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_003_pos.ksh
@@ -54,8 +54,7 @@ function cleanup
 	typeset ds
 	typeset data
 	for ds in ${snap[*]}; do
-		snapexists $ds && \
-			log_must zfs destroy -rR $ds
+		snapexists $ds && destroy_dataset $ds -rR
 	done
 	for data in ${file[*]}; do
 		[[ -e $data ]] && rm -f $data

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_004_pos.ksh
@@ -53,8 +53,7 @@ function cleanup
 	typeset ds
 	typeset data
 	for ds in ${snap[*]}; do
-		snapexists $ds && \
-			log_must zfs destroy -rR $ds
+		snapexists $ds && destroy_dataset $ds -rR
 	done
 	for data in ${file[*]}; do
 		[[ -e $data ]] && rm -f $data

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_005_pos.ksh
@@ -46,8 +46,8 @@ verify_runnable "both"
 function cleanup
 {
 	if datasetexists $fssnap ; then
-		datasetexists $clone && log_must zfs destroy $clone
-		log_must zfs destroy $fssnap
+		datasetexists $clone && destroy_dataset $clone
+		destroy_dataset $fssnap
 	fi
 	if datasetexists $clone ; then
 		log_must zfs promote $fs

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_006_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_006_neg.ksh
@@ -62,13 +62,9 @@ set -A args "" \
 
 function cleanup
 {
-	if datasetexists $clone; then
-		log_must zfs destroy $clone
-	fi
+	datasetexists $clone && destroy_dataset $clone
 
-	if datasetexists $recvfs; then
-		log_must zfs destroy -r $recvfs
-	fi
+	datasetexists $recvfs && destroy_dataset $recvfs -r
 
 	if snapexists $snap; then
 		destroy_snapshot  $snap

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_007_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_007_neg.ksh
@@ -47,8 +47,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	snapexists $snap && \
-		log_must zfs destroy -rR $snap
+	snapexists $snap && destroy_dataset $snap -rR
 
 	typeset data
 	for data in $TESTDIR/$TESTFILE0 $TESTDIR/$TESTFILE1; do

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_encryptionroot.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_encryptionroot.ksh
@@ -42,11 +42,11 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -Rf $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -Rf
 	datasetexists $TESTPOOL/clone1 && \
-		log_must zfs destroy -Rf $TESTPOOL/clone1
+		destroy_dataset $TESTPOOL/clone1 -Rf
 	datasetexists $TESTPOOL/clone2 && \
-		log_must zfs destroy -Rf $TESTPOOL/clone2
+		destroy_dataset $TESTPOOL/clone2 -Rf
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_property/zfs_written_property_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_property/zfs_written_property_001_pos.ksh
@@ -36,7 +36,7 @@
 function cleanup
 {
 	for ds in $datasets; do
-		datasetexists $ds && log_must zfs destroy -R $TESTPOOL/$TESTFS1
+		datasetexists $ds && destroy_dataset $TESTPOOL/$TESTFS1 -R
 	done
 }
 function get_prop_mb

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_001_pos.ksh
@@ -48,11 +48,9 @@ function cleanup
 {
 	typeset -i i=0
 
-	datasetexists $rst_root && \
-		log_must zfs destroy -Rf $rst_root
+	datasetexists $rst_root && destroy_dataset $rst_root -Rf
 	while (( i < 2 )); do
-		snapexists ${orig_snap[$i]} && \
-			log_must zfs destroy -f ${orig_snap[$i]}
+		snapexists ${orig_snap[$i]} && destroy_dataset ${orig_snap[$i]} -f
 		log_must rm -f ${bkup[$i]}
 
 		(( i = i + 1 ))
@@ -63,8 +61,7 @@ function cleanup
 
 function recreate_root
 {
-	datasetexists $rst_root && \
-		log_must zfs destroy -Rf $rst_root
+	datasetexists $rst_root && destroy_dataset $rst_root -Rf
 	if [[ -d $TESTDIR1 ]] ; then
 		log_must rm -rf $TESTDIR1
 	fi

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_002_pos.ksh
@@ -50,10 +50,8 @@ function cleanup
 	typeset ds
 
 	while (( i < ${#orig_snap[*]} )); do
-		snapexists ${rst_snap[$i]} && \
-			log_must zfs destroy -f ${rst_snap[$i]}
-		snapexists ${orig_snap[$i]} && \
-			log_must zfs destroy -f ${orig_snap[$i]}
+		snapexists ${rst_snap[$i]} && destroy_dataset ${rst_snap[$i]} -f
+		snapexists ${orig_snap[$i]} && destroy_dataset ${orig_snap[$i]} -f
 		[[ -e ${bkup[$i]} ]] && \
 			log_must rm -rf ${bkup[$i]}
 
@@ -61,8 +59,7 @@ function cleanup
 	done
 
 	for ds in $rst_vol $rst_root; do
-		datasetexists $ds && \
-			log_must zfs destroy -Rf $ds
+		datasetexists $ds && destroy_dataset $ds -Rf
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_003_pos.ksh
@@ -49,7 +49,7 @@ verify_runnable "both"
 function cleanup
 {
 	for snap in $snap2 $snap1; do
-		datasetexists $snap && log_must zfs destroy -rf $snap
+		datasetexists $snap && destroy_dataset $snap -rf
 	done
 	for file in $ibackup $mntpnt/file1 $mntpnt/file2; do
 		[[ -f $file ]] && log_must rm -f $file

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_004_neg.ksh
@@ -49,8 +49,7 @@ function cleanup
 	typeset bkup
 
 	for snap in $init_snap $inc_snap $init_topsnap $inc_topsnap ; do
-		snapexists $snap && \
-			log_must zfs destroy -Rf $snap
+		snapexists $snap && destroy_dataset $snap -Rf
 	done
 
 	for bkup in $full_bkup $inc_bkup $full_topbkup $inc_topbkup; do

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_005_neg.ksh
@@ -53,12 +53,10 @@ function cleanup
 	typeset bkup
 
 	for snap in $init_snap $inc_snap; do
-		snapexists $snap && \
-			log_must zfs destroy -f $snap
+		snapexists $snap && destroy_dataset $snap -f
 	done
 
-	datasetexists $rst_root && \
-		log_must zfs destroy -Rf $rst_root
+	datasetexists $rst_root && destroy_dataset $rst_root -Rf
 
 	for bkup in $full_bkup $inc_bkup; do
 		[[ -e $bkup ]] && \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_006_pos.ksh
@@ -51,7 +51,7 @@ verify_runnable "both"
 function cleanup
 {
 	for snap in $snap2 $snap1; do
-		datasetexists $snap && log_must zfs destroy -rf $snap
+		datasetexists $snap && destroy_dataset $snap -rf
 	done
 	for file in $fbackup1 $fbackup2 $mntpnt/file1 $mntpnt/file2; do
 		[[ -f $file ]] && log_must rm -f $file
@@ -59,10 +59,10 @@ function cleanup
 
 	if is_global_zone; then
 		datasetexists $TESTPOOL/$TESTFS/$TESTFS1 && \
-			log_must zfs destroy -rf $TESTPOOL/$TESTFS/$TESTFS1
+			destroy_dataset $TESTPOOL/$TESTFS/$TESTFS1 -rf
 	else
 		datasetexists $TESTPOOL/${ZONE_CTR}0 && \
-			log_must zfs destroy -rf $TESTPOOL/${ZONE_CTR}0
+			destroy_dataset $TESTPOOL/${ZONE_CTR}0 -rf
 	fi
 
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_007_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_007_neg.ksh
@@ -47,7 +47,7 @@ verify_runnable "both"
 function cleanup
 {
 	for snap in $snap2 $snap1; do
-		datasetexists $snap && log_must zfs destroy -rf $snap
+		datasetexists $snap && destroy_dataset $snap -rf
 	done
 	for file in $ibackup $mntpnt/file1 $mntpnt/file2; do
 		[[ -f $file ]] && log_must rm -f $file

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_008_pos.ksh
@@ -47,9 +47,7 @@
 function cleanup
 {
 	for dset in $rst_snap $rst_fs $orig_snap; do
-		if datasetexists $dset; then
-			log_must zfs destroy -fr $dset
-		fi
+		datasetexists $dset && destroy_dataset $dset -fr
 	done
 
 	for file in $fbackup $mnt_file $tmp_out; do
@@ -59,7 +57,7 @@ function cleanup
 	done
 
 	if datasetexists $TESTPOOL/$TESTFS; then
-		log_must zfs destroy -Rf $TESTPOOL/$TESTFS
+		destroy_dataset $TESTPOOL/$TESTFS -Rf
 		log_must zfs create $TESTPOOL/$TESTFS
 		log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 	fi
@@ -99,9 +97,7 @@ for orig_fs in $datasets ; do
 	log_must eval "zfs send $orig_snap > $fbackup"
 
 	for opt in "-v"  "-vn"; do
-		if datasetexists $rst_fs; then
-			log_must zfs destroy -fr $rst_fs
-		fi
+		datasetexists $rst_fs && destroy_dataset $rst_fs -fr
 		log_note "Check ZFS receive $opt [<filesystem|snapshot>]"
 		log_must eval "zfs receive $opt $rst_fs < $fbackup > $tmp_out 2>&1"
 		if [[ $opt == "-v" ]]; then

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_009_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_009_neg.ksh
@@ -48,13 +48,10 @@ function cleanup
 {
 	typeset ds
 
-	if snapexists $snap; then
-		log_must zfs destroy $snap
-	fi
+	snapexists $snap && destroy_dataset $snap
+
 	for ds in $ctr1 $ctr2 $fs1; do
-		if datasetexists $ds; then
-			log_must zfs destroy -rf $ds
-		fi
+		datasetexists $ds && destroy_dataset $ds -rf
 	done
 	if [[ -d $TESTDIR2 ]]; then
 		rm -rf $TESTDIR2

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_013_pos.ksh
@@ -39,7 +39,7 @@ tpoolfile=$TEST_BASE_DIR/temptank.$$
 function cleanup
 {
     for fs in $src_fs $dst_fs; do
-        datasetexists $fs && log_must zfs destroy -rf $fs
+        datasetexists $fs && log_must destroy_dataset $fs -rf
     done
     zpool destroy $temppool
     [[ -f $streamfile ]] && log_must rm -f $streamfile

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_from_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_from_encrypted.ksh
@@ -41,10 +41,10 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_from_zstd.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_from_zstd.ksh
@@ -40,10 +40,10 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_raw.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_raw.ksh
@@ -44,10 +44,10 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_raw_-d.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_raw_-d.ksh
@@ -38,7 +38,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 	rm -f $sendfile
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_raw_incremental.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_raw_incremental.ksh
@@ -43,10 +43,10 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
 
 	[[ -f $ibackup ]] && log_must rm -f $ibackup
 	[[ -f $ibackup_trunc ]] && log_must rm -f $ibackup_trunc

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_to_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_to_encrypted.ksh
@@ -38,10 +38,10 @@ verify_runnable "both"
 
 function cleanup
 {
-	snapexists $snap && log_must_busy zfs destroy -f $snap
+	snapexists $snap && destroy_dataset $snap -f
 
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename.kshlib
@@ -108,13 +108,11 @@ function cleanup
                 ((i = i + 1))
 	done
 
-	if snapexists $TESTPOOL/$TESTFS@snapshot; then
-		log_must zfs destroy -fR $TESTPOOL/$TESTFS@snapshot
-	fi
+	snapexists $TESTPOOL/$TESTFS@snapshot && \
+		 destroy_dataset $TESTPOOL/$TESTFS@snapshot -fR
 
-	if datasetexists $TESTPOOL/$RECVFS; then
-		log_must zfs destroy -r $TESTPOOL/$RECVFS
-	fi
+	datasetexists $TESTPOOL/$RECVFS && \
+		destroy_dataset $TESTPOOL/$RECVFS -r
 }
 
 function cmp_data #<$1 src data, $2 tgt data>

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_003_pos.ksh
@@ -44,7 +44,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $snap && log_must zfs destroy $snap
+	datasetexists $snap && destroy_dataset $snap
 }
 
 log_assert "'zfs rename' can address the abbreviated snapshot name."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_007_pos.ksh
@@ -46,9 +46,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $TESTPOOL/$TESTFS ; then
-		log_must zfs destroy -Rf $TESTPOOL/$TESTFS
-	fi
+	datasetexists $TESTPOOL/$TESTFS && \
+		destroy_dataset $TESTPOOL/$TESTFS -Rf
 	log_must zfs create $TESTPOOL/$TESTFS
 	log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_008_pos.ksh
@@ -47,12 +47,11 @@ function cleanup
 {
 	typeset -i i=0
 	while ((i < ${#datasets[@]})); do
-		if datasetexists ${datasets[$i]}@snap ; then
-			log_must zfs destroy ${datasets[$i]}@snap
-		fi
-		if datasetexists ${datasets[$i]}@snap-new ; then
-			log_must zfs destroy ${datasets[$i]}@snap-new
-		fi
+		datasetexists ${datasets[$i]}@snap && \
+			destroy_dataset ${datasets[$i]}@snap
+
+		datasetexists ${datasets[$i]}@snap-new && \
+			destroy_dataset ${datasets[$i]}@snap-new
 
 		((i += 1))
 	done

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_011_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_011_pos.ksh
@@ -46,19 +46,18 @@ verify_runnable "both"
 
 function additional_cleanup
 {
-	if datasetexists $TESTPOOL/notexist ; then
-		log_must zfs destroy -Rf $TESTPOOL/notexist
-	fi
+	datasetexists $TESTPOOL/notexist && \
+		destroy_dataset $TESTPOOL/notexist -Rf
 
-	if datasetexists $TESTPOOL/$TESTFS ; then
-		log_must zfs destroy -Rf $TESTPOOL/$TESTFS
-	fi
+	datasetexists $TESTPOOL/$TESTFS && \
+		destroy_dataset $TESTPOOL/$TESTFS -Rf
+
 	log_must zfs create $TESTPOOL/$TESTFS
 
 	if is_global_zone ; then
-		if datasetexists $TESTPOOL/$TESTVOL ; then
-			log_must zfs destroy -Rf $TESTPOOL/$TESTVOL
-		fi
+		datasetexists $TESTPOOL/$TESTVOL && \
+			destroy_dataset $TESTPOOL/$TESTVOL -Rf
+
 		log_must zfs create -V $VOLSIZE $TESTPOOL/$TESTVOL
 	fi
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_013_pos.ksh
@@ -46,21 +46,17 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $TESTPOOL/$TESTCTR@snap-new ; then
-		log_must zfs destroy -f $TESTPOOL/$TESTCTR@snap-new
-	fi
+	datasetexists $TESTPOOL/$TESTCTR@snap-new && \
+		destroy_dataset $TESTPOOL/$TESTCTR@snap-new -f
 
-	if datasetexists $TESTPOOL/$TESTCTR@snap ; then
-		log_must zfs destroy -f $TESTPOOL/$TESTCTR@snap
-	fi
+	datasetexists $TESTPOOL/$TESTCTR@snap && \
+		destroy_dataset $TESTPOOL/$TESTCTR@snap -f
 
-	if datasetexists $TESTPOOL@snap-new ; then
-		log_must zfs destroy -f $TESTPOOL@snap-new
-	fi
+	datasetexists $TESTPOOL@snap-new && \
+		destroy_dataset $TESTPOOL@snap-new -f
 
-	if datasetexists $TESTPOOL@snap ; then
-		log_must zfs destroy -f $TESTPOOL@snap
-	fi
+	datasetexists $TESTPOOL@snap && \
+		destroy_dataset $TESTPOOL@snap -f
 }
 
 log_assert "zfs rename -r can rename snapshot when child datasets" \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_encrypted_child.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_encrypted_child.ksh
@@ -42,9 +42,9 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
 	datasetexists $TESTPOOL/$TESTFS3 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS3
+		destroy_dataset $TESTPOOL/$TESTFS3 -r
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_to_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_to_encrypted.ksh
@@ -37,7 +37,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_001_pos.ksh
@@ -76,14 +76,14 @@ function test_n_check #opt num_snap_clone num_rollback
 		pkill -x dd
 	fi
 
-	datasetexists $FS && log_must zfs destroy -Rf $FS
+	datasetexists $FS && destroy_dataset $FS -Rf
 	if datasetexists $VOL; then
 		if ismounted $TESTDIR1 $NEWFS_DEFAULT_FS; then
 			log_must umount -f $TESTDIR1
 			sleep 0.1
 		fi
 
-		log_must zfs destroy -Rf $VOL
+		destroy_dataset $VOL -Rf
 	fi
 
 	# Create specified test environment

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_003_neg.ksh
@@ -51,9 +51,7 @@ function cleanup
 {
 	pkill ${DD##*/}
 	for snap in $FSSNAP0 $FSSNAP1 $FSSNAP2; do
-		if snapexists $snap; then
-			log_must zfs destroy -Rf $snap
-		fi
+		snapexists $snap && destroy_dataset $snap -Rf
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_004_neg.ksh
@@ -51,9 +51,8 @@ function cleanup
 	typeset ds
 
 	for ds in $TESTPOOL $TESTPOOL/$TESTFS $TESTPOOL/$TESTVOL; do
-		if snapexists ${ds}@$TESTSNAP; then
-			log_must zfs destroy ${ds}@$TESTSNAP
-		fi
+		snapexists ${ds}@$TESTSNAP && \
+			destroy_dataset ${ds}@$TESTSNAP
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_common.kshlib
@@ -181,9 +181,7 @@ function cleanup_env
 
 	for dtst in $FS $VOL; do
 		for snap in $TESTSNAP $TESTSNAP1 $TESTSNAP2; do
-			if snapexists $dtst@$snap; then
-				 log_must zfs destroy -Rf $dtst@$snap
-			fi
+			snapexists $dtst@$snap && destroy_dataset $dtst@$snap -Rf
 		done
 	done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send-b.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send-b.ksh
@@ -35,7 +35,7 @@ verify_runnable "both"
 function cleanup
 {
 	for ds in "$SENDFS" "$BACKUP" "$RESTORE"; do
-		datasetexists $ds && log_must zfs destroy -r $ds
+		datasetexists $ds && destroy_dataset $ds -r
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_001_pos.ksh
@@ -50,12 +50,10 @@ verify_runnable "both"
 function cleanup
 {
 	for snap in $init_snap $inc_snap $rst_snap $rst_inc_snap; do
-                snapexists $snap && \
-                        log_must zfs destroy -f $snap
+                snapexists $snap && destroy_dataset $snap -f
         done
 
-	datasetexists $rst_root && \
-		log_must zfs destroy -Rf $rst_root
+	datasetexists $rst_root && destroy_dataset $rst_root -Rf
 
 	for file in $full_bkup $inc_bkup \
 			$init_data $inc_data

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_002_pos.ksh
@@ -48,11 +48,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	snapexists $snap && \
-		log_must zfs destroy $snap
-
-	datasetexists $ctr && \
-		log_must zfs destroy -r $ctr
+	snapexists $snap && destroy_dataset $snap
+	datasetexists $ctr && destroy_dataset $ctr -r
 
 	[[ -e $origfile ]] && \
 		log_must rm -f $origfile

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_003_pos.ksh
@@ -44,8 +44,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $snap1 && log_must zfs destroy $snap1
-	datasetexists $snap2 && log_must zfs destroy $snap2
+	datasetexists $snap1 && destroy_dataset $snap1
+	datasetexists $snap2 && destroy_dataset $snap2
 }
 
 log_assert "'zfs send -i' can deal with abbreviated snapshot name."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_004_neg.ksh
@@ -48,8 +48,7 @@ function cleanup
 	typeset snap f
 
 	for snap in $snap1 $snap2 $snap3; do
-		snapexists $snap && \
-			log_must zfs destroy -f $snap
+		snapexists $snap && destroy_dataset $snap -f
 	done
 
 	for f in $tmpfile1 $tmpfile2; do

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_005_pos.ksh
@@ -50,7 +50,7 @@ function cleanup
 	log_must zpool import $TESTPOOL
 
 	datasetexists $TESTPOOL@snap && \
-	    log_must zfs destroy -r $TESTPOOL@snap
+		destroy_dataset $TESTPOOL@snap -r
 }
 
 log_assert "'zfs send -R' can send from read-only pools"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_encrypted.ksh
@@ -42,7 +42,7 @@ verify_runnable "both"
 function cleanup
 {
     datasetexists $TESTPOOL/$TESTFS1 && \
-        log_must zfs destroy -r $TESTPOOL/$TESTFS1
+	    destroy_dataset $TESTPOOL/$TESTFS1 -r
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_encrypted_unloaded.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_encrypted_unloaded.ksh
@@ -37,7 +37,7 @@ verify_runnable "both"
 function cleanup
 {
     datasetexists $TESTPOOL/$TESTFS1 && \
-        log_must zfs destroy -r $TESTPOOL/$TESTFS1
+	    destroy_dataset $TESTPOOL/$TESTFS1 -r
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_raw.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_raw.ksh
@@ -38,11 +38,9 @@ verify_runnable "both"
 
 function cleanup
 {
-	snapexists $snap && \
-		log_must zfs destroy $snap
-
+	snapexists $snap && destroy_dataset $snap
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_sparse.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_sparse.ksh
@@ -31,8 +31,8 @@ verify_runnable "both"
 
 function cleanup
 {
-        datasetexists $SENDFS && log_must zfs destroy -r $SENDFS
-        datasetexists $RECVFS && log_must zfs destroy -r $RECVFS
+        datasetexists $SENDFS && destroy_dataset $SENDFS -r
+        datasetexists $RECVFS && destroy_dataset $RECVFS -r
 }
 
 #
@@ -63,8 +63,8 @@ function write_compare_files # <sendfs> <recvfs> <offset>
 		log_fail "$sendfile ($sendsz) and $recvfile ($recvsz) differ."
 	fi
 	# cleanup
-	log_must zfs destroy -r $sendfs
-	log_must zfs destroy -r $recvfs
+	destroy_dataset $sendfs -r
+	destroy_dataset $recvfs -r
 }
 
 log_assert "'zfs send' should be able to send (big) sparse files correctly."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/canmount_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/canmount_001_pos.ksh
@@ -63,12 +63,11 @@ set -A values "on" "off"
 
 function cleanup
 {
-	if snapexists $TESTPOOL/$TESTFS@$TESTSNAP ; then
-		log_must zfs destroy -R $TESTPOOL/$TESTFS@$TESTSNAP
-	fi
-	if snapexists $TESTPOOL/$TESTVOL@$TESTSNAP ; then
-		log_must zfs destroy -R $TESTPOOL/$TESTVOL@$TESTSNAP
-	fi
+	snapexists $TESTPOOL/$TESTFS@$TESTSNAP && \
+		destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP -R
+
+	snapexists $TESTPOOL/$TESTVOL@$TESTSNAP && \
+		destroy_dataset $TESTPOOL/$TESTVOL@$TESTSNAP -R
 
 	[[ -n $old_ctr_canmount ]] && \
 		log_must zfs set canmount=$old_ctr_canmount $TESTPOOL/$TESTCTR

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/canmount_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/canmount_002_pos.ksh
@@ -76,18 +76,17 @@ function cleanup
 	ds=$TESTPOOL/$TESTCLONE
 	if datasetexists $ds; then
 		mntp=$(get_prop mountpoint $ds)
-		log_must zfs destroy $ds
+		destroy_dataset $ds
 		if [[ -d $mntp ]]; then
 			rm -fr $mntp
 		fi
 	fi
 
-	if snapexists $TESTPOOL/$TESTFS@$TESTSNAP ; then
-		log_must zfs destroy -R $TESTPOOL/$TESTFS@$TESTSNAP
-	fi
-	if snapexists $TESTPOOL/$TESTVOL@$TESTSNAP ; then
-		log_must zfs destroy -R $TESTPOOL/$TESTVOL@$TESTSNAP
-	fi
+	snapexists $TESTPOOL/$TESTFS@$TESTSNAP && \
+		destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP -R
+
+	snapexists $TESTPOOL/$TESTVOL@$TESTSNAP && \
+		destroy_dataset $TESTPOOL/$TESTVOL@$TESTSNAP -R
 
 	zfs unmount -a > /dev/null 2>&1
 	log_must zfs mount -a

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/canmount_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/canmount_003_pos.ksh
@@ -63,15 +63,14 @@ function cleanup
 	ds=$TESTPOOL/$TESTCLONE
 	if datasetexists $ds; then
 		mntp=$(get_prop mountpoint $ds)
-		log_must zfs destroy $ds
+		destroy_dataset $ds
 		if [[ -d $mntp ]]; then
 			log_must rm -fr $mntp
 		fi
 	fi
 
-	if snapexists $TESTPOOL/$TESTFS@$TESTSNAP ; then
-		log_must zfs destroy -R $TESTPOOL/$TESTFS@$TESTSNAP
-	fi
+	snapexists $TESTPOOL/$TESTFS@$TESTSNAP && \
+		destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP -R
 
 	zfs unmount -a > /dev/null 2>&1
 	log_must zfs mount -a

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/readonly_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/readonly_001_pos.ksh
@@ -48,7 +48,7 @@ function cleanup
 {
 	for dataset in $TESTPOOL/$TESTFS $TESTPOOL/$TESTVOL ; do
 		snapexists ${dataset}@$TESTSNAP && \
-			log_must zfs destroy -R ${dataset}@$TESTSNAP
+			destroy_dataset ${dataset}@$TESTSNAP -R
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/snapdir_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/snapdir_001_pos.ksh
@@ -48,8 +48,7 @@ verify_runnable "both"
 function cleanup
 {
 	for dataset in $all_datasets; do
-		snapexists ${dataset}@snap && \
-			log_must zfs destroy ${dataset}@snap
+		snapexists ${dataset}@snap && destroy_dataset ${dataset}@snap
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/user_property_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/user_property_004_pos.ksh
@@ -46,9 +46,7 @@ function cleanup
 {
 	for fs in $TESTPOOL/$TESTFS $TESTPOOL/$TESTVOL $TESTPOOL ; do
 		typeset fssnap=$fs@snap
-		if datasetexists $fssnap ; then
-			log_must zfs destroy -f $fssnap
-		fi
+		datasetexists $fssnap && destroy_dataset $fssnap -f
 	done
 	cleanup_user_prop $TESTPOOL
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_003_neg.ksh
@@ -48,9 +48,8 @@ function cleanup
 	if [ -e $badpath ]; then
 		rm -f $badpath
 	fi
-	if datasetexists $TESTPOOL/foo; then
-		log_must zfs destroy $TESTPOOL/foo
-	fi
+
+	datasetexists $TESTPOOL/foo && destroy_dataset $TESTPOOL/foo
 }
 
 log_assert "'zfs set mountpoint/sharenfs' fails with invalid scenarios"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_keylocation.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_keylocation.ksh
@@ -45,7 +45,8 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
+	cleanup_https
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_001_pos.ksh
@@ -66,11 +66,10 @@ function cleanup
 	fi
 
 	datasetexists $TESTPOOL/$TESTFS-clone && \
-		log_must zfs destroy -f $TESTPOOL/$TESTFS-clone
+		destroy_dataset $TESTPOOL/$TESTFS-clone -f
 
-	if snapexists "$TESTPOOL/$TESTFS@snapshot"; then
-		log_must zfs destroy -f $TESTPOOL/$TESTFS@snapshot
-	fi
+	snapexists "$TESTPOOL/$TESTFS@snapshot" && \
+		destroy_dataset $TESTPOOL/$TESTFS@snapshot -f
 
 	log_must zfs share -a
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_004_pos.ksh
@@ -47,9 +47,8 @@ verify_runnable "global"
 
 function cleanup
 {
-	if snapexists $TESTPOOL/$TESTFS@snapshot; then
-		log_must zfs destroy $TESTPOOL/$TESTFS@snapshot
-	fi
+	snapexists $TESTPOOL/$TESTFS@snapshot && \
+		destroy_dataset $TESTPOOL/$TESTFS@snapshot
 
 	log_must zfs set sharenfs=off $TESTPOOL/$TESTFS
 	log_must unshare_fs $TESTPOOL/$TESTFS

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_006_pos.ksh
@@ -53,7 +53,7 @@ function cleanup
 	fi
 
 	datasetexists $TESTPOOL/$TESTCTR/$TESTFS2 && \
-		log_must zfs destroy $TESTPOOL/$TESTCTR/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTCTR/$TESTFS2
 
 	typeset fs=""
 	for fs in $mntp $TESTDIR1 $TESTDIR2

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_011_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_011_pos.ksh
@@ -51,13 +51,11 @@ function cleanup
 	log_must zfs set sharenfs=off $TESTPOOL/$TESTFS
 	unshare_fs $TESTPOOL/$TESTFS
 
-	if snapexists "$TESTPOOL/$TESTFS@snapshot"; then
-		log_must zfs destroy -f $TESTPOOL/$TESTFS@snapshot
-	fi
+	snapexists "$TESTPOOL/$TESTFS@snapshot" && \
+		destroy_dataset $TESTPOOL/$TESTFS@snapshot -f
 
-	if datasetexists $TESTPOOL/$TESTFS/fs2 ; then
-		log_must zfs destroy -f $TESTPOOL/$TESTFS/fs2
-	fi
+	datasetexists $TESTPOOL/$TESTFS/fs2 && \
+		destroy_dataset $TESTPOOL/$TESTFS/fs2 -f
 }
 
 log_assert "Verify that umount and destroy fail, and do not unshare the shared" \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_concurrent_shares.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_concurrent_shares.ksh
@@ -67,11 +67,11 @@ function cleanup
 		fi
 
 		datasetexists $TESTPOOL/$TESTFS1/$fs && \
-			log_must zfs destroy -f $TESTPOOL/$TESTFS1/$fs
+			destroy_dataset $TESTPOOL/$TESTFS1/$fs -f
 		datasetexists $TESTPOOL/$TESTFS2/$fs && \
-			log_must zfs destroy -f $TESTPOOL/$TESTFS2/$fs
+			destroy_dataset $TESTPOOL/$TESTFS2/$fs -f
 		datasetexists $TESTPOOL/$TESTFS3/$fs && \
-			log_must zfs destroy -f $TESTPOOL/$TESTFS3/$fs
+			destroy_dataset $TESTPOOL/$TESTFS3/$fs -f
 	done
 
 	log_must zfs share -a

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_001_neg.ksh
@@ -89,7 +89,7 @@ function cleanup_all
 
 	while (( i < ${#args[*]} )); do
 		for snap in ${args[i]}; do
-			snapexists $snap && log_must zfs destroy -f $snap
+			snapexists $snap && destroy_dataset $snap -f
 		done
 		(( i = i + 1 ))
 	done

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_002_neg.ksh
@@ -53,12 +53,11 @@ function cleanup
 	for snap in $TESTPOOL/$TESTCTR/$TESTFS1@$TESTSNAP \
 		$TESTPOOL/$TESTCTR/$TESTVOL@$TESTSNAP;
 	do
-		snapexists $snap && \
-			log_must zfs destroy $snap
+		snapexists $snap && destroy_dataset $snap
 	done
 
 	datasetexists $TESTPOOL/$TESTCTR/$TESTVOL && \
-		log_must zfs destroy -rf $TESTPOOL/$TESTCTR/$TESTVOL
+		destroy_dataset $TESTPOOL/$TESTCTR/$TESTVOL -rf
 
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_004_neg.ksh
@@ -44,9 +44,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $initfs ; then
-		log_must zfs destroy -rf $initfs
-	fi
+	datasetexists $initfs && destroy_dataset $initfs -rf
 }
 
 log_assert "Verify recursive snapshotting could not break ZFS."
@@ -70,9 +68,7 @@ while ((ret == 0)); do
 		# is incorrect
 		#
 		if ((len >= 255)); then
-			if datasetexists $basefs; then
-				log_must zfs destroy -r $basefs
-			fi
+			datasetexists $basefs && destroy_dataset $basefs -r
 			basefs=${basefs%/*}
 			len=$(echo $basefs| wc -c)
 		fi

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_005_neg.ksh
@@ -45,9 +45,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $initfs ; then
-		log_must zfs destroy -rf $initfs
-	fi
+	datasetexists $initfs && destroy_dataset $initfs -rf
 }
 
 log_assert "Verify long name filesystem with snapshot should not break ZFS."
@@ -71,9 +69,7 @@ while ((ret == 0)); do
 		# is incorrect
 		#
 		if ((len >= 255)); then
-			if datasetexists $basefs; then
-				log_must zfs destroy -r $basefs
-			fi
+			datasetexists $basefs && destroy_dataset $basefs -r
 			basefs=${basefs%/*}
 			len=$(echo $basefs| wc -c)
 		fi

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_006_pos.ksh
@@ -46,9 +46,7 @@ function cleanup
 {
 	for fs in $TESTPOOL/$TESTFS $TESTPOOL/$TESTVOL $TESTPOOL ; do
 		typeset fssnap=$fs@snap
-		if datasetexists $fssnap ; then
-			log_must zfs destroy -rf $fssnap
-		fi
+		datasetexists $fssnap && destroy_dataset $fssnap -rf
 	done
 	cleanup_user_prop $TESTPOOL
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_007_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_007_neg.ksh
@@ -46,9 +46,7 @@ function cleanup
 {
 	for fs in $TESTPOOL/$TESTFS $TESTPOOL/$TESTVOL $TESTPOOL/$TESTCTR $TESTPOOL ; do
 		typeset fssnap=$fs@snap
-		if datasetexists $fssnap ; then
-			log_must zfs destroy -rf $fssnap
-		fi
+		datasetexists $fssnap && destroy_dataset $fssnap -rf
 	done
 	cleanup_user_prop $TESTPOOL
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_009_pos.ksh
@@ -34,10 +34,10 @@ ZFS_MAX_DATASET_NAME_LEN=256
 function cleanup
 {
 	for ds in $datasets; do
-		datasetexists $ds && log_must zfs destroy -r $ds
+		datasetexists $ds && destroy_dataset $ds -r
 	done
-	zfs destroy -r $TESTPOOL/TESTFS4
-	zfs destroy -r $TESTPOOL/TESTFS5
+	destroy_dataset $TESTPOOL/TESTFS4 -r
+	destroy_dataset $TESTPOOL/TESTFS5 -r
 }
 datasets="$TESTPOOL/$TESTFS1 $TESTPOOL/$TESTFS2
     $TESTPOOL/$TESTFS3"
@@ -70,8 +70,7 @@ i=0
 while (( i < ${#valid_args[*]} )); do
 	log_must zfs snapshot ${valid_args[i]}
 	for token in ${valid_args[i]}; do
-		log_must snapexists $token && \
-		    log_must zfs destroy $token
+		snapexists $token && destroy_dataset $token
 	done
 	((i = i + 1))
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unload-key/zfs_unload-key.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unload-key/zfs_unload-key.ksh
@@ -43,7 +43,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unload-key/zfs_unload-key_all.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unload-key/zfs_unload-key_all.ksh
@@ -38,9 +38,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
-	datasetexists $TESTPOOL/zvol && log_must zfs destroy $TESTPOOL/zvol
+	datasetexists $TESTPOOL/$TESTFS1 && destroy_dataset $TESTPOOL/$TESTFS1 -r
+	datasetexists $TESTPOOL/zvol && destroy_dataset $TESTPOOL/zvol
 	poolexists $TESTPOOL1 && log_must destroy_pool $TESTPOOL1
 }
 log_onexit cleanup
@@ -62,7 +61,7 @@ log_must zpool create -O encryption=on -O keyformat=passphrase \
 log_must zfs unmount $TESTPOOL/$TESTFS1
 log_must zfs unmount $TESTPOOL1
 
-log_must zfs unload-key -a
+log_must_busy zfs unload-key -a
 
 log_must key_unavailable $TESTPOOL/$TESTFS1
 log_must key_unavailable $TESTPOOL/$TESTFS1/child

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unload-key/zfs_unload-key_recursive.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unload-key/zfs_unload-key_recursive.ksh
@@ -41,7 +41,7 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_001_pos.ksh
@@ -55,7 +55,7 @@ function cleanup
 		log_must zfs umount -f $TESTDIR2
 
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2
 
 	[[ -d $TESTDIR2 ]] && \
 		log_must rm -rf $TESTDIR2

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_008_neg.ksh
@@ -53,14 +53,10 @@ verify_runnable "both"
 function cleanup
 {
 	for ds in $vol $fs1; do
-		if datasetexists $ds; then
-			log_must zfs destroy -f $ds
-		fi
+		datasetexists $ds && destroy_dataset $ds -f
 	done
 
-	if snapexists $snap; then
-		log_must zfs destroy $snap
-	fi
+	snapexists $snap && destroy_dataset $snap
 
 	if [[ -e /tmp/$file ]]; then
 		rm -f /tmp/$file

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_009_pos.ksh
@@ -55,9 +55,7 @@ function cleanup
 
 	for fs in $TESTPOOL/$TESTFS $TESTPOOL ; do
 		typeset snap=$fs@$TESTSNAP
-		if snapexists $snap; then
-			log_must zfs destroy $snap
-		fi
+		snapexists $snap && destroy_dataset $snap
 	done
 
 	if ! poolexists $TESTPOOL && is_global_zone; then

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_unload_keys.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_unload_keys.ksh
@@ -46,11 +46,11 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
 	datasetexists $TESTPOOL/$TESTFS2/newroot && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2/newroot
+		destroy_dataset $TESTPOOL/$TESTFS2/newroot -r
 	datasetexists $TESTPOOL/$TESTFS2/child && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2/child
+		destroy_dataset $TESTPOOL/$TESTFS2/child -r
 
 }
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unshare/zfs_unshare_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unshare/zfs_unshare_001_pos.ksh
@@ -62,17 +62,14 @@ function cleanup
 	[[ -d $TESTDIR2 ]] && \
 		log_must rm -rf $TESTDIR2
 
-	if datasetexists "$TESTPOOL/$TESTCLONE"; then
-		log_must zfs destroy -f $TESTPOOL/$TESTCLONE
-	fi
+	datasetexists "$TESTPOOL/$TESTCLONE" && \
+		destroy_dataset $TESTPOOL/$TESTCLONE -f
 
-	if snapexists "$TESTPOOL/$TESTFS2@snapshot"; then
-		log_must zfs destroy -f $TESTPOOL/$TESTFS2@snapshot
-	fi
+	snapexists "$TESTPOOL/$TESTFS2@snapshot" && \
+		destroy_dataset $TESTPOOL/$TESTFS2@snapshot -f
 
-	if datasetexists "$TESTPOOL/$TESTFS2"; then
-		log_must zfs destroy -f $TESTPOOL/$TESTFS2
-	fi
+	datasetexists "$TESTPOOL/$TESTFS2" && \
+		destroy_dataset $TESTPOOL/$TESTFS2 -f
 }
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unshare/zfs_unshare_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unshare/zfs_unshare_002_pos.ksh
@@ -65,17 +65,14 @@ function cleanup
 	[[ -d $TESTDIR2 ]] && \
 		log_must rm -rf $TESTDIR2
 
-	if datasetexists "$TESTPOOL/$TESTCLONE"; then
-		log_must zfs destroy -f $TESTPOOL/$TESTCLONE
-	fi
+	datasetexists "$TESTPOOL/$TESTCLONE" && \
+		destroy_dataset $TESTPOOL/$TESTCLONE -f
 
-	if snapexists "$TESTPOOL/$TESTFS2@snapshot"; then
-		log_must zfs destroy -f $TESTPOOL/$TESTFS2@snapshot
-	fi
+	snapexists "$TESTPOOL/$TESTFS2@snapshot" && \
+		destroy_dataset $TESTPOOL/$TESTFS2@snapshot -f
 
-	if datasetexists "$TESTPOOL/$TESTFS2"; then
-		log_must zfs destroy -f $TESTPOOL/$TESTFS2
-	fi
+	datasetexists "$TESTPOOL/$TESTFS2" && \
+		destroy_dataset $TESTPOOL/$TESTFS2 -f
 }
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unshare/zfs_unshare_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unshare/zfs_unshare_003_pos.ksh
@@ -49,9 +49,8 @@ verify_runnable "global"
 
 function cleanup
 {
-	if snapexists $TESTPOOL/$TESTFS@snapshot; then
-		log_must zfs destroy $TESTPOOL/$TESTFS@snapshot
-	fi
+	snapexists $TESTPOOL/$TESTFS@snapshot && \
+		destroy_dataset $TESTPOOL/$TESTFS@snapshot
 
 	log_must zfs set sharenfs=off $TESTPOOL/$TESTFS
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unshare/zfs_unshare_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unshare/zfs_unshare_007_pos.ksh
@@ -42,9 +42,8 @@ verify_runnable "global"
 
 function cleanup
 {
-	if datasetexists "$TESTPOOL/$TESTFS/shared1"; then
-		log_must zfs destroy -f $TESTPOOL/$TESTFS/shared1
-	fi
+	datasetexists "$TESTPOOL/$TESTFS/shared1" && \
+		destroy_dataset $TESTPOOL/$TESTFS/shared1 -f
 }
 
 log_assert "Verify 'zfs destroy' will unshare the dataset"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/zfs_upgrade_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/zfs_upgrade_001_pos.ksh
@@ -50,9 +50,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $rootfs ; then
-		log_must zfs destroy -Rf $rootfs
-	fi
+	datasetexists $rootfs && destroy_dataset $rootfs -Rf
 	log_must zfs create $rootfs
 
 	for file in $output $oldoutput ; do
@@ -116,9 +114,7 @@ if (( i != COUNT - OLDCOUNT )); then
 fi
 
 for fs in $old_datasets ; do
-	if datasetexists $fs ; then
-		log_must zfs destroy -Rf $fs
-	fi
+	datasetexists $fs && destroy_dataset $fs -Rf
 done
 
 log_must eval 'zfs upgrade > $output 2>&1'

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/zfs_upgrade_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/zfs_upgrade_003_pos.ksh
@@ -47,9 +47,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $rootfs ; then
-		log_must zfs destroy -Rf $rootfs
-	fi
+	datasetexists $rootfs && destroy_dataset $rootfs -Rf
 	log_must zfs create $rootfs
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/zfs_upgrade_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/zfs_upgrade_004_pos.ksh
@@ -47,9 +47,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $rootfs ; then
-		log_must zfs destroy -Rf $rootfs
-	fi
+	datasetexists $rootfs && destroy_dataset $rootfs -Rf
 	log_must zfs create $rootfs
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/zfs_upgrade_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/zfs_upgrade_005_pos.ksh
@@ -47,9 +47,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	if datasetexists $rootfs ; then
-		log_must zfs destroy -Rf $rootfs
-	fi
+	datasetexists $rootfs && destroy_dataset $rootfs -Rf
 	log_must zfs create $rootfs
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_001_pos.ksh
@@ -48,8 +48,7 @@ verify_runnable "global"
 function cleanup
 {
 	poolexists $TESTPOOL2 && destroy_pool $TESTPOOL2
-	datasetexists $TESTPOOL1/$TESTVOL && \
-		log_must zfs destroy -f $TESTPOOL1/$TESTVOL
+	datasetexists $TESTPOOL1/$TESTVOL && destroy_dataset $TESTPOOL1/$TESTVOL -f
 
 	typeset pool
 	for pool in $TESTPOOL1 $TESTPOOL; do

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh
@@ -59,7 +59,7 @@ function cleanup
 	typeset -i i=0
 	while (( $i < ${#datasets[*]} )); do
 		datasetexists ${datasets[i]} && \
-			log_must zfs destroy ${datasets[i]}
+			destroy_dataset ${datasets[i]}
 		(( i = i + 1 ))
 	done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_history/zpool_history_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_history/zpool_history_001_neg.ksh
@@ -51,8 +51,8 @@ set -A neg_opt "$TESTPOOL/$TESTCTR" "$TESTPOOL/$TESTVOL" "-t $TESTPOOL" \
 
 function cleanup
 {
-	datasetexists $clone && log_must zfs destroy $clone
-	datasetexists $snap && log_must zfs destroy $snap
+	datasetexists $clone && destroy_dataset $clone
+	datasetexists $snap && destroy_dataset $snap
 }
 
 log_assert "Verify 'zpool history' can deal with non-existent pools and " \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/cleanup.ksh
@@ -37,8 +37,7 @@ verify_runnable "global"
 log_must set_tunable32 SCAN_SUSPEND_PROGRESS 0
 
 for pool in "$TESTPOOL" "$TESTPOOL1"; do
-	datasetexists $pool/$TESTFS && \
-		log_must zfs destroy -Rf $pool/$TESTFS
+	datasetexists $pool/$TESTFS && destroy_dataset $pool/$TESTFS -Rf
 	destroy_pool "$pool"
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_012_pos.ksh
@@ -84,9 +84,9 @@ function cleanup
 
 	destroy_pool $TESTPOOL1
 
-	if datasetexists $TESTPOOL/$TESTFS; then
-		log_must zfs destroy -Rf $TESTPOOL/$TESTFS
-	fi
+	datasetexists $TESTPOOL/$TESTFS && \
+		destroy_dataset $TESTPOOL/$TESTFS -Rf
+
 	log_must zfs create $TESTPOOL/$TESTFS
 	log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_encrypted_unloaded.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_encrypted_unloaded.ksh
@@ -39,7 +39,7 @@ verify_runnable "global"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/features/async_destroy/async_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/features/async_destroy/async_destroy_001_pos.ksh
@@ -48,7 +48,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TEST_FS && log_must zfs destroy $TEST_FS
+	datasetexists $TEST_FS && destroy_dataset $TEST_FS
 	log_must set_tunable64 ASYNC_BLOCK_MAX_BLOCKS 100000
 }
 

--- a/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_001_pos.ksh
@@ -47,7 +47,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TEST_FS && log_must zfs destroy $TEST_FS
+	datasetexists $TEST_FS && destroy_dataset $TEST_FS
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_002_pos.ksh
@@ -48,7 +48,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TEST_FS && log_must zfs destroy $TEST_FS
+	datasetexists $TEST_FS && destroy_dataset $TEST_FS
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_004_neg.ksh
@@ -44,9 +44,7 @@ TEST_STREAM=$TESTDIR/ldnsnap
 
 function cleanup
 {
-	if datasetexists $TEST_FS ; then
-		log_must zfs destroy -r $TEST_FS
-	fi
+	datasetexists $TEST_FS && destroy_dataset $TEST_FS -r
 
 	if datasetexists $LGCYPOOL ; then
 		log_must zpool destroy -f $LGCYPOOL

--- a/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_005_pos.ksh
@@ -40,13 +40,8 @@ TEST_FILEINCR=bar
 
 function cleanup
 {
-	if datasetexists $TEST_SEND_FS ; then
-		log_must zfs destroy -r $TEST_SEND_FS
-	fi
-
-	if datasetexists $TEST_RECV_FS ; then
-		log_must zfs destroy -r $TEST_RECV_FS
-	fi
+	datasetexists $TEST_SEND_FS && destroy_dataset $TEST_SEND_FS -r
+	datasetexists $TEST_RECV_FS && destroy_dataset $TEST_RECV_FS -r
 
 	rm -f $TEST_STREAM
 	rm -f $TEST_STREAMINCR

--- a/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_006_pos.ksh
@@ -49,7 +49,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TEST_FS && log_must zfs destroy $TEST_FS
+	datasetexists $TEST_FS && destroy_dataset $TEST_FS
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_009_pos.ksh
@@ -39,7 +39,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TEST_FS && log_must zfs destroy $TEST_FS
+	datasetexists $TEST_FS && destroy_dataset $TEST_FS
 }
 
 log_onexit cleanup
@@ -64,7 +64,7 @@ done
 
 log_must wait
 
-log_must zpool export $TESTPOOL
+log_must_busy zpool export $TESTPOOL
 log_must zpool import $TESTPOOL
 log_must ls -lR "/$TEST_FS/" >/dev/null 2>&1
 log_must zdb -d $TESTPOOL

--- a/tests/zfs-tests/tests/functional/history/history_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_002_pos.ksh
@@ -49,7 +49,7 @@ function cleanup
 	[[ -f $tmpfile ]] && rm -f $tmpfile
 	[[ -f $tmpfile2 ]] && rm -f $tmpfile2
 	for dataset in $fs $newfs $fsclone $vol $newvol $volclone; do
-		datasetexists $dataset && zfs destroy -Rf $dataset
+		datasetexists $dataset && destroy_dataset $dataset -Rf
 	done
 	rm -rf /history.$$
 }

--- a/tests/zfs-tests/tests/functional/history/history_006_neg.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_006_neg.ksh
@@ -47,9 +47,7 @@ verify_runnable "global"
 
 function cleanup
 {
-	if datasetexists $fs ; then
-		log_must zfs destroy -rf $fs
-	fi
+	datasetexists $fs && destroy_dataset $fs -rf
 	log_must zfs create $fs
 }
 

--- a/tests/zfs-tests/tests/functional/history/history_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_007_pos.ksh
@@ -62,7 +62,7 @@ migratedpoolname=$MIGRATEDPOOLNAME
 typeset -i RET=1
 typeset -i linenum=0
 
-[[ ! -d $import_dir ]] && log_must mkdir $import_dir
+[[ ! -d $import_dir ]] && log_must mkdir -p $import_dir
 
 # We test the migrations on both uniform platform and cross platform
 for arch in "i386" "sparc"; do

--- a/tests/zfs-tests/tests/functional/history/history_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_008_pos.ksh
@@ -47,9 +47,7 @@ verify_runnable "global"
 
 function cleanup
 {
-	if datasetexists $root_testfs; then
-		log_must zfs destroy -rf $root_testfs
-	fi
+	datasetexists $root_testfs && destroy_dataset $root_testfs -rf
 	log_must zfs create $root_testfs
 }
 

--- a/tests/zfs-tests/tests/functional/history/history_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_010_pos.ksh
@@ -47,7 +47,7 @@ function cleanup
 {
 	del_user $HIST_USER
 	del_group $HIST_GROUP
-	datasetexists $root_testfs && log_must zfs destroy -rf $root_testfs
+	datasetexists $root_testfs && destroy_dataset $root_testfs -rf
 }
 
 log_assert "Verify internal long history information are correct."

--- a/tests/zfs-tests/tests/functional/history/history_common.kshlib
+++ b/tests/zfs-tests/tests/functional/history/history_common.kshlib
@@ -72,9 +72,9 @@ function run_and_verify
 	# Run the command as the specified user, and find the new history.
 	zpool history $flags $pool > $OLD_HISTORY 2>/dev/null
 	if [[ $user == "root" ]]; then
-		log_must eval "$fullcmd"
+		log_must_busy eval "$fullcmd"
 	else
-		log_must user_run $user "$fullcmd"
+		log_must_busy user_run $user "$fullcmd"
 	fi
 	zpool history $flags $pool > $TMP_HISTORY 2>/dev/null
 	diff $OLD_HISTORY $TMP_HISTORY | grep "^> " | sed 's/^> //g' \

--- a/tests/zfs-tests/tests/functional/largest_pool/largest_pool_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/largest_pool/largest_pool_001_pos.ksh
@@ -91,13 +91,13 @@ function cleanup
 		if ismounted $TESTPOOL/$TESTFS ; then
 			log_must zfs unmount $TESTPOOL/$TESTFS
 		fi
-		log_must zfs destroy $TESTPOOL/$TESTFS
+		destroy_dataset $TESTPOOL/$TESTFS
 	fi
 
 	destroy_pool $TESTPOOL
 
 	datasetexists $TESTPOOL2/$TESTVOL && \
-		log_must zfs destroy $TESTPOOL2/$TESTVOL
+		destroy_dataset $TESTPOOL2/$TESTVOL
 
 	destroy_pool $TESTPOOL2
 
@@ -154,7 +154,7 @@ for volsize in $VOLSIZES; do
 	log_note "Destroy zfs, volume & zpool"
 	log_must zfs destroy $TESTPOOL/$TESTFS
 	destroy_pool $TESTPOOL
-	log_must zfs destroy $TESTPOOL2/$TESTVOL
+	log_must_busy zfs destroy $TESTPOOL2/$TESTVOL
 	destroy_pool $TESTPOOL2
 done
 

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_copies.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_copies.ksh
@@ -34,7 +34,7 @@ log_onexit cleanup
 
 function cleanup
 {
-	datasetexists $origin && log_must zfs destroy -R $origin
+	datasetexists $origin && destroy_dataset $origin -R
 	log_must zfs create -o mountpoint=$TESTDIR $origin
 }
 

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_mtime.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_mtime.ksh
@@ -34,7 +34,7 @@ log_onexit cleanup
 
 function cleanup
 {
-	datasetexists $origin && log_must zfs destroy -R $origin
+	datasetexists $origin && destroy_dataset $origin -R
 	log_must zfs create -o mountpoint=$TESTDIR $origin
 }
 

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_negative.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_negative.ksh
@@ -36,7 +36,7 @@ log_onexit cleanup
 
 function cleanup
 {
-	datasetexists $origin && log_must zfs destroy -R $origin
+	datasetexists $origin && destroy_dataset $origin -R
 	log_must zfs create -o mountpoint=$TESTDIR $origin
 }
 

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_promoted_clone.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_promoted_clone.ksh
@@ -36,7 +36,7 @@ log_onexit cleanup
 
 function cleanup
 {
-	datasetexists $origin && log_must zfs destroy -R $TESTPOOL/clone
+	datasetexists $origin && destroy_dataset $TESTPOOL/clone -R
 	log_must zfs create -o mountpoint=$TESTDIR $origin
 }
 

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_recsize.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_recsize.ksh
@@ -34,7 +34,7 @@ log_onexit cleanup
 
 function cleanup
 {
-	datasetexists $origin && log_must zfs destroy -R $origin
+	datasetexists $origin && destroy_dataset $origin -R
 	log_must zfs create -o mountpoint=$TESTDIR $origin
 }
 

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_sync.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_sync.ksh
@@ -34,7 +34,7 @@ log_onexit cleanup
 
 function cleanup
 {
-	datasetexists $origin && log_must zfs destroy -R $origin
+	datasetexists $origin && destroy_dataset $origin -R
 	log_must zfs create -o mountpoint=$TESTDIR $origin
 }
 

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_varying_compression.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_varying_compression.ksh
@@ -41,7 +41,7 @@ log_onexit cleanup
 
 function cleanup
 {
-	datasetexists $origin && log_must zfs destroy -R $origin
+	datasetexists $origin && destroy_dataset $origin -R
 	log_must zfs create -o mountpoint=$TESTDIR $origin
 }
 

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_volume.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_volume.ksh
@@ -37,7 +37,7 @@ log_onexit cleanup
 
 function cleanup
 {
-	datasetexists $origin && log_must zfs destroy -R $origin
+	datasetexists $origin && destroy_dataset $origin -R
 	# No need to recreate the volume as no other tests expect it.
 }
 

--- a/tests/zfs-tests/tests/functional/procfs/procfs_list_basic.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/procfs_list_basic.ksh
@@ -42,7 +42,7 @@
 
 function cleanup
 {
-	datasetexists $FS && log_must zfs destroy -r $FS
+	datasetexists $FS && destroy_dataset $FS -r
 }
 
 function count_snap_cmds

--- a/tests/zfs-tests/tests/functional/procfs/procfs_list_concurrent_readers.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/procfs_list_concurrent_readers.ksh
@@ -43,7 +43,7 @@ function cleanup
 {
 	[[ -z $msgs1 ]] || log_must rm $msgs1
 	[[ -z $msgs2 ]] || log_must rm $msgs2
-	datasetexists $FS && log_must zfs destroy -r $FS
+	datasetexists $FS && destroy_dataset $FS -r
 }
 
 typeset -r ZFS_DBGMSG=/proc/spl/kstat/zfs/dbgmsg

--- a/tests/zfs-tests/tests/functional/projectquota/projectquota_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectquota_004_neg.ksh
@@ -43,9 +43,7 @@
 
 function cleanup
 {
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 
 	log_must cleanup_projectquota
 }

--- a/tests/zfs-tests/tests/functional/projectquota/projectquota_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectquota_005_pos.ksh
@@ -43,9 +43,7 @@
 
 function cleanup
 {
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 
 	log_must cleanup_projectquota
 }

--- a/tests/zfs-tests/tests/functional/projectquota/projectquota_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectquota_008_pos.ksh
@@ -48,9 +48,7 @@
 
 function cleanup
 {
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 
 	log_must cleanup_projectquota
 }

--- a/tests/zfs-tests/tests/functional/projectquota/projectquota_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectquota_009_pos.ksh
@@ -49,9 +49,7 @@
 function cleanup
 {
 	for ds in $TESTPOOL/fs $TESTPOOL/fs-rename $TESTPOOL/fs-clone; do
-		if datasetexists $ds; then
-			log_must zfs destroy -rRf $ds
-		fi
+		datasetexists $ds && destroy_dataset $ds -rRf
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/projectquota/projectspace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectspace_001_pos.ksh
@@ -45,9 +45,7 @@
 
 function cleanup
 {
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 
 	log_must cleanup_projectquota
 }

--- a/tests/zfs-tests/tests/functional/projectquota/projectspace_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectspace_002_pos.ksh
@@ -44,9 +44,7 @@
 
 function cleanup
 {
-	if datasetexists $snapfs; then
-		log_must zfs destroy $snapfs
-	fi
+	datasetexists $snapfs && destroy_dataset $snapfs
 
 	log_must cleanup_projectquota
 }

--- a/tests/zfs-tests/tests/functional/projectquota/projectspace_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectspace_003_pos.ksh
@@ -45,9 +45,7 @@
 
 function cleanup
 {
-	if datasetexists $snapfs; then
-		log_must zfs destroy $snapfs
-	fi
+	datasetexists $snapfs && destroy_dataset $snapfs
 
 	log_must cleanup_projectquota
 }

--- a/tests/zfs-tests/tests/functional/projectquota/projectspace_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectspace_004_pos.ksh
@@ -44,9 +44,7 @@
 
 function cleanup
 {
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 
 	log_must cleanup_projectquota
 }

--- a/tests/zfs-tests/tests/functional/quota/quota_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_005_pos.ksh
@@ -48,8 +48,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $fs_child && \
-		log_must zfs destroy $fs_child
+	datasetexists $fs_child && destroy_dataset $fs_child
 
 	log_must zfs set quota=$quota_val $fs
 }

--- a/tests/zfs-tests/tests/functional/refreserv/refreserv_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/refreserv/refreserv_002_pos.ksh
@@ -50,11 +50,9 @@ function cleanup
 	if is_global_zone ; then
 		log_must zfs set refreservation=none $TESTPOOL
 
-		if datasetexists $TESTPOOL@snap ; then
-			log_must zfs destroy -f $TESTPOOL@snap
-		fi
+		datasetexists $TESTPOOL@snap && destroy_dataset $TESTPOOL@snap -f
 	fi
-	log_must zfs destroy -rf $TESTPOOL/$TESTFS
+	destroy_dataset $TESTPOOL/$TESTFS -rf
 	log_must zfs create $TESTPOOL/$TESTFS
 	log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 }

--- a/tests/zfs-tests/tests/functional/reservation/reservation_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_002_pos.ksh
@@ -54,7 +54,7 @@ verify_runnable "both"
 function cleanup
 {
 	for obj in $OBJ_LIST; do
-		datasetexists $obj && log_must_busy zfs destroy -f $obj
+		datasetexists $obj && destroy_dataset $obj -f
 	done
 
 	log_must zero_reservation $TESTPOOL/$TESTFS

--- a/tests/zfs-tests/tests/functional/reservation/reservation_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_003_pos.ksh
@@ -59,7 +59,7 @@ function cleanup
 	log_must zero_reservation $TESTPOOL/$TESTFS
 
 	for obj in $OBJ_LIST; do
-	datasetexists $obj && log_must zfs destroy -f $obj
+	datasetexists $obj && destroy_dataset $obj -f
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/reservation/reservation_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_004_pos.ksh
@@ -56,7 +56,7 @@ verify_runnable "both"
 function cleanup {
 
 	for obj in $OBJ_LIST; do
-		datasetexists $obj && log_must_busy zfs destroy -f $obj
+		datasetexists $obj && destroy_dataset $obj -f
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/reservation/reservation_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_005_pos.ksh
@@ -59,7 +59,7 @@ log_assert "Verify space released when reservation on a dataset is set "\
 function cleanup
 {
 	for obj in $OBJ_LIST; do
-		datasetexists $obj && log_must zfs destroy -f $obj
+		datasetexists $obj && destroy_dataset $obj -f
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/reservation/reservation_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_007_pos.ksh
@@ -56,10 +56,10 @@ log_assert "Verify reservations on data sets doesn't affect other data sets " \
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS2 && \
-	    log_must zfs destroy -f $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -f
 
 	datasetexists $TESTPOOL/$TESTFS1 && \
-	    log_must zfs destroy -f $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 
 log_onexit cleanup
@@ -100,7 +100,7 @@ function create_resv_destroy { # args1 dataset1 args2 dataset2
 	# available totals should revert back to the values they
 	# had after creating the first dataset.
 	#
-	log_must zfs destroy -f $dataset2
+	log_must_busy zfs destroy -f $dataset2
 
 	avail_dest_dset2=`get_prop available $TESTPOOL`
 	used_dest_dset2=`get_prop used $TESTPOOL`
@@ -112,7 +112,7 @@ function create_resv_destroy { # args1 dataset1 args2 dataset2
 	# After destroying the first dataset the space used and
 	# space available totals should revert back to the values
 	# they had when the pool was first created.
-	log_must zfs destroy -f $dataset1
+	log_must_busy zfs destroy -f $dataset1
 
 	avail_dest_dset1=`get_prop available $TESTPOOL`
 	used_dest_dset1=`get_prop used $TESTPOOL`

--- a/tests/zfs-tests/tests/functional/reservation/reservation_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_008_pos.ksh
@@ -57,7 +57,7 @@ function cleanup
 	typeset -i loop=0
 	while (($loop < $RESV_NUM_FS)); do
 		datasetexists $TESTPOOL/${TESTFS}$loop && \
-		    log_must zfs destroy -f $TESTPOOL/${TESTFS}$loop
+		    destroy_dataset $TESTPOOL/${TESTFS}$loop -f
 
 		[[ -d ${TESTDIR}$loop ]] && log_must rm -r ${TESTDIR}$loop
 

--- a/tests/zfs-tests/tests/functional/reservation/reservation_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_009_pos.ksh
@@ -58,7 +58,9 @@ function cleanup
 {
 	log_must rm -rf $TESTDIR/$TESTFILE1
 	log_must rm -rf $TESTDIR/$TESTFILE2
-	log_must zfs destroy -f $TESTPOOL/$TESTFS1
+
+	datasetexists $TESTPOOL/$TESTFS1 && \
+		destroy_dataset $TESTPOOL/$TESTFS1 -f
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/reservation/reservation_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_010_pos.ksh
@@ -57,7 +57,7 @@ log_assert "Destroying top level filesystem with reservation allows more " \
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS1 && \
-	    log_must zfs destroy $TESTPOOL/$TESTFS1
+		destroy_dataset $TESTPOOL/$TESTFS1
 
 	[[ -e $TESTDIR/$TESTFILE1 ]] && log_must rm -rf $TESTDIR/$TESTFILE1
 	[[ -e $TESTDIR/$TESTFILE2 ]] && log_must rm -rf $TESTDIR/$TESTFILE2

--- a/tests/zfs-tests/tests/functional/reservation/reservation_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_013_pos.ksh
@@ -58,7 +58,7 @@ log_assert "Reservation properties preserved across exports and imports"
 function cleanup
 {
 	for obj in $OBJ_LIST; do
-                datasetexists $obj && log_must zfs destroy -f $obj
+                datasetexists $obj && destroy_dataset $obj -f
         done
 
 	log_must zero_reservation $TESTPOOL/$TESTFS
@@ -91,7 +91,7 @@ log_must zfs set reservation=$resv_set $TESTPOOL/$TESTFS1
 log_must zfs set reservation=$resv_set $TESTPOOL/$TESTFS1/$TESTFS2
 log_must zfs set reservation=$resv_set $TESTPOOL/$TESTVOL2
 
-log_must zpool export $TESTPOOL
+log_must_busy zpool export $TESTPOOL
 log_must zpool import $TESTPOOL
 
 for obj in $TESTPOOL/$TESTFS $OBJ_LIST; do

--- a/tests/zfs-tests/tests/functional/reservation/reservation_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_014_pos.ksh
@@ -54,7 +54,7 @@ function cleanup
 	#
 	# Note we don't destroy $TESTFS as it's used by other tests
 	for obj in $OBJ_LIST ; do
-		datasetexists $obj && log_must zfs destroy -f $obj
+		datasetexists $obj && destroy_dataset $obj -f
 	done
 
 	log_must zero_reservation $TESTPOOL/$TESTFS

--- a/tests/zfs-tests/tests/functional/reservation/reservation_015_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_015_pos.ksh
@@ -57,7 +57,7 @@ log_assert "Setting volume reservation to 'none' allows more data to be " \
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTVOL && \
-	log_must zfs destroy $TESTPOOL/$TESTVOL
+		destroy_dataset $TESTPOOL/$TESTVOL
 
 	[[ -e $TESTDIR/$TESTFILE1 ]] && log_must rm -rf $TESTDIR/$TESTFILE1
 	[[ -e $TESTDIR/$TESTFILE2 ]] && log_must rm -rf $TESTDIR/$TESTFILE2
@@ -76,6 +76,7 @@ space_avail=$(largest_volsize_from_pool $TESTPOOL)
 resv_size_set=$(floor_volsize $resv_size_set)
 
 log_must zfs create -V $resv_size_set $TESTPOOL/$TESTVOL
+block_device_wait $TESTPOOL/$TESTVOL
 
 space_avail_still=`get_prop available $TESTPOOL`
 

--- a/tests/zfs-tests/tests/functional/reservation/reservation_016_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_016_pos.ksh
@@ -56,7 +56,7 @@ log_assert "Destroying a regular volume with reservation allows more data to" \
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTVOL && \
-	    log_must zfs destroy $TESTPOOL/$TESTVOL
+	    destroy_dataset $TESTPOOL/$TESTVOL
 
 	[[ -e $TESTDIR/$TESTFILE1 ]] && log_must rm -rf $TESTDIR/$TESTFILE1
 	[[ -e $TESTDIR/$TESTFILE2 ]] && log_must rm -rf $TESTDIR/$TESTFILE2
@@ -76,6 +76,7 @@ vol_set_size=$(floor_volsize $vol_set_size)
 # Creating a regular volume implicitly sets its reservation
 # property to the same value.
 log_must zfs create -V $vol_set_size $TESTPOOL/$TESTVOL
+block_device_wait $TESTPOOL/$TESTVOL
 
 space_avail_still=$(get_prop available $TESTPOOL)
 fill_size=$((space_avail_still + $RESV_TOLERANCE))

--- a/tests/zfs-tests/tests/functional/reservation/reservation_018_pos.ksh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_018_pos.ksh
@@ -47,7 +47,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $fs_child && log_must zfs destroy $fs_child
+	datasetexists $fs_child && destroy_dataset $fs_child
 	log_must zfs set reservation=$reserv_val $fs
 }
 

--- a/tests/zfs-tests/tests/functional/rsend/send-c_lz4_disabled.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_lz4_disabled.ksh
@@ -52,8 +52,8 @@ for compress in off gzip; do
 		poolexists $POOL3 && destroy_pool $POOL3
 		log_must zpool create $pool_opt $POOL3 $DISK3
 
-		datasetexists $send_ds && log_must_busy zfs destroy -r $send_ds
-		datasetexists $recv_ds && log_must_busy zfs destroy -r $recv_ds
+		datasetexists $send_ds && destroy_dataset $send_ds -r
+		datasetexists $recv_ds && destroy_dataset $recv_ds -r
 
 		log_must zfs create -o compress=$compress $send_ds
 		typeset dir=$(get_prop mountpoint $send_ds)

--- a/tests/zfs-tests/tests/functional/rsend/send-c_recv_lz4_disabled.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_recv_lz4_disabled.ksh
@@ -50,8 +50,8 @@ datasetexists $POOL3 && log_must zpool destroy $POOL3
 log_must zpool create -d $POOL3 $DISK3
 
 for compress in "${compress_prop_vals[@]}"; do
-	datasetexists $send_ds && log_must_busy zfs destroy -r $send_ds
-	datasetexists $recv_ds && log_must_busy zfs destroy -r $recv_ds
+	datasetexists $send_ds && destroy_dataset $send_ds -r
+	datasetexists $recv_ds && destroy_dataset $recv_ds -r
 
 	log_must zfs create -o compress=$compress $send_ds
 	typeset dir=$(get_prop mountpoint $send_ds)

--- a/tests/zfs-tests/tests/functional/rsend/send-c_stream_size_estimate.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_stream_size_estimate.ksh
@@ -61,8 +61,8 @@ log_onexit cleanup_pool $POOL2
 write_compressible $BACKDIR ${megs}m
 
 for compress in "${compress_prop_vals[@]}"; do
-	datasetexists $send_ds && log_must_busy zfs destroy -r $send_ds
-	datasetexists $send_vol && log_must_busy zfs destroy -r $send_vol
+	datasetexists $send_ds && destroy_dataset $send_ds -r
+	datasetexists $send_vol && destroy_dataset $send_vol -r
 	log_must zfs create -o compress=$compress $send_ds
 	log_must zfs create -V 1g -o compress=$compress $send_vol
 	block_device_wait

--- a/tests/zfs-tests/tests/functional/rsend/send-cpL_varied_recsize.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-cpL_varied_recsize.ksh
@@ -55,8 +55,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TESTPOOL/128k && log_must_busy zfs destroy $TESTPOOL/128k
-	datasetexists $TESTPOOL/1m && log_must_busy zfs destroy $TESTPOOL/1m
+	datasetexists $TESTPOOL/128k && destroy_dataset $TESTPOOL/128k
+	datasetexists $TESTPOOL/1m && destroy_dataset $TESTPOOL/1m
 	cleanup_pool $POOL2
 	destroy_pool $POOL3
 }

--- a/tests/zfs-tests/tests/functional/rsend/send_encrypted_files.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_encrypted_files.ksh
@@ -46,9 +46,9 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
 	datasetexists $TESTPOOL/recv && \
-		log_must zfs destroy -r $TESTPOOL/recv
+		destroy_dataset $TESTPOOL/recv -r
 	[[ -f $keyfile ]] && log_must rm $keyfile
 	[[ -f $sendfile ]] && log_must rm $sendfile
 }

--- a/tests/zfs-tests/tests/functional/rsend/send_encrypted_truncated_files.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_encrypted_truncated_files.ksh
@@ -42,9 +42,9 @@ verify_runnable "both"
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS2 && \
-		log_must zfs destroy -r $TESTPOOL/$TESTFS2
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
 	datasetexists $TESTPOOL/recv && \
-		log_must zfs destroy -r $TESTPOOL/recv
+		destroy_dataset $TESTPOOL/recv -r
 	[[ -f $keyfile ]] && log_must rm $keyfile
 	[[ -f $sendfile ]] && log_must rm $sendfile
 }

--- a/tests/zfs-tests/tests/functional/rsend/send_mixed_raw.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_mixed_raw.ksh
@@ -49,11 +49,11 @@ verify_runnable "both"
 function cleanup
 {
     datasetexists $TESTPOOL/$TESTFS3 && \
-        log_must zfs destroy -r $TESTPOOL/$TESTFS3
+        destroy_dataset $TESTPOOL/$TESTFS3 -r
     datasetexists $TESTPOOL/$TESTFS2 && \
-        log_must zfs destroy -r $TESTPOOL/$TESTFS2
+        destroy_dataset $TESTPOOL/$TESTFS2 -r
     datasetexists $TESTPOOL/$TESTFS1 && \
-        log_must zfs destroy -r $TESTPOOL/$TESTFS1
+        destroy_dataset $TESTPOOL/$TESTFS1 -r
 }
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/rsend/send_realloc_dnode_size.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_realloc_dnode_size.ksh
@@ -49,13 +49,8 @@ function cleanup
 	rm -f $BACKDIR/fs-dn-2k
 	rm -f $BACKDIR/fs-attr
 
-	if datasetexists $POOL/fs ; then
-		log_must zfs destroy -rR $POOL/fs
-	fi
-
-	if datasetexists $POOL/newfs ; then
-		log_must zfs destroy -rR $POOL/newfs
-	fi
+	datasetexists $POOL/fs && destroy_dataset $POOL/fs -rR
+	datasetexists $POOL/newfs && destroy_dataset $POOL/newfs -rR
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/snapshot/clone_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/clone_001_pos.ksh
@@ -96,8 +96,8 @@ function cleanup_all
 		(( i = i + 4 ))
 	done
 
-	datasetexists $TESTPOOL1/$TESTFS  && \
-		log_must zfs destroy -f $TESTPOOL1/$TESTFS
+	datasetexists $TESTPOOL1/$TESTFS && \
+		destroy_dataset $TESTPOOL1/$TESTFS -f
 
 	destroy_pool $TESTPOOL1
 

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_011_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_011_pos.ksh
@@ -51,8 +51,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	snapexists $SNAPPOOL && \
-		log_must zfs destroy -r $SNAPPOOL
+	snapexists $SNAPPOOL && destroy_dataset $SNAPPOOL -r
 
 	[[ -e $TESTDIR ]] && \
 		log_must rm -rf $TESTDIR/* > /dev/null 2>&1

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_012_pos.ksh
@@ -55,15 +55,14 @@ function cleanup
 {
 	if datasetexists $clone1; then
 		log_must zfs promote $ctrfs
-		log_must zfs destroy $clone1
+		destroy_dataset $clone1
 	fi
 
-	snapexists $snapctr && \
-		log_must zfs destroy -r $snapctr
+	snapexists $snapctr && destroy_dataset $snapctr -r
 
 	if snapexists $clone@$TESTSNAP1; then
 		log_must zfs promote $ctrfs
-		log_must zfs destroy -rR $ctrfs@$TESTSNAP1
+		destroy_dataset $ctrfs@$TESTSNAP1 -rR
 	fi
 }
 

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_013_pos.ksh
@@ -48,11 +48,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $ctrfs && \
-		zfs destroy -r $ctrfs
-
-	snapexists $snappool && \
-		log_must zfs destroy -r $snappool
+	datasetexists $ctrfs && destroy_dataset $ctrfs -r
+	snapexists $snappool && destroy_dataset $snappool -r
 
 	[[ -e $TESTDIR ]] && \
 		log_must rm -rf $TESTDIR/* > /dev/null 2>&1

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_014_pos.ksh
@@ -51,8 +51,7 @@ function cleanup
 	[[ -e $TESTDIR1 ]] && \
 		log_must rm -rf $TESTDIR1/* > /dev/null 2>&1
 
-	snapexists $SNAPCTR && \
-		log_must zfs destroy $SNAPCTR
+	snapexists $SNAPCTR && destroy_dataset $SNAPCTR
 
 	datasetexists $TESTPOOL/$TESTCTR/$TESTFS1 && \
 		log_must zfs set quota=none $TESTPOOL/$TESTCTR/$TESTFS1

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_015_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_015_pos.ksh
@@ -54,7 +54,7 @@ function cleanup
 	typeset -i i=0
 	while ((i < snap_cnt)); do
 		typeset snap=$fs@snap.$i
-		datasetexists $snap && log_must zfs destroy -f $snap
+		datasetexists $snap && destroy_dataset $snap -f
 
 		((i += 1))
 	done

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_016_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_016_pos.ksh
@@ -47,19 +47,12 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $SNAPFS && \
-		log_must zfs destroy -Rf $SNAPFS
-	datasetexists $TESTPOOL/$TESTFS@snap_a && \
-		log_must zfs destroy -Rf $TESTPOOL/$TESTFS@snap_a
-	datasetexists $TESTPOOL/$TESTFS@snap_b && \
-		log_must zfs destroy -Rf $TESTPOOL/$TESTFS@snap_b
-	datasetexists $TESTPOOL/$TESTCLONE@snap_a && \
-		log_must zfs destroy -Rf $TESTPOOL/$TESTCLONE@snap_a
-
-	datasetexists $TESTPOOL/$TESTCLONE && \
-		log_must zfs destroy $TESTPOOL/$TESTCLONE
-	datasetexists $TESTPOOL/$TESTFS && \
-		log_must zfs destroy $TESTPOOL/$TESTFS
+	datasetexists $SNAPFS && destroy_dataset $SNAPFS -Rf
+	datasetexists $TESTPOOL/$TESTFS@snap_a && destroy_dataset $TESTPOOL/$TESTFS@snap_a -Rf
+	datasetexists $TESTPOOL/$TESTFS@snap_b && destroy_dataset $TESTPOOL/$TESTFS@snap_b -Rf
+	datasetexists $TESTPOOL/$TESTCLONE@snap_a && destroy_dataset $TESTPOOL/$TESTCLONE@snap_a -Rf
+	datasetexists $TESTPOOL/$TESTCLONE && destroy_dataset $TESTPOOL/$TESTCLONE
+	datasetexists $TESTPOOL/$TESTFS && destroy_dataset $TESTPOOL/$TESTFS
 
 	log_must zfs create $TESTPOOL/$TESTFS
 	log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_017_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_017_pos.ksh
@@ -56,9 +56,8 @@ function cleanup
 {
 	cd $SAVED_DIR
 
-	if datasetexists $TESTPOOL/$TESTFS ; then
-		log_must zfs destroy -Rf $TESTPOOL/$TESTFS
-	fi
+	datasetexists $TESTPOOL/$TESTFS && \
+		destroy_dataset $TESTPOOL/$TESTFS -Rf
 
 	log_must zfs create $TESTPOOL/$TESTFS
 	log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS

--- a/tests/zfs-tests/tests/functional/snapused/snapused_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapused/snapused_001_pos.ksh
@@ -51,7 +51,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	log_must zfs destroy -rR $USEDTEST
+	datasetexists $USEDTEST && destroy_dataset $USEDTEST -rR
 }
 
 log_assert "Verify used is correct."

--- a/tests/zfs-tests/tests/functional/snapused/snapused_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapused/snapused_002_pos.ksh
@@ -49,7 +49,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	log_must zfs destroy -rR $USEDTEST
+	datasetexists $USEDTEST && destroy_dataset $USEDTEST -rR
 }
 
 log_assert "Verify usedbychildren is correct."

--- a/tests/zfs-tests/tests/functional/snapused/snapused_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapused/snapused_003_pos.ksh
@@ -48,7 +48,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	log_must zfs destroy -rR $USEDTEST
+	datasetexists $USEDTEST && destroy_dataset $USEDTEST -rR
 }
 
 log_assert "Verify usedbydataset is correct."

--- a/tests/zfs-tests/tests/functional/snapused/snapused_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapused/snapused_004_pos.ksh
@@ -53,7 +53,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	log_must zfs destroy -rR $USEDTEST
+	datasetexists $USEDTEST && destroy_dataset $USEDTEST -rR
 }
 
 log_assert "Verify usedbyrefreservation is correct."

--- a/tests/zfs-tests/tests/functional/snapused/snapused_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapused/snapused_005_pos.ksh
@@ -47,7 +47,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	log_must zfs destroy -rR $USEDTEST
+	datasetexists $USEDTEST && destroy_dataset $USEDTEST -rR
 }
 
 log_assert "Verify usedbysnapshots is correct."

--- a/tests/zfs-tests/tests/functional/userquota/groupspace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/groupspace_001_pos.ksh
@@ -45,9 +45,7 @@
 
 function cleanup
 {
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 
 	log_must cleanup_quota
 }

--- a/tests/zfs-tests/tests/functional/userquota/groupspace_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/groupspace_002_pos.ksh
@@ -45,9 +45,7 @@
 
 function cleanup
 {
-	if datasetexists $snapfs; then
-		log_must zfs destroy $snapfs
-	fi
+	datasetexists $snapfs && destroy_dataset $snapfs
 	log_must cleanup_quota
 }
 

--- a/tests/zfs-tests/tests/functional/userquota/groupspace_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/groupspace_003_pos.ksh
@@ -46,9 +46,7 @@
 
 function cleanup
 {
-	if datasetexists $snapfs; then
-		log_must zfs destroy $snapfs
-	fi
+	datasetexists $snapfs && destroy_dataset $snapfs
 
 	log_must rm -f ${QFILE}_*
 	log_must cleanup_quota

--- a/tests/zfs-tests/tests/functional/userquota/userquota_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userquota_005_neg.ksh
@@ -44,9 +44,7 @@
 
 function cleanup
 {
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 
 	log_must cleanup_quota
 }

--- a/tests/zfs-tests/tests/functional/userquota/userquota_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userquota_006_pos.ksh
@@ -44,9 +44,7 @@
 
 function cleanup
 {
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 
 	log_must cleanup_quota
 }

--- a/tests/zfs-tests/tests/functional/userquota/userquota_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userquota_009_pos.ksh
@@ -49,9 +49,7 @@
 
 function cleanup
 {
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 
 	log_must cleanup_quota
 }

--- a/tests/zfs-tests/tests/functional/userquota/userquota_011_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userquota_011_pos.ksh
@@ -49,9 +49,7 @@
 function cleanup
 {
 	for ds in $TESTPOOL/fs $TESTPOOL/fs-rename $TESTPOOL/fs-clone; do
-		if datasetexists $ds; then
-			log_must zfs destroy -rRf $ds
-		fi
+		datasetexists $ds && destroy_dataset $ds -rRf
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/userquota/userquota_012_neg.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userquota_012_neg.ksh
@@ -46,9 +46,7 @@ function cleanup
 {
 	cleanup_quota
 
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/userquota/userspace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userspace_001_pos.ksh
@@ -45,9 +45,7 @@
 
 function cleanup
 {
-	if datasetexists $snap_fs; then
-		log_must zfs destroy $snap_fs
-	fi
+	datasetexists $snap_fs && destroy_dataset $snap_fs
 
 	log_must cleanup_quota
 }

--- a/tests/zfs-tests/tests/functional/userquota/userspace_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userspace_002_pos.ksh
@@ -45,9 +45,7 @@
 
 function cleanup
 {
-	if datasetexists $snapfs; then
-		log_must zfs destroy $snapfs
-	fi
+	datasetexists $snapfs && destroy_dataset $snapfs
 
 	log_must cleanup_quota
 }

--- a/tests/zfs-tests/tests/functional/userquota/userspace_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userspace_003_pos.ksh
@@ -47,9 +47,7 @@
 
 function cleanup
 {
-	if datasetexists $snapfs; then
-		log_must zfs destroy $snapfs
-	fi
+	datasetexists $snapfs && destroy_dataset $snapfs
 
 	log_must rm -f ${QFILE}_*
 	log_must cleanup_quota

--- a/tests/zfs-tests/tests/functional/zvol/zvol_cli/zvol_cli_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_cli/zvol_cli_002_pos.ksh
@@ -45,7 +45,7 @@ verify_runnable "global"
 function cleanup
 {
 	datasetexists $TESTPOOL/$LONGVOLNAME && \
-		zfs destroy $TESTPOOL/$LONGVOLNAME
+		destroy_dataset $TESTPOOL/$LONGVOLNAME
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_common.shlib
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_common.shlib
@@ -63,9 +63,8 @@ function default_zvol_setup # disk_device volume_size block_size
 #
 function default_zvol_cleanup
 {
-        if datasetexists $TESTPOOL/$TESTVOL ; then
-		log_must zfs destroy $TESTPOOL/$TESTVOL
-	fi
+	datasetexists $TESTPOOL/$TESTVOL && \
+		destroy_dataset $TESTPOOL/$TESTVOL
 
         destroy_pool $TESTPOOL
 }

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
@@ -49,7 +49,7 @@ volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
 function cleanup
 {
 	snapexists $TESTPOOL/$TESTVOL@snap && \
-		zfs destroy $TESTPOOL/$TESTVOL@snap
+		destroy_dataset $TESTPOOL/$TESTVOL@snap
 
 	ismounted $TESTDIR $NEWFS_DEFAULT_FS
 	(( $? == 0 )) && log_must umount $TESTDIR

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_004_pos.ksh
@@ -65,9 +65,8 @@ function cleanup
 
 	typeset snap
 	for snap in snap0 snap1 ; do
-		if datasetexists $TESTPOOL/$TESTVOL@$snap ; then
-			log_must zfs destroy $TESTPOOL/$TESTVOL@$snap
-		fi
+		datasetexists $TESTPOOL/$TESTVOL@$snap && \
+			 destroy_dataset $TESTPOOL/$TESTVOL@$snap
 	done
 	zfs set volsize=$volsize $TESTPOOL/$TESTVOL
 }

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_snapdev.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_snapdev.ksh
@@ -43,8 +43,8 @@ verify_runnable "global"
 
 function cleanup
 {
-	datasetexists $VOLFS && log_must zfs destroy -r $VOLFS
-	datasetexists $ZVOL && log_must zfs destroy -r $ZVOL
+	datasetexists $VOLFS && destroy_dataset $VOLFS -r
+	datasetexists $ZVOL && destroy_dataset $ZVOL -r
 	log_must zfs inherit snapdev $TESTPOOL
 	block_device_wait
 	udev_cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_004_pos.ksh
@@ -47,7 +47,7 @@ verify_runnable "global"
 function cleanup
 {
 	is_swap_inuse $swapname && log_must swap_cleanup $swapname
-	datasetexists $vol && log_must zfs destroy $vol
+	datasetexists $vol && destroy_dataset $vol
 }
 
 log_assert "For an added swap zvol, (2G <= volsize <= 16G)"


### PR DESCRIPTION
### Motivation and Context
See #12700 but s/2.1/2.0/

### Description
I cherrypicked the cherrypicks from 2.1 on top of 2.0-release, and then hand-resolved the two merge conflicts there.

And then I yanked in 63f4b959a6 because alloc_class_0{12,13}_pos failed, 012 because it fails if 011 failed first.

### How Has This Been Tested?
Like #12700, it passed -r sanity when I pushed it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
