### PR TITLE
Handle partial reads (on Linux) (for 2.0)

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -254,7 +254,9 @@ zfs_read(struct znode *zp, uio_t *uio, int ioflag, cred_t *cr)
 	}
 
 	ASSERT(uio->uio_loffset < zp->z_size);
+#if defined(__linux__)
 	ssize_t start_offset = uio->uio_loffset;
+#endif
 	ssize_t n = MIN(uio->uio_resid, zp->z_size - uio->uio_loffset);
 	ssize_t start_resid = n;
 
@@ -277,13 +279,18 @@ zfs_read(struct znode *zp, uio_t *uio, int ioflag, cred_t *cr)
 			/* convert checksum errors into IO errors */
 			if (error == ECKSUM)
 				error = SET_ERROR(EIO);
+
+#if defined(__linux__)
 			/*
 			 * if we actually read some bytes, bubbling EFAULT
-			 * up to become EAGAIN isn't what we want here.
+			 * up to become EAGAIN isn't what we want here...
+			 *
+			 * ...on Linux, at least. On FBSD, doing this breaks.
 			 */
 			if (error == EFAULT &&
 			    (uio->uio_loffset - start_offset) != 0)
 				error = 0;
+#endif
 			break;
 		}
 


### PR DESCRIPTION
### Motivation and Context
@tonyhutter pointed out that the first of these commits wasn't in 2.0.x yet when I suggested including the second, and this seemed like an unfortunate enough issue to warrant pulling in.

### Description
Cherrypicked 59eab10, fixed conflicts and differences, then 0567946 and same.

### How Has This Been Tested?
It built on my one test host, and most importantly, passed checkstyle. Beyond that...that's what the CI is for, right? ;)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
