### PR TITLE
argSUSed: cmd, tests, contrib

### DIFF
--- a/cmd/raidz_test/raidz_test.c
+++ b/cmd/raidz_test/raidz_test.c
@@ -266,12 +266,8 @@ cmp_data(raidz_test_opts_t *opts, raidz_map_t *rm)
 static int
 init_rand(void *data, size_t size, void *private)
 {
-	int i;
-	int *dst = (int *)data;
-
-	for (i = 0; i < size / sizeof (int); i++)
-		dst[i] = rand_data[i];
-
+	(void) private;
+	memcpy(data, rand_data, size);
 	return (0);
 }
 

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -383,10 +383,10 @@ livelist_verify(dsl_deadlist_t *dl, void *arg)
  * Check for errors in the livelist entry and discard the intermediary
  * data structures
  */
-/* ARGSUSED */
 static int
 sublivelist_verify_lightweight(void *args, dsl_deadlist_entry_t *dle)
 {
+	(void) args;
 	sublivelist_verify_t sv;
 	zfs_btree_create(&sv.sv_leftover, livelist_block_compare,
 	    sizeof (sublivelist_verify_block_t));
@@ -916,10 +916,10 @@ fatal(const char *fmt, ...)
 	exit(1);
 }
 
-/* ARGSUSED */
 static void
 dump_packed_nvlist(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) size;
 	nvlist_t *nv;
 	size_t nvsize = *(uint64_t *)data;
 	char *packed = umem_alloc(nvsize, UMEM_NOFAIL);
@@ -935,10 +935,10 @@ dump_packed_nvlist(objset_t *os, uint64_t object, void *data, size_t size)
 	nvlist_free(nv);
 }
 
-/* ARGSUSED */
 static void
 dump_history_offsets(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) os, (void) object, (void) size;
 	spa_history_phys_t *shp = data;
 
 	if (shp == NULL)
@@ -1058,26 +1058,25 @@ dump_zap_stats(objset_t *os, uint64_t object)
 	dump_histogram(zs.zs_buckets_with_n_entries, ZAP_HISTOGRAM_SIZE, 0);
 }
 
-/*ARGSUSED*/
 static void
 dump_none(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) os, (void) object, (void) data, (void) size;
 }
 
-/*ARGSUSED*/
 static void
 dump_unknown(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) os, (void) object, (void) data, (void) size;
 	(void) printf("\tUNKNOWN OBJECT TYPE\n");
 }
 
-/*ARGSUSED*/
 static void
 dump_uint8(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) os, (void) object, (void) data, (void) size;
 }
 
-/*ARGSUSED*/
 static void
 dump_uint64(objset_t *os, uint64_t object, void *data, size_t size)
 {
@@ -1134,10 +1133,10 @@ dump_uint64(objset_t *os, uint64_t object, void *data, size_t size)
 		kmem_free(arr, oursize);
 }
 
-/*ARGSUSED*/
 static void
 dump_zap(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) data, (void) size;
 	zap_cursor_t zc;
 	zap_attribute_t attr;
 	void *prop;
@@ -1254,10 +1253,10 @@ dump_bpobj(objset_t *os, uint64_t object, void *data, size_t size)
 	}
 }
 
-/* ARGSUSED */
 static void
 dump_bpobj_subobjs(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) data, (void) size;
 	dmu_object_info_t doi;
 	int64_t i;
 
@@ -1283,18 +1282,18 @@ dump_bpobj_subobjs(objset_t *os, uint64_t object, void *data, size_t size)
 	kmem_free(subobjs, doi.doi_max_offset);
 }
 
-/*ARGSUSED*/
 static void
 dump_ddt_zap(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) data, (void) size;
 	dump_zap_stats(os, object);
 	/* contents are printed elsewhere, properly decoded */
 }
 
-/*ARGSUSED*/
 static void
 dump_sa_attrs(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) data, (void) size;
 	zap_cursor_t zc;
 	zap_attribute_t attr;
 
@@ -1318,10 +1317,10 @@ dump_sa_attrs(objset_t *os, uint64_t object, void *data, size_t size)
 	zap_cursor_fini(&zc);
 }
 
-/*ARGSUSED*/
 static void
 dump_sa_layouts(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) data, (void) size;
 	zap_cursor_t zc;
 	zap_attribute_t attr;
 	uint16_t *layout_attrs;
@@ -1356,10 +1355,10 @@ dump_sa_layouts(objset_t *os, uint64_t object, void *data, size_t size)
 	zap_cursor_fini(&zc);
 }
 
-/*ARGSUSED*/
 static void
 dump_zpldir(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) data, (void) size;
 	zap_cursor_t zc;
 	zap_attribute_t attr;
 	const char *typenames[] = {
@@ -2215,10 +2214,10 @@ next:
 	free(buf);
 }
 
-/*ARGSUSED*/
 static void
 dump_dnode(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) os, (void) object, (void) data, (void) size;
 }
 
 static uint64_t
@@ -2440,19 +2439,17 @@ visit_indirect(spa_t *spa, const dnode_phys_t *dnp,
 	return (err);
 }
 
-/*ARGSUSED*/
 static void
 dump_indirect(dnode_t *dn)
 {
 	dnode_phys_t *dnp = dn->dn_phys;
-	int j;
 	zbookmark_phys_t czb;
 
 	(void) printf("Indirect blocks:\n");
 
 	SET_BOOKMARK(&czb, dmu_objset_id(dn->dn_objset),
 	    dn->dn_object, dnp->dn_nlevels - 1, 0);
-	for (j = 0; j < dnp->dn_nblkptr; j++) {
+	for (int j = 0; j < dnp->dn_nblkptr; j++) {
 		czb.zb_blkid = j;
 		(void) visit_indirect(dmu_objset_spa(dn->dn_objset), dnp,
 		    &dnp->dn_blkptr[j], &czb);
@@ -2461,10 +2458,10 @@ dump_indirect(dnode_t *dn)
 	(void) printf("\n");
 }
 
-/*ARGSUSED*/
 static void
 dump_dsl_dir(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) os, (void) object;
 	dsl_dir_phys_t *dd = data;
 	time_t crtime;
 	char nice[32];
@@ -2518,10 +2515,10 @@ dump_dsl_dir(objset_t *os, uint64_t object, void *data, size_t size)
 	    (u_longlong_t)dd->dd_clones);
 }
 
-/*ARGSUSED*/
 static void
 dump_dsl_dataset(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) os, (void) object;
 	dsl_dataset_phys_t *ds = data;
 	time_t crtime;
 	char used[32], compressed[32], uncompressed[32], unique[32];
@@ -2581,10 +2578,10 @@ dump_dsl_dataset(objset_t *os, uint64_t object, void *data, size_t size)
 	(void) printf("\t\tbp = %s\n", blkbuf);
 }
 
-/* ARGSUSED */
 static int
 dump_bptree_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
 {
+	(void) arg, (void) tx;
 	char blkbuf[BP_SPRINTF_LEN];
 
 	if (bp->blk_birth != 0) {
@@ -2622,10 +2619,10 @@ dump_bptree(objset_t *os, uint64_t obj, const char *name)
 	(void) bptree_iterate(os, obj, B_FALSE, dump_bptree_cb, NULL, NULL);
 }
 
-/* ARGSUSED */
 static int
 dump_bpobj_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 {
+	(void) arg, (void) tx;
 	char blkbuf[BP_SPRINTF_LEN];
 
 	ASSERT(bp->blk_birth != 0);
@@ -3187,10 +3184,10 @@ dump_znode_symlink(sa_handle_t *hdl)
 		(void) printf("\ttarget	%s\n", linktarget);
 }
 
-/*ARGSUSED*/
 static void
 dump_znode(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) data, (void) size;
 	char path[MAXPATHLEN * 2];	/* allow for xattr and failure prefix */
 	sa_handle_t *hdl;
 	uint64_t xattr, rdev, gen;
@@ -3282,16 +3279,16 @@ dump_znode(objset_t *os, uint64_t object, void *data, size_t size)
 	sa_handle_destroy(hdl);
 }
 
-/*ARGSUSED*/
 static void
 dump_acl(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) os, (void) object, (void) data, (void) size;
 }
 
-/*ARGSUSED*/
 static void
 dump_dmu_objset(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	(void) os, (void) object, (void) data, (void) size;
 }
 
 static object_viewer_t *object_viewer[DMU_OT_NUMTYPES + 1] = {
@@ -4985,10 +4982,10 @@ static uint64_t dataset_feature_count[SPA_FEATURES];
 static uint64_t global_feature_count[SPA_FEATURES];
 static uint64_t remap_deadlist_count = 0;
 
-/*ARGSUSED*/
 static int
 dump_one_objset(const char *dsname, void *arg)
 {
+	(void) arg;
 	int error;
 	objset_t *os;
 	spa_feature_t f;
@@ -5553,7 +5550,6 @@ static metaslab_ops_t zdb_metaslab_ops = {
 	NULL	/* alloc */
 };
 
-/* ARGSUSED */
 static int
 load_unflushed_svr_segs_cb(spa_t *spa, space_map_entry_t *sme,
     uint64_t txg, void *arg)
@@ -5582,11 +5578,12 @@ load_unflushed_svr_segs_cb(spa_t *spa, space_map_entry_t *sme,
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 claim_segment_impl_cb(uint64_t inner_offset, vdev_t *vd, uint64_t offset,
     uint64_t size, void *arg)
 {
+	(void) inner_offset, (void) arg;
+
 	/*
 	 * This callback was called through a remap from
 	 * a device being removed. Therefore, the vdev that
@@ -5660,11 +5657,11 @@ zdb_claim_removing(spa_t *spa, zdb_cb_t *zcb)
 	spa_config_exit(spa, SCL_CONFIG, FTAG);
 }
 
-/* ARGSUSED */
 static int
 increment_indirect_mapping_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx)
 {
+	(void) tx;
 	zdb_cb_t *zcb = arg;
 	spa_t *spa = zcb->zcb_spa;
 	vdev_t *vd;
@@ -6276,10 +6273,10 @@ zdb_leak_fini(spa_t *spa, zdb_cb_t *zcb)
 	return (leaks);
 }
 
-/* ARGSUSED */
 static int
 count_block_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
 {
+	(void) tx;
 	zdb_cb_t *zcb = arg;
 
 	if (dump_opt['b'] >= 5) {
@@ -6736,11 +6733,11 @@ typedef struct zdb_ddt_entry {
 	avl_node_t	zdde_node;
 } zdb_ddt_entry_t;
 
-/* ARGSUSED */
 static int
 zdb_ddt_add_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
     const zbookmark_phys_t *zb, const dnode_phys_t *dnp, void *arg)
 {
+	(void) zilog, (void) dnp;
 	avl_tree_t *t = arg;
 	avl_index_t where;
 	zdb_ddt_entry_t *zdde, zdde_search;
@@ -7363,10 +7360,10 @@ verify_checkpoint(spa_t *spa)
 	return (error);
 }
 
-/* ARGSUSED */
 static void
 mos_leaks_cb(void *arg, uint64_t start, uint64_t size)
 {
+	(void) arg;
 	for (uint64_t i = start; i < size; i++) {
 		(void) printf("MOS object %llu referenced but not allocated\n",
 		    (u_longlong_t)i);
@@ -7967,6 +7964,7 @@ static boolean_t
 zdb_decompress_block(abd_t *pabd, void *buf, void *lbuf, uint64_t lsize,
     uint64_t psize, int flags)
 {
+	(void) buf;
 	boolean_t exceeded = B_FALSE;
 	/*
 	 * We don't know how the data was compressed, so just try

--- a/cmd/zdb/zdb_il.c
+++ b/cmd/zdb/zdb_il.c
@@ -60,10 +60,10 @@ print_log_bp(const blkptr_t *bp, const char *prefix)
 	(void) printf("%s%s\n", prefix, blkbuf);
 }
 
-/* ARGSUSED */
 static void
 zil_prt_rec_create(zilog_t *zilog, int txtype, const void *arg)
 {
+	(void) zilog;
 	const lr_create_t *lr = arg;
 	time_t crtime = lr->lr_crtime[0];
 	char *name, *link;
@@ -96,20 +96,20 @@ zil_prt_rec_create(zilog_t *zilog, int txtype, const void *arg)
 	    (u_longlong_t)lr->lr_gen, (u_longlong_t)lr->lr_rdev);
 }
 
-/* ARGSUSED */
 static void
 zil_prt_rec_remove(zilog_t *zilog, int txtype, const void *arg)
 {
+	(void) zilog, (void) txtype;
 	const lr_remove_t *lr = arg;
 
 	(void) printf("%sdoid %llu, name %s\n", tab_prefix,
 	    (u_longlong_t)lr->lr_doid, (char *)(lr + 1));
 }
 
-/* ARGSUSED */
 static void
 zil_prt_rec_link(zilog_t *zilog, int txtype, const void *arg)
 {
+	(void) zilog, (void) txtype;
 	const lr_link_t *lr = arg;
 
 	(void) printf("%sdoid %llu, link_obj %llu, name %s\n", tab_prefix,
@@ -117,10 +117,10 @@ zil_prt_rec_link(zilog_t *zilog, int txtype, const void *arg)
 	    (char *)(lr + 1));
 }
 
-/* ARGSUSED */
 static void
 zil_prt_rec_rename(zilog_t *zilog, int txtype, const void *arg)
 {
+	(void) zilog, (void) txtype;
 	const lr_rename_t *lr = arg;
 	char *snm = (char *)(lr + 1);
 	char *tnm = snm + strlen(snm) + 1;
@@ -130,10 +130,10 @@ zil_prt_rec_rename(zilog_t *zilog, int txtype, const void *arg)
 	(void) printf("%ssrc %s tgt %s\n", tab_prefix, snm, tnm);
 }
 
-/* ARGSUSED */
 static int
 zil_prt_rec_write_cb(void *data, size_t len, void *unused)
 {
+	(void) unused;
 	char *cdata = data;
 
 	for (size_t i = 0; i < len; i++) {
@@ -146,7 +146,6 @@ zil_prt_rec_write_cb(void *data, size_t len, void *unused)
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 zil_prt_rec_write(zilog_t *zilog, int txtype, const void *arg)
 {
@@ -209,10 +208,10 @@ out:
 	abd_free(data);
 }
 
-/* ARGSUSED */
 static void
 zil_prt_rec_truncate(zilog_t *zilog, int txtype, const void *arg)
 {
+	(void) zilog, (void) txtype;
 	const lr_truncate_t *lr = arg;
 
 	(void) printf("%sfoid %llu, offset 0x%llx, length 0x%llx\n", tab_prefix,
@@ -220,10 +219,10 @@ zil_prt_rec_truncate(zilog_t *zilog, int txtype, const void *arg)
 	    (u_longlong_t)lr->lr_length);
 }
 
-/* ARGSUSED */
 static void
 zil_prt_rec_setattr(zilog_t *zilog, int txtype, const void *arg)
 {
+	(void) zilog, (void) txtype;
 	const lr_setattr_t *lr = arg;
 	time_t atime = (time_t)lr->lr_atime[0];
 	time_t mtime = (time_t)lr->lr_mtime[0];
@@ -266,10 +265,10 @@ zil_prt_rec_setattr(zilog_t *zilog, int txtype, const void *arg)
 	}
 }
 
-/* ARGSUSED */
 static void
 zil_prt_rec_acl(zilog_t *zilog, int txtype, const void *arg)
 {
+	(void) zilog, (void) txtype;
 	const lr_acl_t *lr = arg;
 
 	(void) printf("%sfoid %llu, aclcnt %llu\n", tab_prefix,
@@ -307,10 +306,10 @@ static zil_rec_info_t zil_rec_info[TX_MAX_TYPE] = {
 	{.zri_print = zil_prt_rec_write,    .zri_name = "TX_WRITE2          "},
 };
 
-/* ARGSUSED */
 static int
 print_log_record(zilog_t *zilog, const lr_t *lr, void *arg, uint64_t claim_txg)
 {
+	(void) arg, (void) claim_txg;
 	int txtype;
 	int verbose = MAX(dump_opt['d'], dump_opt['i']);
 
@@ -341,11 +340,11 @@ print_log_record(zilog_t *zilog, const lr_t *lr, void *arg, uint64_t claim_txg)
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 print_log_block(zilog_t *zilog, const blkptr_t *bp, void *arg,
     uint64_t claim_txg)
 {
+	(void) arg;
 	char blkbuf[BP_SPRINTF_LEN + 10];
 	int verbose = MAX(dump_opt['d'], dump_opt['i']);
 	const char *claim;
@@ -396,7 +395,6 @@ print_log_stats(int verbose)
 	(void) printf("\n");
 }
 
-/* ARGSUSED */
 void
 dump_intent_log(zilog_t *zilog)
 {

--- a/cmd/zed/agents/fmd_api.c
+++ b/cmd/zed/agents/fmd_api.c
@@ -97,6 +97,7 @@ _umem_logging_init(void)
 int
 fmd_hdl_register(fmd_hdl_t *hdl, int version, const fmd_hdl_info_t *mip)
 {
+	(void) version;
 	fmd_module_t *mp = (fmd_module_t *)hdl;
 
 	mp->mod_info = mip;
@@ -179,18 +180,21 @@ fmd_hdl_getspecific(fmd_hdl_t *hdl)
 void *
 fmd_hdl_alloc(fmd_hdl_t *hdl, size_t size, int flags)
 {
+	(void) hdl;
 	return (umem_alloc(size, flags));
 }
 
 void *
 fmd_hdl_zalloc(fmd_hdl_t *hdl, size_t size, int flags)
 {
+	(void) hdl;
 	return (umem_zalloc(size, flags));
 }
 
 void
 fmd_hdl_free(fmd_hdl_t *hdl, void *data, size_t size)
 {
+	(void) hdl;
 	umem_free(data, size);
 }
 
@@ -217,6 +221,8 @@ fmd_hdl_debug(fmd_hdl_t *hdl, const char *format, ...)
 int32_t
 fmd_prop_get_int32(fmd_hdl_t *hdl, const char *name)
 {
+	(void) hdl;
+
 	/*
 	 * These can be looked up in mp->modinfo->fmdi_props
 	 * For now we just hard code for phase 2. In the
@@ -234,6 +240,8 @@ fmd_prop_get_int32(fmd_hdl_t *hdl, const char *name)
 int64_t
 fmd_prop_get_int64(fmd_hdl_t *hdl, const char *name)
 {
+	(void) hdl;
+
 	/*
 	 * These can be looked up in mp->modinfo->fmdi_props
 	 * For now we just hard code for phase 2. In the
@@ -337,12 +345,14 @@ fmd_case_uuresolved(fmd_hdl_t *hdl, const char *uuid)
 int
 fmd_case_solved(fmd_hdl_t *hdl, fmd_case_t *cp)
 {
+	(void) hdl;
 	return ((cp->ci_state >= FMD_CASE_SOLVED) ? FMD_B_TRUE : FMD_B_FALSE);
 }
 
 void
 fmd_case_add_ereport(fmd_hdl_t *hdl, fmd_case_t *cp, fmd_event_t *ep)
 {
+	(void) hdl, (void) cp, (void) ep;
 }
 
 static void
@@ -444,19 +454,21 @@ fmd_case_add_suspect(fmd_hdl_t *hdl, fmd_case_t *cp, nvlist_t *fault)
 void
 fmd_case_setspecific(fmd_hdl_t *hdl, fmd_case_t *cp, void *data)
 {
+	(void) hdl;
 	cp->ci_data = data;
 }
 
 void *
 fmd_case_getspecific(fmd_hdl_t *hdl, fmd_case_t *cp)
 {
+	(void) hdl;
 	return (cp->ci_data);
 }
 
 void
 fmd_buf_create(fmd_hdl_t *hdl, fmd_case_t *cp, const char *name, size_t size)
 {
-	assert(strcmp(name, "data") == 0);
+	assert(strcmp(name, "data") == 0), (void) name;
 	assert(cp->ci_bufptr == NULL);
 	assert(size < (1024 * 1024));
 
@@ -468,7 +480,8 @@ void
 fmd_buf_read(fmd_hdl_t *hdl, fmd_case_t *cp,
     const char *name, void *buf, size_t size)
 {
-	assert(strcmp(name, "data") == 0);
+	(void) hdl;
+	assert(strcmp(name, "data") == 0), (void) name;
 	assert(cp->ci_bufptr != NULL);
 	assert(size <= cp->ci_bufsiz);
 
@@ -479,7 +492,8 @@ void
 fmd_buf_write(fmd_hdl_t *hdl, fmd_case_t *cp,
     const char *name, const void *buf, size_t size)
 {
-	assert(strcmp(name, "data") == 0);
+	(void) hdl;
+	assert(strcmp(name, "data") == 0), (void) name;
 	assert(cp->ci_bufptr != NULL);
 	assert(cp->ci_bufsiz >= size);
 
@@ -583,6 +597,7 @@ _timer_notify(union sigval sv)
 fmd_timer_t *
 fmd_timer_install(fmd_hdl_t *hdl, void *arg, fmd_event_t *ep, hrtime_t delta)
 {
+	(void) ep;
 	struct sigevent sev;
 	struct itimerspec its;
 	fmd_timer_t *ftp;
@@ -626,6 +641,7 @@ nvlist_t *
 fmd_nvl_create_fault(fmd_hdl_t *hdl, const char *class, uint8_t certainty,
     nvlist_t *asru, nvlist_t *fru, nvlist_t *resource)
 {
+	(void) hdl;
 	nvlist_t *nvl;
 	int err = 0;
 
@@ -689,6 +705,7 @@ fmd_strmatch(const char *s, const char *p)
 int
 fmd_nvl_class_match(fmd_hdl_t *hdl, nvlist_t *nvl, const char *pattern)
 {
+	(void) hdl;
 	char *class;
 
 	return (nvl != NULL &&
@@ -699,6 +716,7 @@ fmd_nvl_class_match(fmd_hdl_t *hdl, nvlist_t *nvl, const char *pattern)
 nvlist_t *
 fmd_nvl_alloc(fmd_hdl_t *hdl, int flags)
 {
+	(void) hdl, (void) flags;
 	nvlist_t *nvl = NULL;
 
 	if (nvlist_alloc(&nvl, NV_UNIQUE_NAME, 0) != 0)

--- a/cmd/zed/agents/zfs_agents.c
+++ b/cmd/zed/agents/zfs_agents.c
@@ -327,6 +327,8 @@ zfs_agent_dispatch(const char *class, const char *subclass, nvlist_t *nvl)
 static void *
 zfs_agent_consumer_thread(void *arg)
 {
+	(void) arg;
+
 	for (;;) {
 		agent_event_t *event;
 

--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -263,7 +263,6 @@ replace_with_spare(fmd_hdl_t *hdl, zpool_handle_t *zhp, nvlist_t *vdev)
  * ASRU is now usable.  ZFS has found the device to be present and
  * functioning.
  */
-/*ARGSUSED*/
 static void
 zfs_vdev_repair(fmd_hdl_t *hdl, nvlist_t *nvl)
 {
@@ -302,11 +301,11 @@ zfs_vdev_repair(fmd_hdl_t *hdl, nvlist_t *nvl)
 	    vdev_guid, pool_guid);
 }
 
-/*ARGSUSED*/
 static void
 zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
     const char *class)
 {
+	(void) ep;
 	uint64_t pool_guid, vdev_guid;
 	zpool_handle_t *zhp;
 	nvlist_t *resource, *fault;

--- a/cmd/zed/zed.c
+++ b/cmd/zed/zed.c
@@ -36,6 +36,7 @@ static volatile sig_atomic_t _got_hup = 0;
 static void
 _exit_handler(int signum)
 {
+	(void) signum;
 	_got_exit = 1;
 }
 
@@ -45,6 +46,7 @@ _exit_handler(int signum)
 static void
 _hup_handler(int signum)
 {
+	(void) signum;
 	_got_hup = 1;
 }
 

--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -187,11 +187,14 @@ _zed_exec_fork_child(uint64_t eid, const char *dir, const char *prog,
 
 static void
 _nop(int sig)
-{}
+{
+	(void) sig;
+}
 
 static void *
 _reap_children(void *arg)
 {
+	(void) arg;
 	struct launched_process_node node, *pnode;
 	pid_t pid;
 	int status;

--- a/cmd/zfs/zfs_iter.c
+++ b/cmd/zfs/zfs_iter.c
@@ -267,9 +267,8 @@ zfs_list_only_by_fast(const zprop_list_t *p)
 	return (B_TRUE);
 }
 
-/* ARGSUSED */
 static int
-zfs_compare(const void *larg, const void *rarg, void *unused)
+zfs_compare(const void *larg, const void *rarg)
 {
 	zfs_handle_t *l = ((zfs_node_t *)larg)->zn_handle;
 	zfs_handle_t *r = ((zfs_node_t *)rarg)->zn_handle;
@@ -430,7 +429,7 @@ zfs_sort(const void *larg, const void *rarg, void *data)
 		}
 	}
 
-	return (zfs_compare(larg, rarg, NULL));
+	return (zfs_compare(larg, rarg));
 }
 
 int

--- a/cmd/zhack/zhack.c
+++ b/cmd/zhack/zhack.c
@@ -107,11 +107,12 @@ fatal(spa_t *spa, void *tag, const char *fmt, ...)
 	exit(1);
 }
 
-/* ARGSUSED */
 static int
 space_delta_cb(dmu_object_type_t bonustype, const void *data,
     zfs_file_info_t *zoi)
 {
+	(void) data, (void) zoi;
+
 	/*
 	 * Is it a valid type of object to track?
 	 */

--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -497,11 +497,11 @@ print_all_handlers(void)
 	return (count + total);
 }
 
-/* ARGSUSED */
 static int
 cancel_one_handler(int id, const char *pool, zinject_record_t *record,
     void *data)
 {
+	(void) pool, (void) record, (void) data;
 	zfs_cmd_t zc = {"\0"};
 
 	zc.zc_guid = (uint64_t)id;

--- a/cmd/zpool/os/freebsd/zpool_vdev_os.c
+++ b/cmd/zpool/os/freebsd/zpool_vdev_os.c
@@ -86,6 +86,7 @@ int
 check_device(const char *name, boolean_t force, boolean_t isspare,
     boolean_t iswholedisk)
 {
+	(void) iswholedisk;
 	char path[MAXPATHLEN];
 
 	if (strncmp(name, _PATH_DEV, sizeof (_PATH_DEV) - 1) != 0)
@@ -99,6 +100,7 @@ check_device(const char *name, boolean_t force, boolean_t isspare,
 boolean_t
 check_sector_size_database(char *path, int *sector_size)
 {
+	(void) path, (void) sector_size;
 	return (0);
 }
 

--- a/cmd/zpool/os/linux/zpool_vdev_os.c
+++ b/cmd/zpool/os/linux/zpool_vdev_os.c
@@ -409,6 +409,7 @@ check_device(const char *path, boolean_t force,
 void
 after_zpool_upgrade(zpool_handle_t *zhp)
 {
+	(void) zhp;
 }
 
 int

--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -63,10 +63,10 @@ struct zpool_list {
 	zfs_type_t	zl_type;
 };
 
-/* ARGSUSED */
 static int
 zpool_compare(const void *larg, const void *rarg, void *unused)
 {
+	(void) unused;
 	zpool_handle_t *l = ((zpool_node_t *)larg)->zn_handle;
 	zpool_handle_t *r = ((zpool_node_t *)rarg)->zn_handle;
 	const char *lname = zpool_get_name(l);

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -1189,10 +1189,10 @@ ztest_kill(ztest_shared_t *zs)
 	(void) kill(getpid(), SIGKILL);
 }
 
-/* ARGSUSED */
 static void
 ztest_record_enospc(const char *s)
 {
+	(void) s;
 	ztest_shared->zs_enospc_count++;
 }
 
@@ -2389,10 +2389,10 @@ zil_replay_func_t *ztest_replay_vector[TX_MAX_TYPE] = {
  * ZIL get_data callbacks
  */
 
-/* ARGSUSED */
 static void
 ztest_get_done(zgd_t *zgd, int error)
 {
+	(void) error;
 	ztest_ds_t *zd = zgd->zgd_private;
 	uint64_t object = ((rl_t *)zgd->zgd_lr)->rl_object;
 
@@ -2409,6 +2409,7 @@ static int
 ztest_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
     struct lwb *lwb, zio_t *zio)
 {
+	(void) arg2;
 	ztest_ds_t *zd = arg;
 	objset_t *os = zd->zd_os;
 	uint64_t object = lr->lr_foid;
@@ -2869,10 +2870,10 @@ ztest_object_init(ztest_ds_t *zd, ztest_od_t *od, size_t size, boolean_t remove)
 	return (rv);
 }
 
-/* ARGSUSED */
 void
 ztest_zil_commit(ztest_ds_t *zd, uint64_t id)
 {
+	(void) id;
 	zilog_t *zilog = zd->zd_zilog;
 
 	(void) pthread_rwlock_rdlock(&zd->zd_zilog_lock);
@@ -2898,10 +2899,10 @@ ztest_zil_commit(ztest_ds_t *zd, uint64_t id)
  * mount/unmount operation.  We hold the dataset across these operations in an
  * attempt to expose any implicit assumptions about ZIL management.
  */
-/* ARGSUSED */
 void
 ztest_zil_remount(ztest_ds_t *zd, uint64_t id)
 {
+	(void) id;
 	objset_t *os = zd->zd_os;
 
 	/*
@@ -2935,10 +2936,10 @@ ztest_zil_remount(ztest_ds_t *zd, uint64_t id)
  * Verify that we can't destroy an active pool, create an existing pool,
  * or create a pool with a bad vdev spec.
  */
-/* ARGSUSED */
 void
 ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	ztest_shared_opts_t *zo = &ztest_opts;
 	spa_t *spa;
 	nvlist_t *nvroot;
@@ -2998,10 +2999,10 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
  * Start and then stop the MMP threads to ensure the startup and shutdown code
  * works properly.  Actual protection and property-related code tested via ZTS.
  */
-/* ARGSUSED */
 void
 ztest_mmp_enable_disable(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	ztest_shared_opts_t *zo = &ztest_opts;
 	spa_t *spa = ztest_spa;
 
@@ -3044,10 +3045,10 @@ ztest_mmp_enable_disable(ztest_ds_t *zd, uint64_t id)
 	spa_config_exit(spa, SCL_CONFIG, FTAG);
 }
 
-/* ARGSUSED */
 void
 ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	spa_t *spa;
 	uint64_t initial_version = SPA_VERSION_INITIAL;
 	uint64_t version, newversion;
@@ -3164,10 +3165,10 @@ ztest_spa_discard_checkpoint(spa_t *spa)
 
 }
 
-/* ARGSUSED */
 void
 ztest_spa_checkpoint_create_discard(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	spa_t *spa = ztest_spa;
 
 	mutex_enter(&ztest_checkpoint_lock);
@@ -3208,10 +3209,10 @@ spa_num_top_vdevs(spa_t *spa)
 /*
  * Verify that vdev_add() works as expected.
  */
-/* ARGSUSED */
 void
 ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
 	spa_t *spa = ztest_spa;
 	uint64_t leaves;
@@ -3298,10 +3299,10 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 	mutex_exit(&ztest_vdev_lock);
 }
 
-/* ARGSUSED */
 void
 ztest_vdev_class_add(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
 	spa_t *spa = ztest_spa;
 	uint64_t leaves;
@@ -3379,10 +3380,10 @@ ztest_vdev_class_add(ztest_ds_t *zd, uint64_t id)
 /*
  * Verify that adding/removing aux devices (l2arc, hot spare) works as expected.
  */
-/* ARGSUSED */
 void
 ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
 	spa_t *spa = ztest_spa;
 	vdev_t *rvd = spa->spa_root_vdev;
@@ -3491,10 +3492,10 @@ ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 /*
  * split a pool if it has mirror tlvdevs
  */
-/* ARGSUSED */
 void
 ztest_split_pool(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
 	spa_t *spa = ztest_spa;
 	vdev_t *rvd = spa->spa_root_vdev;
@@ -3586,10 +3587,10 @@ ztest_split_pool(ztest_ds_t *zd, uint64_t id)
 /*
  * Verify that we can attach and detach devices.
  */
-/* ARGSUSED */
 void
 ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
 	spa_t *spa = ztest_spa;
 	spa_aux_vdev_t *sav = &spa->spa_spares;
@@ -3829,10 +3830,10 @@ out:
 	umem_free(newpath, MAXPATHLEN);
 }
 
-/* ARGSUSED */
 void
 ztest_device_removal(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	spa_t *spa = ztest_spa;
 	vdev_t *vd;
 	uint64_t guid;
@@ -3922,10 +3923,10 @@ grow_vdev(vdev_t *vd, void *arg)
 /*
  * Callback function which expands a given vdev by calling vdev_online().
  */
-/* ARGSUSED */
 static vdev_t *
 online_vdev(vdev_t *vd, void *arg)
 {
+	(void) arg;
 	spa_t *spa = vd->vdev_spa;
 	vdev_t *tvd = vd->vdev_top;
 	uint64_t guid = vd->vdev_guid;
@@ -4006,10 +4007,10 @@ vdev_walk_tree(vdev_t *vd, vdev_t *(*func)(vdev_t *, void *), void *arg)
 /*
  * Verify that dynamic LUN growth works as expected.
  */
-/* ARGSUSED */
 void
 ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	spa_t *spa = ztest_spa;
 	vdev_t *vd, *tvd;
 	metaslab_class_t *mc;
@@ -4161,10 +4162,11 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 /*
  * Verify that dmu_objset_{create,destroy,open,close} work as expected.
  */
-/* ARGSUSED */
 static void
 ztest_objset_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
 {
+	(void) arg, (void) cr;
+
 	/*
 	 * Create the objects common to all ztest datasets.
 	 */
@@ -4241,10 +4243,10 @@ ztest_dataset_create(char *dsname)
 	    ZFS_SYNC_ALWAYS, B_FALSE));
 }
 
-/* ARGSUSED */
 static int
 ztest_objset_destroy_cb(const char *name, void *arg)
 {
+	(void) arg;
 	objset_t *os;
 	dmu_object_info_t doi;
 	int error;
@@ -4317,10 +4319,10 @@ ztest_snapshot_destroy(char *osname, uint64_t id)
 	return (B_TRUE);
 }
 
-/* ARGSUSED */
 void
 ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd;
 	ztest_ds_t *zdtmp;
 	int iters;
 	int error;
@@ -4642,6 +4644,7 @@ ztest_dmu_object_alloc_free(ztest_ds_t *zd, uint64_t id)
 void
 ztest_dmu_object_next_chunk(ztest_ds_t *zd, uint64_t id)
 {
+	(void) id;
 	objset_t *os = zd->zd_os;
 	int dnodes_per_chunk = 1 << dmu_object_alloc_chunk_shift;
 	uint64_t object;
@@ -5188,10 +5191,10 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 	umem_free(od, size);
 }
 
-/* ARGSUSED */
 void
 ztest_dmu_write_parallel(ztest_ds_t *zd, uint64_t id)
 {
+	(void) id;
 	ztest_od_t *od;
 
 	od = umem_alloc(sizeof (ztest_od_t), UMEM_NOFAIL);
@@ -5450,10 +5453,10 @@ out:
 	umem_free(od, sizeof (ztest_od_t));
 }
 
-/* ARGSUSED */
 void
 ztest_zap_parallel(ztest_ds_t *zd, uint64_t id)
 {
+	(void) id;
 	objset_t *os = zd->zd_os;
 	ztest_od_t *od;
 	uint64_t txg, object, count, wsize, wc, zl_wsize, zl_wc;
@@ -5785,10 +5788,10 @@ ztest_dmu_commit_callbacks(ztest_ds_t *zd, uint64_t id)
  * are consistent what was stored in the block tag when it was created,
  * and that its unused bonus buffer space has not been overwritten.
  */
-/* ARGSUSED */
 void
 ztest_verify_dnode_bt(ztest_ds_t *zd, uint64_t id)
 {
+	(void) id;
 	objset_t *os = zd->zd_os;
 	uint64_t obj;
 	int err = 0;
@@ -5820,21 +5823,20 @@ ztest_verify_dnode_bt(ztest_ds_t *zd, uint64_t id)
 	}
 }
 
-/* ARGSUSED */
 void
 ztest_dsl_prop_get_set(ztest_ds_t *zd, uint64_t id)
 {
+	(void) id;
 	zfs_prop_t proplist[] = {
 		ZFS_PROP_CHECKSUM,
 		ZFS_PROP_COMPRESSION,
 		ZFS_PROP_COPIES,
 		ZFS_PROP_DEDUP
 	};
-	int p;
 
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);
 
-	for (p = 0; p < sizeof (proplist) / sizeof (proplist[0]); p++)
+	for (int p = 0; p < sizeof (proplist) / sizeof (proplist[0]); p++)
 		(void) ztest_dsl_prop_set_uint64(zd->zd_name, proplist[p],
 		    ztest_random_dsl_prop(proplist[p]), (int)ztest_random(2));
 
@@ -5844,10 +5846,10 @@ ztest_dsl_prop_get_set(ztest_ds_t *zd, uint64_t id)
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
 }
 
-/* ARGSUSED */
 void
 ztest_spa_prop_get_set(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	nvlist_t *props = NULL;
 
 	(void) pthread_rwlock_rdlock(&ztest_name_lock);
@@ -6008,10 +6010,10 @@ out:
 /*
  * Inject random faults into the on-disk data.
  */
-/* ARGSUSED */
 void
 ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
 	spa_t *spa = ztest_spa;
 	int fd;
@@ -6324,10 +6326,10 @@ ztest_scrub_impl(spa_t *spa)
 /*
  * Scrub the pool.
  */
-/* ARGSUSED */
 void
 ztest_scrub(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	spa_t *spa = ztest_spa;
 	int error;
 
@@ -6352,10 +6354,10 @@ ztest_scrub(ztest_ds_t *zd, uint64_t id)
 /*
  * Change the guid for the pool.
  */
-/* ARGSUSED */
 void
 ztest_reguid(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	spa_t *spa = ztest_spa;
 	uint64_t orig, load;
 	int error;
@@ -6385,6 +6387,7 @@ ztest_reguid(ztest_ds_t *zd, uint64_t id)
 void
 ztest_fletcher(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	hrtime_t end = gethrtime() + NANOSEC;
 
 	while (gethrtime() <= end) {
@@ -6454,6 +6457,7 @@ ztest_fletcher(ztest_ds_t *zd, uint64_t id)
 void
 ztest_fletcher_incr(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	void *buf;
 	size_t size;
 	int *ptr;
@@ -6657,10 +6661,10 @@ ztest_random_concrete_vdev_leaf(vdev_t *vd)
 	return (ztest_random_concrete_vdev_leaf(eligible[child_no]));
 }
 
-/* ARGSUSED */
 void
 ztest_initialize(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	spa_t *spa = ztest_spa;
 	int error = 0;
 
@@ -6729,10 +6733,10 @@ ztest_initialize(ztest_ds_t *zd, uint64_t id)
 	mutex_exit(&ztest_vdev_lock);
 }
 
-/* ARGSUSED */
 void
 ztest_trim(ztest_ds_t *zd, uint64_t id)
 {
+	(void) zd, (void) id;
 	spa_t *spa = ztest_spa;
 	int error = 0;
 
@@ -7246,10 +7250,10 @@ ztest_dataset_close(int d)
 	ztest_zd_fini(zd);
 }
 
-/* ARGSUSED */
 static int
 ztest_replay_zil_cb(const char *name, void *arg)
 {
+	(void) arg;
 	objset_t *os;
 	ztest_ds_t *zdtmp;
 
@@ -7371,7 +7375,7 @@ ztest_freeze(void)
 }
 
 static void
-ztest_import_impl(ztest_shared_t *zs)
+ztest_import_impl(void)
 {
 	importargs_t args = { 0 };
 	nvlist_t *cfg = NULL;
@@ -7404,7 +7408,7 @@ ztest_import(ztest_shared_t *zs)
 
 	kernel_init(SPA_MODE_READ | SPA_MODE_WRITE);
 
-	ztest_import_impl(zs);
+	ztest_import_impl();
 
 	VERIFY0(spa_open(ztest_opts.zo_pool, &spa, FTAG));
 	zs->zs_metaslab_sz =
@@ -7470,7 +7474,7 @@ ztest_run(ztest_shared_t *zs)
 	error = spa_open(ztest_opts.zo_pool, &spa, FTAG);
 	if (error) {
 		VERIFY3S(error, ==, ENOENT);
-		ztest_import_impl(zs);
+		ztest_import_impl();
 		VERIFY0(spa_open(ztest_opts.zo_pool, &spa, FTAG));
 		zs->zs_metaslab_sz =
 		    1ULL << spa->spa_root_vdev->vdev_child[0]->vdev_ms_shift;

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -61,9 +61,9 @@ install() {
 		dracut_install /usr/lib*/gcc/**/libgcc_s.so*
 	fi
 	# shellcheck disable=SC2050
-	if [ "@LIBFETCH_DYNAMIC@" != 0 ]; then
+	if [ @LIBFETCH_DYNAMIC@ != 0 ]; then
 		for d in $libdirs; do
-			[ -e "$d/@LIBFETCH_SONAME@" ] && dracut_install "$d/@LIBFETCH_SONAME@"
+			[ -e "$d/"@LIBFETCH_SONAME@ ] && dracut_install "$d/"@LIBFETCH_SONAME@
 		done
 	fi
 	dracut_install @mounthelperdir@/mount.zfs

--- a/contrib/initramfs/hooks/zfs.in
+++ b/contrib/initramfs/hooks/zfs.in
@@ -30,8 +30,8 @@ find /lib/ -type f -name "libgcc_s.so.[1-9]" | while read -r libgcc; do
 done
 
 # shellcheck disable=SC2050
-if [ "@LIBFETCH_DYNAMIC@" != 0 ]; then
-	find /lib/ -name "@LIBFETCH_SONAME@" | while read -r libfetch; do
+if [ @LIBFETCH_DYNAMIC@ != 0 ]; then
+	find /lib/ -name @LIBFETCH_SONAME@ | while read -r libfetch; do
 		copy_exec "$libfetch"
 	done
 fi

--- a/contrib/pam_zfs_key/pam_zfs_key.c
+++ b/contrib/pam_zfs_key/pam_zfs_key.c
@@ -219,6 +219,8 @@ pw_clear(pam_handle_t *pamh)
 static void
 destroy_pw(pam_handle_t *pamh, void *data, int errcode)
 {
+	(void) pamh, (void) errcode;
+
 	if (data != NULL) {
 		pw_free((pw_password_t *)data);
 	}
@@ -638,6 +640,8 @@ PAM_EXTERN int
 pam_sm_authenticate(pam_handle_t *pamh, int flags,
     int argc, const char **argv)
 {
+	(void) flags, (void) argc, (void) argv;
+
 	if (pw_fetch_lazy(pamh) == NULL) {
 		return (PAM_AUTH_ERR);
 	}
@@ -650,6 +654,7 @@ PAM_EXTERN int
 pam_sm_setcred(pam_handle_t *pamh, int flags,
     int argc, const char **argv)
 {
+	(void) pamh, (void) flags, (void) argc, (void) argv;
 	return (PAM_SUCCESS);
 }
 
@@ -737,6 +742,8 @@ PAM_EXTERN int
 pam_sm_open_session(pam_handle_t *pamh, int flags,
     int argc, const char **argv)
 {
+	(void) flags;
+
 	if (geteuid() != 0) {
 		pam_syslog(pamh, LOG_ERR,
 		    "Cannot zfs_mount when not being root.");
@@ -791,6 +798,8 @@ PAM_EXTERN int
 pam_sm_close_session(pam_handle_t *pamh, int flags,
     int argc, const char **argv)
 {
+	(void) flags;
+
 	if (geteuid() != 0) {
 		pam_syslog(pamh, LOG_ERR,
 		    "Cannot zfs_mount when not being root.");

--- a/tests/zfs-tests/cmd/btree_test/btree_test.c
+++ b/tests/zfs-tests/cmd/btree_test/btree_test.c
@@ -294,6 +294,7 @@ drain_tree(zfs_btree_t *bt, char *why)
 static int
 stress_tree(zfs_btree_t *bt, char *why)
 {
+	(void) why;
 	avl_tree_t avl;
 	int_node_t *node;
 	struct timeval tp;

--- a/tests/zfs-tests/cmd/largest_file/largest_file.c
+++ b/tests/zfs-tests/cmd/largest_file/largest_file.c
@@ -137,9 +137,9 @@ usage(char *name)
 	exit(1);
 }
 
-/* ARGSUSED */
 static void
 sigxfsz(int signo)
 {
+	(void) signo;
 	(void) printf("\nlargest_file: sigxfsz() caught SIGXFSZ\n");
 }

--- a/tests/zfs-tests/cmd/mmap_libaio/mmap_libaio.c
+++ b/tests/zfs-tests/cmd/mmap_libaio/mmap_libaio.c
@@ -52,6 +52,7 @@ do_sync_io(struct iocb *iocb)
 int
 main(int argc, char **argv)
 {
+	(void) argc;
 	char *buf;
 	int page_size = getpagesize();
 	int buf_size = strtol(argv[2], NULL, 0);

--- a/tests/zfs-tests/cmd/rename_dir/rename_dir.c
+++ b/tests/zfs-tests/cmd/rename_dir/rename_dir.c
@@ -49,7 +49,7 @@
 #include <strings.h>
 
 int
-main(int argc, char *argvp[])
+main(void)
 {
 	int i = 1;
 

--- a/tests/zfs-tests/cmd/rm_lnkcnt_zero_file/rm_lnkcnt_zero_file.c
+++ b/tests/zfs-tests/cmd/rm_lnkcnt_zero_file/rm_lnkcnt_zero_file.c
@@ -55,10 +55,10 @@ pickidx(void)
 	return (random() % 1000);
 }
 
-/* ARGSUSED */
 static void *
 mover(void *a)
 {
+	(void) a;
 	char buf[256];
 	int idx, len, ret;
 
@@ -75,10 +75,10 @@ mover(void *a)
 	return (NULL);
 }
 
-/* ARGSUSED */
 static void *
 cleaner(void *a)
 {
+	(void) a;
 	char buf[256];
 	int idx, len, ret;
 

--- a/tests/zfs-tests/cmd/xattrtest/xattrtest.c
+++ b/tests/zfs-tests/cmd/xattrtest/xattrtest.c
@@ -96,12 +96,12 @@ static char script[PATH_MAX] = "/bin/true";
 static char xattrbytes[XATTR_SIZE_MAX];
 
 static int
-usage(int argc, char **argv)
+usage(char *argv0)
 {
 	fprintf(stderr,
 	    "usage: %s [-hvycdrRk] [-n <nth>] [-f <files>] [-x <xattrs>]\n"
 	    "       [-s <bytes>] [-p <path>] [-t <script> ] [-o <phase>]\n",
-	    argv[0]);
+	    argv0);
 
 	fprintf(stderr,
 	    "  --help        -h           This help\n"
@@ -136,7 +136,7 @@ parse_args(int argc, char **argv)
 	while ((c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1) {
 		switch (c) {
 		case 'h':
-			return (usage(argc, argv));
+			return (usage(argv[0]));
 		case 'v':
 			verbose++;
 			break;

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/ereports.c
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/ereports.c
@@ -146,9 +146,8 @@ ereports_dump(libzfs_handle_t *zhdl, int zevent_fd)
 	}
 }
 
-/* ARGSUSED */
 int
-main(int argc, char **argv)
+main(void)
 {
 	libzfs_handle_t *hdl;
 	int fd;

--- a/tests/zfs-tests/tests/functional/ctime/ctime.c
+++ b/tests/zfs-tests/tests/functional/ctime/ctime.c
@@ -303,9 +303,8 @@ static timetest_t timetest_table[] = {
 
 #define	NCOMMAND (sizeof (timetest_table) / sizeof (timetest_table[0]))
 
-/* ARGSUSED */
 int
-main(int argc, char *argv[])
+main(void)
 {
 	int i, ret, fd;
 	char *penv[] = {"TESTDIR", "TESTFILE0"};

--- a/tests/zfs-tests/tests/functional/hkdf/hkdf_test.c
+++ b/tests/zfs-tests/tests/functional/hkdf/hkdf_test.c
@@ -211,7 +211,7 @@ run_test(int i, hkdf_tv_t *tv)
 }
 
 int
-main(int argc, char **argv)
+main(void)
 {
 	int ret, i;
 

--- a/tests/zfs-tests/tests/functional/libzfs/many_fds.c
+++ b/tests/zfs-tests/tests/functional/libzfs/many_fds.c
@@ -35,9 +35,8 @@
 /*
  * Check if libzfs works with more than 255 held file handles.
  */
-/* ARGSUSED */
 int
-main(int argc, char **argv)
+main(void)
 {
 	int i;
 	struct rlimit limit;

--- a/tests/zfs-tests/tests/functional/tmpfile/tmpfile_001_pos.c
+++ b/tests/zfs-tests/tests/functional/tmpfile/tmpfile_001_pos.c
@@ -31,15 +31,13 @@
 static void
 fill_random(char *buf, int len)
 {
-	int i;
 	srand(time(NULL));
-	for (i = 0; i < len; i++) {
+	for (int i = 0; i < len; i++)
 		buf[i] = (char)rand();
-	}
 }
 
 int
-main(int argc, char *argv[])
+main(void)
 {
 	int i, fd;
 	char buf1[BSZ], buf2[BSZ] = {};

--- a/tests/zfs-tests/tests/functional/tmpfile/tmpfile_002_pos.c
+++ b/tests/zfs-tests/tests/functional/tmpfile/tmpfile_002_pos.c
@@ -25,7 +25,7 @@
  */
 
 int
-main(int argc, char *argv[])
+main(void)
 {
 	int i, fd, ret;
 	char spath[1024], dpath[1024];

--- a/tests/zfs-tests/tests/functional/tmpfile/tmpfile_003_pos.c
+++ b/tests/zfs-tests/tests/functional/tmpfile/tmpfile_003_pos.c
@@ -24,7 +24,7 @@
  */
 
 int
-main(int argc, char *argv[])
+main(void)
 {
 	int i, fd;
 	char spath[1024], dpath[1024];

--- a/tests/zfs-tests/tests/functional/tmpfile/tmpfile_stat_mode.c
+++ b/tests/zfs-tests/tests/functional/tmpfile/tmpfile_stat_mode.c
@@ -110,7 +110,7 @@ test_stat_mode(mode_t mask)
 }
 
 int
-main(int argc, char *argv[])
+main(void)
 {
 	fprintf(stdout, "Verify stat(2) for O_TMPFILE file considers umask.\n");
 


### PR DESCRIPTION
### Motivation and Context
~~A comment is a comment.~~ there are 2 unused arguments among us.

### Description
~~Draft because on top of #12829, otherwise~~ g2g

Also, in zdb, is 
```c
static void dump_uint8(objset_t *os, uint64_t object, void *data, size_t size)
```
supposed to be empty?

### How Has This Been Tested?
`make -C cmd/`, `-C tests/`, and `-C contrib` builds clean on clang 14 when configured with `-Wall -Wextra -Wno-sign-compare -Wno-missing-field-initializers` in CFLAGS

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – likewise
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
