### PR TITLE
Enable edonr in FreeBSD

### DIFF
--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -88,9 +88,7 @@ enum zio_checksum {
 	ZIO_CHECKSUM_NOPARITY,
 	ZIO_CHECKSUM_SHA512,
 	ZIO_CHECKSUM_SKEIN,
-#if !defined(__FreeBSD__)
 	ZIO_CHECKSUM_EDONR,
-#endif
 	ZIO_CHECKSUM_FUNCTIONS
 };
 

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -771,10 +771,6 @@ The
 and
 .Sy edonr
 checksum algorithms require enabling the appropriate features on the pool.
-.Fx
-does not support the
-.Sy edonr
-algorithm.
 .Pp
 Please see
 .Xr zpool-features 7

--- a/man/man7/zpool-features.7
+++ b/man/man7/zpool-features.7
@@ -436,10 +436,6 @@ in ZFS, which means that the checksum is pre-seeded with a secret
 to be checksummed.
 Thus the produced checksums are unique to a given pool,
 preventing hash collision attacks on systems with dedup.
-.Pp
-.checksum-spiel edonr
-.Pp
-.Fx does not support the Sy edonr No feature.
 .
 .feature com.delphix embedded_data no
 This feature improves the performance and compression ratio of

--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -12,6 +12,7 @@ KMOD=	openzfs
 .PATH:	${SRCDIR}/avl \
 	${SRCDIR}/lua \
 	${SRCDIR}/nvpair \
+	${SRCDIR}/icp/algs/edonr \
 	${SRCDIR}/os/freebsd/spl \
 	${SRCDIR}/os/freebsd/zfs \
 	${SRCDIR}/unicode \
@@ -72,6 +73,9 @@ SRCS=	vnode_if.h device_if.h bus_if.h
 
 # avl
 SRCS+=	avl.c
+
+# icp
+SRCS+=  edonr.c
 
 #lua
 SRCS+=	lapi.c \
@@ -219,6 +223,7 @@ SRCS+=	abd.c \
 	dsl_scan.c \
 	dsl_synctask.c \
 	dsl_userhold.c \
+	edonr_zfs.c \
 	fm.c \
 	gzip.c \
 	lzjb.c \
@@ -345,6 +350,7 @@ CFLAGS.dmu_traverse.c= -Wno-cast-qual
 CFLAGS.dsl_dir.c= -Wno-cast-qual
 CFLAGS.dsl_deadlist.c= -Wno-cast-qual
 CFLAGS.dsl_prop.c= -Wno-cast-qual
+CFLAGS.edonr.c=-Wno-cast-qual
 CFLAGS.fm.c= -Wno-cast-qual
 CFLAGS.lz4.c= -Wno-cast-qual
 CFLAGS.spa.c= -Wno-cast-qual

--- a/module/zcommon/zfeature_common.c
+++ b/module/zcommon/zfeature_common.c
@@ -227,12 +227,8 @@ zfs_mod_supported_feature(const char *name)
 	 * tree, but this has not been done yet.  Therefore, we return
 	 * that all features except edonr are supported.
 	 */
-#if defined(__FreeBSD__)
-	if (strcmp(name, "org.illumos:edonr") == 0)
-		return (B_FALSE);
-	else
-		return (B_TRUE);
-#elif defined(_KERNEL) || defined(LIB_ZPOOL_BUILD)
+
+#if defined(_KERNEL) || defined(LIB_ZPOOL_BUILD) || defined(__FreeBSD__)
 	return (B_TRUE);
 #else
 	return (zfs_mod_supported(ZFS_SYSFS_POOL_FEATURES, name));

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -83,10 +83,7 @@ zfs_prop_init(void)
 		{ "noparity",   ZIO_CHECKSUM_NOPARITY },
 		{ "sha512",	ZIO_CHECKSUM_SHA512 },
 		{ "skein",	ZIO_CHECKSUM_SKEIN },
-#if !defined(__FreeBSD__)
-
 		{ "edonr",	ZIO_CHECKSUM_EDONR },
-#endif
 		{ NULL }
 	};
 
@@ -103,11 +100,8 @@ zfs_prop_init(void)
 		{ "skein",	ZIO_CHECKSUM_SKEIN },
 		{ "skein,verify",
 				ZIO_CHECKSUM_SKEIN | ZIO_CHECKSUM_VERIFY },
-#if !defined(__FreeBSD__)
-
 		{ "edonr,verify",
 				ZIO_CHECKSUM_EDONR | ZIO_CHECKSUM_VERIFY },
-#endif
 		{ NULL }
 	};
 
@@ -396,21 +390,13 @@ zfs_prop_init(void)
 	zprop_register_index(ZFS_PROP_CHECKSUM, "checksum",
 	    ZIO_CHECKSUM_DEFAULT, PROP_INHERIT, ZFS_TYPE_FILESYSTEM |
 	    ZFS_TYPE_VOLUME,
-#if !defined(__FreeBSD__)
 	    "on | off | fletcher2 | fletcher4 | sha256 | sha512 | skein"
 	    " | edonr",
-#else
-	    "on | off | fletcher2 | fletcher4 | sha256 | sha512 | skein",
-#endif
 	    "CHECKSUM", checksum_table);
 	zprop_register_index(ZFS_PROP_DEDUP, "dedup", ZIO_CHECKSUM_OFF,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
 	    "on | off | verify | sha256[,verify] | sha512[,verify] | "
-#if !defined(__FreeBSD__)
 	    "skein[,verify] | edonr,verify",
-#else
-	    "skein[,verify]",
-#endif
 	    "DEDUP", dedup_table);
 	zprop_register_index(ZFS_PROP_COMPRESSION, "compression",
 	    ZIO_COMPRESS_DEFAULT, PROP_INHERIT,

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -191,12 +191,10 @@ zio_checksum_info_t zio_checksum_table[ZIO_CHECKSUM_FUNCTIONS] = {
 	    abd_checksum_skein_tmpl_init, abd_checksum_skein_tmpl_free,
 	    ZCHECKSUM_FLAG_METADATA | ZCHECKSUM_FLAG_DEDUP |
 	    ZCHECKSUM_FLAG_SALTED | ZCHECKSUM_FLAG_NOPWRITE, "skein"},
-#if !defined(__FreeBSD__)
 	{{abd_checksum_edonr_native,	abd_checksum_edonr_byteswap},
 	    abd_checksum_edonr_tmpl_init, abd_checksum_edonr_tmpl_free,
 	    ZCHECKSUM_FLAG_METADATA | ZCHECKSUM_FLAG_SALTED |
 	    ZCHECKSUM_FLAG_NOPWRITE, "edonr"},
-#endif
 };
 
 /*
@@ -213,10 +211,8 @@ zio_checksum_to_feature(enum zio_checksum cksum)
 		return (SPA_FEATURE_SHA512);
 	case ZIO_CHECKSUM_SKEIN:
 		return (SPA_FEATURE_SKEIN);
-#if !defined(__FreeBSD__)
 	case ZIO_CHECKSUM_EDONR:
 		return (SPA_FEATURE_EDONR);
-#endif
 	default:
 		return (SPA_FEATURE_NONE);
 	}

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -109,7 +109,7 @@ tests = ['tst.destroy_fs', 'tst.destroy_snap', 'tst.get_count_and_limit',
 tags = ['functional', 'channel_program', 'synctask_core']
 
 [tests/functional/checksum]
-tests = ['run_sha2_test', 'run_skein_test', 'filetest_001_pos',
+tests = ['run_edonr_test', 'run_sha2_test', 'run_skein_test', 'filetest_001_pos',
     'filetest_002_pos']
 tags = ['functional', 'checksum']
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -38,10 +38,6 @@ tags = ['functional', 'atime']
 tests = ['chattr_001_pos', 'chattr_002_neg']
 tags = ['functional', 'chattr']
 
-[tests/functional/checksum:Linux]
-tests = ['run_edonr_test']
-tags = ['functional', 'checksum']
-
 [tests/functional/cli_root/zfs:Linux]
 tests = ['zfs_003_neg']
 tags = ['functional', 'cli_root', 'zfs']

--- a/tests/zfs-tests/tests/functional/checksum/Makefile.am
+++ b/tests/zfs-tests/tests/functional/checksum/Makefile.am
@@ -21,13 +21,11 @@ dist_pkgdata_DATA = \
 pkgexecdir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/checksum
 
 pkgexec_PROGRAMS = \
+	edonr_test \
 	skein_test \
 	sha2_test
 
 skein_test_SOURCES = skein_test.c
 sha2_test_SOURCES = sha2_test.c
 
-if BUILD_LINUX
-pkgexec_PROGRAMS += edonr_test
 edonr_test_SOURCES = edonr_test.c
-endif

--- a/tests/zfs-tests/tests/functional/checksum/default.cfg
+++ b/tests/zfs-tests/tests/functional/checksum/default.cfg
@@ -30,7 +30,4 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-set -A CHECKSUM_TYPES "fletcher2" "fletcher4" "sha256" "sha512" "skein"
-if ! is_freebsd; then
-	CHECKSUM_TYPES+=("edonr")
-fi
+set -A CHECKSUM_TYPES "fletcher2" "fletcher4" "sha256" "sha512" "skein" "edonr"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/checksum_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/checksum_001_pos.ksh
@@ -46,10 +46,7 @@
 verify_runnable "both"
 
 set -A dataset "$TESTPOOL" "$TESTPOOL/$TESTFS" "$TESTPOOL/$TESTVOL"
-set -A values "on" "off" "fletcher2" "fletcher4" "sha256" "sha512" "skein" "noparity"
-if is_linux; then
-	values+=("edonr")
-fi
+set -A values "on" "off" "fletcher2" "fletcher4" "sha256" "sha512" "skein" "edonr" "noparity"
 
 log_assert "Setting a valid checksum on a file system, volume," \
 	"it should be successful."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -72,6 +72,7 @@ typeset -a properties=(
     "feature@large_blocks"
     "feature@sha512"
     "feature@skein"
+    "feature@edonr"
     "feature@device_removal"
     "feature@obsolete_counts"
     "feature@zpool_checkpoint"
@@ -96,11 +97,5 @@ if is_linux || is_freebsd; then
 	    "feature@bookmark_v2"
 	    "feature@livelist"
 	    "feature@zstd_compress"
-	)
-fi
-
-if ! is_freebsd; then
-	properties+=(
-	    "feature@edonr"
 	)
 fi


### PR DESCRIPTION
### Motivation and Context
There's no reason to not enable it, as far as I know, so let's drop a platform difference.

### Description
Dropped a lot of ifdefs, included edonr.c as a thing to stuff into openzfs.ko, removed the if linux around things in tests/

### How Has This Been Tested?
```
$ sudo zfs get checksum mypool
NAME    PROPERTY  VALUE      SOURCE
mypool  checksum  edonr      local
$ uname -a
FreeBSD freebsd12box 12.2-RELEASE-p7 FreeBSD 12.2-RELEASE-p7 GENERIC  amd64
$
```
A round of enabling the feature, reading, writing, and reading with zdb to confirm it actually used it, went fine...


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
