### PR TITLE
Temporarily disable SEEK_HOLE to workaround #11900

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -934,6 +934,13 @@ receive of encrypted datasets.
 Intended for users whose pools were created with
 OpenZFS pre-release versions and now have compatibility issues.
 .
+.It Sy zfs_disable_seek_optimizations Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Controls whether SEEK_DATA/SEEK_HOLE will report any results or just
+act like the file is non-sparse (default).
+.Pp
+Note that due to bug #11900, setting this to 0 (e.g. enabling SEEK_*) can
+result in incorrect data being returned.
+.
 .It Sy zfs_key_max_salt_uses Ns = Ns Sy 400000000 Po 4*10^8 Pc Pq ulong
 Maximum number of uses of a single salt value before generating a new one for
 encrypted datasets.

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -675,7 +675,7 @@ tests = ['migration_001_pos', 'migration_002_pos', 'migration_003_pos',
 tags = ['functional', 'migration']
 
 [tests/functional/mmap]
-tests = ['mmap_write_001_pos', 'mmap_read_001_pos', 'mmap_seek_001_pos']
+tests = ['mmap_write_001_pos', 'mmap_read_001_pos']
 tags = ['functional', 'mmap']
 
 [tests/functional/mount]


### PR DESCRIPTION
### Motivation and Context
#11900 is bad and not fixed, so let's degrade behavior and let people force the dangerous behavior back on if they know they need it.

### Description
A tunable for making it always behave as though we've never heard of SEEK_{DATA,HOLE} before.

### How Has This Been Tested?
Ran the emerge testcase that blows up in #11900 in a loop with the tunable set to 1 and 0 - with 1, it never breaks, and with 0, it breaks as usual within 10 runs...on Linux. It also passed the GH actions runs.

On FBSD, I haven't tried it at all, because I don't have a particularly good reproducer there. But since their only reproducer so far was worked around by freebsd/freebsd-src@42881526 I'm not as urgently concerned about that...

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
