### PR TITLE
FreeBSD: fix world build after de198f2d9

### DIFF
--- a/include/os/freebsd/spl/sys/vnode.h
+++ b/include/os/freebsd/spl/sys/vnode.h
@@ -86,6 +86,7 @@ vn_is_readonly(vnode_t *vp)
 	((vp)->v_object != NULL && \
 	(vp)->v_object->resident_page_count > 0)
 
+#ifndef IN_BASE
 static __inline void
 vn_flush_cached_data(vnode_t *vp, boolean_t sync)
 {
@@ -100,6 +101,7 @@ vn_flush_cached_data(vnode_t *vp, boolean_t sync)
 		zfs_vmobject_wunlock(vp->v_object);
 	}
 }
+#endif
 
 #define	vn_exists(vp)		do { } while (0)
 #define	vn_invalid(vp)		do { } while (0)


### PR DESCRIPTION
The inline function vn_flush_cached_data() in vnode.h
must not be compiled when building BASE.

Signed-off-by: Martin Matuska <mm@FreeBSD.org>

### Motivation and Context
Revision de198f2d9 has broken the build of FreeBSD world.

### Description
Simple fix by enclosing inline vn_flush_cached_data() in a #ifndef

### How Has This Been Tested?
FreeBSD universe build.
This change has no effect on non-FreeBSD targets.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
