### PR TITLE
Stop segfaulting on unmount error case

### DIFF
--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -595,9 +595,13 @@ unmount_one(zfs_handle_t *zhp, const char *mountpoint, int flags)
 		default:
 			libzfs_err = EZFS_UMOUNTFAILED;
 		}
-		return (zfs_error_fmt(zhp->zfs_hdl, libzfs_err,
-		    dgettext(TEXT_DOMAIN, "cannot unmount '%s'"),
-		    mountpoint));
+		if (zhp) {
+			return (zfs_error_fmt(zhp->zfs_hdl, libzfs_err,
+			    dgettext(TEXT_DOMAIN, "cannot unmount '%s'"),
+			    mountpoint));
+		} else {
+			return (-1);
+		}
 	}
 
 	return (0);


### PR DESCRIPTION
### Motivation and Context
After a ZTS run errored out, trying to `zpool export testpool2` segfaulted on trying to deref a NULL zhp.

I'm not a fan of my tools segfaulting, personally, unless the world is on fire.

(If there's a better way to extract the error code once this happens, I'm all ears, but with NULL zhp, we've got no hdl...could special-case getting back something negative more than 1, I guess, but that's a big change just to smuggle an error out...)

### Description
Add a NULL check.

### How Has This Been Tested?
It passes testing, but unfortunately I unwedged the system with some `zpool online` commands and haven't had it reproduce since, so I'm basing this working on having a core dump saying it was NULL dereferencing there.

```
#0  0x00007f06cc5eb6a0 in unmount_one (zhp=0x0, mountpoint=0x55e4c18bf350 "/var/tmp/zpool_scrub_offline_device", flags=<optimized out>) at /usr/src/debug/zfs-2.1.99-538_g2408c4a3c.fc34.x86_64/lib/libzfs/libzfs_mount.c:598
        libzfs_err = 2007
        error = <optimized out>
(gdb) list
598                     return (zfs_error_fmt(zhp->zfs_hdl, libzfs_err,
599                         dgettext(TEXT_DOMAIN, "cannot unmount '%s'"),
600                         mountpoint));
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
