### PR TITLE
Upgrade to libabigail 2.0.0

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -34,11 +34,11 @@ jobs:
     - name: CheckABI
       id: CheckABI
       run: |
-        sudo docker run -v $(pwd):/source ghcr.io/openzfs/libabigail make checkabi
+        sudo docker run -v $(pwd):/source ghcr.io/xnox/libabigail make checkabi
     - name: StoreABI
       if: failure() && steps.CheckABI.outcome == 'failure'
       run: |
-        sudo docker run -v $(pwd):/source ghcr.io/openzfs/libabigail make storeabi
+        sudo docker run -v $(pwd):/source ghcr.io/xnox/libabigail make storeabi
     - name: Prepare artifacts
       if: failure() && steps.CheckABI.outcome == 'failure'
       run: |

--- a/Makefile.am
+++ b/Makefile.am
@@ -132,10 +132,11 @@ PHONY += checkabi storeabi
 
 checklibabiversion:
 	libabiversion=`abidw -v | $(SED) 's/[^0-9]//g'`; \
-	if test $$libabiversion -lt "180"; then \
+	if test $$libabiversion -lt "200"; then \
         /bin/echo -e "\n" \
-        "*** Please use libabigail 1.8.0 version or newer;\n" \
-        "*** otherwise results are not consistent!\n"; \
+        "*** Please use libabigail 2.0.0 version or newer;\n" \
+        "*** otherwise results are not consistent!\n" \
+        "(or see https://github.com/openzfs/libabigail-docker )\n"; \
         exit 1; \
     fi;
 

--- a/lib/libnvpair/libnvpair.abi
+++ b/lib/libnvpair/libnvpair.abi
@@ -1,10 +1,8 @@
-<abi-corpus architecture='elf-amd-x86_64' soname='libnvpair.so.3'>
+<abi-corpus version='2.0' architecture='elf-amd-x86_64' soname='libnvpair.so.3'>
   <elf-needed>
     <dependency name='libc.so.6'/>
   </elf-needed>
   <elf-function-symbols>
-    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='dump_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fnvlist_add_boolean' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fnvlist_add_boolean_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -236,262 +234,132 @@
     <elf-symbol name='nv_alloc_nosleep' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nv_fixed_ops' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/fnvpair.c' language='LANG_C99'>
-    <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_nvlist'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+  <abi-instr address-size='64' path='../../module/nvpair/fnvpair.c' language='LANG_C99'>
+    <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_alloc'>
       <return type-id='5ce45b60'/>
     </function-decl>
-    <function-decl name='fnvpair_value_string' mangled-name='fnvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_string'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+    <function-decl name='fnvlist_free' mangled-name='fnvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_free'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_size' mangled-name='fnvlist_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_size'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
+    <function-decl name='fnvlist_pack' mangled-name='fnvlist_pack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='78c01427' name='sizep'/>
       <return type-id='26a90f95'/>
     </function-decl>
-    <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint64'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='9c313c2d'/>
+    <function-decl name='fnvlist_pack_free' mangled-name='fnvlist_pack_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack_free'>
+      <parameter type-id='26a90f95' name='pack'/>
+      <parameter type-id='b59d7dce' name='size'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvpair_value_uint32' mangled-name='fnvpair_value_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint32'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint16' mangled-name='fnvpair_value_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint16'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_uint8' mangled-name='fnvpair_value_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint8'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int64'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='9da381c4'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int32'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='3ff5601b'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int16' mangled-name='fnvpair_value_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int16'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='23bd8cb5'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_int8' mangled-name='fnvpair_value_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int8'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='ee31ee44'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_byte' mangled-name='fnvpair_value_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_byte'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='d8bf0010'/>
-    </function-decl>
-    <function-decl name='fnvpair_value_boolean_value' mangled-name='fnvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_boolean_value'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint64_array' mangled-name='fnvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='5d6479ae'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int64_array' mangled-name='fnvlist_lookup_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='cb785ebf'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint32_array' mangled-name='fnvlist_lookup_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='90421557'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int32_array' mangled-name='fnvlist_lookup_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='4aafb922'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint16_array' mangled-name='fnvlist_lookup_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='8a121f49'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int16_array' mangled-name='fnvlist_lookup_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='f76f73d0'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_uint8_array' mangled-name='fnvlist_lookup_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='ae3e8ca6'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_int8_array' mangled-name='fnvlist_lookup_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='256d5229'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_byte_array' mangled-name='fnvlist_lookup_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='45b65157'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_boolean_array' mangled-name='fnvlist_lookup_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='37e3bd22'/>
-    </function-decl>
-    <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvlist'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
+    <function-decl name='fnvlist_unpack' mangled-name='fnvlist_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_unpack'>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='b59d7dce' name='buflen'/>
       <return type-id='5ce45b60'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_string'>
+    <function-decl name='fnvlist_dup' mangled-name='fnvlist_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_dup'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_merge'>
+      <parameter type-id='5ce45b60' name='dst'/>
+      <parameter type-id='5ce45b60' name='src'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_num_pairs' mangled-name='fnvlist_num_pairs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_num_pairs'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='26a90f95'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64'>
+    <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_value'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='9c313c2d'/>
+      <parameter type-id='c19b74c3' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint32' mangled-name='fnvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32'>
+    <function-decl name='fnvlist_add_byte' mangled-name='fnvlist_add_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='8f92235e'/>
+      <parameter type-id='d8bf0010' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint16' mangled-name='fnvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16'>
+    <function-decl name='fnvlist_add_int8' mangled-name='fnvlist_add_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='149c6638'/>
+      <parameter type-id='ee31ee44' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_uint8' mangled-name='fnvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8'>
+    <function-decl name='fnvlist_add_uint8' mangled-name='fnvlist_add_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='b96825af'/>
+      <parameter type-id='b96825af' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int64' mangled-name='fnvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64'>
+    <function-decl name='fnvlist_add_int16' mangled-name='fnvlist_add_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='9da381c4'/>
+      <parameter type-id='23bd8cb5' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int32' mangled-name='fnvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32'>
+    <function-decl name='fnvlist_add_uint16' mangled-name='fnvlist_add_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='3ff5601b'/>
+      <parameter type-id='149c6638' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int16' mangled-name='fnvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16'>
+    <function-decl name='fnvlist_add_int32' mangled-name='fnvlist_add_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='23bd8cb5'/>
+      <parameter type-id='3ff5601b' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_int8' mangled-name='fnvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8'>
+    <function-decl name='fnvlist_add_uint32' mangled-name='fnvlist_add_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='ee31ee44'/>
+      <parameter type-id='8f92235e' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_byte' mangled-name='fnvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte'>
+    <function-decl name='fnvlist_add_int64' mangled-name='fnvlist_add_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='d8bf0010'/>
+      <parameter type-id='9da381c4' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_value'>
+    <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='c19b74c3'/>
+      <parameter type-id='9c313c2d' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_boolean' mangled-name='fnvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean'>
+    <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='c19b74c3'/>
+      <parameter type-id='80f4b756' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_lookup_nvpair' mangled-name='fnvlist_lookup_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvpair'>
+    <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='3fa542f0'/>
+      <parameter type-id='5ce45b60' name='val'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_remove_nvpair' mangled-name='fnvlist_remove_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove_nvpair'>
+    <function-decl name='fnvlist_add_nvpair' mangled-name='fnvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvpair'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='3fa542f0' name='pair'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove'>
+    <function-decl name='fnvlist_add_boolean_array' mangled-name='fnvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_nvlist_array' mangled-name='fnvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='857bb57e' name='val'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_string_array' mangled-name='fnvlist_add_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='f319fae0' name='val'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint64_array' mangled-name='fnvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='5d6479ae' name='val'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int64_array' mangled-name='fnvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='cb785ebf' name='val'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint32_array' mangled-name='fnvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='90421557' name='val'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int32_array' mangled-name='fnvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4aafb922' name='val'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint16_array' mangled-name='fnvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='8a121f49' name='val'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int16_array' mangled-name='fnvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='f76f73d0' name='val'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_uint8_array' mangled-name='fnvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='ae3e8ca6' name='val'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_add_int8_array' mangled-name='fnvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='256d5229' name='val'/>
+      <parameter type-id='37e3bd22' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
@@ -502,260 +370,266 @@
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_add_boolean_array' mangled-name='fnvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_array'>
+    <function-decl name='fnvlist_add_int8_array' mangled-name='fnvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='37e3bd22' name='val'/>
+      <parameter type-id='256d5229' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_add_nvpair' mangled-name='fnvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvpair'>
+    <function-decl name='fnvlist_add_uint8_array' mangled-name='fnvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='ae3e8ca6' name='val'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int16_array' mangled-name='fnvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='f76f73d0' name='val'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint16_array' mangled-name='fnvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='8a121f49' name='val'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int32_array' mangled-name='fnvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4aafb922' name='val'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint32_array' mangled-name='fnvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='90421557' name='val'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_int64_array' mangled-name='fnvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='cb785ebf' name='val'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_uint64_array' mangled-name='fnvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='5d6479ae' name='val'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_string_array' mangled-name='fnvlist_add_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='f319fae0' name='val'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_add_nvlist_array' mangled-name='fnvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='857bb57e' name='val'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_remove' mangled-name='fnvlist_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fnvlist_remove_nvpair' mangled-name='fnvlist_remove_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_remove_nvpair'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='3fa542f0' name='pair'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_add_nvlist' mangled-name='fnvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist'>
+    <function-decl name='fnvlist_lookup_nvpair' mangled-name='fnvlist_lookup_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvpair'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='5ce45b60' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='3fa542f0'/>
     </function-decl>
-    <function-decl name='fnvlist_add_string' mangled-name='fnvlist_add_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string'>
+    <function-decl name='fnvlist_lookup_boolean' mangled-name='fnvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='80f4b756' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='fnvlist_add_uint64' mangled-name='fnvlist_add_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64'>
+    <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_value'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='9c313c2d' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='fnvlist_add_int64' mangled-name='fnvlist_add_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64'>
+    <function-decl name='fnvlist_lookup_byte' mangled-name='fnvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='9da381c4' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='d8bf0010'/>
     </function-decl>
-    <function-decl name='fnvlist_add_uint32' mangled-name='fnvlist_add_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32'>
+    <function-decl name='fnvlist_lookup_int8' mangled-name='fnvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='8f92235e' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='ee31ee44'/>
     </function-decl>
-    <function-decl name='fnvlist_add_int32' mangled-name='fnvlist_add_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32'>
+    <function-decl name='fnvlist_lookup_int16' mangled-name='fnvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='3ff5601b' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='23bd8cb5'/>
     </function-decl>
-    <function-decl name='fnvlist_add_uint16' mangled-name='fnvlist_add_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16'>
+    <function-decl name='fnvlist_lookup_int32' mangled-name='fnvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='149c6638' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='3ff5601b'/>
     </function-decl>
-    <function-decl name='fnvlist_add_int16' mangled-name='fnvlist_add_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16'>
+    <function-decl name='fnvlist_lookup_int64' mangled-name='fnvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='23bd8cb5' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='9da381c4'/>
     </function-decl>
-    <function-decl name='fnvlist_add_uint8' mangled-name='fnvlist_add_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8'>
+    <function-decl name='fnvlist_lookup_uint8' mangled-name='fnvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='b96825af' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='b96825af'/>
     </function-decl>
-    <function-decl name='fnvlist_add_int8' mangled-name='fnvlist_add_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8'>
+    <function-decl name='fnvlist_lookup_uint16' mangled-name='fnvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='ee31ee44' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='149c6638'/>
     </function-decl>
-    <function-decl name='fnvlist_add_byte' mangled-name='fnvlist_add_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte'>
+    <function-decl name='fnvlist_lookup_uint32' mangled-name='fnvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='d8bf0010' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='8f92235e'/>
     </function-decl>
-    <function-decl name='fnvlist_add_boolean_value' mangled-name='fnvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_value'>
+    <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='c19b74c3' name='val'/>
-      <return type-id='48b5725f'/>
+      <return type-id='9c313c2d'/>
     </function-decl>
-    <function-decl name='fnvlist_add_boolean' mangled-name='fnvlist_add_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean'>
+    <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_string'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_num_pairs' mangled-name='fnvlist_num_pairs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_num_pairs'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <return type-id='b59d7dce'/>
-    </function-decl>
-    <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_merge'>
-      <parameter type-id='5ce45b60' name='dst'/>
-      <parameter type-id='5ce45b60' name='src'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_dup' mangled-name='fnvlist_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_dup'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <return type-id='5ce45b60'/>
-    </function-decl>
-    <function-decl name='fnvlist_unpack' mangled-name='fnvlist_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_unpack'>
-      <parameter type-id='26a90f95' name='buf'/>
-      <parameter type-id='b59d7dce' name='buflen'/>
-      <return type-id='5ce45b60'/>
-    </function-decl>
-    <function-decl name='fnvlist_pack_free' mangled-name='fnvlist_pack_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack_free'>
-      <parameter type-id='26a90f95' name='pack'/>
-      <parameter type-id='b59d7dce' name='size'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_pack' mangled-name='fnvlist_pack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_pack'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='78c01427' name='sizep'/>
       <return type-id='26a90f95'/>
     </function-decl>
-    <function-decl name='fnvlist_size' mangled-name='fnvlist_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_size'>
+    <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvlist'>
       <parameter type-id='5ce45b60' name='nvl'/>
-      <return type-id='b59d7dce'/>
-    </function-decl>
-    <function-decl name='fnvlist_free' mangled-name='fnvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_free'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fnvlist_alloc' mangled-name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_alloc'>
+      <parameter type-id='80f4b756' name='name'/>
       <return type-id='5ce45b60'/>
     </function-decl>
-    <pointer-type-def type-id='c19b74c3' size-in-bits='64' id='37e3bd22'/>
-    <pointer-type-def type-id='a84c031d' size-in-bits='64' id='26a90f95'/>
-    <pointer-type-def type-id='57de658a' size-in-bits='64' id='f319fae0'/>
-    <pointer-type-def type-id='9b45d938' size-in-bits='64' id='80f4b756'/>
-    <pointer-type-def type-id='23bd8cb5' size-in-bits='64' id='f76f73d0'/>
-    <pointer-type-def type-id='3ff5601b' size-in-bits='64' id='4aafb922'/>
-    <pointer-type-def type-id='9da381c4' size-in-bits='64' id='cb785ebf'/>
-    <pointer-type-def type-id='ee31ee44' size-in-bits='64' id='256d5229'/>
-    <pointer-type-def type-id='8e8d4be3' size-in-bits='64' id='5ce45b60'/>
-    <pointer-type-def type-id='5ce45b60' size-in-bits='64' id='857bb57e'/>
-    <pointer-type-def type-id='57928edf' size-in-bits='64' id='3fa542f0'/>
-    <pointer-type-def type-id='b59d7dce' size-in-bits='64' id='78c01427'/>
-    <typedef-decl name='boolean_t' type-id='40ed39d2' id='c19b74c3'/>
-    <typedef-decl name='int16_t' type-id='03896e23' id='23bd8cb5'/>
-    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
-    <typedef-decl name='int64_t' type-id='0c9942d2' id='9da381c4'/>
-    <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
-    <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
-    <typedef-decl name='uchar_t' type-id='002ac4a6' id='d8bf0010'/>
-    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
-    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
-    <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
-    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
-    <typedef-decl name='uint_t' type-id='f0981eeb' id='3502e3ff'/>
-    <pointer-type-def type-id='d8bf0010' size-in-bits='64' id='45b65157'/>
-    <pointer-type-def type-id='149c6638' size-in-bits='64' id='8a121f49'/>
-    <pointer-type-def type-id='8f92235e' size-in-bits='64' id='90421557'/>
-    <pointer-type-def type-id='9c313c2d' size-in-bits='64' id='5d6479ae'/>
-    <pointer-type-def type-id='b96825af' size-in-bits='64' id='ae3e8ca6'/>
-    <pointer-type-def type-id='3502e3ff' size-in-bits='64' id='4dd26a40'/>
-    <type-decl name='void' id='48b5725f'/>
-    <type-decl name='char' size-in-bits='8' id='a84c031d'/>
-    <qualified-type-def type-id='26a90f95' const='yes' id='57de658a'/>
-    <qualified-type-def type-id='a84c031d' const='yes' id='9b45d938'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' id='40ed39d2'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='B_FALSE' value='0'/>
-      <enumerator name='B_TRUE' value='1'/>
-    </enum-decl>
-    <typedef-decl name='__int16_t' type-id='a2185560' id='03896e23'/>
-    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
-    <typedef-decl name='__int64_t' type-id='bd54fe1a' id='0c9942d2'/>
-    <typedef-decl name='__int8_t' type-id='28577a57' id='2171a512'/>
-    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
-    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
-    <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
-    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
-    <typedef-decl name='nvlist_t' type-id='ac266fd9' id='8e8d4be3'/>
-    <typedef-decl name='nvpair_t' type-id='1c34e459' id='57928edf'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='002ac4a6'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='f0981eeb'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='ac266fd9'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvl_priv' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' id='1c34e459'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvp_size' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvp_name_sz' type-id='23bd8cb5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='nvp_reserve' type-id='23bd8cb5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvp_value_elem' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='nvp_type' type-id='8d0687d2' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <type-decl name='int' size-in-bits='32' id='95e97e5e'/>
-    <type-decl name='long int' size-in-bits='64' id='bd54fe1a'/>
-    <type-decl name='short int' size-in-bits='16' id='a2185560'/>
-    <type-decl name='signed char' size-in-bits='8' id='28577a57'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='8efea9e5'/>
-    <typedef-decl name='data_type_t' type-id='08f5ca17' id='8d0687d2'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca17'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
-      <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
-      <enumerator name='DATA_TYPE_BOOLEAN' value='1'/>
-      <enumerator name='DATA_TYPE_BYTE' value='2'/>
-      <enumerator name='DATA_TYPE_INT16' value='3'/>
-      <enumerator name='DATA_TYPE_UINT16' value='4'/>
-      <enumerator name='DATA_TYPE_INT32' value='5'/>
-      <enumerator name='DATA_TYPE_UINT32' value='6'/>
-      <enumerator name='DATA_TYPE_INT64' value='7'/>
-      <enumerator name='DATA_TYPE_UINT64' value='8'/>
-      <enumerator name='DATA_TYPE_STRING' value='9'/>
-      <enumerator name='DATA_TYPE_BYTE_ARRAY' value='10'/>
-      <enumerator name='DATA_TYPE_INT16_ARRAY' value='11'/>
-      <enumerator name='DATA_TYPE_UINT16_ARRAY' value='12'/>
-      <enumerator name='DATA_TYPE_INT32_ARRAY' value='13'/>
-      <enumerator name='DATA_TYPE_UINT32_ARRAY' value='14'/>
-      <enumerator name='DATA_TYPE_INT64_ARRAY' value='15'/>
-      <enumerator name='DATA_TYPE_UINT64_ARRAY' value='16'/>
-      <enumerator name='DATA_TYPE_STRING_ARRAY' value='17'/>
-      <enumerator name='DATA_TYPE_HRTIME' value='18'/>
-      <enumerator name='DATA_TYPE_NVLIST' value='19'/>
-      <enumerator name='DATA_TYPE_NVLIST_ARRAY' value='20'/>
-      <enumerator name='DATA_TYPE_BOOLEAN_VALUE' value='21'/>
-      <enumerator name='DATA_TYPE_INT8' value='22'/>
-      <enumerator name='DATA_TYPE_UINT8' value='23'/>
-      <enumerator name='DATA_TYPE_BOOLEAN_ARRAY' value='24'/>
-      <enumerator name='DATA_TYPE_INT8_ARRAY' value='25'/>
-      <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
-      <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
-    </enum-decl>
+    <function-decl name='fnvlist_lookup_boolean_array' mangled-name='fnvlist_lookup_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='37e3bd22'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_byte_array' mangled-name='fnvlist_lookup_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='45b65157'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int8_array' mangled-name='fnvlist_lookup_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='256d5229'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint8_array' mangled-name='fnvlist_lookup_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='ae3e8ca6'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int16_array' mangled-name='fnvlist_lookup_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='f76f73d0'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint16_array' mangled-name='fnvlist_lookup_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='8a121f49'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int32_array' mangled-name='fnvlist_lookup_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='4aafb922'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint32_array' mangled-name='fnvlist_lookup_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='90421557'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_int64_array' mangled-name='fnvlist_lookup_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='cb785ebf'/>
+    </function-decl>
+    <function-decl name='fnvlist_lookup_uint64_array' mangled-name='fnvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='5d6479ae'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_boolean_value' mangled-name='fnvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_boolean_value'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_byte' mangled-name='fnvpair_value_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_byte'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='d8bf0010'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int8' mangled-name='fnvpair_value_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int8'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='ee31ee44'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int16' mangled-name='fnvpair_value_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int16'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='23bd8cb5'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int32'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='3ff5601b'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int64'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='9da381c4'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint8' mangled-name='fnvpair_value_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint8'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint16' mangled-name='fnvpair_value_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint16'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint32' mangled-name='fnvpair_value_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint32'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint64'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_string' mangled-name='fnvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_string'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='26a90f95'/>
+    </function-decl>
+    <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_nvlist'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/nvpair/nvpair.c' language='LANG_C99'>
     <pointer-type-def type-id='37e3bd22' size-in-bits='64' id='03829398'/>
     <qualified-type-def type-id='26a90f95' const='yes' id='57de658a'/>
     <pointer-type-def type-id='57de658a' size-in-bits='64' id='f319fae0'/>
@@ -776,614 +650,32 @@
     <pointer-type-def type-id='5d6479ae' size-in-bits='64' id='892b4acc'/>
     <pointer-type-def type-id='ae3e8ca6' size-in-bits='64' id='d8774064'/>
     <pointer-type-def type-id='3502e3ff' size-in-bits='64' id='4dd26a40'/>
-    <function-decl name='nvlist_xunpack' mangled-name='nvlist_xunpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xunpack'>
-      <parameter type-id='26a90f95' name='buf'/>
-      <parameter type-id='b59d7dce' name='buflen'/>
-      <parameter type-id='857bb57e' name='nvlp'/>
+    <function-decl name='nv_alloc_init' mangled-name='nv_alloc_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_init'>
       <parameter type-id='11871392' name='nva'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_unpack'>
-      <parameter type-id='26a90f95' name='buf'/>
-      <parameter type-id='b59d7dce' name='buflen'/>
-      <parameter type-id='857bb57e' name='nvlp'/>
-      <parameter type-id='95e97e5e' name='kmflag'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_pack' mangled-name='nvlist_pack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_pack'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='9b23c9ad' name='bufp'/>
-      <parameter type-id='78c01427' name='buflen'/>
-      <parameter type-id='95e97e5e' name='encoding'/>
-      <parameter type-id='95e97e5e' name='kmflag'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_merge' mangled-name='nvlist_merge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_merge'>
-      <parameter type-id='5ce45b60' name='dst'/>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='95e97e5e' name='flag'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvpair' mangled-name='nvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvpair'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_hrtime' mangled-name='nvpair_value_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_hrtime'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='e379e62d' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_nvlist_array' mangled-name='nvpair_value_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='75be733c' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_string_array' mangled-name='nvpair_value_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='c0563f85' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint64_array' mangled-name='nvpair_value_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='892b4acc' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int64_array' mangled-name='nvpair_value_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='e37ce48f' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint32_array' mangled-name='nvpair_value_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='9507d3c7' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int32_array' mangled-name='nvpair_value_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='9aa04798' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint16_array' mangled-name='nvpair_value_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='bd8768d9' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int16_array' mangled-name='nvpair_value_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='7e73928e' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint8_array' mangled-name='nvpair_value_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='d8774064' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int8_array' mangled-name='nvpair_value_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='ee181ab9' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_byte_array' mangled-name='nvpair_value_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='3b0247c7' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_boolean_array' mangled-name='nvpair_value_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='03829398' name='val'/>
-      <parameter type-id='4dd26a40' name='nelem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='857bb57e' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='9b23c9ad' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_double' mangled-name='nvpair_value_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_double'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='7408d286' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='5d6479ae' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int64' mangled-name='nvpair_value_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='cb785ebf' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='90421557' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='4aafb922' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint16' mangled-name='nvpair_value_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='8a121f49' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int16' mangled-name='nvpair_value_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='f76f73d0' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_uint8' mangled-name='nvpair_value_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='ae3e8ca6' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_int8' mangled-name='nvpair_value_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='256d5229' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_byte' mangled-name='nvpair_value_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='45b65157' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_boolean_value' mangled-name='nvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_value'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='37e3bd22' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_exists' mangled-name='nvlist_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_exists'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvpair_embedded_index' mangled-name='nvlist_lookup_nvpair_embedded_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair_embedded_index'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='0b283d2e' name='ret'/>
-      <parameter type-id='7292109c' name='ip'/>
-      <parameter type-id='9b23c9ad' name='ep'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvpair' mangled-name='nvlist_lookup_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='0b283d2e' name='ret'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_pairs' mangled-name='nvlist_lookup_pairs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_pairs'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='95e97e5e' name='flag'/>
+      <parameter type-id='ee1d4944' name='nvo'/>
       <parameter is-variadic='yes'/>
       <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_hrtime' mangled-name='nvlist_lookup_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_hrtime'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='e379e62d' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='75be733c' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_string_array' mangled-name='nvlist_lookup_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='c0563f85' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='892b4acc' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int64_array' mangled-name='nvlist_lookup_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='e37ce48f' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint32_array' mangled-name='nvlist_lookup_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='9507d3c7' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int32_array' mangled-name='nvlist_lookup_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='9aa04798' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint16_array' mangled-name='nvlist_lookup_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='bd8768d9' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int16_array' mangled-name='nvlist_lookup_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='7e73928e' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint8_array' mangled-name='nvlist_lookup_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='d8774064' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int8_array' mangled-name='nvlist_lookup_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='ee181ab9' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_byte_array' mangled-name='nvlist_lookup_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='3b0247c7' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean_array' mangled-name='nvlist_lookup_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='03829398' name='a'/>
-      <parameter type-id='4dd26a40' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='857bb57e' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='9b23c9ad' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_double' mangled-name='nvlist_lookup_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_double'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='7408d286' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='5d6479ae' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='cb785ebf' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint32' mangled-name='nvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='90421557' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int32' mangled-name='nvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4aafb922' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint16' mangled-name='nvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='8a121f49' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int16' mangled-name='nvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='f76f73d0' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_uint8' mangled-name='nvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='ae3e8ca6' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_int8' mangled-name='nvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='256d5229' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_byte' mangled-name='nvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='45b65157' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean_value' mangled-name='nvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_value'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='37e3bd22' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_type_is_array' mangled-name='nvpair_type_is_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type_is_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_type' mangled-name='nvpair_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='8d0687d2'/>
-    </function-decl>
-    <function-decl name='nvpair_name' mangled-name='nvpair_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_name'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='26a90f95'/>
-    </function-decl>
-    <function-decl name='nvlist_empty' mangled-name='nvlist_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_empty'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='nvlist_prev_nvpair' mangled-name='nvlist_prev_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prev_nvpair'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='3fa542f0'/>
-    </function-decl>
-    <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_next_nvpair'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <return type-id='3fa542f0'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='857bb57e' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='5ce45b60' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_hrtime' mangled-name='nvlist_add_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_hrtime'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='cebdd548' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_string_array' mangled-name='nvlist_add_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='f319fae0' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='5d6479ae' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int64_array' mangled-name='nvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='cb785ebf' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint32_array' mangled-name='nvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='90421557' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int32_array' mangled-name='nvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4aafb922' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint16_array' mangled-name='nvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='8a121f49' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int16_array' mangled-name='nvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='f76f73d0' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='ae3e8ca6' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int8_array' mangled-name='nvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='256d5229' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_byte_array' mangled-name='nvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='45b65157' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean_array' mangled-name='nvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_array'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='37e3bd22' name='a'/>
-      <parameter type-id='3502e3ff' name='n'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='80f4b756' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_double' mangled-name='nvlist_add_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_double'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='a0eb0f08' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='9c313c2d' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int64' mangled-name='nvlist_add_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='9da381c4' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint32' mangled-name='nvlist_add_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='8f92235e' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int32' mangled-name='nvlist_add_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='3ff5601b' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint16' mangled-name='nvlist_add_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='149c6638' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int16' mangled-name='nvlist_add_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='23bd8cb5' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint8' mangled-name='nvlist_add_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='b96825af' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_int8' mangled-name='nvlist_add_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='ee31ee44' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_byte' mangled-name='nvlist_add_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='d8bf0010' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean_value' mangled-name='nvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_value'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='c19b74c3' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_dup' mangled-name='nvlist_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_dup'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='857bb57e' name='nvlp'/>
-      <parameter type-id='95e97e5e' name='kmflag'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_free' mangled-name='nvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_free'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_alloc'>
-      <parameter type-id='857bb57e' name='nvlp'/>
-      <parameter type-id='3502e3ff' name='nvflag'/>
-      <parameter type-id='95e97e5e' name='kmflag'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvlist_nvflag' mangled-name='nvlist_nvflag' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_nvflag'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <return type-id='3502e3ff'/>
-    </function-decl>
-    <function-decl name='nvlist_lookup_nv_alloc' mangled-name='nvlist_lookup_nv_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nv_alloc'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <return type-id='11871392'/>
-    </function-decl>
-    <function-decl name='nv_alloc_fini' mangled-name='nv_alloc_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_fini'>
-      <parameter type-id='11871392' name='nva'/>
-      <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='nv_alloc_reset' mangled-name='nv_alloc_reset' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_reset'>
       <parameter type-id='11871392' name='nva'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nv_alloc_init' mangled-name='nv_alloc_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_init'>
+    <function-decl name='nv_alloc_fini' mangled-name='nv_alloc_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nv_alloc_fini'>
       <parameter type-id='11871392' name='nva'/>
-      <parameter type-id='ee1d4944' name='nvo'/>
-      <parameter is-variadic='yes'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nv_alloc' mangled-name='nvlist_lookup_nv_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nv_alloc'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <return type-id='11871392'/>
+    </function-decl>
+    <function-decl name='nvlist_nvflag' mangled-name='nvlist_nvflag' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_nvflag'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <return type-id='3502e3ff'/>
+    </function-decl>
+    <function-decl name='nvlist_alloc' mangled-name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_alloc'>
+      <parameter type-id='857bb57e' name='nvlp'/>
+      <parameter type-id='3502e3ff' name='nvflag'/>
+      <parameter type-id='95e97e5e' name='kmflag'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_xalloc' mangled-name='nvlist_xalloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xalloc'>
@@ -1392,9 +684,20 @@
       <parameter type-id='11871392' name='nva'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='nvlist_remove_nvpair' mangled-name='nvlist_remove_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_nvpair'>
+    <function-decl name='nvlist_free' mangled-name='nvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_free'>
       <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_dup' mangled-name='nvlist_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_dup'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='857bb57e' name='nvlp'/>
+      <parameter type-id='95e97e5e' name='kmflag'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_xdup' mangled-name='nvlist_xdup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xdup'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='857bb57e' name='nvlp'/>
+      <parameter type-id='11871392' name='nva'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_remove_all' mangled-name='nvlist_remove_all' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_all'>
@@ -1408,16 +711,573 @@
       <parameter type-id='8d0687d2' name='type'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='nvlist_xdup' mangled-name='nvlist_xdup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xdup'>
+    <function-decl name='nvlist_remove_nvpair' mangled-name='nvlist_remove_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_remove_nvpair'>
       <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='857bb57e' name='nvlp'/>
-      <parameter type-id='11871392' name='nva'/>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean' mangled-name='nvlist_add_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_value' mangled-name='nvlist_add_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_value'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='c19b74c3' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte' mangled-name='nvlist_add_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='d8bf0010' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8' mangled-name='nvlist_add_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='ee31ee44' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8' mangled-name='nvlist_add_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='b96825af' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16' mangled-name='nvlist_add_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='23bd8cb5' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16' mangled-name='nvlist_add_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='149c6638' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32' mangled-name='nvlist_add_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='3ff5601b' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32' mangled-name='nvlist_add_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='8f92235e' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64' mangled-name='nvlist_add_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='9da381c4' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' mangled-name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='9c313c2d' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_double' mangled-name='nvlist_add_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_double'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='a0eb0f08' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string' mangled-name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='80f4b756' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_boolean_array' mangled-name='nvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='37e3bd22' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_byte_array' mangled-name='nvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='45b65157' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int8_array' mangled-name='nvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='256d5229' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='ae3e8ca6' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int16_array' mangled-name='nvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='f76f73d0' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint16_array' mangled-name='nvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='8a121f49' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int32_array' mangled-name='nvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4aafb922' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint32_array' mangled-name='nvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='90421557' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_int64_array' mangled-name='nvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='cb785ebf' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='5d6479ae' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_string_array' mangled-name='nvlist_add_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='f319fae0' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_hrtime' mangled-name='nvlist_add_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_hrtime'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='cebdd548' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='5ce45b60' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='857bb57e' name='a'/>
+      <parameter type-id='3502e3ff' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_next_nvpair'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='3fa542f0'/>
+    </function-decl>
+    <function-decl name='nvlist_prev_nvpair' mangled-name='nvlist_prev_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prev_nvpair'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='3fa542f0'/>
+    </function-decl>
+    <function-decl name='nvlist_empty' mangled-name='nvlist_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_empty'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='nvpair_name' mangled-name='nvpair_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_name'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='26a90f95'/>
+    </function-decl>
+    <function-decl name='nvpair_type' mangled-name='nvpair_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='8d0687d2'/>
+    </function-decl>
+    <function-decl name='nvpair_type_is_array' mangled-name='nvpair_type_is_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type_is_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_value' mangled-name='nvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_value'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='37e3bd22' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte' mangled-name='nvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='45b65157' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8' mangled-name='nvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='256d5229' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8' mangled-name='nvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='ae3e8ca6' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16' mangled-name='nvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='f76f73d0' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16' mangled-name='nvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='8a121f49' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32' mangled-name='nvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='4aafb922' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32' mangled-name='nvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='90421557' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='cb785ebf' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='5d6479ae' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_double' mangled-name='nvlist_lookup_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_double'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='7408d286' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='9b23c9ad' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='857bb57e' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_boolean_array' mangled-name='nvlist_lookup_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='03829398' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_byte_array' mangled-name='nvlist_lookup_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='3b0247c7' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int8_array' mangled-name='nvlist_lookup_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='ee181ab9' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint8_array' mangled-name='nvlist_lookup_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='d8774064' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int16_array' mangled-name='nvlist_lookup_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='7e73928e' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint16_array' mangled-name='nvlist_lookup_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='bd8768d9' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int32_array' mangled-name='nvlist_lookup_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='9aa04798' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint32_array' mangled-name='nvlist_lookup_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='9507d3c7' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_int64_array' mangled-name='nvlist_lookup_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='e37ce48f' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_uint64_array' mangled-name='nvlist_lookup_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='892b4acc' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_string_array' mangled-name='nvlist_lookup_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='c0563f85' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvlist_array' mangled-name='nvlist_lookup_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist_array'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='75be733c' name='a'/>
+      <parameter type-id='4dd26a40' name='n'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_hrtime' mangled-name='nvlist_lookup_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_hrtime'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='e379e62d' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_pairs' mangled-name='nvlist_lookup_pairs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_pairs'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='95e97e5e' name='flag'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvpair' mangled-name='nvlist_lookup_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='0b283d2e' name='ret'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_lookup_nvpair_embedded_index' mangled-name='nvlist_lookup_nvpair_embedded_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvpair_embedded_index'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='0b283d2e' name='ret'/>
+      <parameter type-id='7292109c' name='ip'/>
+      <parameter type-id='9b23c9ad' name='ep'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_exists' mangled-name='nvlist_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_exists'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='nvpair_value_boolean_value' mangled-name='nvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_value'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='37e3bd22' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_byte' mangled-name='nvpair_value_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='45b65157' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int8' mangled-name='nvpair_value_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='256d5229' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8' mangled-name='nvpair_value_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='ae3e8ca6' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int16' mangled-name='nvpair_value_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='f76f73d0' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint16' mangled-name='nvpair_value_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='8a121f49' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='4aafb922' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='90421557' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int64' mangled-name='nvpair_value_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='cb785ebf' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='5d6479ae' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_double' mangled-name='nvpair_value_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_double'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='7408d286' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='9b23c9ad' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='857bb57e' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_boolean_array' mangled-name='nvpair_value_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='03829398' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_byte_array' mangled-name='nvpair_value_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='3b0247c7' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int8_array' mangled-name='nvpair_value_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='ee181ab9' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint8_array' mangled-name='nvpair_value_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='d8774064' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int16_array' mangled-name='nvpair_value_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='7e73928e' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint16_array' mangled-name='nvpair_value_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='bd8768d9' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int32_array' mangled-name='nvpair_value_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='9aa04798' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint32_array' mangled-name='nvpair_value_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='9507d3c7' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_int64_array' mangled-name='nvpair_value_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='e37ce48f' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_uint64_array' mangled-name='nvpair_value_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='892b4acc' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_string_array' mangled-name='nvpair_value_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='c0563f85' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_nvlist_array' mangled-name='nvpair_value_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist_array'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='75be733c' name='val'/>
+      <parameter type-id='4dd26a40' name='nelem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_hrtime' mangled-name='nvpair_value_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_hrtime'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='e379e62d' name='val'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_nvpair' mangled-name='nvlist_add_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvpair'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_merge' mangled-name='nvlist_merge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_merge'>
+      <parameter type-id='5ce45b60' name='dst'/>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='95e97e5e' name='flag'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_size' mangled-name='nvlist_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_size'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='78c01427' name='size'/>
       <parameter type-id='95e97e5e' name='encoding'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_pack' mangled-name='nvlist_pack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_pack'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='9b23c9ad' name='bufp'/>
+      <parameter type-id='78c01427' name='buflen'/>
+      <parameter type-id='95e97e5e' name='encoding'/>
+      <parameter type-id='95e97e5e' name='kmflag'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_xpack' mangled-name='nvlist_xpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xpack'>
@@ -1428,54 +1288,25 @@
       <parameter type-id='11871392' name='nva'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <pointer-type-def type-id='26a90f95' size-in-bits='64' id='9b23c9ad'/>
-    <pointer-type-def type-id='aca16c06' size-in-bits='64' id='ee1d4944'/>
-    <type-decl name='double' size-in-bits='64' id='a0eb0f08'/>
-    <pointer-type-def type-id='cca08635' size-in-bits='64' id='11871392'/>
-    <typedef-decl name='hrtime_t' type-id='1eb56b1e' id='cebdd548'/>
-    <qualified-type-def type-id='03e8ffd6' const='yes' id='aca16c06'/>
-    <type-decl name='long long int' size-in-bits='64' id='1eb56b1e'/>
-    <typedef-decl name='nv_alloc_t' type-id='98213087' id='cca08635'/>
-    <class-decl name='nv_alloc' size-in-bits='128' is-struct='yes' visibility='default' id='98213087'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nva_ops' type-id='ee1d4944' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nva_arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='nv_alloc_ops_t' type-id='8f6cc4f4' id='03e8ffd6'/>
-    <class-decl name='nv_alloc_ops' size-in-bits='320' is-struct='yes' visibility='default' id='8f6cc4f4'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nv_ao_init' type-id='76da8447' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nv_ao_fini' type-id='fe356f6f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nv_ao_alloc' type-id='9ff7f508' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='nv_ao_free' type-id='520da3f4' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='nv_ao_reset' type-id='fe356f6f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
-    <pointer-type-def type-id='e9ff7293' size-in-bits='64' id='76da8447'/>
-    <pointer-type-def type-id='51a21b4b' size-in-bits='64' id='fe356f6f'/>
-    <pointer-type-def type-id='1169c032' size-in-bits='64' id='520da3f4'/>
-    <pointer-type-def type-id='9fff962e' size-in-bits='64' id='9ff7f508'/>
-    <function-type size-in-bits='64' id='51a21b4b'>
+    <function-decl name='nvlist_unpack' mangled-name='nvlist_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_unpack'>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='b59d7dce' name='buflen'/>
+      <parameter type-id='857bb57e' name='nvlp'/>
+      <parameter type-id='95e97e5e' name='kmflag'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_xunpack' mangled-name='nvlist_xunpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xunpack'>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='b59d7dce' name='buflen'/>
+      <parameter type-id='857bb57e' name='nvlp'/>
       <parameter type-id='11871392' name='nva'/>
-      <return type-id='48b5725f'/>
-    </function-type>
+      <return type-id='95e97e5e'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/nvpair/nvpair_alloc_fixed.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/nvpair/nvpair_alloc_fixed.c' language='LANG_C99'>
     <var-decl name='nv_fixed_ops' type-id='ee1d4944' mangled-name='nv_fixed_ops' visibility='default' elf-symbol-id='nv_fixed_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libnvpair.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='libnvpair.c' language='LANG_C99'>
     <type-decl name='char' size-in-bits='8' id='a84c031d'/>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='8' id='89feb1ec'>
       <subrange length='1' type-id='7359adad' id='52f813b4'/>
@@ -1483,6 +1314,10 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
+    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='b48d2441'/>
     <type-decl name='double' size-in-bits='64' id='a0eb0f08'/>
     <type-decl name='int' size-in-bits='32' id='95e97e5e'/>
     <type-decl name='long int' size-in-bits='64' id='bd54fe1a'/>
@@ -1496,30 +1331,19 @@
     <type-decl name='unsigned short int' size-in-bits='16' id='8efea9e5'/>
     <type-decl name='variadic parameter type' id='2c1145c5'/>
     <type-decl name='void' id='48b5725f'/>
-    <typedef-decl name='nvpair_t' type-id='1c34e459' id='57928edf'/>
-    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' id='1c34e459'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvp_size' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvp_name_sz' type-id='23bd8cb5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='nvp_reserve' type-id='23bd8cb5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvp_value_elem' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='nvp_type' type-id='8d0687d2' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
-    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
-    <typedef-decl name='int16_t' type-id='03896e23' id='23bd8cb5'/>
-    <typedef-decl name='__int16_t' type-id='a2185560' id='03896e23'/>
-    <typedef-decl name='data_type_t' type-id='08f5ca17' id='8d0687d2'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca17'>
+    <typedef-decl name='nvlist_prtctl_t' type-id='196db161' id='b0c1ff8d'/>
+    <enum-decl name='nvlist_indent_mode' id='628aafab'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='NVLIST_INDENT_ABS' value='0'/>
+      <enumerator name='NVLIST_INDENT_TABBED' value='1'/>
+    </enum-decl>
+    <enum-decl name='nvlist_prtctl_fmt' id='c8dcc53a'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='NVLIST_FMT_MEMBER_NAME' value='0'/>
+      <enumerator name='NVLIST_FMT_MEMBER_POSTAMBLE' value='1'/>
+      <enumerator name='NVLIST_FMT_BTWN_ARRAY' value='2'/>
+    </enum-decl>
+    <enum-decl name='data_type_t' naming-typedef-id='8d0687d2' id='aeeae136'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='DATA_TYPE_DONTCARE' value='-1'/>
       <enumerator name='DATA_TYPE_UNKNOWN' value='0'/>
@@ -1551,54 +1375,25 @@
       <enumerator name='DATA_TYPE_UINT8_ARRAY' value='26'/>
       <enumerator name='DATA_TYPE_DOUBLE' value='27'/>
     </enum-decl>
-    <typedef-decl name='regex_t' type-id='19fc9a8c' id='aca3bac8'/>
-    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' id='19fc9a8c'>
+    <typedef-decl name='data_type_t' type-id='aeeae136' id='8d0687d2'/>
+    <class-decl name='nvpair' size-in-bits='128' is-struct='yes' visibility='default' id='1c34e459'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='buffer' type-id='cf536864' visibility='default'/>
+        <var-decl name='nvp_size' type-id='3ff5601b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvp_name_sz' type-id='23bd8cb5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='nvp_reserve' type-id='23bd8cb5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='allocated' type-id='7359adad' visibility='default'/>
+        <var-decl name='nvp_value_elem' type-id='3ff5601b' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='used' type-id='7359adad' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='syntax' type-id='1b72c3b3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fastmap' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='translate' type-id='cf536864' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='re_nsub' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='can_be_null' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='29'>
-        <var-decl name='regs_allocated' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='28'>
-        <var-decl name='fastmap_accurate' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='27'>
-        <var-decl name='no_sub' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='26'>
-        <var-decl name='not_bol' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='25'>
-        <var-decl name='not_eol' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='24'>
-        <var-decl name='newline_anchor' type-id='f0981eeb' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='nvp_type' type-id='8d0687d2' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='reg_syntax_t' type-id='7359adad' id='1b72c3b3'/>
-    <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
-    <typedef-decl name='nvlist_t' type-id='ac266fd9' id='8e8d4be3'/>
+    <typedef-decl name='nvpair_t' type-id='1c34e459' id='57928edf'/>
     <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='ac266fd9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='nvl_version' type-id='3ff5601b' visibility='default'/>
@@ -1616,11 +1411,315 @@
         <var-decl name='nvl_pad' type-id='3ff5601b' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
-    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
-    <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
-    <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
-    <typedef-decl name='nvlist_prtctl_t' type-id='196db161' id='b0c1ff8d'/>
+    <typedef-decl name='nvlist_t' type-id='ac266fd9' id='8e8d4be3'/>
+    <enum-decl name='boolean_t' naming-typedef-id='c19b74c3' id='f58c8277'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='B_FALSE' value='0'/>
+      <enumerator name='B_TRUE' value='1'/>
+    </enum-decl>
+    <typedef-decl name='boolean_t' type-id='f58c8277' id='c19b74c3'/>
+    <typedef-decl name='uchar_t' type-id='002ac4a6' id='d8bf0010'/>
+    <typedef-decl name='uint_t' type-id='f0981eeb' id='3502e3ff'/>
+    <typedef-decl name='hrtime_t' type-id='1eb56b1e' id='cebdd548'/>
+    <class-decl name='nvlist_printops' size-in-bits='3456' is-struct='yes' visibility='default' id='ebc6735b'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='print_boolean' type-id='e7f43f72' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='print_boolean_value' type-id='e7f43f73' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='print_byte' type-id='e7f43f74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='print_int8' type-id='e7f43f75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='print_uint8' type-id='e7f43f76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='print_int16' type-id='e7f43f77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='print_uint16' type-id='e7f43f78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='print_int32' type-id='e7f43f79' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='print_uint32' type-id='e7f43f7a' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='print_int64' type-id='e7f43f7b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='print_uint64' type-id='e7f43f7c' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='print_double' type-id='e7f43f7d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='print_string' type-id='e7f43f7e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='print_hrtime' type-id='e7f43f7f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1792'>
+        <var-decl name='print_nvlist' type-id='e7f43f80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1920'>
+        <var-decl name='print_boolean_array' type-id='e7f43f81' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='print_byte_array' type-id='e7f43f82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='print_int8_array' type-id='e7f43f83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='print_uint8_array' type-id='e7f43f84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='print_int16_array' type-id='e7f43f85' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='print_uint16_array' type-id='e7f43f86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='print_int32_array' type-id='e7f43f87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='print_uint32_array' type-id='e7f43f88' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2944'>
+        <var-decl name='print_int64_array' type-id='e7f43f89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3072'>
+        <var-decl name='print_uint64_array' type-id='e7f43f8a' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3200'>
+        <var-decl name='print_string_array' type-id='e7f43f8b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3328'>
+        <var-decl name='print_nvlist_array' type-id='e7f43f8c' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='6d994334' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__1' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='6a2f50c1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f74'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='8a1fb33a' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__3' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f75'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='506696a8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__4' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='39b623f9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__5' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f77'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='ea6be4eb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__6' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f78'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='f10f1e84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__7' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='1708018d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__8' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7a'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='90174072' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__9' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7b'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='d2af7f32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__10' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7c'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='0b22f759' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__11' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7d'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='3be4d568' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__12' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7e'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='c0d0f877' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__13' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7f'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='e1c54c3c' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__14' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f80'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='19ea27ae' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__15' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f81'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='7ef0e988' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__16' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f82'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='7391ed39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__17' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f83'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='42257af5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__18' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f84'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='330cc0d0' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__19' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f85'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='506ab59a' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__20' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f86'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='ed6a3a3d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__21' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f87'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='750cc41c' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__22' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='292cdbcf' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__23' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f89'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='aaea91b5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__24' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f8a'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='7e85a9b6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__25' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f8b'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='de20bf07' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__26' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f8c'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='2835af80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='nvlist_prtctl' size-in-bits='576' is-struct='yes' visibility='default' id='d2e8bad9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='nvprt_fp' type-id='822cd80b' visibility='default'/>
@@ -1653,7 +1752,73 @@
         <var-decl name='nvprt_custops' type-id='7be54adb' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='__re_long_size_t' type-id='7359adad' id='ba516949'/>
+    <typedef-decl name='reg_syntax_t' type-id='7359adad' id='1b72c3b3'/>
+    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' id='19fc9a8c'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='buffer' type-id='33976309' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='allocated' type-id='ba516949' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='used' type-id='ba516949' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='syntax' type-id='1b72c3b3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='fastmap' type-id='26a90f95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='translate' type-id='cf536864' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='re_nsub' type-id='b59d7dce' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='can_be_null' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='449'>
+        <var-decl name='regs_allocated' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='451'>
+        <var-decl name='fastmap_accurate' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='452'>
+        <var-decl name='no_sub' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='453'>
+        <var-decl name='not_bol' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='454'>
+        <var-decl name='not_eol' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='455'>
+        <var-decl name='newline_anchor' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='regex_t' type-id='19fc9a8c' id='aca3bac8'/>
+    <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
+    <typedef-decl name='int16_t' type-id='03896e23' id='23bd8cb5'/>
+    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
+    <typedef-decl name='int64_t' type-id='0c9942d2' id='9da381c4'/>
+    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
+    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
+    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
+    <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
+    <typedef-decl name='__int8_t' type-id='28577a57' id='2171a512'/>
+    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
+    <typedef-decl name='__int16_t' type-id='a2185560' id='03896e23'/>
+    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
+    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
+    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
+    <typedef-decl name='__int64_t' type-id='bd54fe1a' id='0c9942d2'/>
+    <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
+    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
+    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
     <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
+    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='95e97e5e' visibility='default'/>
@@ -1722,16 +1887,16 @@
         <var-decl name='_offset' type-id='724e4de6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='__pad1' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_codecvt' type-id='570f8c59' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='__pad2' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_wide_data' type-id='c65a1f29' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='__pad3' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_freeres_list' type-id='dca988a5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='__pad4' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_freeres_buf' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='__pad5' type-id='b59d7dce' visibility='default'/>
@@ -1743,351 +1908,13 @@
         <var-decl name='_unused2' type-id='664ac0b7' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='010ae0b9'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_next' type-id='e4c6fa61' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_sbuf' type-id='dca988a5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_pos' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
-    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
-    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
-    <enum-decl name='nvlist_indent_mode' id='628aafab'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='NVLIST_INDENT_ABS' value='0'/>
-      <enumerator name='NVLIST_INDENT_TABBED' value='1'/>
-    </enum-decl>
-    <class-decl name='nvlist_printops' size-in-bits='3456' is-struct='yes' visibility='default' id='ebc6735b'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='print_boolean' type-id='47d8e2d1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='print_boolean_value' type-id='8a6f2dcc' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='print_byte' type-id='bdf563df' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='print_int8' type-id='5636b8e3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='print_uint8' type-id='0119a618' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='print_int16' type-id='4657e0ba' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='print_uint16' type-id='ecfe67d7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='print_int32' type-id='8947fe4c' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='print_uint32' type-id='365a6549' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='print_int64' type-id='d6ce379b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='print_uint64' type-id='bb34572a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='print_double' type-id='ef32d857' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='print_string' type-id='f6ce752a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='print_hrtime' type-id='c61b59cf' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1792'>
-        <var-decl name='print_nvlist' type-id='1178977f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1920'>
-        <var-decl name='print_boolean_array' type-id='15d12763' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2048'>
-        <var-decl name='print_byte_array' type-id='4207d3e6' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='print_int8_array' type-id='e4cdea78' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2304'>
-        <var-decl name='print_uint8_array' type-id='252509cf' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='print_int16_array' type-id='3cf98639' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='print_uint16_array' type-id='060bdb18' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2688'>
-        <var-decl name='print_int32_array' type-id='bbaa8a1b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2816'>
-        <var-decl name='print_uint32_array' type-id='745b46ee' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2944'>
-        <var-decl name='print_int64_array' type-id='223df2d6' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='3072'>
-        <var-decl name='print_uint64_array' type-id='f564486f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='3200'>
-        <var-decl name='print_string_array' type-id='f15f91ac' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='3328'>
-        <var-decl name='print_nvlist_array' type-id='f885c1bf' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='47d8e2d1'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='6d994334' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__1' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='8a6f2dcc'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='6a2f50c1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='boolean_t' type-id='40ed39d2' id='c19b74c3'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' id='40ed39d2'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='B_FALSE' value='0'/>
-      <enumerator name='B_TRUE' value='1'/>
-    </enum-decl>
-    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='bdf563df'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='8a1fb33a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uchar_t' type-id='002ac4a6' id='d8bf0010'/>
-    <class-decl name='__anonymous_struct__3' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='5636b8e3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='506696a8' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
-    <typedef-decl name='__int8_t' type-id='28577a57' id='2171a512'/>
-    <class-decl name='__anonymous_struct__4' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='0119a618'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='39b623f9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
-    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
-    <class-decl name='__anonymous_struct__5' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='4657e0ba'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='ea6be4eb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__6' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='ecfe67d7'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='f10f1e84' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
-    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
-    <class-decl name='__anonymous_struct__7' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='8947fe4c'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='1708018d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__8' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='365a6549'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='90174072' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__9' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='d6ce379b'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='d2af7f32' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='int64_t' type-id='0c9942d2' id='9da381c4'/>
-    <typedef-decl name='__int64_t' type-id='bd54fe1a' id='0c9942d2'/>
-    <class-decl name='__anonymous_struct__10' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='bb34572a'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='0b22f759' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__11' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='ef32d857'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='3be4d568' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__12' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='f6ce752a'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='c0d0f877' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__13' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='c61b59cf'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='e1c54c3c' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='hrtime_t' type-id='1eb56b1e' id='cebdd548'/>
-    <class-decl name='__anonymous_struct__14' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='1178977f'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='19ea27ae' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__15' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='15d12763'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='7ef0e988' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uint_t' type-id='f0981eeb' id='3502e3ff'/>
-    <class-decl name='__anonymous_struct__16' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='4207d3e6'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='7391ed39' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__17' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e4cdea78'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='42257af5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__18' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='252509cf'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='330cc0d0' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__19' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='3cf98639'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='506ab59a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__20' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='060bdb18'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='ed6a3a3d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__21' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='bbaa8a1b'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='750cc41c' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__22' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='745b46ee'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='292cdbcf' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__23' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='223df2d6'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='aaea91b5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__24' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='f564486f'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='7e85a9b6' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__25' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='f15f91ac'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='de20bf07' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__26' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='f885c1bf'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='2835af80' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='nvlist_prtctl_fmt' id='c8dcc53a'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='NVLIST_FMT_MEMBER_NAME' value='0'/>
-      <enumerator name='NVLIST_FMT_MEMBER_POSTAMBLE' value='1'/>
-      <enumerator name='NVLIST_FMT_BTWN_ARRAY' value='2'/>
-    </enum-decl>
+    <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
     <pointer-type-def type-id='aa12d1ba' size-in-bits='64' id='822cd80b'/>
     <pointer-type-def type-id='ec1ed955' size-in-bits='64' id='dca988a5'/>
+    <pointer-type-def type-id='a4036571' size-in-bits='64' id='570f8c59'/>
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
+    <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
     <pointer-type-def type-id='c19b74c3' size-in-bits='64' id='37e3bd22'/>
     <pointer-type-def type-id='a84c031d' size-in-bits='64' id='26a90f95'/>
     <pointer-type-def type-id='26a90f95' size-in-bits='64' id='9b23c9ad'/>
@@ -2156,6 +1983,7 @@
     <pointer-type-def type-id='8e8d4be3' size-in-bits='64' id='5ce45b60'/>
     <pointer-type-def type-id='5ce45b60' size-in-bits='64' id='857bb57e'/>
     <pointer-type-def type-id='57928edf' size-in-bits='64' id='3fa542f0'/>
+    <pointer-type-def type-id='b48d2441' size-in-bits='64' id='33976309'/>
     <pointer-type-def type-id='aca3bac8' size-in-bits='64' id='d33f11cb'/>
     <pointer-type-def type-id='d8bf0010' size-in-bits='64' id='45b65157'/>
     <pointer-type-def type-id='149c6638' size-in-bits='64' id='8a121f49'/>
@@ -2164,190 +1992,46 @@
     <pointer-type-def type-id='b96825af' size-in-bits='64' id='ae3e8ca6'/>
     <pointer-type-def type-id='002ac4a6' size-in-bits='64' id='cf536864'/>
     <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
-    <function-decl name='nvpair_value_match' mangled-name='nvpair_value_match' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='95e97e5e' name='ai'/>
-      <parameter type-id='26a90f95' name='value'/>
-      <parameter type-id='9b23c9ad' name='ep'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='nvpair_value_match_regex' mangled-name='nvpair_value_match_regex' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match_regex'>
-      <parameter type-id='3fa542f0' name='nvp'/>
-      <parameter type-id='95e97e5e' name='ai'/>
-      <parameter type-id='26a90f95' name='value'/>
-      <parameter type-id='d33f11cb' name='value_regex'/>
-      <parameter type-id='9b23c9ad' name='ep'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='dump_nvlist' mangled-name='dump_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dump_nvlist'>
-      <parameter type-id='5ce45b60' name='list'/>
-      <parameter type-id='95e97e5e' name='indent'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prt' mangled-name='nvlist_prt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prt'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
+    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='b48d2441'/>
+    <function-decl name='nvlist_prtctl_setdest' mangled-name='nvlist_prtctl_setdest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setdest'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_print' mangled-name='nvlist_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print'>
       <parameter type-id='822cd80b' name='fp'/>
-      <parameter type-id='5ce45b60' name='nvl'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctl_free' mangled-name='nvlist_prtctl_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_free'>
+    <function-decl name='nvlist_prtctl_getdest' mangled-name='nvlist_prtctl_getdest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_getdest'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
+      <return type-id='822cd80b'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_setindent' mangled-name='nvlist_prtctl_setindent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setindent'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='628aafab' name='mode'/>
+      <parameter type-id='95e97e5e' name='start'/>
+      <parameter type-id='95e97e5e' name='inc'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctl_alloc' mangled-name='nvlist_prtctl_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_alloc'>
-      <return type-id='b0c1ff8d'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_nvlist_array' mangled-name='nvlist_prtctlop_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist_array'>
+    <function-decl name='nvlist_prtctl_doindent' mangled-name='nvlist_prtctl_doindent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_doindent'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='44f188f2' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
+      <parameter type-id='95e97e5e' name='onemore'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctlop_string_array' mangled-name='nvlist_prtctlop_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string_array'>
+    <function-decl name='nvlist_prtctl_setfmt' mangled-name='nvlist_prtctl_setfmt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setfmt'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='90d5edb9' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
+      <parameter type-id='c8dcc53a' name='which'/>
+      <parameter type-id='80f4b756' name='fmt'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctlop_uint64_array' mangled-name='nvlist_prtctlop_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64_array'>
+    <function-decl name='nvlist_prtctl_dofmt' mangled-name='nvlist_prtctl_dofmt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_dofmt'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='470a7fd4' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
+      <parameter type-id='c8dcc53a' name='which'/>
+      <parameter is-variadic='yes'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctlop_int64_array' mangled-name='nvlist_prtctlop_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64_array'>
+    <function-decl name='nvlist_prtctlop_boolean' mangled-name='nvlist_prtctlop_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='8b41e457' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint32_array' mangled-name='nvlist_prtctlop_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32_array'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='d94cdfa1' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int32_array' mangled-name='nvlist_prtctlop_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32_array'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='b3fae562' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint16_array' mangled-name='nvlist_prtctlop_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16_array'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='5cbe16ab' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int16_array' mangled-name='nvlist_prtctlop_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16_array'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='cbda43ac' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint8_array' mangled-name='nvlist_prtctlop_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8_array'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='eddda806' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int8_array' mangled-name='nvlist_prtctlop_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8_array'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='f9668a57' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_byte_array' mangled-name='nvlist_prtctlop_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte_array'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='108e6453' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_boolean_array' mangled-name='nvlist_prtctlop_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_array'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='ed8aa8ba' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_nvlist' mangled-name='nvlist_prtctlop_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='001d8764' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_hrtime' mangled-name='nvlist_prtctlop_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_hrtime'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='ee62ad8e' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_string' mangled-name='nvlist_prtctlop_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='2809de35' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_double' mangled-name='nvlist_prtctlop_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_double'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='e44553b6' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint64' mangled-name='nvlist_prtctlop_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='2c8c4457' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int64' mangled-name='nvlist_prtctlop_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='0ca7b13c' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint32' mangled-name='nvlist_prtctlop_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='7f8ee7e4' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int32' mangled-name='nvlist_prtctlop_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='4db8acf3' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint16' mangled-name='nvlist_prtctlop_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='92988dea' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int16' mangled-name='nvlist_prtctlop_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='957d9f35' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_uint8' mangled-name='nvlist_prtctlop_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='eb944897' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_int8' mangled-name='nvlist_prtctlop_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='a91bad5a' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='nvlist_prtctlop_byte' mangled-name='nvlist_prtctlop_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte'>
-      <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='519bf35c' name='func'/>
+      <parameter type-id='1263777a' name='func'/>
       <parameter type-id='eaa32e2f' name='private'/>
       <return type-id='48b5725f'/>
     </function-decl>
@@ -2357,44 +2041,192 @@
       <parameter type-id='eaa32e2f' name='private'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctlop_boolean' mangled-name='nvlist_prtctlop_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean'>
+    <function-decl name='nvlist_prtctlop_byte' mangled-name='nvlist_prtctlop_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='1263777a' name='func'/>
+      <parameter type-id='519bf35c' name='func'/>
       <parameter type-id='eaa32e2f' name='private'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctl_dofmt' mangled-name='nvlist_prtctl_dofmt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_dofmt'>
+    <function-decl name='nvlist_prtctlop_int8' mangled-name='nvlist_prtctlop_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='c8dcc53a' name='which'/>
-      <parameter is-variadic='yes'/>
+      <parameter type-id='a91bad5a' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctl_setfmt' mangled-name='nvlist_prtctl_setfmt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setfmt'>
+    <function-decl name='nvlist_prtctlop_uint8' mangled-name='nvlist_prtctlop_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='c8dcc53a' name='which'/>
-      <parameter type-id='80f4b756' name='fmt'/>
+      <parameter type-id='eb944897' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctl_doindent' mangled-name='nvlist_prtctl_doindent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_doindent'>
+    <function-decl name='nvlist_prtctlop_int16' mangled-name='nvlist_prtctlop_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='95e97e5e' name='onemore'/>
+      <parameter type-id='957d9f35' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctl_setindent' mangled-name='nvlist_prtctl_setindent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setindent'>
+    <function-decl name='nvlist_prtctlop_uint16' mangled-name='nvlist_prtctlop_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='628aafab' name='mode'/>
-      <parameter type-id='95e97e5e' name='start'/>
-      <parameter type-id='95e97e5e' name='inc'/>
+      <parameter type-id='92988dea' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctl_getdest' mangled-name='nvlist_prtctl_getdest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_getdest'>
+    <function-decl name='nvlist_prtctlop_int32' mangled-name='nvlist_prtctlop_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <return type-id='822cd80b'/>
+      <parameter type-id='4db8acf3' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='nvlist_prtctl_setdest' mangled-name='nvlist_prtctl_setdest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setdest'>
+    <function-decl name='nvlist_prtctlop_uint32' mangled-name='nvlist_prtctlop_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='7f8ee7e4' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int64' mangled-name='nvlist_prtctlop_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='0ca7b13c' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint64' mangled-name='nvlist_prtctlop_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='2c8c4457' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_double' mangled-name='nvlist_prtctlop_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_double'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='e44553b6' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_string' mangled-name='nvlist_prtctlop_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='2809de35' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_hrtime' mangled-name='nvlist_prtctlop_hrtime' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_hrtime'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='ee62ad8e' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_nvlist' mangled-name='nvlist_prtctlop_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='001d8764' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_boolean_array' mangled-name='nvlist_prtctlop_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_boolean_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='ed8aa8ba' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_byte_array' mangled-name='nvlist_prtctlop_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_byte_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='108e6453' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int8_array' mangled-name='nvlist_prtctlop_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int8_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='f9668a57' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint8_array' mangled-name='nvlist_prtctlop_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint8_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='eddda806' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int16_array' mangled-name='nvlist_prtctlop_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int16_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='cbda43ac' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint16_array' mangled-name='nvlist_prtctlop_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint16_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='5cbe16ab' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int32_array' mangled-name='nvlist_prtctlop_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int32_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='b3fae562' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint32_array' mangled-name='nvlist_prtctlop_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint32_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='d94cdfa1' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_int64_array' mangled-name='nvlist_prtctlop_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_int64_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='8b41e457' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_uint64_array' mangled-name='nvlist_prtctlop_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_uint64_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='470a7fd4' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_string_array' mangled-name='nvlist_prtctlop_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='90d5edb9' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctlop_nvlist_array' mangled-name='nvlist_prtctlop_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_nvlist_array'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <parameter type-id='44f188f2' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_alloc' mangled-name='nvlist_prtctl_alloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_alloc'>
+      <return type-id='b0c1ff8d'/>
+    </function-decl>
+    <function-decl name='nvlist_prtctl_free' mangled-name='nvlist_prtctl_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_free'>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_print' mangled-name='nvlist_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print'>
       <parameter type-id='822cd80b' name='fp'/>
+      <parameter type-id='5ce45b60' name='nvl'/>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvlist_prt' mangled-name='nvlist_prt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prt'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='b0c1ff8d' name='pctl'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='dump_nvlist' mangled-name='dump_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dump_nvlist'>
+      <parameter type-id='5ce45b60' name='list'/>
+      <parameter type-id='95e97e5e' name='indent'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='nvpair_value_match_regex' mangled-name='nvpair_value_match_regex' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match_regex'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='95e97e5e' name='ai'/>
+      <parameter type-id='26a90f95' name='value'/>
+      <parameter type-id='d33f11cb' name='value_regex'/>
+      <parameter type-id='9b23c9ad' name='ep'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvpair_value_match' mangled-name='nvpair_value_match' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match'>
+      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='95e97e5e' name='ai'/>
+      <parameter type-id='26a90f95' name='value'/>
+      <parameter type-id='9b23c9ad' name='ep'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-type size-in-bits='64' id='9f88f76e'>
       <parameter type-id='196db161'/>
@@ -2853,14 +2685,14 @@
       <return type-id='95e97e5e'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libnvpair_json.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='libnvpair_json.c' language='LANG_C99'>
     <function-decl name='nvlist_print_json' mangled-name='nvlist_print_json' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print_json'>
       <parameter type-id='822cd80b' name='fp'/>
       <parameter type-id='5ce45b60' name='nvl'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='nvpair_alloc_system.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='nvpair_alloc_system.c' language='LANG_C99'>
     <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='d5027220'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='gp_offset' type-id='f0981eeb' visibility='default'/>
@@ -2875,6 +2707,7 @@
         <var-decl name='reg_save_area' type-id='eaa32e2f' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='nv_alloc_ops_t' type-id='8f6cc4f4' id='03e8ffd6'/>
     <class-decl name='nv_alloc' size-in-bits='128' is-struct='yes' visibility='default' id='98213087'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='nva_ops' type-id='ee1d4944' visibility='default'/>
@@ -2883,7 +2716,7 @@
         <var-decl name='nva_arg' type-id='eaa32e2f' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='nv_alloc_ops_t' type-id='8f6cc4f4' id='03e8ffd6'/>
+    <typedef-decl name='nv_alloc_t' type-id='98213087' id='cca08635'/>
     <class-decl name='nv_alloc_ops' size-in-bits='320' is-struct='yes' visibility='default' id='8f6cc4f4'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='nv_ao_init' type-id='76da8447' visibility='default'/>
@@ -2901,7 +2734,6 @@
         <var-decl name='nv_ao_reset' type-id='fe356f6f' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='nv_alloc_t' type-id='98213087' id='cca08635'/>
     <pointer-type-def type-id='d5027220' size-in-bits='64' id='b7f2d5e6'/>
     <qualified-type-def type-id='03e8ffd6' const='yes' id='aca16c06'/>
     <pointer-type-def type-id='aca16c06' size-in-bits='64' id='ee1d4944'/>
@@ -2916,6 +2748,10 @@
       <parameter type-id='b7f2d5e6'/>
       <return type-id='95e97e5e'/>
     </function-type>
+    <function-type size-in-bits='64' id='51a21b4b'>
+      <parameter type-id='11871392'/>
+      <return type-id='48b5725f'/>
+    </function-type>
     <function-type size-in-bits='64' id='1169c032'>
       <parameter type-id='11871392'/>
       <parameter type-id='eaa32e2f'/>
@@ -2928,7 +2764,7 @@
       <return type-id='eaa32e2f'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='assert.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='assert.c' language='LANG_C99'>
     <var-decl name='libspl_assert_ok' type-id='95e97e5e' mangled-name='libspl_assert_ok' visibility='default' elf-symbol-id='libspl_assert_ok'/>
     <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
       <parameter type-id='80f4b756' name='file'/>

--- a/lib/libuutil/libuutil.abi
+++ b/lib/libuutil/libuutil.abi
@@ -1,12 +1,10 @@
-<abi-corpus architecture='elf-amd-x86_64' soname='libuutil.so.3'>
+<abi-corpus version='2.0' architecture='elf-amd-x86_64' soname='libuutil.so.3'>
   <elf-needed>
     <dependency name='libpthread.so.0'/>
     <dependency name='libc.so.6'/>
     <dependency name='ld-linux-x86-64.so.2'/>
   </elf-needed>
   <elf-function-symbols>
-    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -260,63 +258,41 @@
     <elf-symbol name='uu_exit_ok_value' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='uu_exit_usage_value' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/avl/avl.c' language='LANG_C99'>
     <typedef-decl name='avl_tree_t' type-id='b351119f' id='f20fbd51'/>
     <typedef-decl name='avl_index_t' type-id='e475ab95' id='fba6cb51'/>
     <pointer-type-def type-id='fba6cb51' size-in-bits='64' id='32adbf30'/>
     <pointer-type-def type-id='f20fbd51' size-in-bits='64' id='a3681dea'/>
-    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
+    <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
       <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='63e171df' name='cookie'/>
+      <parameter type-id='eaa32e2f' name='oldnode'/>
+      <parameter type-id='95e97e5e' name='left'/>
       <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
+    <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
       <parameter type-id='a3681dea' name='tree'/>
-      <return type-id='c19b74c3'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
+    <function-decl name='avl_last' mangled-name='avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
       <parameter type-id='a3681dea' name='tree'/>
-      <return type-id='ee1f298e'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
+    <function-decl name='avl_nearest' mangled-name='avl_nearest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
       <parameter type-id='a3681dea' name='tree'/>
-      <return type-id='48b5725f'/>
+      <parameter type-id='fba6cb51' name='where'/>
+      <parameter type-id='95e97e5e' name='direction'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
+    <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
       <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='585e1de9' name='compar'/>
-      <parameter type-id='b59d7dce' name='size'/>
-      <parameter type-id='b59d7dce' name='offset'/>
-      <return type-id='48b5725f'/>
+      <parameter type-id='eaa32e2f' name='value'/>
+      <parameter type-id='32adbf30' name='where'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_swap' mangled-name='avl_swap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
-      <parameter type-id='a3681dea' name='tree1'/>
-      <parameter type-id='a3681dea' name='tree2'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='avl_update' mangled-name='avl_update' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
-      <parameter type-id='a3681dea' name='t'/>
-      <parameter type-id='eaa32e2f' name='obj'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
-      <parameter type-id='a3681dea' name='t'/>
-      <parameter type-id='eaa32e2f' name='obj'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
-      <parameter type-id='a3681dea' name='t'/>
-      <parameter type-id='eaa32e2f' name='obj'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='avl_remove' mangled-name='avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
+    <function-decl name='avl_insert' mangled-name='avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
       <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='avl_add' mangled-name='avl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
-      <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='eaa32e2f' name='new_node'/>
+      <parameter type-id='eaa32e2f' name='new_data'/>
+      <parameter type-id='fba6cb51' name='where'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='avl_insert_here' mangled-name='avl_insert_here' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
@@ -326,84 +302,67 @@
       <parameter type-id='95e97e5e' name='direction'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='avl_insert' mangled-name='avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
+    <function-decl name='avl_add' mangled-name='avl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
       <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='eaa32e2f' name='new_data'/>
-      <parameter type-id='fba6cb51' name='where'/>
+      <parameter type-id='eaa32e2f' name='new_node'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
+    <function-decl name='avl_remove' mangled-name='avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
       <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='eaa32e2f' name='value'/>
-      <parameter type-id='32adbf30' name='where'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
+      <parameter type-id='a3681dea' name='t'/>
+      <parameter type-id='eaa32e2f' name='obj'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
+      <parameter type-id='a3681dea' name='t'/>
+      <parameter type-id='eaa32e2f' name='obj'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='avl_update' mangled-name='avl_update' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
+      <parameter type-id='a3681dea' name='t'/>
+      <parameter type-id='eaa32e2f' name='obj'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='avl_swap' mangled-name='avl_swap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
+      <parameter type-id='a3681dea' name='tree1'/>
+      <parameter type-id='a3681dea' name='tree2'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
+      <parameter type-id='a3681dea' name='tree'/>
+      <parameter type-id='585e1de9' name='compar'/>
+      <parameter type-id='b59d7dce' name='size'/>
+      <parameter type-id='b59d7dce' name='offset'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
+      <parameter type-id='a3681dea' name='tree'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
+      <parameter type-id='a3681dea' name='tree'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
+      <parameter type-id='a3681dea' name='tree'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
+      <parameter type-id='a3681dea' name='tree'/>
+      <parameter type-id='63e171df' name='cookie'/>
       <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_nearest' mangled-name='avl_nearest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
-      <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='fba6cb51' name='where'/>
-      <parameter type-id='95e97e5e' name='direction'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='avl_last' mangled-name='avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
-      <parameter type-id='a3681dea' name='tree'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
-      <parameter type-id='a3681dea' name='tree'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
-      <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='eaa32e2f' name='oldnode'/>
-      <parameter type-id='95e97e5e' name='left'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='b351119f'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='bf311473' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='585e1de9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='ee1f298e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_pad' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <type-decl name='int' size-in-bits='32' id='95e97e5e'/>
-    <pointer-type-def type-id='96ee24a5' size-in-bits='64' id='585e1de9'/>
-    <typedef-decl name='boolean_t' type-id='08f5ca17' id='c19b74c3'/>
-    <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
-    <typedef-decl name='uintptr_t' type-id='7359adad' id='e475ab95'/>
-    <typedef-decl name='ulong_t' type-id='7359adad' id='ee1f298e'/>
-    <type-decl name='void' id='48b5725f'/>
-    <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
-    <pointer-type-def type-id='eaa32e2f' size-in-bits='64' id='63e171df'/>
-    <pointer-type-def type-id='428b67b3' size-in-bits='64' id='bf311473'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca17'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='B_FALSE' value='0'/>
-      <enumerator name='B_TRUE' value='1'/>
-    </enum-decl>
-    <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='428b67b3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='f0f65199' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='e475ab95' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <array-type-def dimensions='1' type-id='bf311473' size-in-bits='128' id='f0f65199'>
-      <subrange length='2' type-id='7359adad' id='52efc4ef'/>
-    </array-type-def>
+    <function-type size-in-bits='64' id='96ee24a5'>
+      <parameter type-id='eaa32e2f'/>
+      <parameter type-id='eaa32e2f'/>
+      <return type-id='95e97e5e'/>
+    </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='assert.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='assert.c' language='LANG_C99'>
     <var-decl name='libspl_assert_ok' type-id='95e97e5e' mangled-name='libspl_assert_ok' visibility='default' elf-symbol-id='libspl_assert_ok'/>
     <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
       <parameter type-id='80f4b756' name='file'/>
@@ -413,20 +372,17 @@
       <parameter is-variadic='yes'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <pointer-type-def type-id='9b45d938' size-in-bits='64' id='80f4b756'/>
-    <qualified-type-def type-id='a84c031d' const='yes' id='9b45d938'/>
-    <type-decl name='char' size-in-bits='8' id='a84c031d'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='atomic.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='atomic.c' language='LANG_C99'>
     <type-decl name='unsigned short int' size-in-bits='16' id='8efea9e5'/>
-    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
-    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
-    <typedef-decl name='ssize_t' type-id='41060289' id='79a0948f'/>
-    <typedef-decl name='__ssize_t' type-id='bd54fe1a' id='41060289'/>
-    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
-    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
     <typedef-decl name='int16_t' type-id='03896e23' id='23bd8cb5'/>
+    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
+    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
     <typedef-decl name='__int16_t' type-id='a2185560' id='03896e23'/>
+    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
+    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
+    <typedef-decl name='__ssize_t' type-id='bd54fe1a' id='41060289'/>
+    <typedef-decl name='ssize_t' type-id='41060289' id='79a0948f'/>
     <qualified-type-def type-id='149c6638' volatile='yes' id='5120c5f7'/>
     <pointer-type-def type-id='5120c5f7' size-in-bits='64' id='93977ae7'/>
     <qualified-type-def type-id='8f92235e' volatile='yes' id='430e0681'/>
@@ -437,261 +393,36 @@
     <pointer-type-def type-id='6f7e09cb' size-in-bits='64' id='64698d33'/>
     <qualified-type-def type-id='48b5725f' volatile='yes' id='b0b3cbf9'/>
     <pointer-type-def type-id='b0b3cbf9' size-in-bits='64' id='fe09dd29'/>
-    <function-decl name='membar_consumer' mangled-name='membar_consumer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='membar_producer' mangled-name='membar_producer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='membar_enter' mangled-name='membar_enter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='3502e3ff' name='value'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='3502e3ff' name='value'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='eaa32e2f' name='bits'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
+    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
       <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='b96825af'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='eaa32e2f' name='exp'/>
-      <parameter type-id='eaa32e2f' name='des'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
+    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
       <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='149c6638'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
+    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
       <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='b96825af'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
+    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
       <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='149c6638'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
+    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
       <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='8f92235e'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='ee31ee44' name='bits'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
+    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
       <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='ee31ee44' name='bits'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='ee31ee44' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='atomic_add_8' mangled-name='atomic_add_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
@@ -699,37 +430,212 @@
       <parameter type-id='ee31ee44' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
+    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
       <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
+    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
       <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
-      <parameter type-id='93977ae7' name='target'/>
+    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
+    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
       <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='ee31ee44' name='bits'/>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='ee31ee44' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='ee31ee44' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='ee1f298e'/>
     </function-decl>
     <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
       <parameter type-id='aa323ea4' name='target'/>
@@ -755,26 +661,73 @@
       <parameter type-id='ee1f298e' name='des'/>
       <return type-id='ee1f298e'/>
     </function-decl>
-    <type-decl name='long int' size-in-bits='64' id='bd54fe1a'/>
-    <type-decl name='short int' size-in-bits='16' id='a2185560'/>
-    <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
-    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
-    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
-    <typedef-decl name='uint_t' type-id='f0981eeb' id='3502e3ff'/>
-    <typedef-decl name='__int8_t' type-id='28577a57' id='2171a512'/>
-    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
-    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='f0981eeb'/>
-    <type-decl name='signed char' size-in-bits='8' id='28577a57'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='002ac4a6'/>
+    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='eaa32e2f' name='exp'/>
+      <parameter type-id='eaa32e2f' name='des'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='eaa32e2f' name='bits'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='3502e3ff' name='value'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='3502e3ff' name='value'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='membar_enter' mangled-name='membar_enter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='membar_producer' mangled-name='membar_producer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='membar_consumer' mangled-name='membar_consumer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
+      <return type-id='48b5725f'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='getexecname.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='getexecname.c' language='LANG_C99'>
     <function-decl name='getexecname' mangled-name='getexecname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getexecname'>
       <return type-id='80f4b756'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='list.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='list.c' language='LANG_C99'>
+    <typedef-decl name='list_node_t' type-id='b0b5e45e' id='b21843b2'/>
     <typedef-decl name='list_t' type-id='e824dae9' id='0899125f'/>
+    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' id='b0b5e45e'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='b03eadb4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='b03eadb4' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' id='e824dae9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='list_size' type-id='b59d7dce' visibility='default'/>
@@ -786,67 +739,32 @@
         <var-decl name='list_head' type-id='b0b5e45e' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' id='b0b5e45e'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='b03eadb4' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='prev' type-id='b03eadb4' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='list_node_t' type-id='b0b5e45e' id='b21843b2'/>
     <pointer-type-def type-id='b0b5e45e' size-in-bits='64' id='b03eadb4'/>
     <pointer-type-def type-id='b21843b2' size-in-bits='64' id='ccc38265'/>
     <pointer-type-def type-id='0899125f' size-in-bits='64' id='352ec160'/>
-    <function-decl name='list_is_empty' mangled-name='list_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+    <function-decl name='list_create' mangled-name='list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
       <parameter type-id='352ec160' name='list'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='list_link_active' mangled-name='list_link_active' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
-      <parameter type-id='ccc38265' name='ln'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='list_link_init' mangled-name='list_link_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
-      <parameter type-id='ccc38265' name='ln'/>
+      <parameter type-id='b59d7dce' name='size'/>
+      <parameter type-id='b59d7dce' name='offset'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_link_replace' mangled-name='list_link_replace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
-      <parameter type-id='ccc38265' name='lold'/>
-      <parameter type-id='ccc38265' name='lnew'/>
+    <function-decl name='list_destroy' mangled-name='list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
+      <parameter type-id='352ec160' name='list'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_move_tail' mangled-name='list_move_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
-      <parameter type-id='352ec160' name='dst'/>
-      <parameter type-id='352ec160' name='src'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='list_prev' mangled-name='list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
+    <function-decl name='list_insert_after' mangled-name='list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <return type-id='eaa32e2f'/>
+      <parameter type-id='eaa32e2f' name='nobject'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_next' mangled-name='list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
+    <function-decl name='list_insert_before' mangled-name='list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <return type-id='eaa32e2f'/>
+      <parameter type-id='eaa32e2f' name='nobject'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_tail' mangled-name='list_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_head' mangled-name='list_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_remove_head' mangled-name='list_remove_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_remove' mangled-name='list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
+    <function-decl name='list_insert_head' mangled-name='list_insert_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
       <return type-id='48b5725f'/>
@@ -856,49 +774,76 @@
       <parameter type-id='eaa32e2f' name='object'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_insert_head' mangled-name='list_insert_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
+    <function-decl name='list_remove' mangled-name='list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_insert_before' mangled-name='list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
+    <function-decl name='list_remove_head' mangled-name='list_remove_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_head' mangled-name='list_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_tail' mangled-name='list_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_next' mangled-name='list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <parameter type-id='eaa32e2f' name='nobject'/>
-      <return type-id='48b5725f'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='list_insert_after' mangled-name='list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
+    <function-decl name='list_prev' mangled-name='list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <parameter type-id='eaa32e2f' name='nobject'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_move_tail' mangled-name='list_move_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
+      <parameter type-id='352ec160' name='dst'/>
+      <parameter type-id='352ec160' name='src'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_destroy' mangled-name='list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
-      <parameter type-id='352ec160' name='list'/>
+    <function-decl name='list_link_replace' mangled-name='list_link_replace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
+      <parameter type-id='ccc38265' name='lold'/>
+      <parameter type-id='ccc38265' name='lnew'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_create' mangled-name='list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
-      <parameter type-id='352ec160' name='list'/>
-      <parameter type-id='b59d7dce' name='size'/>
-      <parameter type-id='b59d7dce' name='offset'/>
+    <function-decl name='list_link_init' mangled-name='list_link_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
+      <parameter type-id='ccc38265' name='ln'/>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='list_link_active' mangled-name='list_link_active' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
+      <parameter type-id='ccc38265' name='ln'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='list_is_empty' mangled-name='list_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='mkdirp.c' language='LANG_C99'>
-    <typedef-decl name='mode_t' type-id='e1c52942' id='d50d396c'/>
+  <abi-instr address-size='64' path='mkdirp.c' language='LANG_C99'>
     <typedef-decl name='__mode_t' type-id='f0981eeb' id='e1c52942'/>
+    <typedef-decl name='mode_t' type-id='e1c52942' id='d50d396c'/>
     <function-decl name='mkdirp' mangled-name='mkdirp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
       <parameter type-id='80f4b756' name='d'/>
       <parameter type-id='d50d396c' name='mode'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/gethostid.c' language='LANG_C99'>
     <function-decl name='get_system_hostid' mangled-name='get_system_hostid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
       <return type-id='7359adad'/>
     </function-decl>
+    <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/getmntany.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='03085adc' size-in-bits='192' id='083f8d58'>
       <subrange length='3' type-id='7359adad' id='56f209d2'/>
     </array-type-def>
@@ -908,6 +853,23 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='26a90f95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='26a90f95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='26a90f95' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' id='0c544dc0'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -976,24 +938,18 @@
       </data-member>
     </class-decl>
     <typedef-decl name='__dev_t' type-id='7359adad' id='35ed8932'/>
-    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
-    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
     <typedef-decl name='__uid_t' type-id='f0981eeb' id='cc5fcceb'/>
     <typedef-decl name='__gid_t' type-id='f0981eeb' id='d94ec6d9'/>
+    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
+    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
     <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
+    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
+    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
     <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
     <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='03085adc' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
     <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
     <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
+    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='95e97e5e' visibility='default'/>
@@ -1062,16 +1018,16 @@
         <var-decl name='_offset' type-id='724e4de6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='__pad1' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_codecvt' type-id='570f8c59' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='__pad2' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_wide_data' type-id='c65a1f29' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='__pad3' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_freeres_list' type-id='dca988a5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='__pad4' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_freeres_buf' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='__pad5' type-id='b59d7dce' visibility='default'/>
@@ -1083,46 +1039,26 @@
         <var-decl name='_unused2' type-id='664ac0b7' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='010ae0b9'>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_next' type-id='e4c6fa61' visibility='default'/>
+        <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_sbuf' type-id='dca988a5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_pos' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
-    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
-    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='26a90f95' visibility='default'/>
+        <var-decl name='tv_nsec' type-id='03085adc' visibility='default'/>
       </data-member>
     </class-decl>
     <pointer-type-def type-id='aa12d1ba' size-in-bits='64' id='822cd80b'/>
     <pointer-type-def type-id='ec1ed955' size-in-bits='64' id='dca988a5'/>
+    <pointer-type-def type-id='a4036571' size-in-bits='64' id='570f8c59'/>
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
+    <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
     <pointer-type-def type-id='0c544dc0' size-in-bits='64' id='394fc496'/>
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
-    <function-decl name='getextmntent' mangled-name='getextmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='394fc496' name='entry'/>
-      <parameter type-id='62f7a03d' name='statbuf'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <function-decl name='getmntany' mangled-name='getmntany' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
       <parameter type-id='822cd80b' name='fp'/>
       <parameter type-id='9d424d31' name='mgetp'/>
@@ -1134,20 +1070,25 @@
       <parameter type-id='9d424d31' name='mgetp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <pointer-type-def type-id='a84c031d' size-in-bits='64' id='26a90f95'/>
+    <function-decl name='getextmntent' mangled-name='getextmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='394fc496' name='entry'/>
+      <parameter type-id='62f7a03d' name='statbuf'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/zone.c' language='LANG_C99'>
     <typedef-decl name='zoneid_t' type-id='95e97e5e' id='4da03624'/>
     <function-decl name='getzoneid' mangled-name='getzoneid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
       <return type-id='4da03624'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='page.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='page.c' language='LANG_C99'>
     <function-decl name='spl_pagesize' mangled-name='spl_pagesize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
       <return type-id='b59d7dce'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcat.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='strlcat.c' language='LANG_C99'>
     <function-decl name='strlcat' mangled-name='strlcat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
       <parameter type-id='26a90f95' name='dst'/>
       <parameter type-id='80f4b756' name='src'/>
@@ -1155,7 +1096,7 @@
       <return type-id='b59d7dce'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcpy.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='strlcpy.c' language='LANG_C99'>
     <function-decl name='strlcpy' mangled-name='strlcpy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
       <parameter type-id='26a90f95' name='dst'/>
       <parameter type-id='80f4b756' name='src'/>
@@ -1163,13 +1104,13 @@
       <return type-id='b59d7dce'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='timestamp.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='timestamp.c' language='LANG_C99'>
     <function-decl name='print_timestamp' mangled-name='print_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
       <parameter type-id='3502e3ff' name='timestamp_fmt'/>
       <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_alloc.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='uu_alloc.c' language='LANG_C99'>
     <type-decl name='char' size-in-bits='8' id='a84c031d'/>
     <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
     <type-decl name='variadic parameter type' id='2c1145c5'/>
@@ -1179,9 +1120,21 @@
     <qualified-type-def type-id='a84c031d' const='yes' id='9b45d938'/>
     <pointer-type-def type-id='9b45d938' size-in-bits='64' id='80f4b756'/>
     <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
-    <function-decl name='uu_msprintf' mangled-name='uu_msprintf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_msprintf'>
-      <parameter type-id='80f4b756' name='format'/>
-      <parameter is-variadic='yes'/>
+    <function-decl name='uu_zalloc' mangled-name='uu_zalloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_zalloc'>
+      <parameter type-id='b59d7dce' name='n'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_free' mangled-name='uu_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_free'>
+      <parameter type-id='eaa32e2f' name='p'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_strdup' mangled-name='uu_strdup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strdup'>
+      <parameter type-id='80f4b756' name='str'/>
+      <return type-id='26a90f95'/>
+    </function-decl>
+    <function-decl name='uu_strndup' mangled-name='uu_strndup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strndup'>
+      <parameter type-id='80f4b756' name='s'/>
+      <parameter type-id='b59d7dce' name='n'/>
       <return type-id='26a90f95'/>
     </function-decl>
     <function-decl name='uu_memdup' mangled-name='uu_memdup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_memdup'>
@@ -1189,25 +1142,13 @@
       <parameter type-id='b59d7dce' name='sz'/>
       <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='uu_strndup' mangled-name='uu_strndup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strndup'>
-      <parameter type-id='80f4b756' name='s'/>
-      <parameter type-id='b59d7dce' name='n'/>
+    <function-decl name='uu_msprintf' mangled-name='uu_msprintf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_msprintf'>
+      <parameter type-id='80f4b756' name='format'/>
+      <parameter is-variadic='yes'/>
       <return type-id='26a90f95'/>
-    </function-decl>
-    <function-decl name='uu_strdup' mangled-name='uu_strdup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strdup'>
-      <parameter type-id='80f4b756' name='str'/>
-      <return type-id='26a90f95'/>
-    </function-decl>
-    <function-decl name='uu_free' mangled-name='uu_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_free'>
-      <parameter type-id='eaa32e2f' name='p'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_zalloc' mangled-name='uu_zalloc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_zalloc'>
-      <parameter type-id='b59d7dce' name='n'/>
-      <return type-id='eaa32e2f'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_avl.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='uu_avl.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='bf311473' size-in-bits='128' id='f0f65199'>
       <subrange length='2' type-id='7359adad' id='52efc4ef'/>
     </array-type-def>
@@ -1226,6 +1167,38 @@
     </array-type-def>
     <type-decl name='unsigned char' size-in-bits='8' id='002ac4a6'/>
     <type-decl name='unsigned int' size-in-bits='32' id='f0981eeb'/>
+    <typedef-decl name='uu_compare_fn_t' type-id='add6e811' id='40f93560'/>
+    <typedef-decl name='uu_walk_fn_t' type-id='96ee24a5' id='9d1aa0dc'/>
+    <typedef-decl name='uu_avl_pool_t' type-id='12a530a8' id='7f84e390'/>
+    <typedef-decl name='uu_avl_t' type-id='4af029d1' id='bb7f0973'/>
+    <class-decl name='uu_avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='f65f4326'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uan_opaque' type-id='0ce65a8b' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_avl_node_t' type-id='f65f4326' id='73a65116'/>
+    <typedef-decl name='uu_avl_walk_t' type-id='e70a39e3' id='edd8457b'/>
+    <typedef-decl name='uu_avl_index_t' type-id='e475ab95' id='5d7f5fc8'/>
+    <class-decl name='uu_avl_walk' size-in-bits='320' is-struct='yes' visibility='default' id='e70a39e3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uaw_next' type-id='5842d146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uaw_prev' type-id='5842d146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uaw_avl' type-id='a5c21a38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='uaw_next_result' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='uaw_dir' type-id='ee31ee44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='264'>
+        <var-decl name='uaw_robust' type-id='b96825af' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='uu_avl' size-in-bits='960' is-struct='yes' visibility='default' id='4af029d1'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ua_next_enc' type-id='e475ab95' visibility='default'/>
@@ -1252,7 +1225,6 @@
         <var-decl name='ua_null_walk' type-id='edd8457b' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='uintptr_t' type-id='7359adad' id='e475ab95'/>
     <class-decl name='uu_avl_pool' size-in-bits='2176' is-struct='yes' visibility='default' id='12a530a8'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='uap_next' type-id='de82c773' visibility='default'/>
@@ -1285,22 +1257,48 @@
         <var-decl name='uap_null_avl' type-id='bb7f0973' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='uu_avl_pool_t' type-id='12a530a8' id='7f84e390'/>
-    <typedef-decl name='uu_compare_fn_t' type-id='add6e811' id='40f93560'/>
-    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
-    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
-    <typedef-decl name='pthread_mutex_t' type-id='c4794498' id='7a6844eb'/>
-    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' id='c4794498'>
-      <data-member access='private'>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='428b67b3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_child' type-id='f0f65199' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_pcb' type-id='e475ab95' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='b351119f'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_root' type-id='bf311473' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avl_compar' type-id='585e1de9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_offset' type-id='b59d7dce' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='avl_numnodes' type-id='ee1f298e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avl_pad' type-id='b59d7dce' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='ulong_t' type-id='7359adad' id='ee1f298e'/>
+    <typedef-decl name='uintptr_t' type-id='7359adad' id='e475ab95'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='7a6844eb' visibility='default' id='70681f9b'>
+      <data-member access='public'>
         <var-decl name='__data' type-id='4c734837' visibility='default'/>
       </data-member>
-      <data-member access='private'>
+      <data-member access='public'>
         <var-decl name='__size' type-id='36c46961' visibility='default'/>
       </data-member>
-      <data-member access='private'>
+      <data-member access='public'>
         <var-decl name='__align' type-id='bd54fe1a' visibility='default'/>
       </data-member>
     </union-decl>
+    <typedef-decl name='pthread_mutex_t' type-id='70681f9b' id='7a6844eb'/>
+    <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
+    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
+    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
     <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='4c734837'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__lock' type-id='95e97e5e' visibility='default'/>
@@ -1327,7 +1325,6 @@
         <var-decl name='__list' type-id='518fb49c' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__pthread_list_t' type-id='0e01899c' id='518fb49c'/>
     <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='0e01899c'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__prev' type-id='4d98cd5a' visibility='default'/>
@@ -1336,66 +1333,10 @@
         <var-decl name='__next' type-id='4d98cd5a' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='uu_avl_t' type-id='4af029d1' id='bb7f0973'/>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='b351119f'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='bf311473' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='585e1de9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='ee1f298e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_pad' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='428b67b3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='f0f65199' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='e475ab95' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='ulong_t' type-id='7359adad' id='ee1f298e'/>
-    <class-decl name='uu_avl_walk' size-in-bits='320' is-struct='yes' visibility='default' id='e70a39e3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='uaw_next' type-id='5842d146' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uaw_prev' type-id='5842d146' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='uaw_avl' type-id='a5c21a38' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='uaw_next_result' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='uaw_dir' type-id='ee31ee44' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='264'>
-        <var-decl name='uaw_robust' type-id='b96825af' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uu_avl_walk_t' type-id='e70a39e3' id='edd8457b'/>
-    <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
+    <typedef-decl name='__pthread_list_t' type-id='0e01899c' id='518fb49c'/>
     <typedef-decl name='__int8_t' type-id='28577a57' id='2171a512'/>
-    <typedef-decl name='uu_avl_index_t' type-id='e475ab95' id='5d7f5fc8'/>
-    <typedef-decl name='uu_walk_fn_t' type-id='96ee24a5' id='9d1aa0dc'/>
-    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
+    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
     <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
-    <typedef-decl name='uu_avl_node_t' type-id='f65f4326' id='73a65116'/>
-    <class-decl name='uu_avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='f65f4326'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='uan_opaque' type-id='0ce65a8b' visibility='default'/>
-      </data-member>
-    </class-decl>
     <pointer-type-def type-id='0e01899c' size-in-bits='64' id='4d98cd5a'/>
     <pointer-type-def type-id='428b67b3' size-in-bits='64' id='bf311473'/>
     <pointer-type-def type-id='96ee24a5' size-in-bits='64' id='585e1de9'/>
@@ -1407,100 +1348,15 @@
     <pointer-type-def type-id='40f93560' size-in-bits='64' id='d502b39f'/>
     <pointer-type-def type-id='9d1aa0dc' size-in-bits='64' id='30a42b6d'/>
     <pointer-type-def type-id='eaa32e2f' size-in-bits='64' id='63e171df'/>
-    <function-decl name='uu_avl_release' mangled-name='uu_avl_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_release'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_avl_lockup' mangled-name='uu_avl_lockup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_lockup'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_avl_nearest_prev' mangled-name='uu_avl_nearest_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_prev'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <parameter type-id='5d7f5fc8' name='idx'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_avl_nearest_next' mangled-name='uu_avl_nearest_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_next'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <parameter type-id='5d7f5fc8' name='idx'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_insert'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <parameter type-id='eaa32e2f' name='elem'/>
-      <parameter type-id='5d7f5fc8' name='idx'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_avl_find' mangled-name='uu_avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_find'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <parameter type-id='eaa32e2f' name='elem'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <parameter type-id='813a2225' name='out'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_teardown'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <parameter type-id='63e171df' name='cookie'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_remove'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <parameter type-id='eaa32e2f' name='elem'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_avl_walk' mangled-name='uu_avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <parameter type-id='30a42b6d' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
+    <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_create'>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='b59d7dce' name='objsize'/>
+      <parameter type-id='b59d7dce' name='nodeoffset'/>
+      <parameter type-id='d502b39f' name='compare_func'/>
       <parameter type-id='8f92235e' name='flags'/>
-      <return type-id='95e97e5e'/>
+      <return type-id='de82c773'/>
     </function-decl>
-    <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_end'>
-      <parameter type-id='5842d146' name='wp'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_next'>
-      <parameter type-id='5842d146' name='wp'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_start'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <parameter type-id='8f92235e' name='flags'/>
-      <return type-id='5842d146'/>
-    </function-decl>
-    <function-decl name='uu_avl_prev' mangled-name='uu_avl_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_prev'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <parameter type-id='eaa32e2f' name='node'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_avl_next' mangled-name='uu_avl_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_next'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <parameter type-id='eaa32e2f' name='node'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_avl_last' mangled-name='uu_avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_last'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_avl_first' mangled-name='uu_avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_first'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_avl_numnodes' mangled-name='uu_avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_numnodes'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <return type-id='b59d7dce'/>
-    </function-decl>
-    <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_destroy'>
-      <parameter type-id='a5c21a38' name='ap'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_avl_create' mangled-name='uu_avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_create'>
-      <parameter type-id='de82c773' name='pp'/>
-      <parameter type-id='eaa32e2f' name='parent'/>
-      <parameter type-id='8f92235e' name='flags'/>
-      <return type-id='a5c21a38'/>
-    </function-decl>
-    <function-decl name='uu_avl_node_fini' mangled-name='uu_avl_node_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_fini'>
-      <parameter type-id='eaa32e2f' name='base'/>
-      <parameter type-id='2dc35b9d' name='np'/>
+    <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_destroy'>
       <parameter type-id='de82c773' name='pp'/>
       <return type-id='48b5725f'/>
     </function-decl>
@@ -1510,23 +1366,103 @@
       <parameter type-id='de82c773' name='pp'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='uu_avl_pool_destroy' mangled-name='uu_avl_pool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_destroy'>
+    <function-decl name='uu_avl_node_fini' mangled-name='uu_avl_node_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_node_fini'>
+      <parameter type-id='eaa32e2f' name='base'/>
+      <parameter type-id='2dc35b9d' name='np'/>
       <parameter type-id='de82c773' name='pp'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='uu_avl_pool_create' mangled-name='uu_avl_pool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_pool_create'>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='b59d7dce' name='objsize'/>
-      <parameter type-id='b59d7dce' name='nodeoffset'/>
-      <parameter type-id='d502b39f' name='compare_func'/>
+    <function-decl name='uu_avl_create' mangled-name='uu_avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_create'>
+      <parameter type-id='de82c773' name='pp'/>
+      <parameter type-id='eaa32e2f' name='parent'/>
       <parameter type-id='8f92235e' name='flags'/>
-      <return type-id='de82c773'/>
+      <return type-id='a5c21a38'/>
     </function-decl>
-    <function-type size-in-bits='64' id='96ee24a5'>
-      <parameter type-id='eaa32e2f'/>
-      <parameter type-id='eaa32e2f'/>
+    <function-decl name='uu_avl_destroy' mangled-name='uu_avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_destroy'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_avl_numnodes' mangled-name='uu_avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_numnodes'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
+    <function-decl name='uu_avl_first' mangled-name='uu_avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_first'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_avl_last' mangled-name='uu_avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_last'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_avl_next' mangled-name='uu_avl_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_next'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <parameter type-id='eaa32e2f' name='node'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_avl_prev' mangled-name='uu_avl_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_prev'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <parameter type-id='eaa32e2f' name='node'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk_start' mangled-name='uu_avl_walk_start' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_start'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <parameter type-id='8f92235e' name='flags'/>
+      <return type-id='5842d146'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk_next' mangled-name='uu_avl_walk_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_next'>
+      <parameter type-id='5842d146' name='wp'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk_end' mangled-name='uu_avl_walk_end' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk_end'>
+      <parameter type-id='5842d146' name='wp'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_avl_walk' mangled-name='uu_avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_walk'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <parameter type-id='30a42b6d' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <parameter type-id='8f92235e' name='flags'/>
       <return type-id='95e97e5e'/>
-    </function-type>
+    </function-decl>
+    <function-decl name='uu_avl_remove' mangled-name='uu_avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_remove'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <parameter type-id='eaa32e2f' name='elem'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_avl_teardown' mangled-name='uu_avl_teardown' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_teardown'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <parameter type-id='63e171df' name='cookie'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_avl_find' mangled-name='uu_avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_find'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <parameter type-id='eaa32e2f' name='elem'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <parameter type-id='813a2225' name='out'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_avl_insert' mangled-name='uu_avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_insert'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <parameter type-id='eaa32e2f' name='elem'/>
+      <parameter type-id='5d7f5fc8' name='idx'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_avl_nearest_next' mangled-name='uu_avl_nearest_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_next'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <parameter type-id='5d7f5fc8' name='idx'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_avl_nearest_prev' mangled-name='uu_avl_nearest_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_nearest_prev'>
+      <parameter type-id='a5c21a38' name='ap'/>
+      <parameter type-id='5d7f5fc8' name='idx'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_avl_lockup' mangled-name='uu_avl_lockup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_lockup'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_avl_release' mangled-name='uu_avl_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_avl_release'>
+      <return type-id='48b5725f'/>
+    </function-decl>
     <function-type size-in-bits='64' id='add6e811'>
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='eaa32e2f'/>
@@ -1534,7 +1470,7 @@
       <return type-id='95e97e5e'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_ident.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='uu_ident.c' language='LANG_C99'>
     <typedef-decl name='uint_t' type-id='f0981eeb' id='3502e3ff'/>
     <function-decl name='uu_check_name' mangled-name='uu_check_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_check_name'>
       <parameter type-id='80f4b756' name='name'/>
@@ -1542,10 +1478,49 @@
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_list.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='uu_list.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='e475ab95' size-in-bits='128' id='d0e9cdae'>
       <subrange length='2' type-id='7359adad' id='52efc4ef'/>
     </array-type-def>
+    <typedef-decl name='uu_list_pool_t' type-id='55168cab' id='38a2549d'/>
+    <typedef-decl name='uu_list_t' type-id='1d04bdf0' id='82e88484'/>
+    <class-decl name='uu_list_node' size-in-bits='128' is-struct='yes' visibility='default' id='f8f3cec5'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uln_opaque' type-id='d0e9cdae' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_list_node_t' type-id='f8f3cec5' id='c4dc472f'/>
+    <typedef-decl name='uu_list_walk_t' type-id='b80e3208' id='9fed32d2'/>
+    <typedef-decl name='uu_list_index_t' type-id='e475ab95' id='f0dd35ff'/>
+    <class-decl name='uu_list_node_impl' size-in-bits='128' is-struct='yes' visibility='default' id='700a795c'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uln_next' type-id='5af1298a' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uln_prev' type-id='5af1298a' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='uu_list_node_impl_t' type-id='700a795c' id='8e5864b0'/>
+    <class-decl name='uu_list_walk' size-in-bits='320' is-struct='yes' visibility='default' id='b80e3208'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ulw_next' type-id='4d848103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ulw_prev' type-id='4d848103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ulw_list' type-id='0c0b229b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='ulw_dir' type-id='ee31ee44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='200'>
+        <var-decl name='ulw_robust' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ulw_next_result' type-id='a085247f' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='uu_list' size-in-bits='896' is-struct='yes' visibility='default' id='1d04bdf0'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ul_next_enc' type-id='e475ab95' visibility='default'/>
@@ -1613,45 +1588,6 @@
         <var-decl name='ulp_null_list' type-id='82e88484' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='uu_list_pool_t' type-id='55168cab' id='38a2549d'/>
-    <typedef-decl name='uu_list_t' type-id='1d04bdf0' id='82e88484'/>
-    <typedef-decl name='uu_list_node_impl_t' type-id='700a795c' id='8e5864b0'/>
-    <class-decl name='uu_list_node_impl' size-in-bits='128' is-struct='yes' visibility='default' id='700a795c'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='uln_next' type-id='5af1298a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uln_prev' type-id='5af1298a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='uu_list_walk' size-in-bits='320' is-struct='yes' visibility='default' id='b80e3208'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ulw_next' type-id='4d848103' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='ulw_prev' type-id='4d848103' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ulw_list' type-id='0c0b229b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='ulw_dir' type-id='ee31ee44' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='200'>
-        <var-decl name='ulw_robust' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='ulw_next_result' type-id='a085247f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uu_list_walk_t' type-id='b80e3208' id='9fed32d2'/>
-    <typedef-decl name='uu_list_index_t' type-id='e475ab95' id='f0dd35ff'/>
-    <typedef-decl name='uu_list_node_t' type-id='f8f3cec5' id='c4dc472f'/>
-    <class-decl name='uu_list_node' size-in-bits='128' is-struct='yes' visibility='default' id='f8f3cec5'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='uln_opaque' type-id='d0e9cdae' visibility='default'/>
-      </data-member>
-    </class-decl>
     <pointer-type-def type-id='f0dd35ff' size-in-bits='64' id='ecbc0046'/>
     <pointer-type-def type-id='700a795c' size-in-bits='64' id='5af1298a'/>
     <pointer-type-def type-id='8e5864b0' size-in-bits='64' id='a085247f'/>
@@ -1659,112 +1595,15 @@
     <pointer-type-def type-id='38a2549d' size-in-bits='64' id='0941e04e'/>
     <pointer-type-def type-id='82e88484' size-in-bits='64' id='0c0b229b'/>
     <pointer-type-def type-id='9fed32d2' size-in-bits='64' id='4d848103'/>
-    <function-decl name='uu_list_release' mangled-name='uu_list_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_release'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_list_lockup' mangled-name='uu_list_lockup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_lockup'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_list_prev' mangled-name='uu_list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_prev'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='eaa32e2f' name='elem'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_list_next' mangled-name='uu_list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_next'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='eaa32e2f' name='elem'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_list_last' mangled-name='uu_list_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_last'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_list_first' mangled-name='uu_list_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_first'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_list_numnodes' mangled-name='uu_list_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_numnodes'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <return type-id='b59d7dce'/>
-    </function-decl>
-    <function-decl name='uu_list_insert_after' mangled-name='uu_list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_after'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='eaa32e2f' name='target'/>
-      <parameter type-id='eaa32e2f' name='elem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='uu_list_insert_before' mangled-name='uu_list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_before'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='eaa32e2f' name='target'/>
-      <parameter type-id='eaa32e2f' name='elem'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='uu_list_teardown' mangled-name='uu_list_teardown' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_teardown'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='63e171df' name='cookie'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_list_remove' mangled-name='uu_list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_remove'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='eaa32e2f' name='elem'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_list_walk' mangled-name='uu_list_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='30a42b6d' name='func'/>
-      <parameter type-id='eaa32e2f' name='private'/>
+    <function-decl name='uu_list_pool_create' mangled-name='uu_list_pool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_create'>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='b59d7dce' name='objsize'/>
+      <parameter type-id='b59d7dce' name='nodeoffset'/>
+      <parameter type-id='d502b39f' name='compare_func'/>
       <parameter type-id='8f92235e' name='flags'/>
-      <return type-id='95e97e5e'/>
+      <return type-id='0941e04e'/>
     </function-decl>
-    <function-decl name='uu_list_walk_end' mangled-name='uu_list_walk_end' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_end'>
-      <parameter type-id='4d848103' name='wp'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_list_walk_next' mangled-name='uu_list_walk_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_next'>
-      <parameter type-id='4d848103' name='wp'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_list_walk_start' mangled-name='uu_list_walk_start' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_start'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='8f92235e' name='flags'/>
-      <return type-id='4d848103'/>
-    </function-decl>
-    <function-decl name='uu_list_nearest_prev' mangled-name='uu_list_nearest_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_prev'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='f0dd35ff' name='idx'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_list_nearest_next' mangled-name='uu_list_nearest_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_next'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='f0dd35ff' name='idx'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_list_find' mangled-name='uu_list_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_find'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='eaa32e2f' name='elem'/>
-      <parameter type-id='eaa32e2f' name='private'/>
-      <parameter type-id='ecbc0046' name='out'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='uu_list_insert' mangled-name='uu_list_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <parameter type-id='eaa32e2f' name='elem'/>
-      <parameter type-id='f0dd35ff' name='idx'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_list_destroy' mangled-name='uu_list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_destroy'>
-      <parameter type-id='0c0b229b' name='lp'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_list_create' mangled-name='uu_list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_create'>
-      <parameter type-id='0941e04e' name='pp'/>
-      <parameter type-id='eaa32e2f' name='parent'/>
-      <parameter type-id='8f92235e' name='flags'/>
-      <return type-id='0c0b229b'/>
-    </function-decl>
-    <function-decl name='uu_list_node_fini' mangled-name='uu_list_node_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_fini'>
-      <parameter type-id='eaa32e2f' name='base'/>
-      <parameter type-id='dbe143f4' name='np_arg'/>
+    <function-decl name='uu_list_pool_destroy' mangled-name='uu_list_pool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_destroy'>
       <parameter type-id='0941e04e' name='pp'/>
       <return type-id='48b5725f'/>
     </function-decl>
@@ -1774,38 +1613,135 @@
       <parameter type-id='0941e04e' name='pp'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='uu_list_pool_destroy' mangled-name='uu_list_pool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_destroy'>
+    <function-decl name='uu_list_node_fini' mangled-name='uu_list_node_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_node_fini'>
+      <parameter type-id='eaa32e2f' name='base'/>
+      <parameter type-id='dbe143f4' name='np_arg'/>
       <parameter type-id='0941e04e' name='pp'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='uu_list_pool_create' mangled-name='uu_list_pool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_pool_create'>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='b59d7dce' name='objsize'/>
-      <parameter type-id='b59d7dce' name='nodeoffset'/>
-      <parameter type-id='d502b39f' name='compare_func'/>
+    <function-decl name='uu_list_create' mangled-name='uu_list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_create'>
+      <parameter type-id='0941e04e' name='pp'/>
+      <parameter type-id='eaa32e2f' name='parent'/>
       <parameter type-id='8f92235e' name='flags'/>
-      <return type-id='0941e04e'/>
+      <return type-id='0c0b229b'/>
+    </function-decl>
+    <function-decl name='uu_list_destroy' mangled-name='uu_list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_destroy'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_list_insert' mangled-name='uu_list_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='eaa32e2f' name='elem'/>
+      <parameter type-id='f0dd35ff' name='idx'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_list_find' mangled-name='uu_list_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_find'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='eaa32e2f' name='elem'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <parameter type-id='ecbc0046' name='out'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_list_nearest_next' mangled-name='uu_list_nearest_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_next'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='f0dd35ff' name='idx'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_list_nearest_prev' mangled-name='uu_list_nearest_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_nearest_prev'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='f0dd35ff' name='idx'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_list_walk_start' mangled-name='uu_list_walk_start' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_start'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='8f92235e' name='flags'/>
+      <return type-id='4d848103'/>
+    </function-decl>
+    <function-decl name='uu_list_walk_next' mangled-name='uu_list_walk_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_next'>
+      <parameter type-id='4d848103' name='wp'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_list_walk_end' mangled-name='uu_list_walk_end' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk_end'>
+      <parameter type-id='4d848103' name='wp'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_list_walk' mangled-name='uu_list_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_walk'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='30a42b6d' name='func'/>
+      <parameter type-id='eaa32e2f' name='private'/>
+      <parameter type-id='8f92235e' name='flags'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='uu_list_remove' mangled-name='uu_list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_remove'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='eaa32e2f' name='elem'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_list_teardown' mangled-name='uu_list_teardown' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_teardown'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='63e171df' name='cookie'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_list_insert_before' mangled-name='uu_list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_before'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='eaa32e2f' name='target'/>
+      <parameter type-id='eaa32e2f' name='elem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='uu_list_insert_after' mangled-name='uu_list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_insert_after'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='eaa32e2f' name='target'/>
+      <parameter type-id='eaa32e2f' name='elem'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='uu_list_numnodes' mangled-name='uu_list_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_numnodes'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
+    <function-decl name='uu_list_first' mangled-name='uu_list_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_first'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_list_last' mangled-name='uu_list_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_last'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_list_next' mangled-name='uu_list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_next'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='eaa32e2f' name='elem'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_list_prev' mangled-name='uu_list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_prev'>
+      <parameter type-id='0c0b229b' name='lp'/>
+      <parameter type-id='eaa32e2f' name='elem'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='uu_list_lockup' mangled-name='uu_list_lockup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_lockup'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_list_release' mangled-name='uu_list_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_list_release'>
+      <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_misc.c' language='LANG_C99'>
-    <function-decl name='uu_panic' mangled-name='uu_panic' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_panic'>
-      <parameter type-id='80f4b756' name='format'/>
-      <parameter is-variadic='yes'/>
+  <abi-instr address-size='64' path='uu_misc.c' language='LANG_C99'>
+    <function-decl name='uu_set_error' mangled-name='uu_set_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_set_error'>
+      <parameter type-id='3502e3ff' name='code'/>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_error' mangled-name='uu_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_error'>
+      <return type-id='8f92235e'/>
     </function-decl>
     <function-decl name='uu_strerror' mangled-name='uu_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strerror'>
       <parameter type-id='8f92235e' name='code'/>
       <return type-id='80f4b756'/>
     </function-decl>
-    <function-decl name='uu_error' mangled-name='uu_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_error'>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='uu_set_error' mangled-name='uu_set_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_set_error'>
-      <parameter type-id='3502e3ff' name='code'/>
+    <function-decl name='uu_panic' mangled-name='uu_panic' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_panic'>
+      <parameter type-id='80f4b756' name='format'/>
+      <parameter is-variadic='yes'/>
       <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_pname.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='uu_pname.c' language='LANG_C99'>
     <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='d5027220'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='gp_offset' type-id='f0981eeb' visibility='default'/>
@@ -1825,15 +1761,35 @@
     <var-decl name='uu_exit_ok_value' type-id='95e97e5e' mangled-name='uu_exit_ok_value' visibility='default' elf-symbol-id='uu_exit_ok_value'/>
     <var-decl name='uu_exit_fatal_value' type-id='95e97e5e' mangled-name='uu_exit_fatal_value' visibility='default' elf-symbol-id='uu_exit_fatal_value'/>
     <var-decl name='uu_exit_usage_value' type-id='95e97e5e' mangled-name='uu_exit_usage_value' visibility='default' elf-symbol-id='uu_exit_usage_value'/>
-    <function-decl name='uu_getpname' mangled-name='uu_getpname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_getpname'>
-      <return type-id='80f4b756'/>
+    <function-decl name='uu_exit_ok' mangled-name='uu_exit_ok' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_ok'>
+      <return type-id='7292109c'/>
     </function-decl>
-    <function-decl name='uu_setpname' mangled-name='uu_setpname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_setpname'>
-      <parameter type-id='26a90f95' name='arg0'/>
-      <return type-id='80f4b756'/>
+    <function-decl name='uu_exit_fatal' mangled-name='uu_exit_fatal' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_fatal'>
+      <return type-id='7292109c'/>
     </function-decl>
-    <function-decl name='uu_xdie' mangled-name='uu_xdie' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_xdie'>
-      <parameter type-id='95e97e5e' name='status'/>
+    <function-decl name='uu_exit_usage' mangled-name='uu_exit_usage' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_usage'>
+      <return type-id='7292109c'/>
+    </function-decl>
+    <function-decl name='uu_alt_exit' mangled-name='uu_alt_exit' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_alt_exit'>
+      <parameter type-id='95e97e5e' name='profile'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_vwarn' mangled-name='uu_vwarn' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vwarn'>
+      <parameter type-id='80f4b756' name='format'/>
+      <parameter type-id='b7f2d5e6' name='alist'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_warn' mangled-name='uu_warn' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_warn'>
+      <parameter type-id='80f4b756' name='format'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_vdie' mangled-name='uu_vdie' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vdie'>
+      <parameter type-id='80f4b756' name='format'/>
+      <parameter type-id='b7f2d5e6' name='alist'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='uu_die' mangled-name='uu_die' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_die'>
       <parameter type-id='80f4b756' name='format'/>
       <parameter is-variadic='yes'/>
       <return type-id='48b5725f'/>
@@ -1844,49 +1800,29 @@
       <parameter type-id='b7f2d5e6' name='alist'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='uu_die' mangled-name='uu_die' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_die'>
+    <function-decl name='uu_xdie' mangled-name='uu_xdie' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_xdie'>
+      <parameter type-id='95e97e5e' name='status'/>
       <parameter type-id='80f4b756' name='format'/>
       <parameter is-variadic='yes'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='uu_vdie' mangled-name='uu_vdie' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vdie'>
-      <parameter type-id='80f4b756' name='format'/>
-      <parameter type-id='b7f2d5e6' name='alist'/>
-      <return type-id='48b5725f'/>
+    <function-decl name='uu_setpname' mangled-name='uu_setpname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_setpname'>
+      <parameter type-id='26a90f95' name='arg0'/>
+      <return type-id='80f4b756'/>
     </function-decl>
-    <function-decl name='uu_warn' mangled-name='uu_warn' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_warn'>
-      <parameter type-id='80f4b756' name='format'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_vwarn' mangled-name='uu_vwarn' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_vwarn'>
-      <parameter type-id='80f4b756' name='format'/>
-      <parameter type-id='b7f2d5e6' name='alist'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_alt_exit' mangled-name='uu_alt_exit' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_alt_exit'>
-      <parameter type-id='95e97e5e' name='profile'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='uu_exit_usage' mangled-name='uu_exit_usage' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_usage'>
-      <return type-id='7292109c'/>
-    </function-decl>
-    <function-decl name='uu_exit_fatal' mangled-name='uu_exit_fatal' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_fatal'>
-      <return type-id='7292109c'/>
-    </function-decl>
-    <function-decl name='uu_exit_ok' mangled-name='uu_exit_ok' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_exit_ok'>
-      <return type-id='7292109c'/>
+    <function-decl name='uu_getpname' mangled-name='uu_getpname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_getpname'>
+      <return type-id='80f4b756'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='uu_string.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='uu_string.c' language='LANG_C99'>
     <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='9cac1fee'/>
-    <typedef-decl name='boolean_t' type-id='08f5ca17' id='c19b74c3'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca17'>
+    <enum-decl name='boolean_t' naming-typedef-id='c19b74c3' id='f58c8277'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='B_FALSE' value='0'/>
       <enumerator name='B_TRUE' value='1'/>
     </enum-decl>
-    <function-decl name='uu_strbw' mangled-name='uu_strbw' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strbw'>
+    <typedef-decl name='boolean_t' type-id='f58c8277' id='c19b74c3'/>
+    <function-decl name='uu_streq' mangled-name='uu_streq' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_streq'>
       <parameter type-id='80f4b756' name='a'/>
       <parameter type-id='80f4b756' name='b'/>
       <return type-id='c19b74c3'/>
@@ -1896,7 +1832,7 @@
       <parameter type-id='80f4b756' name='b'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='uu_streq' mangled-name='uu_streq' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_streq'>
+    <function-decl name='uu_strbw' mangled-name='uu_strbw' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uu_strbw'>
       <parameter type-id='80f4b756' name='a'/>
       <parameter type-id='80f4b756' name='b'/>
       <return type-id='c19b74c3'/>

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -1,4 +1,4 @@
-<abi-corpus architecture='elf-amd-x86_64' soname='libzfs.so.4'>
+<abi-corpus version='2.0' architecture='elf-amd-x86_64' soname='libzfs.so.4'>
   <elf-needed>
     <dependency name='libzfs_core.so.3'/>
     <dependency name='libnvpair.so.3'/>
@@ -15,8 +15,6 @@
     <dependency name='ld-linux-x86-64.so.2'/>
   </elf-needed>
   <elf-function-symbols>
-    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -583,62 +581,40 @@
     <elf-symbol name='zfs_max_dataset_nesting' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_userquota_prop_prefixes' size='96' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='../../module/avl/avl.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/avl/avl.c' language='LANG_C99'>
     <typedef-decl name='avl_index_t' type-id='e475ab95' id='fba6cb51'/>
     <pointer-type-def type-id='fba6cb51' size-in-bits='64' id='32adbf30'/>
     <pointer-type-def type-id='eaa32e2f' size-in-bits='64' id='63e171df'/>
-    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
+    <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
       <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='63e171df' name='cookie'/>
+      <parameter type-id='eaa32e2f' name='oldnode'/>
+      <parameter type-id='95e97e5e' name='left'/>
       <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
+    <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
       <parameter type-id='a3681dea' name='tree'/>
-      <return type-id='c19b74c3'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
+    <function-decl name='avl_last' mangled-name='avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
       <parameter type-id='a3681dea' name='tree'/>
-      <return type-id='ee1f298e'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
+    <function-decl name='avl_nearest' mangled-name='avl_nearest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
       <parameter type-id='a3681dea' name='tree'/>
-      <return type-id='48b5725f'/>
+      <parameter type-id='fba6cb51' name='where'/>
+      <parameter type-id='95e97e5e' name='direction'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
+    <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
       <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='585e1de9' name='compar'/>
-      <parameter type-id='b59d7dce' name='size'/>
-      <parameter type-id='b59d7dce' name='offset'/>
-      <return type-id='48b5725f'/>
+      <parameter type-id='eaa32e2f' name='value'/>
+      <parameter type-id='32adbf30' name='where'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_swap' mangled-name='avl_swap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
-      <parameter type-id='a3681dea' name='tree1'/>
-      <parameter type-id='a3681dea' name='tree2'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='avl_update' mangled-name='avl_update' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
-      <parameter type-id='a3681dea' name='t'/>
-      <parameter type-id='eaa32e2f' name='obj'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
-      <parameter type-id='a3681dea' name='t'/>
-      <parameter type-id='eaa32e2f' name='obj'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
-      <parameter type-id='a3681dea' name='t'/>
-      <parameter type-id='eaa32e2f' name='obj'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='avl_remove' mangled-name='avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
+    <function-decl name='avl_insert' mangled-name='avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
       <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='avl_add' mangled-name='avl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
-      <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='eaa32e2f' name='new_node'/>
+      <parameter type-id='eaa32e2f' name='new_data'/>
+      <parameter type-id='fba6cb51' name='where'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='avl_insert_here' mangled-name='avl_insert_here' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert_here'>
@@ -648,85 +624,67 @@
       <parameter type-id='95e97e5e' name='direction'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='avl_insert' mangled-name='avl_insert' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_insert'>
+    <function-decl name='avl_add' mangled-name='avl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_add'>
       <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='eaa32e2f' name='new_data'/>
-      <parameter type-id='fba6cb51' name='where'/>
+      <parameter type-id='eaa32e2f' name='new_node'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='avl_find' mangled-name='avl_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_find'>
+    <function-decl name='avl_remove' mangled-name='avl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_remove'>
       <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='eaa32e2f' name='value'/>
-      <parameter type-id='32adbf30' name='where'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='avl_update_lt' mangled-name='avl_update_lt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_lt'>
+      <parameter type-id='a3681dea' name='t'/>
+      <parameter type-id='eaa32e2f' name='obj'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='avl_update_gt' mangled-name='avl_update_gt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update_gt'>
+      <parameter type-id='a3681dea' name='t'/>
+      <parameter type-id='eaa32e2f' name='obj'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='avl_update' mangled-name='avl_update' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_update'>
+      <parameter type-id='a3681dea' name='t'/>
+      <parameter type-id='eaa32e2f' name='obj'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='avl_swap' mangled-name='avl_swap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_swap'>
+      <parameter type-id='a3681dea' name='tree1'/>
+      <parameter type-id='a3681dea' name='tree2'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='avl_create' mangled-name='avl_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_create'>
+      <parameter type-id='a3681dea' name='tree'/>
+      <parameter type-id='585e1de9' name='compar'/>
+      <parameter type-id='b59d7dce' name='size'/>
+      <parameter type-id='b59d7dce' name='offset'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='avl_destroy' mangled-name='avl_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy'>
+      <parameter type-id='a3681dea' name='tree'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='avl_numnodes' mangled-name='avl_numnodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_numnodes'>
+      <parameter type-id='a3681dea' name='tree'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='avl_is_empty' mangled-name='avl_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_is_empty'>
+      <parameter type-id='a3681dea' name='tree'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='avl_destroy_nodes' mangled-name='avl_destroy_nodes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_destroy_nodes'>
+      <parameter type-id='a3681dea' name='tree'/>
+      <parameter type-id='63e171df' name='cookie'/>
       <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='avl_nearest' mangled-name='avl_nearest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_nearest'>
-      <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='fba6cb51' name='where'/>
-      <parameter type-id='95e97e5e' name='direction'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='avl_last' mangled-name='avl_last' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_last'>
-      <parameter type-id='a3681dea' name='tree'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='avl_first' mangled-name='avl_first' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_first'>
-      <parameter type-id='a3681dea' name='tree'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='avl_walk' mangled-name='avl_walk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='avl_walk'>
-      <parameter type-id='a3681dea' name='tree'/>
-      <parameter type-id='eaa32e2f' name='oldnode'/>
-      <parameter type-id='95e97e5e' name='left'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <pointer-type-def type-id='f20fbd51' size-in-bits='64' id='a3681dea'/>
-    <type-decl name='int' size-in-bits='32' id='95e97e5e'/>
-    <pointer-type-def type-id='96ee24a5' size-in-bits='64' id='585e1de9'/>
-    <typedef-decl name='boolean_t' type-id='08f5ca17' id='c19b74c3'/>
-    <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
-    <typedef-decl name='uintptr_t' type-id='7359adad' id='e475ab95'/>
-    <typedef-decl name='ulong_t' type-id='7359adad' id='ee1f298e'/>
-    <type-decl name='void' id='48b5725f'/>
-    <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca17'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='B_FALSE' value='0'/>
-      <enumerator name='B_TRUE' value='1'/>
-    </enum-decl>
-    <typedef-decl name='avl_tree_t' type-id='b351119f' id='f20fbd51'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='b351119f'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='bf311473' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='585e1de9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='ee1f298e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_pad' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='428b67b3' size-in-bits='64' id='bf311473'/>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='428b67b3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='f0f65199' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='e475ab95' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <array-type-def dimensions='1' type-id='bf311473' size-in-bits='128' id='f0f65199'>
-      <subrange length='2' type-id='7359adad' id='52efc4ef'/>
-    </array-type-def>
+    <function-type size-in-bits='64' id='96ee24a5'>
+      <parameter type-id='eaa32e2f'/>
+      <parameter type-id='eaa32e2f'/>
+      <return type-id='95e97e5e'/>
+    </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='rdwr_efi.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='rdwr_efi.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='288' id='16e6f2c6'>
       <subrange length='36' type-id='7359adad' id='ae666bde'/>
     </array-type-def>
@@ -742,6 +700,32 @@
     <array-type-def dimensions='1' type-id='3502e3ff' size-in-bits='256' id='01d84ed4'>
       <subrange length='8' type-id='7359adad' id='56e0c0b1'/>
     </array-type-def>
+    <class-decl name='dk_part' size-in-bits='960' is-struct='yes' visibility='default' id='a65ae39c'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_start' type-id='804dc465' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_size' type-id='804dc465' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_guid' type-id='214f32ea' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_tag' type-id='d908a348' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='272'>
+        <var-decl name='p_flag' type-id='d908a348' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='p_name' type-id='16e6f2c6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='p_uguid' type-id='214f32ea' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='p_resv' type-id='01d84ed4' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='dk_gpt' size-in-bits='1920' is-struct='yes' visibility='default' id='dd4a2e5a'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='efi_version' type-id='3502e3ff' visibility='default'/>
@@ -803,59 +787,14 @@
         <var-decl name='node_addr' type-id='0f562bd0' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='dk_part' size-in-bits='960' is-struct='yes' visibility='default' id='a65ae39c'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='p_start' type-id='804dc465' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='p_size' type-id='804dc465' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='p_guid' type-id='214f32ea' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='p_tag' type-id='d908a348' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='272'>
-        <var-decl name='p_flag' type-id='d908a348' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='p_name' type-id='16e6f2c6' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='p_uguid' type-id='214f32ea' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='p_resv' type-id='01d84ed4' visibility='default'/>
-      </data-member>
-    </class-decl>
     <typedef-decl name='ushort_t' type-id='8efea9e5' id='d908a348'/>
     <pointer-type-def type-id='dd4a2e5a' size-in-bits='64' id='0d8119a8'/>
     <pointer-type-def type-id='0d8119a8' size-in-bits='64' id='c43b27a6'/>
     <var-decl name='efi_debug' type-id='95e97e5e' mangled-name='efi_debug' visibility='default' elf-symbol-id='efi_debug'/>
-    <function-decl name='efi_err_check' mangled-name='efi_err_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_err_check'>
-      <parameter type-id='0d8119a8' name='vtoc'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='efi_type' mangled-name='efi_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_type'>
+    <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_init'>
       <parameter type-id='95e97e5e' name='fd'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='efi_free' mangled-name='efi_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_free'>
-      <parameter type-id='0d8119a8' name='ptr'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='efi_write' mangled-name='efi_write' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_write'>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <parameter type-id='0d8119a8' name='vtoc'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='efi_use_whole_disk' mangled-name='efi_use_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_use_whole_disk'>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='efi_rescan' mangled-name='efi_rescan' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_rescan'>
-      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='8f92235e' name='nparts'/>
+      <parameter type-id='c43b27a6' name='vtoc'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='efi_alloc_and_read' mangled-name='efi_alloc_and_read' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_read'>
@@ -863,51 +802,35 @@
       <parameter type-id='c43b27a6' name='vtoc'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='efi_alloc_and_init' mangled-name='efi_alloc_and_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_alloc_and_init'>
+    <function-decl name='efi_rescan' mangled-name='efi_rescan' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_rescan'>
       <parameter type-id='95e97e5e' name='fd'/>
-      <parameter type-id='8f92235e' name='nparts'/>
-      <parameter type-id='c43b27a6' name='vtoc'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <type-decl name='char' size-in-bits='8' id='a84c031d'/>
-    <typedef-decl name='diskaddr_t' type-id='9b3ff54f' id='804dc465'/>
-    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
-    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
-    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
-    <typedef-decl name='uint_t' type-id='f0981eeb' id='3502e3ff'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='8efea9e5'/>
-    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
-    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
-    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
-    <typedef-decl name='longlong_t' type-id='1eb56b1e' id='9b3ff54f'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='f0981eeb'/>
-    <type-decl name='long long int' size-in-bits='64' id='1eb56b1e'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='002ac4a6'/>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libshare.c' language='LANG_C99'>
-    <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_validate_shareopts'>
-      <parameter type-id='26a90f95' name='options'/>
-      <parameter type-id='26a90f95' name='proto'/>
+    <function-decl name='efi_use_whole_disk' mangled-name='efi_use_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_use_whole_disk'>
+      <parameter type-id='95e97e5e' name='fd'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='sa_errorstr' mangled-name='sa_errorstr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_errorstr'>
-      <parameter type-id='95e97e5e' name='err'/>
-      <return type-id='26a90f95'/>
+    <function-decl name='efi_write' mangled-name='efi_write' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_write'>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='0d8119a8' name='vtoc'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_commit_shares'>
-      <parameter type-id='80f4b756' name='protocol'/>
+    <function-decl name='efi_free' mangled-name='efi_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_free'>
+      <parameter type-id='0d8119a8' name='ptr'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='sa_is_shared' mangled-name='sa_is_shared' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_is_shared'>
-      <parameter type-id='80f4b756' name='mountpoint'/>
-      <parameter type-id='26a90f95' name='protocol'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='sa_disable_share' mangled-name='sa_disable_share' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_disable_share'>
-      <parameter type-id='80f4b756' name='mountpoint'/>
-      <parameter type-id='26a90f95' name='protocol'/>
+    <function-decl name='efi_type' mangled-name='efi_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_type'>
+      <parameter type-id='95e97e5e' name='fd'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='efi_err_check' mangled-name='efi_err_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_err_check'>
+      <parameter type-id='0d8119a8' name='vtoc'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='8efea9e5'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='libshare.c' language='LANG_C99'>
     <function-decl name='sa_enable_share' mangled-name='sa_enable_share' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_enable_share'>
       <parameter type-id='80f4b756' name='zfsname'/>
       <parameter type-id='80f4b756' name='mountpoint'/>
@@ -915,15 +838,34 @@
       <parameter type-id='26a90f95' name='protocol'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <pointer-type-def type-id='a84c031d' size-in-bits='64' id='26a90f95'/>
-    <pointer-type-def type-id='9b45d938' size-in-bits='64' id='80f4b756'/>
-    <qualified-type-def type-id='a84c031d' const='yes' id='9b45d938'/>
+    <function-decl name='sa_disable_share' mangled-name='sa_disable_share' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_disable_share'>
+      <parameter type-id='80f4b756' name='mountpoint'/>
+      <parameter type-id='26a90f95' name='protocol'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='sa_is_shared' mangled-name='sa_is_shared' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_is_shared'>
+      <parameter type-id='80f4b756' name='mountpoint'/>
+      <parameter type-id='26a90f95' name='protocol'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='sa_commit_shares' mangled-name='sa_commit_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_commit_shares'>
+      <parameter type-id='80f4b756' name='protocol'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='sa_errorstr' mangled-name='sa_errorstr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_errorstr'>
+      <parameter type-id='95e97e5e' name='err'/>
+      <return type-id='26a90f95'/>
+    </function-decl>
+    <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_validate_shareopts'>
+      <parameter type-id='26a90f95' name='options'/>
+      <parameter type-id='26a90f95' name='proto'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/smb.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/smb.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='2040' id='11641789'>
       <subrange length='255' type-id='7359adad' id='36e7f891'/>
     </array-type-def>
-    <typedef-decl name='smb_share_t' type-id='a75bc907' id='2d05afd9'/>
     <class-decl name='smb_share_s' size-in-bits='36992' is-struct='yes' visibility='default' id='a75bc907'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='name' type-id='11641789' visibility='default'/>
@@ -941,14 +883,12 @@
         <var-decl name='next' type-id='05ed1c5f' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='smb_share_t' type-id='a75bc907' id='2d05afd9'/>
     <pointer-type-def type-id='a75bc907' size-in-bits='64' id='05ed1c5f'/>
     <pointer-type-def type-id='2d05afd9' size-in-bits='64' id='a3e5c654'/>
     <var-decl name='smb_shares' type-id='a3e5c654' visibility='default'/>
-    <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='32768' id='d16c6df4'>
-      <subrange length='4096' type-id='7359adad' id='bc1b5ddc'/>
-    </array-type-def>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='assert.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='assert.c' language='LANG_C99'>
     <var-decl name='libspl_assert_ok' type-id='95e97e5e' mangled-name='libspl_assert_ok' visibility='default' elf-symbol-id='libspl_assert_ok'/>
     <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
       <parameter type-id='80f4b756' name='file'/>
@@ -959,15 +899,15 @@
       <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='atomic.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='atomic.c' language='LANG_C99'>
     <type-decl name='signed char' size-in-bits='8' id='28577a57'/>
     <type-decl name='unsigned short int' size-in-bits='16' id='8efea9e5'/>
-    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
-    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
-    <typedef-decl name='int16_t' type-id='03896e23' id='23bd8cb5'/>
-    <typedef-decl name='__int16_t' type-id='a2185560' id='03896e23'/>
     <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
+    <typedef-decl name='int16_t' type-id='03896e23' id='23bd8cb5'/>
+    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
     <typedef-decl name='__int8_t' type-id='28577a57' id='2171a512'/>
+    <typedef-decl name='__int16_t' type-id='a2185560' id='03896e23'/>
+    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
     <qualified-type-def type-id='149c6638' volatile='yes' id='5120c5f7'/>
     <pointer-type-def type-id='5120c5f7' size-in-bits='64' id='93977ae7'/>
     <qualified-type-def type-id='8f92235e' volatile='yes' id='430e0681'/>
@@ -978,261 +918,36 @@
     <pointer-type-def type-id='6f7e09cb' size-in-bits='64' id='64698d33'/>
     <qualified-type-def type-id='48b5725f' volatile='yes' id='b0b3cbf9'/>
     <pointer-type-def type-id='b0b3cbf9' size-in-bits='64' id='fe09dd29'/>
-    <function-decl name='membar_consumer' mangled-name='membar_consumer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='membar_producer' mangled-name='membar_producer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='membar_enter' mangled-name='membar_enter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='3502e3ff' name='value'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='3502e3ff' name='value'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='eaa32e2f' name='bits'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
+    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
       <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='b96825af'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='eaa32e2f' name='exp'/>
-      <parameter type-id='eaa32e2f' name='des'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
+    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
       <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='149c6638'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
+    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
       <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='b96825af'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
+    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
       <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='149c6638'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
+    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
       <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='8f92235e'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='ee31ee44' name='bits'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
+    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
       <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='ee31ee44' name='bits'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='ee31ee44' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='atomic_add_8' mangled-name='atomic_add_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
@@ -1240,37 +955,212 @@
       <parameter type-id='ee31ee44' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
+    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
       <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
+    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
       <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
-      <parameter type-id='93977ae7' name='target'/>
+    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
+    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
       <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='ee31ee44' name='bits'/>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='ee31ee44' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='ee31ee44' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='ee1f298e'/>
     </function-decl>
     <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
       <parameter type-id='aa323ea4' name='target'/>
@@ -1296,20 +1186,73 @@
       <parameter type-id='ee1f298e' name='des'/>
       <return type-id='ee1f298e'/>
     </function-decl>
-    <type-decl name='long int' size-in-bits='64' id='bd54fe1a'/>
-    <type-decl name='short int' size-in-bits='16' id='a2185560'/>
-    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
-    <typedef-decl name='ssize_t' type-id='41060289' id='79a0948f'/>
-    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
-    <typedef-decl name='__ssize_t' type-id='bd54fe1a' id='41060289'/>
+    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='eaa32e2f' name='exp'/>
+      <parameter type-id='eaa32e2f' name='des'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='eaa32e2f' name='bits'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='3502e3ff' name='value'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='3502e3ff' name='value'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='membar_enter' mangled-name='membar_enter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='membar_producer' mangled-name='membar_producer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='membar_consumer' mangled-name='membar_consumer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
+      <return type-id='48b5725f'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='getexecname.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='getexecname.c' language='LANG_C99'>
     <function-decl name='getexecname' mangled-name='getexecname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getexecname'>
       <return type-id='80f4b756'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='list.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='list.c' language='LANG_C99'>
+    <typedef-decl name='list_node_t' type-id='b0b5e45e' id='b21843b2'/>
     <typedef-decl name='list_t' type-id='e824dae9' id='0899125f'/>
+    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' id='b0b5e45e'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='b03eadb4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='b03eadb4' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' id='e824dae9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='list_size' type-id='b59d7dce' visibility='default'/>
@@ -1321,67 +1264,32 @@
         <var-decl name='list_head' type-id='b0b5e45e' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' id='b0b5e45e'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='b03eadb4' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='prev' type-id='b03eadb4' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='list_node_t' type-id='b0b5e45e' id='b21843b2'/>
     <pointer-type-def type-id='b0b5e45e' size-in-bits='64' id='b03eadb4'/>
     <pointer-type-def type-id='b21843b2' size-in-bits='64' id='ccc38265'/>
     <pointer-type-def type-id='0899125f' size-in-bits='64' id='352ec160'/>
-    <function-decl name='list_is_empty' mangled-name='list_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+    <function-decl name='list_create' mangled-name='list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
       <parameter type-id='352ec160' name='list'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='list_link_active' mangled-name='list_link_active' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
-      <parameter type-id='ccc38265' name='ln'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='list_link_init' mangled-name='list_link_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
-      <parameter type-id='ccc38265' name='ln'/>
+      <parameter type-id='b59d7dce' name='size'/>
+      <parameter type-id='b59d7dce' name='offset'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_link_replace' mangled-name='list_link_replace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
-      <parameter type-id='ccc38265' name='lold'/>
-      <parameter type-id='ccc38265' name='lnew'/>
+    <function-decl name='list_destroy' mangled-name='list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
+      <parameter type-id='352ec160' name='list'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_move_tail' mangled-name='list_move_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
-      <parameter type-id='352ec160' name='dst'/>
-      <parameter type-id='352ec160' name='src'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='list_prev' mangled-name='list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
+    <function-decl name='list_insert_after' mangled-name='list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <return type-id='eaa32e2f'/>
+      <parameter type-id='eaa32e2f' name='nobject'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_next' mangled-name='list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
+    <function-decl name='list_insert_before' mangled-name='list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <return type-id='eaa32e2f'/>
+      <parameter type-id='eaa32e2f' name='nobject'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_tail' mangled-name='list_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_head' mangled-name='list_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_remove_head' mangled-name='list_remove_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_remove' mangled-name='list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
+    <function-decl name='list_insert_head' mangled-name='list_insert_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
       <return type-id='48b5725f'/>
@@ -1391,49 +1299,74 @@
       <parameter type-id='eaa32e2f' name='object'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_insert_head' mangled-name='list_insert_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
+    <function-decl name='list_remove' mangled-name='list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_insert_before' mangled-name='list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
+    <function-decl name='list_remove_head' mangled-name='list_remove_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_head' mangled-name='list_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_tail' mangled-name='list_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_next' mangled-name='list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <parameter type-id='eaa32e2f' name='nobject'/>
-      <return type-id='48b5725f'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='list_insert_after' mangled-name='list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
+    <function-decl name='list_prev' mangled-name='list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <parameter type-id='eaa32e2f' name='nobject'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_move_tail' mangled-name='list_move_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
+      <parameter type-id='352ec160' name='dst'/>
+      <parameter type-id='352ec160' name='src'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_destroy' mangled-name='list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
-      <parameter type-id='352ec160' name='list'/>
+    <function-decl name='list_link_replace' mangled-name='list_link_replace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
+      <parameter type-id='ccc38265' name='lold'/>
+      <parameter type-id='ccc38265' name='lnew'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_create' mangled-name='list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
-      <parameter type-id='352ec160' name='list'/>
-      <parameter type-id='b59d7dce' name='size'/>
-      <parameter type-id='b59d7dce' name='offset'/>
+    <function-decl name='list_link_init' mangled-name='list_link_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
+      <parameter type-id='ccc38265' name='ln'/>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='list_link_active' mangled-name='list_link_active' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
+      <parameter type-id='ccc38265' name='ln'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='list_is_empty' mangled-name='list_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='mkdirp.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='mkdirp.c' language='LANG_C99'>
     <typedef-decl name='mode_t' type-id='e1c52942' id='d50d396c'/>
     <function-decl name='mkdirp' mangled-name='mkdirp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
       <parameter type-id='80f4b756' name='d'/>
       <parameter type-id='d50d396c' name='mode'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <typedef-decl name='__mode_t' type-id='f0981eeb' id='e1c52942'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/gethostid.c' language='LANG_C99'>
     <function-decl name='get_system_hostid' mangled-name='get_system_hostid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
       <return type-id='7359adad'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/getmntany.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='03085adc' size-in-bits='192' id='083f8d58'>
       <subrange length='3' type-id='7359adad' id='56f209d2'/>
     </array-type-def>
@@ -1443,6 +1376,9 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' id='0c544dc0'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -1511,24 +1447,18 @@
       </data-member>
     </class-decl>
     <typedef-decl name='__dev_t' type-id='7359adad' id='35ed8932'/>
-    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
-    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
-    <typedef-decl name='__mode_t' type-id='f0981eeb' id='e1c52942'/>
     <typedef-decl name='__gid_t' type-id='f0981eeb' id='d94ec6d9'/>
+    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
+    <typedef-decl name='__mode_t' type-id='f0981eeb' id='e1c52942'/>
+    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
     <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
+    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
+    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
     <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
     <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='03085adc' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
     <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
     <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
+    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='95e97e5e' visibility='default'/>
@@ -1597,16 +1527,16 @@
         <var-decl name='_offset' type-id='724e4de6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='__pad1' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_codecvt' type-id='570f8c59' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='__pad2' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_wide_data' type-id='c65a1f29' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='__pad3' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_freeres_list' type-id='dca988a5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='__pad4' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_freeres_buf' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='__pad5' type-id='b59d7dce' visibility='default'/>
@@ -1618,31 +1548,25 @@
         <var-decl name='_unused2' type-id='664ac0b7' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='010ae0b9'>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_next' type-id='e4c6fa61' visibility='default'/>
+        <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_sbuf' type-id='dca988a5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_pos' type-id='95e97e5e' visibility='default'/>
+        <var-decl name='tv_nsec' type-id='03085adc' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
-    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
     <pointer-type-def type-id='aa12d1ba' size-in-bits='64' id='822cd80b'/>
     <pointer-type-def type-id='ec1ed955' size-in-bits='64' id='dca988a5'/>
+    <pointer-type-def type-id='a4036571' size-in-bits='64' id='570f8c59'/>
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
+    <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
     <pointer-type-def type-id='0c544dc0' size-in-bits='64' id='394fc496'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
-    <function-decl name='getextmntent' mangled-name='getextmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='394fc496' name='entry'/>
-      <parameter type-id='62f7a03d' name='statbuf'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <function-decl name='getmntany' mangled-name='getmntany' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
       <parameter type-id='822cd80b' name='fp'/>
       <parameter type-id='9d424d31' name='mgetp'/>
@@ -1654,35 +1578,25 @@
       <parameter type-id='9d424d31' name='mgetp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
-    <typedef-decl name='__uid_t' type-id='f0981eeb' id='cc5fcceb'/>
-    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='26a90f95' visibility='default'/>
-      </data-member>
-    </class-decl>
+    <function-decl name='getextmntent' mangled-name='getextmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='394fc496' name='entry'/>
+      <parameter type-id='62f7a03d' name='statbuf'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/zone.c' language='LANG_C99'>
     <typedef-decl name='zoneid_t' type-id='95e97e5e' id='4da03624'/>
     <function-decl name='getzoneid' mangled-name='getzoneid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
       <return type-id='4da03624'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='page.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='page.c' language='LANG_C99'>
     <function-decl name='spl_pagesize' mangled-name='spl_pagesize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
       <return type-id='b59d7dce'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcat.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='strlcat.c' language='LANG_C99'>
     <function-decl name='strlcat' mangled-name='strlcat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
       <parameter type-id='26a90f95' name='dst'/>
       <parameter type-id='80f4b756' name='src'/>
@@ -1690,7 +1604,7 @@
       <return type-id='b59d7dce'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcpy.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='strlcpy.c' language='LANG_C99'>
     <function-decl name='strlcpy' mangled-name='strlcpy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
       <parameter type-id='26a90f95' name='dst'/>
       <parameter type-id='80f4b756' name='src'/>
@@ -1698,13 +1612,13 @@
       <return type-id='b59d7dce'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='timestamp.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='timestamp.c' language='LANG_C99'>
     <function-decl name='print_timestamp' mangled-name='print_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
       <parameter type-id='3502e3ff' name='timestamp_fmt'/>
       <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='thread_pool.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='thread_pool.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='384' id='36d7f119'>
       <subrange length='48' type-id='7359adad' id='8f6d2a81'/>
     </array-type-def>
@@ -1715,6 +1629,28 @@
     <array-type-def dimensions='1' type-id='f0981eeb' size-in-bits='64' id='0d532ec1'>
       <subrange length='2' type-id='7359adad' id='52efc4ef'/>
     </array-type-def>
+    <typedef-decl name='tpool_t' type-id='88d1b7f9' id='b1bbf10d'/>
+    <typedef-decl name='tpool_job_t' type-id='3b8579e5' id='66a0afc9'/>
+    <class-decl name='tpool_job' size-in-bits='192' is-struct='yes' visibility='default' id='3b8579e5'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tpj_next' type-id='f32b30e4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tpj_func' type-id='b7f9d8e6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='tpj_arg' type-id='eaa32e2f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='tpool_active_t' type-id='c8d086f4' id='6fcda10e'/>
+    <class-decl name='tpool_active' size-in-bits='128' is-struct='yes' visibility='default' id='c8d086f4'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tpa_next' type-id='ad33e5e7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tpa_tid' type-id='4051f5e7' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='tpool' size-in-bits='2496' is-struct='yes' visibility='default' id='88d1b7f9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='tp_forw' type-id='9cf59a50' visibility='default'/>
@@ -1768,25 +1704,34 @@
         <var-decl name='tp_idle' type-id='95e97e5e' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='tpool_t' type-id='88d1b7f9' id='b1bbf10d'/>
-    <typedef-decl name='pthread_cond_t' type-id='be6ed7a7' id='62fab762'/>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' id='be6ed7a7'>
-      <data-member access='private'>
+    <typedef-decl name='pthread_t' type-id='7359adad' id='4051f5e7'/>
+    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' id='b63afacd'>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='6093ff7c' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='bd54fe1a' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <typedef-decl name='pthread_attr_t' type-id='b63afacd' id='7d8569fd'/>
+    <union-decl name='pthread_cond_t' size-in-bits='384' naming-typedef-id='62fab762' visibility='default' id='cbb12c12'>
+      <data-member access='public'>
         <var-decl name='__data' type-id='c987b47c' visibility='default'/>
       </data-member>
-      <data-member access='private'>
+      <data-member access='public'>
         <var-decl name='__size' type-id='36d7f119' visibility='default'/>
       </data-member>
-      <data-member access='private'>
+      <data-member access='public'>
         <var-decl name='__align' type-id='1eb56b1e' visibility='default'/>
       </data-member>
     </union-decl>
+    <typedef-decl name='pthread_cond_t' type-id='cbb12c12' id='62fab762'/>
     <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' id='c987b47c'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='' type-id='2516de83' visibility='default'/>
+        <var-decl name='' type-id='ac5ab595' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='' type-id='fc82e0c5' visibility='default'/>
+        <var-decl name='' type-id='ac5ab596' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='__g_refs' type-id='0d532ec1' visibility='default'/>
@@ -1804,15 +1749,15 @@
         <var-decl name='__g_signals' type-id='0d532ec1' visibility='default'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='64' is-anonymous='yes' visibility='default' id='2516de83'>
-      <data-member access='private'>
+    <union-decl name='__anonymous_union__1' size-in-bits='64' is-anonymous='yes' visibility='default' id='ac5ab595'>
+      <data-member access='public'>
         <var-decl name='__wseq' type-id='3a47d82b' visibility='default'/>
       </data-member>
-      <data-member access='private'>
-        <var-decl name='__wseq32' type-id='2e971cfd' visibility='default'/>
+      <data-member access='public'>
+        <var-decl name='__wseq32' type-id='e7f43f72' visibility='default'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='2e971cfd'>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f72'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__low' type-id='f0981eeb' visibility='default'/>
       </data-member>
@@ -1820,43 +1765,12 @@
         <var-decl name='__high' type-id='f0981eeb' visibility='default'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__2' size-in-bits='64' is-anonymous='yes' visibility='default' id='fc82e0c5'>
-      <data-member access='private'>
+    <union-decl name='__anonymous_union__2' size-in-bits='64' is-anonymous='yes' visibility='default' id='ac5ab596'>
+      <data-member access='public'>
         <var-decl name='__g1_start' type-id='3a47d82b' visibility='default'/>
       </data-member>
-      <data-member access='private'>
-        <var-decl name='__g1_start32' type-id='2e971cfd' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='tpool_active' size-in-bits='128' is-struct='yes' visibility='default' id='c8d086f4'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tpa_next' type-id='ad33e5e7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tpa_tid' type-id='4051f5e7' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='tpool_active_t' type-id='c8d086f4' id='6fcda10e'/>
-    <typedef-decl name='pthread_t' type-id='7359adad' id='4051f5e7'/>
-    <class-decl name='tpool_job' size-in-bits='192' is-struct='yes' visibility='default' id='3b8579e5'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tpj_next' type-id='f32b30e4' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tpj_func' type-id='b7f9d8e6' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tpj_arg' type-id='eaa32e2f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='tpool_job_t' type-id='3b8579e5' id='66a0afc9'/>
-    <typedef-decl name='pthread_attr_t' type-id='b63afacd' id='7d8569fd'/>
-    <union-decl name='pthread_attr_t' size-in-bits='448' visibility='default' id='b63afacd'>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='6093ff7c' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='bd54fe1a' visibility='default'/>
+      <data-member access='public'>
+        <var-decl name='__g1_start32' type-id='e7f43f72' visibility='default'/>
       </data-member>
     </union-decl>
     <pointer-type-def type-id='7d8569fd' size-in-bits='64' id='7347a39e'/>
@@ -1864,40 +1778,6 @@
     <pointer-type-def type-id='66a0afc9' size-in-bits='64' id='f32b30e4'/>
     <pointer-type-def type-id='b1bbf10d' size-in-bits='64' id='9cf59a50'/>
     <pointer-type-def type-id='c5c76c9c' size-in-bits='64' id='b7f9d8e6'/>
-    <function-decl name='tpool_member' mangled-name='tpool_member' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_member'>
-      <parameter type-id='9cf59a50' name='tpool'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='tpool_resume' mangled-name='tpool_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_resume'>
-      <parameter type-id='9cf59a50' name='tpool'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='tpool_suspended' mangled-name='tpool_suspended' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspended'>
-      <parameter type-id='9cf59a50' name='tpool'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='tpool_suspend' mangled-name='tpool_suspend' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspend'>
-      <parameter type-id='9cf59a50' name='tpool'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='tpool_wait' mangled-name='tpool_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_wait'>
-      <parameter type-id='9cf59a50' name='tpool'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='tpool_abandon' mangled-name='tpool_abandon' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_abandon'>
-      <parameter type-id='9cf59a50' name='tpool'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='tpool_destroy' mangled-name='tpool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_destroy'>
-      <parameter type-id='9cf59a50' name='tpool'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_dispatch'>
-      <parameter type-id='9cf59a50' name='tpool'/>
-      <parameter type-id='b7f9d8e6' name='func'/>
-      <parameter type-id='eaa32e2f' name='arg'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
     <function-decl name='tpool_create' mangled-name='tpool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_create'>
       <parameter type-id='3502e3ff' name='min_threads'/>
       <parameter type-id='3502e3ff' name='max_threads'/>
@@ -1905,63 +1785,46 @@
       <parameter type-id='7347a39e' name='attr'/>
       <return type-id='9cf59a50'/>
     </function-decl>
+    <function-decl name='tpool_dispatch' mangled-name='tpool_dispatch' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_dispatch'>
+      <parameter type-id='9cf59a50' name='tpool'/>
+      <parameter type-id='b7f9d8e6' name='func'/>
+      <parameter type-id='eaa32e2f' name='arg'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='tpool_destroy' mangled-name='tpool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_destroy'>
+      <parameter type-id='9cf59a50' name='tpool'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='tpool_abandon' mangled-name='tpool_abandon' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_abandon'>
+      <parameter type-id='9cf59a50' name='tpool'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='tpool_wait' mangled-name='tpool_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_wait'>
+      <parameter type-id='9cf59a50' name='tpool'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='tpool_suspend' mangled-name='tpool_suspend' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspend'>
+      <parameter type-id='9cf59a50' name='tpool'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='tpool_suspended' mangled-name='tpool_suspended' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_suspended'>
+      <parameter type-id='9cf59a50' name='tpool'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='tpool_resume' mangled-name='tpool_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_resume'>
+      <parameter type-id='9cf59a50' name='tpool'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='tpool_member' mangled-name='tpool_member' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_member'>
+      <parameter type-id='9cf59a50' name='tpool'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-type size-in-bits='64' id='c5c76c9c'>
       <parameter type-id='eaa32e2f'/>
       <return type-id='48b5725f'/>
     </function-type>
-    <typedef-decl name='pthread_mutex_t' type-id='c4794498' id='7a6844eb'/>
-    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' id='c4794498'>
-      <data-member access='private'>
-        <var-decl name='__data' type-id='4c734837' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='36c46961' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='bd54fe1a' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='320' id='36c46961'>
-      <subrange length='40' type-id='7359adad' id='8f80b239'/>
-    </array-type-def>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='4c734837'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__lock' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__count' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__owner' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__nusers' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__kind' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='__spins' type-id='a2185560' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='__elision' type-id='a2185560' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='518fb49c' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__pthread_list_t' type-id='0e01899c' id='518fb49c'/>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='0e01899c'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='4d98cd5a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='4d98cd5a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='0e01899c' size-in-bits='64' id='4d98cd5a'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/cityhash.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/zcommon/cityhash.c' language='LANG_C99'>
     <function-decl name='cityhash4' mangled-name='cityhash4' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='cityhash4'>
       <parameter type-id='9c313c2d' name='w1'/>
       <parameter type-id='9c313c2d' name='w2'/>
@@ -1969,41 +1832,11 @@
       <parameter type-id='9c313c2d' name='w4'/>
       <return type-id='9c313c2d'/>
     </function-decl>
-    <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
-    <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfeature_common.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/zcommon/zfeature_common.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='83f29ca2' size-in-bits='15232' id='d96379d0'>
       <subrange length='34' type-id='7359adad' id='6a6a7e00'/>
     </array-type-def>
-    <typedef-decl name='zfeature_info_t' type-id='1178d146' id='83f29ca2'/>
-    <class-decl name='zfeature_info' size-in-bits='448' is-struct='yes' visibility='default' id='1178d146'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fi_feature' type-id='d6618c78' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='fi_uname' type-id='80f4b756' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='fi_guid' type-id='80f4b756' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='fi_desc' type-id='80f4b756' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fi_flags' type-id='fc329033' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='fi_zfs_mod_supported' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='fi_type' type-id='732d2bb2' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='fi_depends' type-id='1acff326' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='spa_feature_t' type-id='33ecb627' id='d6618c78'/>
     <enum-decl name='spa_feature' id='33ecb627'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='SPA_FEATURE_NONE' value='-1'/>
@@ -2043,7 +1876,7 @@
       <enumerator name='SPA_FEATURE_DRAID' value='33'/>
       <enumerator name='SPA_FEATURES' value='34'/>
     </enum-decl>
-    <typedef-decl name='zfeature_flags_t' type-id='6db816a4' id='fc329033'/>
+    <typedef-decl name='spa_feature_t' type-id='33ecb627' id='d6618c78'/>
     <enum-decl name='zfeature_flags' id='6db816a4'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZFEATURE_FLAG_READONLY_COMPAT' value='1'/>
@@ -2051,42 +1884,67 @@
       <enumerator name='ZFEATURE_FLAG_ACTIVATE_ON_ENABLE' value='4'/>
       <enumerator name='ZFEATURE_FLAG_PER_DATASET' value='8'/>
     </enum-decl>
-    <typedef-decl name='zfeature_type_t' type-id='c4fa2355' id='732d2bb2'/>
+    <typedef-decl name='zfeature_flags_t' type-id='6db816a4' id='fc329033'/>
     <enum-decl name='zfeature_type' id='c4fa2355'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZFEATURE_TYPE_BOOLEAN' value='0'/>
       <enumerator name='ZFEATURE_TYPE_UINT64_ARRAY' value='1'/>
       <enumerator name='ZFEATURE_NUM_TYPES' value='2'/>
     </enum-decl>
+    <typedef-decl name='zfeature_type_t' type-id='c4fa2355' id='732d2bb2'/>
+    <class-decl name='zfeature_info' size-in-bits='448' is-struct='yes' visibility='default' id='1178d146'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fi_feature' type-id='d6618c78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fi_uname' type-id='80f4b756' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fi_guid' type-id='80f4b756' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='fi_desc' type-id='80f4b756' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='fi_flags' type-id='fc329033' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='fi_zfs_mod_supported' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='fi_type' type-id='732d2bb2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='fi_depends' type-id='1acff326' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfeature_info_t' type-id='1178d146' id='83f29ca2'/>
     <qualified-type-def type-id='d6618c78' const='yes' id='81a65028'/>
     <pointer-type-def type-id='81a65028' size-in-bits='64' id='1acff326'/>
     <pointer-type-def type-id='d6618c78' size-in-bits='64' id='a8425263'/>
-    <var-decl name='zfeature_checks_disable' type-id='c19b74c3' mangled-name='zfeature_checks_disable' visibility='default' elf-symbol-id='zfeature_checks_disable'/>
     <var-decl name='spa_feature_table' type-id='d96379d0' mangled-name='spa_feature_table' visibility='default' elf-symbol-id='spa_feature_table'/>
-    <function-decl name='zpool_feature_init' mangled-name='zpool_feature_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_feature_init'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfeature_depends_on' mangled-name='zfeature_depends_on' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_depends_on'>
-      <parameter type-id='d6618c78' name='fid'/>
-      <parameter type-id='d6618c78' name='check'/>
+    <var-decl name='zfeature_checks_disable' type-id='c19b74c3' mangled-name='zfeature_checks_disable' visibility='default' elf-symbol-id='zfeature_checks_disable'/>
+    <function-decl name='zfeature_is_valid_guid' mangled-name='zfeature_is_valid_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_valid_guid'>
+      <parameter type-id='80f4b756' name='name'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='zfeature_lookup_name' mangled-name='zfeature_lookup_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_name'>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='a8425263' name='res'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='zfeature_is_supported' mangled-name='zfeature_is_supported' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_supported'>
+      <parameter type-id='80f4b756' name='guid'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='zfeature_lookup_guid' mangled-name='zfeature_lookup_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_guid'>
       <parameter type-id='80f4b756' name='guid'/>
       <parameter type-id='a8425263' name='res'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfeature_is_supported' mangled-name='zfeature_is_supported' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_supported'>
-      <parameter type-id='80f4b756' name='guid'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfeature_is_valid_guid' mangled-name='zfeature_is_valid_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_valid_guid'>
+    <function-decl name='zfeature_lookup_name' mangled-name='zfeature_lookup_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_lookup_name'>
       <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='a8425263' name='res'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfeature_depends_on' mangled-name='zfeature_depends_on' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_depends_on'>
+      <parameter type-id='d6618c78' name='fid'/>
+      <parameter type-id='d6618c78' name='check'/>
       <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='zfs_mod_supported' mangled-name='zfs_mod_supported' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mod_supported'>
@@ -2094,12 +1952,14 @@
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='c19b74c3'/>
     </function-decl>
+    <function-decl name='zpool_feature_init' mangled-name='zpool_feature_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_feature_init'>
+      <return type-id='48b5725f'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_comutil.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/zcommon/zfs_comutil.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='80f4b756' size-in-bits='2624' id='ef31fedf'>
       <subrange length='41' type-id='7359adad' id='cb834f44'/>
     </array-type-def>
-    <typedef-decl name='zpool_load_policy_t' type-id='2f65b36f' id='d11b7617'/>
     <class-decl name='zpool_load_policy' size-in-bits='256' is-struct='yes' visibility='default' id='2f65b36f'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zlp_rewind' type-id='8f92235e' visibility='default'/>
@@ -2114,69 +1974,56 @@
         <var-decl name='zlp_txg' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='zpool_load_policy_t' type-id='2f65b36f' id='d11b7617'/>
     <pointer-type-def type-id='d11b7617' size-in-bits='64' id='23432aaa'/>
     <var-decl name='zfs_history_event_names' type-id='ef31fedf' mangled-name='zfs_history_event_names' visibility='default' elf-symbol-id='zfs_history_event_names'/>
-    <function-decl name='zfs_dataset_name_hidden' mangled-name='zfs_dataset_name_hidden' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_name_hidden'>
-      <parameter type-id='80f4b756' name='name'/>
+    <function-decl name='zfs_allocatable_devs' mangled-name='zfs_allocatable_devs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_allocatable_devs'>
+      <parameter type-id='5ce45b60' name='nv'/>
       <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_spa_version_map' mangled-name='zfs_spa_version_map' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version_map'>
-      <parameter type-id='95e97e5e' name='zpl_version'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_zpl_version_map' mangled-name='zfs_zpl_version_map' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_zpl_version_map'>
-      <parameter type-id='95e97e5e' name='spa_version'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_load_policy'>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='23432aaa' name='zlpp'/>
-      <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='zfs_special_devs' mangled-name='zfs_special_devs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_special_devs'>
       <parameter type-id='5ce45b60' name='nv'/>
       <parameter type-id='26a90f95' name='type'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='zfs_allocatable_devs' mangled-name='zfs_allocatable_devs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_allocatable_devs'>
-      <parameter type-id='5ce45b60' name='nv'/>
+    <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_load_policy'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='23432aaa' name='zlpp'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_zpl_version_map' mangled-name='zfs_zpl_version_map' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_zpl_version_map'>
+      <parameter type-id='95e97e5e' name='spa_version'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_spa_version_map' mangled-name='zfs_spa_version_map' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version_map'>
+      <parameter type-id='95e97e5e' name='zpl_version'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_dataset_name_hidden' mangled-name='zfs_dataset_name_hidden' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_name_hidden'>
+      <parameter type-id='80f4b756' name='name'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <pointer-type-def type-id='8e8d4be3' size-in-bits='64' id='5ce45b60'/>
-    <typedef-decl name='nvlist_t' type-id='ac266fd9' id='8e8d4be3'/>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='ac266fd9'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvl_priv' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-    </class-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_deleg.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/zcommon/zfs_deleg.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='f3f851ad' size-in-bits='infinite' id='bc4e5d90'>
       <subrange length='infinite' id='031f2035'/>
     </array-type-def>
-    <typedef-decl name='zfs_deleg_perm_tab_t' type-id='5aa05c1f' id='f3f851ad'/>
-    <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' id='5aa05c1f'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='z_perm' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='z_note' type-id='4613c173' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zfs_deleg_note_t' type-id='08f5ca18' id='4613c173'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca18'>
+    <enum-decl name='zfs_deleg_who_type_t' naming-typedef-id='36d4bd5a' id='b5fa5816'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='ZFS_DELEG_WHO_UNKNOWN' value='0'/>
+      <enumerator name='ZFS_DELEG_USER' value='117'/>
+      <enumerator name='ZFS_DELEG_USER_SETS' value='85'/>
+      <enumerator name='ZFS_DELEG_GROUP' value='103'/>
+      <enumerator name='ZFS_DELEG_GROUP_SETS' value='71'/>
+      <enumerator name='ZFS_DELEG_EVERYONE' value='101'/>
+      <enumerator name='ZFS_DELEG_EVERYONE_SETS' value='69'/>
+      <enumerator name='ZFS_DELEG_CREATE' value='99'/>
+      <enumerator name='ZFS_DELEG_CREATE_SETS' value='67'/>
+      <enumerator name='ZFS_DELEG_NAMED_SET' value='115'/>
+      <enumerator name='ZFS_DELEG_NAMED_SET_SETS' value='83'/>
+    </enum-decl>
+    <typedef-decl name='zfs_deleg_who_type_t' type-id='b5fa5816' id='36d4bd5a'/>
+    <enum-decl name='zfs_deleg_note_t' naming-typedef-id='4613c173' id='729d4547'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZFS_DELEG_NOTE_CREATE' value='0'/>
       <enumerator name='ZFS_DELEG_NOTE_DESTROY' value='1'/>
@@ -2211,22 +2058,25 @@
       <enumerator name='ZFS_DELEG_NOTE_PROJECTOBJQUOTA' value='30'/>
       <enumerator name='ZFS_DELEG_NOTE_NONE' value='31'/>
     </enum-decl>
-    <typedef-decl name='zfs_deleg_who_type_t' type-id='40ed39d2' id='36d4bd5a'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' id='40ed39d2'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZFS_DELEG_WHO_UNKNOWN' value='0'/>
-      <enumerator name='ZFS_DELEG_USER' value='117'/>
-      <enumerator name='ZFS_DELEG_USER_SETS' value='85'/>
-      <enumerator name='ZFS_DELEG_GROUP' value='103'/>
-      <enumerator name='ZFS_DELEG_GROUP_SETS' value='71'/>
-      <enumerator name='ZFS_DELEG_EVERYONE' value='101'/>
-      <enumerator name='ZFS_DELEG_EVERYONE_SETS' value='69'/>
-      <enumerator name='ZFS_DELEG_CREATE' value='99'/>
-      <enumerator name='ZFS_DELEG_CREATE_SETS' value='67'/>
-      <enumerator name='ZFS_DELEG_NAMED_SET' value='115'/>
-      <enumerator name='ZFS_DELEG_NAMED_SET_SETS' value='83'/>
-    </enum-decl>
+    <typedef-decl name='zfs_deleg_note_t' type-id='729d4547' id='4613c173'/>
+    <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' id='5aa05c1f'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='z_perm' type-id='26a90f95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='z_note' type-id='4613c173' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_deleg_perm_tab_t' type-id='5aa05c1f' id='f3f851ad'/>
     <var-decl name='zfs_deleg_perm_tab' type-id='bc4e5d90' mangled-name='zfs_deleg_perm_tab' visibility='default' elf-symbol-id='zfs_deleg_perm_tab'/>
+    <function-decl name='zfs_deleg_canonicalize_perm' mangled-name='zfs_deleg_canonicalize_perm' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_canonicalize_perm'>
+      <parameter type-id='80f4b756' name='perm'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_deleg_verify_nvlist' mangled-name='zfs_deleg_verify_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_verify_nvlist'>
+      <parameter type-id='5ce45b60' name='nvp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='zfs_deleg_whokey' mangled-name='zfs_deleg_whokey' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_whokey'>
       <parameter type-id='26a90f95' name='attr'/>
       <parameter type-id='36d4bd5a' name='type'/>
@@ -2234,16 +2084,8 @@
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zfs_deleg_verify_nvlist' mangled-name='zfs_deleg_verify_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_verify_nvlist'>
-      <parameter type-id='5ce45b60' name='nvp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_deleg_canonicalize_perm' mangled-name='zfs_deleg_canonicalize_perm' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_deleg_canonicalize_perm'>
-      <parameter type-id='80f4b756' name='perm'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/zcommon/zfs_fletcher.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='9c313c2d' size-in-bits='256' id='85c64d26'>
       <subrange length='4' type-id='7359adad' id='16fe7105'/>
     </array-type-def>
@@ -2262,20 +2104,18 @@
     <array-type-def dimensions='1' type-id='6d059eaa' size-in-bits='1024' id='729b6ebb'>
       <subrange length='4' type-id='7359adad' id='16fe7105'/>
     </array-type-def>
-    <typedef-decl name='zio_abd_checksum_func_t' type-id='3f8e8d11' id='c2eb138a'/>
-    <class-decl name='zio_abd_checksum_func' size-in-bits='192' is-struct='yes' visibility='default' id='aa14691a'>
+    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' id='1d53e28b'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='acf_init' type-id='0bcca125' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='acf_fini' type-id='bfe36153' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='acf_iter' type-id='1e276399' visibility='default'/>
+        <var-decl name='zc_word' type-id='85c64d26' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zio_abd_checksum_init_t' type-id='a5444274' id='029a8ebe'/>
-    <typedef-decl name='zio_abd_checksum_data_t' type-id='4bf4b004' id='74e39470'/>
+    <typedef-decl name='zio_cksum_t' type-id='1d53e28b' id='39730d0b'/>
+    <enum-decl name='zio_byteorder_t' naming-typedef-id='595a65ec' id='fc861be0'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='ZIO_CHECKSUM_NATIVE' value='0'/>
+      <enumerator name='ZIO_CHECKSUM_BYTESWAP' value='1'/>
+    </enum-decl>
+    <typedef-decl name='zio_byteorder_t' type-id='fc861be0' id='595a65ec'/>
     <class-decl name='zio_abd_checksum_data' size-in-bits='256' is-struct='yes' visibility='default' id='4bf4b004'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='acd_byteorder' type-id='595a65ec' visibility='default'/>
@@ -2290,62 +2130,64 @@
         <var-decl name='acd_private' type-id='eaa32e2f' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zio_byteorder_t' type-id='08f5ca19' id='595a65ec'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca19'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZIO_CHECKSUM_NATIVE' value='0'/>
-      <enumerator name='ZIO_CHECKSUM_BYTESWAP' value='1'/>
-    </enum-decl>
-    <typedef-decl name='fletcher_4_ctx_t' type-id='1f951ade' id='4b675395'/>
-    <union-decl name='fletcher_4_ctx' size-in-bits='2048' visibility='default' id='1f951ade'>
-      <data-member access='private'>
-        <var-decl name='scalar' type-id='39730d0b' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='superscalar' type-id='729b6ebb' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='sse' type-id='cbd91ec1' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='avx' type-id='481f90b1' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='avx512' type-id='16582e69' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='zio_cksum_t' type-id='1d53e28b' id='39730d0b'/>
-    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' id='1d53e28b'>
+    <typedef-decl name='zio_abd_checksum_data_t' type-id='4bf4b004' id='74e39470'/>
+    <typedef-decl name='zio_abd_checksum_init_t' type-id='a5444274' id='029a8ebe'/>
+    <typedef-decl name='zio_abd_checksum_fini_t' type-id='a5444274' id='d6fd5c6c'/>
+    <typedef-decl name='zio_abd_checksum_iter_t' type-id='f4a1892e' id='cefa0f4a'/>
+    <class-decl name='zio_abd_checksum_func' size-in-bits='192' is-struct='yes' visibility='default' id='aa14691a'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_word' type-id='85c64d26' visibility='default'/>
+        <var-decl name='acf_init' type-id='0bcca125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='acf_fini' type-id='bfe36153' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='acf_iter' type-id='1e276399' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_superscalar_t' type-id='28efb250' id='6d059eaa'/>
+    <typedef-decl name='zio_abd_checksum_func_t' type-id='3f8e8d11' id='c2eb138a'/>
     <class-decl name='zfs_fletcher_superscalar' size-in-bits='256' is-struct='yes' visibility='default' id='28efb250'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='v' type-id='85c64d26' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_sse_t' type-id='acd4019a' id='7c1ab40c'/>
+    <typedef-decl name='zfs_fletcher_superscalar_t' type-id='28efb250' id='6d059eaa'/>
     <class-decl name='zfs_fletcher_sse' size-in-bits='128' is-struct='yes' visibility='default' id='acd4019a'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='v' type-id='c1c22e6c' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_avx_t' type-id='8c208dfa' id='8240361c'/>
+    <typedef-decl name='zfs_fletcher_sse_t' type-id='acd4019a' id='7c1ab40c'/>
     <class-decl name='zfs_fletcher_avx' size-in-bits='256' is-struct='yes' visibility='default' id='8c208dfa'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='v' type-id='85c64d26' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_fletcher_avx512_t' type-id='c6d0c382' id='90dbb6d6'/>
+    <typedef-decl name='zfs_fletcher_avx_t' type-id='8c208dfa' id='8240361c'/>
     <class-decl name='zfs_fletcher_avx512' size-in-bits='512' is-struct='yes' visibility='default' id='c6d0c382'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='v' type-id='c5d13f42' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zio_abd_checksum_fini_t' type-id='a5444274' id='d6fd5c6c'/>
-    <typedef-decl name='zio_abd_checksum_iter_t' type-id='f4a1892e' id='cefa0f4a'/>
+    <typedef-decl name='zfs_fletcher_avx512_t' type-id='c6d0c382' id='90dbb6d6'/>
+    <union-decl name='fletcher_4_ctx' size-in-bits='2048' visibility='default' id='1f951ade'>
+      <data-member access='public'>
+        <var-decl name='scalar' type-id='39730d0b' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='superscalar' type-id='729b6ebb' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='sse' type-id='cbd91ec1' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='avx' type-id='481f90b1' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='avx512' type-id='16582e69' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <typedef-decl name='fletcher_4_ctx_t' type-id='1f951ade' id='4b675395'/>
     <qualified-type-def type-id='aa14691a' const='yes' id='3f8e8d11'/>
     <pointer-type-def type-id='4b675395' size-in-bits='64' id='0f7df99e'/>
     <pointer-type-def type-id='74e39470' size-in-bits='64' id='eefe7427'/>
@@ -2354,36 +2196,11 @@
     <pointer-type-def type-id='cefa0f4a' size-in-bits='64' id='1e276399'/>
     <pointer-type-def type-id='39730d0b' size-in-bits='64' id='c24fc2ee'/>
     <var-decl name='fletcher_4_abd_ops' type-id='c2eb138a' mangled-name='fletcher_4_abd_ops' visibility='default' elf-symbol-id='fletcher_4_abd_ops'/>
-    <function-decl name='fletcher_4_fini' mangled-name='fletcher_4_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_fini'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fletcher_4_init' mangled-name='fletcher_4_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_init'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fletcher_4_incremental_byteswap' mangled-name='fletcher_4_incremental_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_byteswap'>
-      <parameter type-id='eaa32e2f' name='buf'/>
-      <parameter type-id='b59d7dce' name='size'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='fletcher_4_native_varsize' mangled-name='fletcher_4_native_varsize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native_varsize'>
-      <parameter type-id='eaa32e2f' name='buf'/>
-      <parameter type-id='9c313c2d' name='size'/>
+    <function-decl name='fletcher_init' mangled-name='fletcher_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_init'>
       <parameter type-id='c24fc2ee' name='zcp'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fletcher_4_impl_set' mangled-name='fletcher_4_impl_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_impl_set'>
-      <parameter type-id='80f4b756' name='val'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='fletcher_2_byteswap' mangled-name='fletcher_2_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_byteswap'>
-      <parameter type-id='eaa32e2f' name='buf'/>
-      <parameter type-id='9c313c2d' name='size'/>
-      <parameter type-id='eaa32e2f' name='ctx_template'/>
-      <parameter type-id='c24fc2ee' name='zcp'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='fletcher_2_incremental_byteswap' mangled-name='fletcher_2_incremental_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_byteswap'>
+    <function-decl name='fletcher_2_incremental_native' mangled-name='fletcher_2_incremental_native' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_native'>
       <parameter type-id='eaa32e2f' name='buf'/>
       <parameter type-id='b59d7dce' name='size'/>
       <parameter type-id='eaa32e2f' name='data'/>
@@ -2396,20 +2213,33 @@
       <parameter type-id='c24fc2ee' name='zcp'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fletcher_2_incremental_native' mangled-name='fletcher_2_incremental_native' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_native'>
+    <function-decl name='fletcher_2_incremental_byteswap' mangled-name='fletcher_2_incremental_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_incremental_byteswap'>
       <parameter type-id='eaa32e2f' name='buf'/>
       <parameter type-id='b59d7dce' name='size'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='fletcher_init' mangled-name='fletcher_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_init'>
+    <function-decl name='fletcher_2_byteswap' mangled-name='fletcher_2_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_2_byteswap'>
+      <parameter type-id='eaa32e2f' name='buf'/>
+      <parameter type-id='9c313c2d' name='size'/>
+      <parameter type-id='eaa32e2f' name='ctx_template'/>
       <parameter type-id='c24fc2ee' name='zcp'/>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fletcher_4_impl_set' mangled-name='fletcher_4_impl_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_impl_set'>
+      <parameter type-id='80f4b756' name='val'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='fletcher_4_native' mangled-name='fletcher_4_native' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native'>
       <parameter type-id='eaa32e2f' name='buf'/>
       <parameter type-id='9c313c2d' name='size'/>
       <parameter type-id='eaa32e2f' name='ctx_template'/>
+      <parameter type-id='c24fc2ee' name='zcp'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fletcher_4_native_varsize' mangled-name='fletcher_4_native_varsize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_native_varsize'>
+      <parameter type-id='eaa32e2f' name='buf'/>
+      <parameter type-id='9c313c2d' name='size'/>
       <parameter type-id='c24fc2ee' name='zcp'/>
       <return type-id='48b5725f'/>
     </function-decl>
@@ -2426,6 +2256,18 @@
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='fletcher_4_incremental_byteswap' mangled-name='fletcher_4_incremental_byteswap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_incremental_byteswap'>
+      <parameter type-id='eaa32e2f' name='buf'/>
+      <parameter type-id='b59d7dce' name='size'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='fletcher_4_init' mangled-name='fletcher_4_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_init'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fletcher_4_fini' mangled-name='fletcher_4_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_fini'>
+      <return type-id='48b5725f'/>
+    </function-decl>
     <function-type size-in-bits='64' id='f4a1892e'>
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='b59d7dce'/>
@@ -2436,12 +2278,11 @@
       <parameter type-id='eefe7427'/>
       <return type-id='48b5725f'/>
     </function-type>
-    <array-type-def dimensions='1' type-id='9c313c2d' size-in-bits='128' id='c1c22e6c'>
-      <subrange length='2' type-id='7359adad' id='52efc4ef'/>
-    </array-type-def>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_avx512.c' language='LANG_C99'>
-    <typedef-decl name='fletcher_4_ops_t' type-id='57f479a0' id='eba91718'/>
+  <abi-instr address-size='64' path='../../module/zcommon/zfs_fletcher_avx512.c' language='LANG_C99'>
+    <typedef-decl name='fletcher_4_init_f' type-id='173aa527' id='b9ae1656'/>
+    <typedef-decl name='fletcher_4_fini_f' type-id='0ad5b8a8' id='c4c1f4fc'/>
+    <typedef-decl name='fletcher_4_compute_f' type-id='38147eff' id='ad1dc4cb'/>
     <class-decl name='fletcher_4_func' size-in-bits='512' is-struct='yes' visibility='default' id='57f479a0'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='init_native' type-id='b9ae1656' visibility='default'/>
@@ -2468,9 +2309,7 @@
         <var-decl name='name' type-id='80f4b756' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='fletcher_4_init_f' type-id='173aa527' id='b9ae1656'/>
-    <typedef-decl name='fletcher_4_fini_f' type-id='0ad5b8a8' id='c4c1f4fc'/>
-    <typedef-decl name='fletcher_4_compute_f' type-id='38147eff' id='ad1dc4cb'/>
+    <typedef-decl name='fletcher_4_ops_t' type-id='57f479a0' id='eba91718'/>
     <qualified-type-def type-id='eba91718' const='yes' id='9eeabdc8'/>
     <pointer-type-def type-id='e9e61702' size-in-bits='64' id='297d38bc'/>
     <pointer-type-def type-id='fe40251b' size-in-bits='64' id='173aa527'/>
@@ -2497,22 +2336,21 @@
       <return type-id='48b5725f'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_intel.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/zcommon/zfs_fletcher_intel.c' language='LANG_C99'>
     <var-decl name='fletcher_4_avx2_ops' type-id='9eeabdc8' mangled-name='fletcher_4_avx2_ops' visibility='default' elf-symbol-id='fletcher_4_avx2_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_sse.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/zcommon/zfs_fletcher_sse.c' language='LANG_C99'>
     <var-decl name='fletcher_4_sse2_ops' type-id='9eeabdc8' mangled-name='fletcher_4_sse2_ops' visibility='default' elf-symbol-id='fletcher_4_sse2_ops'/>
     <var-decl name='fletcher_4_ssse3_ops' type-id='9eeabdc8' mangled-name='fletcher_4_ssse3_ops' visibility='default' elf-symbol-id='fletcher_4_ssse3_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar.c' language='LANG_C99'>
     <var-decl name='fletcher_4_superscalar_ops' type-id='9eeabdc8' mangled-name='fletcher_4_superscalar_ops' visibility='default' elf-symbol-id='fletcher_4_superscalar_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar4.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/zcommon/zfs_fletcher_superscalar4.c' language='LANG_C99'>
     <var-decl name='fletcher_4_superscalar4_ops' type-id='9eeabdc8' mangled-name='fletcher_4_superscalar4_ops' visibility='default' elf-symbol-id='fletcher_4_superscalar4_ops'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_namecheck.c' language='LANG_C99'>
-    <typedef-decl name='namecheck_err_t' type-id='08f5ca1a' id='8e0af06e'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca1a'>
+  <abi-instr address-size='64' path='../../module/zcommon/zfs_namecheck.c' language='LANG_C99'>
+    <enum-decl name='namecheck_err_t' naming-typedef-id='8e0af06e' id='f43bbcda'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='NAME_ERR_LEADING_SLASH' value='0'/>
       <enumerator name='NAME_ERR_EMPTY_COMPONENT' value='1'/>
@@ -2528,26 +2366,30 @@
       <enumerator name='NAME_ERR_NO_AT' value='11'/>
       <enumerator name='NAME_ERR_NO_POUND' value='12'/>
     </enum-decl>
+    <typedef-decl name='namecheck_err_t' type-id='f43bbcda' id='8e0af06e'/>
     <pointer-type-def type-id='8e0af06e' size-in-bits='64' id='053457bd'/>
     <var-decl name='zfs_max_dataset_nesting' type-id='95e97e5e' mangled-name='zfs_max_dataset_nesting' visibility='default' elf-symbol-id='zfs_max_dataset_nesting'/>
-    <function-decl name='pool_namecheck' mangled-name='pool_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pool_namecheck'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <parameter type-id='053457bd' name='why'/>
-      <parameter type-id='26a90f95' name='what'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='mountpoint_namecheck' mangled-name='mountpoint_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mountpoint_namecheck'>
+    <function-decl name='get_dataset_depth' mangled-name='get_dataset_depth' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_dataset_depth'>
       <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='053457bd' name='why'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='snapshot_namecheck' mangled-name='snapshot_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='snapshot_namecheck'>
+    <function-decl name='zfs_component_namecheck' mangled-name='zfs_component_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_component_namecheck'>
       <parameter type-id='80f4b756' name='path'/>
       <parameter type-id='053457bd' name='why'/>
       <parameter type-id='26a90f95' name='what'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='bookmark_namecheck' mangled-name='bookmark_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='bookmark_namecheck'>
+    <function-decl name='permset_namecheck' mangled-name='permset_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='permset_namecheck'>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='053457bd' name='why'/>
+      <parameter type-id='26a90f95' name='what'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='dataset_nestcheck' mangled-name='dataset_nestcheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_nestcheck'>
+      <parameter type-id='80f4b756' name='path'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='entity_namecheck' mangled-name='entity_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='entity_namecheck'>
       <parameter type-id='80f4b756' name='path'/>
       <parameter type-id='053457bd' name='why'/>
       <parameter type-id='26a90f95' name='what'/>
@@ -2559,46 +2401,60 @@
       <parameter type-id='26a90f95' name='what'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='dataset_nestcheck' mangled-name='dataset_nestcheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dataset_nestcheck'>
-      <parameter type-id='80f4b756' name='path'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='permset_namecheck' mangled-name='permset_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='permset_namecheck'>
+    <function-decl name='bookmark_namecheck' mangled-name='bookmark_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='bookmark_namecheck'>
       <parameter type-id='80f4b756' name='path'/>
       <parameter type-id='053457bd' name='why'/>
       <parameter type-id='26a90f95' name='what'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='get_dataset_depth' mangled-name='get_dataset_depth' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_dataset_depth'>
-      <parameter type-id='80f4b756' name='path'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_component_namecheck' mangled-name='zfs_component_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_component_namecheck'>
+    <function-decl name='snapshot_namecheck' mangled-name='snapshot_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='snapshot_namecheck'>
       <parameter type-id='80f4b756' name='path'/>
       <parameter type-id='053457bd' name='why'/>
       <parameter type-id='26a90f95' name='what'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='entity_namecheck' mangled-name='entity_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='entity_namecheck'>
+    <function-decl name='mountpoint_namecheck' mangled-name='mountpoint_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mountpoint_namecheck'>
       <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='053457bd' name='why'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='pool_namecheck' mangled-name='pool_namecheck' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='pool_namecheck'>
+      <parameter type-id='80f4b756' name='pool'/>
       <parameter type-id='053457bd' name='why'/>
       <parameter type-id='26a90f95' name='what'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zfs_prop.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='../../module/zcommon/zfs_prop.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='80f4b756' size-in-bits='768' id='35e4b367'>
       <subrange length='12' type-id='7359adad' id='84827bdc'/>
     </array-type-def>
-    <typedef-decl name='zprop_type_t' type-id='08f5ca1b' id='31429eff'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca1b'>
+    <enum-decl name='zprop_type_t' naming-typedef-id='31429eff' id='87676253'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='PROP_TYPE_NUMBER' value='0'/>
       <enumerator name='PROP_TYPE_STRING' value='1'/>
       <enumerator name='PROP_TYPE_INDEX' value='2'/>
     </enum-decl>
-    <typedef-decl name='zprop_desc_t' type-id='686c4527' id='ffa52b96'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='704' is-struct='yes' is-anonymous='yes' naming-typedef-id='ffa52b96' visibility='default' id='686c4527'>
+    <typedef-decl name='zprop_type_t' type-id='87676253' id='31429eff'/>
+    <enum-decl name='zprop_attr_t' naming-typedef-id='999701cc' id='77d05200'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='PROP_DEFAULT' value='0'/>
+      <enumerator name='PROP_READONLY' value='1'/>
+      <enumerator name='PROP_INHERIT' value='2'/>
+      <enumerator name='PROP_ONETIME' value='3'/>
+      <enumerator name='PROP_ONETIME_DEFAULT' value='4'/>
+    </enum-decl>
+    <typedef-decl name='zprop_attr_t' type-id='77d05200' id='999701cc'/>
+    <class-decl name='zfs_index' size-in-bits='128' is-struct='yes' visibility='default' id='87957af9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pi_name' type-id='80f4b756' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pi_value' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zprop_index_t' type-id='87957af9' id='64636ce3'/>
+    <class-decl name='zprop_desc_t' size-in-bits='704' is-struct='yes' naming-typedef-id='ffa52b96' visibility='default' id='bbff5e4b'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='pd_name' type-id='80f4b756' visibility='default'/>
       </data-member>
@@ -2642,110 +2498,27 @@
         <var-decl name='pd_table_size' type-id='b59d7dce' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zprop_attr_t' type-id='40ed39d3' id='999701cc'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' id='40ed39d3'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='PROP_DEFAULT' value='0'/>
-      <enumerator name='PROP_READONLY' value='1'/>
-      <enumerator name='PROP_INHERIT' value='2'/>
-      <enumerator name='PROP_ONETIME' value='3'/>
-      <enumerator name='PROP_ONETIME_DEFAULT' value='4'/>
-    </enum-decl>
-    <typedef-decl name='zprop_index_t' type-id='87957af9' id='64636ce3'/>
-    <class-decl name='zfs_index' size-in-bits='128' is-struct='yes' visibility='default' id='87957af9'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='pi_name' type-id='80f4b756' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pi_value' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-    </class-decl>
+    <typedef-decl name='zprop_desc_t' type-id='bbff5e4b' id='ffa52b96'/>
     <pointer-type-def type-id='80f4b756' size-in-bits='64' id='7d3cd834'/>
     <qualified-type-def type-id='64636ce3' const='yes' id='072f7953'/>
     <pointer-type-def type-id='072f7953' size-in-bits='64' id='c8bc397b'/>
     <pointer-type-def type-id='ffa52b96' size-in-bits='64' id='76c8174b'/>
     <var-decl name='zfs_userquota_prop_prefixes' type-id='35e4b367' mangled-name='zfs_userquota_prop_prefixes' visibility='default' elf-symbol-id='zfs_userquota_prop_prefixes'/>
-    <function-decl name='zfs_prop_align_right' mangled-name='zfs_prop_align_right' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_align_right'>
+    <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_table'>
+      <return type-id='76c8174b'/>
+    </function-decl>
+    <function-decl name='zfs_prop_init' mangled-name='zfs_prop_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_init'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_prop_delegatable' mangled-name='zfs_prop_delegatable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_delegatable'>
       <parameter type-id='58603c44' name='prop'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='zfs_prop_column_name' mangled-name='zfs_prop_column_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_column_name'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='80f4b756'/>
+    <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_to_prop'>
+      <parameter type-id='80f4b756' name='propname'/>
+      <return type-id='58603c44'/>
     </function-decl>
-    <function-decl name='zfs_prop_is_string' mangled-name='zfs_prop_is_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_is_string'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_values' mangled-name='zfs_prop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_values'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zfs_prop_valid_keylocation' mangled-name='zfs_prop_valid_keylocation' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_keylocation'>
-      <parameter type-id='80f4b756' name='str'/>
-      <parameter type-id='c19b74c3' name='encrypted'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_prop_encryption_key_param' mangled-name='zfs_prop_encryption_key_param' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_encryption_key_param'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_prop_inheritable' mangled-name='zfs_prop_inheritable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inheritable'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_to_name'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_numeric'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='9c313c2d'/>
-    </function-decl>
-    <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_string'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zfs_prop_setonce' mangled-name='zfs_prop_setonce' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_setonce'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_prop_visible' mangled-name='zfs_prop_visible' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_visible'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_prop_readonly' mangled-name='zfs_prop_readonly' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_readonly'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_type' mangled-name='zfs_prop_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_type'>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='31429eff'/>
-    </function-decl>
-    <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_for_type'>
-      <parameter type-id='95e97e5e' name='prop'/>
-      <parameter type-id='2e45de5d' name='types'/>
-      <parameter type-id='c19b74c3' name='headcheck'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_prop_random_value' mangled-name='zfs_prop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_random_value'>
-      <parameter type-id='58603c44' name='prop'/>
-      <parameter type-id='9c313c2d' name='seed'/>
-      <return type-id='9c313c2d'/>
-    </function-decl>
-    <function-decl name='zfs_prop_index_to_string' mangled-name='zfs_prop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_index_to_string'>
-      <parameter type-id='58603c44' name='prop'/>
-      <parameter type-id='9c313c2d' name='index'/>
-      <parameter type-id='7d3cd834' name='string'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_string_to_index' mangled-name='zfs_prop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_string_to_index'>
-      <parameter type-id='58603c44' name='prop'/>
-      <parameter type-id='80f4b756' name='string'/>
-      <parameter type-id='5d6479ae' name='index'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_written' mangled-name='zfs_prop_written' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_written'>
+    <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_user'>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='c19b74c3'/>
     </function-decl>
@@ -2753,160 +2526,133 @@
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_user'>
+    <function-decl name='zfs_prop_written' mangled-name='zfs_prop_written' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_written'>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_to_prop'>
-      <parameter type-id='80f4b756' name='propname'/>
-      <return type-id='58603c44'/>
-    </function-decl>
-    <function-decl name='zfs_prop_delegatable' mangled-name='zfs_prop_delegatable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_delegatable'>
+    <function-decl name='zfs_prop_string_to_index' mangled-name='zfs_prop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_string_to_index'>
       <parameter type-id='58603c44' name='prop'/>
-      <return type-id='c19b74c3'/>
+      <parameter type-id='80f4b756' name='string'/>
+      <parameter type-id='5d6479ae' name='index'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_prop_init' mangled-name='zfs_prop_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_init'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_table' mangled-name='zfs_prop_get_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_table'>
-      <return type-id='76c8174b'/>
-    </function-decl>
-    <typedef-decl name='zfs_prop_t' type-id='3fed383f' id='58603c44'/>
-    <typedef-decl name='zfs_type_t' type-id='40ed39d4' id='2e45de5d'/>
-    <pointer-type-def type-id='9c313c2d' size-in-bits='64' id='5d6479ae'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' id='40ed39d4'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZFS_TYPE_FILESYSTEM' value='1'/>
-      <enumerator name='ZFS_TYPE_SNAPSHOT' value='2'/>
-      <enumerator name='ZFS_TYPE_VOLUME' value='4'/>
-      <enumerator name='ZFS_TYPE_POOL' value='8'/>
-      <enumerator name='ZFS_TYPE_BOOKMARK' value='16'/>
-    </enum-decl>
-    <enum-decl name='__anonymous_enum__2' is-anonymous='yes' id='3fed383f'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZPROP_CONT' value='-2'/>
-      <enumerator name='ZPROP_INVAL' value='-1'/>
-      <enumerator name='ZFS_PROP_TYPE' value='0'/>
-      <enumerator name='ZFS_PROP_CREATION' value='1'/>
-      <enumerator name='ZFS_PROP_USED' value='2'/>
-      <enumerator name='ZFS_PROP_AVAILABLE' value='3'/>
-      <enumerator name='ZFS_PROP_REFERENCED' value='4'/>
-      <enumerator name='ZFS_PROP_COMPRESSRATIO' value='5'/>
-      <enumerator name='ZFS_PROP_MOUNTED' value='6'/>
-      <enumerator name='ZFS_PROP_ORIGIN' value='7'/>
-      <enumerator name='ZFS_PROP_QUOTA' value='8'/>
-      <enumerator name='ZFS_PROP_RESERVATION' value='9'/>
-      <enumerator name='ZFS_PROP_VOLSIZE' value='10'/>
-      <enumerator name='ZFS_PROP_VOLBLOCKSIZE' value='11'/>
-      <enumerator name='ZFS_PROP_RECORDSIZE' value='12'/>
-      <enumerator name='ZFS_PROP_MOUNTPOINT' value='13'/>
-      <enumerator name='ZFS_PROP_SHARENFS' value='14'/>
-      <enumerator name='ZFS_PROP_CHECKSUM' value='15'/>
-      <enumerator name='ZFS_PROP_COMPRESSION' value='16'/>
-      <enumerator name='ZFS_PROP_ATIME' value='17'/>
-      <enumerator name='ZFS_PROP_DEVICES' value='18'/>
-      <enumerator name='ZFS_PROP_EXEC' value='19'/>
-      <enumerator name='ZFS_PROP_SETUID' value='20'/>
-      <enumerator name='ZFS_PROP_READONLY' value='21'/>
-      <enumerator name='ZFS_PROP_ZONED' value='22'/>
-      <enumerator name='ZFS_PROP_SNAPDIR' value='23'/>
-      <enumerator name='ZFS_PROP_ACLMODE' value='24'/>
-      <enumerator name='ZFS_PROP_ACLINHERIT' value='25'/>
-      <enumerator name='ZFS_PROP_CREATETXG' value='26'/>
-      <enumerator name='ZFS_PROP_NAME' value='27'/>
-      <enumerator name='ZFS_PROP_CANMOUNT' value='28'/>
-      <enumerator name='ZFS_PROP_ISCSIOPTIONS' value='29'/>
-      <enumerator name='ZFS_PROP_XATTR' value='30'/>
-      <enumerator name='ZFS_PROP_NUMCLONES' value='31'/>
-      <enumerator name='ZFS_PROP_COPIES' value='32'/>
-      <enumerator name='ZFS_PROP_VERSION' value='33'/>
-      <enumerator name='ZFS_PROP_UTF8ONLY' value='34'/>
-      <enumerator name='ZFS_PROP_NORMALIZE' value='35'/>
-      <enumerator name='ZFS_PROP_CASE' value='36'/>
-      <enumerator name='ZFS_PROP_VSCAN' value='37'/>
-      <enumerator name='ZFS_PROP_NBMAND' value='38'/>
-      <enumerator name='ZFS_PROP_SHARESMB' value='39'/>
-      <enumerator name='ZFS_PROP_REFQUOTA' value='40'/>
-      <enumerator name='ZFS_PROP_REFRESERVATION' value='41'/>
-      <enumerator name='ZFS_PROP_GUID' value='42'/>
-      <enumerator name='ZFS_PROP_PRIMARYCACHE' value='43'/>
-      <enumerator name='ZFS_PROP_SECONDARYCACHE' value='44'/>
-      <enumerator name='ZFS_PROP_USEDSNAP' value='45'/>
-      <enumerator name='ZFS_PROP_USEDDS' value='46'/>
-      <enumerator name='ZFS_PROP_USEDCHILD' value='47'/>
-      <enumerator name='ZFS_PROP_USEDREFRESERV' value='48'/>
-      <enumerator name='ZFS_PROP_USERACCOUNTING' value='49'/>
-      <enumerator name='ZFS_PROP_STMF_SHAREINFO' value='50'/>
-      <enumerator name='ZFS_PROP_DEFER_DESTROY' value='51'/>
-      <enumerator name='ZFS_PROP_USERREFS' value='52'/>
-      <enumerator name='ZFS_PROP_LOGBIAS' value='53'/>
-      <enumerator name='ZFS_PROP_UNIQUE' value='54'/>
-      <enumerator name='ZFS_PROP_OBJSETID' value='55'/>
-      <enumerator name='ZFS_PROP_DEDUP' value='56'/>
-      <enumerator name='ZFS_PROP_MLSLABEL' value='57'/>
-      <enumerator name='ZFS_PROP_SYNC' value='58'/>
-      <enumerator name='ZFS_PROP_DNODESIZE' value='59'/>
-      <enumerator name='ZFS_PROP_REFRATIO' value='60'/>
-      <enumerator name='ZFS_PROP_WRITTEN' value='61'/>
-      <enumerator name='ZFS_PROP_CLONES' value='62'/>
-      <enumerator name='ZFS_PROP_LOGICALUSED' value='63'/>
-      <enumerator name='ZFS_PROP_LOGICALREFERENCED' value='64'/>
-      <enumerator name='ZFS_PROP_INCONSISTENT' value='65'/>
-      <enumerator name='ZFS_PROP_VOLMODE' value='66'/>
-      <enumerator name='ZFS_PROP_FILESYSTEM_LIMIT' value='67'/>
-      <enumerator name='ZFS_PROP_SNAPSHOT_LIMIT' value='68'/>
-      <enumerator name='ZFS_PROP_FILESYSTEM_COUNT' value='69'/>
-      <enumerator name='ZFS_PROP_SNAPSHOT_COUNT' value='70'/>
-      <enumerator name='ZFS_PROP_SNAPDEV' value='71'/>
-      <enumerator name='ZFS_PROP_ACLTYPE' value='72'/>
-      <enumerator name='ZFS_PROP_SELINUX_CONTEXT' value='73'/>
-      <enumerator name='ZFS_PROP_SELINUX_FSCONTEXT' value='74'/>
-      <enumerator name='ZFS_PROP_SELINUX_DEFCONTEXT' value='75'/>
-      <enumerator name='ZFS_PROP_SELINUX_ROOTCONTEXT' value='76'/>
-      <enumerator name='ZFS_PROP_RELATIME' value='77'/>
-      <enumerator name='ZFS_PROP_REDUNDANT_METADATA' value='78'/>
-      <enumerator name='ZFS_PROP_OVERLAY' value='79'/>
-      <enumerator name='ZFS_PROP_PREV_SNAP' value='80'/>
-      <enumerator name='ZFS_PROP_RECEIVE_RESUME_TOKEN' value='81'/>
-      <enumerator name='ZFS_PROP_ENCRYPTION' value='82'/>
-      <enumerator name='ZFS_PROP_KEYLOCATION' value='83'/>
-      <enumerator name='ZFS_PROP_KEYFORMAT' value='84'/>
-      <enumerator name='ZFS_PROP_PBKDF2_SALT' value='85'/>
-      <enumerator name='ZFS_PROP_PBKDF2_ITERS' value='86'/>
-      <enumerator name='ZFS_PROP_ENCRYPTION_ROOT' value='87'/>
-      <enumerator name='ZFS_PROP_KEY_GUID' value='88'/>
-      <enumerator name='ZFS_PROP_KEYSTATUS' value='89'/>
-      <enumerator name='ZFS_PROP_REMAPTXG' value='90'/>
-      <enumerator name='ZFS_PROP_SPECIAL_SMALL_BLOCKS' value='91'/>
-      <enumerator name='ZFS_PROP_IVSET_GUID' value='92'/>
-      <enumerator name='ZFS_PROP_REDACTED' value='93'/>
-      <enumerator name='ZFS_PROP_REDACT_SNAPS' value='94'/>
-      <enumerator name='ZFS_NUM_PROPS' value='95'/>
-    </enum-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zpool_prop.c' language='LANG_C99'>
-    <function-decl name='zpool_prop_align_right' mangled-name='zpool_prop_align_right' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_align_right'>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zpool_prop_column_name' mangled-name='zpool_prop_column_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_column_name'>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zpool_prop_values' mangled-name='zpool_prop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_values'>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zpool_prop_random_value' mangled-name='zpool_prop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_random_value'>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <parameter type-id='9c313c2d' name='seed'/>
-      <return type-id='9c313c2d'/>
-    </function-decl>
-    <function-decl name='zpool_prop_index_to_string' mangled-name='zpool_prop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_index_to_string'>
-      <parameter type-id='5d0c23fb' name='prop'/>
+    <function-decl name='zfs_prop_index_to_string' mangled-name='zfs_prop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_index_to_string'>
+      <parameter type-id='58603c44' name='prop'/>
       <parameter type-id='9c313c2d' name='index'/>
       <parameter type-id='7d3cd834' name='string'/>
       <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_prop_random_value' mangled-name='zfs_prop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_random_value'>
+      <parameter type-id='58603c44' name='prop'/>
+      <parameter type-id='9c313c2d' name='seed'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
+    <function-decl name='zfs_prop_valid_for_type' mangled-name='zfs_prop_valid_for_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_for_type'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='2e45de5d' name='types'/>
+      <parameter type-id='c19b74c3' name='headcheck'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_type' mangled-name='zfs_prop_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_type'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='31429eff'/>
+    </function-decl>
+    <function-decl name='zfs_prop_readonly' mangled-name='zfs_prop_readonly' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_readonly'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_prop_visible' mangled-name='zfs_prop_visible' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_visible'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_prop_setonce' mangled-name='zfs_prop_setonce' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_setonce'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_prop_default_string' mangled-name='zfs_prop_default_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_string'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_prop_default_numeric' mangled-name='zfs_prop_default_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_default_numeric'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
+    <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_to_name'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_prop_inheritable' mangled-name='zfs_prop_inheritable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inheritable'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_prop_encryption_key_param' mangled-name='zfs_prop_encryption_key_param' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_encryption_key_param'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_prop_valid_keylocation' mangled-name='zfs_prop_valid_keylocation' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_valid_keylocation'>
+      <parameter type-id='80f4b756' name='str'/>
+      <parameter type-id='c19b74c3' name='encrypted'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_prop_values' mangled-name='zfs_prop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_values'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_prop_is_string' mangled-name='zfs_prop_is_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_is_string'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_prop_column_name' mangled-name='zfs_prop_column_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_column_name'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_prop_align_right' mangled-name='zfs_prop_align_right' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_align_right'>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../module/zcommon/zpool_prop.c' language='LANG_C99'>
+    <function-decl name='zpool_prop_get_table' mangled-name='zpool_prop_get_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_table'>
+      <return type-id='76c8174b'/>
+    </function-decl>
+    <function-decl name='zpool_prop_init' mangled-name='zpool_prop_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_init'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zpool_name_to_prop' mangled-name='zpool_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_to_prop'>
+      <parameter type-id='80f4b756' name='propname'/>
+      <return type-id='5d0c23fb'/>
+    </function-decl>
+    <function-decl name='zpool_prop_to_name' mangled-name='zpool_prop_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_to_name'>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zpool_prop_get_type' mangled-name='zpool_prop_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_type'>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <return type-id='31429eff'/>
+    </function-decl>
+    <function-decl name='zpool_prop_readonly' mangled-name='zpool_prop_readonly' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_readonly'>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zpool_prop_setonce' mangled-name='zpool_prop_setonce' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_setonce'>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_string'>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_numeric'>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
+    <function-decl name='zpool_prop_feature' mangled-name='zpool_prop_feature' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_feature'>
+      <parameter type-id='80f4b756' name='name'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zpool_prop_unsupported' mangled-name='zpool_prop_unsupported' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_unsupported'>
+      <parameter type-id='80f4b756' name='name'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='zpool_prop_string_to_index' mangled-name='zpool_prop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_string_to_index'>
       <parameter type-id='5d0c23fb' name='prop'/>
@@ -2914,179 +2660,31 @@
       <parameter type-id='5d6479ae' name='index'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_prop_unsupported' mangled-name='zpool_prop_unsupported' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_unsupported'>
-      <parameter type-id='80f4b756' name='name'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zpool_prop_feature' mangled-name='zpool_prop_feature' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_feature'>
-      <parameter type-id='80f4b756' name='name'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zpool_prop_default_numeric' mangled-name='zpool_prop_default_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_numeric'>
+    <function-decl name='zpool_prop_index_to_string' mangled-name='zpool_prop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_index_to_string'>
       <parameter type-id='5d0c23fb' name='prop'/>
-      <return type-id='9c313c2d'/>
-    </function-decl>
-    <function-decl name='zpool_prop_default_string' mangled-name='zpool_prop_default_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_default_string'>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zpool_prop_setonce' mangled-name='zpool_prop_setonce' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_setonce'>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zpool_prop_readonly' mangled-name='zpool_prop_readonly' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_readonly'>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zpool_prop_get_type' mangled-name='zpool_prop_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_type'>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <return type-id='31429eff'/>
-    </function-decl>
-    <function-decl name='zpool_prop_to_name' mangled-name='zpool_prop_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_to_name'>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zpool_name_to_prop' mangled-name='zpool_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_name_to_prop'>
-      <parameter type-id='80f4b756' name='propname'/>
-      <return type-id='5d0c23fb'/>
-    </function-decl>
-    <function-decl name='zpool_prop_init' mangled-name='zpool_prop_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_init'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zpool_prop_get_table' mangled-name='zpool_prop_get_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_table'>
-      <return type-id='76c8174b'/>
-    </function-decl>
-    <typedef-decl name='zpool_prop_t' type-id='40ed39d5' id='5d0c23fb'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' id='40ed39d5'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZPOOL_PROP_INVAL' value='-1'/>
-      <enumerator name='ZPOOL_PROP_NAME' value='0'/>
-      <enumerator name='ZPOOL_PROP_SIZE' value='1'/>
-      <enumerator name='ZPOOL_PROP_CAPACITY' value='2'/>
-      <enumerator name='ZPOOL_PROP_ALTROOT' value='3'/>
-      <enumerator name='ZPOOL_PROP_HEALTH' value='4'/>
-      <enumerator name='ZPOOL_PROP_GUID' value='5'/>
-      <enumerator name='ZPOOL_PROP_VERSION' value='6'/>
-      <enumerator name='ZPOOL_PROP_BOOTFS' value='7'/>
-      <enumerator name='ZPOOL_PROP_DELEGATION' value='8'/>
-      <enumerator name='ZPOOL_PROP_AUTOREPLACE' value='9'/>
-      <enumerator name='ZPOOL_PROP_CACHEFILE' value='10'/>
-      <enumerator name='ZPOOL_PROP_FAILUREMODE' value='11'/>
-      <enumerator name='ZPOOL_PROP_LISTSNAPS' value='12'/>
-      <enumerator name='ZPOOL_PROP_AUTOEXPAND' value='13'/>
-      <enumerator name='ZPOOL_PROP_DEDUPDITTO' value='14'/>
-      <enumerator name='ZPOOL_PROP_DEDUPRATIO' value='15'/>
-      <enumerator name='ZPOOL_PROP_FREE' value='16'/>
-      <enumerator name='ZPOOL_PROP_ALLOCATED' value='17'/>
-      <enumerator name='ZPOOL_PROP_READONLY' value='18'/>
-      <enumerator name='ZPOOL_PROP_ASHIFT' value='19'/>
-      <enumerator name='ZPOOL_PROP_COMMENT' value='20'/>
-      <enumerator name='ZPOOL_PROP_EXPANDSZ' value='21'/>
-      <enumerator name='ZPOOL_PROP_FREEING' value='22'/>
-      <enumerator name='ZPOOL_PROP_FRAGMENTATION' value='23'/>
-      <enumerator name='ZPOOL_PROP_LEAKED' value='24'/>
-      <enumerator name='ZPOOL_PROP_MAXBLOCKSIZE' value='25'/>
-      <enumerator name='ZPOOL_PROP_TNAME' value='26'/>
-      <enumerator name='ZPOOL_PROP_MAXDNODESIZE' value='27'/>
-      <enumerator name='ZPOOL_PROP_MULTIHOST' value='28'/>
-      <enumerator name='ZPOOL_PROP_CHECKPOINT' value='29'/>
-      <enumerator name='ZPOOL_PROP_LOAD_GUID' value='30'/>
-      <enumerator name='ZPOOL_PROP_AUTOTRIM' value='31'/>
-      <enumerator name='ZPOOL_PROP_COMPATIBILITY' value='32'/>
-      <enumerator name='ZPOOL_NUM_PROPS' value='33'/>
-    </enum-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='../../module/zcommon/zprop_common.c' language='LANG_C99'>
-    <function-decl name='zprop_width' mangled-name='zprop_width' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_width'>
-      <parameter type-id='95e97e5e' name='prop'/>
-      <parameter type-id='37e3bd22' name='fixed'/>
-      <parameter type-id='2e45de5d' name='type'/>
-      <return type-id='b59d7dce'/>
-    </function-decl>
-    <function-decl name='zprop_valid_for_type' mangled-name='zprop_valid_for_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_valid_for_type'>
-      <parameter type-id='95e97e5e' name='prop'/>
-      <parameter type-id='2e45de5d' name='type'/>
-      <parameter type-id='c19b74c3' name='headcheck'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zprop_values' mangled-name='zprop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_values'>
-      <parameter type-id='95e97e5e' name='prop'/>
-      <parameter type-id='2e45de5d' name='type'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zprop_random_value' mangled-name='zprop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_random_value'>
-      <parameter type-id='95e97e5e' name='prop'/>
-      <parameter type-id='9c313c2d' name='seed'/>
-      <parameter type-id='2e45de5d' name='type'/>
-      <return type-id='9c313c2d'/>
-    </function-decl>
-    <function-decl name='zprop_index_to_string' mangled-name='zprop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_index_to_string'>
-      <parameter type-id='95e97e5e' name='prop'/>
       <parameter type-id='9c313c2d' name='index'/>
       <parameter type-id='7d3cd834' name='string'/>
-      <parameter type-id='2e45de5d' name='type'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zprop_string_to_index' mangled-name='zprop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_string_to_index'>
-      <parameter type-id='95e97e5e' name='prop'/>
-      <parameter type-id='80f4b756' name='string'/>
-      <parameter type-id='5d6479ae' name='index'/>
-      <parameter type-id='2e45de5d' name='type'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='zpool_prop_random_value' mangled-name='zpool_prop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_random_value'>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <parameter type-id='9c313c2d' name='seed'/>
+      <return type-id='9c313c2d'/>
     </function-decl>
-    <function-decl name='zprop_name_to_prop' mangled-name='zprop_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_name_to_prop'>
-      <parameter type-id='80f4b756' name='propname'/>
-      <parameter type-id='2e45de5d' name='type'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='zpool_prop_values' mangled-name='zpool_prop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_values'>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <return type-id='80f4b756'/>
     </function-decl>
-    <function-decl name='zprop_iter_common' mangled-name='zprop_iter_common' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter_common'>
-      <parameter type-id='1ec3747a' name='func'/>
-      <parameter type-id='eaa32e2f' name='cb'/>
-      <parameter type-id='c19b74c3' name='show_all'/>
-      <parameter type-id='c19b74c3' name='ordered'/>
-      <parameter type-id='2e45de5d' name='type'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='zpool_prop_column_name' mangled-name='zpool_prop_column_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_column_name'>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <return type-id='80f4b756'/>
     </function-decl>
-    <function-decl name='zprop_register_hidden' mangled-name='zprop_register_hidden' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_hidden'>
-      <parameter type-id='95e97e5e' name='prop'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='31429eff' name='type'/>
-      <parameter type-id='999701cc' name='attr'/>
-      <parameter type-id='95e97e5e' name='objset_types'/>
-      <parameter type-id='80f4b756' name='colname'/>
-      <return type-id='48b5725f'/>
+    <function-decl name='zpool_prop_align_right' mangled-name='zpool_prop_align_right' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_align_right'>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='zprop_register_index' mangled-name='zprop_register_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_index'>
-      <parameter type-id='95e97e5e' name='prop'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='9c313c2d' name='def'/>
-      <parameter type-id='999701cc' name='attr'/>
-      <parameter type-id='95e97e5e' name='objset_types'/>
-      <parameter type-id='80f4b756' name='values'/>
-      <parameter type-id='80f4b756' name='colname'/>
-      <parameter type-id='c8bc397b' name='idx_tbl'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zprop_register_number' mangled-name='zprop_register_number' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_number'>
-      <parameter type-id='95e97e5e' name='prop'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='9c313c2d' name='def'/>
-      <parameter type-id='999701cc' name='attr'/>
-      <parameter type-id='95e97e5e' name='objset_types'/>
-      <parameter type-id='80f4b756' name='values'/>
-      <parameter type-id='80f4b756' name='colname'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zprop_register_string' mangled-name='zprop_register_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_string'>
-      <parameter type-id='95e97e5e' name='prop'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='80f4b756' name='def'/>
-      <parameter type-id='999701cc' name='attr'/>
-      <parameter type-id='95e97e5e' name='objset_types'/>
-      <parameter type-id='80f4b756' name='values'/>
-      <parameter type-id='80f4b756' name='colname'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../module/zcommon/zprop_common.c' language='LANG_C99'>
     <function-decl name='zprop_register_impl' mangled-name='zprop_register_impl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_impl'>
       <parameter type-id='95e97e5e' name='prop'/>
       <parameter type-id='80f4b756' name='name'/>
@@ -3102,14 +2700,101 @@
       <parameter type-id='c8bc397b' name='idx_tbl'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <pointer-type-def type-id='c19b74c3' size-in-bits='64' id='37e3bd22'/>
-    <typedef-decl name='zprop_func' type-id='2e711a2a' id='1ec3747a'/>
-    <pointer-type-def type-id='c70fa2e8' size-in-bits='64' id='2e711a2a'/>
+    <function-decl name='zprop_register_string' mangled-name='zprop_register_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_string'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='80f4b756' name='def'/>
+      <parameter type-id='999701cc' name='attr'/>
+      <parameter type-id='95e97e5e' name='objset_types'/>
+      <parameter type-id='80f4b756' name='values'/>
+      <parameter type-id='80f4b756' name='colname'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zprop_register_number' mangled-name='zprop_register_number' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_number'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='9c313c2d' name='def'/>
+      <parameter type-id='999701cc' name='attr'/>
+      <parameter type-id='95e97e5e' name='objset_types'/>
+      <parameter type-id='80f4b756' name='values'/>
+      <parameter type-id='80f4b756' name='colname'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zprop_register_index' mangled-name='zprop_register_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_index'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='9c313c2d' name='def'/>
+      <parameter type-id='999701cc' name='attr'/>
+      <parameter type-id='95e97e5e' name='objset_types'/>
+      <parameter type-id='80f4b756' name='values'/>
+      <parameter type-id='80f4b756' name='colname'/>
+      <parameter type-id='c8bc397b' name='idx_tbl'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zprop_register_hidden' mangled-name='zprop_register_hidden' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_register_hidden'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='31429eff' name='type'/>
+      <parameter type-id='999701cc' name='attr'/>
+      <parameter type-id='95e97e5e' name='objset_types'/>
+      <parameter type-id='80f4b756' name='colname'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zprop_iter_common' mangled-name='zprop_iter_common' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter_common'>
+      <parameter type-id='1ec3747a' name='func'/>
+      <parameter type-id='eaa32e2f' name='cb'/>
+      <parameter type-id='c19b74c3' name='show_all'/>
+      <parameter type-id='c19b74c3' name='ordered'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zprop_name_to_prop' mangled-name='zprop_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_name_to_prop'>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zprop_string_to_index' mangled-name='zprop_string_to_index' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_string_to_index'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='80f4b756' name='string'/>
+      <parameter type-id='5d6479ae' name='index'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zprop_index_to_string' mangled-name='zprop_index_to_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_index_to_string'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='9c313c2d' name='index'/>
+      <parameter type-id='7d3cd834' name='string'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zprop_random_value' mangled-name='zprop_random_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_random_value'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='9c313c2d' name='seed'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
+    <function-decl name='zprop_values' mangled-name='zprop_values' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_values'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zprop_valid_for_type' mangled-name='zprop_valid_for_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_valid_for_type'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <parameter type-id='c19b74c3' name='headcheck'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zprop_width' mangled-name='zprop_width' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_width'>
+      <parameter type-id='95e97e5e' name='prop'/>
+      <parameter type-id='37e3bd22' name='fixed'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_changelist.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='libzfs_changelist.c' language='LANG_C99'>
     <type-decl name='void' id='48b5725f'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_config.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='libzfs_config.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='bf311473' size-in-bits='128' id='f0f65199'>
       <subrange length='2' type-id='7359adad' id='52efc4ef'/>
     </array-type-def>
@@ -3123,6 +2808,7 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='320' id='36c46961'>
       <subrange length='40' type-id='7359adad' id='8f80b239'/>
     </array-type-def>
+    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='b48d2441'/>
     <class-decl name='uu_avl' is-struct='yes' visibility='default' is-declaration-only='yes' id='4af029d1'/>
     <class-decl name='uu_avl_pool' is-struct='yes' visibility='default' is-declaration-only='yes' id='12a530a8'/>
     <type-decl name='int' size-in-bits='32' id='95e97e5e'/>
@@ -3133,6 +2819,113 @@
     <type-decl name='unsigned char' size-in-bits='8' id='002ac4a6'/>
     <type-decl name='unsigned int' size-in-bits='32' id='f0981eeb'/>
     <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
+    <typedef-decl name='uu_avl_pool_t' type-id='12a530a8' id='7f84e390'/>
+    <typedef-decl name='uu_avl_t' type-id='4af029d1' id='bb7f0973'/>
+    <typedef-decl name='zfs_handle_t' type-id='f6ee4445' id='775509eb'/>
+    <typedef-decl name='zpool_handle_t' type-id='67002a8a' id='b1efc708'/>
+    <typedef-decl name='libzfs_handle_t' type-id='c8a9d9d8' id='95942d0c'/>
+    <typedef-decl name='zpool_iter_f' type-id='3aebb66f' id='fa476e62'/>
+    <typedef-decl name='zfs_iter_f' type-id='5571cde4' id='d8e49ab9'/>
+    <typedef-decl name='avl_tree_t' type-id='b351119f' id='f20fbd51'/>
+    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='428b67b3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_child' type-id='f0f65199' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_pcb' type-id='e475ab95' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='b351119f'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='avl_root' type-id='bf311473' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avl_compar' type-id='585e1de9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avl_offset' type-id='b59d7dce' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='avl_numnodes' type-id='ee1f298e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avl_pad' type-id='b59d7dce' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' id='098f0221'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dds_num_clones' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dds_creation_txg' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dds_guid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dds_type' type-id='230f1e16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='dds_is_snapshot' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='232'>
+        <var-decl name='dds_inconsistent' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='240'>
+        <var-decl name='dds_redacted' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='248'>
+        <var-decl name='dds_origin' type-id='d1617432' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='dmu_objset_stats_t' type-id='098f0221' id='b2c14f17'/>
+    <enum-decl name='zfs_type_t' naming-typedef-id='2e45de5d' id='5d8f7321'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='ZFS_TYPE_FILESYSTEM' value='1'/>
+      <enumerator name='ZFS_TYPE_SNAPSHOT' value='2'/>
+      <enumerator name='ZFS_TYPE_VOLUME' value='4'/>
+      <enumerator name='ZFS_TYPE_POOL' value='8'/>
+      <enumerator name='ZFS_TYPE_BOOKMARK' value='16'/>
+    </enum-decl>
+    <typedef-decl name='zfs_type_t' type-id='5d8f7321' id='2e45de5d'/>
+    <enum-decl name='dmu_objset_type' id='6b1b19f9'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='DMU_OST_NONE' value='0'/>
+      <enumerator name='DMU_OST_META' value='1'/>
+      <enumerator name='DMU_OST_ZFS' value='2'/>
+      <enumerator name='DMU_OST_ZVOL' value='3'/>
+      <enumerator name='DMU_OST_OTHER' value='4'/>
+      <enumerator name='DMU_OST_ANY' value='5'/>
+      <enumerator name='DMU_OST_NUMTYPES' value='6'/>
+    </enum-decl>
+    <typedef-decl name='dmu_objset_type_t' type-id='6b1b19f9' id='230f1e16'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='ac266fd9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvl_version' type-id='3ff5601b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvl_nvflag' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvl_priv' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvl_flag' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='nvl_pad' type-id='3ff5601b' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='nvlist_t' type-id='ac266fd9' id='8e8d4be3'/>
+    <enum-decl name='boolean_t' naming-typedef-id='c19b74c3' id='f58c8277'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='B_FALSE' value='0'/>
+      <enumerator name='B_TRUE' value='1'/>
+    </enum-decl>
+    <typedef-decl name='boolean_t' type-id='f58c8277' id='c19b74c3'/>
+    <typedef-decl name='ulong_t' type-id='7359adad' id='ee1f298e'/>
+    <typedef-decl name='longlong_t' type-id='1eb56b1e' id='9b3ff54f'/>
+    <typedef-decl name='diskaddr_t' type-id='9b3ff54f' id='804dc465'/>
     <class-decl name='libzfs_handle' size-in-bits='18240' is-struct='yes' visibility='default' id='c8a9d9d8'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='libzfs_error' type-id='95e97e5e' visibility='default'/>
@@ -3192,195 +2985,6 @@
         <var-decl name='libfetch_load_error' type-id='26a90f95' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' id='67002a8a'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zpool_hdl' type-id='b0382bb3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zpool_next' type-id='4c81de99' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zpool_name' type-id='d1617432' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='zpool_state' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='zpool_config_size' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2304'>
-        <var-decl name='zpool_config' type-id='5ce45b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2368'>
-        <var-decl name='zpool_old_config' type-id='5ce45b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='zpool_props' type-id='5ce45b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2496'>
-        <var-decl name='zpool_start_block' type-id='804dc465' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='libzfs_handle_t' type-id='c8a9d9d8' id='95942d0c'/>
-    <typedef-decl name='zpool_handle_t' type-id='67002a8a' id='b1efc708'/>
-    <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
-    <typedef-decl name='nvlist_t' type-id='ac266fd9' id='8e8d4be3'/>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='ac266fd9'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvl_priv' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
-    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
-    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
-    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
-    <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
-    <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
-    <typedef-decl name='diskaddr_t' type-id='9b3ff54f' id='804dc465'/>
-    <typedef-decl name='longlong_t' type-id='1eb56b1e' id='9b3ff54f'/>
-    <typedef-decl name='uu_avl_pool_t' type-id='12a530a8' id='7f84e390'/>
-    <typedef-decl name='uu_avl_t' type-id='4af029d1' id='bb7f0973'/>
-    <typedef-decl name='boolean_t' type-id='08f5ca17' id='c19b74c3'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca17'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='B_FALSE' value='0'/>
-      <enumerator name='B_TRUE' value='1'/>
-    </enum-decl>
-    <typedef-decl name='pthread_mutex_t' type-id='c4794498' id='7a6844eb'/>
-    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' id='c4794498'>
-      <data-member access='private'>
-        <var-decl name='__data' type-id='4c734837' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__size' type-id='36c46961' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='__align' type-id='bd54fe1a' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='4c734837'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__lock' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='__count' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__owner' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__nusers' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__kind' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='__spins' type-id='a2185560' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='__elision' type-id='a2185560' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='__list' type-id='518fb49c' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__pthread_list_t' type-id='0e01899c' id='518fb49c'/>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='0e01899c'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='4d98cd5a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='4d98cd5a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='avl_tree_t' type-id='b351119f' id='f20fbd51'/>
-    <class-decl name='avl_tree' size-in-bits='320' is-struct='yes' visibility='default' id='b351119f'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_root' type-id='bf311473' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avl_compar' type-id='585e1de9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_offset' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='avl_numnodes' type-id='ee1f298e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avl_pad' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='avl_node' size-in-bits='192' is-struct='yes' visibility='default' id='428b67b3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='avl_child' type-id='f0f65199' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avl_pcb' type-id='e475ab95' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='uintptr_t' type-id='7359adad' id='e475ab95'/>
-    <typedef-decl name='ulong_t' type-id='7359adad' id='ee1f298e'/>
-    <typedef-decl name='regex_t' type-id='19fc9a8c' id='aca3bac8'/>
-    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' id='19fc9a8c'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='buffer' type-id='cf536864' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='allocated' type-id='7359adad' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='used' type-id='7359adad' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='syntax' type-id='1b72c3b3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='fastmap' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='translate' type-id='cf536864' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='re_nsub' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='31'>
-        <var-decl name='can_be_null' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='29'>
-        <var-decl name='regs_allocated' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='28'>
-        <var-decl name='fastmap_accurate' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='27'>
-        <var-decl name='no_sub' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='26'>
-        <var-decl name='not_bol' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='25'>
-        <var-decl name='not_eol' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='24'>
-        <var-decl name='newline_anchor' type-id='f0981eeb' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='reg_syntax_t' type-id='7359adad' id='1b72c3b3'/>
-    <typedef-decl name='zfs_iter_f' type-id='5571cde4' id='d8e49ab9'/>
-    <typedef-decl name='zfs_handle_t' type-id='f6ee4445' id='775509eb'/>
     <class-decl name='zfs_handle' size-in-bits='4928' is-struct='yes' visibility='default' id='f6ee4445'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zfs_hdl' type-id='b0382bb3' visibility='default'/>
@@ -3419,56 +3023,139 @@
         <var-decl name='zfs_props_table' type-id='ae3e8ca6' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_type_t' type-id='40ed39d4' id='2e45de5d'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' id='40ed39d4'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZFS_TYPE_FILESYSTEM' value='1'/>
-      <enumerator name='ZFS_TYPE_SNAPSHOT' value='2'/>
-      <enumerator name='ZFS_TYPE_VOLUME' value='4'/>
-      <enumerator name='ZFS_TYPE_POOL' value='8'/>
-      <enumerator name='ZFS_TYPE_BOOKMARK' value='16'/>
-    </enum-decl>
-    <typedef-decl name='dmu_objset_stats_t' type-id='098f0221' id='b2c14f17'/>
-    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' id='098f0221'>
+    <class-decl name='zpool_handle' size-in-bits='2560' is-struct='yes' visibility='default' id='67002a8a'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dds_num_clones' type-id='9c313c2d' visibility='default'/>
+        <var-decl name='zpool_hdl' type-id='b0382bb3' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='dds_creation_txg' type-id='9c313c2d' visibility='default'/>
+        <var-decl name='zpool_next' type-id='4c81de99' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='dds_guid' type-id='9c313c2d' visibility='default'/>
+        <var-decl name='zpool_name' type-id='d1617432' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='dds_type' type-id='230f1e16' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='zpool_state' type-id='95e97e5e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dds_is_snapshot' type-id='b96825af' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='zpool_config_size' type-id='b59d7dce' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='232'>
-        <var-decl name='dds_inconsistent' type-id='b96825af' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='zpool_config' type-id='5ce45b60' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='240'>
-        <var-decl name='dds_redacted' type-id='b96825af' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='2368'>
+        <var-decl name='zpool_old_config' type-id='5ce45b60' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='248'>
-        <var-decl name='dds_origin' type-id='d1617432' visibility='default'/>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='zpool_props' type-id='5ce45b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2496'>
+        <var-decl name='zpool_start_block' type-id='804dc465' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='dmu_objset_type_t' type-id='6b1b19f9' id='230f1e16'/>
-    <enum-decl name='dmu_objset_type' id='6b1b19f9'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='DMU_OST_NONE' value='0'/>
-      <enumerator name='DMU_OST_META' value='1'/>
-      <enumerator name='DMU_OST_ZFS' value='2'/>
-      <enumerator name='DMU_OST_ZVOL' value='3'/>
-      <enumerator name='DMU_OST_OTHER' value='4'/>
-      <enumerator name='DMU_OST_ANY' value='5'/>
-      <enumerator name='DMU_OST_NUMTYPES' value='6'/>
-    </enum-decl>
+    <typedef-decl name='__re_long_size_t' type-id='7359adad' id='ba516949'/>
+    <typedef-decl name='reg_syntax_t' type-id='7359adad' id='1b72c3b3'/>
+    <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' id='19fc9a8c'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='buffer' type-id='33976309' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='allocated' type-id='ba516949' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='used' type-id='ba516949' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='syntax' type-id='1b72c3b3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='fastmap' type-id='26a90f95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='translate' type-id='cf536864' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='re_nsub' type-id='b59d7dce' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='can_be_null' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='449'>
+        <var-decl name='regs_allocated' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='451'>
+        <var-decl name='fastmap_accurate' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='452'>
+        <var-decl name='no_sub' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='453'>
+        <var-decl name='not_bol' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='454'>
+        <var-decl name='not_eol' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='455'>
+        <var-decl name='newline_anchor' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='regex_t' type-id='19fc9a8c' id='aca3bac8'/>
+    <typedef-decl name='uintptr_t' type-id='7359adad' id='e475ab95'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='7a6844eb' visibility='default' id='70681f9b'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='4c734837' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='36c46961' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='bd54fe1a' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <typedef-decl name='pthread_mutex_t' type-id='70681f9b' id='7a6844eb'/>
+    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
     <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
+    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
+    <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='4c734837'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='f0981eeb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='a2185560' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='a2185560' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='518fb49c' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='0e01899c'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='4d98cd5a' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='4d98cd5a' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pthread_list_t' type-id='0e01899c' id='518fb49c'/>
     <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
-    <typedef-decl name='zpool_iter_f' type-id='3aebb66f' id='fa476e62'/>
+    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
+    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
+    <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
+    <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
     <pointer-type-def type-id='0e01899c' size-in-bits='64' id='4d98cd5a'/>
     <pointer-type-def type-id='428b67b3' size-in-bits='64' id='bf311473'/>
     <pointer-type-def type-id='c19b74c3' size-in-bits='64' id='37e3bd22'/>
@@ -3481,6 +3168,7 @@
     <pointer-type-def type-id='95942d0c' size-in-bits='64' id='b0382bb3'/>
     <pointer-type-def type-id='8e8d4be3' size-in-bits='64' id='5ce45b60'/>
     <pointer-type-def type-id='5ce45b60' size-in-bits='64' id='857bb57e'/>
+    <pointer-type-def type-id='b48d2441' size-in-bits='64' id='33976309'/>
     <pointer-type-def type-id='b96825af' size-in-bits='64' id='ae3e8ca6'/>
     <pointer-type-def type-id='002ac4a6' size-in-bits='64' id='cf536864'/>
     <pointer-type-def type-id='7f84e390' size-in-bits='64' id='de82c773'/>
@@ -3488,11 +3176,26 @@
     <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
     <pointer-type-def type-id='775509eb' size-in-bits='64' id='9200a744'/>
     <pointer-type-def type-id='b1efc708' size-in-bits='64' id='4c81de99'/>
-    <function-decl name='zfs_iter_root' mangled-name='zfs_iter_root' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_root'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
+    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='b48d2441'/>
+    <class-decl name='uu_avl' is-struct='yes' visibility='default' is-declaration-only='yes' id='4af029d1'/>
+    <class-decl name='uu_avl_pool' is-struct='yes' visibility='default' is-declaration-only='yes' id='12a530a8'/>
+    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_config'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='857bb57e' name='oldconfig'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_features'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_refresh_stats'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='37e3bd22' name='missing'/>
       <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_skip_pool' mangled-name='zpool_skip_pool' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_skip_pool'>
+      <parameter type-id='80f4b756' name='poolname'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='zpool_iter' mangled-name='zpool_iter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_iter'>
       <parameter type-id='b0382bb3' name='hdl'/>
@@ -3500,29 +3203,12 @@
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_skip_pool' mangled-name='zpool_skip_pool' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_skip_pool'>
-      <parameter type-id='80f4b756' name='poolname'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zpool_refresh_stats' mangled-name='zpool_refresh_stats' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_refresh_stats'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='37e3bd22' name='missing'/>
+    <function-decl name='zfs_iter_root' mangled-name='zfs_iter_root' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_root'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_get_features' mangled-name='zpool_get_features' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_features'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <return type-id='5ce45b60'/>
-    </function-decl>
-    <function-decl name='zpool_get_config' mangled-name='zpool_get_config' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_config'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='857bb57e' name='oldconfig'/>
-      <return type-id='5ce45b60'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='96ee24a5'>
-      <parameter type-id='eaa32e2f'/>
-      <parameter type-id='eaa32e2f'/>
-      <return type-id='95e97e5e'/>
-    </function-type>
     <function-type size-in-bits='64' id='cb9628fa'>
       <parameter type-id='9200a744'/>
       <parameter type-id='eaa32e2f'/>
@@ -3534,36 +3220,14 @@
       <return type-id='95e97e5e'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_crypto.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='libzfs_crypto.c' language='LANG_C99'>
     <typedef-decl name='uint_t' type-id='f0981eeb' id='3502e3ff'/>
     <pointer-type-def type-id='ae3e8ca6' size-in-bits='64' id='d8774064'/>
     <pointer-type-def type-id='3502e3ff' size-in-bits='64' id='4dd26a40'/>
-    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
+    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='5ce45b60' name='raw_props'/>
-      <parameter type-id='c19b74c3' name='inheritkey'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='c19b74c3' name='noop'/>
-      <parameter type-id='26a90f95' name='alt_keylocation'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='26a90f95' name='fsname'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='9200a744' name='origin_zhp'/>
-      <parameter type-id='26a90f95' name='parent_name'/>
-      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='37e3bd22' name='is_encroot'/>
+      <parameter type-id='26a90f95' name='buf'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_crypto_create' mangled-name='zfs_crypto_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_create'>
@@ -3576,41 +3240,36 @@
       <parameter type-id='4dd26a40' name='wkeylen_out'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_crypto_get_encryption_root' mangled-name='zfs_crypto_get_encryption_root' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_get_encryption_root'>
+    <function-decl name='zfs_crypto_clone_check' mangled-name='zfs_crypto_clone_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_clone_check'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='9200a744' name='origin_zhp'/>
+      <parameter type-id='26a90f95' name='parent_name'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_attempt_load_keys' mangled-name='zfs_crypto_attempt_load_keys' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_attempt_load_keys'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='26a90f95' name='fsname'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_load_key' mangled-name='zfs_crypto_load_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_load_key'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='37e3bd22' name='is_encroot'/>
-      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='c19b74c3' name='noop'/>
+      <parameter type-id='26a90f95' name='alt_keylocation'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_unload_key' mangled-name='zfs_crypto_unload_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_unload_key'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_crypto_rewrap' mangled-name='zfs_crypto_rewrap' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_crypto_rewrap'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='5ce45b60' name='raw_props'/>
+      <parameter type-id='c19b74c3' name='inheritkey'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_dataset.c' language='LANG_C99'>
-    <typedef-decl name='zfs_wait_activity_t' type-id='08f5ca1c' id='3024501a'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca1c'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
-      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
-    </enum-decl>
-    <typedef-decl name='zfs_userquota_prop_t' type-id='40ed39d6' id='279fde6a'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' id='40ed39d6'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZFS_PROP_USERUSED' value='0'/>
-      <enumerator name='ZFS_PROP_USERQUOTA' value='1'/>
-      <enumerator name='ZFS_PROP_GROUPUSED' value='2'/>
-      <enumerator name='ZFS_PROP_GROUPQUOTA' value='3'/>
-      <enumerator name='ZFS_PROP_USEROBJUSED' value='4'/>
-      <enumerator name='ZFS_PROP_USEROBJQUOTA' value='5'/>
-      <enumerator name='ZFS_PROP_GROUPOBJUSED' value='6'/>
-      <enumerator name='ZFS_PROP_GROUPOBJQUOTA' value='7'/>
-      <enumerator name='ZFS_PROP_PROJECTUSED' value='8'/>
-      <enumerator name='ZFS_PROP_PROJECTQUOTA' value='9'/>
-      <enumerator name='ZFS_PROP_PROJECTOBJUSED' value='10'/>
-      <enumerator name='ZFS_PROP_PROJECTOBJQUOTA' value='11'/>
-      <enumerator name='ZFS_NUM_USERQUOTA_PROPS' value='12'/>
-    </enum-decl>
-    <typedef-decl name='zfs_userspace_cb_t' type-id='ca64ff60' id='16c5f410'/>
-    <typedef-decl name='uid_t' type-id='cc5fcceb' id='354978ed'/>
-    <typedef-decl name='__uid_t' type-id='f0981eeb' id='cc5fcceb'/>
-    <typedef-decl name='zprop_list_t' type-id='bd9b4291' id='bdb8ac4f'/>
+  <abi-instr address-size='64' path='libzfs_dataset.c' language='LANG_C99'>
     <class-decl name='zprop_list' size-in-bits='448' is-struct='yes' visibility='default' id='bd9b4291'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='pl_prop' type-id='95e97e5e' visibility='default'/>
@@ -3634,20 +3293,21 @@
         <var-decl name='pl_fixed' type-id='c19b74c3' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='renameflags_t' type-id='7aee5792' id='067170c2'/>
+    <typedef-decl name='zprop_list_t' type-id='bd9b4291' id='bdb8ac4f'/>
     <class-decl name='renameflags' size-in-bits='32' is-struct='yes' visibility='default' id='7aee5792'>
-      <data-member access='public' layout-offset-in-bits='31'>
+      <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='recursive' type-id='95e97e5e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='30'>
+      <data-member access='public' layout-offset-in-bits='1'>
         <var-decl name='nounmount' type-id='95e97e5e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='29'>
+      <data-member access='public' layout-offset-in-bits='2'>
         <var-decl name='forceunmount' type-id='95e97e5e' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_prop_t' type-id='3fed383f' id='58603c44'/>
-    <enum-decl name='__anonymous_enum__2' is-anonymous='yes' id='3fed383f'>
+    <typedef-decl name='renameflags_t' type-id='7aee5792' id='067170c2'/>
+    <typedef-decl name='zfs_userspace_cb_t' type-id='ca64ff60' id='16c5f410'/>
+    <enum-decl name='zfs_prop_t' naming-typedef-id='58603c44' id='4b000d60'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZPROP_CONT' value='-2'/>
       <enumerator name='ZPROP_INVAL' value='-1'/>
@@ -3748,8 +3408,25 @@
       <enumerator name='ZFS_PROP_REDACT_SNAPS' value='94'/>
       <enumerator name='ZFS_NUM_PROPS' value='95'/>
     </enum-decl>
-    <typedef-decl name='zprop_source_t' type-id='3eed36ac' id='a2256d42'/>
-    <enum-decl name='__anonymous_enum__3' is-anonymous='yes' id='3eed36ac'>
+    <typedef-decl name='zfs_prop_t' type-id='4b000d60' id='58603c44'/>
+    <enum-decl name='zfs_userquota_prop_t' naming-typedef-id='279fde6a' id='5258d2f6'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='ZFS_PROP_USERUSED' value='0'/>
+      <enumerator name='ZFS_PROP_USERQUOTA' value='1'/>
+      <enumerator name='ZFS_PROP_GROUPUSED' value='2'/>
+      <enumerator name='ZFS_PROP_GROUPQUOTA' value='3'/>
+      <enumerator name='ZFS_PROP_USEROBJUSED' value='4'/>
+      <enumerator name='ZFS_PROP_USEROBJQUOTA' value='5'/>
+      <enumerator name='ZFS_PROP_GROUPOBJUSED' value='6'/>
+      <enumerator name='ZFS_PROP_GROUPOBJQUOTA' value='7'/>
+      <enumerator name='ZFS_PROP_PROJECTUSED' value='8'/>
+      <enumerator name='ZFS_PROP_PROJECTQUOTA' value='9'/>
+      <enumerator name='ZFS_PROP_PROJECTOBJUSED' value='10'/>
+      <enumerator name='ZFS_PROP_PROJECTOBJQUOTA' value='11'/>
+      <enumerator name='ZFS_NUM_USERQUOTA_PROPS' value='12'/>
+    </enum-decl>
+    <typedef-decl name='zfs_userquota_prop_t' type-id='5258d2f6' id='279fde6a'/>
+    <enum-decl name='zprop_source_t' naming-typedef-id='a2256d42' id='5903f80e'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZPROP_SRC_NONE' value='1'/>
       <enumerator name='ZPROP_SRC_DEFAULT' value='2'/>
@@ -3758,6 +3435,13 @@
       <enumerator name='ZPROP_SRC_INHERITED' value='16'/>
       <enumerator name='ZPROP_SRC_RECEIVED' value='32'/>
     </enum-decl>
+    <typedef-decl name='zprop_source_t' type-id='5903f80e' id='a2256d42'/>
+    <enum-decl name='zfs_wait_activity_t' naming-typedef-id='3024501a' id='527d5dc6'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
+      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
+    </enum-decl>
+    <typedef-decl name='zfs_wait_activity_t' type-id='527d5dc6' id='3024501a'/>
     <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -3772,6 +3456,8 @@
         <var-decl name='mnt_mntopts' type-id='26a90f95' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='__uid_t' type-id='f0981eeb' id='cc5fcceb'/>
+    <typedef-decl name='uid_t' type-id='cc5fcceb' id='354978ed'/>
     <pointer-type-def type-id='26a90f95' size-in-bits='64' id='9b23c9ad'/>
     <qualified-type-def type-id='775509eb' const='yes' id='5eadf2db'/>
     <pointer-type-def type-id='5eadf2db' size-in-bits='64' id='fcd57163'/>
@@ -3783,281 +3469,75 @@
     <pointer-type-def type-id='bdb8ac4f' size-in-bits='64' id='3a9b2288'/>
     <pointer-type-def type-id='3a9b2288' size-in-bits='64' id='e4378506'/>
     <pointer-type-def type-id='a2256d42' size-in-bits='64' id='debc6aa3'/>
-    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='3024501a' name='activity'/>
-      <parameter type-id='37e3bd22' name='missing'/>
-      <parameter type-id='37e3bd22' name='waited'/>
+    <function-decl name='zfs_type_to_name' mangled-name='zfs_type_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_type_to_name'>
+      <parameter type-id='2e45de5d' name='type'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_valid'>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='2e45de5d' name='type'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
-      <parameter type-id='4c81de99' name='zph'/>
-      <parameter type-id='9c313c2d' name='volsize'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <return type-id='9c313c2d'/>
-    </function-decl>
-    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='857bb57e' name='nvl'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='c19b74c3' name='un'/>
-      <parameter type-id='5ce45b60' name='nvl'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='857bb57e' name='nvl'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_release' mangled-name='zfs_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='80f4b756' name='tag'/>
-      <parameter type-id='c19b74c3' name='recursive'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='cleanup_fd'/>
-      <parameter type-id='5ce45b60' name='holds'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_hold' mangled-name='zfs_hold' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='80f4b756' name='tag'/>
-      <parameter type-id='c19b74c3' name='recursive'/>
-      <parameter type-id='95e97e5e' name='cleanup_fd'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='279fde6a' name='type'/>
-      <parameter type-id='16c5f410' name='func'/>
-      <parameter type-id='eaa32e2f' name='arg'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
+    <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_free_handles'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='26a90f95' name='dataset'/>
-      <parameter type-id='26a90f95' name='path'/>
-      <parameter type-id='26a90f95' name='oldname'/>
-      <parameter type-id='26a90f95' name='newname'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='26a90f95' name='dataset'/>
-      <parameter type-id='26a90f95' name='path'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='26a90f95' name='dataset'/>
-      <parameter type-id='26a90f95' name='path'/>
-      <parameter type-id='26a90f95' name='resource'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='26a90f95' name='dataset'/>
-      <parameter type-id='26a90f95' name='path'/>
-      <parameter type-id='26a90f95' name='resource'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='ae3e8ca6' name='props'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
+    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_refresh_properties'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='e4378506' name='plp'/>
-      <parameter type-id='c19b74c3' name='received'/>
-      <parameter type-id='c19b74c3' name='literal'/>
-      <return type-id='95e97e5e'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='5ce45b60'/>
+    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_handle_dup'>
+      <parameter type-id='9200a744' name='zhp_orig'/>
+      <return type-id='9200a744'/>
     </function-decl>
-    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='5ce45b60'/>
+    <function-decl name='zfs_bookmark_exists' mangled-name='zfs_bookmark_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_bookmark_exists'>
+      <parameter type-id='80f4b756' name='path'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='5ce45b60'/>
-    </function-decl>
-    <function-decl name='zfs_rename' mangled-name='zfs_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='target'/>
-      <parameter type-id='067170c2' name='flags'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='9200a744' name='snap'/>
-      <parameter type-id='c19b74c3' name='force'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
+    <function-decl name='zfs_open' mangled-name='zfs_open' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_open'>
       <parameter type-id='b0382bb3' name='hdl'/>
       <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='c19b74c3' name='recursive'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <return type-id='95e97e5e'/>
+      <parameter type-id='95e97e5e' name='types'/>
+      <return type-id='9200a744'/>
     </function-decl>
-    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
+    <function-decl name='zfs_close' mangled-name='zfs_close' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_close'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_init'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='5ce45b60' name='snaps'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <return type-id='95e97e5e'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zfs_promote' mangled-name='zfs_promote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_clone' mangled-name='zfs_clone' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='target'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
+    <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_fini'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='5ce45b60' name='snaps'/>
-      <parameter type-id='c19b74c3' name='defer'/>
-      <return type-id='95e97e5e'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='26a90f95' name='snapname'/>
-      <parameter type-id='c19b74c3' name='defer'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='c19b74c3' name='defer'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_create' mangled-name='zfs_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
+    <function-decl name='libzfs_mnttab_cache' mangled-name='libzfs_mnttab_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_cache'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='2e45de5d' name='type'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <return type-id='95e97e5e'/>
+      <parameter type-id='c19b74c3' name='enable'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
+    <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_find'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='80f4b756' name='fsname'/>
+      <parameter type-id='9d424d31' name='entry'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
+    <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_add'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='special'/>
+      <parameter type-id='80f4b756' name='mountp'/>
+      <parameter type-id='80f4b756' name='mntopts'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_remove'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='fsname'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='26a90f95' name='buf'/>
-      <parameter type-id='b59d7dce' name='buflen'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_get_underlying_type' mangled-name='zfs_get_underlying_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_type'>
-      <parameter type-id='fcd57163' name='zhp'/>
-      <return type-id='2e45de5d'/>
-    </function-decl>
-    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_type'>
-      <parameter type-id='fcd57163' name='zhp'/>
-      <return type-id='2e45de5d'/>
-    </function-decl>
-    <function-decl name='zfs_get_pool_name' mangled-name='zfs_get_pool_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_name'>
-      <parameter type-id='fcd57163' name='zhp'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_name'>
-      <parameter type-id='fcd57163' name='zhp'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_written' mangled-name='zfs_prop_get_written' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='propname'/>
-      <parameter type-id='26a90f95' name='propbuf'/>
-      <parameter type-id='95e97e5e' name='proplen'/>
-      <parameter type-id='c19b74c3' name='literal'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_written_int' mangled-name='zfs_prop_get_written_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written_int'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='propname'/>
-      <parameter type-id='5d6479ae' name='propvalue'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_userquota' mangled-name='zfs_prop_get_userquota' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='propname'/>
-      <parameter type-id='26a90f95' name='propbuf'/>
-      <parameter type-id='95e97e5e' name='proplen'/>
-      <parameter type-id='c19b74c3' name='literal'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_userquota_int' mangled-name='zfs_prop_get_userquota_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota_int'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='propname'/>
-      <parameter type-id='5d6479ae' name='propvalue'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_numeric' mangled-name='zfs_prop_get_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_numeric'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='58603c44' name='prop'/>
-      <parameter type-id='5d6479ae' name='value'/>
-      <parameter type-id='debc6aa3' name='src'/>
-      <parameter type-id='26a90f95' name='statbuf'/>
-      <parameter type-id='b59d7dce' name='statlen'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_int'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='58603c44' name='prop'/>
-      <return type-id='9c313c2d'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='58603c44' name='prop'/>
-      <parameter type-id='26a90f95' name='propbuf'/>
-      <parameter type-id='b59d7dce' name='proplen'/>
-      <parameter type-id='debc6aa3' name='src'/>
-      <parameter type-id='26a90f95' name='statbuf'/>
-      <parameter type-id='b59d7dce' name='statlen'/>
-      <parameter type-id='c19b74c3' name='literal'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_clones_nvl'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='5ce45b60'/>
-    </function-decl>
-    <function-decl name='zfs_prop_get_recvd' mangled-name='zfs_prop_get_recvd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_recvd'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='propname'/>
-      <parameter type-id='26a90f95' name='propbuf'/>
-      <parameter type-id='b59d7dce' name='proplen'/>
-      <parameter type-id='c19b74c3' name='literal'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_inherit' mangled-name='zfs_prop_inherit' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inherit'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='propname'/>
-      <parameter type-id='c19b74c3' name='received'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_set_list' mangled-name='zfs_prop_set_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='propname'/>
-      <parameter type-id='80f4b756' name='propval'/>
+      <parameter type-id='7292109c' name='spa_version'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_valid_proplist' mangled-name='zfs_valid_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valid_proplist'>
@@ -4071,75 +3551,21 @@
       <parameter type-id='80f4b756' name='errbuf'/>
       <return type-id='5ce45b60'/>
     </function-decl>
-    <function-decl name='zfs_spa_version' mangled-name='zfs_spa_version' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_spa_version'>
+    <function-decl name='zfs_prop_set' mangled-name='zfs_prop_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='7292109c' name='spa_version'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='80f4b756' name='propval'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='libzfs_mnttab_remove' mangled-name='libzfs_mnttab_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_remove'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='fsname'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_add' mangled-name='libzfs_mnttab_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_add'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='special'/>
-      <parameter type-id='80f4b756' name='mountp'/>
-      <parameter type-id='80f4b756' name='mntopts'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_cache' mangled-name='libzfs_mnttab_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_cache'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='c19b74c3' name='enable'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_fini' mangled-name='libzfs_mnttab_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_fini'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_init' mangled-name='libzfs_mnttab_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_init'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_close' mangled-name='zfs_close' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_close'>
+    <function-decl name='zfs_prop_set_list' mangled-name='zfs_prop_set_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list'>
       <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_open' mangled-name='zfs_open' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_open'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='95e97e5e' name='types'/>
-      <return type-id='9200a744'/>
-    </function-decl>
-    <function-decl name='zfs_bookmark_exists' mangled-name='zfs_bookmark_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_bookmark_exists'>
-      <parameter type-id='80f4b756' name='path'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_handle_dup' mangled-name='zfs_handle_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_handle_dup'>
-      <parameter type-id='9200a744' name='zhp_orig'/>
-      <return type-id='9200a744'/>
-    </function-decl>
-    <function-decl name='zfs_refresh_properties' mangled-name='zfs_refresh_properties' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_refresh_properties'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zpool_free_handles' mangled-name='zpool_free_handles' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_free_handles'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_name_valid' mangled-name='zfs_name_valid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_valid'>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='2e45de5d' name='type'/>
+      <parameter type-id='5ce45b60' name='props'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_type_to_name' mangled-name='zfs_type_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_type_to_name'>
-      <parameter type-id='2e45de5d' name='type'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='libzfs_mnttab_find' mangled-name='libzfs_mnttab_find' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_mnttab_find'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='fsname'/>
-      <parameter type-id='9d424d31' name='entry'/>
+    <function-decl name='zfs_prop_inherit' mangled-name='zfs_prop_inherit' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inherit'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='c19b74c3' name='received'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='getprop_uint64' mangled-name='getprop_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getprop_uint64'>
@@ -4148,11 +3574,271 @@
       <parameter type-id='9b23c9ad' name='source'/>
       <return type-id='9c313c2d'/>
     </function-decl>
+    <function-decl name='zfs_prop_get_recvd' mangled-name='zfs_prop_get_recvd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_recvd'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='26a90f95' name='propbuf'/>
+      <parameter type-id='b59d7dce' name='proplen'/>
+      <parameter type-id='c19b74c3' name='literal'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_get_clones_nvl' mangled-name='zfs_get_clones_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_clones_nvl'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get' mangled-name='zfs_prop_get' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='58603c44' name='prop'/>
+      <parameter type-id='26a90f95' name='propbuf'/>
+      <parameter type-id='b59d7dce' name='proplen'/>
+      <parameter type-id='debc6aa3' name='src'/>
+      <parameter type-id='26a90f95' name='statbuf'/>
+      <parameter type-id='b59d7dce' name='statlen'/>
+      <parameter type-id='c19b74c3' name='literal'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_int' mangled-name='zfs_prop_get_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_int'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='58603c44' name='prop'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_numeric' mangled-name='zfs_prop_get_numeric' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_numeric'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='58603c44' name='prop'/>
+      <parameter type-id='5d6479ae' name='value'/>
+      <parameter type-id='debc6aa3' name='src'/>
+      <parameter type-id='26a90f95' name='statbuf'/>
+      <parameter type-id='b59d7dce' name='statlen'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_userquota_int' mangled-name='zfs_prop_get_userquota_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota_int'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='5d6479ae' name='propvalue'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_userquota' mangled-name='zfs_prop_get_userquota' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_userquota'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='26a90f95' name='propbuf'/>
+      <parameter type-id='95e97e5e' name='proplen'/>
+      <parameter type-id='c19b74c3' name='literal'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_written_int' mangled-name='zfs_prop_get_written_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written_int'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='5d6479ae' name='propvalue'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_prop_get_written' mangled-name='zfs_prop_get_written' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_written'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='26a90f95' name='propbuf'/>
+      <parameter type-id='95e97e5e' name='proplen'/>
+      <parameter type-id='c19b74c3' name='literal'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_get_name' mangled-name='zfs_get_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_name'>
+      <parameter type-id='fcd57163' name='zhp'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_get_pool_name' mangled-name='zfs_get_pool_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_name'>
+      <parameter type-id='fcd57163' name='zhp'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_get_type' mangled-name='zfs_get_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_type'>
+      <parameter type-id='fcd57163' name='zhp'/>
+      <return type-id='2e45de5d'/>
+    </function-decl>
+    <function-decl name='zfs_get_underlying_type' mangled-name='zfs_get_underlying_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_type'>
+      <parameter type-id='fcd57163' name='zhp'/>
+      <return type-id='2e45de5d'/>
+    </function-decl>
+    <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='b59d7dce' name='buflen'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='zfs_dataset_exists' mangled-name='zfs_dataset_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dataset_exists'>
       <parameter type-id='b0382bb3' name='hdl'/>
       <parameter type-id='80f4b756' name='path'/>
       <parameter type-id='2e45de5d' name='types'/>
       <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_create_ancestors' mangled-name='zfs_create_ancestors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_create' mangled-name='zfs_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_destroy' mangled-name='zfs_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='c19b74c3' name='defer'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_destroy_snaps' mangled-name='zfs_destroy_snaps' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='26a90f95' name='snapname'/>
+      <parameter type-id='c19b74c3' name='defer'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_destroy_snaps_nvl' mangled-name='zfs_destroy_snaps_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='5ce45b60' name='snaps'/>
+      <parameter type-id='c19b74c3' name='defer'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_clone' mangled-name='zfs_clone' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_clone'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='target'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_promote' mangled-name='zfs_promote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_promote'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_snapshot_nvl' mangled-name='zfs_snapshot_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot_nvl'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='5ce45b60' name='snaps'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_snapshot' mangled-name='zfs_snapshot' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_snapshot'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='c19b74c3' name='recursive'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_rollback' mangled-name='zfs_rollback' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rollback'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='9200a744' name='snap'/>
+      <parameter type-id='c19b74c3' name='force'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_rename' mangled-name='zfs_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_rename'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='target'/>
+      <parameter type-id='067170c2' name='flags'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_get_all_props' mangled-name='zfs_get_all_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_all_props'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='zfs_get_recvd_props' mangled-name='zfs_get_recvd_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_recvd_props'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='zfs_get_user_props' mangled-name='zfs_get_user_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_user_props'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='zfs_expand_proplist' mangled-name='zfs_expand_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_expand_proplist'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='e4378506' name='plp'/>
+      <parameter type-id='c19b74c3' name='received'/>
+      <parameter type-id='c19b74c3' name='literal'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_prune_proplist' mangled-name='zfs_prune_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prune_proplist'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='ae3e8ca6' name='props'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_add' mangled-name='zfs_smb_acl_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_add'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='26a90f95' name='dataset'/>
+      <parameter type-id='26a90f95' name='path'/>
+      <parameter type-id='26a90f95' name='resource'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_remove' mangled-name='zfs_smb_acl_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_remove'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='26a90f95' name='dataset'/>
+      <parameter type-id='26a90f95' name='path'/>
+      <parameter type-id='26a90f95' name='resource'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_purge' mangled-name='zfs_smb_acl_purge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_purge'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='26a90f95' name='dataset'/>
+      <parameter type-id='26a90f95' name='path'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_smb_acl_rename' mangled-name='zfs_smb_acl_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_smb_acl_rename'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='26a90f95' name='dataset'/>
+      <parameter type-id='26a90f95' name='path'/>
+      <parameter type-id='26a90f95' name='oldname'/>
+      <parameter type-id='26a90f95' name='newname'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_userspace' mangled-name='zfs_userspace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_userspace'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='279fde6a' name='type'/>
+      <parameter type-id='16c5f410' name='func'/>
+      <parameter type-id='eaa32e2f' name='arg'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_hold' mangled-name='zfs_hold' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='80f4b756' name='tag'/>
+      <parameter type-id='c19b74c3' name='recursive'/>
+      <parameter type-id='95e97e5e' name='cleanup_fd'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_hold_nvl' mangled-name='zfs_hold_nvl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_hold_nvl'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='95e97e5e' name='cleanup_fd'/>
+      <parameter type-id='5ce45b60' name='holds'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_release' mangled-name='zfs_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_release'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='80f4b756' name='tag'/>
+      <parameter type-id='c19b74c3' name='recursive'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_get_fsacl' mangled-name='zfs_get_fsacl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_fsacl'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='857bb57e' name='nvl'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_set_fsacl' mangled-name='zfs_set_fsacl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_set_fsacl'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='c19b74c3' name='un'/>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_get_holds' mangled-name='zfs_get_holds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_holds'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='857bb57e' name='nvl'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zvol_volsize_to_reservation' mangled-name='zvol_volsize_to_reservation' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zvol_volsize_to_reservation'>
+      <parameter type-id='4c81de99' name='zph'/>
+      <parameter type-id='9c313c2d' name='volsize'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
+    <function-decl name='zfs_wait_status' mangled-name='zfs_wait_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_wait_status'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='3024501a' name='activity'/>
+      <parameter type-id='37e3bd22' name='missing'/>
+      <parameter type-id='37e3bd22' name='waited'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-type size-in-bits='64' id='7e291ce6'>
       <parameter type-id='eaa32e2f'/>
@@ -4162,7 +3848,7 @@
       <return type-id='95e97e5e'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_diff.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='libzfs_diff.c' language='LANG_C99'>
     <function-decl name='zfs_show_diffs' mangled-name='zfs_show_diffs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_show_diffs'>
       <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='95e97e5e' name='outfd'/>
@@ -4172,8 +3858,9 @@
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_import.c' language='LANG_C99'>
-    <typedef-decl name='pool_config_ops_t' type-id='1a21babe' id='b1e62775'/>
+  <abi-instr address-size='64' path='libzfs_import.c' language='LANG_C99'>
+    <typedef-decl name='refresh_config_func_t' type-id='29f040d2' id='b7c58eaa'/>
+    <typedef-decl name='pool_active_func_t' type-id='baa42fef' id='de5d1d8f'/>
     <class-decl name='pool_config_ops' size-in-bits='128' is-struct='yes' visibility='default' id='8b092c69'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='pco_refresh_config' type-id='e7c00489' visibility='default'/>
@@ -4182,9 +3869,7 @@
         <var-decl name='pco_pool_active' type-id='9eadf5e0' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='refresh_config_func_t' type-id='29f040d2' id='b7c58eaa'/>
-    <typedef-decl name='pool_active_func_t' type-id='baa42fef' id='de5d1d8f'/>
-    <typedef-decl name='pool_state_t' type-id='4871ac24' id='084a08a3'/>
+    <typedef-decl name='pool_config_ops_t' type-id='1a21babe' id='b1e62775'/>
     <enum-decl name='pool_state' id='4871ac24'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='POOL_STATE_ACTIVE' value='0'/>
@@ -4196,21 +3881,22 @@
       <enumerator name='POOL_STATE_UNAVAIL' value='6'/>
       <enumerator name='POOL_STATE_POTENTIALLY_ACTIVE' value='7'/>
     </enum-decl>
+    <typedef-decl name='pool_state_t' type-id='4871ac24' id='084a08a3'/>
     <qualified-type-def type-id='8b092c69' const='yes' id='1a21babe'/>
     <pointer-type-def type-id='de5d1d8f' size-in-bits='64' id='9eadf5e0'/>
     <pointer-type-def type-id='084a08a3' size-in-bits='64' id='b9ea57b8'/>
     <pointer-type-def type-id='b7c58eaa' size-in-bits='64' id='e7c00489'/>
     <var-decl name='libzfs_config_ops' type-id='b1e62775' mangled-name='libzfs_config_ops' visibility='default' elf-symbol-id='libzfs_config_ops'/>
+    <function-decl name='zpool_clear_label' mangled-name='zpool_clear_label' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear_label'>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='zpool_in_use' mangled-name='zpool_in_use' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_in_use'>
       <parameter type-id='b0382bb3' name='hdl'/>
       <parameter type-id='95e97e5e' name='fd'/>
       <parameter type-id='b9ea57b8' name='state'/>
       <parameter type-id='9b23c9ad' name='namestr'/>
       <parameter type-id='37e3bd22' name='inuse'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_clear_label' mangled-name='zpool_clear_label' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear_label'>
-      <parameter type-id='95e97e5e' name='fd'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-type size-in-bits='64' id='baa42fef'>
@@ -4226,42 +3912,8 @@
       <return type-id='5ce45b60'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_iter.c' language='LANG_C99'>
-    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='c19b74c3' name='allowrecursion'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
-      <parameter type-id='9200a744' name='fs_zhp'/>
-      <parameter type-id='80f4b756' name='spec_orig'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='arg'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='d8e49ab9' name='callback'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <parameter type-id='9c313c2d' name='min_txg'/>
-      <parameter type-id='9c313c2d' name='max_txg'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
+  <abi-instr address-size='64' path='libzfs_iter.c' language='LANG_C99'>
+    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
       <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>
@@ -4276,19 +3928,64 @@
       <parameter type-id='9c313c2d' name='max_txg'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
+    <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='d8e49ab9' name='callback'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <parameter type-id='9c313c2d' name='min_txg'/>
+      <parameter type-id='9c313c2d' name='max_txg'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
+      <parameter type-id='9200a744' name='fs_zhp'/>
+      <parameter type-id='80f4b756' name='spec_orig'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='arg'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='c19b74c3' name='allowrecursion'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
       <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_mount.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='libzfs_mount.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='f1bd64e2' size-in-bits='384' id='b2c36c9f'>
       <subrange length='2' type-id='7359adad' id='52efc4ef'/>
     </array-type-def>
-    <typedef-decl name='proto_table_t' type-id='9faf92fc' id='f1bd64e2'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='f1bd64e2' visibility='default' id='9faf92fc'>
+    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' id='803dac95'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cb_handles' type-id='4507922a' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='cb_alloc' type-id='b59d7dce' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='cb_used' type-id='b59d7dce' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='get_all_cb_t' type-id='803dac95' id='9b293607'/>
+    <class-decl name='proto_table_t' size-in-bits='192' is-struct='yes' naming-typedef-id='f1bd64e2' visibility='default' id='f4c8e1ed'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='p_prop' type-id='58603c44' visibility='default'/>
       </data-member>
@@ -4302,130 +3999,24 @@
         <var-decl name='p_unshare_err' type-id='95e97e5e' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='get_all_cb_t' type-id='803dac95' id='9b293607'/>
-    <class-decl name='get_all_cb' size-in-bits='192' is-struct='yes' visibility='default' id='803dac95'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='cb_handles' type-id='4507922a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='cb_alloc' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='cb_used' type-id='b59d7dce' visibility='default'/>
-      </data-member>
-    </class-decl>
+    <typedef-decl name='proto_table_t' type-id='f4c8e1ed' id='f1bd64e2'/>
     <pointer-type-def type-id='9b293607' size-in-bits='64' id='77bf1784'/>
     <pointer-type-def type-id='9200a744' size-in-bits='64' id='4507922a'/>
     <var-decl name='proto_table' type-id='b2c36c9f' visibility='default'/>
-    <function-decl name='zpool_disable_datasets' mangled-name='zpool_disable_datasets' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_disable_datasets'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='c19b74c3' name='force'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='is_mounted' mangled-name='is_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mounted'>
+      <parameter type-id='b0382bb3' name='zfs_hdl'/>
+      <parameter type-id='80f4b756' name='special'/>
+      <parameter type-id='9b23c9ad' name='where'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='mntopts'/>
-      <parameter type-id='95e97e5e' name='flags'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='4507922a' name='handles'/>
-      <parameter type-id='b59d7dce' name='num_handles'/>
-      <parameter type-id='d8e49ab9' name='func'/>
-      <parameter type-id='eaa32e2f' name='data'/>
-      <parameter type-id='c19b74c3' name='parallel'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
-      <parameter type-id='77bf1784' name='cbp'/>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='mountpoint'/>
-      <parameter type-id='80f4b756' name='proto'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='mountpoint'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='mountpoint'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='mountpoint'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
-      <parameter type-id='80f4b756' name='proto'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_commit_all_shares' mangled-name='zfs_commit_all_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_all_shares'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_commit_smb_shares' mangled-name='zfs_commit_smb_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_smb_shares'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_commit_nfs_shares' mangled-name='zfs_commit_nfs_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_nfs_shares'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
+    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mounted'>
       <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='9b23c9ad' name='where'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
+    <function-decl name='zfs_mount' mangled-name='zfs_mount' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='9b23c9ad' name='where'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_share' mangled-name='zfs_share' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='mountpoint'/>
+      <parameter type-id='80f4b756' name='options'/>
       <parameter type-id='95e97e5e' name='flags'/>
       <return type-id='95e97e5e'/>
     </function-decl>
@@ -4436,111 +4027,132 @@
       <parameter type-id='80f4b756' name='mountpoint'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_mount' mangled-name='zfs_mount' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount'>
+    <function-decl name='zfs_unmount' mangled-name='zfs_unmount' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmount'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='options'/>
+      <parameter type-id='80f4b756' name='mountpoint'/>
       <parameter type-id='95e97e5e' name='flags'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_is_mounted' mangled-name='zfs_is_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_mounted'>
+    <function-decl name='zfs_unmountall' mangled-name='zfs_unmountall' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unmountall'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='95e97e5e' name='flags'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_is_shared' mangled-name='zfs_is_shared' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_share' mangled-name='zfs_share' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_unshare' mangled-name='zfs_unshare' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_is_shared_nfs' mangled-name='zfs_is_shared_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_nfs'>
       <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='9b23c9ad' name='where'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='is_mounted' mangled-name='is_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mounted'>
-      <parameter type-id='b0382bb3' name='zfs_hdl'/>
-      <parameter type-id='80f4b756' name='special'/>
+    <function-decl name='zfs_is_shared_smb' mangled-name='zfs_is_shared_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_is_shared_smb'>
+      <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='9b23c9ad' name='where'/>
       <return type-id='c19b74c3'/>
     </function-decl>
+    <function-decl name='zfs_commit_nfs_shares' mangled-name='zfs_commit_nfs_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_nfs_shares'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_commit_smb_shares' mangled-name='zfs_commit_smb_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_smb_shares'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_commit_all_shares' mangled-name='zfs_commit_all_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_all_shares'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_commit_shares' mangled-name='zfs_commit_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_commit_shares'>
+      <parameter type-id='80f4b756' name='proto'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_share_nfs' mangled-name='zfs_share_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_nfs'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_unshare_nfs' mangled-name='zfs_unshare_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_nfs'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='mountpoint'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_unshare_smb' mangled-name='zfs_unshare_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare_smb'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='mountpoint'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_nfs' mangled-name='zfs_unshareall_nfs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_nfs'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_smb' mangled-name='zfs_unshareall_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_smb'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall' mangled-name='zfs_unshareall' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_bypath' mangled-name='zfs_unshareall_bypath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bypath'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='mountpoint'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_unshareall_bytype' mangled-name='zfs_unshareall_bytype' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshareall_bytype'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='mountpoint'/>
+      <parameter type-id='80f4b756' name='proto'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='libzfs_add_handle' mangled-name='libzfs_add_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_add_handle'>
+      <parameter type-id='77bf1784' name='cbp'/>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_foreach_mountpoint' mangled-name='zfs_foreach_mountpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_foreach_mountpoint'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='4507922a' name='handles'/>
+      <parameter type-id='b59d7dce' name='num_handles'/>
+      <parameter type-id='d8e49ab9' name='func'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <parameter type-id='c19b74c3' name='parallel'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zpool_enable_datasets' mangled-name='zpool_enable_datasets' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_enable_datasets'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='mntopts'/>
+      <parameter type-id='95e97e5e' name='flags'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_disable_datasets' mangled-name='zpool_disable_datasets' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_disable_datasets'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='c19b74c3' name='force'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_pool.c' language='LANG_C99'>
-    <typedef-decl name='zpool_wait_activity_t' type-id='08f5ca1d' id='73446457'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca1d'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
-      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
-      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
-      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
-      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
-      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
-      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
-      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
-      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
-    </enum-decl>
-    <typedef-decl name='splitflags_t' type-id='dc01bf52' id='325c1e34'/>
+  <abi-instr address-size='64' path='libzfs_pool.c' language='LANG_C99'>
     <class-decl name='splitflags' size-in-bits='64' is-struct='yes' visibility='default' id='dc01bf52'>
-      <data-member access='public' layout-offset-in-bits='31'>
+      <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='dryrun' type-id='95e97e5e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='30'>
+      <data-member access='public' layout-offset-in-bits='1'>
         <var-decl name='import' type-id='95e97e5e' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='name_flags' type-id='95e97e5e' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='vdev_aux_t' type-id='7f5bcca4' id='9d774e0b'/>
-    <enum-decl name='vdev_aux' id='7f5bcca4'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='VDEV_AUX_NONE' value='0'/>
-      <enumerator name='VDEV_AUX_OPEN_FAILED' value='1'/>
-      <enumerator name='VDEV_AUX_CORRUPT_DATA' value='2'/>
-      <enumerator name='VDEV_AUX_NO_REPLICAS' value='3'/>
-      <enumerator name='VDEV_AUX_BAD_GUID_SUM' value='4'/>
-      <enumerator name='VDEV_AUX_TOO_SMALL' value='5'/>
-      <enumerator name='VDEV_AUX_BAD_LABEL' value='6'/>
-      <enumerator name='VDEV_AUX_VERSION_NEWER' value='7'/>
-      <enumerator name='VDEV_AUX_VERSION_OLDER' value='8'/>
-      <enumerator name='VDEV_AUX_UNSUP_FEAT' value='9'/>
-      <enumerator name='VDEV_AUX_SPARED' value='10'/>
-      <enumerator name='VDEV_AUX_ERR_EXCEEDED' value='11'/>
-      <enumerator name='VDEV_AUX_IO_FAILURE' value='12'/>
-      <enumerator name='VDEV_AUX_BAD_LOG' value='13'/>
-      <enumerator name='VDEV_AUX_EXTERNAL' value='14'/>
-      <enumerator name='VDEV_AUX_SPLIT_POOL' value='15'/>
-      <enumerator name='VDEV_AUX_BAD_ASHIFT' value='16'/>
-      <enumerator name='VDEV_AUX_EXTERNAL_PERSIST' value='17'/>
-      <enumerator name='VDEV_AUX_ACTIVE' value='18'/>
-      <enumerator name='VDEV_AUX_CHILDREN_OFFLINE' value='19'/>
-      <enumerator name='VDEV_AUX_ASHIFT_TOO_BIG' value='20'/>
-    </enum-decl>
-    <typedef-decl name='vdev_state_t' type-id='21566197' id='35acf840'/>
-    <enum-decl name='vdev_state' id='21566197'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='VDEV_STATE_UNKNOWN' value='0'/>
-      <enumerator name='VDEV_STATE_CLOSED' value='1'/>
-      <enumerator name='VDEV_STATE_OFFLINE' value='2'/>
-      <enumerator name='VDEV_STATE_REMOVED' value='3'/>
-      <enumerator name='VDEV_STATE_CANT_OPEN' value='4'/>
-      <enumerator name='VDEV_STATE_FAULTED' value='5'/>
-      <enumerator name='VDEV_STATE_DEGRADED' value='6'/>
-      <enumerator name='VDEV_STATE_HEALTHY' value='7'/>
-    </enum-decl>
-    <typedef-decl name='pool_scan_func_t' type-id='1b092565' id='7313fbe2'/>
-    <enum-decl name='pool_scan_func' id='1b092565'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='POOL_SCAN_NONE' value='0'/>
-      <enumerator name='POOL_SCAN_SCRUB' value='1'/>
-      <enumerator name='POOL_SCAN_RESILVER' value='2'/>
-      <enumerator name='POOL_SCAN_FUNCS' value='3'/>
-    </enum-decl>
-    <typedef-decl name='pool_scrub_cmd_t' type-id='a1474cbd' id='b51cf3c2'/>
-    <enum-decl name='pool_scrub_cmd' id='a1474cbd'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='POOL_SCRUB_NORMAL' value='0'/>
-      <enumerator name='POOL_SCRUB_PAUSE' value='1'/>
-      <enumerator name='POOL_SCRUB_FLAGS_END' value='2'/>
-    </enum-decl>
-    <typedef-decl name='pool_trim_func_t' type-id='54ed608a' id='b1146b8d'/>
-    <enum-decl name='pool_trim_func' id='54ed608a'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='POOL_TRIM_START' value='0'/>
-      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
-      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
-      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
-    </enum-decl>
-    <typedef-decl name='trimflags_t' type-id='8ef58008' id='a093cbb8'/>
+    <typedef-decl name='splitflags_t' type-id='dc01bf52' id='325c1e34'/>
     <class-decl name='trimflags' size-in-bits='192' is-struct='yes' visibility='default' id='8ef58008'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='fullpool' type-id='c19b74c3' visibility='default'/>
@@ -4555,16 +4167,17 @@
         <var-decl name='rate' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='pool_initialize_func_t' type-id='5c246ad4' id='7063e1ab'/>
-    <enum-decl name='pool_initialize_func' id='5c246ad4'>
+    <typedef-decl name='trimflags_t' type-id='8ef58008' id='a093cbb8'/>
+    <enum-decl name='zpool_compat_status_t' naming-typedef-id='901b78d1' id='20676925'>
       <underlying-type type-id='9cac1fee'/>
-      <enumerator name='POOL_INITIALIZE_START' value='0'/>
-      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
-      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
-      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
+      <enumerator name='ZPOOL_COMPATIBILITY_OK' value='0'/>
+      <enumerator name='ZPOOL_COMPATIBILITY_WARNTOKEN' value='1'/>
+      <enumerator name='ZPOOL_COMPATIBILITY_BADTOKEN' value='2'/>
+      <enumerator name='ZPOOL_COMPATIBILITY_BADFILE' value='3'/>
+      <enumerator name='ZPOOL_COMPATIBILITY_NOFILES' value='4'/>
     </enum-decl>
-    <typedef-decl name='zpool_prop_t' type-id='40ed39d5' id='5d0c23fb'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' id='40ed39d5'>
+    <typedef-decl name='zpool_compat_status_t' type-id='20676925' id='901b78d1'/>
+    <enum-decl name='zpool_prop_t' naming-typedef-id='5d0c23fb' id='af1ba157'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZPOOL_PROP_INVAL' value='-1'/>
       <enumerator name='ZPOOL_PROP_NAME' value='0'/>
@@ -4602,148 +4215,319 @@
       <enumerator name='ZPOOL_PROP_COMPATIBILITY' value='32'/>
       <enumerator name='ZPOOL_NUM_PROPS' value='33'/>
     </enum-decl>
-    <typedef-decl name='zpool_compat_status_t' type-id='3fed3840' id='901b78d1'/>
-    <enum-decl name='__anonymous_enum__2' is-anonymous='yes' id='3fed3840'>
+    <typedef-decl name='zpool_prop_t' type-id='af1ba157' id='5d0c23fb'/>
+    <enum-decl name='vdev_state' id='21566197'>
       <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZPOOL_COMPATIBILITY_OK' value='0'/>
-      <enumerator name='ZPOOL_COMPATIBILITY_WARNTOKEN' value='1'/>
-      <enumerator name='ZPOOL_COMPATIBILITY_BADTOKEN' value='2'/>
-      <enumerator name='ZPOOL_COMPATIBILITY_BADFILE' value='3'/>
-      <enumerator name='ZPOOL_COMPATIBILITY_NOFILES' value='4'/>
+      <enumerator name='VDEV_STATE_UNKNOWN' value='0'/>
+      <enumerator name='VDEV_STATE_CLOSED' value='1'/>
+      <enumerator name='VDEV_STATE_OFFLINE' value='2'/>
+      <enumerator name='VDEV_STATE_REMOVED' value='3'/>
+      <enumerator name='VDEV_STATE_CANT_OPEN' value='4'/>
+      <enumerator name='VDEV_STATE_FAULTED' value='5'/>
+      <enumerator name='VDEV_STATE_DEGRADED' value='6'/>
+      <enumerator name='VDEV_STATE_HEALTHY' value='7'/>
     </enum-decl>
+    <typedef-decl name='vdev_state_t' type-id='21566197' id='35acf840'/>
+    <enum-decl name='vdev_aux' id='7f5bcca4'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='VDEV_AUX_NONE' value='0'/>
+      <enumerator name='VDEV_AUX_OPEN_FAILED' value='1'/>
+      <enumerator name='VDEV_AUX_CORRUPT_DATA' value='2'/>
+      <enumerator name='VDEV_AUX_NO_REPLICAS' value='3'/>
+      <enumerator name='VDEV_AUX_BAD_GUID_SUM' value='4'/>
+      <enumerator name='VDEV_AUX_TOO_SMALL' value='5'/>
+      <enumerator name='VDEV_AUX_BAD_LABEL' value='6'/>
+      <enumerator name='VDEV_AUX_VERSION_NEWER' value='7'/>
+      <enumerator name='VDEV_AUX_VERSION_OLDER' value='8'/>
+      <enumerator name='VDEV_AUX_UNSUP_FEAT' value='9'/>
+      <enumerator name='VDEV_AUX_SPARED' value='10'/>
+      <enumerator name='VDEV_AUX_ERR_EXCEEDED' value='11'/>
+      <enumerator name='VDEV_AUX_IO_FAILURE' value='12'/>
+      <enumerator name='VDEV_AUX_BAD_LOG' value='13'/>
+      <enumerator name='VDEV_AUX_EXTERNAL' value='14'/>
+      <enumerator name='VDEV_AUX_SPLIT_POOL' value='15'/>
+      <enumerator name='VDEV_AUX_BAD_ASHIFT' value='16'/>
+      <enumerator name='VDEV_AUX_EXTERNAL_PERSIST' value='17'/>
+      <enumerator name='VDEV_AUX_ACTIVE' value='18'/>
+      <enumerator name='VDEV_AUX_CHILDREN_OFFLINE' value='19'/>
+      <enumerator name='VDEV_AUX_ASHIFT_TOO_BIG' value='20'/>
+    </enum-decl>
+    <typedef-decl name='vdev_aux_t' type-id='7f5bcca4' id='9d774e0b'/>
+    <enum-decl name='pool_scan_func' id='1b092565'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='POOL_SCAN_NONE' value='0'/>
+      <enumerator name='POOL_SCAN_SCRUB' value='1'/>
+      <enumerator name='POOL_SCAN_RESILVER' value='2'/>
+      <enumerator name='POOL_SCAN_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_scan_func_t' type-id='1b092565' id='7313fbe2'/>
+    <enum-decl name='pool_scrub_cmd' id='a1474cbd'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='POOL_SCRUB_NORMAL' value='0'/>
+      <enumerator name='POOL_SCRUB_PAUSE' value='1'/>
+      <enumerator name='POOL_SCRUB_FLAGS_END' value='2'/>
+    </enum-decl>
+    <typedef-decl name='pool_scrub_cmd_t' type-id='a1474cbd' id='b51cf3c2'/>
+    <enum-decl name='pool_initialize_func' id='5c246ad4'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='POOL_INITIALIZE_START' value='0'/>
+      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
+      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
+      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_initialize_func_t' type-id='5c246ad4' id='7063e1ab'/>
+    <enum-decl name='pool_trim_func' id='54ed608a'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='POOL_TRIM_START' value='0'/>
+      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
+      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
+      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_trim_func_t' type-id='54ed608a' id='b1146b8d'/>
+    <enum-decl name='zpool_wait_activity_t' naming-typedef-id='73446457' id='849338e3'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
+      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
+      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
+      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
+      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
+      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
+      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
+      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
+      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
+    </enum-decl>
+    <typedef-decl name='zpool_wait_activity_t' type-id='849338e3' id='73446457'/>
     <qualified-type-def type-id='8e8d4be3' const='yes' id='693c3853'/>
     <pointer-type-def type-id='693c3853' size-in-bits='64' id='22cce67b'/>
     <pointer-type-def type-id='a093cbb8' size-in-bits='64' id='b13f38c3'/>
     <pointer-type-def type-id='35acf840' size-in-bits='64' id='17f3480d'/>
-    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
+    <function-decl name='zpool_props_refresh' mangled-name='zpool_props_refresh' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_props_refresh'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='857bb57e' name='nvlp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
+    <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='22cce67b' name='envmap'/>
-      <return type-id='95e97e5e'/>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <parameter type-id='debc6aa3' name='src'/>
+      <return type-id='9c313c2d'/>
     </function-decl>
-    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='73446457' name='activity'/>
-      <parameter type-id='37e3bd22' name='missing'/>
-      <parameter type-id='37e3bd22' name='waited'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='zpool_state_to_name' mangled-name='zpool_state_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_state_to_name'>
+      <parameter type-id='35acf840' name='state'/>
+      <parameter type-id='9d774e0b' name='aux'/>
+      <return type-id='80f4b756'/>
     </function-decl>
-    <function-decl name='zpool_wait' mangled-name='zpool_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='73446457' name='activity'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='zpool_pool_state_to_name' mangled-name='zpool_pool_state_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_pool_state_to_name'>
+      <parameter type-id='084a08a3' name='state'/>
+      <return type-id='80f4b756'/>
     </function-decl>
-    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
+    <function-decl name='zpool_get_state_str' mangled-name='zpool_get_state_str' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state_str'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='9c313c2d' name='dsobj'/>
-      <parameter type-id='9c313c2d' name='obj'/>
-      <parameter type-id='26a90f95' name='pathname'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='5d0c23fb' name='prop'/>
+      <parameter type-id='26a90f95' name='buf'/>
       <parameter type-id='b59d7dce' name='len'/>
-      <return type-id='48b5725f'/>
+      <parameter type-id='debc6aa3' name='srctype'/>
+      <parameter type-id='c19b74c3' name='literal'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
+    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='9c313c2d' name='dsobj'/>
-      <parameter type-id='9c313c2d' name='obj'/>
-      <parameter type-id='26a90f95' name='pathname'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='80f4b756' name='propval'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='e4378506' name='plp'/>
+      <parameter type-id='c19b74c3' name='literal'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='26a90f95' name='buf'/>
       <parameter type-id='b59d7dce' name='len'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='pool'/>
+      <return type-id='4c81de99'/>
+    </function-decl>
+    <function-decl name='zpool_open' mangled-name='zpool_open' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='pool'/>
+      <return type-id='4c81de99'/>
+    </function-decl>
+    <function-decl name='zpool_close' mangled-name='zpool_close' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
+      <parameter type-id='4c81de99' name='zhp'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='9c313c2d' name='eid'/>
-      <parameter type-id='95e97e5e' name='zevent_fd'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='7292109c' name='count'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='857bb57e' name='nvp'/>
-      <parameter type-id='7292109c' name='dropped'/>
-      <parameter type-id='f0981eeb' name='flags'/>
-      <parameter type-id='95e97e5e' name='zevent_fd'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
+    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='857bb57e' name='nvhisp'/>
-      <parameter type-id='5d6479ae' name='off'/>
-      <parameter type-id='37e3bd22' name='eof'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
+      <parameter type-id='4c81de99' name='zhp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
+    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
+      <parameter type-id='80f4b756' name='name'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zpool_create' mangled-name='zpool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='message'/>
+      <parameter type-id='80f4b756' name='pool'/>
+      <parameter type-id='5ce45b60' name='nvroot'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='5ce45b60' name='fsprops'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
-      <parameter type-id='95e97e5e' name='argc'/>
-      <parameter type-id='9b23c9ad' name='argv'/>
-      <parameter type-id='26a90f95' name='string'/>
-      <parameter type-id='95e97e5e' name='len'/>
+    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='log_str'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_add' mangled-name='zpool_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='5ce45b60' name='nvroot'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_export' mangled-name='zpool_export' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='c19b74c3' name='force'/>
+      <parameter type-id='80f4b756' name='log_str'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='log_str'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='95e97e5e' name='reason'/>
+      <parameter type-id='5ce45b60' name='config'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='9c313c2d' name='new_version'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='857bb57e' name='nverrlistp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
+    <function-decl name='zpool_import' mangled-name='zpool_import' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='5ce45b60' name='nv'/>
-      <parameter type-id='95e97e5e' name='name_flags'/>
-      <return type-id='26a90f95'/>
-    </function-decl>
-    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='eaa32e2f' name='data'/>
+      <parameter type-id='5ce45b60' name='config'/>
+      <parameter type-id='80f4b756' name='newname'/>
+      <parameter type-id='26a90f95' name='altroot'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='eaa32e2f' name='data'/>
+    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
+      <parameter type-id='5ce45b60' name='config'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='5ce45b60' name='config'/>
+      <parameter type-id='80f4b756' name='newname'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='95e97e5e' name='flags'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
+    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
       <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='7063e1ab' name='cmd_type'/>
+      <parameter type-id='5ce45b60' name='vds'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
+    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='7063e1ab' name='cmd_type'/>
+      <parameter type-id='5ce45b60' name='vds'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_trim' mangled-name='zpool_trim' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='b1146b8d' name='cmd_type'/>
+      <parameter type-id='5ce45b60' name='vds'/>
+      <parameter type-id='b13f38c3' name='trim_flags'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_scan' mangled-name='zpool_scan' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='7313fbe2' name='func'/>
+      <parameter type-id='b51cf3c2' name='cmd'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='ppath'/>
+      <parameter type-id='37e3bd22' name='avail_spare'/>
+      <parameter type-id='37e3bd22' name='l2cache'/>
+      <parameter type-id='37e3bd22' name='log'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='37e3bd22' name='avail_spare'/>
+      <parameter type-id='37e3bd22' name='l2cache'/>
+      <parameter type-id='37e3bd22' name='log'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='26a90f95' name='physpath'/>
+      <parameter type-id='b59d7dce' name='phypath_size'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='95e97e5e' name='flags'/>
+      <parameter type-id='17f3480d' name='newstate'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='c19b74c3' name='istmp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='9c313c2d' name='guid'/>
+      <parameter type-id='9d774e0b' name='aux'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_clear' mangled-name='zpool_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
+    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='5ce45b60' name='rewindnvl'/>
+      <parameter type-id='9c313c2d' name='guid'/>
+      <parameter type-id='9d774e0b' name='aux'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
+    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='5d6479ae' name='sizep'/>
+      <parameter type-id='80f4b756' name='old_disk'/>
+      <parameter type-id='80f4b756' name='new_disk'/>
+      <parameter type-id='5ce45b60' name='nvroot'/>
+      <parameter type-id='95e97e5e' name='replacing'/>
+      <parameter type-id='c19b74c3' name='rebuild'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
+    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='80f4b756' name='path'/>
       <return type-id='95e97e5e'/>
@@ -4756,236 +4540,138 @@
       <parameter type-id='325c1e34' name='flags'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_vdev_detach' mangled-name='zpool_vdev_detach' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_detach'>
+    <function-decl name='zpool_vdev_remove' mangled-name='zpool_vdev_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove'>
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='80f4b756' name='path'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_vdev_attach' mangled-name='zpool_vdev_attach' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_attach'>
+    <function-decl name='zpool_vdev_remove_cancel' mangled-name='zpool_vdev_remove_cancel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_remove_cancel'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='old_disk'/>
-      <parameter type-id='80f4b756' name='new_disk'/>
-      <parameter type-id='5ce45b60' name='nvroot'/>
-      <parameter type-id='95e97e5e' name='replacing'/>
-      <parameter type-id='c19b74c3' name='rebuild'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_vdev_degrade' mangled-name='zpool_vdev_degrade' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_degrade'>
+    <function-decl name='zpool_vdev_indirect_size' mangled-name='zpool_vdev_indirect_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_indirect_size'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='5d6479ae' name='sizep'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_clear' mangled-name='zpool_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_clear'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='5ce45b60' name='rewindnvl'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_vdev_clear' mangled-name='zpool_vdev_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_clear'>
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='9c313c2d' name='guid'/>
-      <parameter type-id='9d774e0b' name='aux'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_vdev_fault' mangled-name='zpool_vdev_fault' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_fault'>
+    <function-decl name='zpool_reguid' mangled-name='zpool_reguid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reguid'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='9c313c2d' name='guid'/>
-      <parameter type-id='9d774e0b' name='aux'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_vdev_offline' mangled-name='zpool_vdev_offline' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_offline'>
+    <function-decl name='zpool_reopen_one' mangled-name='zpool_reopen_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_reopen_one'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='c19b74c3' name='istmp'/>
+      <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_vdev_online' mangled-name='zpool_vdev_online' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_online'>
+    <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='95e97e5e' name='flags'/>
-      <parameter type-id='17f3480d' name='newstate'/>
+      <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_vdev_path_to_guid' mangled-name='zpool_vdev_path_to_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_path_to_guid'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='path'/>
-      <return type-id='9c313c2d'/>
-    </function-decl>
-    <function-decl name='zpool_get_physpath' mangled-name='zpool_get_physpath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_physpath'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='26a90f95' name='physpath'/>
-      <parameter type-id='b59d7dce' name='phypath_size'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='37e3bd22' name='avail_spare'/>
-      <parameter type-id='37e3bd22' name='l2cache'/>
-      <parameter type-id='37e3bd22' name='log'/>
-      <return type-id='5ce45b60'/>
-    </function-decl>
-    <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='ppath'/>
-      <parameter type-id='37e3bd22' name='avail_spare'/>
-      <parameter type-id='37e3bd22' name='l2cache'/>
-      <parameter type-id='37e3bd22' name='log'/>
-      <return type-id='5ce45b60'/>
-    </function-decl>
-    <function-decl name='zpool_scan' mangled-name='zpool_scan' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_scan'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='7313fbe2' name='func'/>
-      <parameter type-id='b51cf3c2' name='cmd'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_trim' mangled-name='zpool_trim' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='b1146b8d' name='cmd_type'/>
-      <parameter type-id='5ce45b60' name='vds'/>
-      <parameter type-id='b13f38c3' name='trim_flags'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_initialize_wait' mangled-name='zpool_initialize_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_wait'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='7063e1ab' name='cmd_type'/>
-      <parameter type-id='5ce45b60' name='vds'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_initialize' mangled-name='zpool_initialize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='7063e1ab' name='cmd_type'/>
-      <parameter type-id='5ce45b60' name='vds'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_import_props' mangled-name='zpool_import_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
+    <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='5ce45b60' name='config'/>
-      <parameter type-id='80f4b756' name='newname'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <parameter type-id='95e97e5e' name='flags'/>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='5ce45b60' name='nv'/>
+      <parameter type-id='95e97e5e' name='name_flags'/>
+      <return type-id='26a90f95'/>
+    </function-decl>
+    <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='857bb57e' name='nverrlistp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
-      <parameter type-id='5ce45b60' name='config'/>
+    <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='9c313c2d' name='new_version'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_save_arguments' mangled-name='zfs_save_arguments' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_save_arguments'>
+      <parameter type-id='95e97e5e' name='argc'/>
+      <parameter type-id='9b23c9ad' name='argv'/>
+      <parameter type-id='26a90f95' name='string'/>
+      <parameter type-id='95e97e5e' name='len'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zpool_import' mangled-name='zpool_import' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
+    <function-decl name='zpool_log_history' mangled-name='zpool_log_history' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_log_history'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='5ce45b60' name='config'/>
-      <parameter type-id='80f4b756' name='newname'/>
-      <parameter type-id='26a90f95' name='altroot'/>
+      <parameter type-id='80f4b756' name='message'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_explain_recover' mangled-name='zpool_explain_recover' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_explain_recover'>
+    <function-decl name='zpool_get_history' mangled-name='zpool_get_history' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_history'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='857bb57e' name='nvhisp'/>
+      <parameter type-id='5d6479ae' name='off'/>
+      <parameter type-id='37e3bd22' name='eof'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_events_next' mangled-name='zpool_events_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_next'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='95e97e5e' name='reason'/>
-      <parameter type-id='5ce45b60' name='config'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zpool_export_force' mangled-name='zpool_export_force' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export_force'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='log_str'/>
+      <parameter type-id='857bb57e' name='nvp'/>
+      <parameter type-id='7292109c' name='dropped'/>
+      <parameter type-id='f0981eeb' name='flags'/>
+      <parameter type-id='95e97e5e' name='zevent_fd'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_export' mangled-name='zpool_export' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_export'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='c19b74c3' name='force'/>
-      <parameter type-id='80f4b756' name='log_str'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_add' mangled-name='zpool_add' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_add'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='5ce45b60' name='nvroot'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_discard_checkpoint' mangled-name='zpool_discard_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_discard_checkpoint'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_checkpoint' mangled-name='zpool_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_checkpoint'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_destroy' mangled-name='zpool_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_destroy'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='log_str'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_create' mangled-name='zpool_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_create'>
+    <function-decl name='zpool_events_clear' mangled-name='zpool_events_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_clear'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='pool'/>
-      <parameter type-id='5ce45b60' name='nvroot'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <parameter type-id='5ce45b60' name='fsprops'/>
+      <parameter type-id='7292109c' name='count'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_is_draid_spare' mangled-name='zpool_is_draid_spare' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_is_draid_spare'>
-      <parameter type-id='80f4b756' name='name'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zpool_get_state' mangled-name='zpool_get_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
-      <parameter type-id='4c81de99' name='zhp'/>
+    <function-decl name='zpool_events_seek' mangled-name='zpool_events_seek' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_events_seek'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='9c313c2d' name='eid'/>
+      <parameter type-id='95e97e5e' name='zevent_fd'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_get_name' mangled-name='zpool_get_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_name'>
+    <function-decl name='zpool_obj_to_path' mangled-name='zpool_obj_to_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zpool_close' mangled-name='zpool_close' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_close'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zpool_open' mangled-name='zpool_open' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='pool'/>
-      <return type-id='4c81de99'/>
-    </function-decl>
-    <function-decl name='zpool_open_canfail' mangled-name='zpool_open_canfail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_open_canfail'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='pool'/>
-      <return type-id='4c81de99'/>
-    </function-decl>
-    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='propname'/>
-      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='9c313c2d' name='dsobj'/>
+      <parameter type-id='9c313c2d' name='obj'/>
+      <parameter type-id='26a90f95' name='pathname'/>
       <parameter type-id='b59d7dce' name='len'/>
-      <return type-id='95e97e5e'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zpool_expand_proplist' mangled-name='zpool_expand_proplist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_expand_proplist'>
+    <function-decl name='zpool_obj_to_path_ds' mangled-name='zpool_obj_to_path_ds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_obj_to_path_ds'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='e4378506' name='plp'/>
-      <parameter type-id='c19b74c3' name='literal'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_set_prop' mangled-name='zpool_set_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_prop'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='80f4b756' name='propname'/>
-      <parameter type-id='80f4b756' name='propval'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_get_prop' mangled-name='zpool_get_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='9c313c2d' name='dsobj'/>
+      <parameter type-id='9c313c2d' name='obj'/>
+      <parameter type-id='26a90f95' name='pathname'/>
       <parameter type-id='b59d7dce' name='len'/>
-      <parameter type-id='debc6aa3' name='srctype'/>
-      <parameter type-id='c19b74c3' name='literal'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zpool_wait' mangled-name='zpool_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='73446457' name='activity'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_pool_state_to_name' mangled-name='zpool_pool_state_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_pool_state_to_name'>
-      <parameter type-id='084a08a3' name='state'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zpool_state_to_name' mangled-name='zpool_state_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_state_to_name'>
-      <parameter type-id='35acf840' name='state'/>
-      <parameter type-id='9d774e0b' name='aux'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
+    <function-decl name='zpool_wait_status' mangled-name='zpool_wait_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_wait_status'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='5d0c23fb' name='prop'/>
-      <parameter type-id='debc6aa3' name='src'/>
-      <return type-id='9c313c2d'/>
-    </function-decl>
-    <function-decl name='zpool_props_refresh' mangled-name='zpool_props_refresh' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_props_refresh'>
-      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='73446457' name='activity'/>
+      <parameter type-id='37e3bd22' name='missing'/>
+      <parameter type-id='37e3bd22' name='waited'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_get_state_str' mangled-name='zpool_get_state_str' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state_str'>
+    <function-decl name='zpool_set_bootenv' mangled-name='zpool_set_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_set_bootenv'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <return type-id='80f4b756'/>
+      <parameter type-id='22cce67b' name='envmap'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_get_bootenv' mangled-name='zpool_get_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_bootenv'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='857bb57e' name='nvlp'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zpool_load_compat' mangled-name='zpool_load_compat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_load_compat'>
       <parameter type-id='80f4b756' name='compat'/>
@@ -4995,50 +4681,7 @@
       <return type-id='901b78d1'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_sendrecv.c' language='LANG_C99'>
-    <typedef-decl name='recvflags_t' type-id='34a384dc' id='9e59d1d4'/>
-    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' id='34a384dc'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='verbose' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='isprefix' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='istail' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='dryrun' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='force' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='canmountoff' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='resumable' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='byteswap' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='nomount' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='holds' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='skipholds' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='domount' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='forceunmount' type-id='c19b74c3' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='sendflags_t' type-id='f6aa15be' id='945467e6'/>
+  <abi-instr address-size='64' path='libzfs_sendrecv.c' language='LANG_C99'>
     <class-decl name='sendflags' size-in-bits='544' is-struct='yes' visibility='default' id='f6aa15be'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='verbosity' type-id='95e97e5e' visibility='default'/>
@@ -5092,26 +4735,78 @@
         <var-decl name='saved' type-id='c19b74c3' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='sendflags_t' type-id='f6aa15be' id='945467e6'/>
     <typedef-decl name='snapfilter_cb_t' type-id='d2a5e211' id='3d3ffb69'/>
+    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' id='34a384dc'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='verbose' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='isprefix' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='istail' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='dryrun' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='force' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='canmountoff' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='resumable' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='byteswap' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='nomount' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='holds' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='skipholds' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='domount' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='forceunmount' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='recvflags_t' type-id='34a384dc' id='9e59d1d4'/>
     <pointer-type-def type-id='f20fbd51' size-in-bits='64' id='a3681dea'/>
     <pointer-type-def type-id='9e59d1d4' size-in-bits='64' id='4ea84b4f'/>
     <pointer-type-def type-id='945467e6' size-in-bits='64' id='8def7735'/>
     <pointer-type-def type-id='3d3ffb69' size-in-bits='64' id='72a26210'/>
-    <function-decl name='zfs_receive' mangled-name='zfs_receive' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='tosnap'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <parameter type-id='4ea84b4f' name='flags'/>
-      <parameter type-id='95e97e5e' name='infd'/>
-      <parameter type-id='a3681dea' name='stream_avl'/>
+    <function-decl name='zfs_send_progress' mangled-name='zfs_send_progress' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_progress'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='5d6479ae' name='bytes_written'/>
+      <parameter type-id='5d6479ae' name='blocks_visited'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_send_one' mangled-name='zfs_send_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_one'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='from'/>
-      <parameter type-id='95e97e5e' name='fd'/>
+    <function-decl name='zfs_send_resume_token_to_nvlist' mangled-name='zfs_send_resume_token_to_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume_token_to_nvlist'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='token'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='zfs_send_resume' mangled-name='zfs_send_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume'>
+      <parameter type-id='b0382bb3' name='hdl'/>
       <parameter type-id='8def7735' name='flags'/>
-      <parameter type-id='80f4b756' name='redactbook'/>
+      <parameter type-id='95e97e5e' name='outfd'/>
+      <parameter type-id='80f4b756' name='resume_token'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_send_saved' mangled-name='zfs_send_saved' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_saved'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='8def7735' name='flags'/>
+      <parameter type-id='95e97e5e' name='outfd'/>
+      <parameter type-id='80f4b756' name='resume_token'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_send' mangled-name='zfs_send' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send'>
@@ -5125,30 +4820,21 @@
       <parameter type-id='857bb57e' name='debugnvp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_send_saved' mangled-name='zfs_send_saved' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_saved'>
+    <function-decl name='zfs_send_one' mangled-name='zfs_send_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_one'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='8def7735' name='flags'/>
-      <parameter type-id='95e97e5e' name='outfd'/>
-      <parameter type-id='80f4b756' name='resume_token'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_send_resume' mangled-name='zfs_send_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='8def7735' name='flags'/>
-      <parameter type-id='95e97e5e' name='outfd'/>
-      <parameter type-id='80f4b756' name='resume_token'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_send_resume_token_to_nvlist' mangled-name='zfs_send_resume_token_to_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_resume_token_to_nvlist'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='token'/>
-      <return type-id='5ce45b60'/>
-    </function-decl>
-    <function-decl name='zfs_send_progress' mangled-name='zfs_send_progress' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_progress'>
-      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='from'/>
       <parameter type-id='95e97e5e' name='fd'/>
-      <parameter type-id='5d6479ae' name='bytes_written'/>
-      <parameter type-id='5d6479ae' name='blocks_visited'/>
+      <parameter type-id='8def7735' name='flags'/>
+      <parameter type-id='80f4b756' name='redactbook'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_receive' mangled-name='zfs_receive' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_receive'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='tosnap'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='4ea84b4f' name='flags'/>
+      <parameter type-id='95e97e5e' name='infd'/>
+      <parameter type-id='a3681dea' name='stream_avl'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-type size-in-bits='64' id='d2a5e211'>
@@ -5157,9 +4843,8 @@
       <return type-id='c19b74c3'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_status.c' language='LANG_C99'>
-    <typedef-decl name='zpool_status_t' type-id='08f5ca1e' id='d3dd6294'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca1e'>
+  <abi-instr address-size='64' path='libzfs_status.c' language='LANG_C99'>
+    <enum-decl name='zpool_status_t' naming-typedef-id='d3dd6294' id='5e770b40'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZPOOL_STATUS_CORRUPT_CACHE' value='0'/>
       <enumerator name='ZPOOL_STATUS_MISSING_DEV_R' value='1'/>
@@ -5195,7 +4880,7 @@
       <enumerator name='ZPOOL_STATUS_INCOMPATIBLE_FEAT' value='31'/>
       <enumerator name='ZPOOL_STATUS_OK' value='32'/>
     </enum-decl>
-    <typedef-decl name='zpool_errata_t' type-id='d9abbf54' id='688c495b'/>
+    <typedef-decl name='zpool_status_t' type-id='5e770b40' id='d3dd6294'/>
     <enum-decl name='zpool_errata' id='d9abbf54'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZPOOL_ERRATA_NONE' value='0'/>
@@ -5204,21 +4889,22 @@
       <enumerator name='ZPOOL_ERRATA_ZOL_6845_ENCRYPTION' value='3'/>
       <enumerator name='ZPOOL_ERRATA_ZOL_8308_ENCRYPTION' value='4'/>
     </enum-decl>
+    <typedef-decl name='zpool_errata_t' type-id='d9abbf54' id='688c495b'/>
     <pointer-type-def type-id='688c495b' size-in-bits='64' id='cec6f2e4'/>
-    <function-decl name='zpool_import_status' mangled-name='zpool_import_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_status'>
-      <parameter type-id='5ce45b60' name='config'/>
-      <parameter type-id='9b23c9ad' name='msgid'/>
-      <parameter type-id='cec6f2e4' name='errata'/>
-      <return type-id='d3dd6294'/>
-    </function-decl>
     <function-decl name='zpool_get_status' mangled-name='zpool_get_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_status'>
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='9b23c9ad' name='msgid'/>
       <parameter type-id='cec6f2e4' name='errata'/>
       <return type-id='d3dd6294'/>
     </function-decl>
+    <function-decl name='zpool_import_status' mangled-name='zpool_import_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_status'>
+      <parameter type-id='5ce45b60' name='config'/>
+      <parameter type-id='9b23c9ad' name='msgid'/>
+      <parameter type-id='cec6f2e4' name='errata'/>
+      <return type-id='d3dd6294'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_util.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='libzfs_util.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='95e97e5e' size-in-bits='192' id='e41bdf22'>
       <subrange length='6' type-id='7359adad' id='52fa524b'/>
     </array-type-def>
@@ -5226,8 +4912,16 @@
     <array-type-def dimensions='1' type-id='19cefcee' size-in-bits='160' alignment-in-bits='32' id='3fcf57d2'>
       <subrange length='5' type-id='7359adad' id='53010e10'/>
     </array-type-def>
-    <typedef-decl name='zprop_func' type-id='2e711a2a' id='1ec3747a'/>
-    <typedef-decl name='zprop_get_cbdata_t' type-id='f3d3c319' id='f3d87113'/>
+    <enum-decl name='zfs_get_column_t' naming-typedef-id='19cefcee' id='223bdcaa'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='GET_COL_NONE' value='0'/>
+      <enumerator name='GET_COL_NAME' value='1'/>
+      <enumerator name='GET_COL_PROPERTY' value='2'/>
+      <enumerator name='GET_COL_VALUE' value='3'/>
+      <enumerator name='GET_COL_RECVD' value='4'/>
+      <enumerator name='GET_COL_SOURCE' value='5'/>
+    </enum-decl>
+    <typedef-decl name='zfs_get_column_t' type-id='223bdcaa' id='19cefcee'/>
     <class-decl name='zprop_get_cbdata' size-in-bits='640' is-struct='yes' visibility='default' id='f3d3c319'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='cb_sources' type-id='95e97e5e' visibility='default'/>
@@ -5254,51 +4948,89 @@
         <var-decl name='cb_type' type-id='2e45de5d' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_get_column_t' type-id='08f5ca1f' id='19cefcee'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca1f'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='GET_COL_NONE' value='0'/>
-      <enumerator name='GET_COL_NAME' value='1'/>
-      <enumerator name='GET_COL_PROPERTY' value='2'/>
-      <enumerator name='GET_COL_VALUE' value='3'/>
-      <enumerator name='GET_COL_RECVD' value='4'/>
-      <enumerator name='GET_COL_SOURCE' value='5'/>
-    </enum-decl>
+    <typedef-decl name='zprop_get_cbdata_t' type-id='f3d3c319' id='f3d87113'/>
+    <typedef-decl name='zprop_func' type-id='2e711a2a' id='1ec3747a'/>
     <pointer-type-def type-id='9b23c9ad' size-in-bits='64' id='c0563f85'/>
     <pointer-type-def type-id='c70fa2e8' size-in-bits='64' id='2e711a2a'/>
     <pointer-type-def type-id='f3d87113' size-in-bits='64' id='0d2a0670'/>
-    <function-decl name='printf_color' mangled-name='printf_color' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
-      <parameter type-id='26a90f95' name='color'/>
-      <parameter type-id='26a90f95' name='format'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_version_print' mangled-name='zfs_version_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_version_userland' mangled-name='zfs_version_userland' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_userland'>
-      <parameter type-id='26a90f95' name='version'/>
-      <parameter type-id='95e97e5e' name='len'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zprop_iter' mangled-name='zprop_iter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter'>
-      <parameter type-id='1ec3747a' name='func'/>
-      <parameter type-id='eaa32e2f' name='cb'/>
-      <parameter type-id='c19b74c3' name='show_all'/>
-      <parameter type-id='c19b74c3' name='ordered'/>
-      <parameter type-id='2e45de5d' name='type'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zprop_free_list' mangled-name='zprop_free_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_free_list'>
-      <parameter type-id='3a9b2288' name='pl'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zprop_get_list' mangled-name='zprop_get_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_get_list'>
+    <function-decl name='libzfs_errno' mangled-name='libzfs_errno' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_errno'>
       <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='26a90f95' name='props'/>
-      <parameter type-id='e4378506' name='listp'/>
-      <parameter type-id='2e45de5d' name='type'/>
       <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='libzfs_error_action' mangled-name='libzfs_error_action' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_action'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='libzfs_error_description' mangled-name='libzfs_error_description' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_description'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='95e97e5e' name='error'/>
+      <parameter type-id='80f4b756' name='msg'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='libzfs_print_on_error' mangled-name='libzfs_print_on_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_print_on_error'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='c19b74c3' name='printerr'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process'>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='9b23c9ad' name='argv'/>
+      <parameter type-id='95e97e5e' name='flags'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='libzfs_run_process_get_stdout' mangled-name='libzfs_run_process_get_stdout' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout'>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='9b23c9ad' name='argv'/>
+      <parameter type-id='9b23c9ad' name='env'/>
+      <parameter type-id='c0563f85' name='lines'/>
+      <parameter type-id='7292109c' name='lines_cnt'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='libzfs_run_process_get_stdout_nopath' mangled-name='libzfs_run_process_get_stdout_nopath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout_nopath'>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='9b23c9ad' name='argv'/>
+      <parameter type-id='9b23c9ad' name='env'/>
+      <parameter type-id='c0563f85' name='lines'/>
+      <parameter type-id='7292109c' name='lines_cnt'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='libzfs_free_str_array' mangled-name='libzfs_free_str_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_free_str_array'>
+      <parameter type-id='9b23c9ad' name='strs'/>
+      <parameter type-id='95e97e5e' name='count'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_envvar_is_set'>
+      <parameter type-id='26a90f95' name='envvar'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='libzfs_init' mangled-name='libzfs_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
+      <return type-id='b0382bb3'/>
+    </function-decl>
+    <function-decl name='libzfs_fini' mangled-name='libzfs_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_fini'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_handle'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <return type-id='b0382bb3'/>
+    </function-decl>
+    <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_handle'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='b0382bb3'/>
+    </function-decl>
+    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_handle'>
+      <parameter type-id='fcd57163' name='zhp'/>
+      <return type-id='4c81de99'/>
+    </function-decl>
+    <function-decl name='zfs_path_to_zhandle' mangled-name='zfs_path_to_zhandle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_path_to_zhandle'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='2e45de5d' name='argtype'/>
+      <return type-id='9200a744'/>
     </function-decl>
     <function-decl name='zprop_print_one_property' mangled-name='zprop_print_one_property' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_print_one_property'>
       <parameter type-id='80f4b756' name='name'/>
@@ -5310,89 +5042,37 @@
       <parameter type-id='80f4b756' name='recvd_value'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zfs_path_to_zhandle' mangled-name='zfs_path_to_zhandle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_path_to_zhandle'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='2e45de5d' name='argtype'/>
-      <return type-id='9200a744'/>
-    </function-decl>
-    <function-decl name='zfs_get_pool_handle' mangled-name='zfs_get_pool_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_pool_handle'>
-      <parameter type-id='fcd57163' name='zhp'/>
-      <return type-id='4c81de99'/>
-    </function-decl>
-    <function-decl name='zfs_get_handle' mangled-name='zfs_get_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_handle'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <return type-id='b0382bb3'/>
-    </function-decl>
-    <function-decl name='zpool_get_handle' mangled-name='zpool_get_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_handle'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <return type-id='b0382bb3'/>
-    </function-decl>
-    <function-decl name='libzfs_fini' mangled-name='libzfs_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_fini'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='libzfs_init' mangled-name='libzfs_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
-      <return type-id='b0382bb3'/>
-    </function-decl>
-    <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_envvar_is_set'>
-      <parameter type-id='26a90f95' name='envvar'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='libzfs_free_str_array' mangled-name='libzfs_free_str_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_free_str_array'>
-      <parameter type-id='9b23c9ad' name='strs'/>
-      <parameter type-id='95e97e5e' name='count'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='libzfs_run_process_get_stdout_nopath' mangled-name='libzfs_run_process_get_stdout_nopath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout_nopath'>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='9b23c9ad' name='argv'/>
-      <parameter type-id='9b23c9ad' name='env'/>
-      <parameter type-id='c0563f85' name='lines'/>
-      <parameter type-id='7292109c' name='lines_cnt'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='libzfs_run_process_get_stdout' mangled-name='libzfs_run_process_get_stdout' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process_get_stdout'>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='9b23c9ad' name='argv'/>
-      <parameter type-id='9b23c9ad' name='env'/>
-      <parameter type-id='c0563f85' name='lines'/>
-      <parameter type-id='7292109c' name='lines_cnt'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='libzfs_run_process' mangled-name='libzfs_run_process' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_run_process'>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='9b23c9ad' name='argv'/>
-      <parameter type-id='95e97e5e' name='flags'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='libzfs_print_on_error' mangled-name='libzfs_print_on_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_print_on_error'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='c19b74c3' name='printerr'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_standard_error' mangled-name='zfs_standard_error' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_standard_error'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='95e97e5e' name='error'/>
-      <parameter type-id='80f4b756' name='msg'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='libzfs_error_action' mangled-name='libzfs_error_action' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_action'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='libzfs_errno' mangled-name='libzfs_errno' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_errno'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='libzfs_error_description' mangled-name='libzfs_error_description' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_description'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
     <function-decl name='zfs_nicestrtonum' mangled-name='zfs_nicestrtonum' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicestrtonum'>
       <parameter type-id='b0382bb3' name='hdl'/>
       <parameter type-id='80f4b756' name='value'/>
       <parameter type-id='5d6479ae' name='num'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zprop_get_list' mangled-name='zprop_get_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_get_list'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='26a90f95' name='props'/>
+      <parameter type-id='e4378506' name='listp'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zprop_free_list' mangled-name='zprop_free_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_free_list'>
+      <parameter type-id='3a9b2288' name='pl'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zprop_iter' mangled-name='zprop_iter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_iter'>
+      <parameter type-id='1ec3747a' name='func'/>
+      <parameter type-id='eaa32e2f' name='cb'/>
+      <parameter type-id='c19b74c3' name='show_all'/>
+      <parameter type-id='c19b74c3' name='ordered'/>
+      <parameter type-id='2e45de5d' name='type'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_version_userland' mangled-name='zfs_version_userland' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_userland'>
+      <parameter type-id='26a90f95' name='version'/>
+      <parameter type-id='95e97e5e' name='len'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_version_print' mangled-name='zfs_version_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_print'>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='color_start' mangled-name='color_start' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_start'>
@@ -5402,33 +5082,20 @@
     <function-decl name='color_end' mangled-name='color_end' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_end'>
       <return type-id='48b5725f'/>
     </function-decl>
+    <function-decl name='printf_color' mangled-name='printf_color' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
+      <parameter type-id='26a90f95' name='color'/>
+      <parameter type-id='26a90f95' name='format'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-type size-in-bits='64' id='c70fa2e8'>
       <parameter type-id='95e97e5e'/>
       <parameter type-id='eaa32e2f'/>
       <return type-id='95e97e5e'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_mount_os.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/libzfs_mount_os.c' language='LANG_C99'>
     <pointer-type-def type-id='7359adad' size-in-bits='64' id='1d2c2b85'/>
-    <function-decl name='zpool_disable_volume_os' mangled-name='zpool_disable_volume_os' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_disable_volume_os'>
-      <parameter type-id='80f4b756' name='name'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zpool_disable_datasets_os' mangled-name='zpool_disable_datasets_os' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_disable_datasets_os'>
-      <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='c19b74c3' name='force'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_mount_delegation_check' mangled-name='zfs_mount_delegation_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_delegation_check'>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_adjust_mount_options' mangled-name='zfs_adjust_mount_options' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_adjust_mount_options'>
-      <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='80f4b756' name='mntpoint'/>
-      <parameter type-id='26a90f95' name='mntopts'/>
-      <parameter type-id='26a90f95' name='mtabopt'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
     <function-decl name='zfs_parse_mount_options' mangled-name='zfs_parse_mount_options' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_mount_options'>
       <parameter type-id='26a90f95' name='mntopts'/>
       <parameter type-id='1d2c2b85' name='mntflags'/>
@@ -5438,8 +5105,27 @@
       <parameter type-id='26a90f95' name='mtabopt'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='zfs_adjust_mount_options' mangled-name='zfs_adjust_mount_options' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_adjust_mount_options'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='80f4b756' name='mntpoint'/>
+      <parameter type-id='26a90f95' name='mntopts'/>
+      <parameter type-id='26a90f95' name='mtabopt'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zfs_mount_delegation_check' mangled-name='zfs_mount_delegation_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_mount_delegation_check'>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_disable_datasets_os' mangled-name='zpool_disable_datasets_os' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_disable_datasets_os'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='c19b74c3' name='force'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zpool_disable_volume_os' mangled-name='zpool_disable_volume_os' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_disable_volume_os'>
+      <parameter type-id='80f4b756' name='name'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_pool_os.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/libzfs_pool_os.c' language='LANG_C99'>
     <function-decl name='zpool_label_disk' mangled-name='zpool_label_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk'>
       <parameter type-id='b0382bb3' name='hdl'/>
       <parameter type-id='4c81de99' name='zhp'/>
@@ -5447,7 +5133,7 @@
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_util_os.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/libzfs_util_os.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='32768' id='d16c6df4'>
       <subrange length='4096' type-id='7359adad' id='bc1b5ddc'/>
     </array-type-def>
@@ -5460,7 +5146,101 @@
     <array-type-def dimensions='1' type-id='b96825af' size-in-bits='24' id='d3490169'>
       <subrange length='3' type-id='7359adad' id='56f209d2'/>
     </array-type-def>
-    <typedef-decl name='zfs_cmd_t' type-id='3522cd69' id='a5559cdd'/>
+    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' id='09fcdc01'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_magic' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_versioninfo' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_creation_time' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_type' type-id='230f1e16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='drr_flags' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_fromguid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_toname' type-id='d1617432' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='3216f820'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zi_objset' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zi_object' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zi_start' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zi_end' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='zi_guid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='zi_level' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='zi_error' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='zi_type' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='zi_freq' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='zi_failfast' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zi_func' type-id='d1617432' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='zi_iotype' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2592'>
+        <var-decl name='zi_duration' type-id='3ff5601b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2624'>
+        <var-decl name='zi_timer' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='zi_nlanes' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2752'>
+        <var-decl name='zi_cmd' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2784'>
+        <var-decl name='zi_dvas' type-id='8f92235e' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zinject_record_t' type-id='3216f820' id='a4301ca6'/>
+    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='feb6f2da'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='z_exportdata' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='z_sharedata' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='z_sharetype' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='z_sharemax' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_share_t' type-id='feb6f2da' id='ee5cec36'/>
     <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='3522cd69'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zc_name' type-id='d16c6df4' visibility='default'/>
@@ -5568,102 +5348,7 @@
         <var-decl name='zc_zoneid' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_share_t' type-id='feb6f2da' id='ee5cec36'/>
-    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='feb6f2da'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='z_exportdata' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='z_sharedata' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='z_sharetype' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='z_sharemax' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' id='09fcdc01'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_magic' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_versioninfo' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_creation_time' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_type' type-id='230f1e16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_flags' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_fromguid' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_toname' type-id='d1617432' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zinject_record_t' type-id='3216f820' id='a4301ca6'/>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='3216f820'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zi_objset' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zi_object' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zi_start' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zi_end' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zi_guid' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='zi_level' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='zi_error' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='zi_type' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='zi_freq' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='zi_failfast' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='zi_func' type-id='d1617432' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='zi_iotype' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2592'>
-        <var-decl name='zi_duration' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2624'>
-        <var-decl name='zi_timer' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2688'>
-        <var-decl name='zi_nlanes' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2752'>
-        <var-decl name='zi_cmd' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2784'>
-        <var-decl name='zi_dvas' type-id='8f92235e' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zfs_stat_t' type-id='6417f0b9' id='0371a9c7'/>
+    <typedef-decl name='zfs_cmd_t' type-id='3522cd69' id='a5559cdd'/>
     <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' id='6417f0b9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zs_gen' type-id='9c313c2d' visibility='default'/>
@@ -5678,90 +5363,83 @@
         <var-decl name='zs_ctime' type-id='c1c22e6c' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='zfs_stat_t' type-id='6417f0b9' id='0371a9c7'/>
     <pointer-type-def type-id='a5559cdd' size-in-bits='64' id='e4ec4540'/>
-    <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_kernel'>
-      <parameter type-id='26a90f95' name='version'/>
-      <parameter type-id='95e97e5e' name='len'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_destroy_snaps_nvl_os' mangled-name='zfs_destroy_snaps_nvl_os' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl_os'>
-      <parameter type-id='b0382bb3' name='hdl'/>
-      <parameter type-id='5ce45b60' name='snaps'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='libzfs_error_init' mangled-name='libzfs_error_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_init'>
-      <parameter type-id='95e97e5e' name='error'/>
-      <return type-id='80f4b756'/>
-    </function-decl>
     <function-decl name='zfs_ioctl' mangled-name='zfs_ioctl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_ioctl'>
       <parameter type-id='b0382bb3' name='hdl'/>
       <parameter type-id='95e97e5e' name='request'/>
       <parameter type-id='e4ec4540' name='zc'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='libzfs_error_init' mangled-name='libzfs_error_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_error_init'>
+      <parameter type-id='95e97e5e' name='error'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_destroy_snaps_nvl_os' mangled-name='zfs_destroy_snaps_nvl_os' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_destroy_snaps_nvl_os'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='5ce45b60' name='snaps'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_version_kernel' mangled-name='zfs_version_kernel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_kernel'>
+      <parameter type-id='26a90f95' name='version'/>
+      <parameter type-id='95e97e5e' name='len'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_device_path_os.c' language='LANG_C99'>
-    <function-decl name='is_mpath_whole_disk' mangled-name='is_mpath_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mpath_whole_disk'>
-      <parameter type-id='80f4b756' name='path'/>
-      <return type-id='c19b74c3'/>
+  <abi-instr address-size='64' path='os/linux/zutil_device_path_os.c' language='LANG_C99'>
+    <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_append_partition'>
+      <parameter type-id='26a90f95' name='path'/>
+      <parameter type-id='b59d7dce' name='max_len'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_get_underlying_path' mangled-name='zfs_get_underlying_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_path'>
-      <parameter type-id='80f4b756' name='dev_name'/>
-      <return type-id='26a90f95'/>
-    </function-decl>
-    <function-decl name='zfs_dev_is_whole_disk' mangled-name='zfs_dev_is_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_whole_disk'>
-      <parameter type-id='80f4b756' name='dev_name'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_dev_is_dm' mangled-name='zfs_dev_is_dm' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_dm'>
-      <parameter type-id='80f4b756' name='dev_name'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='zfs_get_enclosure_sysfs_path' mangled-name='zfs_get_enclosure_sysfs_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_enclosure_sysfs_path'>
-      <parameter type-id='80f4b756' name='dev_name'/>
+    <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_partition'>
+      <parameter type-id='26a90f95' name='path'/>
       <return type-id='26a90f95'/>
     </function-decl>
     <function-decl name='zfs_strip_path' mangled-name='zfs_strip_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_path'>
       <parameter type-id='26a90f95' name='path'/>
       <return type-id='26a90f95'/>
     </function-decl>
-    <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_partition'>
-      <parameter type-id='26a90f95' name='path'/>
+    <function-decl name='zfs_get_enclosure_sysfs_path' mangled-name='zfs_get_enclosure_sysfs_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_enclosure_sysfs_path'>
+      <parameter type-id='80f4b756' name='dev_name'/>
       <return type-id='26a90f95'/>
     </function-decl>
-    <function-decl name='zfs_append_partition' mangled-name='zfs_append_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_append_partition'>
-      <parameter type-id='26a90f95' name='path'/>
-      <parameter type-id='b59d7dce' name='max_len'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='zfs_dev_is_dm' mangled-name='zfs_dev_is_dm' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_dm'>
+      <parameter type-id='80f4b756' name='dev_name'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_dev_is_whole_disk' mangled-name='zfs_dev_is_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_is_whole_disk'>
+      <parameter type-id='80f4b756' name='dev_name'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_get_underlying_path' mangled-name='zfs_get_underlying_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_underlying_path'>
+      <parameter type-id='80f4b756' name='dev_name'/>
+      <return type-id='26a90f95'/>
+    </function-decl>
+    <function-decl name='is_mpath_whole_disk' mangled-name='is_mpath_whole_disk' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='is_mpath_whole_disk'>
+      <parameter type-id='80f4b756' name='path'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zutil_import_os.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/zutil_import_os.c' language='LANG_C99'>
     <class-decl name='udev_device' is-struct='yes' visibility='default' is-declaration-only='yes' id='640b33ca'/>
     <qualified-type-def type-id='80f4b756' const='yes' id='b99c00c9'/>
     <pointer-type-def type-id='b99c00c9' size-in-bits='64' id='13956559'/>
     <pointer-type-def type-id='b59d7dce' size-in-bits='64' id='78c01427'/>
     <pointer-type-def type-id='640b33ca' size-in-bits='64' id='b32bae08'/>
-    <function-decl name='update_vdev_config_dev_strs' mangled-name='update_vdev_config_dev_strs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='update_vdev_config_dev_strs'>
-      <parameter type-id='5ce45b60' name='nv'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk_wait'>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='95e97e5e' name='timeout_ms'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zfs_device_get_devid' mangled-name='zfs_device_get_devid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_devid'>
-      <parameter type-id='b32bae08' name='dev'/>
-      <parameter type-id='26a90f95' name='bufptr'/>
-      <parameter type-id='b59d7dce' name='buflen'/>
+    <class-decl name='udev_device' is-struct='yes' visibility='default' is-declaration-only='yes' id='640b33ca'/>
+    <function-decl name='zfs_dev_flush' mangled-name='zfs_dev_flush' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_flush'>
+      <parameter type-id='95e97e5e' name='fd'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zpool_default_search_paths' mangled-name='zpool_default_search_paths' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_default_search_paths'>
       <parameter type-id='78c01427' name='count'/>
       <return type-id='13956559'/>
     </function-decl>
-    <function-decl name='zfs_dev_flush' mangled-name='zfs_dev_flush' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dev_flush'>
-      <parameter type-id='95e97e5e' name='fd'/>
+    <function-decl name='zfs_device_get_devid' mangled-name='zfs_device_get_devid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_devid'>
+      <parameter type-id='b32bae08' name='dev'/>
+      <parameter type-id='26a90f95' name='bufptr'/>
+      <parameter type-id='b59d7dce' name='buflen'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_device_get_physical' mangled-name='zfs_device_get_physical' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_device_get_physical'>
@@ -5770,15 +5448,26 @@
       <parameter type-id='b59d7dce' name='buflen'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='zpool_label_disk_wait' mangled-name='zpool_label_disk_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_label_disk_wait'>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='95e97e5e' name='timeout_ms'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='update_vdev_config_dev_strs' mangled-name='update_vdev_config_dev_strs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='update_vdev_config_dev_strs'>
+      <parameter type-id='5ce45b60' name='nv'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_device_path.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='zutil_device_path.c' language='LANG_C99'>
     <typedef-decl name='ssize_t' type-id='41060289' id='79a0948f'/>
     <typedef-decl name='__ssize_t' type-id='bd54fe1a' id='41060289'/>
-    <function-decl name='zfs_strcmp_pathname' mangled-name='zfs_strcmp_pathname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strcmp_pathname'>
-      <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='80f4b756' name='cmp'/>
-      <parameter type-id='95e97e5e' name='wholedisk'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='zfs_basename' mangled-name='zfs_basename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_basename'>
+      <parameter type-id='80f4b756' name='path'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
+    <function-decl name='zfs_dirnamelen' mangled-name='zfs_dirnamelen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dirnamelen'>
+      <parameter type-id='80f4b756' name='path'/>
+      <return type-id='79a0948f'/>
     </function-decl>
     <function-decl name='zfs_resolve_shortname' mangled-name='zfs_resolve_shortname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_resolve_shortname'>
       <parameter type-id='80f4b756' name='name'/>
@@ -5786,17 +5475,14 @@
       <parameter type-id='b59d7dce' name='len'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zfs_dirnamelen' mangled-name='zfs_dirnamelen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_dirnamelen'>
-      <parameter type-id='80f4b756' name='path'/>
-      <return type-id='79a0948f'/>
-    </function-decl>
-    <function-decl name='zfs_basename' mangled-name='zfs_basename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_basename'>
-      <parameter type-id='80f4b756' name='path'/>
-      <return type-id='80f4b756'/>
+    <function-decl name='zfs_strcmp_pathname' mangled-name='zfs_strcmp_pathname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strcmp_pathname'>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='80f4b756' name='cmp'/>
+      <parameter type-id='95e97e5e' name='wholedisk'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_import.c' language='LANG_C99'>
-    <typedef-decl name='importargs_t' type-id='7ac83801' id='7a842a6b'/>
+  <abi-instr address-size='64' path='zutil_import.c' language='LANG_C99'>
     <class-decl name='importargs' size-in-bits='448' is-struct='yes' visibility='default' id='7ac83801'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='path' type-id='9b23c9ad' visibility='default'/>
@@ -5823,14 +5509,13 @@
         <var-decl name='policy' type-id='5ce45b60' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='importargs_t' type-id='7ac83801' id='7a842a6b'/>
     <pointer-type-def type-id='7a842a6b' size-in-bits='64' id='07ee4a58'/>
     <pointer-type-def type-id='b1e62775' size-in-bits='64' id='f095e320'/>
-    <function-decl name='zpool_find_config' mangled-name='zpool_find_config' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_config'>
-      <parameter type-id='eaa32e2f' name='hdl'/>
-      <parameter type-id='80f4b756' name='target'/>
-      <parameter type-id='857bb57e' name='configp'/>
-      <parameter type-id='07ee4a58' name='args'/>
-      <parameter type-id='f095e320' name='pco'/>
+    <function-decl name='zpool_read_label' mangled-name='zpool_read_label' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_read_label'>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='857bb57e' name='config'/>
+      <parameter type-id='7292109c' name='num_labels'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zpool_search_import' mangled-name='zpool_search_import' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_search_import'>
@@ -5839,14 +5524,16 @@
       <parameter type-id='f095e320' name='pco'/>
       <return type-id='5ce45b60'/>
     </function-decl>
-    <function-decl name='zpool_read_label' mangled-name='zpool_read_label' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_read_label'>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <parameter type-id='857bb57e' name='config'/>
-      <parameter type-id='7292109c' name='num_labels'/>
+    <function-decl name='zpool_find_config' mangled-name='zpool_find_config' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_config'>
+      <parameter type-id='eaa32e2f' name='hdl'/>
+      <parameter type-id='80f4b756' name='target'/>
+      <parameter type-id='857bb57e' name='configp'/>
+      <parameter type-id='07ee4a58' name='args'/>
+      <parameter type-id='f095e320' name='pco'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_nicenum.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='zutil_nicenum.c' language='LANG_C99'>
     <enum-decl name='zfs_nicenum_format' id='29cf1969'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZFS_NICENUM_1024' value='0'/>
@@ -5855,13 +5542,18 @@
       <enumerator name='ZFS_NICENUM_RAW' value='3'/>
       <enumerator name='ZFS_NICENUM_RAWTIME' value='4'/>
     </enum-decl>
-    <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicebytes'>
+    <function-decl name='zfs_isnumber' mangled-name='zfs_isnumber' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_isnumber'>
+      <parameter type-id='80f4b756' name='str'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_nicenum_format' mangled-name='zfs_nicenum_format' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum_format'>
       <parameter type-id='9c313c2d' name='num'/>
       <parameter type-id='26a90f95' name='buf'/>
       <parameter type-id='b59d7dce' name='buflen'/>
+      <parameter type-id='29cf1969' name='format'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zfs_niceraw' mangled-name='zfs_niceraw' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_niceraw'>
+    <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum'>
       <parameter type-id='9c313c2d' name='num'/>
       <parameter type-id='26a90f95' name='buf'/>
       <parameter type-id='b59d7dce' name='buflen'/>
@@ -5873,29 +5565,23 @@
       <parameter type-id='b59d7dce' name='buflen'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zfs_nicenum' mangled-name='zfs_nicenum' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum'>
+    <function-decl name='zfs_niceraw' mangled-name='zfs_niceraw' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_niceraw'>
       <parameter type-id='9c313c2d' name='num'/>
       <parameter type-id='26a90f95' name='buf'/>
       <parameter type-id='b59d7dce' name='buflen'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='zfs_nicenum_format' mangled-name='zfs_nicenum_format' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicenum_format'>
+    <function-decl name='zfs_nicebytes' mangled-name='zfs_nicebytes' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_nicebytes'>
       <parameter type-id='9c313c2d' name='num'/>
       <parameter type-id='26a90f95' name='buf'/>
       <parameter type-id='b59d7dce' name='buflen'/>
-      <parameter type-id='29cf1969' name='format'/>
       <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='zfs_isnumber' mangled-name='zfs_isnumber' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_isnumber'>
-      <parameter type-id='80f4b756' name='str'/>
-      <return type-id='c19b74c3'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='zutil_pool.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='zutil_pool.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='853fd5dc' size-in-bits='32768' id='b505fc2f'>
       <subrange length='64' type-id='7359adad' id='b10be967'/>
     </array-type-def>
-    <typedef-decl name='ddt_stat_t' type-id='65242dfe' id='853fd5dc'/>
     <class-decl name='ddt_stat' size-in-bits='512' is-struct='yes' visibility='default' id='65242dfe'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='dds_blocks' type-id='9c313c2d' visibility='default'/>
@@ -5922,17 +5608,23 @@
         <var-decl name='dds_ref_dsize' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='ddt_histogram_t' type-id='bc2b3086' id='2d7fe832'/>
+    <typedef-decl name='ddt_stat_t' type-id='65242dfe' id='853fd5dc'/>
     <class-decl name='ddt_histogram' size-in-bits='32768' is-struct='yes' visibility='default' id='bc2b3086'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ddh_stat' type-id='b505fc2f' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='ddt_histogram_t' type-id='bc2b3086' id='2d7fe832'/>
     <qualified-type-def type-id='2d7fe832' const='yes' id='ec92d602'/>
     <pointer-type-def type-id='ec92d602' size-in-bits='64' id='932720f8'/>
     <qualified-type-def type-id='853fd5dc' const='yes' id='764c298c'/>
     <pointer-type-def type-id='764c298c' size-in-bits='64' id='dfe59052'/>
     <pointer-type-def type-id='857bb57e' size-in-bits='64' id='75be733c'/>
+    <function-decl name='zpool_dump_ddt' mangled-name='zpool_dump_ddt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_dump_ddt'>
+      <parameter type-id='dfe59052' name='dds_total'/>
+      <parameter type-id='932720f8' name='ddh'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
     <function-decl name='zpool_history_unpack' mangled-name='zpool_history_unpack' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_history_unpack'>
       <parameter type-id='26a90f95' name='buf'/>
       <parameter type-id='9c313c2d' name='bytes_read'/>
@@ -5940,11 +5632,6 @@
       <parameter type-id='75be733c' name='records'/>
       <parameter type-id='4dd26a40' name='numrecords'/>
       <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zpool_dump_ddt' mangled-name='zpool_dump_ddt' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_dump_ddt'>
-      <parameter type-id='dfe59052' name='dds_total'/>
-      <parameter type-id='932720f8' name='ddh'/>
-      <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>
 </abi-corpus>

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -1,4 +1,4 @@
-<abi-corpus architecture='elf-amd-x86_64' soname='libzfs_core.so.3'>
+<abi-corpus version='2.0' architecture='elf-amd-x86_64' soname='libzfs_core.so.3'>
   <elf-needed>
     <dependency name='libnvpair.so.3'/>
     <dependency name='libpthread.so.0'/>
@@ -6,8 +6,6 @@
     <dependency name='ld-linux-x86-64.so.2'/>
   </elf-needed>
   <elf-function-symbols>
-    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -215,7 +213,7 @@
   <elf-variable-symbols>
     <elf-symbol name='libspl_assert_ok' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='assert.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='assert.c' language='LANG_C99'>
     <type-decl name='variadic parameter type' id='2c1145c5'/>
     <var-decl name='libspl_assert_ok' type-id='95e97e5e' mangled-name='libspl_assert_ok' visibility='default' elf-symbol-id='libspl_assert_ok'/>
     <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
@@ -226,26 +224,21 @@
       <parameter is-variadic='yes'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <pointer-type-def type-id='9b45d938' size-in-bits='64' id='80f4b756'/>
-    <type-decl name='int' size-in-bits='32' id='95e97e5e'/>
-    <type-decl name='void' id='48b5725f'/>
-    <qualified-type-def type-id='a84c031d' const='yes' id='9b45d938'/>
-    <type-decl name='char' size-in-bits='8' id='a84c031d'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='atomic.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='atomic.c' language='LANG_C99'>
     <type-decl name='long int' size-in-bits='64' id='bd54fe1a'/>
     <type-decl name='short int' size-in-bits='16' id='a2185560'/>
     <type-decl name='signed char' size-in-bits='8' id='28577a57'/>
     <type-decl name='unsigned short int' size-in-bits='16' id='8efea9e5'/>
     <typedef-decl name='ulong_t' type-id='7359adad' id='ee1f298e'/>
-    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
-    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
-    <typedef-decl name='ssize_t' type-id='41060289' id='79a0948f'/>
-    <typedef-decl name='__ssize_t' type-id='bd54fe1a' id='41060289'/>
-    <typedef-decl name='int16_t' type-id='03896e23' id='23bd8cb5'/>
-    <typedef-decl name='__int16_t' type-id='a2185560' id='03896e23'/>
     <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
+    <typedef-decl name='int16_t' type-id='03896e23' id='23bd8cb5'/>
+    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
     <typedef-decl name='__int8_t' type-id='28577a57' id='2171a512'/>
+    <typedef-decl name='__int16_t' type-id='a2185560' id='03896e23'/>
+    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
+    <typedef-decl name='__ssize_t' type-id='bd54fe1a' id='41060289'/>
+    <typedef-decl name='ssize_t' type-id='41060289' id='79a0948f'/>
     <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
     <qualified-type-def type-id='149c6638' volatile='yes' id='5120c5f7'/>
     <pointer-type-def type-id='5120c5f7' size-in-bits='64' id='93977ae7'/>
@@ -257,261 +250,36 @@
     <pointer-type-def type-id='6f7e09cb' size-in-bits='64' id='64698d33'/>
     <qualified-type-def type-id='48b5725f' volatile='yes' id='b0b3cbf9'/>
     <pointer-type-def type-id='b0b3cbf9' size-in-bits='64' id='fe09dd29'/>
-    <function-decl name='membar_consumer' mangled-name='membar_consumer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='membar_producer' mangled-name='membar_producer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='membar_enter' mangled-name='membar_enter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='3502e3ff' name='value'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='3502e3ff' name='value'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='eaa32e2f' name='bits'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
+    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
       <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='b96825af'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='eaa32e2f' name='exp'/>
-      <parameter type-id='eaa32e2f' name='des'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
+    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
       <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='149c6638'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
+    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
       <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='b96825af'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
+    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
       <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='149c6638'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
+    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
       <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='8f92235e'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='ee31ee44' name='bits'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
+    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
       <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='ee31ee44' name='bits'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='ee1f298e'/>
-    </function-decl>
-    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
-      <parameter type-id='3a147f31' name='target'/>
-      <return type-id='8f92235e'/>
-    </function-decl>
-    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
-      <parameter type-id='93977ae7' name='target'/>
-      <return type-id='149c6638'/>
-    </function-decl>
-    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <return type-id='b96825af'/>
-    </function-decl>
-    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='ee1f298e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='8f92235e' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='149c6638' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='b96825af' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <parameter type-id='ee31ee44' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
-      <parameter type-id='fe09dd29' name='target'/>
-      <parameter type-id='79a0948f' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
-      <parameter type-id='64698d33' name='target'/>
-      <parameter type-id='bd54fe1a' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <parameter type-id='3ff5601b' name='bits'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
-      <parameter type-id='93977ae7' name='target'/>
-      <parameter type-id='23bd8cb5' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='atomic_add_8' mangled-name='atomic_add_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8'>
@@ -519,37 +287,212 @@
       <parameter type-id='ee31ee44' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_dec_ulong' mangled-name='atomic_dec_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_dec_32' mangled-name='atomic_dec_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32'>
-      <parameter type-id='3a147f31' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_dec_16' mangled-name='atomic_dec_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16'>
+    <function-decl name='atomic_add_16' mangled-name='atomic_add_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16'>
       <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_dec_8' mangled-name='atomic_dec_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8'>
-      <parameter type-id='aa323ea4' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_inc_ulong' mangled-name='atomic_inc_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong'>
-      <parameter type-id='64698d33' name='target'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='atomic_inc_32' mangled-name='atomic_inc_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32'>
+    <function-decl name='atomic_add_32' mangled-name='atomic_add_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32'>
       <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_inc_16' mangled-name='atomic_inc_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16'>
-      <parameter type-id='93977ae7' name='target'/>
+    <function-decl name='atomic_add_long' mangled-name='atomic_add_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='atomic_inc_8' mangled-name='atomic_inc_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8'>
+    <function-decl name='atomic_add_ptr' mangled-name='atomic_add_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8' mangled-name='atomic_sub_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8'>
       <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='ee31ee44' name='bits'/>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16' mangled-name='atomic_sub_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32' mangled-name='atomic_sub_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long' mangled-name='atomic_sub_long' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr' mangled-name='atomic_sub_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_8' mangled-name='atomic_or_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_16' mangled-name='atomic_or_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_32' mangled-name='atomic_or_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong' mangled-name='atomic_or_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_8' mangled-name='atomic_and_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_16' mangled-name='atomic_and_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_32' mangled-name='atomic_and_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong' mangled-name='atomic_and_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='atomic_inc_8_nv' mangled-name='atomic_inc_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_inc_16_nv' mangled-name='atomic_inc_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_inc_32_nv' mangled-name='atomic_inc_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_inc_ulong_nv' mangled-name='atomic_inc_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_inc_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_dec_8_nv' mangled-name='atomic_dec_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_dec_16_nv' mangled-name='atomic_dec_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_dec_32_nv' mangled-name='atomic_dec_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_dec_ulong_nv' mangled-name='atomic_dec_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_dec_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_add_8_nv' mangled-name='atomic_add_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='ee31ee44' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_add_16_nv' mangled-name='atomic_add_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_add_32_nv' mangled-name='atomic_add_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_add_long_nv' mangled-name='atomic_add_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_long_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_add_ptr_nv' mangled-name='atomic_add_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_add_ptr_nv'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_sub_8_nv' mangled-name='atomic_sub_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='ee31ee44' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_sub_16_nv' mangled-name='atomic_sub_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='23bd8cb5' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_sub_32_nv' mangled-name='atomic_sub_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='3ff5601b' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_sub_long_nv' mangled-name='atomic_sub_long_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_long_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='bd54fe1a' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_sub_ptr_nv' mangled-name='atomic_sub_ptr_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_sub_ptr_nv'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='79a0948f' name='bits'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_or_8_nv' mangled-name='atomic_or_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_or_16_nv' mangled-name='atomic_or_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_or_32_nv' mangled-name='atomic_or_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_or_ulong_nv' mangled-name='atomic_or_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_or_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_and_8_nv' mangled-name='atomic_and_8_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_8_nv'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_and_16_nv' mangled-name='atomic_and_16_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_16_nv'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_and_32_nv' mangled-name='atomic_and_32_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_32_nv'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_and_ulong_nv' mangled-name='atomic_and_ulong_nv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_and_ulong_nv'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='ee1f298e'/>
     </function-decl>
     <function-decl name='atomic_cas_8' mangled-name='atomic_cas_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_8'>
       <parameter type-id='aa323ea4' name='target'/>
@@ -575,24 +518,74 @@
       <parameter type-id='ee1f298e' name='des'/>
       <return type-id='ee1f298e'/>
     </function-decl>
-    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
-    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
-    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
-    <typedef-decl name='uint_t' type-id='f0981eeb' id='3502e3ff'/>
+    <function-decl name='atomic_cas_ptr' mangled-name='atomic_cas_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_cas_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='eaa32e2f' name='exp'/>
+      <parameter type-id='eaa32e2f' name='des'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_swap_8' mangled-name='atomic_swap_8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_8'>
+      <parameter type-id='aa323ea4' name='target'/>
+      <parameter type-id='b96825af' name='bits'/>
+      <return type-id='b96825af'/>
+    </function-decl>
+    <function-decl name='atomic_swap_16' mangled-name='atomic_swap_16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_16'>
+      <parameter type-id='93977ae7' name='target'/>
+      <parameter type-id='149c6638' name='bits'/>
+      <return type-id='149c6638'/>
+    </function-decl>
+    <function-decl name='atomic_swap_32' mangled-name='atomic_swap_32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_32'>
+      <parameter type-id='3a147f31' name='target'/>
+      <parameter type-id='8f92235e' name='bits'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ulong' mangled-name='atomic_swap_ulong' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ulong'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='ee1f298e' name='bits'/>
+      <return type-id='ee1f298e'/>
+    </function-decl>
+    <function-decl name='atomic_swap_ptr' mangled-name='atomic_swap_ptr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_swap_ptr'>
+      <parameter type-id='fe09dd29' name='target'/>
+      <parameter type-id='eaa32e2f' name='bits'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='atomic_set_long_excl' mangled-name='atomic_set_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_set_long_excl'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='3502e3ff' name='value'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='atomic_clear_long_excl' mangled-name='atomic_clear_long_excl' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='atomic_clear_long_excl'>
+      <parameter type-id='64698d33' name='target'/>
+      <parameter type-id='3502e3ff' name='value'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='membar_enter' mangled-name='membar_enter' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_enter'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='membar_producer' mangled-name='membar_producer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_producer'>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='membar_consumer' mangled-name='membar_consumer' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='membar_consumer'>
+      <return type-id='48b5725f'/>
+    </function-decl>
     <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
-    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
-    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
-    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='f0981eeb'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='002ac4a6'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='getexecname.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='getexecname.c' language='LANG_C99'>
     <function-decl name='getexecname' mangled-name='getexecname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getexecname'>
       <return type-id='80f4b756'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='list.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='list.c' language='LANG_C99'>
+    <typedef-decl name='list_node_t' type-id='b0b5e45e' id='b21843b2'/>
     <typedef-decl name='list_t' type-id='e824dae9' id='0899125f'/>
+    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' id='b0b5e45e'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='b03eadb4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='b03eadb4' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='list' size-in-bits='256' is-struct='yes' visibility='default' id='e824dae9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='list_size' type-id='b59d7dce' visibility='default'/>
@@ -605,67 +598,32 @@
       </data-member>
     </class-decl>
     <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
-    <class-decl name='list_node' size-in-bits='128' is-struct='yes' visibility='default' id='b0b5e45e'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='b03eadb4' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='prev' type-id='b03eadb4' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='list_node_t' type-id='b0b5e45e' id='b21843b2'/>
     <pointer-type-def type-id='b0b5e45e' size-in-bits='64' id='b03eadb4'/>
     <pointer-type-def type-id='b21843b2' size-in-bits='64' id='ccc38265'/>
     <pointer-type-def type-id='0899125f' size-in-bits='64' id='352ec160'/>
-    <function-decl name='list_is_empty' mangled-name='list_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+    <function-decl name='list_create' mangled-name='list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
       <parameter type-id='352ec160' name='list'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='list_link_active' mangled-name='list_link_active' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
-      <parameter type-id='ccc38265' name='ln'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='list_link_init' mangled-name='list_link_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
-      <parameter type-id='ccc38265' name='ln'/>
+      <parameter type-id='b59d7dce' name='size'/>
+      <parameter type-id='b59d7dce' name='offset'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_link_replace' mangled-name='list_link_replace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
-      <parameter type-id='ccc38265' name='lold'/>
-      <parameter type-id='ccc38265' name='lnew'/>
+    <function-decl name='list_destroy' mangled-name='list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
+      <parameter type-id='352ec160' name='list'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_move_tail' mangled-name='list_move_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
-      <parameter type-id='352ec160' name='dst'/>
-      <parameter type-id='352ec160' name='src'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='list_prev' mangled-name='list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
+    <function-decl name='list_insert_after' mangled-name='list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <return type-id='eaa32e2f'/>
+      <parameter type-id='eaa32e2f' name='nobject'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_next' mangled-name='list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
+    <function-decl name='list_insert_before' mangled-name='list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <return type-id='eaa32e2f'/>
+      <parameter type-id='eaa32e2f' name='nobject'/>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_tail' mangled-name='list_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_head' mangled-name='list_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_remove_head' mangled-name='list_remove_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
-      <parameter type-id='352ec160' name='list'/>
-      <return type-id='eaa32e2f'/>
-    </function-decl>
-    <function-decl name='list_remove' mangled-name='list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
+    <function-decl name='list_insert_head' mangled-name='list_insert_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
       <return type-id='48b5725f'/>
@@ -675,49 +633,75 @@
       <parameter type-id='eaa32e2f' name='object'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_insert_head' mangled-name='list_insert_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_head'>
+    <function-decl name='list_remove' mangled-name='list_remove' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_insert_before' mangled-name='list_insert_before' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_before'>
+    <function-decl name='list_remove_head' mangled-name='list_remove_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_head'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_remove_tail' mangled-name='list_remove_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_remove_tail'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_head' mangled-name='list_head' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_head'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_tail' mangled-name='list_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_tail'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_next' mangled-name='list_next' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_next'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <parameter type-id='eaa32e2f' name='nobject'/>
-      <return type-id='48b5725f'/>
+      <return type-id='eaa32e2f'/>
     </function-decl>
-    <function-decl name='list_insert_after' mangled-name='list_insert_after' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_insert_after'>
+    <function-decl name='list_prev' mangled-name='list_prev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_prev'>
       <parameter type-id='352ec160' name='list'/>
       <parameter type-id='eaa32e2f' name='object'/>
-      <parameter type-id='eaa32e2f' name='nobject'/>
+      <return type-id='eaa32e2f'/>
+    </function-decl>
+    <function-decl name='list_move_tail' mangled-name='list_move_tail' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_move_tail'>
+      <parameter type-id='352ec160' name='dst'/>
+      <parameter type-id='352ec160' name='src'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_destroy' mangled-name='list_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_destroy'>
-      <parameter type-id='352ec160' name='list'/>
+    <function-decl name='list_link_replace' mangled-name='list_link_replace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_replace'>
+      <parameter type-id='ccc38265' name='lold'/>
+      <parameter type-id='ccc38265' name='lnew'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='list_create' mangled-name='list_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_create'>
-      <parameter type-id='352ec160' name='list'/>
-      <parameter type-id='b59d7dce' name='size'/>
-      <parameter type-id='b59d7dce' name='offset'/>
+    <function-decl name='list_link_init' mangled-name='list_link_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_init'>
+      <parameter type-id='ccc38265' name='ln'/>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='list_link_active' mangled-name='list_link_active' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_link_active'>
+      <parameter type-id='ccc38265' name='ln'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='list_is_empty' mangled-name='list_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='list_is_empty'>
+      <parameter type-id='352ec160' name='list'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='mkdirp.c' language='LANG_C99'>
-    <typedef-decl name='mode_t' type-id='e1c52942' id='d50d396c'/>
+  <abi-instr address-size='64' path='mkdirp.c' language='LANG_C99'>
     <typedef-decl name='__mode_t' type-id='f0981eeb' id='e1c52942'/>
+    <typedef-decl name='mode_t' type-id='e1c52942' id='d50d396c'/>
     <function-decl name='mkdirp' mangled-name='mkdirp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='mkdirp'>
       <parameter type-id='80f4b756' name='d'/>
       <parameter type-id='d50d396c' name='mode'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/gethostid.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/gethostid.c' language='LANG_C99'>
     <function-decl name='get_system_hostid' mangled-name='get_system_hostid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_system_hostid'>
       <return type-id='7359adad'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/getmntany.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/getmntany.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='03085adc' size-in-bits='192' id='083f8d58'>
       <subrange length='3' type-id='7359adad' id='56f209d2'/>
     </array-type-def>
@@ -727,6 +711,23 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
+    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mnt_mountp' type-id='26a90f95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mnt_fstype' type-id='26a90f95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mnt_mntopts' type-id='26a90f95' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' id='0c544dc0'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -795,24 +796,18 @@
       </data-member>
     </class-decl>
     <typedef-decl name='__dev_t' type-id='7359adad' id='35ed8932'/>
-    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
-    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
     <typedef-decl name='__uid_t' type-id='f0981eeb' id='cc5fcceb'/>
     <typedef-decl name='__gid_t' type-id='f0981eeb' id='d94ec6d9'/>
+    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
+    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
     <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
+    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
+    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
     <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
     <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='03085adc' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
     <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
     <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
+    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='95e97e5e' visibility='default'/>
@@ -881,16 +876,16 @@
         <var-decl name='_offset' type-id='724e4de6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='__pad1' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_codecvt' type-id='570f8c59' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='__pad2' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_wide_data' type-id='c65a1f29' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='__pad3' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_freeres_list' type-id='dca988a5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='__pad4' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_freeres_buf' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='__pad5' type-id='b59d7dce' visibility='default'/>
@@ -902,46 +897,26 @@
         <var-decl name='_unused2' type-id='664ac0b7' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='010ae0b9'>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_next' type-id='e4c6fa61' visibility='default'/>
+        <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_sbuf' type-id='dca988a5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_pos' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
-    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
-    <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='mnt_mountp' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mnt_fstype' type-id='26a90f95' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='mnt_mntopts' type-id='26a90f95' visibility='default'/>
+        <var-decl name='tv_nsec' type-id='03085adc' visibility='default'/>
       </data-member>
     </class-decl>
     <pointer-type-def type-id='aa12d1ba' size-in-bits='64' id='822cd80b'/>
     <pointer-type-def type-id='ec1ed955' size-in-bits='64' id='dca988a5'/>
+    <pointer-type-def type-id='a4036571' size-in-bits='64' id='570f8c59'/>
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
+    <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
     <pointer-type-def type-id='0c544dc0' size-in-bits='64' id='394fc496'/>
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
-    <function-decl name='getextmntent' mangled-name='getextmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
-      <parameter type-id='80f4b756' name='path'/>
-      <parameter type-id='394fc496' name='entry'/>
-      <parameter type-id='62f7a03d' name='statbuf'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <function-decl name='getmntany' mangled-name='getmntany' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
       <parameter type-id='822cd80b' name='fp'/>
       <parameter type-id='9d424d31' name='mgetp'/>
@@ -953,20 +928,25 @@
       <parameter type-id='9d424d31' name='mgetp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <pointer-type-def type-id='a84c031d' size-in-bits='64' id='26a90f95'/>
+    <function-decl name='getextmntent' mangled-name='getextmntent' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getextmntent'>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='394fc496' name='entry'/>
+      <parameter type-id='62f7a03d' name='statbuf'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/zone.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/zone.c' language='LANG_C99'>
     <typedef-decl name='zoneid_t' type-id='95e97e5e' id='4da03624'/>
     <function-decl name='getzoneid' mangled-name='getzoneid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getzoneid'>
       <return type-id='4da03624'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='page.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='page.c' language='LANG_C99'>
     <function-decl name='spl_pagesize' mangled-name='spl_pagesize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
       <return type-id='b59d7dce'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcat.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='strlcat.c' language='LANG_C99'>
     <function-decl name='strlcat' mangled-name='strlcat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcat'>
       <parameter type-id='26a90f95' name='dst'/>
       <parameter type-id='80f4b756' name='src'/>
@@ -974,7 +954,7 @@
       <return type-id='b59d7dce'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='strlcpy.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='strlcpy.c' language='LANG_C99'>
     <function-decl name='strlcpy' mangled-name='strlcpy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='strlcpy'>
       <parameter type-id='26a90f95' name='dst'/>
       <parameter type-id='80f4b756' name='src'/>
@@ -982,13 +962,13 @@
       <return type-id='b59d7dce'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='timestamp.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='timestamp.c' language='LANG_C99'>
     <function-decl name='print_timestamp' mangled-name='print_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
       <parameter type-id='3502e3ff' name='timestamp_fmt'/>
       <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='libzfs_core.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='libzfs_core.c' language='LANG_C99'>
     <type-decl name='char' size-in-bits='8' id='a84c031d'/>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='2048' id='d1617432'>
       <subrange length='256' type-id='7359adad' id='36e5b9fa'/>
@@ -1023,241 +1003,28 @@
     <type-decl name='unsigned int' size-in-bits='32' id='f0981eeb'/>
     <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
     <type-decl name='void' id='48b5725f'/>
-    <typedef-decl name='nvlist_t' type-id='ac266fd9' id='8e8d4be3'/>
-    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='ac266fd9'>
+    <enum-decl name='lzc_dataset_type' id='bc9887f1'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='LZC_DATSET_TYPE_ZFS' value='2'/>
+      <enumerator name='LZC_DATSET_TYPE_ZVOL' value='3'/>
+    </enum-decl>
+    <enum-decl name='lzc_send_flags' id='bfbd3c8e'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='LZC_SEND_FLAG_EMBED_DATA' value='1'/>
+      <enumerator name='LZC_SEND_FLAG_LARGE_BLOCK' value='2'/>
+      <enumerator name='LZC_SEND_FLAG_COMPRESS' value='4'/>
+      <enumerator name='LZC_SEND_FLAG_RAW' value='8'/>
+      <enumerator name='LZC_SEND_FLAG_SAVED' value='16'/>
+    </enum-decl>
+    <class-decl name='ddt_key' size-in-bits='320' is-struct='yes' visibility='default' id='e0a4a1cb'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nvl_version' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='nvl_nvflag' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nvl_priv' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='nvl_flag' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='nvl_pad' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
-    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
-    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
-    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
-    <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
-    <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
-    <typedef-decl name='zfs_wait_activity_t' type-id='08f5ca17' id='3024501a'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca17'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
-      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
-    </enum-decl>
-    <typedef-decl name='boolean_t' type-id='40ed39d2' id='c19b74c3'/>
-    <enum-decl name='__anonymous_enum__1' is-anonymous='yes' id='40ed39d2'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='B_FALSE' value='0'/>
-      <enumerator name='B_TRUE' value='1'/>
-    </enum-decl>
-    <typedef-decl name='zpool_wait_activity_t' type-id='3fed383f' id='73446457'/>
-    <enum-decl name='__anonymous_enum__2' is-anonymous='yes' id='3fed383f'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
-      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
-      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
-      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
-      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
-      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
-      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
-      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
-      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
-    </enum-decl>
-    <typedef-decl name='pool_trim_func_t' type-id='54ed608a' id='b1146b8d'/>
-    <enum-decl name='pool_trim_func' id='54ed608a'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='POOL_TRIM_START' value='0'/>
-      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
-      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
-      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
-    </enum-decl>
-    <typedef-decl name='pool_initialize_func_t' type-id='5c246ad4' id='7063e1ab'/>
-    <enum-decl name='pool_initialize_func' id='5c246ad4'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='POOL_INITIALIZE_START' value='0'/>
-      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
-      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
-      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
-    </enum-decl>
-    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
-    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
-    <typedef-decl name='uint_t' type-id='f0981eeb' id='3502e3ff'/>
-    <typedef-decl name='dmu_replay_record_t' type-id='781a52d7' id='8b8fc893'/>
-    <class-decl name='dmu_replay_record' size-in-bits='2496' is-struct='yes' visibility='default' id='781a52d7'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_type' type-id='3eed36ac' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='drr_payloadlen' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_u' type-id='edc8c94a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <enum-decl name='__anonymous_enum__3' is-anonymous='yes' id='3eed36ac'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='DRR_BEGIN' value='0'/>
-      <enumerator name='DRR_OBJECT' value='1'/>
-      <enumerator name='DRR_FREEOBJECTS' value='2'/>
-      <enumerator name='DRR_WRITE' value='3'/>
-      <enumerator name='DRR_FREE' value='4'/>
-      <enumerator name='DRR_END' value='5'/>
-      <enumerator name='DRR_WRITE_BYREF' value='6'/>
-      <enumerator name='DRR_SPILL' value='7'/>
-      <enumerator name='DRR_WRITE_EMBEDDED' value='8'/>
-      <enumerator name='DRR_OBJECT_RANGE' value='9'/>
-      <enumerator name='DRR_REDACT' value='10'/>
-      <enumerator name='DRR_NUMTYPES' value='11'/>
-    </enum-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' id='edc8c94a'>
-      <data-member access='private'>
-        <var-decl name='drr_begin' type-id='09fcdc01' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_end' type-id='6ee25631' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_object' type-id='f9ad530b' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_freeobjects' type-id='a27d958e' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_write' type-id='4cc69e4b' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_free' type-id='c836cfd2' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_write_byref' type-id='e511cdce' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_spill' type-id='1e69a80a' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_write_embedded' type-id='98b1345e' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_object_range' type-id='aba1f9e1' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_redact' type-id='50389039' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='drr_checksum' type-id='a5fe3647' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' id='09fcdc01'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_magic' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_versioninfo' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_creation_time' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_type' type-id='230f1e16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_flags' type-id='8f92235e' visibility='default'/>
+        <var-decl name='ddk_cksum' type-id='39730d0b' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_fromguid' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_toname' type-id='d1617432' visibility='default'/>
+        <var-decl name='ddk_prop' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='dmu_objset_type_t' type-id='6b1b19f9' id='230f1e16'/>
-    <enum-decl name='dmu_objset_type' id='6b1b19f9'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='DMU_OST_NONE' value='0'/>
-      <enumerator name='DMU_OST_META' value='1'/>
-      <enumerator name='DMU_OST_ZFS' value='2'/>
-      <enumerator name='DMU_OST_ZVOL' value='3'/>
-      <enumerator name='DMU_OST_OTHER' value='4'/>
-      <enumerator name='DMU_OST_ANY' value='5'/>
-      <enumerator name='DMU_OST_NUMTYPES' value='6'/>
-    </enum-decl>
-    <class-decl name='drr_end' size-in-bits='320' is-struct='yes' visibility='default' id='6ee25631'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_checksum' type-id='39730d0b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zio_cksum_t' type-id='1d53e28b' id='39730d0b'/>
-    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' id='1d53e28b'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zc_word' type-id='85c64d26' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='drr_object' size-in-bits='448' is-struct='yes' visibility='default' id='f9ad530b'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='drr_object' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_type' type-id='5c9d8906' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='drr_bonustype' type-id='5c9d8906' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='drr_blksz' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='drr_bonuslen' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='drr_checksumtype' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='200'>
-        <var-decl name='drr_compress' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='208'>
-        <var-decl name='drr_dn_slots' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='216'>
-        <var-decl name='drr_flags' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='drr_raw_bonuslen' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='drr_toguid' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='drr_indblkshift' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drr_nlevels' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='drr_nblkptr' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='drr_pad' type-id='0f4ddd0b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='drr_maxblkid' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='dmu_object_type_t' type-id='04b3b0b9' id='5c9d8906'/>
+    <typedef-decl name='ddt_key_t' type-id='e0a4a1cb' id='67f6d2cf'/>
     <enum-decl name='dmu_object_type' id='04b3b0b9'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='DMU_OT_NONE' value='0'/>
@@ -1336,6 +1103,225 @@
       <enumerator name='DMU_OTN_ZAP_ENC_DATA' value='164'/>
       <enumerator name='DMU_OTN_ZAP_ENC_METADATA' value='228'/>
     </enum-decl>
+    <typedef-decl name='dmu_object_type_t' type-id='04b3b0b9' id='5c9d8906'/>
+    <enum-decl name='dmu_objset_type' id='6b1b19f9'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='DMU_OST_NONE' value='0'/>
+      <enumerator name='DMU_OST_META' value='1'/>
+      <enumerator name='DMU_OST_ZFS' value='2'/>
+      <enumerator name='DMU_OST_ZVOL' value='3'/>
+      <enumerator name='DMU_OST_OTHER' value='4'/>
+      <enumerator name='DMU_OST_ANY' value='5'/>
+      <enumerator name='DMU_OST_NUMTYPES' value='6'/>
+    </enum-decl>
+    <typedef-decl name='dmu_objset_type_t' type-id='6b1b19f9' id='230f1e16'/>
+    <enum-decl name='pool_initialize_func' id='5c246ad4'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='POOL_INITIALIZE_START' value='0'/>
+      <enumerator name='POOL_INITIALIZE_CANCEL' value='1'/>
+      <enumerator name='POOL_INITIALIZE_SUSPEND' value='2'/>
+      <enumerator name='POOL_INITIALIZE_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_initialize_func_t' type-id='5c246ad4' id='7063e1ab'/>
+    <enum-decl name='pool_trim_func' id='54ed608a'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='POOL_TRIM_START' value='0'/>
+      <enumerator name='POOL_TRIM_CANCEL' value='1'/>
+      <enumerator name='POOL_TRIM_SUSPEND' value='2'/>
+      <enumerator name='POOL_TRIM_FUNCS' value='3'/>
+    </enum-decl>
+    <typedef-decl name='pool_trim_func_t' type-id='54ed608a' id='b1146b8d'/>
+    <enum-decl name='zpool_wait_activity_t' naming-typedef-id='73446457' id='849338e3'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
+      <enumerator name='ZPOOL_WAIT_FREE' value='1'/>
+      <enumerator name='ZPOOL_WAIT_INITIALIZE' value='2'/>
+      <enumerator name='ZPOOL_WAIT_REPLACE' value='3'/>
+      <enumerator name='ZPOOL_WAIT_REMOVE' value='4'/>
+      <enumerator name='ZPOOL_WAIT_RESILVER' value='5'/>
+      <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
+      <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
+      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='8'/>
+    </enum-decl>
+    <typedef-decl name='zpool_wait_activity_t' type-id='849338e3' id='73446457'/>
+    <enum-decl name='zfs_wait_activity_t' naming-typedef-id='3024501a' id='527d5dc6'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='ZFS_WAIT_DELETEQ' value='0'/>
+      <enumerator name='ZFS_WAIT_NUM_ACTIVITIES' value='1'/>
+    </enum-decl>
+    <typedef-decl name='zfs_wait_activity_t' type-id='527d5dc6' id='3024501a'/>
+    <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='ac266fd9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nvl_version' type-id='3ff5601b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='nvl_nvflag' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nvl_priv' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvl_flag' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='nvl_pad' type-id='3ff5601b' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='nvlist_t' type-id='ac266fd9' id='8e8d4be3'/>
+    <class-decl name='zio_cksum' size-in-bits='256' is-struct='yes' visibility='default' id='1d53e28b'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zc_word' type-id='85c64d26' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zio_cksum_t' type-id='1d53e28b' id='39730d0b'/>
+    <class-decl name='drr_begin' size-in-bits='2432' is-struct='yes' visibility='default' id='09fcdc01'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_magic' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_versioninfo' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_creation_time' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_type' type-id='230f1e16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='drr_flags' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_fromguid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_toname' type-id='d1617432' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dmu_replay_record' size-in-bits='2496' is-struct='yes' visibility='default' id='781a52d7'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_type' type-id='08f5ca17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='drr_payloadlen' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_u' type-id='ac5ab595' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca17'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='DRR_BEGIN' value='0'/>
+      <enumerator name='DRR_OBJECT' value='1'/>
+      <enumerator name='DRR_FREEOBJECTS' value='2'/>
+      <enumerator name='DRR_WRITE' value='3'/>
+      <enumerator name='DRR_FREE' value='4'/>
+      <enumerator name='DRR_END' value='5'/>
+      <enumerator name='DRR_WRITE_BYREF' value='6'/>
+      <enumerator name='DRR_SPILL' value='7'/>
+      <enumerator name='DRR_WRITE_EMBEDDED' value='8'/>
+      <enumerator name='DRR_OBJECT_RANGE' value='9'/>
+      <enumerator name='DRR_REDACT' value='10'/>
+      <enumerator name='DRR_NUMTYPES' value='11'/>
+    </enum-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' id='ac5ab595'>
+      <data-member access='public'>
+        <var-decl name='drr_begin' type-id='09fcdc01' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_end' type-id='6ee25631' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_object' type-id='f9ad530b' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_freeobjects' type-id='a27d958e' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_write' type-id='4cc69e4b' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_free' type-id='c836cfd2' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_write_byref' type-id='e511cdce' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_spill' type-id='1e69a80a' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_write_embedded' type-id='98b1345e' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_object_range' type-id='aba1f9e1' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_redact' type-id='50389039' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='drr_checksum' type-id='a5fe3647' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='drr_end' size-in-bits='320' is-struct='yes' visibility='default' id='6ee25631'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_checksum' type-id='39730d0b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='drr_object' size-in-bits='448' is-struct='yes' visibility='default' id='f9ad530b'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='drr_object' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='drr_type' type-id='5c9d8906' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='drr_bonustype' type-id='5c9d8906' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='drr_blksz' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='drr_bonuslen' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='drr_checksumtype' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='200'>
+        <var-decl name='drr_compress' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='208'>
+        <var-decl name='drr_dn_slots' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='216'>
+        <var-decl name='drr_flags' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='drr_raw_bonuslen' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='drr_toguid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='drr_indblkshift' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='328'>
+        <var-decl name='drr_nlevels' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='drr_nblkptr' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='344'>
+        <var-decl name='drr_pad' type-id='0f4ddd0b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='drr_maxblkid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='drr_freeobjects' size-in-bits='192' is-struct='yes' visibility='default' id='a27d958e'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='drr_firstobj' type-id='9c313c2d' visibility='default'/>
@@ -1392,15 +1378,6 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
         <var-decl name='drr_mac' type-id='fa9986a5' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='ddt_key_t' type-id='e0a4a1cb' id='67f6d2cf'/>
-    <class-decl name='ddt_key' size-in-bits='320' is-struct='yes' visibility='default' id='e0a4a1cb'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='ddk_cksum' type-id='39730d0b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='ddk_prop' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
     <class-decl name='drr_free' size-in-bits='256' is-struct='yes' visibility='default' id='c836cfd2'>
@@ -1564,19 +1541,22 @@
         <var-decl name='drr_checksum' type-id='39730d0b' visibility='default'/>
       </data-member>
     </class-decl>
-    <enum-decl name='lzc_send_flags' id='bfbd3c8e'>
+    <typedef-decl name='dmu_replay_record_t' type-id='781a52d7' id='8b8fc893'/>
+    <enum-decl name='boolean_t' naming-typedef-id='c19b74c3' id='f58c8277'>
       <underlying-type type-id='9cac1fee'/>
-      <enumerator name='LZC_SEND_FLAG_EMBED_DATA' value='1'/>
-      <enumerator name='LZC_SEND_FLAG_LARGE_BLOCK' value='2'/>
-      <enumerator name='LZC_SEND_FLAG_COMPRESS' value='4'/>
-      <enumerator name='LZC_SEND_FLAG_RAW' value='8'/>
-      <enumerator name='LZC_SEND_FLAG_SAVED' value='16'/>
+      <enumerator name='B_FALSE' value='0'/>
+      <enumerator name='B_TRUE' value='1'/>
     </enum-decl>
-    <enum-decl name='lzc_dataset_type' id='bc9887f1'>
-      <underlying-type type-id='9cac1fee'/>
-      <enumerator name='LZC_DATSET_TYPE_ZFS' value='2'/>
-      <enumerator name='LZC_DATSET_TYPE_ZVOL' value='3'/>
-    </enum-decl>
+    <typedef-decl name='boolean_t' type-id='f58c8277' id='c19b74c3'/>
+    <typedef-decl name='uint_t' type-id='f0981eeb' id='3502e3ff'/>
+    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
+    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
+    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
+    <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
+    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
+    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
+    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
+    <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
     <pointer-type-def type-id='c19b74c3' size-in-bits='64' id='37e3bd22'/>
     <pointer-type-def type-id='a84c031d' size-in-bits='64' id='26a90f95'/>
     <qualified-type-def type-id='a84c031d' const='yes' id='9b45d938'/>
@@ -1589,137 +1569,181 @@
     <pointer-type-def type-id='5ce45b60' size-in-bits='64' id='857bb57e'/>
     <pointer-type-def type-id='9c313c2d' size-in-bits='64' id='5d6479ae'/>
     <pointer-type-def type-id='b96825af' size-in-bits='64' id='ae3e8ca6'/>
-    <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bootenv'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <parameter type-id='857bb57e' name='outnvl'/>
+    <function-decl name='libzfs_core_init' mangled-name='libzfs_core_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_init'>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_set_bootenv'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <parameter type-id='22cce67b' name='env'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_fini'>
+      <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_fs'>
-      <parameter type-id='80f4b756' name='fs'/>
-      <parameter type-id='3024501a' name='activity'/>
-      <parameter type-id='37e3bd22' name='waited'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_wait_tag' mangled-name='lzc_wait_tag' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_tag'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <parameter type-id='73446457' name='activity'/>
-      <parameter type-id='9c313c2d' name='tag'/>
-      <parameter type-id='37e3bd22' name='waited'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_wait' mangled-name='lzc_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <parameter type-id='73446457' name='activity'/>
-      <parameter type-id='37e3bd22' name='waited'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_redact' mangled-name='lzc_redact' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_redact'>
-      <parameter type-id='80f4b756' name='snapshot'/>
-      <parameter type-id='80f4b756' name='bookname'/>
-      <parameter type-id='5ce45b60' name='snapnv'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_trim' mangled-name='lzc_trim' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_trim'>
-      <parameter type-id='80f4b756' name='poolname'/>
-      <parameter type-id='b1146b8d' name='cmd_type'/>
-      <parameter type-id='9c313c2d' name='rate'/>
-      <parameter type-id='c19b74c3' name='secure'/>
-      <parameter type-id='5ce45b60' name='vdevs'/>
-      <parameter type-id='857bb57e' name='errlist'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_initialize' mangled-name='lzc_initialize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_initialize'>
-      <parameter type-id='80f4b756' name='poolname'/>
-      <parameter type-id='7063e1ab' name='cmd_type'/>
-      <parameter type-id='5ce45b60' name='vdevs'/>
-      <parameter type-id='857bb57e' name='errlist'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_reopen' mangled-name='lzc_reopen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_reopen'>
-      <parameter type-id='80f4b756' name='pool_name'/>
-      <parameter type-id='c19b74c3' name='scrub_restart'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_change_key' mangled-name='lzc_change_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_change_key'>
+    <function-decl name='lzc_create' mangled-name='lzc_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_create'>
       <parameter type-id='80f4b756' name='fsname'/>
-      <parameter type-id='9c313c2d' name='crypt_cmd'/>
+      <parameter type-id='bc9887f1' name='type'/>
       <parameter type-id='5ce45b60' name='props'/>
       <parameter type-id='ae3e8ca6' name='wkeydata'/>
       <parameter type-id='3502e3ff' name='wkeylen'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='lzc_unload_key' mangled-name='lzc_unload_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_unload_key'>
+    <function-decl name='lzc_clone' mangled-name='lzc_clone' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_clone'>
       <parameter type-id='80f4b756' name='fsname'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_load_key' mangled-name='lzc_load_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_load_key'>
-      <parameter type-id='80f4b756' name='fsname'/>
-      <parameter type-id='c19b74c3' name='noop'/>
-      <parameter type-id='ae3e8ca6' name='wkeydata'/>
-      <parameter type-id='3502e3ff' name='wkeylen'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_channel_program_nosync' mangled-name='lzc_channel_program_nosync' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program_nosync'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <parameter type-id='80f4b756' name='program'/>
-      <parameter type-id='9c313c2d' name='timeout'/>
-      <parameter type-id='9c313c2d' name='memlimit'/>
-      <parameter type-id='5ce45b60' name='argnvl'/>
-      <parameter type-id='857bb57e' name='outnvl'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_pool_checkpoint_discard' mangled-name='lzc_pool_checkpoint_discard' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint_discard'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_pool_checkpoint' mangled-name='lzc_pool_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_channel_program' mangled-name='lzc_channel_program' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <parameter type-id='80f4b756' name='program'/>
-      <parameter type-id='9c313c2d' name='instrlimit'/>
-      <parameter type-id='9c313c2d' name='memlimit'/>
-      <parameter type-id='5ce45b60' name='argnvl'/>
-      <parameter type-id='857bb57e' name='outnvl'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_bookmarks'>
-      <parameter type-id='5ce45b60' name='bmarks'/>
-      <parameter type-id='857bb57e' name='errlist'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_get_bookmark_props' mangled-name='lzc_get_bookmark_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmark_props'>
-      <parameter type-id='80f4b756' name='bookmark'/>
-      <parameter type-id='857bb57e' name='props'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_get_bookmarks' mangled-name='lzc_get_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmarks'>
-      <parameter type-id='80f4b756' name='fsname'/>
+      <parameter type-id='80f4b756' name='origin'/>
       <parameter type-id='5ce45b60' name='props'/>
-      <parameter type-id='857bb57e' name='bmarks'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='lzc_bookmark' mangled-name='lzc_bookmark' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_bookmark'>
-      <parameter type-id='5ce45b60' name='bookmarks'/>
-      <parameter type-id='857bb57e' name='errlist'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback_to'>
-      <parameter type-id='80f4b756' name='fsname'/>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_rollback' mangled-name='lzc_rollback' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback'>
+    <function-decl name='lzc_promote' mangled-name='lzc_promote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_promote'>
       <parameter type-id='80f4b756' name='fsname'/>
       <parameter type-id='26a90f95' name='snapnamebuf'/>
       <parameter type-id='95e97e5e' name='snapnamelen'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_rename' mangled-name='lzc_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rename'>
+      <parameter type-id='80f4b756' name='source'/>
+      <parameter type-id='80f4b756' name='target'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_destroy' mangled-name='lzc_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy'>
+      <parameter type-id='80f4b756' name='fsname'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_snapshot' mangled-name='lzc_snapshot' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snapshot'>
+      <parameter type-id='5ce45b60' name='snaps'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='857bb57e' name='errlist'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_snaps' mangled-name='lzc_destroy_snaps' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_snaps'>
+      <parameter type-id='5ce45b60' name='snaps'/>
+      <parameter type-id='c19b74c3' name='defer'/>
+      <parameter type-id='857bb57e' name='errlist'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_snaprange_space' mangled-name='lzc_snaprange_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snaprange_space'>
+      <parameter type-id='80f4b756' name='firstsnap'/>
+      <parameter type-id='80f4b756' name='lastsnap'/>
+      <parameter type-id='5d6479ae' name='usedp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_exists' mangled-name='lzc_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_exists'>
+      <parameter type-id='80f4b756' name='dataset'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='lzc_sync' mangled-name='lzc_sync' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_sync'>
+      <parameter type-id='80f4b756' name='pool_name'/>
+      <parameter type-id='5ce45b60' name='innvl'/>
+      <parameter type-id='857bb57e' name='outnvl'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_hold' mangled-name='lzc_hold' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_hold'>
+      <parameter type-id='5ce45b60' name='holds'/>
+      <parameter type-id='95e97e5e' name='cleanup_fd'/>
+      <parameter type-id='857bb57e' name='errlist'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_release' mangled-name='lzc_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_release'>
+      <parameter type-id='5ce45b60' name='holds'/>
+      <parameter type-id='857bb57e' name='errlist'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_get_holds' mangled-name='lzc_get_holds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_holds'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='857bb57e' name='holdsp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_send' mangled-name='lzc_send' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='80f4b756' name='from'/>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='bfbd3c8e' name='flags'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_send_redacted' mangled-name='lzc_send_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_redacted'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='80f4b756' name='from'/>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='bfbd3c8e' name='flags'/>
+      <parameter type-id='80f4b756' name='redactbook'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_send_resume' mangled-name='lzc_send_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='80f4b756' name='from'/>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='bfbd3c8e' name='flags'/>
+      <parameter type-id='9c313c2d' name='resumeobj'/>
+      <parameter type-id='9c313c2d' name='resumeoff'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_send_resume_redacted' mangled-name='lzc_send_resume_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume_redacted'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='80f4b756' name='from'/>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='bfbd3c8e' name='flags'/>
+      <parameter type-id='9c313c2d' name='resumeobj'/>
+      <parameter type-id='9c313c2d' name='resumeoff'/>
+      <parameter type-id='80f4b756' name='redactbook'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_send_space_resume_redacted' mangled-name='lzc_send_space_resume_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space_resume_redacted'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='80f4b756' name='from'/>
+      <parameter type-id='bfbd3c8e' name='flags'/>
+      <parameter type-id='9c313c2d' name='resumeobj'/>
+      <parameter type-id='9c313c2d' name='resumeoff'/>
+      <parameter type-id='9c313c2d' name='resume_bytes'/>
+      <parameter type-id='80f4b756' name='redactbook'/>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='5d6479ae' name='spacep'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_send_space' mangled-name='lzc_send_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='80f4b756' name='from'/>
+      <parameter type-id='bfbd3c8e' name='flags'/>
+      <parameter type-id='5d6479ae' name='spacep'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_receive' mangled-name='lzc_receive' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='80f4b756' name='origin'/>
+      <parameter type-id='c19b74c3' name='force'/>
+      <parameter type-id='c19b74c3' name='raw'/>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_receive_resumable' mangled-name='lzc_receive_resumable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_resumable'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='80f4b756' name='origin'/>
+      <parameter type-id='c19b74c3' name='force'/>
+      <parameter type-id='c19b74c3' name='raw'/>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_receive_with_header' mangled-name='lzc_receive_with_header' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_header'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='80f4b756' name='origin'/>
+      <parameter type-id='c19b74c3' name='force'/>
+      <parameter type-id='c19b74c3' name='resumable'/>
+      <parameter type-id='c19b74c3' name='raw'/>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='8341348b' name='begin_record'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_receive_one' mangled-name='lzc_receive_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_one'>
+      <parameter type-id='80f4b756' name='snapname'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='80f4b756' name='origin'/>
+      <parameter type-id='c19b74c3' name='force'/>
+      <parameter type-id='c19b74c3' name='resumable'/>
+      <parameter type-id='c19b74c3' name='raw'/>
+      <parameter type-id='95e97e5e' name='input_fd'/>
+      <parameter type-id='8341348b' name='begin_record'/>
+      <parameter type-id='95e97e5e' name='cleanup_fd'/>
+      <parameter type-id='5d6479ae' name='read_bytes'/>
+      <parameter type-id='5d6479ae' name='errflags'/>
+      <parameter type-id='5d6479ae' name='action_handle'/>
+      <parameter type-id='857bb57e' name='errors'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='lzc_receive_with_cmdprops' mangled-name='lzc_receive_with_cmdprops' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_cmdprops'>
@@ -1741,185 +1765,141 @@
       <parameter type-id='857bb57e' name='errors'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='lzc_receive_one' mangled-name='lzc_receive_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_one'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <parameter type-id='80f4b756' name='origin'/>
-      <parameter type-id='c19b74c3' name='force'/>
-      <parameter type-id='c19b74c3' name='resumable'/>
-      <parameter type-id='c19b74c3' name='raw'/>
-      <parameter type-id='95e97e5e' name='input_fd'/>
-      <parameter type-id='8341348b' name='begin_record'/>
-      <parameter type-id='95e97e5e' name='cleanup_fd'/>
-      <parameter type-id='5d6479ae' name='read_bytes'/>
-      <parameter type-id='5d6479ae' name='errflags'/>
-      <parameter type-id='5d6479ae' name='action_handle'/>
-      <parameter type-id='857bb57e' name='errors'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_receive_with_header' mangled-name='lzc_receive_with_header' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_with_header'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <parameter type-id='80f4b756' name='origin'/>
-      <parameter type-id='c19b74c3' name='force'/>
-      <parameter type-id='c19b74c3' name='resumable'/>
-      <parameter type-id='c19b74c3' name='raw'/>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <parameter type-id='8341348b' name='begin_record'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_receive_resumable' mangled-name='lzc_receive_resumable' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive_resumable'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <parameter type-id='80f4b756' name='origin'/>
-      <parameter type-id='c19b74c3' name='force'/>
-      <parameter type-id='c19b74c3' name='raw'/>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_receive' mangled-name='lzc_receive' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_receive'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <parameter type-id='80f4b756' name='origin'/>
-      <parameter type-id='c19b74c3' name='force'/>
-      <parameter type-id='c19b74c3' name='raw'/>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_send_space' mangled-name='lzc_send_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='80f4b756' name='from'/>
-      <parameter type-id='bfbd3c8e' name='flags'/>
-      <parameter type-id='5d6479ae' name='spacep'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_send_space_resume_redacted' mangled-name='lzc_send_space_resume_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_space_resume_redacted'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='80f4b756' name='from'/>
-      <parameter type-id='bfbd3c8e' name='flags'/>
-      <parameter type-id='9c313c2d' name='resumeobj'/>
-      <parameter type-id='9c313c2d' name='resumeoff'/>
-      <parameter type-id='9c313c2d' name='resume_bytes'/>
-      <parameter type-id='80f4b756' name='redactbook'/>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <parameter type-id='5d6479ae' name='spacep'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_send_resume_redacted' mangled-name='lzc_send_resume_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume_redacted'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='80f4b756' name='from'/>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <parameter type-id='bfbd3c8e' name='flags'/>
-      <parameter type-id='9c313c2d' name='resumeobj'/>
-      <parameter type-id='9c313c2d' name='resumeoff'/>
-      <parameter type-id='80f4b756' name='redactbook'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_send_resume' mangled-name='lzc_send_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_resume'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='80f4b756' name='from'/>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <parameter type-id='bfbd3c8e' name='flags'/>
-      <parameter type-id='9c313c2d' name='resumeobj'/>
-      <parameter type-id='9c313c2d' name='resumeoff'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_send_redacted' mangled-name='lzc_send_redacted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send_redacted'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='80f4b756' name='from'/>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <parameter type-id='bfbd3c8e' name='flags'/>
-      <parameter type-id='80f4b756' name='redactbook'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_send' mangled-name='lzc_send' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_send'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='80f4b756' name='from'/>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <parameter type-id='bfbd3c8e' name='flags'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_get_holds' mangled-name='lzc_get_holds' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_holds'>
-      <parameter type-id='80f4b756' name='snapname'/>
-      <parameter type-id='857bb57e' name='holdsp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_release' mangled-name='lzc_release' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_release'>
-      <parameter type-id='5ce45b60' name='holds'/>
-      <parameter type-id='857bb57e' name='errlist'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_hold' mangled-name='lzc_hold' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_hold'>
-      <parameter type-id='5ce45b60' name='holds'/>
-      <parameter type-id='95e97e5e' name='cleanup_fd'/>
-      <parameter type-id='857bb57e' name='errlist'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_sync' mangled-name='lzc_sync' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_sync'>
-      <parameter type-id='80f4b756' name='pool_name'/>
-      <parameter type-id='5ce45b60' name='innvl'/>
-      <parameter type-id='857bb57e' name='outnvl'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_exists' mangled-name='lzc_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_exists'>
-      <parameter type-id='80f4b756' name='dataset'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
-    <function-decl name='lzc_snaprange_space' mangled-name='lzc_snaprange_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snaprange_space'>
-      <parameter type-id='80f4b756' name='firstsnap'/>
-      <parameter type-id='80f4b756' name='lastsnap'/>
-      <parameter type-id='5d6479ae' name='usedp'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_destroy_snaps' mangled-name='lzc_destroy_snaps' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_snaps'>
-      <parameter type-id='5ce45b60' name='snaps'/>
-      <parameter type-id='c19b74c3' name='defer'/>
-      <parameter type-id='857bb57e' name='errlist'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_snapshot' mangled-name='lzc_snapshot' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_snapshot'>
-      <parameter type-id='5ce45b60' name='snaps'/>
-      <parameter type-id='5ce45b60' name='props'/>
-      <parameter type-id='857bb57e' name='errlist'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_destroy' mangled-name='lzc_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy'>
-      <parameter type-id='80f4b756' name='fsname'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_rename' mangled-name='lzc_rename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rename'>
-      <parameter type-id='80f4b756' name='source'/>
-      <parameter type-id='80f4b756' name='target'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzc_promote' mangled-name='lzc_promote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_promote'>
+    <function-decl name='lzc_rollback' mangled-name='lzc_rollback' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback'>
       <parameter type-id='80f4b756' name='fsname'/>
       <parameter type-id='26a90f95' name='snapnamebuf'/>
       <parameter type-id='95e97e5e' name='snapnamelen'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='lzc_clone' mangled-name='lzc_clone' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_clone'>
+    <function-decl name='lzc_rollback_to' mangled-name='lzc_rollback_to' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_rollback_to'>
       <parameter type-id='80f4b756' name='fsname'/>
-      <parameter type-id='80f4b756' name='origin'/>
-      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='80f4b756' name='snapname'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='lzc_create' mangled-name='lzc_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_create'>
+    <function-decl name='lzc_bookmark' mangled-name='lzc_bookmark' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_bookmark'>
+      <parameter type-id='5ce45b60' name='bookmarks'/>
+      <parameter type-id='857bb57e' name='errlist'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_get_bookmarks' mangled-name='lzc_get_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmarks'>
       <parameter type-id='80f4b756' name='fsname'/>
-      <parameter type-id='bc9887f1' name='type'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='857bb57e' name='bmarks'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_get_bookmark_props' mangled-name='lzc_get_bookmark_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bookmark_props'>
+      <parameter type-id='80f4b756' name='bookmark'/>
+      <parameter type-id='857bb57e' name='props'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_bookmarks'>
+      <parameter type-id='5ce45b60' name='bmarks'/>
+      <parameter type-id='857bb57e' name='errlist'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_channel_program' mangled-name='lzc_channel_program' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program'>
+      <parameter type-id='80f4b756' name='pool'/>
+      <parameter type-id='80f4b756' name='program'/>
+      <parameter type-id='9c313c2d' name='instrlimit'/>
+      <parameter type-id='9c313c2d' name='memlimit'/>
+      <parameter type-id='5ce45b60' name='argnvl'/>
+      <parameter type-id='857bb57e' name='outnvl'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_pool_checkpoint' mangled-name='lzc_pool_checkpoint' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint'>
+      <parameter type-id='80f4b756' name='pool'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_pool_checkpoint_discard' mangled-name='lzc_pool_checkpoint_discard' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_pool_checkpoint_discard'>
+      <parameter type-id='80f4b756' name='pool'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_channel_program_nosync' mangled-name='lzc_channel_program_nosync' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_channel_program_nosync'>
+      <parameter type-id='80f4b756' name='pool'/>
+      <parameter type-id='80f4b756' name='program'/>
+      <parameter type-id='9c313c2d' name='timeout'/>
+      <parameter type-id='9c313c2d' name='memlimit'/>
+      <parameter type-id='5ce45b60' name='argnvl'/>
+      <parameter type-id='857bb57e' name='outnvl'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_load_key' mangled-name='lzc_load_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_load_key'>
+      <parameter type-id='80f4b756' name='fsname'/>
+      <parameter type-id='c19b74c3' name='noop'/>
+      <parameter type-id='ae3e8ca6' name='wkeydata'/>
+      <parameter type-id='3502e3ff' name='wkeylen'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_unload_key' mangled-name='lzc_unload_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_unload_key'>
+      <parameter type-id='80f4b756' name='fsname'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_change_key' mangled-name='lzc_change_key' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_change_key'>
+      <parameter type-id='80f4b756' name='fsname'/>
+      <parameter type-id='9c313c2d' name='crypt_cmd'/>
       <parameter type-id='5ce45b60' name='props'/>
       <parameter type-id='ae3e8ca6' name='wkeydata'/>
       <parameter type-id='3502e3ff' name='wkeylen'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_fini'>
-      <return type-id='48b5725f'/>
+    <function-decl name='lzc_reopen' mangled-name='lzc_reopen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_reopen'>
+      <parameter type-id='80f4b756' name='pool_name'/>
+      <parameter type-id='c19b74c3' name='scrub_restart'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='libzfs_core_init' mangled-name='libzfs_core_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_init'>
+    <function-decl name='lzc_initialize' mangled-name='lzc_initialize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_initialize'>
+      <parameter type-id='80f4b756' name='poolname'/>
+      <parameter type-id='7063e1ab' name='cmd_type'/>
+      <parameter type-id='5ce45b60' name='vdevs'/>
+      <parameter type-id='857bb57e' name='errlist'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_trim' mangled-name='lzc_trim' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_trim'>
+      <parameter type-id='80f4b756' name='poolname'/>
+      <parameter type-id='b1146b8d' name='cmd_type'/>
+      <parameter type-id='9c313c2d' name='rate'/>
+      <parameter type-id='c19b74c3' name='secure'/>
+      <parameter type-id='5ce45b60' name='vdevs'/>
+      <parameter type-id='857bb57e' name='errlist'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_redact' mangled-name='lzc_redact' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_redact'>
+      <parameter type-id='80f4b756' name='snapshot'/>
+      <parameter type-id='80f4b756' name='bookname'/>
+      <parameter type-id='5ce45b60' name='snapnv'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_wait' mangled-name='lzc_wait' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait'>
+      <parameter type-id='80f4b756' name='pool'/>
+      <parameter type-id='73446457' name='activity'/>
+      <parameter type-id='37e3bd22' name='waited'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_wait_tag' mangled-name='lzc_wait_tag' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_tag'>
+      <parameter type-id='80f4b756' name='pool'/>
+      <parameter type-id='73446457' name='activity'/>
+      <parameter type-id='9c313c2d' name='tag'/>
+      <parameter type-id='37e3bd22' name='waited'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_wait_fs' mangled-name='lzc_wait_fs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_wait_fs'>
+      <parameter type-id='80f4b756' name='fs'/>
+      <parameter type-id='3024501a' name='activity'/>
+      <parameter type-id='37e3bd22' name='waited'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_set_bootenv' mangled-name='lzc_set_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_set_bootenv'>
+      <parameter type-id='80f4b756' name='pool'/>
+      <parameter type-id='22cce67b' name='env'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_get_bootenv' mangled-name='lzc_get_bootenv' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_get_bootenv'>
+      <parameter type-id='80f4b756' name='pool'/>
+      <parameter type-id='857bb57e' name='outnvl'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='os/linux/libzfs_core_ioctl.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='os/linux/libzfs_core_ioctl.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='32768' id='d16c6df4'>
       <subrange length='4096' type-id='7359adad' id='bc1b5ddc'/>
     </array-type-def>
@@ -1929,7 +1909,102 @@
     <array-type-def dimensions='1' type-id='9c313c2d' size-in-bits='128' id='c1c22e6c'>
       <subrange length='2' type-id='7359adad' id='52efc4ef'/>
     </array-type-def>
-    <typedef-decl name='zfs_cmd_t' type-id='3522cd69' id='a5559cdd'/>
+    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' id='098f0221'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dds_num_clones' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dds_creation_txg' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dds_guid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dds_type' type-id='230f1e16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='dds_is_snapshot' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='232'>
+        <var-decl name='dds_inconsistent' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='240'>
+        <var-decl name='dds_redacted' type-id='b96825af' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='248'>
+        <var-decl name='dds_origin' type-id='d1617432' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='dmu_objset_stats_t' type-id='098f0221' id='b2c14f17'/>
+    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='3216f820'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zi_objset' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='zi_object' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='zi_start' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='zi_end' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='zi_guid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='zi_level' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='zi_error' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='zi_type' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='zi_freq' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='zi_failfast' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zi_func' type-id='d1617432' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='zi_iotype' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2592'>
+        <var-decl name='zi_duration' type-id='3ff5601b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2624'>
+        <var-decl name='zi_timer' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='zi_nlanes' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2752'>
+        <var-decl name='zi_cmd' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2784'>
+        <var-decl name='zi_dvas' type-id='8f92235e' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zinject_record_t' type-id='3216f820' id='a4301ca6'/>
+    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='feb6f2da'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='z_exportdata' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='z_sharedata' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='z_sharetype' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='z_sharemax' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_share_t' type-id='feb6f2da' id='ee5cec36'/>
     <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='3522cd69'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zc_name' type-id='d16c6df4' visibility='default'/>
@@ -2037,103 +2112,7 @@
         <var-decl name='zc_zoneid' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='zfs_share_t' type-id='feb6f2da' id='ee5cec36'/>
-    <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='feb6f2da'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='z_exportdata' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='z_sharedata' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='z_sharetype' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='z_sharemax' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='dmu_objset_stats_t' type-id='098f0221' id='b2c14f17'/>
-    <class-decl name='dmu_objset_stats' size-in-bits='2304' is-struct='yes' visibility='default' id='098f0221'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dds_num_clones' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='dds_creation_txg' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='dds_guid' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='dds_type' type-id='230f1e16' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dds_is_snapshot' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='232'>
-        <var-decl name='dds_inconsistent' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='240'>
-        <var-decl name='dds_redacted' type-id='b96825af' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='248'>
-        <var-decl name='dds_origin' type-id='d1617432' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zinject_record_t' type-id='3216f820' id='a4301ca6'/>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='3216f820'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='zi_objset' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='zi_object' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='zi_start' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='zi_end' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zi_guid' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='zi_level' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='zi_error' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='zi_type' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='zi_freq' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='zi_failfast' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='zi_func' type-id='d1617432' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='zi_iotype' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2592'>
-        <var-decl name='zi_duration' type-id='3ff5601b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2624'>
-        <var-decl name='zi_timer' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2688'>
-        <var-decl name='zi_nlanes' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2752'>
-        <var-decl name='zi_cmd' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2784'>
-        <var-decl name='zi_dvas' type-id='8f92235e' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='zfs_stat_t' type-id='6417f0b9' id='0371a9c7'/>
+    <typedef-decl name='zfs_cmd_t' type-id='3522cd69' id='a5559cdd'/>
     <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' id='6417f0b9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zs_gen' type-id='9c313c2d' visibility='default'/>
@@ -2148,6 +2127,7 @@
         <var-decl name='zs_ctime' type-id='c1c22e6c' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='zfs_stat_t' type-id='6417f0b9' id='0371a9c7'/>
     <pointer-type-def type-id='a5559cdd' size-in-bits='64' id='e4ec4540'/>
     <function-decl name='lzc_ioctl_fd' mangled-name='lzc_ioctl_fd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_ioctl_fd'>
       <parameter type-id='95e97e5e' name='fd'/>

--- a/lib/libzfsbootenv/libzfsbootenv.abi
+++ b/lib/libzfsbootenv/libzfsbootenv.abi
@@ -1,12 +1,10 @@
-<abi-corpus architecture='elf-amd-x86_64' soname='libzfsbootenv.so.1'>
+<abi-corpus version='2.0' architecture='elf-amd-x86_64' soname='libzfsbootenv.so.1'>
   <elf-needed>
     <dependency name='libzfs.so.4'/>
     <dependency name='libnvpair.so.3'/>
     <dependency name='libc.so.6'/>
   </elf-needed>
   <elf-function-symbols>
-    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_add_pair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_bootenv_print' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_get_boot_device' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -16,42 +14,53 @@
     <elf-symbol name='lzbe_remove_pair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_set_boot_device' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
-  <abi-instr version='1.0' address-size='64' path='lzbe_device.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='lzbe_device.c' language='LANG_C99'>
     <type-decl name='char' size-in-bits='8' id='a84c031d'/>
     <type-decl name='int' size-in-bits='32' id='95e97e5e'/>
     <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='9cac1fee'/>
     <type-decl name='void' id='48b5725f'/>
-    <typedef-decl name='lzbe_flags_t' type-id='2b77720b' id='a1936f04'/>
     <enum-decl name='lzbe_flags' id='2b77720b'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='lzbe_add' value='0'/>
       <enumerator name='lzbe_replace' value='1'/>
     </enum-decl>
+    <typedef-decl name='lzbe_flags_t' type-id='2b77720b' id='a1936f04'/>
     <pointer-type-def type-id='a84c031d' size-in-bits='64' id='26a90f95'/>
     <pointer-type-def type-id='26a90f95' size-in-bits='64' id='9b23c9ad'/>
     <qualified-type-def type-id='a84c031d' const='yes' id='9b45d938'/>
     <pointer-type-def type-id='9b45d938' size-in-bits='64' id='80f4b756'/>
-    <function-decl name='lzbe_get_boot_device' mangled-name='lzbe_get_boot_device' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_get_boot_device'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <parameter type-id='9b23c9ad' name='device'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
     <function-decl name='lzbe_set_boot_device' mangled-name='lzbe_set_boot_device' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_set_boot_device'>
       <parameter type-id='80f4b756' name='pool'/>
       <parameter type-id='a1936f04' name='flag'/>
       <parameter type-id='80f4b756' name='device'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='lzbe_get_boot_device' mangled-name='lzbe_get_boot_device' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_get_boot_device'>
+      <parameter type-id='80f4b756' name='pool'/>
+      <parameter type-id='9b23c9ad' name='device'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='lzbe_pair.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='lzbe_pair.c' language='LANG_C99'>
     <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
     <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
     <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
     <pointer-type-def type-id='eaa32e2f' size-in-bits='64' id='63e171df'/>
-    <function-decl name='lzbe_remove_pair' mangled-name='lzbe_remove_pair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_remove_pair'>
-      <parameter type-id='eaa32e2f' name='ptr'/>
+    <function-decl name='lzbe_nvlist_get' mangled-name='lzbe_nvlist_get' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_get'>
+      <parameter type-id='80f4b756' name='pool'/>
       <parameter type-id='80f4b756' name='key'/>
+      <parameter type-id='63e171df' name='ptr'/>
       <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzbe_nvlist_set' mangled-name='lzbe_nvlist_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_set'>
+      <parameter type-id='80f4b756' name='pool'/>
+      <parameter type-id='80f4b756' name='key'/>
+      <parameter type-id='eaa32e2f' name='ptr'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzbe_nvlist_free' mangled-name='lzbe_nvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_free'>
+      <parameter type-id='eaa32e2f' name='ptr'/>
+      <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='lzbe_add_pair' mangled-name='lzbe_add_pair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_add_pair'>
       <parameter type-id='eaa32e2f' name='ptr'/>
@@ -61,34 +70,29 @@
       <parameter type-id='b59d7dce' name='size'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='lzbe_nvlist_free' mangled-name='lzbe_nvlist_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_free'>
+    <function-decl name='lzbe_remove_pair' mangled-name='lzbe_remove_pair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_remove_pair'>
       <parameter type-id='eaa32e2f' name='ptr'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='lzbe_nvlist_set' mangled-name='lzbe_nvlist_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_set'>
-      <parameter type-id='80f4b756' name='pool'/>
       <parameter type-id='80f4b756' name='key'/>
-      <parameter type-id='eaa32e2f' name='ptr'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='lzbe_nvlist_get' mangled-name='lzbe_nvlist_get' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_nvlist_get'>
-      <parameter type-id='80f4b756' name='pool'/>
-      <parameter type-id='80f4b756' name='key'/>
-      <parameter type-id='63e171df' name='ptr'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='lzbe_util.c' language='LANG_C99'>
+  <abi-instr address-size='64' path='lzbe_util.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='8' id='89feb1ec'>
       <subrange length='1' type-id='7359adad' id='52f813b4'/>
     </array-type-def>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <type-decl name='long int' size-in-bits='64' id='bd54fe1a'/>
     <type-decl name='signed char' size-in-bits='8' id='28577a57'/>
     <type-decl name='unsigned short int' size-in-bits='16' id='8efea9e5'/>
+    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
+    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
     <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
+    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='95e97e5e' visibility='default'/>
@@ -157,16 +161,16 @@
         <var-decl name='_offset' type-id='724e4de6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='__pad1' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_codecvt' type-id='570f8c59' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='__pad2' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_wide_data' type-id='c65a1f29' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='__pad3' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_freeres_list' type-id='dca988a5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='__pad4' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='_freeres_buf' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='__pad5' type-id='b59d7dce' visibility='default'/>
@@ -178,24 +182,15 @@
         <var-decl name='_unused2' type-id='664ac0b7' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='010ae0b9'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_next' type-id='e4c6fa61' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_sbuf' type-id='dca988a5' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_pos' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
-    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
-    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
     <pointer-type-def type-id='aa12d1ba' size-in-bits='64' id='822cd80b'/>
     <pointer-type-def type-id='ec1ed955' size-in-bits='64' id='dca988a5'/>
+    <pointer-type-def type-id='a4036571' size-in-bits='64' id='570f8c59'/>
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
+    <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
+    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
+    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
+    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <function-decl name='lzbe_bootenv_print' mangled-name='lzbe_bootenv_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_bootenv_print'>
       <parameter type-id='80f4b756' name='pool'/>
       <parameter type-id='80f4b756' name='nvlist'/>


### PR DESCRIPTION
Upgrade to libabigail 2.0.0

Currently using my own CI image, until https://github.com/openzfs/libabigail-docker/pull/2 is merged

### Motivation and Context
Most distributions are upgrading to new libabigail 2.0.0 thus our builds should support the new version of libabigail to maintain ABI checking capability.

### Description
Upgrade CI and abi files using libabigail 2.0.0

### How Has This Been Tested?
By updating the CI

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
