### PR TITLE
Fix typo in zpool.8

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -40,7 +40,7 @@
 .Cm version
 .Nm
 .Cm subcommand
-.Op Ar argumentss
+.Op Ar arguments
 .
 .Sh DESCRIPTION
 The


### PR DESCRIPTION
Update zpool.8 to avoid parseltongue.