### PR TITLE
Replace wrong occurrences of `affect` by `effect` in the man pages.

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1729,7 +1729,7 @@ A higher number indicates that we care more about how filled in a segment is,
 while a lower number indicates we care more about the size of the extent without
 considering the gaps within a segment.
 This value is only tunable upon module insertion.
-Changing the value afterwards will have no affect on scrub or resilver performance.
+Changing the value afterwards will have no effect on scrub or resilver performance.
 .
 .It Sy zfs_scan_issue_strategy Ns = Ns Sy 0 Pq int
 Determines the order that data will be verified while scrubbing or resilvering:

--- a/man/man8/zfs-receive.8
+++ b/man/man8/zfs-receive.8
@@ -280,7 +280,7 @@ If the send stream was sent with
 .Fl c
 then overriding the
 .Sy compression
-property will have no affect on received data but the
+property will have no effect on received data but the
 .Sy compression
 property will be set.
 To have the data recompressed on receive remove the


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While reading the man page for zfs-receive I came across a wrong usage of the word affect, where the word effect should have been used instead.

### Description
I replaced the word affect by the word effect in above mentioned man page, but additionally searched the whole repository for similar cases and found a second case in another man page, which I also fixed.

Since the short commit message already mentions everything, I did not add the longer description which is encouraged by the contributing document.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
