### PR TITLE
Add more explicit warning about dedup being dropped

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -5101,7 +5101,10 @@ zfs_receive_impl(libzfs_handle_t *hdl, const char *tosnap,
 		} else {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 			    "stream has unsupported feature, feature flags = "
-			    "%llx"), (unsigned long long)featureflags);
+			    "%llx (unknown flags = %llx)"),
+			    (u_longlong_t)featureflags,
+			    (u_longlong_t)((featureflags) &
+			    ~DMU_BACKUP_FEATURE_MASK));
 		}
 		return (zfs_error(hdl, EZFS_BADSTREAM, errbuf));
 	}

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -5088,9 +5088,21 @@ zfs_receive_impl(libzfs_handle_t *hdl, const char *tosnap,
 
 	if (!DMU_STREAM_SUPPORTED(featureflags) ||
 	    (hdrtype != DMU_SUBSTREAM && hdrtype != DMU_COMPOUNDSTREAM)) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "stream has unsupported feature, feature flags = %llx"),
-		    (unsigned long long)featureflags);
+		/*
+		 * Let's be explicit about this one, since rather than
+		 * being a new feature we can't know, it's an old
+		 * feature we dropped.
+		 */
+		if (featureflags & DMU_BACKUP_FEATURE_DEDUP) {
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "stream has deprecated feature: dedup, try "
+			    "'zstream redup [send in a file] | zfs recv "
+			    "[...]'"));
+		} else {
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "stream has unsupported feature, feature flags = "
+			    "%llx"), (unsigned long long)featureflags);
+		}
 		return (zfs_error(hdl, EZFS_BADSTREAM, errbuf));
 	}
 


### PR DESCRIPTION
### Motivation and Context
Someone ran into this because of Ubuntu's, uh, ["fun" choices about HWE](https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1949249), and while we concluded this was the problem by guessing, a more helpful message might have been nice.

### Description
Just special-case an error message for a failure we know is coming, rather than a feature we've never heard of.

(Actually, I suppose it might also be helpful to print _which_ flags are unknown/unsupported in the non-special case...we do have the bitmask right there...hm...)

### How Has This Been Tested?
I tried it on a send -D stream with and without, and it correctly printed the changed message.

Also, it passed when I pushed it and it triggered the GH actions runs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
