### PR TITLE
Add zfs-test facility to automatically rerun failing tests

### DIFF
--- a/.github/workflows/zfs-tests-functional.yml
+++ b/.github/workflows/zfs-tests-functional.yml
@@ -64,7 +64,7 @@ jobs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: Tests
       run: |
-        /usr/share/zfs/zfs-tests.sh -v -s 3G
+        /usr/share/zfs/zfs-tests.sh -vR -s 3G
     - name: Prepare artifacts
       if: failure()
       run: |

--- a/.github/workflows/zfs-tests-sanity.yml
+++ b/.github/workflows/zfs-tests-sanity.yml
@@ -60,7 +60,7 @@ jobs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: Tests
       run: |
-        /usr/share/zfs/zfs-tests.sh -v -s 3G -r sanity
+        /usr/share/zfs/zfs-tests.sh -vR -s 3G -r sanity
     - name: Prepare artifacts
       if: failure()
       run: |

--- a/tests/test-runner/bin/test-runner.py.in
+++ b/tests/test-runner/bin/test-runner.py.in
@@ -497,7 +497,7 @@ Tags: %s
             self.failsafe, failsafe_user, self.tags)
 
     def filter(self, keeplist):
-        self.tests = [ x for x in self.tests if x in keeplist ]
+        self.tests = [x for x in self.tests if x in keeplist]
 
     def verify(self):
         """
@@ -767,8 +767,8 @@ class TestRun(object):
             config.add_section(test)
             for prop in Test.props:
                 if prop not in self.props:
-                    config.set(testgroup, prop,
-                        getattr(self.testgroups[testgroup], prop))
+                    config.set(test, prop,
+                               getattr(self.tests[test], prop))
 
         for testgroup in sorted(self.testgroups.keys()):
             config.add_section(testgroup)
@@ -776,7 +776,7 @@ class TestRun(object):
             for prop in TestGroup.props:
                 if prop not in self.props:
                     config.set(testgroup, prop,
-                        getattr(self.testgroups[testgroup], prop))
+                               getattr(self.testgroups[testgroup], prop))
 
         try:
             with open(options.template, 'w') as f:
@@ -977,17 +977,17 @@ def filter_tests(testrun, options):
 
     failed = {}
     while True:
-            line = fh.readline()
-            if not line:
-                 break
-            m = re.match(r'Test: .*(tests/.*)/(\S+).*\[FAIL\]', line)
-            if not m:
-                continue
-            group, test = m.group(1, 2)
-            try:
-                failed[group].append(test)
-            except KeyError:
-                failed[group] = [ test ]
+        line = fh.readline()
+        if not line:
+            break
+        m = re.match(r'Test: .*(tests/.*)/(\S+).*\[FAIL\]', line)
+        if not m:
+            continue
+        group, test = m.group(1, 2)
+        try:
+            failed[group].append(test)
+        except KeyError:
+            failed[group] = [test]
     fh.close()
 
     testrun.filter(failed)

--- a/tests/test-runner/bin/test-runner.py.in
+++ b/tests/test-runner/bin/test-runner.py.in
@@ -27,6 +27,7 @@ except ImportError:
 import os
 import sys
 import ctypes
+import re
 
 from datetime import datetime
 from optparse import OptionParser
@@ -495,6 +496,9 @@ Tags: %s
             self.timeout, self.user, self.pre, pre_user, self.post, post_user,
             self.failsafe, failsafe_user, self.tags)
 
+    def filter(self, keeplist):
+        self.tests = [ x for x in self.tests if x in keeplist ]
+
     def verify(self):
         """
         Check the pre/post/failsafe scripts, user and tests in this TestGroup.
@@ -656,6 +660,24 @@ class TestRun(object):
 
             testgroup.verify()
 
+    def filter(self, keeplist):
+        for group in list(self.testgroups.keys()):
+            if group not in keeplist:
+                del self.testgroups[group]
+                continue
+
+            g = self.testgroups[group]
+
+            if g.pre and os.path.basename(g.pre) in keeplist[group]:
+                continue
+
+            g.filter(keeplist[group])
+
+        for test in list(self.tests.keys()):
+            directory, base = os.path.split(test)
+            if directory not in keeplist or base not in keeplist[directory]:
+                del self.tests[test]
+
     def read(self, options):
         """
         Read in the specified runfiles, and apply the TestRun properties
@@ -743,10 +765,18 @@ class TestRun(object):
 
         for test in sorted(self.tests.keys()):
             config.add_section(test)
+            for prop in Test.props:
+                if prop not in self.props:
+                    config.set(testgroup, prop,
+                        getattr(self.testgroups[testgroup], prop))
 
         for testgroup in sorted(self.testgroups.keys()):
             config.add_section(testgroup)
             config.set(testgroup, 'tests', self.testgroups[testgroup].tests)
+            for prop in TestGroup.props:
+                if prop not in self.props:
+                    config.set(testgroup, prop,
+                        getattr(self.testgroups[testgroup], prop))
 
         try:
             with open(options.template, 'w') as f:
@@ -796,7 +826,7 @@ class TestRun(object):
             return
 
         global LOG_FILE_OBJ
-        if options.cmd != 'wrconfig':
+        if not options.template:
             try:
                 old = os.umask(0)
                 os.makedirs(self.outputdir, mode=0o777)
@@ -939,17 +969,37 @@ def find_tests(testrun, options):
             testrun.addtest(p, options)
 
 
+def filter_tests(testrun, options):
+    try:
+        fh = open(options.logfile, "r")
+    except Exception as e:
+        fail('%s' % e)
+
+    failed = {}
+    while True:
+            line = fh.readline()
+            if not line:
+                 break
+            m = re.match(r'Test: .*(tests/.*)/(\S+).*\[FAIL\]', line)
+            if not m:
+                continue
+            group, test = m.group(1, 2)
+            try:
+                failed[group].append(test)
+            except KeyError:
+                failed[group] = [ test ]
+    fh.close()
+
+    testrun.filter(failed)
+
+
 def fail(retstr, ret=1):
     print('%s: %s' % (sys.argv[0], retstr))
     exit(ret)
 
 
 def options_cb(option, opt_str, value, parser):
-    path_options = ['outputdir', 'template', 'testdir']
-
-    if option.dest == 'runfiles' and '-w' in parser.rargs or \
-            option.dest == 'template' and '-c' in parser.rargs:
-        fail('-c and -w are mutually exclusive.')
+    path_options = ['outputdir', 'template', 'testdir', 'logfile']
 
     if opt_str in parser.rargs:
         fail('%s may only be specified once.' % opt_str)
@@ -957,8 +1007,6 @@ def options_cb(option, opt_str, value, parser):
     if option.dest == 'runfiles':
         parser.values.cmd = 'rdconfig'
         value = set(os.path.abspath(p) for p in value.split(','))
-    if option.dest == 'template':
-        parser.values.cmd = 'wrconfig'
     if option.dest == 'tags':
         value = [x.strip() for x in value.split(',')]
 
@@ -975,6 +1023,10 @@ def parse_args():
                       help='Specify tests to run via config files.')
     parser.add_option('-d', action='store_true', default=False, dest='dryrun',
                       help='Dry run. Print tests, but take no other action.')
+    parser.add_option('-l', action='callback', callback=options_cb,
+                      default=None, dest='logfile', metavar='logfile',
+                      type='string',
+                      help='Read logfile and re-run tests which failed.')
     parser.add_option('-g', action='store_true', default=False,
                       dest='do_groups', help='Make directories TestGroups.')
     parser.add_option('-o', action='callback', callback=options_cb,
@@ -1021,9 +1073,6 @@ def parse_args():
                       help='Number of times to run the test run.')
     (options, pathnames) = parser.parse_args()
 
-    if not options.runfiles and not options.template:
-        options.cmd = 'runtests'
-
     if options.runfiles and len(pathnames):
         fail('Extraneous arguments.')
 
@@ -1034,18 +1083,20 @@ def parse_args():
 
 def main():
     options = parse_args()
+
     testrun = TestRun(options)
 
-    if options.cmd == 'runtests':
-        find_tests(testrun, options)
-    elif options.cmd == 'rdconfig':
+    if options.runfiles:
         testrun.read(options)
-    elif options.cmd == 'wrconfig':
+    else:
         find_tests(testrun, options)
+
+    if options.logfile:
+        filter_tests(testrun, options)
+
+    if options.template:
         testrun.write(options)
         exit(0)
-    else:
-        fail('Unknown command specified')
 
     testrun.complete_outputdirs()
     testrun.run(options)

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -21,6 +21,7 @@
 import os
 import re
 import sys
+import argparse
 
 #
 # This script parses the stdout of zfstest, which has this format:
@@ -380,11 +381,31 @@ def process_results(pathname):
 
     return d
 
+class ListMaybesAction(argparse.Action):
+    def __init__(self,
+                 option_strings,
+                 dest="SUPPRESS",
+                 default="SUPPRESS",
+                 help="list flaky tests and exit"):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs=0,
+            help=help)
+    def __call__(self, parser, namespace, values, option_string=None):
+        for test in maybe:
+            print(test)
+        sys.exit(0)
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        usage('usage: %s <pathname>' % sys.argv[0])
-    results = process_results(sys.argv[1])
+    parser = argparse.ArgumentParser(description='Analyze ZTS logs')
+    parser.add_argument('logfile')
+    parser.add_argument('--list-maybes', action=ListMaybesAction)
+    parser.add_argument('--no-maybes', action='store_false', dest='maybes')
+    args = parser.parse_args()
+
+    results = process_results(args.logfile)
 
     if summary['total'] == 0:
         print("\n\nNo test results were found.")
@@ -393,6 +414,7 @@ if __name__ == "__main__":
 
     expected = []
     unexpected = []
+    all_maybes = True
 
     for test in list(results.keys()):
         if results[test] == "PASS":
@@ -405,11 +427,16 @@ if __name__ == "__main__":
             if setup in maybe and maybe[setup][0] == "SKIP":
                 continue
 
-        if ((test not in known or results[test] not in known[test][0]) and
-                (test not in maybe or results[test] not in maybe[test][0])):
-            unexpected.append(test)
-        else:
+        if (test in known and results[test] in known[test][0]):
             expected.append(test)
+        elif test in maybe and results[test] in maybe[test][0]:
+            if results[test] == 'SKIP' or args.maybes:
+                expected.append(test)
+            elif not args.maybes:
+                unexpected.append(test)
+        else:
+            unexpected.append(test)
+            all_maybes = False
 
     print("\nTests with results other than PASS that are expected:")
     for test in sorted(expected):
@@ -455,5 +482,7 @@ if __name__ == "__main__":
 
     if len(unexpected) == 0:
         sys.exit(0)
+    elif not args.maybes and all_maybes:
+        sys.exit(2)
     else:
         sys.exit(1)

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -381,6 +381,7 @@ def process_results(pathname):
 
     return d
 
+
 class ListMaybesAction(argparse.Action):
     def __init__(self,
                  option_strings,
@@ -393,10 +394,12 @@ class ListMaybesAction(argparse.Action):
             default=default,
             nargs=0,
             help=help)
+
     def __call__(self, parser, namespace, values, option_string=None):
         for test in maybe:
             print(test)
         sys.exit(0)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Analyze ZTS logs')

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -387,7 +387,7 @@ class ListMaybesAction(argparse.Action):
                  dest="SUPPRESS",
                  default="SUPPRESS",
                  help="list flaky tests and exit"):
-        super().__init__(
+        super(ListMaybesAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
             default=default,


### PR DESCRIPTION
### Motivation and Context
This was a project proposed as part of the Quality theme for the hackthon for the 2021 OpenZFS Developer Summit. The idea is to improve the usability of the automated tests that get run when a PR is created by having failing tests automatically rerun in order to make flaky tests less impactful.

### Description
This started a port of the Illumos commit `13365 Add option to testrunner to re-run just failed tests`. That commit contains the basic infrastructure in test-runner.py to filter a list of tests down to only include ones that failed in some previous logfile.

There are changes to `zts-report.py.in` to print the list of tests on the `maybe` list, which are the flaky ones. There's also the option to do the report as usual, but change the return code to a different value if all failures were on the maybe or known failure lists.

There are changes to `zfs-tests.sh`, which are what actually triggers rerunning the failing tests. If the rerun flag is passed, and the report indicates that all test failures were known failures or flaky tests, then we isolate the failed flaky tests and rerun them.

There are also changes to the github workflows to use the new option. This is a slightly different interface than the one they elected to use in Illumos; they added a `-l` flag that allows a logfile to be passed when you rerun the zfs-tests command. I elected to go with this approach as it was more ergonomic for the automation use case, though the `-l` option can also be added if needed.

### How Has This Been Tested?
Local runs of zfs-test did automatically rerun the failing tests when the option was provided, and behaved as usual when it was omitted.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
