### PR TITLE
Add `const` to all nvlist_add_*_array functions to properly expose their real behavior

### DIFF
--- a/cmd/zed/agents/fmd_api.c
+++ b/cmd/zed/agents/fmd_api.c
@@ -428,7 +428,8 @@ fmd_case_add_suspect(fmd_hdl_t *hdl, fmd_case_t *cp, nvlist_t *fault)
 	err |= nvlist_add_string(nvl, FM_SUSPECT_DIAG_CODE, code);
 	err |= nvlist_add_int64_array(nvl, FM_SUSPECT_DIAG_TIME, tod, 2);
 	err |= nvlist_add_uint32(nvl, FM_SUSPECT_FAULT_SZ, 1);
-	err |= nvlist_add_nvlist_array(nvl, FM_SUSPECT_FAULT_LIST, &fault, 1);
+	err |= nvlist_add_nvlist_array(nvl, FM_SUSPECT_FAULT_LIST,
+	    (const nvlist_t **)&fault, 1);
 
 	if (err)
 		zed_log_die("failed to populate nvlist");

--- a/cmd/zed/agents/zfs_mod.c
+++ b/cmd/zed/agents/zfs_mod.c
@@ -414,8 +414,8 @@ zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 	    ZPOOL_CONFIG_VDEV_ENC_SYSFS_PATH, enc_sysfs_path) != 0) ||
 	    nvlist_add_uint64(newvd, ZPOOL_CONFIG_WHOLE_DISK, wholedisk) != 0 ||
 	    nvlist_add_string(nvroot, ZPOOL_CONFIG_TYPE, VDEV_TYPE_ROOT) != 0 ||
-	    nvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN, &newvd,
-	    1) != 0) {
+	    nvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
+	    (const nvlist_t **)&newvd, 1) != 0) {
 		zed_log_msg(LOG_WARNING, "zfs_mod: unable to add nvlist pairs");
 		nvlist_free(newvd);
 		nvlist_free(nvroot);

--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -239,7 +239,7 @@ replace_with_spare(fmd_hdl_t *hdl, zpool_handle_t *zhp, nvlist_t *vdev)
 			    ZPOOL_CONFIG_ASHIFT, ashift);
 
 		(void) nvlist_add_nvlist_array(replacement,
-		    ZPOOL_CONFIG_CHILDREN, &spares[s], 1);
+		    ZPOOL_CONFIG_CHILDREN, (const nvlist_t **)&spares[s], 1);
 
 		fmd_hdl_debug(hdl, "zpool_vdev_replace '%s' with spare '%s'",
 		    dev_name, zfs_basename(spare_name));

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -8010,7 +8010,8 @@ zfs_do_channel_program(int argc, char **argv)
 	 * }
 	 */
 	nvlist_t *argnvl = fnvlist_alloc();
-	fnvlist_add_string_array(argnvl, ZCP_ARG_CLIARGV, argv + 2, argc - 2);
+	fnvlist_add_string_array(argnvl, ZCP_ARG_CLIARGV,
+	    (const char **)argv + 2, argc - 2);
 
 	if (sync_flag) {
 		ret = lzc_channel_program(poolname, progbuf,

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -1647,8 +1647,8 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 					}
 				}
 				verify(nvlist_add_nvlist_array(nv,
-				    ZPOOL_CONFIG_CHILDREN, child,
-				    children) == 0);
+				    ZPOOL_CONFIG_CHILDREN,
+				    (const nvlist_t **)child, children) == 0);
 
 				for (c = 0; c < children; c++)
 					nvlist_free(child[c]);
@@ -1713,13 +1713,13 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 	verify(nvlist_add_string(nvroot, ZPOOL_CONFIG_TYPE,
 	    VDEV_TYPE_ROOT) == 0);
 	verify(nvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
-	    top, toplevels) == 0);
+	    (const nvlist_t **)top, toplevels) == 0);
 	if (nspares != 0)
 		verify(nvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_SPARES,
-		    spares, nspares) == 0);
+		    (const nvlist_t **)spares, nspares) == 0);
 	if (nl2cache != 0)
 		verify(nvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_L2CACHE,
-		    l2cache, nl2cache) == 0);
+		    (const nvlist_t **)l2cache, nl2cache) == 0);
 
 spec_out:
 	for (t = 0; t < toplevels; t++)

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -1287,7 +1287,8 @@ make_vdev_raid(char *path, char *aux, char *pool, size_t size,
 	    ztest_opts.zo_raid_type);
 	fnvlist_add_uint64(raid, ZPOOL_CONFIG_NPARITY,
 	    ztest_opts.zo_raid_parity);
-	fnvlist_add_nvlist_array(raid, ZPOOL_CONFIG_CHILDREN, child, r);
+	fnvlist_add_nvlist_array(raid, ZPOOL_CONFIG_CHILDREN,
+	    (const nvlist_t **)child, r);
 
 	if (strcmp(ztest_opts.zo_raid_type, VDEV_TYPE_DRAID) == 0) {
 		uint64_t ndata = ztest_opts.zo_draid_data;
@@ -1335,7 +1336,8 @@ make_vdev_mirror(char *path, char *aux, char *pool, size_t size,
 
 	mirror = fnvlist_alloc();
 	fnvlist_add_string(mirror, ZPOOL_CONFIG_TYPE, VDEV_TYPE_MIRROR);
-	fnvlist_add_nvlist_array(mirror, ZPOOL_CONFIG_CHILDREN, child, m);
+	fnvlist_add_nvlist_array(mirror, ZPOOL_CONFIG_CHILDREN,
+	    (const nvlist_t **)child, m);
 
 	for (c = 0; c < m; c++)
 		fnvlist_free(child[c]);
@@ -1374,7 +1376,7 @@ make_vdev_root(char *path, char *aux, char *pool, size_t size, uint64_t ashift,
 	root = fnvlist_alloc();
 	fnvlist_add_string(root, ZPOOL_CONFIG_TYPE, VDEV_TYPE_ROOT);
 	fnvlist_add_nvlist_array(root, aux ? aux : ZPOOL_CONFIG_CHILDREN,
-	    child, t);
+	    (const nvlist_t **)child, t);
 
 	for (c = 0; c < t; c++)
 		fnvlist_free(child[c]);
@@ -3550,8 +3552,8 @@ ztest_split_pool(ztest_ds_t *zd, uint64_t id)
 	/* OK, create a config that can be used to split */
 	split = fnvlist_alloc();
 	fnvlist_add_string(split, ZPOOL_CONFIG_TYPE, VDEV_TYPE_ROOT);
-	fnvlist_add_nvlist_array(split, ZPOOL_CONFIG_CHILDREN, schild,
-	    lastlogid != 0 ? lastlogid : schildren);
+	fnvlist_add_nvlist_array(split, ZPOOL_CONFIG_CHILDREN,
+	    (const nvlist_t **)schild, lastlogid != 0 ? lastlogid : schildren);
 
 	config = fnvlist_alloc();
 	fnvlist_add_nvlist(config, ZPOOL_CONFIG_VDEV_TREE, split);

--- a/contrib/pyzfs/libzfs_core/bindings/libnvpair.py
+++ b/contrib/pyzfs/libzfs_core/bindings/libnvpair.py
@@ -79,20 +79,30 @@ CDEF = """
     int nvlist_add_uint64(nvlist_t *, const char *, uint64_t);
     int nvlist_add_string(nvlist_t *, const char *, const char *);
     int nvlist_add_nvlist(nvlist_t *, const char *, nvlist_t *);
-    int nvlist_add_boolean_array(nvlist_t *, const char *, boolean_t *,
-        uint_t);
-    int nvlist_add_byte_array(nvlist_t *, const char *, uchar_t *, uint_t);
-    int nvlist_add_int8_array(nvlist_t *, const char *, int8_t *, uint_t);
-    int nvlist_add_uint8_array(nvlist_t *, const char *, uint8_t *, uint_t);
-    int nvlist_add_int16_array(nvlist_t *, const char *, int16_t *, uint_t);
-    int nvlist_add_uint16_array(nvlist_t *, const char *, uint16_t *, uint_t);
-    int nvlist_add_int32_array(nvlist_t *, const char *, int32_t *, uint_t);
-    int nvlist_add_uint32_array(nvlist_t *, const char *, uint32_t *, uint_t);
-    int nvlist_add_int64_array(nvlist_t *, const char *, int64_t *, uint_t);
-    int nvlist_add_uint64_array(nvlist_t *, const char *, uint64_t *, uint_t);
-    int nvlist_add_string_array(nvlist_t *, const char *, char *const *,
-        uint_t);
-    int nvlist_add_nvlist_array(nvlist_t *, const char *, nvlist_t **, uint_t);
+    int nvlist_add_boolean_array(nvlist_t *, const char *,
+        const boolean_t *, uint_t);
+    int nvlist_add_byte_array(nvlist_t *, const char *,
+        const uchar_t *, uint_t);
+    int nvlist_add_int8_array(nvlist_t *, const char *,
+        const int8_t *, uint_t);
+    int nvlist_add_uint8_array(nvlist_t *, const char *,
+        const uint8_t *, uint_t);
+    int nvlist_add_int16_array(nvlist_t *, const char *,
+        const int16_t *, uint_t);
+    int nvlist_add_uint16_array(nvlist_t *, const char *,
+        const uint16_t *, uint_t);
+    int nvlist_add_int32_array(nvlist_t *, const char *,
+        const int32_t *, uint_t);
+    int nvlist_add_uint32_array(nvlist_t *, const char *,
+        const uint32_t *, uint_t);
+    int nvlist_add_int64_array(nvlist_t *, const char *,
+        const int64_t *, uint_t);
+    int nvlist_add_uint64_array(nvlist_t *, const char *,
+        const uint64_t *, uint_t);
+    int nvlist_add_string_array(nvlist_t *, const char *,
+        const char * const *, uint_t);
+    int nvlist_add_nvlist_array(nvlist_t *, const char *,
+        const nvlist_t * const *, uint_t);
 
     nvpair_t *nvlist_next_nvpair(nvlist_t *, nvpair_t *);
     nvpair_t *nvlist_prev_nvpair(nvlist_t *, nvpair_t *);

--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -154,7 +154,7 @@ _SYS_NVPAIR_H void nvlist_free(nvlist_t *);
 _SYS_NVPAIR_H int nvlist_size(nvlist_t *, size_t *, int);
 _SYS_NVPAIR_H int nvlist_pack(nvlist_t *, char **, size_t *, int, int);
 _SYS_NVPAIR_H int nvlist_unpack(char *, size_t, nvlist_t **, int);
-_SYS_NVPAIR_H int nvlist_dup(nvlist_t *, nvlist_t **, int);
+_SYS_NVPAIR_H int nvlist_dup(const nvlist_t *, nvlist_t **, int);
 _SYS_NVPAIR_H int nvlist_merge(nvlist_t *, nvlist_t *, int);
 
 _SYS_NVPAIR_H uint_t nvlist_nvflag(nvlist_t *);
@@ -163,7 +163,7 @@ _SYS_NVPAIR_H int nvlist_xalloc(nvlist_t **, uint_t, nv_alloc_t *);
 _SYS_NVPAIR_H int nvlist_xpack(nvlist_t *, char **, size_t *, int,
     nv_alloc_t *);
 _SYS_NVPAIR_H int nvlist_xunpack(char *, size_t, nvlist_t **, nv_alloc_t *);
-_SYS_NVPAIR_H int nvlist_xdup(nvlist_t *, nvlist_t **, nv_alloc_t *);
+_SYS_NVPAIR_H int nvlist_xdup(const nvlist_t *, nvlist_t **, nv_alloc_t *);
 _SYS_NVPAIR_H nv_alloc_t *nvlist_lookup_nv_alloc(nvlist_t *);
 
 _SYS_NVPAIR_H int nvlist_add_nvpair(nvlist_t *, nvpair_t *);
@@ -179,31 +179,31 @@ _SYS_NVPAIR_H int nvlist_add_uint32(nvlist_t *, const char *, uint32_t);
 _SYS_NVPAIR_H int nvlist_add_int64(nvlist_t *, const char *, int64_t);
 _SYS_NVPAIR_H int nvlist_add_uint64(nvlist_t *, const char *, uint64_t);
 _SYS_NVPAIR_H int nvlist_add_string(nvlist_t *, const char *, const char *);
-_SYS_NVPAIR_H int nvlist_add_nvlist(nvlist_t *, const char *, nvlist_t *);
+_SYS_NVPAIR_H int nvlist_add_nvlist(nvlist_t *, const char *, const nvlist_t *);
 _SYS_NVPAIR_H int nvlist_add_boolean_array(nvlist_t *, const char *,
-    boolean_t *, uint_t);
-_SYS_NVPAIR_H int nvlist_add_byte_array(nvlist_t *, const char *, uchar_t *,
-    uint_t);
-_SYS_NVPAIR_H int nvlist_add_int8_array(nvlist_t *, const char *, int8_t *,
-    uint_t);
-_SYS_NVPAIR_H int nvlist_add_uint8_array(nvlist_t *, const char *, uint8_t *,
-    uint_t);
-_SYS_NVPAIR_H int nvlist_add_int16_array(nvlist_t *, const char *, int16_t *,
-    uint_t);
-_SYS_NVPAIR_H int nvlist_add_uint16_array(nvlist_t *, const char *, uint16_t *,
-    uint_t);
-_SYS_NVPAIR_H int nvlist_add_int32_array(nvlist_t *, const char *, int32_t *,
-    uint_t);
-_SYS_NVPAIR_H int nvlist_add_uint32_array(nvlist_t *, const char *, uint32_t *,
-    uint_t);
-_SYS_NVPAIR_H int nvlist_add_int64_array(nvlist_t *, const char *, int64_t *,
-    uint_t);
-_SYS_NVPAIR_H int nvlist_add_uint64_array(nvlist_t *, const char *, uint64_t *,
-    uint_t);
+    const boolean_t *, uint_t);
+_SYS_NVPAIR_H int nvlist_add_byte_array(nvlist_t *, const char *,
+    const uchar_t *, uint_t);
+_SYS_NVPAIR_H int nvlist_add_int8_array(nvlist_t *, const char *,
+    const int8_t *, uint_t);
+_SYS_NVPAIR_H int nvlist_add_uint8_array(nvlist_t *, const char *,
+    const uint8_t *, uint_t);
+_SYS_NVPAIR_H int nvlist_add_int16_array(nvlist_t *, const char *,
+    const int16_t *, uint_t);
+_SYS_NVPAIR_H int nvlist_add_uint16_array(nvlist_t *, const char *,
+    const uint16_t *, uint_t);
+_SYS_NVPAIR_H int nvlist_add_int32_array(nvlist_t *, const char *,
+    const int32_t *, uint_t);
+_SYS_NVPAIR_H int nvlist_add_uint32_array(nvlist_t *, const char *,
+    const uint32_t *, uint_t);
+_SYS_NVPAIR_H int nvlist_add_int64_array(nvlist_t *, const char *,
+    const int64_t *, uint_t);
+_SYS_NVPAIR_H int nvlist_add_uint64_array(nvlist_t *, const char *,
+    const uint64_t *, uint_t);
 _SYS_NVPAIR_H int nvlist_add_string_array(nvlist_t *, const char *,
-    char * const *, uint_t);
+    const char * const *, uint_t);
 _SYS_NVPAIR_H int nvlist_add_nvlist_array(nvlist_t *, const char *,
-    nvlist_t **, uint_t);
+    const nvlist_t * const *, uint_t);
 _SYS_NVPAIR_H int nvlist_add_hrtime(nvlist_t *, const char *, hrtime_t);
 #if !defined(_KERNEL) && !defined(_STANDALONE)
 _SYS_NVPAIR_H int nvlist_add_double(nvlist_t *, const char *, double);
@@ -213,18 +213,25 @@ _SYS_NVPAIR_H int nvlist_remove(nvlist_t *, const char *, data_type_t);
 _SYS_NVPAIR_H int nvlist_remove_all(nvlist_t *, const char *);
 _SYS_NVPAIR_H int nvlist_remove_nvpair(nvlist_t *, nvpair_t *);
 
-_SYS_NVPAIR_H int nvlist_lookup_boolean(nvlist_t *, const char *);
-_SYS_NVPAIR_H int nvlist_lookup_boolean_value(nvlist_t *, const char *,
+_SYS_NVPAIR_H int nvlist_lookup_boolean(const nvlist_t *, const char *);
+_SYS_NVPAIR_H int nvlist_lookup_boolean_value(const nvlist_t *, const char *,
     boolean_t *);
-_SYS_NVPAIR_H int nvlist_lookup_byte(nvlist_t *, const char *, uchar_t *);
-_SYS_NVPAIR_H int nvlist_lookup_int8(nvlist_t *, const char *, int8_t *);
-_SYS_NVPAIR_H int nvlist_lookup_uint8(nvlist_t *, const char *, uint8_t *);
-_SYS_NVPAIR_H int nvlist_lookup_int16(nvlist_t *, const char *, int16_t *);
-_SYS_NVPAIR_H int nvlist_lookup_uint16(nvlist_t *, const char *, uint16_t *);
-_SYS_NVPAIR_H int nvlist_lookup_int32(nvlist_t *, const char *, int32_t *);
-_SYS_NVPAIR_H int nvlist_lookup_uint32(nvlist_t *, const char *, uint32_t *);
-_SYS_NVPAIR_H int nvlist_lookup_int64(nvlist_t *, const char *, int64_t *);
-_SYS_NVPAIR_H int nvlist_lookup_uint64(nvlist_t *, const char *, uint64_t *);
+_SYS_NVPAIR_H int nvlist_lookup_byte(const nvlist_t *, const char *, uchar_t *);
+_SYS_NVPAIR_H int nvlist_lookup_int8(const nvlist_t *, const char *, int8_t *);
+_SYS_NVPAIR_H int nvlist_lookup_uint8(const nvlist_t *, const char *,
+    uint8_t *);
+_SYS_NVPAIR_H int nvlist_lookup_int16(const nvlist_t *, const char *,
+    int16_t *);
+_SYS_NVPAIR_H int nvlist_lookup_uint16(const nvlist_t *, const char *,
+    uint16_t *);
+_SYS_NVPAIR_H int nvlist_lookup_int32(const nvlist_t *, const char *,
+    int32_t *);
+_SYS_NVPAIR_H int nvlist_lookup_uint32(const nvlist_t *, const char *,
+    uint32_t *);
+_SYS_NVPAIR_H int nvlist_lookup_int64(const nvlist_t *, const char *,
+    int64_t *);
+_SYS_NVPAIR_H int nvlist_lookup_uint64(const nvlist_t *, const char *,
+    uint64_t *);
 _SYS_NVPAIR_H int nvlist_lookup_string(nvlist_t *, const char *, char **);
 _SYS_NVPAIR_H int nvlist_lookup_nvlist(nvlist_t *, const char *, nvlist_t **);
 _SYS_NVPAIR_H int nvlist_lookup_boolean_array(nvlist_t *, const char *,
@@ -254,31 +261,32 @@ _SYS_NVPAIR_H int nvlist_lookup_nvlist_array(nvlist_t *, const char *,
 _SYS_NVPAIR_H int nvlist_lookup_hrtime(nvlist_t *, const char *, hrtime_t *);
 _SYS_NVPAIR_H int nvlist_lookup_pairs(nvlist_t *, int, ...);
 #if !defined(_KERNEL) && !defined(_STANDALONE)
-_SYS_NVPAIR_H int nvlist_lookup_double(nvlist_t *, const char *, double *);
+_SYS_NVPAIR_H int nvlist_lookup_double(const nvlist_t *, const char *,
+    double *);
 #endif
 
 _SYS_NVPAIR_H int nvlist_lookup_nvpair(nvlist_t *, const char *, nvpair_t **);
 _SYS_NVPAIR_H int nvlist_lookup_nvpair_embedded_index(nvlist_t *, const char *,
     nvpair_t **, int *, char **);
-_SYS_NVPAIR_H boolean_t nvlist_exists(nvlist_t *, const char *);
-_SYS_NVPAIR_H boolean_t nvlist_empty(nvlist_t *);
+_SYS_NVPAIR_H boolean_t nvlist_exists(const nvlist_t *, const char *);
+_SYS_NVPAIR_H boolean_t nvlist_empty(const nvlist_t *);
 
 /* processing nvpair */
-_SYS_NVPAIR_H nvpair_t *nvlist_next_nvpair(nvlist_t *, nvpair_t *);
-_SYS_NVPAIR_H nvpair_t *nvlist_prev_nvpair(nvlist_t *, nvpair_t *);
-_SYS_NVPAIR_H char *nvpair_name(nvpair_t *);
-_SYS_NVPAIR_H data_type_t nvpair_type(nvpair_t *);
-_SYS_NVPAIR_H int nvpair_type_is_array(nvpair_t *);
-_SYS_NVPAIR_H int nvpair_value_boolean_value(nvpair_t *, boolean_t *);
-_SYS_NVPAIR_H int nvpair_value_byte(nvpair_t *, uchar_t *);
-_SYS_NVPAIR_H int nvpair_value_int8(nvpair_t *, int8_t *);
-_SYS_NVPAIR_H int nvpair_value_uint8(nvpair_t *, uint8_t *);
-_SYS_NVPAIR_H int nvpair_value_int16(nvpair_t *, int16_t *);
-_SYS_NVPAIR_H int nvpair_value_uint16(nvpair_t *, uint16_t *);
-_SYS_NVPAIR_H int nvpair_value_int32(nvpair_t *, int32_t *);
-_SYS_NVPAIR_H int nvpair_value_uint32(nvpair_t *, uint32_t *);
-_SYS_NVPAIR_H int nvpair_value_int64(nvpair_t *, int64_t *);
-_SYS_NVPAIR_H int nvpair_value_uint64(nvpair_t *, uint64_t *);
+_SYS_NVPAIR_H nvpair_t *nvlist_next_nvpair(nvlist_t *, const nvpair_t *);
+_SYS_NVPAIR_H nvpair_t *nvlist_prev_nvpair(nvlist_t *, const nvpair_t *);
+_SYS_NVPAIR_H char *nvpair_name(const nvpair_t *);
+_SYS_NVPAIR_H data_type_t nvpair_type(const nvpair_t *);
+_SYS_NVPAIR_H int nvpair_type_is_array(const nvpair_t *);
+_SYS_NVPAIR_H int nvpair_value_boolean_value(const nvpair_t *, boolean_t *);
+_SYS_NVPAIR_H int nvpair_value_byte(const nvpair_t *, uchar_t *);
+_SYS_NVPAIR_H int nvpair_value_int8(const nvpair_t *, int8_t *);
+_SYS_NVPAIR_H int nvpair_value_uint8(const nvpair_t *, uint8_t *);
+_SYS_NVPAIR_H int nvpair_value_int16(const nvpair_t *, int16_t *);
+_SYS_NVPAIR_H int nvpair_value_uint16(const nvpair_t *, uint16_t *);
+_SYS_NVPAIR_H int nvpair_value_int32(const nvpair_t *, int32_t *);
+_SYS_NVPAIR_H int nvpair_value_uint32(const nvpair_t *, uint32_t *);
+_SYS_NVPAIR_H int nvpair_value_int64(const nvpair_t *, int64_t *);
+_SYS_NVPAIR_H int nvpair_value_uint64(const nvpair_t *, uint64_t *);
 _SYS_NVPAIR_H int nvpair_value_string(nvpair_t *, char **);
 _SYS_NVPAIR_H int nvpair_value_nvlist(nvpair_t *, nvlist_t **);
 _SYS_NVPAIR_H int nvpair_value_boolean_array(nvpair_t *, boolean_t **,
@@ -296,7 +304,7 @@ _SYS_NVPAIR_H int nvpair_value_string_array(nvpair_t *, char ***, uint_t *);
 _SYS_NVPAIR_H int nvpair_value_nvlist_array(nvpair_t *, nvlist_t ***, uint_t *);
 _SYS_NVPAIR_H int nvpair_value_hrtime(nvpair_t *, hrtime_t *);
 #if !defined(_KERNEL) && !defined(_STANDALONE)
-_SYS_NVPAIR_H int nvpair_value_double(nvpair_t *, double *);
+_SYS_NVPAIR_H int nvpair_value_double(const nvpair_t *, double *);
 #endif
 
 _SYS_NVPAIR_H nvlist_t *fnvlist_alloc(void);
@@ -305,7 +313,7 @@ _SYS_NVPAIR_H size_t fnvlist_size(nvlist_t *);
 _SYS_NVPAIR_H char *fnvlist_pack(nvlist_t *, size_t *);
 _SYS_NVPAIR_H void fnvlist_pack_free(char *, size_t);
 _SYS_NVPAIR_H nvlist_t *fnvlist_unpack(char *, size_t);
-_SYS_NVPAIR_H nvlist_t *fnvlist_dup(nvlist_t *);
+_SYS_NVPAIR_H nvlist_t *fnvlist_dup(const nvlist_t *);
 _SYS_NVPAIR_H void fnvlist_merge(nvlist_t *, nvlist_t *);
 _SYS_NVPAIR_H size_t fnvlist_num_pairs(nvlist_t *);
 
@@ -325,45 +333,46 @@ _SYS_NVPAIR_H void fnvlist_add_string(nvlist_t *, const char *, const char *);
 _SYS_NVPAIR_H void fnvlist_add_nvlist(nvlist_t *, const char *, nvlist_t *);
 _SYS_NVPAIR_H void fnvlist_add_nvpair(nvlist_t *, nvpair_t *);
 _SYS_NVPAIR_H void fnvlist_add_boolean_array(nvlist_t *, const char *,
-    boolean_t *, uint_t);
-_SYS_NVPAIR_H void fnvlist_add_byte_array(nvlist_t *, const char *, uchar_t *,
-    uint_t);
-_SYS_NVPAIR_H void fnvlist_add_int8_array(nvlist_t *, const char *, int8_t *,
-    uint_t);
-_SYS_NVPAIR_H void fnvlist_add_uint8_array(nvlist_t *, const char *, uint8_t *,
-    uint_t);
-_SYS_NVPAIR_H void fnvlist_add_int16_array(nvlist_t *, const char *, int16_t *,
-    uint_t);
+    const boolean_t *, uint_t);
+_SYS_NVPAIR_H void fnvlist_add_byte_array(nvlist_t *, const char *,
+    const uchar_t *, uint_t);
+_SYS_NVPAIR_H void fnvlist_add_int8_array(nvlist_t *, const char *,
+    const int8_t *, uint_t);
+_SYS_NVPAIR_H void fnvlist_add_uint8_array(nvlist_t *, const char *,
+    const uint8_t *, uint_t);
+_SYS_NVPAIR_H void fnvlist_add_int16_array(nvlist_t *, const char *,
+    const int16_t *, uint_t);
 _SYS_NVPAIR_H void fnvlist_add_uint16_array(nvlist_t *, const char *,
-    uint16_t *, uint_t);
-_SYS_NVPAIR_H void fnvlist_add_int32_array(nvlist_t *, const char *, int32_t *,
-    uint_t);
+    const uint16_t *, uint_t);
+_SYS_NVPAIR_H void fnvlist_add_int32_array(nvlist_t *, const char *,
+    const int32_t *, uint_t);
 _SYS_NVPAIR_H void fnvlist_add_uint32_array(nvlist_t *, const char *,
-    uint32_t *, uint_t);
-_SYS_NVPAIR_H void fnvlist_add_int64_array(nvlist_t *, const char *, int64_t *,
-    uint_t);
+    const uint32_t *, uint_t);
+_SYS_NVPAIR_H void fnvlist_add_int64_array(nvlist_t *, const char *,
+    const int64_t *, uint_t);
 _SYS_NVPAIR_H void fnvlist_add_uint64_array(nvlist_t *, const char *,
-    uint64_t *, uint_t);
+    const uint64_t *, uint_t);
 _SYS_NVPAIR_H void fnvlist_add_string_array(nvlist_t *, const char *,
-    char * const *, uint_t);
+    const char * const *, uint_t);
 _SYS_NVPAIR_H void fnvlist_add_nvlist_array(nvlist_t *, const char *,
-    nvlist_t **, uint_t);
+    const nvlist_t * const *, uint_t);
 
 _SYS_NVPAIR_H void fnvlist_remove(nvlist_t *, const char *);
 _SYS_NVPAIR_H void fnvlist_remove_nvpair(nvlist_t *, nvpair_t *);
 
 _SYS_NVPAIR_H nvpair_t *fnvlist_lookup_nvpair(nvlist_t *, const char *);
-_SYS_NVPAIR_H boolean_t fnvlist_lookup_boolean(nvlist_t *, const char *);
-_SYS_NVPAIR_H boolean_t fnvlist_lookup_boolean_value(nvlist_t *, const char *);
-_SYS_NVPAIR_H uchar_t fnvlist_lookup_byte(nvlist_t *, const char *);
-_SYS_NVPAIR_H int8_t fnvlist_lookup_int8(nvlist_t *, const char *);
-_SYS_NVPAIR_H int16_t fnvlist_lookup_int16(nvlist_t *, const char *);
-_SYS_NVPAIR_H int32_t fnvlist_lookup_int32(nvlist_t *, const char *);
-_SYS_NVPAIR_H int64_t fnvlist_lookup_int64(nvlist_t *, const char *);
-_SYS_NVPAIR_H uint8_t fnvlist_lookup_uint8(nvlist_t *, const char *);
-_SYS_NVPAIR_H uint16_t fnvlist_lookup_uint16(nvlist_t *, const char *);
-_SYS_NVPAIR_H uint32_t fnvlist_lookup_uint32(nvlist_t *, const char *);
-_SYS_NVPAIR_H uint64_t fnvlist_lookup_uint64(nvlist_t *, const char *);
+_SYS_NVPAIR_H boolean_t fnvlist_lookup_boolean(const nvlist_t *, const char *);
+_SYS_NVPAIR_H boolean_t fnvlist_lookup_boolean_value(const nvlist_t *,
+    const char *);
+_SYS_NVPAIR_H uchar_t fnvlist_lookup_byte(const nvlist_t *, const char *);
+_SYS_NVPAIR_H int8_t fnvlist_lookup_int8(const nvlist_t *, const char *);
+_SYS_NVPAIR_H int16_t fnvlist_lookup_int16(const nvlist_t *, const char *);
+_SYS_NVPAIR_H int32_t fnvlist_lookup_int32(const nvlist_t *, const char *);
+_SYS_NVPAIR_H int64_t fnvlist_lookup_int64(const nvlist_t *, const char *);
+_SYS_NVPAIR_H uint8_t fnvlist_lookup_uint8(const nvlist_t *, const char *);
+_SYS_NVPAIR_H uint16_t fnvlist_lookup_uint16(const nvlist_t *, const char *);
+_SYS_NVPAIR_H uint32_t fnvlist_lookup_uint32(const nvlist_t *, const char *);
+_SYS_NVPAIR_H uint64_t fnvlist_lookup_uint64(const nvlist_t *, const char *);
 _SYS_NVPAIR_H char *fnvlist_lookup_string(nvlist_t *, const char *);
 _SYS_NVPAIR_H nvlist_t *fnvlist_lookup_nvlist(nvlist_t *, const char *);
 _SYS_NVPAIR_H boolean_t *fnvlist_lookup_boolean_array(nvlist_t *, const char *,
@@ -387,16 +396,16 @@ _SYS_NVPAIR_H int64_t *fnvlist_lookup_int64_array(nvlist_t *, const char *,
 _SYS_NVPAIR_H uint64_t *fnvlist_lookup_uint64_array(nvlist_t *, const char *,
     uint_t *);
 
-_SYS_NVPAIR_H boolean_t fnvpair_value_boolean_value(nvpair_t *nvp);
-_SYS_NVPAIR_H uchar_t fnvpair_value_byte(nvpair_t *nvp);
-_SYS_NVPAIR_H int8_t fnvpair_value_int8(nvpair_t *nvp);
-_SYS_NVPAIR_H int16_t fnvpair_value_int16(nvpair_t *nvp);
-_SYS_NVPAIR_H int32_t fnvpair_value_int32(nvpair_t *nvp);
-_SYS_NVPAIR_H int64_t fnvpair_value_int64(nvpair_t *nvp);
-_SYS_NVPAIR_H uint8_t fnvpair_value_uint8(nvpair_t *nvp);
-_SYS_NVPAIR_H uint16_t fnvpair_value_uint16(nvpair_t *nvp);
-_SYS_NVPAIR_H uint32_t fnvpair_value_uint32(nvpair_t *nvp);
-_SYS_NVPAIR_H uint64_t fnvpair_value_uint64(nvpair_t *nvp);
+_SYS_NVPAIR_H boolean_t fnvpair_value_boolean_value(const nvpair_t *nvp);
+_SYS_NVPAIR_H uchar_t fnvpair_value_byte(const nvpair_t *nvp);
+_SYS_NVPAIR_H int8_t fnvpair_value_int8(const nvpair_t *nvp);
+_SYS_NVPAIR_H int16_t fnvpair_value_int16(const nvpair_t *nvp);
+_SYS_NVPAIR_H int32_t fnvpair_value_int32(const nvpair_t *nvp);
+_SYS_NVPAIR_H int64_t fnvpair_value_int64(const nvpair_t *nvp);
+_SYS_NVPAIR_H uint8_t fnvpair_value_uint8(const nvpair_t *nvp);
+_SYS_NVPAIR_H uint16_t fnvpair_value_uint16(const nvpair_t *nvp);
+_SYS_NVPAIR_H uint32_t fnvpair_value_uint32(const nvpair_t *nvp);
+_SYS_NVPAIR_H uint64_t fnvpair_value_uint64(const nvpair_t *nvp);
 _SYS_NVPAIR_H char *fnvpair_value_string(nvpair_t *nvp);
 _SYS_NVPAIR_H nvlist_t *fnvpair_value_nvlist(nvpair_t *nvp);
 

--- a/include/sys/nvpair_impl.h
+++ b/include/sys/nvpair_impl.h
@@ -74,7 +74,7 @@ struct i_nvp {
 typedef struct {
 	i_nvp_t		*nvp_list;	/* linked list of nvpairs */
 	i_nvp_t		*nvp_last;	/* last nvpair */
-	i_nvp_t		*nvp_curr;	/* current walker nvpair */
+	const i_nvp_t	*nvp_curr;	/* current walker nvpair */
 	nv_alloc_t	*nvp_nva;	/* pluggable allocator */
 	uint32_t	nvp_stat;	/* internal state */
 

--- a/lib/libnvpair/libnvpair.abi
+++ b/lib/libnvpair/libnvpair.abi
@@ -3,6 +3,8 @@
     <dependency name='libc.so.6'/>
   </elf-needed>
   <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='dump_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fnvlist_add_boolean' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fnvlist_add_boolean_array' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -262,7 +264,7 @@
       <return type-id='5ce45b60'/>
     </function-decl>
     <function-decl name='fnvlist_dup' mangled-name='fnvlist_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_dup'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <return type-id='5ce45b60'/>
     </function-decl>
     <function-decl name='fnvlist_merge' mangled-name='fnvlist_merge' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_merge'>
@@ -359,84 +361,84 @@
     <function-decl name='fnvlist_add_boolean_array' mangled-name='fnvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_boolean_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='37e3bd22' name='val'/>
+      <parameter type-id='c5f6c15b' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_byte_array' mangled-name='fnvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_byte_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='45b65157' name='val'/>
+      <parameter type-id='d1db479e' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_int8_array' mangled-name='fnvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int8_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='256d5229' name='val'/>
+      <parameter type-id='a06445da' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_uint8_array' mangled-name='fnvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint8_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='ae3e8ca6' name='val'/>
+      <parameter type-id='9f7200cf' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_int16_array' mangled-name='fnvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int16_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='f76f73d0' name='val'/>
+      <parameter type-id='a3eb883d' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_uint16_array' mangled-name='fnvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint16_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='8a121f49' name='val'/>
+      <parameter type-id='1b7d11c6' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_int32_array' mangled-name='fnvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int32_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4aafb922' name='val'/>
+      <parameter type-id='1f526493' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_uint32_array' mangled-name='fnvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint32_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='90421557' name='val'/>
+      <parameter type-id='a6798dcc' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_int64_array' mangled-name='fnvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_int64_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='cb785ebf' name='val'/>
+      <parameter type-id='505bed1a' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_uint64_array' mangled-name='fnvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_uint64_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='5d6479ae' name='val'/>
+      <parameter type-id='713a56f5' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_string_array' mangled-name='fnvlist_add_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_string_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='f319fae0' name='val'/>
+      <parameter type-id='13956559' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='fnvlist_add_nvlist_array' mangled-name='fnvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_add_nvlist_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='857bb57e' name='val'/>
+      <parameter type-id='3bbfee2e' name='val'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='48b5725f'/>
     </function-decl>
@@ -456,57 +458,57 @@
       <return type-id='3fa542f0'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_boolean' mangled-name='fnvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_boolean_value' mangled-name='fnvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_boolean_value'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_byte' mangled-name='fnvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_byte'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='d8bf0010'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_int8' mangled-name='fnvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int8'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='ee31ee44'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_int16' mangled-name='fnvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int16'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='23bd8cb5'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_int32' mangled-name='fnvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int32'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='3ff5601b'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_int64' mangled-name='fnvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_int64'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='9da381c4'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_uint8' mangled-name='fnvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint8'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='b96825af'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_uint16' mangled-name='fnvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint16'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='149c6638'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_uint32' mangled-name='fnvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint32'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='8f92235e'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_uint64' mangled-name='fnvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_uint64'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='9c313c2d'/>
     </function-decl>
@@ -581,43 +583,43 @@
       <return type-id='5d6479ae'/>
     </function-decl>
     <function-decl name='fnvpair_value_boolean_value' mangled-name='fnvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_boolean_value'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='fnvpair_value_byte' mangled-name='fnvpair_value_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_byte'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='d8bf0010'/>
     </function-decl>
     <function-decl name='fnvpair_value_int8' mangled-name='fnvpair_value_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int8'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='ee31ee44'/>
     </function-decl>
     <function-decl name='fnvpair_value_int16' mangled-name='fnvpair_value_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int16'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='23bd8cb5'/>
     </function-decl>
     <function-decl name='fnvpair_value_int32' mangled-name='fnvpair_value_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int32'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='3ff5601b'/>
     </function-decl>
     <function-decl name='fnvpair_value_int64' mangled-name='fnvpair_value_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_int64'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='9da381c4'/>
     </function-decl>
     <function-decl name='fnvpair_value_uint8' mangled-name='fnvpair_value_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint8'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='b96825af'/>
     </function-decl>
     <function-decl name='fnvpair_value_uint16' mangled-name='fnvpair_value_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint16'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='149c6638'/>
     </function-decl>
     <function-decl name='fnvpair_value_uint32' mangled-name='fnvpair_value_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint32'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='8f92235e'/>
     </function-decl>
     <function-decl name='fnvpair_value_uint64' mangled-name='fnvpair_value_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_uint64'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='9c313c2d'/>
     </function-decl>
     <function-decl name='fnvpair_value_string' mangled-name='fnvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_string'>
@@ -631,9 +633,35 @@
   </abi-instr>
   <abi-instr address-size='64' path='../../module/nvpair/nvpair.c' language='LANG_C99'>
     <pointer-type-def type-id='37e3bd22' size-in-bits='64' id='03829398'/>
-    <qualified-type-def type-id='26a90f95' const='yes' id='57de658a'/>
-    <pointer-type-def type-id='57de658a' size-in-bits='64' id='f319fae0'/>
     <pointer-type-def type-id='9b23c9ad' size-in-bits='64' id='c0563f85'/>
+    <qualified-type-def type-id='c19b74c3' const='yes' id='12373e33'/>
+    <pointer-type-def type-id='12373e33' size-in-bits='64' id='c5f6c15b'/>
+    <qualified-type-def type-id='80f4b756' const='yes' id='b99c00c9'/>
+    <pointer-type-def type-id='b99c00c9' size-in-bits='64' id='13956559'/>
+    <qualified-type-def type-id='23bd8cb5' const='yes' id='75f7b0c5'/>
+    <pointer-type-def type-id='75f7b0c5' size-in-bits='64' id='a3eb883d'/>
+    <qualified-type-def type-id='3ff5601b' const='yes' id='922df12b'/>
+    <pointer-type-def type-id='922df12b' size-in-bits='64' id='1f526493'/>
+    <qualified-type-def type-id='9da381c4' const='yes' id='f07b7694'/>
+    <pointer-type-def type-id='f07b7694' size-in-bits='64' id='505bed1a'/>
+    <qualified-type-def type-id='ee31ee44' const='yes' id='721c32d4'/>
+    <pointer-type-def type-id='721c32d4' size-in-bits='64' id='a06445da'/>
+    <qualified-type-def type-id='8e8d4be3' const='yes' id='693c3853'/>
+    <pointer-type-def type-id='693c3853' size-in-bits='64' id='22cce67b'/>
+    <qualified-type-def type-id='22cce67b' const='yes' id='d2816df0'/>
+    <pointer-type-def type-id='d2816df0' size-in-bits='64' id='3bbfee2e'/>
+    <qualified-type-def type-id='57928edf' const='yes' id='642ee20f'/>
+    <pointer-type-def type-id='642ee20f' size-in-bits='64' id='dace003f'/>
+    <qualified-type-def type-id='d8bf0010' const='yes' id='a9125480'/>
+    <pointer-type-def type-id='a9125480' size-in-bits='64' id='d1db479e'/>
+    <qualified-type-def type-id='149c6638' const='yes' id='b01a5ac8'/>
+    <pointer-type-def type-id='b01a5ac8' size-in-bits='64' id='1b7d11c6'/>
+    <qualified-type-def type-id='8f92235e' const='yes' id='b9930aae'/>
+    <pointer-type-def type-id='b9930aae' size-in-bits='64' id='a6798dcc'/>
+    <qualified-type-def type-id='9c313c2d' const='yes' id='c3b7ba7d'/>
+    <pointer-type-def type-id='c3b7ba7d' size-in-bits='64' id='713a56f5'/>
+    <qualified-type-def type-id='b96825af' const='yes' id='2b61797f'/>
+    <pointer-type-def type-id='2b61797f' size-in-bits='64' id='9f7200cf'/>
     <pointer-type-def type-id='a0eb0f08' size-in-bits='64' id='7408d286'/>
     <pointer-type-def type-id='cebdd548' size-in-bits='64' id='e379e62d'/>
     <pointer-type-def type-id='95e97e5e' size-in-bits='64' id='7292109c'/>
@@ -689,13 +717,13 @@
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='nvlist_dup' mangled-name='nvlist_dup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_dup'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='857bb57e' name='nvlp'/>
       <parameter type-id='95e97e5e' name='kmflag'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_xdup' mangled-name='nvlist_xdup' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_xdup'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='857bb57e' name='nvlp'/>
       <parameter type-id='11871392' name='nva'/>
       <return type-id='95e97e5e'/>
@@ -796,77 +824,77 @@
     <function-decl name='nvlist_add_boolean_array' mangled-name='nvlist_add_boolean_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_boolean_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='37e3bd22' name='a'/>
+      <parameter type-id='c5f6c15b' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_byte_array' mangled-name='nvlist_add_byte_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_byte_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='45b65157' name='a'/>
+      <parameter type-id='d1db479e' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_int8_array' mangled-name='nvlist_add_int8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int8_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='256d5229' name='a'/>
+      <parameter type-id='a06445da' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_uint8_array' mangled-name='nvlist_add_uint8_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint8_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='ae3e8ca6' name='a'/>
+      <parameter type-id='9f7200cf' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_int16_array' mangled-name='nvlist_add_int16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int16_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='f76f73d0' name='a'/>
+      <parameter type-id='a3eb883d' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_uint16_array' mangled-name='nvlist_add_uint16_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint16_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='8a121f49' name='a'/>
+      <parameter type-id='1b7d11c6' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_int32_array' mangled-name='nvlist_add_int32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int32_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='4aafb922' name='a'/>
+      <parameter type-id='1f526493' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_uint32_array' mangled-name='nvlist_add_uint32_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint32_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='90421557' name='a'/>
+      <parameter type-id='a6798dcc' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_int64_array' mangled-name='nvlist_add_int64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_int64_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='cb785ebf' name='a'/>
+      <parameter type-id='505bed1a' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_uint64_array' mangled-name='nvlist_add_uint64_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_uint64_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='5d6479ae' name='a'/>
+      <parameter type-id='713a56f5' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_string_array' mangled-name='nvlist_add_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_string_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='f319fae0' name='a'/>
+      <parameter type-id='13956559' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
@@ -879,109 +907,109 @@
     <function-decl name='nvlist_add_nvlist' mangled-name='nvlist_add_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='5ce45b60' name='val'/>
+      <parameter type-id='22cce67b' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_nvlist_array' mangled-name='nvlist_add_nvlist_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_add_nvlist_array'>
       <parameter type-id='5ce45b60' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='857bb57e' name='a'/>
+      <parameter type-id='3bbfee2e' name='a'/>
       <parameter type-id='3502e3ff' name='n'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_next_nvpair'>
       <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='3fa542f0'/>
     </function-decl>
     <function-decl name='nvlist_prev_nvpair' mangled-name='nvlist_prev_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prev_nvpair'>
       <parameter type-id='5ce45b60' name='nvl'/>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='3fa542f0'/>
     </function-decl>
     <function-decl name='nvlist_empty' mangled-name='nvlist_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_empty'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='nvpair_name' mangled-name='nvpair_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_name'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='26a90f95'/>
     </function-decl>
     <function-decl name='nvpair_type' mangled-name='nvpair_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='8d0687d2'/>
     </function-decl>
     <function-decl name='nvpair_type_is_array' mangled-name='nvpair_type_is_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type_is_array'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_boolean' mangled-name='nvlist_lookup_boolean' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_boolean_value' mangled-name='nvlist_lookup_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_boolean_value'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='37e3bd22' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_byte' mangled-name='nvlist_lookup_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_byte'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='45b65157' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_int8' mangled-name='nvlist_lookup_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int8'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='256d5229' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_uint8' mangled-name='nvlist_lookup_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint8'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='ae3e8ca6' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_int16' mangled-name='nvlist_lookup_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int16'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='f76f73d0' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_uint16' mangled-name='nvlist_lookup_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint16'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='8a121f49' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_int32' mangled-name='nvlist_lookup_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int32'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='4aafb922' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_uint32' mangled-name='nvlist_lookup_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint32'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='90421557' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_int64' mangled-name='nvlist_lookup_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_int64'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='cb785ebf' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_uint64' mangled-name='nvlist_lookup_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_uint64'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='5d6479ae' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_double' mangled-name='nvlist_lookup_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_double'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='7408d286' name='val'/>
       <return type-id='95e97e5e'/>
@@ -1109,62 +1137,62 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_exists' mangled-name='nvlist_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_exists'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
       <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='nvpair_value_boolean_value' mangled-name='nvpair_value_boolean_value' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_boolean_value'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='37e3bd22' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_byte' mangled-name='nvpair_value_byte' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_byte'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='45b65157' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_int8' mangled-name='nvpair_value_int8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int8'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='256d5229' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_uint8' mangled-name='nvpair_value_uint8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint8'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='ae3e8ca6' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_int16' mangled-name='nvpair_value_int16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int16'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='f76f73d0' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_uint16' mangled-name='nvpair_value_uint16' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint16'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='8a121f49' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_int32' mangled-name='nvpair_value_int32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int32'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='4aafb922' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_uint32' mangled-name='nvpair_value_uint32' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint32'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='90421557' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_int64' mangled-name='nvpair_value_int64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_int64'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='cb785ebf' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_uint64' mangled-name='nvpair_value_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_uint64'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='5d6479ae' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_double' mangled-name='nvpair_value_double' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_double'>
-      <parameter type-id='3fa542f0' name='nvp'/>
+      <parameter type-id='dace003f' name='nvp'/>
       <parameter type-id='7408d286' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
@@ -1314,10 +1342,6 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
-    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='b48d2441'/>
     <type-decl name='double' size-in-bits='64' id='a0eb0f08'/>
     <type-decl name='int' size-in-bits='32' id='95e97e5e'/>
     <type-decl name='long int' size-in-bits='64' id='bd54fe1a'/>
@@ -1330,7 +1354,6 @@
     <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
     <type-decl name='unsigned short int' size-in-bits='16' id='8efea9e5'/>
     <type-decl name='variadic parameter type' id='2c1145c5'/>
-    <type-decl name='void' id='48b5725f'/>
     <typedef-decl name='nvlist_prtctl_t' type-id='196db161' id='b0c1ff8d'/>
     <enum-decl name='nvlist_indent_mode' id='628aafab'>
       <underlying-type type-id='9cac1fee'/>
@@ -1752,17 +1775,16 @@
         <var-decl name='nvprt_custops' type-id='7be54adb' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__re_long_size_t' type-id='7359adad' id='ba516949'/>
     <typedef-decl name='reg_syntax_t' type-id='7359adad' id='1b72c3b3'/>
     <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' id='19fc9a8c'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='buffer' type-id='33976309' visibility='default'/>
+        <var-decl name='buffer' type-id='cf536864' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='allocated' type-id='ba516949' visibility='default'/>
+        <var-decl name='allocated' type-id='7359adad' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='used' type-id='ba516949' visibility='default'/>
+        <var-decl name='used' type-id='7359adad' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='syntax' type-id='1b72c3b3' visibility='default'/>
@@ -1799,26 +1821,18 @@
       </data-member>
     </class-decl>
     <typedef-decl name='regex_t' type-id='19fc9a8c' id='aca3bac8'/>
-    <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
-    <typedef-decl name='int16_t' type-id='03896e23' id='23bd8cb5'/>
-    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
-    <typedef-decl name='int64_t' type-id='0c9942d2' id='9da381c4'/>
-    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
-    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
-    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
-    <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
-    <typedef-decl name='__int8_t' type-id='28577a57' id='2171a512'/>
-    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
-    <typedef-decl name='__int16_t' type-id='a2185560' id='03896e23'/>
-    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
-    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
-    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
-    <typedef-decl name='__int64_t' type-id='bd54fe1a' id='0c9942d2'/>
-    <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
-    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
-    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
-    <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
     <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='010ae0b9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_next' type-id='e4c6fa61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_sbuf' type-id='dca988a5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_pos' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='95e97e5e' visibility='default'/>
@@ -1887,16 +1901,16 @@
         <var-decl name='_offset' type-id='724e4de6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='570f8c59' visibility='default'/>
+        <var-decl name='__pad1' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='c65a1f29' visibility='default'/>
+        <var-decl name='__pad2' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='dca988a5' visibility='default'/>
+        <var-decl name='__pad3' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='__pad4' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='__pad5' type-id='b59d7dce' visibility='default'/>
@@ -1908,13 +1922,30 @@
         <var-decl name='_unused2' type-id='664ac0b7' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
+    <typedef-decl name='int16_t' type-id='03896e23' id='23bd8cb5'/>
+    <typedef-decl name='int32_t' type-id='33f57a65' id='3ff5601b'/>
+    <typedef-decl name='int64_t' type-id='0c9942d2' id='9da381c4'/>
+    <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
+    <typedef-decl name='uint16_t' type-id='253c2d2a' id='149c6638'/>
+    <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
+    <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
+    <typedef-decl name='__int8_t' type-id='28577a57' id='2171a512'/>
+    <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
+    <typedef-decl name='__int16_t' type-id='a2185560' id='03896e23'/>
+    <typedef-decl name='__uint16_t' type-id='8efea9e5' id='253c2d2a'/>
+    <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
+    <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
+    <typedef-decl name='__int64_t' type-id='bd54fe1a' id='0c9942d2'/>
+    <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
+    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
+    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
+    <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
     <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
     <pointer-type-def type-id='aa12d1ba' size-in-bits='64' id='822cd80b'/>
     <pointer-type-def type-id='ec1ed955' size-in-bits='64' id='dca988a5'/>
-    <pointer-type-def type-id='a4036571' size-in-bits='64' id='570f8c59'/>
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
-    <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
     <pointer-type-def type-id='c19b74c3' size-in-bits='64' id='37e3bd22'/>
     <pointer-type-def type-id='a84c031d' size-in-bits='64' id='26a90f95'/>
     <pointer-type-def type-id='26a90f95' size-in-bits='64' id='9b23c9ad'/>
@@ -1983,7 +2014,6 @@
     <pointer-type-def type-id='8e8d4be3' size-in-bits='64' id='5ce45b60'/>
     <pointer-type-def type-id='5ce45b60' size-in-bits='64' id='857bb57e'/>
     <pointer-type-def type-id='57928edf' size-in-bits='64' id='3fa542f0'/>
-    <pointer-type-def type-id='b48d2441' size-in-bits='64' id='33976309'/>
     <pointer-type-def type-id='aca3bac8' size-in-bits='64' id='d33f11cb'/>
     <pointer-type-def type-id='d8bf0010' size-in-bits='64' id='45b65157'/>
     <pointer-type-def type-id='149c6638' size-in-bits='64' id='8a121f49'/>
@@ -1992,10 +2022,6 @@
     <pointer-type-def type-id='b96825af' size-in-bits='64' id='ae3e8ca6'/>
     <pointer-type-def type-id='002ac4a6' size-in-bits='64' id='cf536864'/>
     <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
-    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='b48d2441'/>
     <function-decl name='nvlist_prtctl_setdest' mangled-name='nvlist_prtctl_setdest' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctl_setdest'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
       <parameter type-id='822cd80b' name='fp'/>
@@ -2684,6 +2710,7 @@
       <parameter type-id='3502e3ff'/>
       <return type-id='95e97e5e'/>
     </function-type>
+    <type-decl name='void' id='48b5725f'/>
   </abi-instr>
   <abi-instr address-size='64' path='libnvpair_json.c' language='LANG_C99'>
     <function-decl name='nvlist_print_json' mangled-name='nvlist_print_json' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_print_json'>

--- a/lib/libuutil/libuutil.abi
+++ b/lib/libuutil/libuutil.abi
@@ -5,6 +5,8 @@
     <dependency name='ld-linux-x86-64.so.2'/>
   </elf-needed>
   <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -853,9 +855,6 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -890,66 +889,18 @@
         <var-decl name='mnt_minor' type-id='3502e3ff' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' id='0bbec9cd'>
+    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='010ae0b9'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='st_dev' type-id='35ed8932' visibility='default'/>
+        <var-decl name='_next' type-id='e4c6fa61' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='71288a47' visibility='default'/>
+        <var-decl name='_sbuf' type-id='dca988a5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_nlink' type-id='80f0b9df' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='st_mode' type-id='e1c52942' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='st_uid' type-id='cc5fcceb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='st_gid' type-id='d94ec6d9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__pad0' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='st_rdev' type-id='35ed8932' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='st_size' type-id='79989e9c' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='st_blksize' type-id='d3f10a7f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_blocks' type-id='4e711bf1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__glibc_reserved' type-id='083f8d58' visibility='default'/>
+        <var-decl name='_pos' type-id='95e97e5e' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__dev_t' type-id='7359adad' id='35ed8932'/>
-    <typedef-decl name='__uid_t' type-id='f0981eeb' id='cc5fcceb'/>
-    <typedef-decl name='__gid_t' type-id='f0981eeb' id='d94ec6d9'/>
-    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
-    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
-    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
-    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
-    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
-    <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
-    <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
-    <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
-    <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
-    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='95e97e5e' visibility='default'/>
@@ -1018,16 +969,16 @@
         <var-decl name='_offset' type-id='724e4de6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='570f8c59' visibility='default'/>
+        <var-decl name='__pad1' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='c65a1f29' visibility='default'/>
+        <var-decl name='__pad2' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='dca988a5' visibility='default'/>
+        <var-decl name='__pad3' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='__pad4' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='__pad5' type-id='b59d7dce' visibility='default'/>
@@ -1039,6 +990,65 @@
         <var-decl name='_unused2' type-id='664ac0b7' visibility='default'/>
       </data-member>
     </class-decl>
+    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' id='0bbec9cd'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='st_dev' type-id='35ed8932' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='st_ino' type-id='71288a47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='st_nlink' type-id='80f0b9df' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='st_mode' type-id='e1c52942' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_uid' type-id='cc5fcceb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_gid' type-id='d94ec6d9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__pad0' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='st_rdev' type-id='35ed8932' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='st_size' type-id='79989e9c' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='st_blksize' type-id='d3f10a7f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='st_blocks' type-id='4e711bf1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='st_atim' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='st_mtim' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='st_ctim' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='__glibc_reserved' type-id='083f8d58' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__dev_t' type-id='7359adad' id='35ed8932'/>
+    <typedef-decl name='__uid_t' type-id='f0981eeb' id='cc5fcceb'/>
+    <typedef-decl name='__gid_t' type-id='f0981eeb' id='d94ec6d9'/>
+    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
+    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
+    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
+    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
+    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
+    <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
+    <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
+    <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
+    <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
     <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
@@ -1049,16 +1059,11 @@
     </class-decl>
     <pointer-type-def type-id='aa12d1ba' size-in-bits='64' id='822cd80b'/>
     <pointer-type-def type-id='ec1ed955' size-in-bits='64' id='dca988a5'/>
-    <pointer-type-def type-id='a4036571' size-in-bits='64' id='570f8c59'/>
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
-    <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
     <pointer-type-def type-id='0c544dc0' size-in-bits='64' id='394fc496'/>
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <function-decl name='getmntany' mangled-name='getmntany' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
       <parameter type-id='822cd80b' name='fp'/>
       <parameter type-id='9d424d31' name='mgetp'/>
@@ -1114,7 +1119,6 @@
     <type-decl name='char' size-in-bits='8' id='a84c031d'/>
     <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
     <type-decl name='variadic parameter type' id='2c1145c5'/>
-    <type-decl name='void' id='48b5725f'/>
     <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
     <pointer-type-def type-id='a84c031d' size-in-bits='64' id='26a90f95'/>
     <qualified-type-def type-id='a84c031d' const='yes' id='9b45d938'/>
@@ -1147,6 +1151,7 @@
       <parameter is-variadic='yes'/>
       <return type-id='26a90f95'/>
     </function-decl>
+    <type-decl name='void' id='48b5725f'/>
   </abi-instr>
   <abi-instr address-size='64' path='uu_avl.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='bf311473' size-in-bits='128' id='f0f65199'>
@@ -1299,6 +1304,15 @@
     <typedef-decl name='int8_t' type-id='2171a512' id='ee31ee44'/>
     <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
     <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='0e01899c'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='4d98cd5a' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='4d98cd5a' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pthread_list_t' type-id='0e01899c' id='518fb49c'/>
     <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='4c734837'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__lock' type-id='95e97e5e' visibility='default'/>
@@ -1325,15 +1339,6 @@
         <var-decl name='__list' type-id='518fb49c' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='0e01899c'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='4d98cd5a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='4d98cd5a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__pthread_list_t' type-id='0e01899c' id='518fb49c'/>
     <typedef-decl name='__int8_t' type-id='28577a57' id='2171a512'/>
     <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
     <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -10,11 +10,14 @@
     <dependency name='libm.so.6'/>
     <dependency name='libcrypto.so.1.1'/>
     <dependency name='libz.so.1'/>
+    <dependency name='libdl.so.2'/>
     <dependency name='libpthread.so.0'/>
     <dependency name='libc.so.6'/>
     <dependency name='ld-linux-x86-64.so.2'/>
   </elf-needed>
   <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1398,9 +1401,6 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <class-decl name='extmnttab' size-in-bits='320' is-struct='yes' visibility='default' id='0c544dc0'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -1421,66 +1421,18 @@
         <var-decl name='mnt_minor' type-id='3502e3ff' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' id='0bbec9cd'>
+    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='010ae0b9'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='st_dev' type-id='35ed8932' visibility='default'/>
+        <var-decl name='_next' type-id='e4c6fa61' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='71288a47' visibility='default'/>
+        <var-decl name='_sbuf' type-id='dca988a5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_nlink' type-id='80f0b9df' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='st_mode' type-id='e1c52942' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='st_uid' type-id='cc5fcceb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='st_gid' type-id='d94ec6d9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__pad0' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='st_rdev' type-id='35ed8932' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='st_size' type-id='79989e9c' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='st_blksize' type-id='d3f10a7f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_blocks' type-id='4e711bf1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__glibc_reserved' type-id='083f8d58' visibility='default'/>
+        <var-decl name='_pos' type-id='95e97e5e' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__dev_t' type-id='7359adad' id='35ed8932'/>
-    <typedef-decl name='__gid_t' type-id='f0981eeb' id='d94ec6d9'/>
-    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
-    <typedef-decl name='__mode_t' type-id='f0981eeb' id='e1c52942'/>
-    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
-    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
-    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
-    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
-    <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
-    <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
-    <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
-    <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
-    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='95e97e5e' visibility='default'/>
@@ -1549,16 +1501,16 @@
         <var-decl name='_offset' type-id='724e4de6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='570f8c59' visibility='default'/>
+        <var-decl name='__pad1' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='c65a1f29' visibility='default'/>
+        <var-decl name='__pad2' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='dca988a5' visibility='default'/>
+        <var-decl name='__pad3' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='__pad4' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='__pad5' type-id='b59d7dce' visibility='default'/>
@@ -1570,6 +1522,65 @@
         <var-decl name='_unused2' type-id='664ac0b7' visibility='default'/>
       </data-member>
     </class-decl>
+    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' id='0bbec9cd'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='st_dev' type-id='35ed8932' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='st_ino' type-id='71288a47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='st_nlink' type-id='80f0b9df' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='st_mode' type-id='e1c52942' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_uid' type-id='cc5fcceb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_gid' type-id='d94ec6d9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__pad0' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='st_rdev' type-id='35ed8932' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='st_size' type-id='79989e9c' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='st_blksize' type-id='d3f10a7f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='st_blocks' type-id='4e711bf1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='st_atim' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='st_mtim' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='st_ctim' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='__glibc_reserved' type-id='083f8d58' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__dev_t' type-id='7359adad' id='35ed8932'/>
+    <typedef-decl name='__gid_t' type-id='f0981eeb' id='d94ec6d9'/>
+    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
+    <typedef-decl name='__mode_t' type-id='f0981eeb' id='e1c52942'/>
+    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
+    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
+    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
+    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
+    <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
+    <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
+    <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
+    <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
     <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
@@ -1580,15 +1591,10 @@
     </class-decl>
     <pointer-type-def type-id='aa12d1ba' size-in-bits='64' id='822cd80b'/>
     <pointer-type-def type-id='ec1ed955' size-in-bits='64' id='dca988a5'/>
-    <pointer-type-def type-id='a4036571' size-in-bits='64' id='570f8c59'/>
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
-    <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
     <pointer-type-def type-id='0c544dc0' size-in-bits='64' id='394fc496'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <function-decl name='getmntany' mangled-name='getmntany' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
       <parameter type-id='822cd80b' name='fp'/>
       <parameter type-id='9d424d31' name='mgetp'/>
@@ -2901,9 +2907,6 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='320' id='36c46961'>
       <subrange length='40' type-id='7359adad' id='8f80b239'/>
     </array-type-def>
-    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='b48d2441'/>
-    <class-decl name='uu_avl' is-struct='yes' visibility='default' is-declaration-only='yes' id='4af029d1'/>
-    <class-decl name='uu_avl_pool' is-struct='yes' visibility='default' is-declaration-only='yes' id='12a530a8'/>
     <type-decl name='int' size-in-bits='32' id='95e97e5e'/>
     <type-decl name='long int' size-in-bits='64' id='bd54fe1a'/>
     <type-decl name='long long int' size-in-bits='64' id='1eb56b1e'/>
@@ -3146,17 +3149,16 @@
         <var-decl name='zpool_start_block' type-id='804dc465' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__re_long_size_t' type-id='7359adad' id='ba516949'/>
     <typedef-decl name='reg_syntax_t' type-id='7359adad' id='1b72c3b3'/>
     <class-decl name='re_pattern_buffer' size-in-bits='512' is-struct='yes' visibility='default' id='19fc9a8c'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='buffer' type-id='33976309' visibility='default'/>
+        <var-decl name='buffer' type-id='cf536864' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='allocated' type-id='ba516949' visibility='default'/>
+        <var-decl name='allocated' type-id='7359adad' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='used' type-id='ba516949' visibility='default'/>
+        <var-decl name='used' type-id='7359adad' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='syntax' type-id='1b72c3b3' visibility='default'/>
@@ -3210,6 +3212,15 @@
     <typedef-decl name='uint8_t' type-id='c51d6389' id='b96825af'/>
     <typedef-decl name='uint32_t' type-id='62f1140c' id='8f92235e'/>
     <typedef-decl name='uint64_t' type-id='8910171f' id='9c313c2d'/>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='0e01899c'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='4d98cd5a' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='4d98cd5a' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pthread_list_t' type-id='0e01899c' id='518fb49c'/>
     <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='4c734837'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__lock' type-id='95e97e5e' visibility='default'/>
@@ -3236,15 +3247,6 @@
         <var-decl name='__list' type-id='518fb49c' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='0e01899c'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__prev' type-id='4d98cd5a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__next' type-id='4d98cd5a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__pthread_list_t' type-id='0e01899c' id='518fb49c'/>
     <typedef-decl name='__uint8_t' type-id='002ac4a6' id='c51d6389'/>
     <typedef-decl name='__int32_t' type-id='95e97e5e' id='33f57a65'/>
     <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
@@ -3262,7 +3264,6 @@
     <pointer-type-def type-id='95942d0c' size-in-bits='64' id='b0382bb3'/>
     <pointer-type-def type-id='8e8d4be3' size-in-bits='64' id='5ce45b60'/>
     <pointer-type-def type-id='5ce45b60' size-in-bits='64' id='857bb57e'/>
-    <pointer-type-def type-id='b48d2441' size-in-bits='64' id='33976309'/>
     <pointer-type-def type-id='b96825af' size-in-bits='64' id='ae3e8ca6'/>
     <pointer-type-def type-id='002ac4a6' size-in-bits='64' id='cf536864'/>
     <pointer-type-def type-id='7f84e390' size-in-bits='64' id='de82c773'/>
@@ -3270,7 +3271,6 @@
     <pointer-type-def type-id='48b5725f' size-in-bits='64' id='eaa32e2f'/>
     <pointer-type-def type-id='775509eb' size-in-bits='64' id='9200a744'/>
     <pointer-type-def type-id='b1efc708' size-in-bits='64' id='4c81de99'/>
-    <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='b48d2441'/>
     <class-decl name='uu_avl' is-struct='yes' visibility='default' is-declaration-only='yes' id='4af029d1'/>
     <class-decl name='uu_avl_pool' is-struct='yes' visibility='default' is-declaration-only='yes' id='12a530a8'/>
     <function-decl name='zpool_get_config' mangled-name='zpool_get_config' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_config'>
@@ -4172,6 +4172,10 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_share_smb' mangled-name='zfs_share_smb' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_share_smb'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_shareall' mangled-name='zfs_shareall' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_shareall'>
       <parameter type-id='9200a744' name='zhp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
@@ -5619,7 +5623,6 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='os/linux/zutil_import_os.c' language='LANG_C99'>
-    <class-decl name='udev_device' is-struct='yes' visibility='default' is-declaration-only='yes' id='640b33ca'/>
     <qualified-type-def type-id='80f4b756' const='yes' id='b99c00c9'/>
     <pointer-type-def type-id='b99c00c9' size-in-bits='64' id='13956559'/>
     <pointer-type-def type-id='b59d7dce' size-in-bits='64' id='78c01427'/>

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -3807,8 +3807,8 @@ zpool_vdev_split(zpool_handle_t *zhp, char *newname, nvlist_t **newroot,
 	}
 
 	/* Add all the children we found */
-	if (nvlist_add_nvlist_array(*newroot, ZPOOL_CONFIG_CHILDREN, varray,
-	    lastlog == 0 ? vcount : lastlog) != 0)
+	if (nvlist_add_nvlist_array(*newroot, ZPOOL_CONFIG_CHILDREN,
+	    (const nvlist_t **)varray, lastlog == 0 ? vcount : lastlog) != 0)
 		goto out;
 
 	/*
@@ -4551,7 +4551,7 @@ zpool_get_history(zpool_handle_t *zhp, nvlist_t **nvhisp, uint64_t *off,
 	if (!err) {
 		verify(nvlist_alloc(nvhisp, NV_UNIQUE_NAME, 0) == 0);
 		verify(nvlist_add_nvlist_array(*nvhisp, ZPOOL_HIST_RECORD,
-		    records, numrecords) == 0);
+		    (const nvlist_t **)records, numrecords) == 0);
 	}
 	for (i = 0; i < numrecords; i++)
 		nvlist_free(records[i]);

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -6,6 +6,8 @@
     <dependency name='ld-linux-x86-64.so.2'/>
   </elf-needed>
   <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_sol_getmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_add_16_nv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -713,9 +715,6 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -750,66 +749,18 @@
         <var-decl name='mnt_minor' type-id='3502e3ff' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' id='0bbec9cd'>
+    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='010ae0b9'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='st_dev' type-id='35ed8932' visibility='default'/>
+        <var-decl name='_next' type-id='e4c6fa61' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='71288a47' visibility='default'/>
+        <var-decl name='_sbuf' type-id='dca988a5' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_nlink' type-id='80f0b9df' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='st_mode' type-id='e1c52942' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='st_uid' type-id='cc5fcceb' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='st_gid' type-id='d94ec6d9' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='__pad0' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='st_rdev' type-id='35ed8932' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='st_size' type-id='79989e9c' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='st_blksize' type-id='d3f10a7f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_blocks' type-id='4e711bf1' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__glibc_reserved' type-id='083f8d58' visibility='default'/>
+        <var-decl name='_pos' type-id='95e97e5e' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__dev_t' type-id='7359adad' id='35ed8932'/>
-    <typedef-decl name='__uid_t' type-id='f0981eeb' id='cc5fcceb'/>
-    <typedef-decl name='__gid_t' type-id='f0981eeb' id='d94ec6d9'/>
-    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
-    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
-    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
-    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
-    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
-    <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
-    <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
-    <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
-    <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
-    <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='95e97e5e' visibility='default'/>
@@ -878,16 +829,16 @@
         <var-decl name='_offset' type-id='724e4de6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='570f8c59' visibility='default'/>
+        <var-decl name='__pad1' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='c65a1f29' visibility='default'/>
+        <var-decl name='__pad2' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='dca988a5' visibility='default'/>
+        <var-decl name='__pad3' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='__pad4' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='__pad5' type-id='b59d7dce' visibility='default'/>
@@ -899,6 +850,65 @@
         <var-decl name='_unused2' type-id='664ac0b7' visibility='default'/>
       </data-member>
     </class-decl>
+    <class-decl name='stat64' size-in-bits='1152' is-struct='yes' visibility='default' id='0bbec9cd'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='st_dev' type-id='35ed8932' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='st_ino' type-id='71288a47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='st_nlink' type-id='80f0b9df' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='st_mode' type-id='e1c52942' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_uid' type-id='cc5fcceb' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_gid' type-id='d94ec6d9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__pad0' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='st_rdev' type-id='35ed8932' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='st_size' type-id='79989e9c' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='st_blksize' type-id='d3f10a7f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='st_blocks' type-id='4e711bf1' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='st_atim' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='st_mtim' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='st_ctim' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='__glibc_reserved' type-id='083f8d58' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__dev_t' type-id='7359adad' id='35ed8932'/>
+    <typedef-decl name='__uid_t' type-id='f0981eeb' id='cc5fcceb'/>
+    <typedef-decl name='__gid_t' type-id='f0981eeb' id='d94ec6d9'/>
+    <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
+    <typedef-decl name='__nlink_t' type-id='7359adad' id='80f0b9df'/>
+    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
+    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
+    <typedef-decl name='__time_t' type-id='bd54fe1a' id='65eda9c0'/>
+    <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
+    <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
+    <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
+    <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
     <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
@@ -909,16 +919,11 @@
     </class-decl>
     <pointer-type-def type-id='aa12d1ba' size-in-bits='64' id='822cd80b'/>
     <pointer-type-def type-id='ec1ed955' size-in-bits='64' id='dca988a5'/>
-    <pointer-type-def type-id='a4036571' size-in-bits='64' id='570f8c59'/>
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
-    <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
     <pointer-type-def type-id='0c544dc0' size-in-bits='64' id='394fc496'/>
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <function-decl name='getmntany' mangled-name='getmntany' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getmntany'>
       <parameter type-id='822cd80b' name='fp'/>
       <parameter type-id='9d424d31' name='mgetp'/>
@@ -1004,7 +1009,6 @@
     <type-decl name='unsigned char' size-in-bits='8' id='002ac4a6'/>
     <type-decl name='unsigned int' size-in-bits='32' id='f0981eeb'/>
     <type-decl name='unsigned long int' size-in-bits='64' id='7359adad'/>
-    <type-decl name='void' id='48b5725f'/>
     <enum-decl name='lzc_dataset_type' id='bc9887f1'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='LZC_DATSET_TYPE_ZFS' value='2'/>
@@ -1912,6 +1916,7 @@
       <parameter type-id='857bb57e' name='outnvl'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <type-decl name='void' id='48b5725f'/>
   </abi-instr>
   <abi-instr address-size='64' path='os/linux/libzfs_core_ioctl.c' language='LANG_C99'>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='32768' id='d16c6df4'>

--- a/lib/libzfsbootenv/libzfsbootenv.abi
+++ b/lib/libzfsbootenv/libzfsbootenv.abi
@@ -5,6 +5,8 @@
     <dependency name='libc.so.6'/>
   </elf-needed>
   <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_add_pair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_bootenv_print' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzbe_get_boot_device' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -18,7 +20,6 @@
     <type-decl name='char' size-in-bits='8' id='a84c031d'/>
     <type-decl name='int' size-in-bits='32' id='95e97e5e'/>
     <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='9cac1fee'/>
-    <type-decl name='void' id='48b5725f'/>
     <enum-decl name='lzbe_flags' id='2b77720b'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='lzbe_add' value='0'/>
@@ -83,16 +84,21 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <type-decl name='long int' size-in-bits='64' id='bd54fe1a'/>
     <type-decl name='signed char' size-in-bits='8' id='28577a57'/>
     <type-decl name='unsigned short int' size-in-bits='16' id='8efea9e5'/>
-    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
-    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
-    <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
     <typedef-decl name='_IO_lock_t' type-id='48b5725f' id='bb4788fa'/>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' id='010ae0b9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_next' type-id='e4c6fa61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_sbuf' type-id='dca988a5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_pos' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+    </class-decl>
     <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' id='ec1ed955'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_flags' type-id='95e97e5e' visibility='default'/>
@@ -161,16 +167,16 @@
         <var-decl name='_offset' type-id='724e4de6' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='_codecvt' type-id='570f8c59' visibility='default'/>
+        <var-decl name='__pad1' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='_wide_data' type-id='c65a1f29' visibility='default'/>
+        <var-decl name='__pad2' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='_freeres_list' type-id='dca988a5' visibility='default'/>
+        <var-decl name='__pad3' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='_freeres_buf' type-id='eaa32e2f' visibility='default'/>
+        <var-decl name='__pad4' type-id='eaa32e2f' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
         <var-decl name='__pad5' type-id='b59d7dce' visibility='default'/>
@@ -182,20 +188,19 @@
         <var-decl name='_unused2' type-id='664ac0b7' visibility='default'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='__off_t' type-id='bd54fe1a' id='79989e9c'/>
+    <typedef-decl name='__off64_t' type-id='bd54fe1a' id='724e4de6'/>
+    <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
     <pointer-type-def type-id='aa12d1ba' size-in-bits='64' id='822cd80b'/>
     <pointer-type-def type-id='ec1ed955' size-in-bits='64' id='dca988a5'/>
-    <pointer-type-def type-id='a4036571' size-in-bits='64' id='570f8c59'/>
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
-    <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
-    <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
-    <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
-    <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <function-decl name='lzbe_bootenv_print' mangled-name='lzbe_bootenv_print' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzbe_bootenv_print'>
       <parameter type-id='80f4b756' name='pool'/>
       <parameter type-id='80f4b756' name='nvlist'/>
       <parameter type-id='822cd80b' name='of'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <type-decl name='void' id='48b5725f'/>
   </abi-instr>
 </abi-corpus>

--- a/lib/libzfsbootenv/lzbe_pair.c
+++ b/lib/libzfsbootenv/lzbe_pair.c
@@ -293,7 +293,8 @@ lzbe_add_pair(void *ptr, const char *key, const char *type, void *value,
 		break;
 
 	case DATA_TYPE_NVLIST_ARRAY:
-		rv = nvlist_add_nvlist_array(nv, key, value, size);
+		rv = nvlist_add_nvlist_array(nv, key, (const nvlist_t **)value,
+		    size);
 		break;
 
 	case DATA_TYPE_BOOLEAN_VALUE:

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -749,7 +749,7 @@ get_configs(libpc_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
 		    nvlist_add_uint64(nvroot, ZPOOL_CONFIG_ID, 0ULL) != 0 ||
 		    nvlist_add_uint64(nvroot, ZPOOL_CONFIG_GUID, guid) != 0 ||
 		    nvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
-		    child, children) != 0) {
+		    (const nvlist_t **)child, children) != 0) {
 			nvlist_free(nvroot);
 			goto nomem;
 		}

--- a/module/nvpair/fnvpair.c
+++ b/module/nvpair/fnvpair.c
@@ -102,7 +102,7 @@ fnvlist_unpack(char *buf, size_t buflen)
 }
 
 nvlist_t *
-fnvlist_dup(nvlist_t *nvl)
+fnvlist_dup(const nvlist_t *nvl)
 {
 	nvlist_t *rv;
 	VERIFY0(nvlist_dup(nvl, &rv, KM_SLEEP));
@@ -213,78 +213,84 @@ fnvlist_add_nvpair(nvlist_t *nvl, nvpair_t *pair)
 
 void
 fnvlist_add_boolean_array(nvlist_t *nvl, const char *name,
-    boolean_t *val, uint_t n)
+    const boolean_t *val, uint_t n)
 {
 	VERIFY0(nvlist_add_boolean_array(nvl, name, val, n));
 }
 
 void
-fnvlist_add_byte_array(nvlist_t *nvl, const char *name, uchar_t *val, uint_t n)
+fnvlist_add_byte_array(nvlist_t *nvl, const char *name, const uchar_t *val,
+    uint_t n)
 {
 	VERIFY0(nvlist_add_byte_array(nvl, name, val, n));
 }
 
 void
-fnvlist_add_int8_array(nvlist_t *nvl, const char *name, int8_t *val, uint_t n)
+fnvlist_add_int8_array(nvlist_t *nvl, const char *name, const int8_t *val,
+    uint_t n)
 {
 	VERIFY0(nvlist_add_int8_array(nvl, name, val, n));
 }
 
 void
-fnvlist_add_uint8_array(nvlist_t *nvl, const char *name, uint8_t *val, uint_t n)
+fnvlist_add_uint8_array(nvlist_t *nvl, const char *name, const uint8_t *val,
+    uint_t n)
 {
 	VERIFY0(nvlist_add_uint8_array(nvl, name, val, n));
 }
 
 void
-fnvlist_add_int16_array(nvlist_t *nvl, const char *name, int16_t *val, uint_t n)
+fnvlist_add_int16_array(nvlist_t *nvl, const char *name, const int16_t *val,
+    uint_t n)
 {
 	VERIFY0(nvlist_add_int16_array(nvl, name, val, n));
 }
 
 void
 fnvlist_add_uint16_array(nvlist_t *nvl, const char *name,
-    uint16_t *val, uint_t n)
+    const uint16_t *val, uint_t n)
 {
 	VERIFY0(nvlist_add_uint16_array(nvl, name, val, n));
 }
 
 void
-fnvlist_add_int32_array(nvlist_t *nvl, const char *name, int32_t *val, uint_t n)
+fnvlist_add_int32_array(nvlist_t *nvl, const char *name, const int32_t *val,
+    uint_t n)
 {
 	VERIFY0(nvlist_add_int32_array(nvl, name, val, n));
 }
 
 void
 fnvlist_add_uint32_array(nvlist_t *nvl, const char *name,
-    uint32_t *val, uint_t n)
+    const uint32_t *val, uint_t n)
 {
 	VERIFY0(nvlist_add_uint32_array(nvl, name, val, n));
 }
 
 void
-fnvlist_add_int64_array(nvlist_t *nvl, const char *name, int64_t *val, uint_t n)
+fnvlist_add_int64_array(nvlist_t *nvl, const char *name, const int64_t *val,
+    uint_t n)
 {
 	VERIFY0(nvlist_add_int64_array(nvl, name, val, n));
 }
 
 void
 fnvlist_add_uint64_array(nvlist_t *nvl, const char *name,
-    uint64_t *val, uint_t n)
+    const uint64_t *val, uint_t n)
 {
 	VERIFY0(nvlist_add_uint64_array(nvl, name, val, n));
 }
 
 void
 fnvlist_add_string_array(nvlist_t *nvl, const char *name,
-    char * const *val, uint_t n)
+    const char * const *val, uint_t n)
 {
 	VERIFY0(nvlist_add_string_array(nvl, name, val, n));
 }
 
 void
 fnvlist_add_nvlist_array(nvlist_t *nvl, const char *name,
-    nvlist_t **val, uint_t n)
+    const nvlist_t * const *val, uint_t n)
 {
 	VERIFY0(nvlist_add_nvlist_array(nvl, name, val, n));
 }
@@ -311,13 +317,13 @@ fnvlist_lookup_nvpair(nvlist_t *nvl, const char *name)
 
 /* returns B_TRUE if the entry exists */
 boolean_t
-fnvlist_lookup_boolean(nvlist_t *nvl, const char *name)
+fnvlist_lookup_boolean(const nvlist_t *nvl, const char *name)
 {
 	return (nvlist_lookup_boolean(nvl, name) == 0);
 }
 
 boolean_t
-fnvlist_lookup_boolean_value(nvlist_t *nvl, const char *name)
+fnvlist_lookup_boolean_value(const nvlist_t *nvl, const char *name)
 {
 	boolean_t rv;
 	VERIFY0(nvlist_lookup_boolean_value(nvl, name, &rv));
@@ -325,7 +331,7 @@ fnvlist_lookup_boolean_value(nvlist_t *nvl, const char *name)
 }
 
 uchar_t
-fnvlist_lookup_byte(nvlist_t *nvl, const char *name)
+fnvlist_lookup_byte(const nvlist_t *nvl, const char *name)
 {
 	uchar_t rv;
 	VERIFY0(nvlist_lookup_byte(nvl, name, &rv));
@@ -333,7 +339,7 @@ fnvlist_lookup_byte(nvlist_t *nvl, const char *name)
 }
 
 int8_t
-fnvlist_lookup_int8(nvlist_t *nvl, const char *name)
+fnvlist_lookup_int8(const nvlist_t *nvl, const char *name)
 {
 	int8_t rv;
 	VERIFY0(nvlist_lookup_int8(nvl, name, &rv));
@@ -341,7 +347,7 @@ fnvlist_lookup_int8(nvlist_t *nvl, const char *name)
 }
 
 int16_t
-fnvlist_lookup_int16(nvlist_t *nvl, const char *name)
+fnvlist_lookup_int16(const nvlist_t *nvl, const char *name)
 {
 	int16_t rv;
 	VERIFY0(nvlist_lookup_int16(nvl, name, &rv));
@@ -349,7 +355,7 @@ fnvlist_lookup_int16(nvlist_t *nvl, const char *name)
 }
 
 int32_t
-fnvlist_lookup_int32(nvlist_t *nvl, const char *name)
+fnvlist_lookup_int32(const nvlist_t *nvl, const char *name)
 {
 	int32_t rv;
 	VERIFY0(nvlist_lookup_int32(nvl, name, &rv));
@@ -357,7 +363,7 @@ fnvlist_lookup_int32(nvlist_t *nvl, const char *name)
 }
 
 int64_t
-fnvlist_lookup_int64(nvlist_t *nvl, const char *name)
+fnvlist_lookup_int64(const nvlist_t *nvl, const char *name)
 {
 	int64_t rv;
 	VERIFY0(nvlist_lookup_int64(nvl, name, &rv));
@@ -365,7 +371,7 @@ fnvlist_lookup_int64(nvlist_t *nvl, const char *name)
 }
 
 uint8_t
-fnvlist_lookup_uint8(nvlist_t *nvl, const char *name)
+fnvlist_lookup_uint8(const nvlist_t *nvl, const char *name)
 {
 	uint8_t rv;
 	VERIFY0(nvlist_lookup_uint8(nvl, name, &rv));
@@ -373,7 +379,7 @@ fnvlist_lookup_uint8(nvlist_t *nvl, const char *name)
 }
 
 uint16_t
-fnvlist_lookup_uint16(nvlist_t *nvl, const char *name)
+fnvlist_lookup_uint16(const nvlist_t *nvl, const char *name)
 {
 	uint16_t rv;
 	VERIFY0(nvlist_lookup_uint16(nvl, name, &rv));
@@ -381,7 +387,7 @@ fnvlist_lookup_uint16(nvlist_t *nvl, const char *name)
 }
 
 uint32_t
-fnvlist_lookup_uint32(nvlist_t *nvl, const char *name)
+fnvlist_lookup_uint32(const nvlist_t *nvl, const char *name)
 {
 	uint32_t rv;
 	VERIFY0(nvlist_lookup_uint32(nvl, name, &rv));
@@ -389,7 +395,7 @@ fnvlist_lookup_uint32(nvlist_t *nvl, const char *name)
 }
 
 uint64_t
-fnvlist_lookup_uint64(nvlist_t *nvl, const char *name)
+fnvlist_lookup_uint64(const nvlist_t *nvl, const char *name)
 {
 	uint64_t rv;
 	VERIFY0(nvlist_lookup_uint64(nvl, name, &rv));
@@ -492,7 +498,7 @@ fnvlist_lookup_uint64_array(nvlist_t *nvl, const char *name, uint_t *n)
 }
 
 boolean_t
-fnvpair_value_boolean_value(nvpair_t *nvp)
+fnvpair_value_boolean_value(const nvpair_t *nvp)
 {
 	boolean_t rv;
 	VERIFY0(nvpair_value_boolean_value(nvp, &rv));
@@ -500,7 +506,7 @@ fnvpair_value_boolean_value(nvpair_t *nvp)
 }
 
 uchar_t
-fnvpair_value_byte(nvpair_t *nvp)
+fnvpair_value_byte(const nvpair_t *nvp)
 {
 	uchar_t rv;
 	VERIFY0(nvpair_value_byte(nvp, &rv));
@@ -508,7 +514,7 @@ fnvpair_value_byte(nvpair_t *nvp)
 }
 
 int8_t
-fnvpair_value_int8(nvpair_t *nvp)
+fnvpair_value_int8(const nvpair_t *nvp)
 {
 	int8_t rv;
 	VERIFY0(nvpair_value_int8(nvp, &rv));
@@ -516,7 +522,7 @@ fnvpair_value_int8(nvpair_t *nvp)
 }
 
 int16_t
-fnvpair_value_int16(nvpair_t *nvp)
+fnvpair_value_int16(const nvpair_t *nvp)
 {
 	int16_t rv;
 	VERIFY0(nvpair_value_int16(nvp, &rv));
@@ -524,7 +530,7 @@ fnvpair_value_int16(nvpair_t *nvp)
 }
 
 int32_t
-fnvpair_value_int32(nvpair_t *nvp)
+fnvpair_value_int32(const nvpair_t *nvp)
 {
 	int32_t rv;
 	VERIFY0(nvpair_value_int32(nvp, &rv));
@@ -532,7 +538,7 @@ fnvpair_value_int32(nvpair_t *nvp)
 }
 
 int64_t
-fnvpair_value_int64(nvpair_t *nvp)
+fnvpair_value_int64(const nvpair_t *nvp)
 {
 	int64_t rv;
 	VERIFY0(nvpair_value_int64(nvp, &rv));
@@ -540,7 +546,7 @@ fnvpair_value_int64(nvpair_t *nvp)
 }
 
 uint8_t
-fnvpair_value_uint8(nvpair_t *nvp)
+fnvpair_value_uint8(const nvpair_t *nvp)
 {
 	uint8_t rv;
 	VERIFY0(nvpair_value_uint8(nvp, &rv));
@@ -548,7 +554,7 @@ fnvpair_value_uint8(nvpair_t *nvp)
 }
 
 uint16_t
-fnvpair_value_uint16(nvpair_t *nvp)
+fnvpair_value_uint16(const nvpair_t *nvp)
 {
 	uint16_t rv;
 	VERIFY0(nvpair_value_uint16(nvp, &rv));
@@ -556,7 +562,7 @@ fnvpair_value_uint16(nvpair_t *nvp)
 }
 
 uint32_t
-fnvpair_value_uint32(nvpair_t *nvp)
+fnvpair_value_uint32(const nvpair_t *nvp)
 {
 	uint32_t rv;
 	VERIFY0(nvpair_value_uint32(nvp, &rv));
@@ -564,7 +570,7 @@ fnvpair_value_uint32(nvpair_t *nvp)
 }
 
 uint64_t
-fnvpair_value_uint64(nvpair_t *nvp)
+fnvpair_value_uint64(const nvpair_t *nvp)
 {
 	uint64_t rv;
 	VERIFY0(nvpair_value_uint64(nvp, &rv));

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -308,7 +308,7 @@ nvt_hash(const char *p)
 }
 
 static boolean_t
-nvt_nvpair_match(nvpair_t *nvp1, nvpair_t *nvp2, uint32_t nvflag)
+nvt_nvpair_match(const nvpair_t *nvp1, const nvpair_t *nvp2, uint32_t nvflag)
 {
 	boolean_t match = B_FALSE;
 	if (nvflag & NV_UNIQUE_NAME_TYPE) {
@@ -324,9 +324,9 @@ nvt_nvpair_match(nvpair_t *nvp1, nvpair_t *nvp2, uint32_t nvflag)
 }
 
 static nvpair_t *
-nvt_lookup_name_type(nvlist_t *nvl, const char *name, data_type_t type)
+nvt_lookup_name_type(const nvlist_t *nvl, const char *name, data_type_t type)
 {
-	nvpriv_t *priv = (nvpriv_t *)(uintptr_t)nvl->nvl_priv;
+	const nvpriv_t *priv = (const nvpriv_t *)(uintptr_t)nvl->nvl_priv;
 	ASSERT(priv != NULL);
 
 	i_nvp_t **tab = priv->nvp_hashtable;
@@ -356,7 +356,7 @@ nvt_lookup_name_type(nvlist_t *nvl, const char *name, data_type_t type)
 }
 
 static nvpair_t *
-nvt_lookup_name(nvlist_t *nvl, const char *name)
+nvt_lookup_name(const nvlist_t *nvl, const char *name)
 {
 	return (nvt_lookup_name_type(nvl, name, DATA_TYPE_DONTCARE));
 }
@@ -462,7 +462,7 @@ nvt_shrink(nvpriv_t *priv)
 }
 
 static int
-nvt_remove_nvpair(nvlist_t *nvl, nvpair_t *nvp)
+nvt_remove_nvpair(nvlist_t *nvl, const nvpair_t *nvp)
 {
 	nvpriv_t *priv = (nvpriv_t *)(uintptr_t)nvl->nvl_priv;
 
@@ -816,16 +816,16 @@ i_validate_nvpair(nvpair_t *nvp)
 }
 
 static int
-nvlist_copy_pairs(nvlist_t *snvl, nvlist_t *dnvl)
+nvlist_copy_pairs(const nvlist_t *snvl, nvlist_t *dnvl)
 {
-	nvpriv_t *priv;
-	i_nvp_t *curr;
+	const nvpriv_t *priv;
+	const i_nvp_t *curr;
 
-	if ((priv = (nvpriv_t *)(uintptr_t)snvl->nvl_priv) == NULL)
+	if ((priv = (const nvpriv_t *)(uintptr_t)snvl->nvl_priv) == NULL)
 		return (EINVAL);
 
 	for (curr = priv->nvp_list; curr != NULL; curr = curr->nvi_next) {
-		nvpair_t *nvp = &curr->nvi_nvp;
+		const nvpair_t *nvp = &curr->nvi_nvp;
 		int err;
 
 		if ((err = nvlist_add_common(dnvl, NVP_NAME(nvp), NVP_TYPE(nvp),
@@ -896,10 +896,10 @@ nvlist_free(nvlist_t *nvl)
 }
 
 static int
-nvlist_contains_nvp(nvlist_t *nvl, nvpair_t *nvp)
+nvlist_contains_nvp(const nvlist_t *nvl, const nvpair_t *nvp)
 {
-	nvpriv_t *priv = (nvpriv_t *)(uintptr_t)nvl->nvl_priv;
-	i_nvp_t *curr;
+	const nvpriv_t *priv = (const nvpriv_t *)(uintptr_t)nvl->nvl_priv;
+	const i_nvp_t *curr;
 
 	if (nvp == NULL)
 		return (0);
@@ -915,13 +915,13 @@ nvlist_contains_nvp(nvlist_t *nvl, nvpair_t *nvp)
  * Make a copy of nvlist
  */
 int
-nvlist_dup(nvlist_t *nvl, nvlist_t **nvlp, int kmflag)
+nvlist_dup(const nvlist_t *nvl, nvlist_t **nvlp, int kmflag)
 {
 	return (nvlist_xdup(nvl, nvlp, nvlist_nv_alloc(kmflag)));
 }
 
 int
-nvlist_xdup(nvlist_t *nvl, nvlist_t **nvlp, nv_alloc_t *nva)
+nvlist_xdup(const nvlist_t *nvl, nvlist_t **nvlp, nv_alloc_t *nva)
 {
 	int err;
 	nvlist_t *ret;
@@ -1356,68 +1356,77 @@ nvlist_add_string(nvlist_t *nvl, const char *name, const char *val)
 
 int
 nvlist_add_boolean_array(nvlist_t *nvl, const char *name,
-    boolean_t *a, uint_t n)
+    const boolean_t *a, uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_BOOLEAN_ARRAY, n, a));
 }
 
 int
-nvlist_add_byte_array(nvlist_t *nvl, const char *name, uchar_t *a, uint_t n)
+nvlist_add_byte_array(nvlist_t *nvl, const char *name, const uchar_t *a,
+    uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_BYTE_ARRAY, n, a));
 }
 
 int
-nvlist_add_int8_array(nvlist_t *nvl, const char *name, int8_t *a, uint_t n)
+nvlist_add_int8_array(nvlist_t *nvl, const char *name, const int8_t *a,
+    uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_INT8_ARRAY, n, a));
 }
 
 int
-nvlist_add_uint8_array(nvlist_t *nvl, const char *name, uint8_t *a, uint_t n)
+nvlist_add_uint8_array(nvlist_t *nvl, const char *name, const uint8_t *a,
+    uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_UINT8_ARRAY, n, a));
 }
 
 int
-nvlist_add_int16_array(nvlist_t *nvl, const char *name, int16_t *a, uint_t n)
+nvlist_add_int16_array(nvlist_t *nvl, const char *name, const int16_t *a,
+    uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_INT16_ARRAY, n, a));
 }
 
 int
-nvlist_add_uint16_array(nvlist_t *nvl, const char *name, uint16_t *a, uint_t n)
+nvlist_add_uint16_array(nvlist_t *nvl, const char *name, const uint16_t *a,
+    uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_UINT16_ARRAY, n, a));
 }
 
 int
-nvlist_add_int32_array(nvlist_t *nvl, const char *name, int32_t *a, uint_t n)
+nvlist_add_int32_array(nvlist_t *nvl, const char *name, const int32_t *a,
+    uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_INT32_ARRAY, n, a));
 }
 
 int
-nvlist_add_uint32_array(nvlist_t *nvl, const char *name, uint32_t *a, uint_t n)
+nvlist_add_uint32_array(nvlist_t *nvl, const char *name, const uint32_t *a,
+    uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_UINT32_ARRAY, n, a));
 }
 
 int
-nvlist_add_int64_array(nvlist_t *nvl, const char *name, int64_t *a, uint_t n)
+nvlist_add_int64_array(nvlist_t *nvl, const char *name, const int64_t *a,
+    uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_INT64_ARRAY, n, a));
 }
 
 int
-nvlist_add_uint64_array(nvlist_t *nvl, const char *name, uint64_t *a, uint_t n)
+nvlist_add_uint64_array(nvlist_t *nvl, const char *name, const uint64_t *a,
+    uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_UINT64_ARRAY, n, a));
 }
 
 int
 nvlist_add_string_array(nvlist_t *nvl, const char *name,
-    char *const *a, uint_t n)
+    const char *const *a, uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_STRING_ARRAY, n, a));
 }
@@ -1429,20 +1438,21 @@ nvlist_add_hrtime(nvlist_t *nvl, const char *name, hrtime_t val)
 }
 
 int
-nvlist_add_nvlist(nvlist_t *nvl, const char *name, nvlist_t *val)
+nvlist_add_nvlist(nvlist_t *nvl, const char *name, const nvlist_t *val)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_NVLIST, 1, val));
 }
 
 int
-nvlist_add_nvlist_array(nvlist_t *nvl, const char *name, nvlist_t **a, uint_t n)
+nvlist_add_nvlist_array(nvlist_t *nvl, const char *name,
+    const nvlist_t * const *a, uint_t n)
 {
 	return (nvlist_add_common(nvl, name, DATA_TYPE_NVLIST_ARRAY, n, a));
 }
 
 /* reading name-value pairs */
 nvpair_t *
-nvlist_next_nvpair(nvlist_t *nvl, nvpair_t *nvp)
+nvlist_next_nvpair(nvlist_t *nvl, const nvpair_t *nvp)
 {
 	nvpriv_t *priv;
 	i_nvp_t *curr;
@@ -1471,7 +1481,7 @@ nvlist_next_nvpair(nvlist_t *nvl, nvpair_t *nvp)
 }
 
 nvpair_t *
-nvlist_prev_nvpair(nvlist_t *nvl, nvpair_t *nvp)
+nvlist_prev_nvpair(nvlist_t *nvl, const nvpair_t *nvp)
 {
 	nvpriv_t *priv;
 	i_nvp_t *curr;
@@ -1495,31 +1505,31 @@ nvlist_prev_nvpair(nvlist_t *nvl, nvpair_t *nvp)
 }
 
 boolean_t
-nvlist_empty(nvlist_t *nvl)
+nvlist_empty(const nvlist_t *nvl)
 {
-	nvpriv_t *priv;
+	const nvpriv_t *priv;
 
 	if (nvl == NULL ||
-	    (priv = (nvpriv_t *)(uintptr_t)nvl->nvl_priv) == NULL)
+	    (priv = (const nvpriv_t *)(uintptr_t)nvl->nvl_priv) == NULL)
 		return (B_TRUE);
 
 	return (priv->nvp_list == NULL);
 }
 
 char *
-nvpair_name(nvpair_t *nvp)
+nvpair_name(const nvpair_t *nvp)
 {
 	return (NVP_NAME(nvp));
 }
 
 data_type_t
-nvpair_type(nvpair_t *nvp)
+nvpair_type(const nvpair_t *nvp)
 {
 	return (NVP_TYPE(nvp));
 }
 
 int
-nvpair_type_is_array(nvpair_t *nvp)
+nvpair_type_is_array(const nvpair_t *nvp)
 {
 	data_type_t type = NVP_TYPE(nvp);
 
@@ -1541,7 +1551,8 @@ nvpair_type_is_array(nvpair_t *nvp)
 }
 
 static int
-nvpair_value_common(nvpair_t *nvp, data_type_t type, uint_t *nelem, void *data)
+nvpair_value_common(const nvpair_t *nvp, data_type_t type, uint_t *nelem,
+    void *data)
 {
 	int value_sz;
 
@@ -1585,6 +1596,10 @@ nvpair_value_common(nvpair_t *nvp, data_type_t type, uint_t *nelem, void *data)
 	case DATA_TYPE_STRING:
 		if (data == NULL)
 			return (EINVAL);
+		/*
+		 * This discards the const from nvp, so all callers for these
+		 * types must not accept const nvpairs.
+		 */
 		*(void **)data = (void *)NVP_VALUE(nvp);
 		if (nelem != NULL)
 			*nelem = 1;
@@ -1604,6 +1619,10 @@ nvpair_value_common(nvpair_t *nvp, data_type_t type, uint_t *nelem, void *data)
 	case DATA_TYPE_NVLIST_ARRAY:
 		if (nelem == NULL || data == NULL)
 			return (EINVAL);
+		/*
+		 * This discards the const from nvp, so all callers for these
+		 * types must not accept const nvpairs.
+		 */
 		if ((*nelem = NVP_NELEM(nvp)) != 0)
 			*(void **)data = (void *)NVP_VALUE(nvp);
 		else
@@ -1618,7 +1637,7 @@ nvpair_value_common(nvpair_t *nvp, data_type_t type, uint_t *nelem, void *data)
 }
 
 static int
-nvlist_lookup_common(nvlist_t *nvl, const char *name, data_type_t type,
+nvlist_lookup_common(const nvlist_t *nvl, const char *name, data_type_t type,
     uint_t *nelem, void *data)
 {
 	if (name == NULL || nvl == NULL || nvl->nvl_priv == 0)
@@ -1635,75 +1654,76 @@ nvlist_lookup_common(nvlist_t *nvl, const char *name, data_type_t type,
 }
 
 int
-nvlist_lookup_boolean(nvlist_t *nvl, const char *name)
+nvlist_lookup_boolean(const nvlist_t *nvl, const char *name)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_BOOLEAN, NULL, NULL));
 }
 
 int
-nvlist_lookup_boolean_value(nvlist_t *nvl, const char *name, boolean_t *val)
+nvlist_lookup_boolean_value(const nvlist_t *nvl, const char *name,
+    boolean_t *val)
 {
 	return (nvlist_lookup_common(nvl, name,
 	    DATA_TYPE_BOOLEAN_VALUE, NULL, val));
 }
 
 int
-nvlist_lookup_byte(nvlist_t *nvl, const char *name, uchar_t *val)
+nvlist_lookup_byte(const nvlist_t *nvl, const char *name, uchar_t *val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_BYTE, NULL, val));
 }
 
 int
-nvlist_lookup_int8(nvlist_t *nvl, const char *name, int8_t *val)
+nvlist_lookup_int8(const nvlist_t *nvl, const char *name, int8_t *val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_INT8, NULL, val));
 }
 
 int
-nvlist_lookup_uint8(nvlist_t *nvl, const char *name, uint8_t *val)
+nvlist_lookup_uint8(const nvlist_t *nvl, const char *name, uint8_t *val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_UINT8, NULL, val));
 }
 
 int
-nvlist_lookup_int16(nvlist_t *nvl, const char *name, int16_t *val)
+nvlist_lookup_int16(const nvlist_t *nvl, const char *name, int16_t *val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_INT16, NULL, val));
 }
 
 int
-nvlist_lookup_uint16(nvlist_t *nvl, const char *name, uint16_t *val)
+nvlist_lookup_uint16(const nvlist_t *nvl, const char *name, uint16_t *val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_UINT16, NULL, val));
 }
 
 int
-nvlist_lookup_int32(nvlist_t *nvl, const char *name, int32_t *val)
+nvlist_lookup_int32(const nvlist_t *nvl, const char *name, int32_t *val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_INT32, NULL, val));
 }
 
 int
-nvlist_lookup_uint32(nvlist_t *nvl, const char *name, uint32_t *val)
+nvlist_lookup_uint32(const nvlist_t *nvl, const char *name, uint32_t *val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_UINT32, NULL, val));
 }
 
 int
-nvlist_lookup_int64(nvlist_t *nvl, const char *name, int64_t *val)
+nvlist_lookup_int64(const nvlist_t *nvl, const char *name, int64_t *val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_INT64, NULL, val));
 }
 
 int
-nvlist_lookup_uint64(nvlist_t *nvl, const char *name, uint64_t *val)
+nvlist_lookup_uint64(const nvlist_t *nvl, const char *name, uint64_t *val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_UINT64, NULL, val));
 }
 
 #if !defined(_KERNEL)
 int
-nvlist_lookup_double(nvlist_t *nvl, const char *name, double *val)
+nvlist_lookup_double(const nvlist_t *nvl, const char *name, double *val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_DOUBLE, NULL, val));
 }
@@ -2079,7 +2099,7 @@ int nvlist_lookup_nvpair_embedded_index(nvlist_t *nvl,
 }
 
 boolean_t
-nvlist_exists(nvlist_t *nvl, const char *name)
+nvlist_exists(const nvlist_t *nvl, const char *name)
 {
 	nvpriv_t *priv;
 	nvpair_t *nvp;
@@ -2100,68 +2120,68 @@ nvlist_exists(nvlist_t *nvl, const char *name)
 }
 
 int
-nvpair_value_boolean_value(nvpair_t *nvp, boolean_t *val)
+nvpair_value_boolean_value(const nvpair_t *nvp, boolean_t *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_BOOLEAN_VALUE, NULL, val));
 }
 
 int
-nvpair_value_byte(nvpair_t *nvp, uchar_t *val)
+nvpair_value_byte(const nvpair_t *nvp, uchar_t *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_BYTE, NULL, val));
 }
 
 int
-nvpair_value_int8(nvpair_t *nvp, int8_t *val)
+nvpair_value_int8(const nvpair_t *nvp, int8_t *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_INT8, NULL, val));
 }
 
 int
-nvpair_value_uint8(nvpair_t *nvp, uint8_t *val)
+nvpair_value_uint8(const nvpair_t *nvp, uint8_t *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_UINT8, NULL, val));
 }
 
 int
-nvpair_value_int16(nvpair_t *nvp, int16_t *val)
+nvpair_value_int16(const nvpair_t *nvp, int16_t *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_INT16, NULL, val));
 }
 
 int
-nvpair_value_uint16(nvpair_t *nvp, uint16_t *val)
+nvpair_value_uint16(const nvpair_t *nvp, uint16_t *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_UINT16, NULL, val));
 }
 
 int
-nvpair_value_int32(nvpair_t *nvp, int32_t *val)
+nvpair_value_int32(const nvpair_t *nvp, int32_t *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_INT32, NULL, val));
 }
 
 int
-nvpair_value_uint32(nvpair_t *nvp, uint32_t *val)
+nvpair_value_uint32(const nvpair_t *nvp, uint32_t *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_UINT32, NULL, val));
 }
 
 int
-nvpair_value_int64(nvpair_t *nvp, int64_t *val)
+nvpair_value_int64(const nvpair_t *nvp, int64_t *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_INT64, NULL, val));
 }
 
 int
-nvpair_value_uint64(nvpair_t *nvp, uint64_t *val)
+nvpair_value_uint64(const nvpair_t *nvp, uint64_t *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_UINT64, NULL, val));
 }
 
 #if !defined(_KERNEL)
 int
-nvpair_value_double(nvpair_t *nvp, double *val)
+nvpair_value_double(const nvpair_t *nvp, double *val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_DOUBLE, NULL, val));
 }

--- a/module/os/freebsd/zfs/spa_os.c
+++ b/module/os/freebsd/zfs/spa_os.c
@@ -152,8 +152,8 @@ spa_generate_rootconf(const char *name)
 	fnvlist_add_string(nvroot, ZPOOL_CONFIG_TYPE, VDEV_TYPE_ROOT);
 	fnvlist_add_uint64(nvroot, ZPOOL_CONFIG_ID, 0ULL);
 	fnvlist_add_uint64(nvroot, ZPOOL_CONFIG_GUID, pgid);
-	fnvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN, tops,
-	    nchildren);
+	fnvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
+	    (const nvlist_t * const *)tops, nchildren);
 
 	/*
 	 * Replace the existing vdev_tree with the new root vdev in

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -702,7 +702,7 @@ i_fm_payload_set(nvlist_t *payload, const char *name, va_list ap)
 		case DATA_TYPE_STRING_ARRAY:
 			nelem = va_arg(ap, int);
 			ret = nvlist_add_string_array(payload, name,
-			    va_arg(ap, char **), nelem);
+			    va_arg(ap, const char **), nelem);
 			break;
 		case DATA_TYPE_NVLIST:
 			ret = nvlist_add_nvlist(payload, name,
@@ -711,7 +711,7 @@ i_fm_payload_set(nvlist_t *payload, const char *name, va_list ap)
 		case DATA_TYPE_NVLIST_ARRAY:
 			nelem = va_arg(ap, int);
 			ret = nvlist_add_nvlist_array(payload, name,
-			    va_arg(ap, nvlist_t **), nelem);
+			    va_arg(ap, const nvlist_t **), nelem);
 			break;
 		default:
 			ret = EINVAL;
@@ -867,8 +867,10 @@ fm_fmri_hc_set(nvlist_t *fmri, int version, const nvlist_t *auth,
 	}
 	va_end(ap);
 
-	if (nvlist_add_nvlist_array(fmri, FM_FMRI_HC_LIST, pairs, npairs) != 0)
+	if (nvlist_add_nvlist_array(fmri, FM_FMRI_HC_LIST,
+	    (const nvlist_t **)pairs, npairs) != 0) {
 		atomic_inc_64(&erpt_kstat_data.fmri_set_failed.value.ui64);
+	}
 
 	for (i = 0; i < npairs; i++)
 		fm_nvlist_destroy(pairs[i], FM_NVA_RETAIN);
@@ -961,8 +963,8 @@ fm_fmri_hc_create(nvlist_t *fmri, int version, const nvlist_t *auth,
 	/*
 	 * Create the fmri hc list
 	 */
-	if (nvlist_add_nvlist_array(fmri, FM_FMRI_HC_LIST, pairs,
-	    npairs + n) != 0) {
+	if (nvlist_add_nvlist_array(fmri, FM_FMRI_HC_LIST,
+	    (const nvlist_t **)pairs, npairs + n) != 0) {
 		atomic_inc_64(&erpt_kstat_data.fmri_set_failed.value.ui64);
 		return;
 	}
@@ -1128,7 +1130,7 @@ fm_fmri_mem_set(nvlist_t *fmri, int version, const nvlist_t *auth,
 
 	if (serial != NULL) {
 		if (nvlist_add_string_array(fmri, FM_FMRI_MEM_SERIAL_ID,
-		    (char **)&serial, 1) != 0) {
+		    (const char **)&serial, 1) != 0) {
 			atomic_inc_64(
 			    &erpt_kstat_data.fmri_set_failed.value.ui64);
 		}

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -1707,7 +1707,7 @@ vdev_draid_spare_create(nvlist_t *nvroot, vdev_t *vd, uint64_t *ndraidp,
 	if (n > 0) {
 		(void) nvlist_remove_all(nvroot, ZPOOL_CONFIG_SPARES);
 		fnvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_SPARES,
-		    new_spares, n);
+		    (const nvlist_t **)new_spares, n);
 	}
 
 	for (int i = 0; i < n; i++)

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -669,7 +669,7 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 
 		if (idx) {
 			fnvlist_add_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN,
-			    child, idx);
+			    (const nvlist_t * const *)child, idx);
 		}
 
 		for (c = 0; c < idx; c++)

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -353,7 +353,8 @@ spa_vdev_remove_aux(nvlist_t *config, char *name, nvlist_t **dev, int count,
 	}
 
 	VERIFY(nvlist_remove(config, name, DATA_TYPE_NVLIST_ARRAY) == 0);
-	VERIFY(nvlist_add_nvlist_array(config, name, newdev, count - 1) == 0);
+	fnvlist_add_nvlist_array(config, name, (const nvlist_t * const *)newdev,
+	    count - 1);
 
 	for (int i = 0; i < count - 1; i++)
 		nvlist_free(newdev[i]);

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -258,8 +258,8 @@ zfs_fuid_sync(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 		VERIFY(nvlist_add_string(fuids[i], FUID_DOMAIN,
 		    domnode->f_ksid->kd_name) == 0);
 	}
-	VERIFY(nvlist_add_nvlist_array(nvp, FUID_NVP_ARRAY,
-	    fuids, numnodes) == 0);
+	fnvlist_add_nvlist_array(nvp, FUID_NVP_ARRAY,
+	    (const nvlist_t * const *)fuids, numnodes);
 	for (i = 0; i != numnodes; i++)
 		nvlist_free(fuids[i]);
 	kmem_free(fuids, numnodes * sizeof (void *));

--- a/tests/zfs-tests/cmd/libzfs_input_check/libzfs_input_check.c
+++ b/tests/zfs-tests/cmd/libzfs_input_check/libzfs_input_check.c
@@ -603,7 +603,7 @@ test_channel_program(const char *pool)
 	nvlist_t *args = fnvlist_alloc();
 
 	fnvlist_add_string(required, "program", program);
-	fnvlist_add_string_array(args, "argv", argv, 1);
+	fnvlist_add_string_array(args, "argv", (const char * const *)argv, 1);
 	fnvlist_add_nvlist(required, "arg", args);
 
 	fnvlist_add_boolean_value(optional, "sync", B_TRUE);

--- a/tests/zfs-tests/cmd/nvlist_to_lua/nvlist_to_lua.c
+++ b/tests/zfs-tests/cmd/nvlist_to_lua/nvlist_to_lua.c
@@ -232,7 +232,7 @@ run_tests(void)
 	}
 	{
 		char *const val[2] = { "0", "1" };
-		fnvlist_add_string_array(nvl, key, val, 2);
+		fnvlist_add_string_array(nvl, key, (const char **)val, 2);
 		test("string_array", B_TRUE, B_FALSE);
 	}
 	{
@@ -241,7 +241,7 @@ run_tests(void)
 		fnvlist_add_string(val[0], "subkey", "subvalue");
 		val[1] = fnvlist_alloc();
 		fnvlist_add_string(val[1], "subkey2", "subvalue2");
-		fnvlist_add_nvlist_array(nvl, key, val, 2);
+		fnvlist_add_nvlist_array(nvl, key, (const nvlist_t **)val, 2);
 		fnvlist_free(val[0]);
 		fnvlist_free(val[1]);
 		test("nvlist_array", B_FALSE, B_FALSE);


### PR DESCRIPTION
### Motivation and Context
When it comes to FFIs using libzfs and libnvpair, it's best to properly expose the exact behavior of the various library routines. This includes properly annotating with `const` when possible, to simplify the burden on users of languages that know and care about this memory construct. In particular, Rust has strong notions of mutability and immutability, and passing a non-mutable reference to libnvpair simplifies things significantly in some cases.

### Description
This PR adds `const` to all the `nvlist_add_*_array` functions, which is appropriate since the code doesn't actually modify the underlying data or any of the intervening pointers. It also adds casts to the callers as necessary to work around the issue described in http://c-faq.com/ansi/constmismatch.html

### How Has This Been Tested?
zfs-precommit and style checking

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
