### PR TITLE
Add macOS to headers

### DIFF
--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -60,7 +60,8 @@ typedef struct abd {
 	union {
 		struct abd_scatter {
 			uint_t		abd_offset;
-#if defined(__FreeBSD__) && defined(_KERNEL)
+#if defined(_KERNEL) && (defined(__FreeBSD__) || defined(__APPLE__))
+			uint_t  abd_chunk_size;
 			void    *abd_chunks[1]; /* actually variable-length */
 #else
 			uint_t		abd_nents;

--- a/include/sys/abd_impl.h
+++ b/include/sys/abd_impl.h
@@ -95,6 +95,9 @@ void abd_iter_unmap(struct abd_iter *);
 #if defined(__FreeBSD__)
 #define	abd_enter_critical(flags)	critical_enter()
 #define	abd_exit_critical(flags)	critical_exit()
+#elif defined(__APPLE__)
+#define	abd_enter_critical(f)		(f) = ml_set_interrupts_enabled(FALSE)
+#define	abd_exit_critical(flags)	ml_set_interrupts_enabled((flags))
 #else
 #define	abd_enter_critical(flags)	local_irq_save(flags)
 #define	abd_exit_critical(flags)	local_irq_restore(flags)

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -186,6 +186,11 @@ typedef enum {
 	ZFS_PROP_IVSET_GUID,		/* not exposed to the user */
 	ZFS_PROP_REDACTED,
 	ZFS_PROP_REDACT_SNAPS,
+	ZFS_PROP_BROWSE,		/* macOS: nobrowse/browse */
+	ZFS_PROP_IGNOREOWNER,	/* macOS: ignoreowner mount */
+	ZFS_PROP_LASTUNMOUNT,	/* macOS: Spotlight required */
+	ZFS_PROP_MIMIC,			/* macOS: mimic=hfs|apfs */
+	ZFS_PROP_DEVDISK,		/* macOS: create IOkit virtual disk */
 	ZFS_NUM_PROPS
 } zfs_prop_t;
 
@@ -456,6 +461,18 @@ typedef enum zfs_key_location {
 	ZFS_KEYLOCATION_URI,
 	ZFS_KEYLOCATION_LOCATIONS
 } zfs_keylocation_t;
+
+typedef enum zfs_mimic {
+	ZFS_MIMIC_OFF = 0,
+	ZFS_MIMIC_HFS,
+	ZFS_MIMIC_APFS
+} zfs_mimic_t;
+
+typedef enum zfs_devdisk {
+	ZFS_DEVDISK_POOLONLY = 0,
+	ZFS_DEVDISK_OFF,
+	ZFS_DEVDISK_ON
+} zfs_devdisk_t;
 
 #define	DEFAULT_PBKDF2_ITERATIONS 350000
 #define	MIN_PBKDF2_ITERATIONS 100000
@@ -1271,7 +1288,7 @@ typedef enum zfs_ioc {
 	/*
 	 * Core features - 81/128 numbers reserved.
 	 */
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__APPLE__)
 	ZFS_IOC_FIRST =	0,
 #else
 	ZFS_IOC_FIRST =	('Z' << 8),
@@ -1375,6 +1392,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_UNJAIL,				/* 0x86 (FreeBSD) */
 	ZFS_IOC_SET_BOOTENV,			/* 0x87 */
 	ZFS_IOC_GET_BOOTENV,			/* 0x88 */
+	ZFS_IOC_PROXY_DATASET,			/* 0x89 (macOS) */
 	ZFS_IOC_LAST
 } zfs_ioc_t;
 

--- a/include/sys/mntent.h
+++ b/include/sys/mntent.h
@@ -79,6 +79,13 @@
 #elif defined(__FreeBSD__)
 #define	MNTOPT_SETUID	"setuid"	/* Set uid allowed */
 #define	MNTOPT_NOSETUID	"nosetuid"	/* Set uid not allowed */
+#elif defined(__APPLE__)
+#define	MNTOPT_SETUID	"setuid"	/* Set uid allowed */
+#define	MNTOPT_NOSETUID	"nosetuid"	/* Set uid not allowed */
+#define	MNTOPT_BROWSE	"browse"	/* browsable autofs mount */
+#define	MNTOPT_NOBROWSE	"nobrowse"	/* non-browsable autofs mount */
+#define	MNTOPT_OWNERS	"owners"	/* don't ignore ownership */
+#define	MNTOPT_NOOWNERS	"noowners"	/* ignore ownership */
 #else
 #error "unknown OS"
 #endif

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -429,6 +429,9 @@ struct spa {
 	boolean_t	spa_waiters_cancel;	/* waiters should return */
 
 	char		*spa_compatibility;	/* compatibility file(s) */
+#ifdef __APPLE__
+	spa_iokit_t	*spa_iokit_proxy;	/* IOKit pool proxy */
+#endif
 
 	/*
 	 * spa_refcount & spa_config_lock must be the last elements

--- a/include/sys/sysevent/dev.h
+++ b/include/sys/sysevent/dev.h
@@ -239,7 +239,7 @@ extern "C" {
 #define	DEV_INSTANCE		"instance"
 #define	DEV_PROP_PREFIX		"prop-"
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #define	DEV_IDENTIFIER		"devid"
 #define	DEV_PATH		"path"
 #define	DEV_IS_PART		"is_slice"

--- a/include/sys/zfs_file.h
+++ b/include/sys/zfs_file.h
@@ -31,6 +31,8 @@ typedef struct zfs_file {
 } zfs_file_t;
 #elif defined(__linux__) || defined(__FreeBSD__)
 typedef struct file zfs_file_t;
+#elif defined(__APPLE__)
+typedef struct spl_fileproc zfs_file_t;
 #else
 #error "unknown OS"
 #endif

--- a/include/sys/zfs_ioctl_impl.h
+++ b/include/sys/zfs_ioctl_impl.h
@@ -76,6 +76,9 @@ int zfs_secpolicy_config(zfs_cmd_t *, nvlist_t *, cred_t *);
 
 void zfs_ioctl_register_dataset_nolog(zfs_ioc_t, zfs_ioc_legacy_func_t *,
     zfs_secpolicy_func_t *, zfs_ioc_poolcheck_t);
+void zfs_ioctl_register_pool(zfs_ioc_t, zfs_ioc_legacy_func_t *,
+    zfs_secpolicy_func_t *, boolean_t, zfs_ioc_poolcheck_t);
+
 
 void zfs_ioctl_register(const char *, zfs_ioc_t, zfs_ioc_func_t *,
     zfs_secpolicy_func_t *, zfs_ioc_namecheck_t, zfs_ioc_poolcheck_t,

--- a/include/sys/zfs_sa.h
+++ b/include/sys/zfs_sa.h
@@ -75,6 +75,16 @@ typedef enum zpl_attr {
 	ZPL_DACL_ACES,
 	ZPL_DXATTR,
 	ZPL_PROJID,
+
+	/*
+	 * Apple defines a ADDEDTIME, which is the time the entry was placed in
+	 * the containing directory. Ie, CRTIME and updated when moved into
+	 * a different directory. This can be retrieved with getxattr
+	 * "FinderInfo" or the getattrlist() syscall.
+	 */
+	ZPL_ADDTIME,
+	ZPL_DOCUMENTID,
+
 	ZPL_END
 } zpl_attr_t;
 

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -112,6 +112,9 @@ extern "C" {
 #define	SA_ZPL_PAD(z)		z->z_attr_table[ZPL_PAD]
 #define	SA_ZPL_PROJID(z)	z->z_attr_table[ZPL_PROJID]
 
+#define	SA_ZPL_ADDTIME(z)	z->z_attr_table[ZPL_ADDTIME]
+#define	SA_ZPL_DOCUMENTID(z)	z->z_attr_table[ZPL_DOCUMENTID]
+
 /*
  * Is ID ephemeral?
  */

--- a/include/zfs_fletcher.h
+++ b/include/zfs_fletcher.h
@@ -131,6 +131,7 @@ typedef struct fletcher_4_func {
 
 _ZFS_FLETCHER_H const fletcher_4_ops_t fletcher_4_superscalar_ops;
 _ZFS_FLETCHER_H const fletcher_4_ops_t fletcher_4_superscalar4_ops;
+_ZFS_FLETCHER_H int fletcher_4_get(char *, size_t);
 
 #if defined(HAVE_SSE2)
 _ZFS_FLETCHER_H const fletcher_4_ops_t fletcher_4_sse2_ops;

--- a/lib/libspl/include/sys/dkio.h
+++ b/lib/libspl/include/sys/dkio.h
@@ -161,7 +161,9 @@ struct dk_geom {
  */
 #define	DKIOCGGEOM	(DKIOC|1)		/* Get geometry */
 #define	DKIOCINFO	(DKIOC|3)		/* Get info */
+#ifndef DKIOCEJECT
 #define	DKIOCEJECT	(DKIOC|6)		/* Generic 'eject' */
+#endif
 #define	DKIOCGVTOC	(DKIOC|11)		/* Get VTOC */
 #define	DKIOCSVTOC	(DKIOC|12)		/* Set VTOC & Write to Disk */
 

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -3406,7 +3406,12 @@
       <enumerator name='ZFS_PROP_IVSET_GUID' value='92'/>
       <enumerator name='ZFS_PROP_REDACTED' value='93'/>
       <enumerator name='ZFS_PROP_REDACT_SNAPS' value='94'/>
-      <enumerator name='ZFS_NUM_PROPS' value='95'/>
+      <enumerator name='ZFS_PROP_BROWSE' value='95'/>
+      <enumerator name='ZFS_PROP_IGNOREOWNER' value='96'/>
+      <enumerator name='ZFS_PROP_LASTUNMOUNT' value='97'/>
+      <enumerator name='ZFS_PROP_MIMIC' value='98'/>
+      <enumerator name='ZFS_PROP_DEVDISK' value='99'/>
+      <enumerator name='ZFS_NUM_PROPS' value='100'/>
     </enum-decl>
     <typedef-decl name='zfs_prop_t' type-id='4b000d60' id='58603c44'/>
     <enum-decl name='zfs_userquota_prop_t' naming-typedef-id='279fde6a' id='5258d2f6'>

--- a/lib/libzutil/zutil_pool.c
+++ b/lib/libzutil/zutil_pool.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <sys/nvpair.h>
 #include <sys/fs/zfs.h>
+#include <sys/sysmacros.h>
 
 #include <libzutil.h>
 

--- a/module/nvpair/nvpair_alloc_spl.c
+++ b/module/nvpair/nvpair_alloc_spl.c
@@ -27,6 +27,7 @@
 #include <sys/nvpair.h>
 #include <sys/kmem.h>
 #include <sys/vmem.h>
+#include <sys/zfs_context_os.h>
 
 static void *
 nv_alloc_sleep_spl(nv_alloc_t *nva, size_t size)

--- a/module/zcommon/zfeature_common.c
+++ b/module/zcommon/zfeature_common.c
@@ -228,7 +228,8 @@ zfs_mod_supported_feature(const char *name)
 	 * that all features except edonr are supported.
 	 */
 
-#if defined(_KERNEL) || defined(LIB_ZPOOL_BUILD) || defined(__FreeBSD__)
+#if defined(_KERNEL) || defined(LIB_ZPOOL_BUILD) || \
+	defined(__FreeBSD__) || defined(__APPLE__)
 	return (B_TRUE);
 #else
 	return (zfs_mod_supported(ZFS_SYSFS_POOL_FEATURES, name));

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -377,6 +377,24 @@ zfs_prop_init(void)
 		{ NULL }
 	};
 
+#ifdef __APPLE__
+	/* __APPLE__ */
+	static zprop_index_t devdisk_table[] = {
+		{ "poolonly",	ZFS_DEVDISK_POOLONLY },
+		{ "off",		ZFS_DEVDISK_OFF },
+		{ "on",			ZFS_DEVDISK_ON },
+		{ NULL }
+	};
+
+	static zprop_index_t mimic_table[] = {
+		{ "off",		ZFS_MIMIC_OFF },
+		{ "hfs",		ZFS_MIMIC_HFS },
+		{ "apfs",		ZFS_MIMIC_APFS },
+		{ NULL }
+	};
+	/* ___APPLE___ */
+#endif
+
 	/* inherit index properties */
 	zprop_register_index(ZFS_PROP_REDUNDANT_METADATA, "redundant_metadata",
 	    ZFS_REDUNDANT_METADATA_ALL,
@@ -574,6 +592,23 @@ zfs_prop_init(void)
 	    "redact_snaps", NULL, PROP_READONLY,
 	    ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "<snapshot>[,...]",
 	    "RSNAPS");
+
+#ifdef __APPLE__
+	zprop_register_index(ZFS_PROP_BROWSE, "com.apple.browse", 1,
+	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM, "on | off", "COM.APPLE.BROWSE",
+	    boolean_table);
+	zprop_register_index(ZFS_PROP_IGNOREOWNER, "com.apple.ignoreowner", 0,
+	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM, "on | off",
+	    "COM.APPLE.IGNOREOWNER", boolean_table);
+	zprop_register_hidden(ZFS_PROP_LASTUNMOUNT, "COM.APPLE.LASTUNMOUNT",
+	    PROP_TYPE_NUMBER, PROP_READONLY, ZFS_TYPE_DATASET, "LASTUNMOUNT");
+	zprop_register_index(ZFS_PROP_MIMIC, "com.apple.mimic", 0,
+	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM, "off | hfs | apfs",
+	    "COM.APPLE.MIMIC_HFS", mimic_table);
+	zprop_register_index(ZFS_PROP_DEVDISK, "com.apple.devdisk", 0,
+	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM, "poolonly | on | off",
+	    "COM.APPLE.DEVDISK", devdisk_table);
+#endif
 
 	/* readonly number properties */
 	zprop_register_number(ZFS_PROP_USED, "used", 0, PROP_READONLY,

--- a/module/zcommon/zprop_common.c
+++ b/module/zcommon/zprop_common.c
@@ -77,7 +77,8 @@ zfs_mod_supported_prop(const char *name, zfs_type_t type)
  * The equivalent _can_ be done on FreeBSD by way of the sysctl
  * tree, but this has not been done yet.
  */
-#if defined(_KERNEL) || defined(LIB_ZPOOL_BUILD) || defined(__FreeBSD__)
+#if defined(_KERNEL) || defined(LIB_ZPOOL_BUILD) || \
+	defined(__FreeBSD__) || defined(__APPLE__)
 	return (B_TRUE);
 #else
 	return (zfs_mod_supported(type == ZFS_TYPE_POOL ?

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -6884,7 +6884,7 @@ zfs_ioctl_register(const char *name, zfs_ioc_t ioc, zfs_ioc_func_t *func,
 	vec->zvec_nvl_key_count = num_keys;
 }
 
-static void
+void
 zfs_ioctl_register_pool(zfs_ioc_t ioc, zfs_ioc_legacy_func_t *func,
     zfs_secpolicy_func_t *secpolicy, boolean_t log_history,
     zfs_ioc_poolcheck_t pool_check)

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -66,6 +66,8 @@ sa_attr_reg_t zfs_attr_table[ZPL_END+1] = {
 	{"ZPL_DACL_ACES", 0, SA_ACL, 0},
 	{"ZPL_DXATTR", 0, SA_UINT8_ARRAY, 0},
 	{"ZPL_PROJID", sizeof (uint64_t), SA_UINT64_ARRAY, 0},
+	{"ZPL_ADDTIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 0},
+	{"ZPL_DOCUMENTID", sizeof (uint64_t), SA_UINT64_ARRAY, 0},
 	{NULL, 0, 0, 0}
 };
 


### PR DESCRIPTION
Attempt to group "most" of the sweeping changes to headers in there,
unless they fit better with an individual commit.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

pre-oiling for macOS inclusion.

### Description
<!--- Describe your changes in detail -->

In particular;

`zfs_ioctl_register_pool()`: promoted away from static, so macOS can
register an ioctl of this style.

`fletcher_4_get();` added to header, even though Linux defines their
own version, and macOS its own. Can #ifdef around, if it upsets
Linux compiles.

`nvpair_alloc_spl.c`: including `zfs_context_os.h` - lots of
porting compile magic in here which helps. But could probably
be rejigged in headers if it is a bit questionable.

Some APPLE comments should perhaps live in macOS sources rather
than in shared sources?

There's a bunch of new macOS specific items added to properties etc, 
so I think ahrens might need to be involved.

Oh fair warning, this starts adding macOS source changes to OpenZFS. I couldn't
stave it off any longer. This is it people!

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
