### PR TITLE
long opts for zdb

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -39,6 +39,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <getopt.h>
 #include <sys/zfs_context.h>
 #include <sys/spa.h>
 #include <sys/spa_impl.h>
@@ -820,65 +821,87 @@ usage(void)
 	    "            z     ZAPs\n"
 	    "            -     Negate effect of next flag\n\n");
 	(void) fprintf(stderr, "    Options to control amount of output:\n");
-	(void) fprintf(stderr, "        -b block statistics\n");
-	(void) fprintf(stderr, "        -c checksum all metadata (twice for "
-	    "all data) blocks\n");
-	(void) fprintf(stderr, "        -C config (or cachefile if alone)\n");
-	(void) fprintf(stderr, "        -d dataset(s)\n");
-	(void) fprintf(stderr, "        -D dedup statistics\n");
-	(void) fprintf(stderr, "        -E decode and display block from an "
-	    "embedded block pointer\n");
-	(void) fprintf(stderr, "        -h pool history\n");
-	(void) fprintf(stderr, "        -i intent logs\n");
-	(void) fprintf(stderr, "        -l read label contents\n");
-	(void) fprintf(stderr, "        -k examine the checkpointed state "
-	    "of the pool\n");
-	(void) fprintf(stderr, "        -L disable leak tracking (do not "
-	    "load spacemaps)\n");
-	(void) fprintf(stderr, "        -m metaslabs\n");
-	(void) fprintf(stderr, "        -M metaslab groups\n");
-	(void) fprintf(stderr, "        -O perform object lookups by path\n");
-	(void) fprintf(stderr, "        -r copy an object by path to file\n");
-	(void) fprintf(stderr, "        -R read and display block from a "
-	    "device\n");
-	(void) fprintf(stderr, "        -s report stats on zdb's I/O\n");
-	(void) fprintf(stderr, "        -S simulate dedup to measure effect\n");
-	(void) fprintf(stderr, "        -v verbose (applies to all "
-	    "others)\n");
-	(void) fprintf(stderr, "        -y perform livelist and metaslab "
-	    "validation on any livelists being deleted\n\n");
+	(void) fprintf(stderr, "        -b --block-stats             "
+	    "block statistics\n");
+	(void) fprintf(stderr, "        -c --checksum                "
+	    "checksum all metadata (twice for all data) blocks\n");
+	(void) fprintf(stderr, "        -C --config                  "
+	    "config (or cachefile if alone)\n");
+	(void) fprintf(stderr, "        -d --datasets                "
+	    "dataset(s)\n");
+	(void) fprintf(stderr, "        -D --dedup-stats             "
+	    "dedup statistics\n");
+	(void) fprintf(stderr, "        -E --embedded-block-pointer=INTEGER\n"
+	    "                                     decode and display block "
+	    "from an embedded block pointer\n");
+	(void) fprintf(stderr, "        -h --history                 "
+	    "pool history\n");
+	(void) fprintf(stderr, "        -i --intent-logs             "
+	    "intent logs\n");
+	(void) fprintf(stderr, "        -l --label                   "
+	    "read label contents\n");
+	(void) fprintf(stderr, "        -k --checkpointed-state      "
+	    "examine the checkpointed state of the pool\n");
+	(void) fprintf(stderr, "        -L --disable-leak-tracking   "
+	    "disable leak tracking (do not load spacemaps)\n");
+	(void) fprintf(stderr, "        -m --metaslabs               "
+	    "metaslabs\n");
+	(void) fprintf(stderr, "        -M --metaslab-groups         "
+	    "metaslab groups\n");
+	(void) fprintf(stderr, "        -O --object-lookups          "
+	    "perform object lookups by path\n");
+	(void) fprintf(stderr, "        -r --copy-object             "
+	    "copy an object by path to file\n");
+	(void) fprintf(stderr, "        -R --read-block              "
+	    "read and display block from a device\n");
+	(void) fprintf(stderr, "        -s --io-stats                "
+	    "report stats on zdb's I/O\n");
+	(void) fprintf(stderr, "        -S --simulate-dedup          "
+	    "simulate dedup to measure effect\n");
+	(void) fprintf(stderr, "        -v --verbose                 "
+	    "verbose (applies to all others)\n");
+	(void) fprintf(stderr, "        -y --livelist                "
+	    "perform livelist and metaslab validation on any livelists being "
+	    "deleted\n\n");
 	(void) fprintf(stderr, "    Below options are intended for use "
 	    "with other options:\n");
-	(void) fprintf(stderr, "        -A ignore assertions (-A), enable "
-	    "panic recovery (-AA) or both (-AAA)\n");
-	(void) fprintf(stderr, "        -e pool is exported/destroyed/"
-	    "has altroot/not in a cachefile\n");
-	(void) fprintf(stderr, "        -F attempt automatic rewind within "
-	    "safe range of transaction groups\n");
-	(void) fprintf(stderr, "        -G dump zfs_dbgmsg buffer before "
-	    "exiting\n");
-	(void) fprintf(stderr, "        -I <number of inflight I/Os> -- "
-	    "specify the maximum number of\n           "
-	    "checksumming I/Os [default is 200]\n");
-	(void) fprintf(stderr, "        -o <variable>=<value> set global "
-	    "variable to an unsigned 32-bit integer\n");
-	(void) fprintf(stderr, "        -p <path> -- use one or more with "
-	    "-e to specify path to vdev dir\n");
-	(void) fprintf(stderr, "        -P print numbers in parseable form\n");
-	(void) fprintf(stderr, "        -q don't print label contents\n");
-	(void) fprintf(stderr, "        -t <txg> -- highest txg to use when "
-	    "searching for uberblocks\n");
-	(void) fprintf(stderr, "        -u uberblock\n");
-	(void) fprintf(stderr, "        -U <cachefile_path> -- use alternate "
-	    "cachefile\n");
-	(void) fprintf(stderr, "        -V do verbatim import\n");
-	(void) fprintf(stderr, "        -x <dumpdir> -- "
+	(void) fprintf(stderr, "        -A --ignore-assertions       "
+	    "ignore assertions (-A), enable panic recovery (-AA) or both "
+	    "(-AAA)\n");
+	(void) fprintf(stderr, "        -e --exported                "
+	    "pool is exported/destroyed/has altroot/not in a cachefile\n");
+	(void) fprintf(stderr, "        -F --automatic-rewind        "
+	    "attempt automatic rewind within safe range of transaction "
+	    "groups\n");
+	(void) fprintf(stderr, "        -G --dump-debug-msg          "
+	    "dump zfs_dbgmsg buffer before exiting\n");
+	(void) fprintf(stderr, "        -I --inflight=INTEGER        "
+	    "specify the maximum number of checksumming I/Os "
+	    "[default is 200]\n");
+	(void) fprintf(stderr, "        -o --option=\"OPTION=INTEGER\" "
+	    "set global variable to an unsigned 32-bit integer\n");
+	(void) fprintf(stderr, "        -p --path==PATH              "
+	    "use one or more with -e to specify path to vdev dir\n");
+	(void) fprintf(stderr, "        -P --parseable               "
+	    "print numbers in parseable form\n");
+	(void) fprintf(stderr, "        -q --skip-label              "
+	    "don't print label contents\n");
+	(void) fprintf(stderr, "        -t --txg=INTEGER             "
+	    "highest txg to use when searching for uberblocks\n");
+	(void) fprintf(stderr, "        -u --uberblock               "
+	    "uberblock\n");
+	(void) fprintf(stderr, "        -U --cachefile=PATH          "
+	    "use alternate cachefile\n");
+	(void) fprintf(stderr, "        -V --verbatim                "
+	    "do verbatim import\n");
+	(void) fprintf(stderr, "        -x --dump-blocks=PATH        "
 	    "dump all read blocks into specified directory\n");
-	(void) fprintf(stderr, "        -X attempt extreme rewind (does not "
-	    "work with dataset)\n");
-	(void) fprintf(stderr, "        -Y attempt all reconstruction "
-	    "combinations for split blocks\n");
-	(void) fprintf(stderr, "        -Z show ZSTD headers \n");
+	(void) fprintf(stderr, "        -X --extreme-rewind          "
+	    "attempt extreme rewind (does not work with dataset)\n");
+	(void) fprintf(stderr, "        -Y --all-reconstruction      "
+	    "attempt all reconstruction combinations for split blocks\n");
+	(void) fprintf(stderr, "        -Z --zstd-headers            "
+	    "show ZSTD headers \n");
 	(void) fprintf(stderr, "Specify an option more than once (e.g. -bb) "
 	    "to make only that option verbose\n");
 	(void) fprintf(stderr, "Default is to dump everything non-verbosely\n");
@@ -8410,8 +8433,50 @@ main(int argc, char **argv)
 	 */
 	zfs_btree_verify_intensity = 3;
 
-	while ((c = getopt(argc, argv,
-	    "AbcCdDeEFGhiI:klLmMo:Op:PqrRsSt:uU:vVx:XYyZ")) != -1) {
+	struct option long_options[] = {
+		{"ignore-assertions",	no_argument,		NULL, 'A'},
+		{"block-stats",		no_argument,		NULL, 'b'},
+		{"checksum",		no_argument,		NULL, 'c'},
+		{"config",		no_argument,		NULL, 'C'},
+		{"datasets",		no_argument,		NULL, 'd'},
+		{"dedup-stats",		no_argument,		NULL, 'D'},
+		{"exported",		no_argument,		NULL, 'e'},
+		{"embedded-block-pointer",	no_argument,	NULL, 'E'},
+		{"automatic-rewind",	no_argument,		NULL, 'F'},
+		{"dump-debug-msg",	no_argument,		NULL, 'G'},
+		{"history",		no_argument,		NULL, 'h'},
+		{"intent-logs",		no_argument,		NULL, 'i'},
+		{"inflight",		required_argument,	NULL, 'I'},
+		{"checkpointed-state",	no_argument,		NULL, 'k'},
+		{"label",		no_argument,		NULL, 'l'},
+		{"disable-leak-tracking",	no_argument,	NULL, 'L'},
+		{"metaslabs",		no_argument,		NULL, 'm'},
+		{"metaslab-groups",	no_argument,		NULL, 'M'},
+		{"option",		required_argument,	NULL, 'o'},
+		{"object-lookups",	no_argument,		NULL, 'O'},
+		{"path",		required_argument,	NULL, 'p'},
+		{"parseable",		no_argument,		NULL, 'P'},
+		{"skip-label",		no_argument,		NULL, 'q'},
+		{"copy-object",		no_argument,		NULL, 'r'},
+		{"read-block",		no_argument,		NULL, 'R'},
+		{"io-stats",		no_argument,		NULL, 's'},
+		{"simulate-dedup",	no_argument,		NULL, 'S'},
+		{"txg",			required_argument,	NULL, 't'},
+		{"uberblock",		no_argument,		NULL, 'u'},
+		{"cachefile",		required_argument,	NULL, 'U'},
+		{"verbose",		no_argument,		NULL, 'v'},
+		{"verbatim",		no_argument,		NULL, 'V'},
+		{"dump-blocks",		required_argument,	NULL, 'x'},
+		{"extreme-rewind",	no_argument,		NULL, 'X'},
+		{"all-reconstruction",	no_argument,		NULL, 'Y'},
+		{"livelist",		no_argument,		NULL, 'y'},
+		{"zstd-headers",	no_argument,		NULL, 'Z'},
+		{0, 0, 0, 0}
+	};
+
+	while ((c = getopt_long(argc, argv,
+	    "AbcCdDeEFGhiI:klLmMo:Op:PqrRsSt:uU:vVx:XYyZ",
+	    long_options, NULL)) != -1) {
 		switch (c) {
 		case 'b':
 		case 'c':

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -109,18 +109,18 @@ that zdb may interpret inconsistent pool data and behave erratically.
 .Sh OPTIONS
 Display options:
 .Bl -tag -width Ds
-.It Fl b
+.It Fl b , -block-stats
 Display statistics regarding the number, size
 .Pq logical, physical and allocated
 and deduplication of blocks.
-.It Fl c
+.It Fl c , -checksum
 Verify the checksum of all metadata blocks while printing block statistics
 .Po see
 .Fl b
 .Pc .
 .Pp
 If specified multiple times, verify the checksums of all blocks.
-.It Fl C
+.It Fl C , -config
 Display information about the configuration.
 If specified with no other options, instead display information about the cache
 file
@@ -133,7 +133,7 @@ cached configuration and the on-disk configuration.
 If specified multiple times with
 .Fl e
 also display the configuration that would be used were the pool to be imported.
-.It Fl d
+.It Fl d , -datasets
 Display information about datasets.
 Specified once, displays basic dataset information: ID, create transaction,
 size, and object count.
@@ -182,7 +182,7 @@ Dump ZAP objects
 .It Sy -
 Negate the effect of next flag
 .El
-.It Fl D
+.It Fl D , -dedup-stats
 Display deduplication statistics, including the deduplication ratio
 .Pq Sy dedup ,
 compression ratio
@@ -203,23 +203,23 @@ Display the statistics independently for each deduplication table.
 Dump the contents of the deduplication tables describing duplicate blocks.
 .It Fl DDDDD
 Also dump the contents of the deduplication tables describing unique blocks.
-.It Fl E Ar word0 : Ns Ar word1 Ns :…: Ns Ar word15
+.It Fl E , -embedded-block-pointer Ns = Ns Ar word0 : Ns Ar word1 Ns :…: Ns Ar word15
 Decode and display block from an embedded block pointer specified by the
 .Ar word
 arguments.
-.It Fl h
+.It Fl h , -history
 Display pool history similar to
 .Nm zpool Cm history ,
 but include internal changes, transaction, and dataset information.
-.It Fl i
+.It Fl i , -intent-logs
 Display information about intent log
 .Pq ZIL
 entries relating to each dataset.
 If specified multiple times, display counts of each intent log transaction type.
-.It Fl k
+.It Fl k , -checkpointed-state
 Examine the checkpointed state of the pool.
 Note, the on disk format of the pool is not reverted to the checkpointed state.
-.It Fl l Ar device
+.It Fl l , -label Ns = Ns Ar device
 Read the vdev labels and L2ARC header from the specified device.
 .Nm Fl l
 will return 0 if valid label was found, 1 if error occurred, and 2 if no valid
@@ -249,12 +249,12 @@ If the
 .Fl u
 option is also specified, also display the uberblocks on this device.
 Specify multiple times to increase verbosity.
-.It Fl L
+.It Fl L , -disable-leak-tracking
 Disable leak detection and the loading of space maps.
 By default,
 .Nm
 verifies that all non-free blocks are referenced, which can be very expensive.
-.It Fl m
+.It Fl m , -metaslabs
 Display the offset, spacemap, free space of each metaslab, all the log
 spacemaps and their obsolete entry statistics.
 .It Fl mm
@@ -265,12 +265,12 @@ Display the maximum contiguous free space, the in-core free space histogram, and
 the percentage of free space in each space map.
 .It Fl mmmm
 Display every spacemap record.
-.It Fl M
+.It Fl M , -metaslab-groups
 Display all "normal" vdev metaslab group information - per-vdev metaslab count, fragmentation,
 and free space histogram, as well as overall pool fragmentation and histogram.
 .It Fl MM
 "Special" vdevs are added to -M's normal output.
-.It Fl O Ar dataset path
+.It Fl O , -object-lookups Ns = Ns Ar dataset path
 Look up the specified
 .Ar path
 inside of the
@@ -283,7 +283,7 @@ must be relative to the root of
 This option can be combined with
 .Fl v
 for increasing verbosity.
-.It Fl r Ar dataset path destination
+.It Fl r , -copy-object Ns = Ns Ar dataset path destination
 Copy the specified
 .Ar path
 inside of the
@@ -297,7 +297,7 @@ This option can be combined with
 .Fl v
 for increasing verbosity.
 .It Xo
-.Fl R Ar poolname vdev : Ns Ar offset : Ns Oo Ar lsize Ns / Oc Ns Ar psize Ns Op : Ns Ar flags
+.Fl R , -read-block Ns = Ns Ar poolname vdev : Ns Ar offset : Ns Oo Ar lsize Ns / Oc Ns Ar psize Ns Op : Ns Ar flags
 .Xc
 Read and display a block from the specified device.
 By default the block is displayed as a hex dump, but see the description of the
@@ -336,36 +336,36 @@ Dump raw uninterpreted block data
 .It Sy v
 Verbose output for guessing compression algorithm
 .El
-.It Fl s
+.It Fl s , -io-stats
 Report statistics on
 .Nm zdb
 I/O.
 Display operation counts, bandwidth, and error counts of I/O to the pool from
 .Nm .
-.It Fl S
+.It Fl S , -simulate-dedup
 Simulate the effects of deduplication, constructing a DDT and then display
 that DDT as with
 .Fl DD .
-.It Fl u
+.It Fl u , -uberblock
 Display the current uberblock.
 .El
 .Pp
 Other options:
 .Bl -tag -width Ds
-.It Fl A
+.It Fl A , -ignore-assertions
 Do not abort should any assertion fail.
 .It Fl AA
 Enable panic recovery, certain errors which would otherwise be fatal are
 demoted to warnings.
 .It Fl AAA
 Do not abort if asserts fail and also enable panic recovery.
-.It Fl e Oo Fl p Ar path Oc Ns …
+.It Fl e , -exported Ns = Ns Oo Fl p Ar path Oc Ns …
 Operate on an exported pool, not present in
 .Pa /etc/zfs/zpool.cache .
 The
 .Fl p
 flag specifies the path under which devices are to be searched.
-.It Fl x Ar dumpdir
+.It Fl x , -dump-blocks Ns = Ns Ar dumpdir
 All blocks accessed will be copied to files in the specified directory.
 The blocks will be placed in sparse files whose name is the same as
 that of the file or device read.
@@ -376,30 +376,30 @@ Note that the
 flags are sufficient to access
 .Pq and thus copy
 all metadata on the pool.
-.It Fl F
+.It Fl F , -automatic-rewind
 Attempt to make an unreadable pool readable by trying progressively older
 transactions.
-.It Fl G
+.It Fl G , -dump-debug-msg
 Dump the contents of the zfs_dbgmsg buffer before exiting
 .Nm .
 zfs_dbgmsg is a buffer used by ZFS to dump advanced debug information.
-.It Fl I Ar inflight I/Os
+.It Fl I , -inflight Ns = Ns Ar inflight I/Os
 Limit the number of outstanding checksum I/Os to the specified value.
 The default value is 200.
 This option affects the performance of the
 .Fl c
 option.
-.It Fl o Ar var Ns = Ns Ar value …
+.It Fl o , -option Ns = Ns Ar var Ns = Ns Ar value …
 Set the given global libzpool variable to the provided value.
 The value must be an unsigned 32-bit integer.
 Currently only little-endian systems are supported to avoid accidentally setting
 the high 32 bits of 64-bit variables.
-.It Fl P
+.It Fl P , -parseable
 Print numbers in an unscaled form more amenable to parsing, e.g.\&
 .Sy 1000000
 rather than
 .Sy 1M .
-.It Fl t Ar transaction
+.It Fl t , -txg Ns = Ns Ar transaction
 Specify the highest transaction to use when searching for uberblocks.
 See also the
 .Fl u
@@ -407,28 +407,28 @@ and
 .Fl l
 options for a means to see the available uberblocks and their associated
 transaction numbers.
-.It Fl U Ar cachefile
+.It Fl U , -cachefile Ns = Ns Ar cachefile
 Use a cache file other than
 .Pa /etc/zfs/zpool.cache .
-.It Fl v
+.It Fl v , -verbose
 Enable verbosity.
 Specify multiple times for increased verbosity.
-.It Fl V
+.It Fl V , -verbatim
 Attempt verbatim import.
 This mimics the behavior of the kernel when loading a pool from a cachefile.
 Only usable with
 .Fl e .
-.It Fl X
+.It Fl X , -extreme-rewind
 Attempt
 .Qq extreme
 transaction rewind, that is attempt the same recovery as
 .Fl F
 but read transactions otherwise deemed too old.
-.It Fl Y
+.It Fl Y , -all-reconstruction
 Attempt all possible combinations when reconstructing indirect split blocks.
 This flag disables the individual I/O deadman timer in order to allow as
 much time as required for the attempted reconstruction.
-.It Fl y
+.It Fl y , -livelist
 Perform validation for livelists that are being deleted.
 Scans through the livelist and metaslabs, checking for duplicate entries
 and compares the two, checking for potential double frees.


### PR DESCRIPTION
### Add long opts for zdb

### Motivation and Context
zdb takes a lot of options, 37 to be precise. With most of the english alphabet taken, introducing new options involves associating alphabets with options in ways that are not very intuitive. Having long options would help in this regard.

### Description
This change introduces long options for zdb. It updates the usage message as well to include the long options.

### How Has This Been Tested?
```
delphix@ip-10-110-212-14:~$ sudo zdb -h
Usage:	zdb [-AbcdDFGhikLMPsvXy] [-e [-V] [-p <path> ...]] [-I <inflight I/Os>]
		[-o <var>=<value>]... [-t <txg>] [-U <cache>] [-x <dumpdir>]
		[<poolname>[/<dataset | objset id>] [<object | range> ...]]
	zdb [-AdiPv] [-e [-V] [-p <path> ...]] [-U <cache>]
		[<poolname>[/<dataset | objset id>] [<object | range> ...]
	zdb [-v] <bookmark>
	zdb -C [-A] [-U <cache>]
	zdb -l [-Aqu] <device>
	zdb -m [-AFLPX] [-e [-V] [-p <path> ...]] [-t <txg>] [-U <cache>]
		<poolname> [<vdev> [<metaslab> ...]]
	zdb -O <dataset> <path>
	zdb -r <dataset> <path> <destination>
	zdb -R [-A] [-e [-V] [-p <path> ...]] [-U <cache>]
		<poolname> <vdev>:<offset>:<size>[:<flags>]
	zdb -E [-A] word0:word1:...:word15
	zdb -S [-AP] [-e [-V] [-p <path> ...]] [-U <cache>] <poolname>

    Dataset name must include at least one separator character '/' or '@'
    If dataset name is specified, only that dataset is dumped
    If object numbers or object number ranges are specified, only those
    objects or ranges are dumped.

    Object ranges take the form <start>:<end>[:<flags>]
        start    Starting object number
        end      Ending object number, or -1 for no upper bound
        flags    Optional flags to select object types:
            A     All objects (this is the default)
            d     ZFS directories
            f     ZFS files 
            m     SPA space maps
            z     ZAPs
            -     Negate effect of next flag

    Options to control amount of output:
        -b --block-stats             block statistics
        -c --checksum                checksum all metadata (twice for all data) blocks
        -C --config                  config (or cachefile if alone)
        -d --datasets                dataset(s)
        -D --dedup-stats             dedup statistics
        -E --embedded-block-pointer=INTEGER
                                     decode and display block from an embedded block pointer
        -h --history                 pool history
        -i --intent-logs             intent logs
        -l --label                   read label contents
        -k --checkpointed-state      examine the checkpointed state of the pool
        -L --disable-leak-tracking   disable leak tracking (do not load spacemaps)
        -m --metaslabs               metaslabs
        -M --metaslab-groups         metaslab groups
        -O --object-lookups          perform object lookups by path
        -r --copy-object             copy an object by path to file
        -R --read-block              read and display block from a device
        -s --io-stats                report stats on zdb's I/O
        -S --simulate-dedup          simulate dedup to measure effect
        -v --verbose                 verbose (applies to all others)
        -y --livelist                perform livelist and metaslab validation on any livelists being deleted

    Below options are intended for use with other options:
        -A --ignore-assertions       ignore assertions (-A), enable panic recovery (-AA) or both (-AAA)
        -e --exported                pool is exported/destroyed/has altroot/not in a cachefile
        -F --automatic-rewind        attempt automatic rewind within safe range of transaction groups
        -G --dump-debug-msg          dump zfs_dbgmsg buffer before exiting
        -I --inflight=INTEGER        specify the maximum number of checksumming I/Os [default is 200]
        -o --option="OPTION=INTEGER" set global variable to an unsigned 32-bit integer
        -p --path==PATH              use one or more with -e to specify path to vdev dir
        -P --parseable               print numbers in parseable form
        -q --skip-label              don't print label contents
        -t --txg=INTEGER             highest txg to use when searching for uberblocks
        -u --uberblock               uberblock
        -U --cachefile=PATH          use alternate cachefile
        -V --verbatim                do verbatim import
        -x --dump-blocks=PATH        dump all read blocks into specified directory
        -X --extreme-rewind          attempt extreme rewind (does not work with dataset)
        -Y --all-reconstruction      attempt all reconstruction combinations for split blocks
        -Z --zstd-headers            show ZSTD headers 
Specify an option more than once (e.g. -bb) to make only that option verbose
Default is to dump everything non-verbosely
delphix@ip-10-110-212-14:~$ 
delphix@ip-10-110-212-14:~$ sudo zdb pool-1 --dump-debug-msg

ZFS_DBGMSG(zdb) START:
spa.c:5152:spa_open_common(): spa_open_common: opening pool-1
spa_misc.c:417:spa_load_note(): spa_load(pool-1, config trusted): LOADING
vdev.c:152:vdev_dbgmsg(): disk vdev '/dev/nvme3n1p1': best uberblock found for spa pool-1. txg 6
spa_misc.c:417:spa_load_note(): spa_load(pool-1, config untrusted): using uberblock with txg=6
spa.c:8311:spa_async_request(): spa=pool-1 async request task=2048
spa_misc.c:417:spa_load_note(): spa_load(pool-1, config trusted): LOADED
ZFS_DBGMSG(zdb) END
delphix@ip-10-110-212-14:~$ sudo zdb pool-1 --uberblock 

Uberblock:
	magic = 0000000000bab10c
	version = 5000
	txg = 6
	guid_sum = 14837908920885127976
	timestamp = 1636499579 UTC = Tue Nov  9 23:12:59 2021
	mmp_magic = 00000000a11cea11
	mmp_delay = 0
	mmp_valid = 0
	checkpoint_txg = 0

delphix@ip-10-110-212-14:~$ sudo zdb pool-1 --foobar
zdb: unrecognized option '--foobar'
Usage:	zdb [-AbcdDFGhikLMPsvXy] [-e [-V] [-p <path> ...]] [-I <inflight I/Os>]
<snip>
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
