### PR TITLE
zfs diff -h/ZFS_DIFF_NO_MANGLE, diff cleanups

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7664,7 +7664,7 @@ zfs_do_diff(int argc, char **argv)
 	int c;
 	struct sigaction sa;
 
-	while ((c = getopt(argc, argv, "FHt")) != -1) {
+	while ((c = getopt(argc, argv, "FHth")) != -1) {
 		switch (c) {
 		case 'F':
 			flags |= ZFS_DIFF_CLASSIFY;
@@ -7674,6 +7674,9 @@ zfs_do_diff(int argc, char **argv)
 			break;
 		case 't':
 			flags |= ZFS_DIFF_TIMESTAMP;
+			break;
+		case 'h':
+			flags |= ZFS_DIFF_NO_MANGLE;
 			break;
 		default:
 			(void) fprintf(stderr,

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -3760,7 +3760,6 @@ zfs_do_list(int argc, char **argv)
  * The '-p' flag creates all the non-existing ancestors of the target first.
  * The '-u' flag prevents file systems from being remounted during rename.
  */
-/* ARGSUSED */
 static int
 zfs_do_rename(int argc, char **argv)
 {
@@ -3859,7 +3858,6 @@ zfs_do_rename(int argc, char **argv)
  *
  * Promotes the given clone fs to be the parent
  */
-/* ARGSUSED */
 static int
 zfs_do_promote(int argc, char **argv)
 {
@@ -5095,10 +5093,10 @@ who_type2weight(zfs_deleg_who_type_t who_type)
 	return (res);
 }
 
-/* ARGSUSED */
 static int
 who_perm_compare(const void *larg, const void *rarg, void *unused)
 {
+	(void) unused;
 	const who_perm_node_t *l = larg;
 	const who_perm_node_t *r = rarg;
 	zfs_deleg_who_type_t ltype = l->who_perm.who_type;
@@ -5118,10 +5116,10 @@ who_perm_compare(const void *larg, const void *rarg, void *unused)
 		return (-1);
 }
 
-/* ARGSUSED */
 static int
 deleg_perm_compare(const void *larg, const void *rarg, void *unused)
 {
+	(void) unused;
 	const deleg_perm_node_t *l = larg;
 	const deleg_perm_node_t *r = rarg;
 	int res =  strncmp(l->dpn_perm.dp_name, r->dpn_perm.dp_name,
@@ -7210,10 +7208,10 @@ typedef struct unshare_unmount_node {
 	uu_avl_node_t	un_avlnode;
 } unshare_unmount_node_t;
 
-/* ARGSUSED */
 static int
 unshare_unmount_compare(const void *larg, const void *rarg, void *unused)
 {
+	(void) unused;
 	const unshare_unmount_node_t *l = larg;
 	const unshare_unmount_node_t *r = rarg;
 
@@ -8614,6 +8612,8 @@ zfs_do_wait(int argc, char **argv)
 static int
 zfs_do_version(int argc, char **argv)
 {
+	(void) argc, (void) argv;
+
 	if (zfs_version_print() == -1)
 		return (1);
 
@@ -8738,7 +8738,6 @@ main(int argc, char **argv)
 /*
  * Attach/detach the given dataset to/from the given jail
  */
-/* ARGSUSED */
 static int
 zfs_do_jail_impl(int argc, char **argv, boolean_t attach)
 {
@@ -8776,7 +8775,6 @@ zfs_do_jail_impl(int argc, char **argv, boolean_t attach)
  *
  * Attach the given dataset to the given jail
  */
-/* ARGSUSED */
 static int
 zfs_do_jail(int argc, char **argv)
 {
@@ -8788,7 +8786,6 @@ zfs_do_jail(int argc, char **argv)
  *
  * Detach the given dataset from the given jail
  */
-/* ARGSUSED */
 static int
 zfs_do_unjail(int argc, char **argv)
 {

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -835,9 +835,10 @@ _LIBZFS_H int zfs_receive(libzfs_handle_t *, const char *, nvlist_t *,
     recvflags_t *, int, avl_tree_t *);
 
 typedef enum diff_flags {
-	ZFS_DIFF_PARSEABLE = 0x1,
-	ZFS_DIFF_TIMESTAMP = 0x2,
-	ZFS_DIFF_CLASSIFY = 0x4
+	ZFS_DIFF_PARSEABLE = 1 << 0,
+	ZFS_DIFF_TIMESTAMP = 1 << 1,
+	ZFS_DIFF_CLASSIFY = 1 << 2,
+	ZFS_DIFF_NO_MANGLE = 1 << 3
 } diff_flags_t;
 
 _LIBZFS_H int zfs_show_diffs(zfs_handle_t *, int, const char *, const char *,

--- a/lib/libspl/os/linux/getmntany.c
+++ b/lib/libspl/os/linux/getmntany.c
@@ -83,7 +83,7 @@ _sol_getmntent(FILE *fp, struct mnttab *mgetp)
 }
 
 static int
-getextmntent_impl(FILE *fp, struct extmnttab *mp, int len)
+getextmntent_impl(FILE *fp, struct extmnttab *mp)
 {
 	int ret;
 	struct stat64 st;
@@ -137,7 +137,7 @@ getextmntent(const char *path, struct extmnttab *entry, struct stat64 *statbuf)
 	 */
 
 	match = 0;
-	while (getextmntent_impl(fp, entry, sizeof (*entry)) == 0) {
+	while (getextmntent_impl(fp, entry) == 0) {
 		if (makedev(entry->mnt_major, entry->mnt_minor) ==
 		    statbuf->st_dev) {
 			match = 1;

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -129,48 +129,35 @@ stream_bytes(FILE *fp, const char *string)
 	}
 }
 
-static void
-print_what(FILE *fp, mode_t what)
+static char
+get_what(mode_t what)
 {
-	char symbol;
-
 	switch (what & S_IFMT) {
 	case S_IFBLK:
-		symbol = 'B';
-		break;
+		return ('B');
 	case S_IFCHR:
-		symbol = 'C';
-		break;
+		return ('C');
 	case S_IFDIR:
-		symbol = '/';
-		break;
+		return ('/');
 #ifdef S_IFDOOR
 	case S_IFDOOR:
-		symbol = '>';
-		break;
+		return ('>');
 #endif
 	case S_IFIFO:
-		symbol = '|';
-		break;
+		return ('|');
 	case S_IFLNK:
-		symbol = '@';
-		break;
+		return ('@');
 #ifdef S_IFPORT
 	case S_IFPORT:
-		symbol = 'P';
-		break;
+		return ('P');
 #endif
 	case S_IFSOCK:
-		symbol = '=';
-		break;
+		return ('=');
 	case S_IFREG:
-		symbol = 'F';
-		break;
+		return ('F');
 	default:
-		symbol = '?';
-		break;
+		return ('?');
 	}
-	(void) fprintf(fp, "%c", symbol);
 }
 
 static void
@@ -194,10 +181,8 @@ print_rename(FILE *fp, differ_info_t *di, const char *old, const char *new,
 		    (longlong_t)isb->zs_ctime[0],
 		    (longlong_t)isb->zs_ctime[1]);
 	(void) fprintf(fp, "%c\t", ZDIFF_RENAMED);
-	if (di->classify) {
-		print_what(fp, isb->zs_mode);
-		(void) fprintf(fp, "\t");
-	}
+	if (di->classify)
+		(void) fprintf(fp, "%c\t", get_what(isb->zs_mode));
 	print_cmn(fp, di, old);
 	if (di->scripted)
 		(void) fprintf(fp, "\t");
@@ -216,10 +201,8 @@ print_link_change(FILE *fp, differ_info_t *di, int delta, const char *file,
 		    (longlong_t)isb->zs_ctime[0],
 		    (longlong_t)isb->zs_ctime[1]);
 	(void) fprintf(fp, "%c\t", ZDIFF_MODIFIED);
-	if (di->classify) {
-		print_what(fp, isb->zs_mode);
-		(void) fprintf(fp, "\t");
-	}
+	if (di->classify)
+		(void) fprintf(fp, "%c\t", get_what(isb->zs_mode));
 	print_cmn(fp, di, file);
 	(void) fprintf(fp, "\t(%+d)", delta);
 	(void) fprintf(fp, "\n");
@@ -234,10 +217,8 @@ print_file(FILE *fp, differ_info_t *di, char type, const char *file,
 		    (longlong_t)isb->zs_ctime[0],
 		    (longlong_t)isb->zs_ctime[1]);
 	(void) fprintf(fp, "%c\t", type);
-	if (di->classify) {
-		print_what(fp, isb->zs_mode);
-		(void) fprintf(fp, "\t");
-	}
+	if (di->classify)
+		(void) fprintf(fp, "%c\t", get_what(isb->zs_mode));
 	print_cmn(fp, di, file);
 	(void) fprintf(fp, "\n");
 }

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -122,9 +122,9 @@ stream_bytes(FILE *fp, const char *string)
 
 	while ((c = *string++) != '\0') {
 		if (c > ' ' && c != '\\' && c < '\177') {
-			(void) fprintf(fp, "%c", c);
+			(void) fputc(c, fp);
 		} else {
-			(void) fprintf(fp, "\\%04o", (uint8_t)c);
+			(void) fprintf(fp, "\\%04hho", (uint8_t)c);
 		}
 	}
 }

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -51,9 +51,9 @@
 #define	ZDIFF_PREFIX		"zfs-diff-%d"
 
 #define	ZDIFF_ADDED	'+'
-#define	ZDIFF_MODIFIED	'M'
+#define	ZDIFF_MODIFIED	"M"
 #define	ZDIFF_REMOVED	'-'
-#define	ZDIFF_RENAMED	'R'
+#define	ZDIFF_RENAMED	"R"
 
 
 /*
@@ -180,16 +180,13 @@ print_rename(FILE *fp, differ_info_t *di, const char *old, const char *new,
 		(void) fprintf(fp, "%10lld.%09lld\t",
 		    (longlong_t)isb->zs_ctime[0],
 		    (longlong_t)isb->zs_ctime[1]);
-	(void) fprintf(fp, "%c\t", ZDIFF_RENAMED);
+	(void) fputs(ZDIFF_RENAMED "\t", fp);
 	if (di->classify)
 		(void) fprintf(fp, "%c\t", get_what(isb->zs_mode));
 	print_cmn(fp, di, old);
-	if (di->scripted)
-		(void) fprintf(fp, "\t");
-	else
-		(void) fprintf(fp, " -> ");
+	(void) fputs(di->scripted ? "\t" : " -> ", fp);
 	print_cmn(fp, di, new);
-	(void) fprintf(fp, "\n");
+	(void) fputc('\n', fp);
 }
 
 static void
@@ -200,12 +197,11 @@ print_link_change(FILE *fp, differ_info_t *di, int delta, const char *file,
 		(void) fprintf(fp, "%10lld.%09lld\t",
 		    (longlong_t)isb->zs_ctime[0],
 		    (longlong_t)isb->zs_ctime[1]);
-	(void) fprintf(fp, "%c\t", ZDIFF_MODIFIED);
+	(void) fputs(ZDIFF_MODIFIED "\t", fp);
 	if (di->classify)
 		(void) fprintf(fp, "%c\t", get_what(isb->zs_mode));
 	print_cmn(fp, di, file);
-	(void) fprintf(fp, "\t(%+d)", delta);
-	(void) fprintf(fp, "\n");
+	(void) fprintf(fp, "\t(%+d)\n", delta);
 }
 
 static void
@@ -220,7 +216,7 @@ print_file(FILE *fp, differ_info_t *di, char type, const char *file,
 	if (di->classify)
 		(void) fprintf(fp, "%c\t", get_what(isb->zs_mode));
 	print_cmn(fp, di, file);
-	(void) fprintf(fp, "\n");
+	(void) fputc('\n', fp);
 }
 
 static int
@@ -313,7 +309,7 @@ write_inuse_diffs_one(FILE *fp, differ_info_t *di, uint64_t dobj)
 			print_link_change(fp, di, change,
 			    change > 0 ? fobjname : tobjname, &tsb);
 		} else if (strcmp(fobjname, tobjname) == 0) {
-			print_file(fp, di, ZDIFF_MODIFIED, fobjname, &tsb);
+			print_file(fp, di, *ZDIFF_MODIFIED, fobjname, &tsb);
 		} else {
 			print_rename(fp, di, fobjname, tobjname, &tsb);
 		}

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -176,8 +176,13 @@ print_what(FILE *fp, mode_t what)
 static void
 print_cmn(FILE *fp, differ_info_t *di, const char *file)
 {
-	stream_bytes(fp, di->dsmnt);
-	stream_bytes(fp, file);
+	if (!di->no_mangle) {
+		stream_bytes(fp, di->dsmnt);
+		stream_bytes(fp, file);
+	} else {
+		(void) fputs(di->dsmnt, fp);
+		(void) fputs(file, fp);
+	}
 }
 
 static void
@@ -752,6 +757,7 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 	di.scripted = (flags & ZFS_DIFF_PARSEABLE);
 	di.classify = (flags & ZFS_DIFF_CLASSIFY);
 	di.timestamped = (flags & ZFS_DIFF_TIMESTAMP);
+	di.no_mangle = (flags & ZFS_DIFF_NO_MANGLE);
 
 	di.outputfd = outfd;
 	di.datafd = pipefd[0];

--- a/lib/libzfs/libzfs_impl.h
+++ b/lib/libzfs/libzfs_impl.h
@@ -232,6 +232,7 @@ typedef struct differ_info {
 	boolean_t scripted;
 	boolean_t classify;
 	boolean_t timestamped;
+	boolean_t no_mangle;
 	uint64_t shares;
 	int zerr;
 	int cleanupfd;

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -5358,7 +5358,6 @@ zpool_set_vdev_prop(zpool_handle_t *zhp, const char *vdevname,
     const char *propname, const char *propval)
 {
 	int ret;
-	vdev_prop_t vprop;
 	nvlist_t *nvl = NULL;
 	nvlist_t *outnvl = NULL;
 	nvlist_t *props;
@@ -5369,8 +5368,6 @@ zpool_set_vdev_prop(zpool_handle_t *zhp, const char *vdevname,
 
 	if ((ret = zpool_vdev_guid(zhp, vdevname, &vdev_guid)) != 0)
 		return (ret);
-
-	vprop = vdev_name_to_prop(propname);
 
 	if (nvlist_alloc(&nvl, NV_UNIQUE_NAME, 0) != 0)
 		return (no_memory(zhp->zpool_hdl));

--- a/man/man8/zfs-diff.8
+++ b/man/man8/zfs-diff.8
@@ -39,7 +39,7 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm diff
-.Op Fl FHt
+.Op Fl FHth
 .Ar snapshot Ar snapshot Ns | Ns Ar filesystem
 .
 .Sh DESCRIPTION
@@ -92,6 +92,10 @@ Give more parsable tab-separated output, without header lines and without
 arrows.
 .It Fl t
 Display the path's inode change time as the first column of output.
+.It Fl h
+Do not
+.Sy \e0 Ns Ar ooo Ns -escape
+non-ASCII paths.
 .El
 .
 .Sh SEE ALSO

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -179,7 +179,7 @@ tags = ['functional', 'cli_root', 'zfs_destroy']
 
 [tests/functional/cli_root/zfs_diff]
 tests = ['zfs_diff_changes', 'zfs_diff_cliargs', 'zfs_diff_timestamp',
-    'zfs_diff_types', 'zfs_diff_encrypted']
+    'zfs_diff_types', 'zfs_diff_encrypted', 'zfs_diff_mangle']
 tags = ['functional', 'cli_root', 'zfs_diff']
 
 [tests/functional/cli_root/zfs_get]

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/Makefile.am
@@ -8,6 +8,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_diff_changes.ksh \
 	zfs_diff_cliargs.ksh \
 	zfs_diff_encrypted.ksh \
+	zfs_diff_mangle.ksh \
 	zfs_diff_timestamp.ksh \
 	zfs_diff_types.ksh
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/socket.c
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/socket.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* ARGSUSED */
 int
 main(int argc, char *argv[])
 {

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_cliargs.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_cliargs.ksh
@@ -39,8 +39,8 @@ function cleanup
 log_assert "'zfs diff' should only work with supported options."
 log_onexit cleanup
 
-typeset goodopts=("" "-F" "-H" "-t" "-FH" "-Ft" "-Ht" "-FHt")
-typeset badopts=("-f" "-h" "-h" "-T" "-Fx" "-Ho" "-tT" "-")
+typeset goodopts=("" "-h" "-t" "-th" "-H" "-Hh" "-Ht" "-Hth" "-F" "-Fh" "-Ft" "-Fth" "-FH" "-FHh" "-FHt" "-FHth")
+typeset badopts=("-f" "-T" "-Fx" "-Ho" "-tT" "-")
 
 DATASET="$TESTPOOL/$TESTFS"
 TESTSNAP1="$DATASET@snap1"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_mangle.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_mangle.ksh
@@ -1,0 +1,48 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs diff' escapes filenames as expected, 'zfs diff -h' doesn't
+#
+# STRATEGY:
+# 1. Prepare a dataset
+# 2. Create some files
+# 3. verify 'zfs diff' mangles them and 'zfs diff -h' doesn't
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zfs destroy -r "$DATASET"
+}
+
+log_assert "'zfs diff' mangles filenames, 'zfs diff -h' doesn't"
+log_onexit cleanup
+
+DATASET="$TESTPOOL/$TESTFS/fs"
+TESTSNAP1="$DATASET@snap1"
+
+# 1. Prepare a dataset
+log_must zfs create "$DATASET"
+MNTPOINT="$(get_prop mountpoint "$DATASET")"
+log_must zfs snapshot "$TESTSNAP1"
+
+printf '%c\t'"$MNTPOINT/"'%s\n' M '' + 'śmieszny żupan'                       + 'достопримечательности'                                                                                                                                                                                              | sort > "$MNTPOINT/śmieszny żupan"
+printf '%c\t'"$MNTPOINT/"'%s\n' M '' + '\0305\0233mieszny\0040\0305\0274upan' + '\0320\0264\0320\0276\0321\0201\0321\0202\0320\0276\0320\0277\0321\0200\0320\0270\0320\0274\0320\0265\0321\0207\0320\0260\0321\0202\0320\0265\0320\0273\0321\0214\0320\0275\0320\0276\0321\0201\0321\0202\0320\0270' | sort > "$MNTPOINT/достопримечательности"
+log_must diff -u <(zfs diff -h "$TESTSNAP1" | grep -vF '<xattrdir>' | sort) "$MNTPOINT/śmieszny żupan"
+log_must diff -u <(zfs diff    "$TESTSNAP1" | grep -vF '<xattrdir>' | sort) "$MNTPOINT/достопримечательности"
+
+log_pass "'zfs diff' mangles filenames, 'zfs diff -h' doesn't"


### PR DESCRIPTION
### Motivation and Context
If I have to write another instance of this
```c
#include <stdio.h>
int main() {
	int c;
	while((c = getchar()) != EOF) {
		if(c == '\\') {
			c = 0;
			getchar(); // 0
			c = (c << 3) | (getchar() - '0');
			c = (c << 3) | (getchar() - '0');
			c = (c << 3) | (getchar() - '0');
		}
		putchar(c);
	}
}
```
to process stuff like this
```
-       /mnt/filling/store/BKP/D/Dokumenty/Domek/4.\0040sprz\0304\0231ty\0040i\0040materia\0305\0202y/_6\0040pompa\0040ciep\0305\0202a/Ochsner/!\0040panel\0040sterowania\0040w\0040salonie/2018.02\0040DSC_1928\0040-\0040panel\0040-\0040pod\0305\0202\0304\0205czenie\0040kabli.jpg
-       /mnt/filling/store/BKP/D/Dokumenty/b.\0040WCM/3.\0040Przyk\0305\0202ady/1.\0040PlatT/Zarz\0304\0205dzanie\0040Jako\0305\0233ci\0304\0205/tech-karty/IPSTLD\0040-\0040\0320\0242\0320\0265\0321\0205\0320\0275\0320\0276\0320\0273\0320\0276\0320\0263\0320\0270\0321\0207\0320\0265\0321\0201\0320\0272\0320\0260\0321\0217\0040\0320\0272\0320\0260\0321\0200\0321\0202\0320\0260\004028\0320\0245\0320\02232\0320\0242\0320\0240\0320\0243.xls/<xattrdir>
```
one more time just to read a diff I will return to monky, in a big way

### Description
The first patch has the -p/NO_MANGLE flags for easy cherry-picking, the rest are NFC and explained in the messages.

Also, nominally, the %o with uint8_t argument should *not* work on big endian, but there didn't seem to be any tests validating that?

Went with -p for, dunno, printable? but not so sure about it. thots?

### How Has This Been Tested?
Ran it. There's a new test, too, which CI will validate hopefully.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv) – new flag, but no ABI breaks I think?
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
