### PR TITLE
ZTS: zfs_list_004_neg should not check paths that belong to ZFS

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_user/zfs_list/zfs_list.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_user/zfs_list/zfs_list.kshlib
@@ -116,3 +116,22 @@ function verify_reverse_sort { # command list name
 			"unexpected number of filesystems found in list output!"
 	fi
 }
+
+function is_fs_type_zfs {
+
+    typeset dirname=$1
+    typeset fs="$(df $dirname | tail -1 | awk '{print $NF}')"
+
+    if is_freebsd; then
+        fs_type=$(mount | awk -v fs=$fs '{if ($3 == fs) print $4}' \
+            | sed -n 's/(\(.*\),/\1/p')
+    elif is_linux; then
+        fs_type=$(mount | awk -v fs=$fs '{if ($3 == fs) print $5}')
+    fi
+
+    if [[ $fs_type == "zfs" ]]; then
+        true
+    else
+        false
+    fi
+}

--- a/tests/zfs-tests/tests/functional/cli_user/zfs_list/zfs_list_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/zfs_list/zfs_list_004_neg.ksh
@@ -29,7 +29,7 @@
 # Copyright (c) 2013, 2016 by Delphix. All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_user/zfs_list/zfs_list.kshlib
 
 #
 # DESCRIPTION:
@@ -55,8 +55,12 @@ paths="$TESTPOOL/NONEXISTFS $TESTPOOL/$TESTFS/NONEXISTFS \
 cd /tmp
 
 for fs in $paths ; do
-	log_mustnot zfs list $fs
-	log_mustnot zfs list -r $fs
+    # In cases when ZFS is on root, /tmp will belong to ZFS and hence must be
+    # skipped
+    if ! is_fs_type_zfs $fs; then
+        log_mustnot zfs list $fs
+        log_mustnot zfs list -r $fs
+    fi
 done
 
 log_pass "'zfs list [-r]' fails while the given dataset/path does not exist " \


### PR DESCRIPTION
When ZFS is on root, /tmp is a ZFS. This causes zfs_list_004_neg to
fail since `zfs list` on /tmp passes when the test expects it not to.
The fix is to exclude paths that belong to ZFS.

Signed-off-by: Palash Gandhi <pbg4930@rit.edu>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
zfs_list_004_neg tests that `zfs list` fails on paths/dataset that:
1. Do not exist
2. Belong to ZFS

The test checks paths like `/tmp` but the test does not take into account whether or not ZFS is on root.

### Description
Add a check to skip paths that belong to ZFS.

### How Has This Been Tested?
Internal runs of zfs-test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
