### PR TITLE
Allow printing special vdev metaslab groups

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1734,10 +1734,11 @@ print_vdev_metaslab_header(vdev_t *vd)
 }
 
 static void
-dump_metaslab_groups(spa_t *spa)
+dump_metaslab_groups(spa_t *spa, boolean_t show_special)
 {
 	vdev_t *rvd = spa->spa_root_vdev;
 	metaslab_class_t *mc = spa_normal_class(spa);
+	metaslab_class_t *smc = spa_special_class(spa);
 	uint64_t fragmentation;
 
 	metaslab_class_histogram_verify(mc);
@@ -1746,7 +1747,8 @@ dump_metaslab_groups(spa_t *spa)
 		vdev_t *tvd = rvd->vdev_child[c];
 		metaslab_group_t *mg = tvd->vdev_mg;
 
-		if (mg == NULL || mg->mg_class != mc)
+		if (mg == NULL || (mg->mg_class != mc &&
+		    (!show_special || mg->mg_class != smc)))
 			continue;
 
 		metaslab_group_histogram_verify(mg);
@@ -7629,7 +7631,7 @@ dump_zpool(spa_t *spa)
 	if (dump_opt['d'] > 2 || dump_opt['m'])
 		dump_metaslabs(spa);
 	if (dump_opt['M'])
-		dump_metaslab_groups(spa);
+		dump_metaslab_groups(spa, dump_opt['M'] > 1);
 	if (dump_opt['d'] > 2 || dump_opt['m']) {
 		dump_log_spacemaps(spa);
 		dump_log_spacemap_obsolete_stats(spa);

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -266,12 +266,10 @@ the percentage of free space in each space map.
 .It Fl mmmm
 Display every spacemap record.
 .It Fl M
-Display the offset, spacemap, and free space of each metaslab.
+Display all "normal" vdev metaslab group information - per-vdev metaslab count, fragmentation,
+and free space histogram, as well as overall pool fragmentation and histogram.
 .It Fl MM
-Also display information about the maximum contiguous free space and the
-percentage of free space in each space map.
-.It Fl MMM
-Display every spacemap record.
+"Special" vdevs are added to -M's normal output.
 .It Fl O Ar dataset path
 Look up the specified
 .Ar path


### PR DESCRIPTION
### Motivation and Context
I added a special vdev to a pool, then was curious to see how it had configured it, only to find `zdb -M` wouldn't tell me.

So I taught `zdb -MM` to tell me.

### Description
Changed the signature and behavior of `dump_metaslab_groups()` to add a "do I print special vdevs too" parameter.

Also updated zdb.8, which has, at a casual examination, been wrong about -M's behavior since it was added to the page - f3a7f6610f repurposed -M but does not seem to show any sign of the varying behavior of different -M flags that was added in the man page, and neither does illumos/illumos-gate@2e4c998, so it's not just a mismerge or missed hunk. (Unless it was missed in the initial merge of patches into illumos-gate, but delphix/delphix-os doesn't seem to have such code either, at least in the 5.3 branch I looked at...)

(Alternately, it could be convinced to also print, say, other classes it currently ignores, but that would have meant testing with increasing numbers of vdev configs, whereas this solves the "problem" I had right now.)

### How Has This Been Tested?
Well, without the patch, it definitely does not print special vdevs with `zdb -M`, `-MM`, or any other number of `-M`, and with it, it does with `-MM` or above and does not with `-M`, on my testbed.

That and a prior iteration where I inadvertently left a debug statement in passed the GH actions tests is all I've done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
