### PR TITLE
zfs load-key: don't enforce minimum passphrase length

### DIFF
--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -245,8 +245,10 @@ validate_key(libzfs_handle_t *hdl, zfs_keyformat_t keyformat,
 		}
 		break;
 	case ZFS_KEYFORMAT_PASSPHRASE:
-		/* verify the length is within bounds when setting a new key,
-		 * but not when loading an existing key */
+		/*
+		 * Verify the length is within bounds when setting a new key,
+		 * but not when loading an existing key.
+		 */
 		if (!do_verify)
 			break;
 		if (keylen > MAX_PASSPHRASE_LEN) {

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -129,7 +129,7 @@ tests = ['umount_unlinked_drain']
 tags = ['functional', 'mount']
 
 [tests/functional/pam:Linux]
-tests = ['pam_basic', 'pam_nounmount']
+tests = ['pam_basic', 'pam_nounmount', 'pam_short_password']
 tags = ['functional', 'pam']
 
 [tests/functional/procfs:Linux]

--- a/tests/zfs-tests/tests/functional/pam/Makefile.am
+++ b/tests/zfs-tests/tests/functional/pam/Makefile.am
@@ -4,4 +4,5 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	pam_basic.ksh \
 	pam_nounmount.ksh \
+	pam_short_password.ksh \
 	utilities.kshlib

--- a/tests/zfs-tests/tests/functional/pam/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/pam/cleanup.ksh
@@ -22,6 +22,7 @@
 
 . $STF_SUITE/tests/functional/pam/utilities.kshlib
 
+rmconfig
 destroy_pool $TESTPOOL
 del_user ${username}
 del_group pamtestgroup

--- a/tests/zfs-tests/tests/functional/pam/pam_basic.ksh
+++ b/tests/zfs-tests/tests/functional/pam/pam_basic.ksh
@@ -26,22 +26,22 @@ log_mustnot ismounted "$TESTPOOL/pam/${username}"
 keystatus unavailable
 
 genconfig "homes=$TESTPOOL/pam runstatedir=${runstatedir}"
-echo "testpass" | pamtester pam_zfs_key_test ${username} open_session
+echo "testpass" | pamtester ${pamservice} ${username} open_session
 references 1
 log_must ismounted "$TESTPOOL/pam/${username}"
 keystatus available
 
-echo "testpass" | pamtester pam_zfs_key_test ${username} open_session
+echo "testpass" | pamtester ${pamservice} ${username} open_session
 references 2
 log_must ismounted "$TESTPOOL/pam/${username}"
 keystatus available
 
-log_must pamtester pam_zfs_key_test ${username} close_session
+log_must pamtester ${pamservice} ${username} close_session
 references 1
 log_must ismounted "$TESTPOOL/pam/${username}"
 keystatus available
 
-log_must pamtester pam_zfs_key_test ${username} close_session
+log_must pamtester ${pamservice} ${username} close_session
 references 0
 log_mustnot ismounted "$TESTPOOL/pam/${username}"
 keystatus unavailable

--- a/tests/zfs-tests/tests/functional/pam/pam_nounmount.ksh
+++ b/tests/zfs-tests/tests/functional/pam/pam_nounmount.ksh
@@ -26,22 +26,22 @@ log_mustnot ismounted "$TESTPOOL/pam/${username}"
 keystatus unavailable
 
 genconfig "homes=$TESTPOOL/pam runstatedir=${runstatedir} nounmount"
-echo "testpass" | pamtester pam_zfs_key_test ${username} open_session
+echo "testpass" | pamtester ${pamservice} ${username} open_session
 references 1
 log_must ismounted "$TESTPOOL/pam/${username}"
 keystatus available
 
-echo "testpass" | pamtester pam_zfs_key_test ${username} open_session
+echo "testpass" | pamtester ${pamservice} ${username} open_session
 references 2
 keystatus available
 log_must ismounted "$TESTPOOL/pam/${username}"
 
-log_must pamtester pam_zfs_key_test ${username} close_session
+log_must pamtester ${pamservice} ${username} close_session
 references 1
 keystatus available
 log_must ismounted "$TESTPOOL/pam/${username}"
 
-log_must pamtester pam_zfs_key_test ${username} close_session
+log_must pamtester ${pamservice} ${username} close_session
 references 0
 keystatus available
 log_must ismounted "$TESTPOOL/pam/${username}"

--- a/tests/zfs-tests/tests/functional/pam/pam_short_password.ksh
+++ b/tests/zfs-tests/tests/functional/pam/pam_short_password.ksh
@@ -1,0 +1,84 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2021 Attila Fülöp <attila@fueloep.org>
+#
+
+
+. $STF_SUITE/tests/functional/pam/utilities.kshlib
+
+if [[ -z pamservice ]]; then
+	pamservice=pam_zfs_key_test
+fi
+
+# DESCRIPTION:
+# If we set the encryption passphrase for a dataset via pam_zfs_key, a minimal
+# passphrase length isn't enforced. This leads to a non-loadable key if
+# `zfs load-key` enforces a minimal length. Make sure this isn't the case.
+
+log_mustnot ismounted "$TESTPOOL/pam/${username}"
+keystatus unavailable
+
+genconfig "homes=$TESTPOOL/pam runstatedir=${runstatedir}"
+
+# Load keys and mount userdir.
+echo "testpass" | pamtester ${pamservice} ${username} open_session
+references 1
+log_must ismounted "$TESTPOOL/pam/${username}"
+keystatus available
+
+# Change user and dataset password to short one.
+printf "short\nshort\n" | pamtester ${pamservice} ${username} chauthtok
+
+# Unmount and unload key.
+log_must pamtester ${pamservice} ${username} close_session
+references 0
+log_mustnot ismounted "$TESTPOOL/pam/${username}"
+keystatus unavailable
+
+# Check if password change succeeded.
+echo "testpass" | pamtester ${pamservice} ${username} open_session
+references 1
+log_mustnot ismounted "$TESTPOOL/pam/${username}"
+keystatus unavailable
+log_must pamtester ${pamservice} ${username} close_session
+references 0
+
+echo "short" | pamtester ${pamservice} ${username} open_session
+references 1
+log_must ismounted "$TESTPOOL/pam/${username}"
+keystatus available
+
+
+# Finally check if `zfs load-key` succeeds with the short password.
+log_must pamtester ${pamservice} ${username} close_session
+references 0
+log_mustnot ismounted "$TESTPOOL/pam/${username}"
+keystatus unavailable
+
+echo "short" | zfs load-key "$TESTPOOL/pam/${username}"
+keystatus available
+zfs unload-key "$TESTPOOL/pam/${username}"
+keystatus unavailable
+
+log_pass "done."

--- a/tests/zfs-tests/tests/functional/pam/utilities.kshlib
+++ b/tests/zfs-tests/tests/functional/pam/utilities.kshlib
@@ -24,6 +24,9 @@
 
 username="pamtestuser"
 runstatedir="${TESTDIR}_run"
+pamservice="pam_zfs_key_test"
+pamconfig="/etc/pam.d/${pamservice}"
+
 function keystatus {
     log_must [ "$(zfs list -Ho keystatus "$TESTPOOL/pam/${username}")" == "$1" ]
 }
@@ -31,7 +34,11 @@ function keystatus {
 function genconfig {
     for i in password auth session; do
 	printf "%s\trequired\tpam_permit.so\n%s\toptional\tpam_zfs_key.so\t%s\n" "$i" "$i" "$1"
-    done > /etc/pam.d/pam_zfs_key_test
+    done > "${pamconfig}"
+}
+
+function rmconfig {
+    log_must rm "${pamconfig}"
 }
 
 function references {


### PR DESCRIPTION
### Motivation and Context

The  pam_zfs_key pam(8) module does not enforce a minimum length while changing the passphrase of the users encrypted home dataset. This can lead to a situation where the key for that dataset can't be loaded with zfs-load-key(8) since it enforces a minimum length. Please see #12651 and #12656 for further details. 

Please note that zfs-load-key(8) still enforces the maximum passphrase length. I think this is reasonable since it  avoids a DOS condition and more recent linux pam(8) enforces a maximum password length of 512 as well [[1]](https://github.com/linux-pam/linux-pam/pull/120/).

Closes #12651 
Closes #12656

### Description

Since, as opposed to zfs-change-key(8), there is no  compelling reason for zfs-load-key(8) to enforce a minimum passphrase length, remove that check. A test to verify that loading short keys succeeds was added to the pam_zfs_key tests. While there, fix a small cleanup bug.

### How Has This Been Tested?

Ran the added test to verify that loading short keys fails on master and succeeds with 97ec67e applied.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
