### PR TITLE
Linux 5.16 compat

### DIFF
--- a/config/kernel-bio.m4
+++ b/config/kernel-bio.m4
@@ -294,9 +294,8 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BIO_SUBMIT_BIO], [
 	ZFS_LINUX_TEST_SRC([submit_bio], [
 		#include <linux/bio.h>
 	],[
-		blk_qc_t blk_qc;
 		struct bio *bio = NULL;
-		blk_qc = submit_bio(bio);
+		(void) submit_bio(bio);
 	])
 ])
 

--- a/include/os/linux/kernel/linux/blkdev_compat.h
+++ b/include/os/linux/kernel/linux/blkdev_compat.h
@@ -30,9 +30,9 @@
 #define	_ZFS_BLKDEV_H
 
 #include <linux/blkdev.h>
-#include <linux/elevator.h>
 #include <linux/backing-dev.h>
 #include <linux/hdreg.h>
+#include <linux/major.h>
 #include <linux/msdos_fs.h>	/* for SECTOR_* */
 
 #ifndef HAVE_BLK_QUEUE_FLAG_SET

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -433,9 +433,9 @@ static inline void
 vdev_submit_bio_impl(struct bio *bio)
 {
 #ifdef HAVE_1ARG_SUBMIT_BIO
-	submit_bio(bio);
+	(void) submit_bio(bio);
 #else
-	submit_bio(0, bio);
+	(void) submit_bio(0, bio);
 #endif
 }
 


### PR DESCRIPTION
### Motivation and Context

Resolve new build failures introduced with the start of the 5.16 kernel
release cycle.

### Description

- Linux 5.16 compat: xgetbv()

    Explicitly include the xcr.h header for xgetbv().  It is no longer
    included indirectly resulting is a build failure.

- Linux 5.16 compat: submit_bio()

    The submit_bio() prototype has changed again.  The version is 5.16
    still only expects a single argument but the return type has changed
    to void.  Since we never used the returned value before update the
    configure check to detect both single arg versions.

- Linux 5.16 compat: linux/elevator.h

    Commit https://github.com/torvalds/linux/commit/2e9bc346 moved
    the elevator.h header under the block/ directory as part of some
    refactoring.  This turns out not to be a problem since there's
    no longer anything we need from the header.  This has been the
    case for some time, this change removes the elevator.h include
    and replaces it with a major.h include.

Note: This commit does not yet address all needed 5.16 compat changes.

### How Has This Been Tested?

Locally compiled with several older kernel versions.  I'm depending
on the CI to check for build failures on a wider range of kernels.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
