### PR TITLE
Update contrib/initramfs/README.initramfs.markdown

### DIFF
--- a/contrib/initramfs/README.initramfs.markdown
+++ b/contrib/initramfs/README.initramfs.markdown
@@ -78,7 +78,7 @@ To use this feature:
 1. Install the `dropbear-initramfs` package.  You may wish to uninstall the
    `cryptsetup-initramfs` package to avoid warnings.
 2. Add your SSH key(s) to `/etc/dropbear-initramfs/authorized_keys`.  Note
-   that Dropbear does not support ed25519 keys; use RSA (2048-bit or more)
-   instead.
+   that Dropbear does not support ed25519 keys before version 2020.79; 
+   in that case, use RSA (2048-bit or more) instead.
 3. Rebuild the initramfs with your keys: `update-initramfs -u`
 4. During the system boot, login via SSH and run: `zfsunlock`


### PR DESCRIPTION
### Motivation and Context

This change updates outdated information.

### How Has This Been Tested?

I manually followed the instructions in contrib/initramfs/README.initramfs.markdown using package https://packages.debian.org/bullseye/dropbear-initramfs version 2020.81-3

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
