### PR TITLE
argSUSed: lib (so also the bit of module that is built for lib), include

### DIFF
--- a/include/os/freebsd/spl/sys/debug.h
+++ b/include/os/freebsd/spl/sys/debug.h
@@ -133,14 +133,14 @@ void spl_dumpstack(void);
  */
 #ifdef NDEBUG
 
-#define	ASSERT(x)		((void)0)
-#define	ASSERT3B(x,y,z)		((void)0)
-#define	ASSERT3S(x,y,z)		((void)0)
-#define	ASSERT3U(x,y,z)		((void)0)
-#define	ASSERT3P(x,y,z)		((void)0)
-#define	ASSERT0(x)		((void)0)
-#define	IMPLY(A, B)		((void)0)
-#define	EQUIV(A, B)		((void)0)
+#define	ASSERT(x)		((void)sizeof(x))
+#define	ASSERT3B(x,y,z)		((void)sizeof(x), (void)sizeof(z))
+#define	ASSERT3S(x,y,z)		((void)sizeof(x), (void)sizeof(z))
+#define	ASSERT3U(x,y,z)		((void)sizeof(x), (void)sizeof(z))
+#define	ASSERT3P(x,y,z)		((void)sizeof(x), (void)sizeof(z))
+#define	ASSERT0(x)		((void)sizeof(x))
+#define	IMPLY(A, B)		((void)sizeof(A), (void)sizeof(B))
+#define	EQUIV(A, B)		((void)sizeof(A), (void)sizeof(B))
 
 /*
  * Debugging enabled (--enable-debug)

--- a/include/os/linux/spl/sys/debug.h
+++ b/include/os/linux/spl/sys/debug.h
@@ -133,14 +133,14 @@ void spl_dumpstack(void);
  */
 #ifdef NDEBUG
 
-#define	ASSERT(x)		((void)0)
-#define	ASSERT3B(x,y,z)		((void)0)
-#define	ASSERT3S(x,y,z)		((void)0)
-#define	ASSERT3U(x,y,z)		((void)0)
-#define	ASSERT3P(x,y,z)		((void)0)
-#define	ASSERT0(x)		((void)0)
-#define	IMPLY(A, B)		((void)0)
-#define	EQUIV(A, B)		((void)0)
+#define	ASSERT(x)		((void)sizeof(x))
+#define	ASSERT3B(x,y,z)		((void)sizeof(x), (void)sizeof(z))
+#define	ASSERT3S(x,y,z)		((void)sizeof(x), (void)sizeof(z))
+#define	ASSERT3U(x,y,z)		((void)sizeof(x), (void)sizeof(z))
+#define	ASSERT3P(x,y,z)		((void)sizeof(x), (void)sizeof(z))
+#define	ASSERT0(x)		((void)sizeof(x))
+#define	IMPLY(A, B)		((void)sizeof(A), (void)sizeof(B))
+#define	EQUIV(A, B)		((void)sizeof(A), (void)sizeof(B))
 
 /*
  * Debugging enabled (--enable-debug)

--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -295,6 +295,8 @@ void arc_buf_freeze(arc_buf_t *buf);
 void arc_buf_thaw(arc_buf_t *buf);
 #ifdef ZFS_DEBUG
 int arc_referenced(arc_buf_t *buf);
+#else
+#define	arc_referenced(buf) ((void) sizeof (buf), 0)
 #endif
 
 int arc_read(zio_t *pio, spa_t *spa, const blkptr_t *bp,

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -664,7 +664,6 @@ typedef struct dmu_buf_user {
  * NOTE: This function should only be called once on a given dmu_buf_user_t.
  *       To allow enforcement of this, dbu must already be zeroed on entry.
  */
-/*ARGSUSED*/
 static inline void
 dmu_buf_init_user(dmu_buf_user_t *dbu, dmu_buf_evict_func_t *evict_func_sync,
     dmu_buf_evict_func_t *evict_func_async,

--- a/include/sys/qat.h
+++ b/include/sys/qat.h
@@ -171,7 +171,7 @@ extern int qat_init(void);
 extern void qat_fini(void);
 
 /* fake CpaStatus used to indicate data was not compressible */
-#define	CPA_STATUS_INCOMPRESSIBLE				(-127)
+#define	CPA_STATUS_INCOMPRESSIBLE		(-127)
 
 extern boolean_t qat_dc_use_accel(size_t s_len);
 extern boolean_t qat_crypt_use_accel(size_t s_len);
@@ -184,16 +184,24 @@ extern int qat_crypt(qat_encrypt_dir_t dir, uint8_t *src_buf, uint8_t *dst_buf,
 extern int qat_checksum(uint64_t cksum, uint8_t *buf, uint64_t size,
     zio_cksum_t *zcp);
 #else
-#define	CPA_STATUS_SUCCESS					0
-#define	CPA_STATUS_INCOMPRESSIBLE				(-127)
+#define	CPA_STATUS_SUCCESS			0
+#define	CPA_STATUS_INCOMPRESSIBLE		(-127)
 #define	qat_init()
 #define	qat_fini()
-#define	qat_dc_use_accel(s_len)					0
-#define	qat_crypt_use_accel(s_len)				0
-#define	qat_checksum_use_accel(s_len)				0
-#define	qat_compress(dir, s, sl, d, dl, cl)			0
-#define	qat_crypt(dir, s, d, a, al, i, db, k, c, el)		0
-#define	qat_checksum(c, buf, s, z)				0
+#define	qat_dc_use_accel(s_len)			((void) sizeof (s_len), 0)
+#define	qat_crypt_use_accel(s_len)		((void) sizeof (s_len), 0)
+#define	qat_checksum_use_accel(s_len)		((void) sizeof (s_len), 0)
+#define	qat_compress(dir, s, sl, d, dl, cl)			\
+	((void) sizeof (dir), (void) sizeof (s), (void) sizeof (sl), \
+	    (void) sizeof (d), (void) sizeof (dl), (void) sizeof (cl), 0)
+#define	qat_crypt(dir, s, d, a, al, i, db, k, c, el)		\
+	((void) sizeof (dir), (void) sizeof (s), (void) sizeof (d), \
+	    (void) sizeof (a),  (void) sizeof (al), (void) sizeof (i), \
+	    (void) sizeof (db), (void) sizeof (k), (void) sizeof (c), \
+	    (void) sizeof (el), 0)
+#define	qat_checksum(c, buf, s, z)				\
+	((void) sizeof (c), (void) sizeof (buf), (void) sizeof (s), \
+	    (void) sizeof (z), 0)
 #endif
 
 #endif /* _SYS_QAT_H */

--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -1564,6 +1564,7 @@ efi_type(int fd)
 	}
 	return (0);
 #else
+	(void) fd;
 	return (ENOSYS);
 #endif
 }

--- a/lib/libnvpair/libnvpair.c
+++ b/lib/libnvpair/libnvpair.c
@@ -253,11 +253,11 @@ NVLIST_ARRPRTFUNC(int64_array, int64_t, longlong_t, "%lld")
 NVLIST_ARRPRTFUNC(uint64_array, uint64_t, u_longlong_t, "0x%llx")
 NVLIST_ARRPRTFUNC(string_array, char *, char *, "%s")
 
-/*ARGSUSED*/
 static int
 nvprint_nvlist(nvlist_prtctl_t pctl, void *private,
     nvlist_t *nvl, const char *name, nvlist_t *value)
 {
+	(void) private, (void) nvl;
 	FILE *fp = pctl->nvprt_fp;
 
 	indent(pctl, 1);
@@ -273,11 +273,11 @@ nvprint_nvlist(nvlist_prtctl_t pctl, void *private,
 	return (1);
 }
 
-/*ARGSUSED*/
 static int
 nvaprint_nvlist_array(nvlist_prtctl_t pctl, void *private,
     nvlist_t *nvl, const char *name, nvlist_t **valuep, uint_t count)
 {
+	(void) private, (void) nvl;
 	FILE *fp = pctl->nvprt_fp;
 	uint_t i;
 

--- a/lib/libnvpair/nvpair_alloc_system.c
+++ b/lib/libnvpair/nvpair_alloc_system.c
@@ -36,10 +36,10 @@ nv_alloc_sys(nv_alloc_t *nva, size_t size)
 	return (kmem_alloc(size, (int)(uintptr_t)nva->nva_arg));
 }
 
-/*ARGSUSED*/
 static void
 nv_free_sys(nv_alloc_t *nva, void *buf, size_t size)
 {
+	(void) nva;
 	kmem_free(buf, size);
 }
 

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -249,6 +249,8 @@ fullerr:
 static boolean_t
 nfs_is_shared_cb(void *userdata, char *line, boolean_t found_mountpoint)
 {
+	(void) line;
+
 	boolean_t *found = userdata;
 	*found = found_mountpoint;
 	return (!found_mountpoint);

--- a/lib/libshare/os/freebsd/nfs.c
+++ b/lib/libshare/os/freebsd/nfs.c
@@ -134,6 +134,7 @@ nfs_enable_share(sa_share_impl_t impl_share)
 static int
 nfs_disable_share_impl(sa_share_impl_t impl_share, FILE *tmpfile)
 {
+	(void) impl_share, (void) tmpfile;
 	return (SA_OK);
 }
 

--- a/lib/libshare/os/linux/nfs.c
+++ b/lib/libshare/os/linux/nfs.c
@@ -440,6 +440,7 @@ nfs_enable_share(sa_share_impl_t impl_share)
 static int
 nfs_disable_share_impl(sa_share_impl_t impl_share, FILE *tmpfile)
 {
+	(void) impl_share, (void) tmpfile;
 	return (SA_OK);
 }
 

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -120,15 +120,15 @@ do {									\
 	__compile_time_assertion__ ## y[(x) ? 1 : -1]
 
 #ifdef NDEBUG
-#define	ASSERT3B(x, y, z)	((void)0)
-#define	ASSERT3S(x, y, z)	((void)0)
-#define	ASSERT3U(x, y, z)	((void)0)
-#define	ASSERT3P(x, y, z)	((void)0)
-#define	ASSERT0(x)		((void)0)
-#define	ASSERT(x)		((void)0)
-#define	assert(x)		((void)0)
-#define	IMPLY(A, B)		((void)0)
-#define	EQUIV(A, B)		((void)0)
+#define	ASSERT3B(x, y, z)	((void) sizeof (x), (void) sizeof (z))
+#define	ASSERT3S(x, y, z)	((void) sizeof (x), (void) sizeof (z))
+#define	ASSERT3U(x, y, z)	((void) sizeof (x), (void) sizeof (z))
+#define	ASSERT3P(x, y, z)	((void) sizeof (x), (void) sizeof (z))
+#define	ASSERT0(x)		((void) sizeof (x))
+#define	ASSERT(x)		((void) sizeof (x))
+#define	assert(x)		((void) sizeof (x))
+#define	IMPLY(A, B)		((void) sizeof (A), (void) sizeof (B))
+#define	EQUIV(A, B)		((void) sizeof (A), (void) sizeof (B))
 #else
 #define	ASSERT3B	VERIFY3B
 #define	ASSERT3S	VERIFY3S

--- a/lib/libspl/include/sys/kmem.h
+++ b/lib/libspl/include/sys/kmem.h
@@ -35,8 +35,8 @@ extern "C" {
 #define	KM_SLEEP	0x00000000	/* same as KM_SLEEP */
 #define	KM_NOSLEEP	0x00000001	/* same as KM_NOSLEEP */
 
-#define	kmem_alloc(size, flags)		malloc(size)
-#define	kmem_free(ptr, size)		free(ptr)
+#define	kmem_alloc(size, flags)		((void) sizeof (flags), malloc(size))
+#define	kmem_free(ptr, size)		((void) sizeof (size), free(ptr))
 
 #ifdef	__cplusplus
 }

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -592,7 +592,6 @@ compare_props(const void *a, const void *b, zfs_prop_t prop)
 		return (strcmp(propb, propa));
 }
 
-/*ARGSUSED*/
 static int
 compare_mountpoints(const void *a, const void *b, void *unused)
 {
@@ -602,13 +601,14 @@ compare_mountpoints(const void *a, const void *b, void *unused)
 	 * hierarchy that is different from the dataset hierarchy, and still
 	 * allow it to be changed.
 	 */
+	(void) unused;
 	return (compare_props(a, b, ZFS_PROP_MOUNTPOINT));
 }
 
-/*ARGSUSED*/
 static int
 compare_dataset_names(const void *a, const void *b, void *unused)
 {
+	(void) unused;
 	return (compare_props(a, b, ZFS_PROP_NAME));
 }
 

--- a/lib/libzfs/libzfs_config.c
+++ b/lib/libzfs/libzfs_config.c
@@ -56,16 +56,14 @@ typedef struct config_node {
 	uu_avl_node_t	cn_avl;
 } config_node_t;
 
-/* ARGSUSED */
 static int
 config_node_compare(const void *a, const void *b, void *unused)
 {
-	int ret;
-
+	(void) unused;
 	const config_node_t *ca = (config_node_t *)a;
 	const config_node_t *cb = (config_node_t *)b;
 
-	ret = strcmp(ca->cn_name, cb->cn_name);
+	int ret = strcmp(ca->cn_name, cb->cn_name);
 
 	if (ret < 0)
 		return (-1);

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -482,6 +482,7 @@ get_key_material_file(libzfs_handle_t *hdl, const char *uri,
     const char *fsname, zfs_keyformat_t keyformat, boolean_t newkey,
     uint8_t **restrict buf, size_t *restrict len_out)
 {
+	(void) fsname, (void) newkey;
 	FILE *f = NULL;
 	int ret = 0;
 
@@ -508,6 +509,7 @@ get_key_material_https(libzfs_handle_t *hdl, const char *uri,
     const char *fsname, zfs_keyformat_t keyformat, boolean_t newkey,
     uint8_t **restrict buf, size_t *restrict len_out)
 {
+	(void) fsname, (void) newkey;
 	int ret = 0;
 	FILE *key = NULL;
 	boolean_t is_http = strncmp(uri, "http:", strlen("http:")) == 0;
@@ -773,7 +775,7 @@ error:
 
 static int
 derive_key(libzfs_handle_t *hdl, zfs_keyformat_t format, uint64_t iters,
-    uint8_t *key_material, size_t key_material_len, uint64_t salt,
+    uint8_t *key_material, uint64_t salt,
     uint8_t **key_out)
 {
 	int ret;
@@ -916,8 +918,7 @@ populate_create_encryption_params_nvlists(libzfs_handle_t *hdl,
 	}
 
 	/* derive a key from the key material */
-	ret = derive_key(hdl, keyformat, iters, key_material, key_material_len,
-	    salt, &key_data);
+	ret = derive_key(hdl, keyformat, iters, key_material, salt, &key_data);
 	if (ret != 0)
 		goto error;
 
@@ -1175,6 +1176,7 @@ int
 zfs_crypto_clone_check(libzfs_handle_t *hdl, zfs_handle_t *origin_zhp,
     char *parent_name, nvlist_t *props)
 {
+	(void) origin_zhp, (void) parent_name;
 	char errbuf[1024];
 
 	(void) snprintf(errbuf, sizeof (errbuf),
@@ -1372,8 +1374,8 @@ try_again:
 		goto error;
 
 	/* derive a key from the key material */
-	ret = derive_key(zhp->zfs_hdl, keyformat, iters, key_material,
-	    key_material_len, salt, &key_data);
+	ret = derive_key(zhp->zfs_hdl, keyformat, iters, key_material, salt,
+	    &key_data);
 	if (ret != 0)
 		goto error;
 

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -3180,6 +3180,7 @@ userquota_propname_decode(const char *propname, boolean_t zoned,
 		if (errno != 0 || *end != '\0')
 			return (EINVAL);
 #else
+		(void) domainlen;
 		return (ENOSYS);
 #endif /* HAVE_IDMAP */
 	} else {

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -39,7 +39,7 @@
 #include "libzfs_impl.h"
 
 static int
-zfs_iter_clones(zfs_handle_t *zhp, int flags, zfs_iter_f func, void *data)
+zfs_iter_clones(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 {
 	nvlist_t *nvl = zfs_get_clones_nvl(zhp);
 	nvpair_t *pair;
@@ -206,6 +206,7 @@ zfs_iter_snapshots(zfs_handle_t *zhp, int flags, zfs_iter_f func,
 int
 zfs_iter_bookmarks(zfs_handle_t *zhp, int flags, zfs_iter_f func, void *data)
 {
+	(void) flags;
 	zfs_handle_t *nzhp;
 	nvlist_t *props = NULL;
 	nvlist_t *bmarks = NULL;
@@ -496,7 +497,7 @@ iter_dependents_cb(zfs_handle_t *zhp, void *arg)
 	ida->first = B_FALSE;
 
 	if (zhp->zfs_type == ZFS_TYPE_SNAPSHOT) {
-		err = zfs_iter_clones(zhp, ida->flags, iter_dependents_cb, ida);
+		err = zfs_iter_clones(zhp, iter_dependents_cb, ida);
 	} else if (zhp->zfs_type != ZFS_TYPE_BOOKMARK) {
 		iter_stack_frame_t isf;
 		iter_stack_frame_t *f;

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -244,12 +244,11 @@ zfs_is_mounted(zfs_handle_t *zhp, char **where)
  * Checks any higher order concerns about whether the given dataset is
  * mountable, false otherwise.  zfs_is_mountable_internal specifically assumes
  * that the caller has verified the sanity of mounting the dataset at
- * mountpoint to the extent the caller wants.
+ * its mountpoint to the extent the caller wants.
  */
 static boolean_t
-zfs_is_mountable_internal(zfs_handle_t *zhp, const char *mountpoint)
+zfs_is_mountable_internal(zfs_handle_t *zhp)
 {
-
 	if (zfs_prop_get_int(zhp, ZFS_PROP_ZONED) &&
 	    getzoneid() == GLOBAL_ZONEID)
 		return (B_FALSE);
@@ -282,7 +281,7 @@ zfs_is_mountable(zfs_handle_t *zhp, char *buf, size_t buflen,
 	if (zfs_prop_get_int(zhp, ZFS_PROP_CANMOUNT) == ZFS_CANMOUNT_OFF)
 		return (B_FALSE);
 
-	if (!zfs_is_mountable_internal(zhp, buf))
+	if (!zfs_is_mountable_internal(zhp))
 		return (B_FALSE);
 
 	if (zfs_prop_get_int(zhp, ZFS_PROP_REDACTED) && !(flags & MS_FORCE))
@@ -402,7 +401,7 @@ zfs_mount_at(zfs_handle_t *zhp, const char *options, int flags,
 		remount = 1;
 
 	/* Potentially duplicates some checks if invoked by zfs_mount(). */
-	if (!zfs_is_mountable_internal(zhp, mountpoint))
+	if (!zfs_is_mountable_internal(zhp))
 		return (0);
 
 	/*

--- a/lib/libzfs/libzfs_status.c
+++ b/lib/libzfs/libzfs_status.c
@@ -96,48 +96,48 @@ static char *zfs_msgid_table[] = {
 
 #define	NMSGID	(sizeof (zfs_msgid_table) / sizeof (zfs_msgid_table[0]))
 
-/* ARGSUSED */
 static int
 vdev_missing(vdev_stat_t *vs, uint_t vsc)
 {
+	(void) vsc;
 	return (vs->vs_state == VDEV_STATE_CANT_OPEN &&
 	    vs->vs_aux == VDEV_AUX_OPEN_FAILED);
 }
 
-/* ARGSUSED */
 static int
 vdev_faulted(vdev_stat_t *vs, uint_t vsc)
 {
+	(void) vsc;
 	return (vs->vs_state == VDEV_STATE_FAULTED);
 }
 
-/* ARGSUSED */
 static int
 vdev_errors(vdev_stat_t *vs, uint_t vsc)
 {
+	(void) vsc;
 	return (vs->vs_state == VDEV_STATE_DEGRADED ||
 	    vs->vs_read_errors != 0 || vs->vs_write_errors != 0 ||
 	    vs->vs_checksum_errors != 0);
 }
 
-/* ARGSUSED */
 static int
 vdev_broken(vdev_stat_t *vs, uint_t vsc)
 {
+	(void) vsc;
 	return (vs->vs_state == VDEV_STATE_CANT_OPEN);
 }
 
-/* ARGSUSED */
 static int
 vdev_offlined(vdev_stat_t *vs, uint_t vsc)
 {
+	(void) vsc;
 	return (vs->vs_state == VDEV_STATE_OFFLINE);
 }
 
-/* ARGSUSED */
 static int
 vdev_removed(vdev_stat_t *vs, uint_t vsc)
 {
+	(void) vsc;
 	return (vs->vs_state == VDEV_STATE_REMOVED);
 }
 

--- a/lib/libzfs/os/freebsd/libzfs_zmount.c
+++ b/lib/libzfs/os/freebsd/libzfs_zmount.c
@@ -123,6 +123,7 @@ do_mount(zfs_handle_t *zhp, const char *mntpt, char *opts, int flags)
 int
 do_unmount(zfs_handle_t *zhp, const char *mntpt, int flags)
 {
+	(void) zhp;
 	if (unmount(mntpt, flags) < 0)
 		return (errno);
 	return (0);
@@ -138,10 +139,12 @@ zfs_mount_delegation_check(void)
 void
 zpool_disable_datasets_os(zpool_handle_t *zhp, boolean_t force)
 {
+	(void) zhp, (void) force;
 }
 
 /* Called from the tail end of zfs_unmount() */
 void
 zpool_disable_volume_os(const char *name)
 {
+	(void) name;
 }

--- a/lib/libzfs/os/linux/libzfs_mount_os.c
+++ b/lib/libzfs/os/linux/libzfs_mount_os.c
@@ -376,6 +376,8 @@ do_mount(zfs_handle_t *zhp, const char *mntpt, char *opts, int flags)
 int
 do_unmount(zfs_handle_t *zhp, const char *mntpt, int flags)
 {
+	(void) zhp;
+
 	if (!libzfs_envvar_is_set("ZFS_MOUNT_HELPER")) {
 		int rv = umount2(mntpt, flags);
 
@@ -416,10 +418,12 @@ zfs_mount_delegation_check(void)
 void
 zpool_disable_datasets_os(zpool_handle_t *zhp, boolean_t force)
 {
+	(void) zhp, (void) force;
 }
 
 /* Called from the tail end of zfs_unmount() */
 void
 zpool_disable_volume_os(const char *name)
 {
+	(void) name;
 }

--- a/lib/libzfs/os/linux/libzfs_util_os.c
+++ b/lib/libzfs/os/linux/libzfs_util_os.c
@@ -187,6 +187,7 @@ find_shares_object(differ_info_t *di)
 int
 zfs_destroy_snaps_nvl_os(libzfs_handle_t *hdl, nvlist_t *snaps)
 {
+	(void) hdl, (void) snaps;
 	return (0);
 }
 

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -476,10 +476,10 @@ lzc_exists(const char *dataset)
  * It was added to preserve the function signature in case it is
  * needed in the future.
  */
-/*ARGSUSED*/
 int
 lzc_sync(const char *pool_name, nvlist_t *innvl, nvlist_t **outnvl)
 {
+	(void) outnvl;
 	return (lzc_ioctl(ZFS_IOC_POOL_SYNC, pool_name, innvl, NULL));
 }
 
@@ -1032,6 +1032,7 @@ lzc_receive_one(const char *snapname, nvlist_t *props,
     uint64_t *read_bytes, uint64_t *errflags, uint64_t *action_handle,
     nvlist_t **errors)
 {
+	(void) action_handle, (void) cleanup_fd;
 	return (recv_impl(snapname, props, NULL, NULL, 0, origin, force,
 	    resumable, raw, input_fd, begin_record,
 	    read_bytes, errflags, errors));
@@ -1053,6 +1054,7 @@ lzc_receive_with_cmdprops(const char *snapname, nvlist_t *props,
     uint64_t *read_bytes, uint64_t *errflags, uint64_t *action_handle,
     nvlist_t **errors)
 {
+	(void) action_handle, (void) cleanup_fd;
 	return (recv_impl(snapname, props, cmdprops, wkeydata, wkeylen, origin,
 	    force, resumable, raw, input_fd, begin_record,
 	    read_bytes, errflags, errors));

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -75,7 +75,6 @@ struct proc p0;
 #define	TS_STACK_MIN	MAX(PTHREAD_STACK_MIN, 32768)
 #define	TS_STACK_MAX	(256 * 1024)
 
-/*ARGSUSED*/
 kthread_t *
 zk_thread_create(void (*func)(void *), void *arg, size_t stksize, int state)
 {
@@ -129,30 +128,35 @@ zk_thread_create(void (*func)(void *), void *arg, size_t stksize, int state)
  * kstats
  * =========================================================================
  */
-/*ARGSUSED*/
 kstat_t *
 kstat_create(const char *module, int instance, const char *name,
     const char *class, uchar_t type, ulong_t ndata, uchar_t ks_flag)
 {
+	(void) module, (void) instance, (void) name, (void) class, (void) type,
+	    (void) ndata, (void) ks_flag;
 	return (NULL);
 }
 
-/*ARGSUSED*/
 void
 kstat_install(kstat_t *ksp)
-{}
+{
+	(void) ksp;
+}
 
-/*ARGSUSED*/
 void
 kstat_delete(kstat_t *ksp)
-{}
+{
+	(void) ksp;
+}
 
 void
 kstat_set_raw_ops(kstat_t *ksp,
     int (*headers)(char *buf, size_t size),
     int (*data)(char *buf, size_t size, void *data),
     void *(*addr)(kstat_t *ksp, loff_t index))
-{}
+{
+	(void) ksp, (void) headers, (void) data, (void) addr;
+}
 
 /*
  * =========================================================================
@@ -163,6 +167,7 @@ kstat_set_raw_ops(kstat_t *ksp,
 void
 mutex_init(kmutex_t *mp, char *name, int type, void *cookie)
 {
+	(void) name, (void) type, (void) cookie;
 	VERIFY0(pthread_mutex_init(&mp->m_lock, NULL));
 	memset(&mp->m_owner, 0, sizeof (pthread_t));
 }
@@ -183,9 +188,7 @@ mutex_enter(kmutex_t *mp)
 int
 mutex_tryenter(kmutex_t *mp)
 {
-	int error;
-
-	error = pthread_mutex_trylock(&mp->m_lock);
+	int error = pthread_mutex_trylock(&mp->m_lock);
 	if (error == 0) {
 		mp->m_owner = pthread_self();
 		return (1);
@@ -211,6 +214,7 @@ mutex_exit(kmutex_t *mp)
 void
 rw_init(krwlock_t *rwlp, char *name, int type, void *arg)
 {
+	(void) name, (void) type, (void) arg;
 	VERIFY0(pthread_rwlock_init(&rwlp->rw_lock, NULL));
 	rwlp->rw_readers = 0;
 	rwlp->rw_owner = 0;
@@ -269,19 +273,20 @@ rw_tryenter(krwlock_t *rwlp, krw_t rw)
 	return (0);
 }
 
-/* ARGSUSED */
 uint32_t
 zone_get_hostid(void *zonep)
 {
 	/*
 	 * We're emulating the system's hostid in userland.
 	 */
+	(void) zonep;
 	return (strtoul(hw_serial, NULL, 10));
 }
 
 int
 rw_tryupgrade(krwlock_t *rwlp)
 {
+	(void) rwlp;
 	return (0);
 }
 
@@ -294,6 +299,7 @@ rw_tryupgrade(krwlock_t *rwlp)
 void
 cv_init(kcondvar_t *cv, char *name, int type, void *arg)
 {
+	(void) name, (void) type, (void) arg;
 	VERIFY0(pthread_cond_init(cv, NULL));
 }
 
@@ -351,11 +357,11 @@ cv_timedwait(kcondvar_t *cv, kmutex_t *mp, clock_t abstime)
 	return (1);
 }
 
-/*ARGSUSED*/
 int
 cv_timedwait_hires(kcondvar_t *cv, kmutex_t *mp, hrtime_t tim, hrtime_t res,
     int flag)
 {
+	(void) res;
 	int error;
 	struct timeval tv;
 	struct timespec ts;
@@ -411,7 +417,9 @@ cv_broadcast(kcondvar_t *cv)
 
 void
 seq_printf(struct seq_file *m, const char *fmt, ...)
-{}
+{
+	(void) m, (void) fmt;
+}
 
 void
 procfs_list_install(const char *module,
@@ -424,6 +432,8 @@ procfs_list_install(const char *module,
     int (*clear)(procfs_list_t *procfs_list),
     size_t procfs_list_node_off)
 {
+	(void) module, (void) submodule, (void) name, (void) mode, (void) show,
+	    (void) show_header, (void) clear;
 	mutex_init(&procfs_list->pl_lock, NULL, MUTEX_DEFAULT, NULL);
 	list_create(&procfs_list->pl_list,
 	    procfs_list_node_off + sizeof (procfs_list_node_t),
@@ -434,7 +444,9 @@ procfs_list_install(const char *module,
 
 void
 procfs_list_uninstall(procfs_list_t *procfs_list)
-{}
+{
+	(void) procfs_list;
+}
 
 void
 procfs_list_destroy(procfs_list_t *procfs_list)
@@ -738,6 +750,7 @@ random_get_pseudo_bytes(uint8_t *ptr, size_t len)
 int
 ddi_strtoul(const char *hw_serial, char **nptr, int base, unsigned long *result)
 {
+	(void) nptr;
 	char *end;
 
 	*result = strtoul(hw_serial, &end, base);
@@ -749,6 +762,7 @@ ddi_strtoul(const char *hw_serial, char **nptr, int base, unsigned long *result)
 int
 ddi_strtoull(const char *str, char **nptr, int base, u_longlong_t *result)
 {
+	(void) nptr;
 	char *end;
 
 	*result = strtoull(str, &end, base);
@@ -826,60 +840,70 @@ kernel_fini(void)
 uid_t
 crgetuid(cred_t *cr)
 {
+	(void) cr;
 	return (0);
 }
 
 uid_t
 crgetruid(cred_t *cr)
 {
+	(void) cr;
 	return (0);
 }
 
 gid_t
 crgetgid(cred_t *cr)
 {
+	(void) cr;
 	return (0);
 }
 
 int
 crgetngroups(cred_t *cr)
 {
+	(void) cr;
 	return (0);
 }
 
 gid_t *
 crgetgroups(cred_t *cr)
 {
+	(void) cr;
 	return (NULL);
 }
 
 int
 zfs_secpolicy_snapshot_perms(const char *name, cred_t *cr)
 {
+	(void) name, (void) cr;
 	return (0);
 }
 
 int
 zfs_secpolicy_rename_perms(const char *from, const char *to, cred_t *cr)
 {
+	(void) from, (void) to, (void) cr;
 	return (0);
 }
 
 int
 zfs_secpolicy_destroy_perms(const char *name, cred_t *cr)
 {
+	(void) name, (void) cr;
 	return (0);
 }
 
 int
 secpolicy_zfs(const cred_t *cr)
 {
+	(void) cr;
 	return (0);
 }
 
 int
 secpolicy_zfs_proc(const cred_t *cr, proc_t *proc)
 {
+	(void) cr, (void) proc;
 	return (0);
 }
 
@@ -926,25 +950,25 @@ kmem_asprintf(const char *fmt, ...)
 	return (buf);
 }
 
-/* ARGSUSED */
 zfs_file_t *
 zfs_onexit_fd_hold(int fd, minor_t *minorp)
 {
+	(void) fd;
 	*minorp = 0;
 	return (NULL);
 }
 
-/* ARGSUSED */
 void
 zfs_onexit_fd_rele(zfs_file_t *fp)
 {
+	(void) fp;
 }
 
-/* ARGSUSED */
 int
 zfs_onexit_add_cb(minor_t minor, void (*func)(void *), void *data,
     uint64_t *action_handle)
 {
+	(void) minor, (void) func, (void) data, (void) action_handle;
 	return (0);
 }
 
@@ -957,6 +981,7 @@ spl_fstrans_mark(void)
 void
 spl_fstrans_unmark(fstrans_cookie_t cookie)
 {
+	(void) cookie;
 }
 
 int
@@ -976,22 +1001,26 @@ void *zvol_tag = "zvol_tag";
 void
 zvol_create_minor(const char *name)
 {
+	(void) name;
 }
 
 void
 zvol_create_minors_recursive(const char *name)
 {
+	(void) name;
 }
 
 void
 zvol_remove_minors(spa_t *spa, const char *name, boolean_t async)
 {
+	(void) spa, (void) name, (void) async;
 }
 
 void
 zvol_rename_minors(spa_t *spa, const char *oldname, const char *newname,
     boolean_t async)
 {
+	(void) spa, (void) oldname, (void) newname, (void) async;
 }
 
 /*
@@ -1285,10 +1314,9 @@ zfs_file_getattr(zfs_file_t *fp, zfs_file_attr_t *zfattr)
 int
 zfs_file_fsync(zfs_file_t *fp, int flags)
 {
-	int rc;
+	(void) flags;
 
-	rc = fsync(fp->f_fd);
-	if (rc < 0)
+	if (fsync(fp->f_fd) < 0)
 		return (errno);
 
 	return (0);
@@ -1310,6 +1338,7 @@ zfs_file_fallocate(zfs_file_t *fp, int mode, loff_t offset, loff_t len)
 #ifdef __linux__
 	return (fallocate(fp->f_fd, mode, offset, len));
 #else
+	(void) fp, (void) mode, (void) offset, (void) len;
 	return (EOPNOTSUPP);
 #endif
 }
@@ -1353,8 +1382,8 @@ zfs_file_unlink(const char *path)
 zfs_file_t *
 zfs_file_get(int fd)
 {
+	(void) fd;
 	abort();
-
 	return (NULL);
 }
 /*
@@ -1368,9 +1397,11 @@ void
 zfs_file_put(zfs_file_t *fp)
 {
 	abort();
+	(void) fp;
 }
 
 void
 zfsvfs_update_fromname(const char *oldname, const char *newname)
 {
+	(void) oldname, (void) newname;
 }

--- a/lib/libzpool/taskq.c
+++ b/lib/libzpool/taskq.c
@@ -134,9 +134,10 @@ taskq_dispatch(taskq_t *tq, task_func_t func, void *arg, uint_t tqflags)
 }
 
 taskqid_t
-taskq_dispatch_delay(taskq_t *tq,  task_func_t func, void *arg, uint_t tqflags,
+taskq_dispatch_delay(taskq_t *tq, task_func_t func, void *arg, uint_t tqflags,
     clock_t expire_time)
 {
+	(void) tq, (void) func, (void) arg, (void) tqflags, (void) expire_time;
 	return (0);
 }
 
@@ -199,12 +200,14 @@ taskq_wait(taskq_t *tq)
 void
 taskq_wait_id(taskq_t *tq, taskqid_t id)
 {
+	(void) id;
 	taskq_wait(tq);
 }
 
 void
 taskq_wait_outstanding(taskq_t *tq, taskqid_t id)
 {
+	(void) id;
 	taskq_wait(tq);
 }
 
@@ -247,11 +250,11 @@ taskq_thread(void *arg)
 	thread_exit();
 }
 
-/*ARGSUSED*/
 taskq_t *
 taskq_create(const char *name, int nthreads, pri_t pri,
     int minalloc, int maxalloc, uint_t flags)
 {
+	(void) pri;
 	taskq_t *tq = kmem_zalloc(sizeof (taskq_t), KM_SLEEP);
 	int t;
 
@@ -356,6 +359,7 @@ taskq_of_curthread(void)
 int
 taskq_cancel_id(taskq_t *tq, taskqid_t id)
 {
+	(void) tq, (void) id;
 	return (ENOENT);
 }
 

--- a/lib/libzpool/util.c
+++ b/lib/libzpool/util.c
@@ -242,6 +242,7 @@ out_ret:
 static nvlist_t *
 refresh_config(void *unused, nvlist_t *tryconfig)
 {
+	(void) unused;
 	return (spa_tryimport(tryconfig));
 }
 
@@ -254,6 +255,7 @@ refresh_config(void *unused, nvlist_t *tryconfig)
 static int
 pool_active(void *unused, const char *name, uint64_t guid, boolean_t *isactive)
 {
+	(void) unused, (void) guid;
 	zfs_iocparm_t zp;
 	zfs_cmd_t *zc = NULL;
 	zfs_cmd_legacy_t *zcl = NULL;
@@ -322,6 +324,7 @@ static int
 pool_active(void *unused, const char *name, uint64_t guid,
     boolean_t *isactive)
 {
+	(void) unused, (void) guid;
 	int fd = open(ZFS_DEV, O_RDWR | O_CLOEXEC);
 	if (fd < 0)
 		return (-1);

--- a/lib/libzutil/os/freebsd/zutil_device_path_os.c
+++ b/lib/libzutil/os/freebsd/zutil_device_path_os.c
@@ -124,9 +124,9 @@ zpool_label_disk_wait(const char *path, int timeout_ms)
 	return (ENODEV);
 }
 
-/* ARGSUSED */
 boolean_t
 is_mpath_whole_disk(const char *path)
 {
+	(void) path;
 	return (B_FALSE);
 }

--- a/lib/libzutil/os/freebsd/zutil_import_os.c
+++ b/lib/libzutil/os/freebsd/zutil_import_os.c
@@ -243,12 +243,14 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 }
 
 int
-zfs_dev_flush(int fd __unused)
+zfs_dev_flush(int fd)
 {
+	(void) fd;
 	return (0);
 }
 
 void
 update_vdevs_config_dev_sysfs_path(nvlist_t *config)
 {
+	(void) config;
 }

--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -668,10 +668,10 @@ is_mpath_whole_disk(const char *path)
 
 #else /* HAVE_LIBUDEV */
 
-/* ARGSUSED */
 boolean_t
 is_mpath_whole_disk(const char *path)
 {
+	(void) path;
 	return (B_FALSE);
 }
 

--- a/lib/libzutil/os/linux/zutil_import_os.c
+++ b/lib/libzutil/os/linux/zutil_import_os.c
@@ -560,17 +560,17 @@ udev_device_is_ready(struct udev_device *dev)
 
 #else
 
-/* ARGSUSED */
 int
 zfs_device_get_devid(struct udev_device *dev, char *bufptr, size_t buflen)
 {
+	(void) dev, (void) bufptr, (void) buflen;
 	return (ENODATA);
 }
 
-/* ARGSUSED */
 int
 zfs_device_get_physical(struct udev_device *dev, char *bufptr, size_t buflen)
 {
+	(void) dev, (void) bufptr, (void) buflen;
 	return (ENODATA);
 }
 
@@ -788,6 +788,8 @@ update_vdev_config_dev_sysfs_path(nvlist_t *nv, char *path)
 static int
 sysfs_path_pool_vdev_iter_f(void *hdl_data, nvlist_t *nv, void *data)
 {
+	(void) hdl_data, (void) data;
+
 	char *path = NULL;
 	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &path) != 0)
 		return (1);

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -1393,6 +1393,7 @@ static nvlist_t *
 zpool_find_import_impl(libpc_handle_t *hdl, importargs_t *iarg,
     pthread_mutex_t *lock, avl_tree_t *cache)
 {
+	(void) lock;
 	nvlist_t *ret = NULL;
 	pool_list_t pools = { 0 };
 	pool_entry_t *pe, *penext;

--- a/module/avl/avl.c
+++ b/module/avl/avl.c
@@ -908,7 +908,6 @@ avl_create(avl_tree_t *tree, int (*compar) (const void *, const void *),
 /*
  * Delete a tree.
  */
-/* ARGSUSED */
 void
 avl_destroy(avl_tree_t *tree)
 {

--- a/module/icp/algs/aes/aes_impl.c
+++ b/module/icp/algs/aes/aes_impl.c
@@ -206,7 +206,6 @@ aes_decrypt_block(const void *ks, const uint8_t *ct, uint8_t *pt)
  * size		Size of key schedule allocated, in bytes
  * kmflag	Flag passed to kmem_alloc(9F); ignored in userland.
  */
-/* ARGSUSED */
 void *
 aes_alloc_keysched(size_t *size, int kmflag)
 {

--- a/module/icp/algs/modes/cbc.c
+++ b/module/icp/algs/modes/cbc.c
@@ -137,7 +137,6 @@ out:
 #define	OTHER(a, ctx) \
 	(((a) == (ctx)->cbc_lastblock) ? (ctx)->cbc_iv : (ctx)->cbc_lastblock)
 
-/* ARGSUSED */
 int
 cbc_decrypt_contiguous_blocks(cbc_ctx_t *ctx, char *data, size_t length,
     crypto_data_t *out, size_t block_size,
@@ -259,7 +258,6 @@ cbc_init_ctx(cbc_ctx_t *cbc_ctx, char *param, size_t param_len,
 	return (CRYPTO_SUCCESS);
 }
 
-/* ARGSUSED */
 void *
 cbc_alloc_ctx(int kmflag)
 {

--- a/module/icp/algs/modes/ccm.c
+++ b/module/icp/algs/modes/ccm.c
@@ -190,7 +190,6 @@ calculate_ccm_mac(ccm_ctx_t *ctx, uint8_t *ccm_mac,
 	}
 }
 
-/* ARGSUSED */
 int
 ccm_encrypt_final(ccm_ctx_t *ctx, crypto_data_t *out, size_t block_size,
     int (*encrypt_block)(const void *, const uint8_t *, uint8_t *),
@@ -342,7 +341,6 @@ ccm_decrypt_incomplete_block(ccm_ctx_t *ctx,
  * returned to the caller.  It will be returned when decrypt_final() is
  * called if the MAC matches
  */
-/* ARGSUSED */
 int
 ccm_mode_decrypt_contiguous_blocks(ccm_ctx_t *ctx, char *data, size_t length,
     crypto_data_t *out, size_t block_size,
@@ -350,6 +348,7 @@ ccm_mode_decrypt_contiguous_blocks(ccm_ctx_t *ctx, char *data, size_t length,
     void (*copy_block)(uint8_t *, uint8_t *),
     void (*xor_block)(uint8_t *, uint8_t *))
 {
+	(void) out;
 	size_t remainder = length;
 	size_t need = 0;
 	uint8_t *datap = (uint8_t *)data;

--- a/module/icp/algs/modes/ctr.c
+++ b/module/icp/algs/modes/ctr.c
@@ -214,7 +214,6 @@ ctr_init_ctx(ctr_ctx_t *ctr_ctx, ulong_t count, uint8_t *cb,
 	return (CRYPTO_SUCCESS);
 }
 
-/* ARGSUSED */
 void *
 ctr_alloc_ctx(int kmflag)
 {

--- a/module/icp/algs/modes/ecb.c
+++ b/module/icp/algs/modes/ecb.c
@@ -114,7 +114,6 @@ out:
 	return (CRYPTO_SUCCESS);
 }
 
-/* ARGSUSED */
 void *
 ecb_alloc_ctx(int kmflag)
 {

--- a/module/icp/algs/modes/gcm.c
+++ b/module/icp/algs/modes/gcm.c
@@ -199,13 +199,13 @@ out:
 	return (CRYPTO_SUCCESS);
 }
 
-/* ARGSUSED */
 int
 gcm_encrypt_final(gcm_ctx_t *ctx, crypto_data_t *out, size_t block_size,
     int (*encrypt_block)(const void *, const uint8_t *, uint8_t *),
     void (*copy_block)(uint8_t *, uint8_t *),
     void (*xor_block)(uint8_t *, uint8_t *))
 {
+	(void) copy_block;
 #ifdef CAN_USE_GCM_ASM
 	if (ctx->gcm_use_avx == B_TRUE)
 		return (gcm_encrypt_final_avx(ctx, out, block_size));
@@ -324,7 +324,6 @@ gcm_decrypt_incomplete_block(gcm_ctx_t *ctx, size_t block_size, size_t index,
 	}
 }
 
-/* ARGSUSED */
 int
 gcm_mode_decrypt_contiguous_blocks(gcm_ctx_t *ctx, char *data, size_t length,
     crypto_data_t *out, size_t block_size,
@@ -332,6 +331,8 @@ gcm_mode_decrypt_contiguous_blocks(gcm_ctx_t *ctx, char *data, size_t length,
     void (*copy_block)(uint8_t *, uint8_t *),
     void (*xor_block)(uint8_t *, uint8_t *))
 {
+	(void) out, (void) block_size, (void) encrypt_block, (void) copy_block,
+	    (void) xor_block;
 	size_t new_len;
 	uint8_t *new;
 

--- a/module/icp/asm-x86_64/aes/aes_aesni.S
+++ b/module/icp/asm-x86_64/aes/aes_aesni.S
@@ -154,26 +154,26 @@
 
 #include <sys/types.h>
 
-/* ARGSUSED */
 void
 aes_encrypt_intel(const uint32_t rk[], int Nr, const uint32_t pt[4],
     uint32_t ct[4]) {
+	(void) rk, (void) Nr, (void) pt, (void) ct;
 }
-/* ARGSUSED */
 void
 aes_decrypt_intel(const uint32_t rk[], int Nr, const uint32_t ct[4],
     uint32_t pt[4]) {
+	(void) rk, (void) Nr, (void) ct, (void) pt;
 }
-/* ARGSUSED */
 int
 rijndael_key_setup_enc_intel(uint32_t rk[], const uint32_t cipherKey[],
     uint64_t keyBits) {
+	(void) rk, (void) cipherKey, (void) keyBits;
 	return (0);
 }
-/* ARGSUSED */
 int
 rijndael_key_setup_dec_intel(uint32_t rk[], const uint32_t cipherKey[],
    uint64_t keyBits) {
+	(void) rk, (void) cipherKey, (void) keyBits;
 	return (0);
 }
 

--- a/module/icp/asm-x86_64/aes/aes_amd64.S
+++ b/module/icp/asm-x86_64/aes/aes_amd64.S
@@ -186,15 +186,15 @@
 #if defined(lint) || defined(__lint)
 
 #include <sys/types.h>
-/* ARGSUSED */
 void
 aes_encrypt_amd64(const uint32_t rk[], int Nr, const uint32_t pt[4],
 	uint32_t ct[4]) {
+   (void) rk, (void) Nr, (void) pt, (void) ct;
 }
-/* ARGSUSED */
 void
 aes_decrypt_amd64(const uint32_t rk[], int Nr, const uint32_t ct[4],
 	uint32_t pt[4]) {
+   (void) rk, (void) Nr, (void) pt, (void) ct;
 }
 
 

--- a/module/icp/asm-x86_64/modes/gcm_pclmulqdq.S
+++ b/module/icp/asm-x86_64/modes/gcm_pclmulqdq.S
@@ -85,9 +85,9 @@
 
 #include <sys/types.h>
 
-/* ARGSUSED */
 void
 gcm_mul_pclmulqdq(uint64_t *x_in, uint64_t *y, uint64_t *res) {
+	(void) x_in, (void) y, (void) res;
 }
 
 #elif defined(HAVE_PCLMULQDQ)	/* guard by instruction set */

--- a/module/icp/asm-x86_64/sha1/sha1-x86_64.S
+++ b/module/icp/asm-x86_64/sha1/sha1-x86_64.S
@@ -59,10 +59,10 @@
 #include <sys/sha1.h>
 
 
-/* ARGSUSED */
 void
 sha1_block_data_order(SHA1_CTX *ctx, const void *inpp, size_t blocks)
 {
+	(void) ctx, (void) inpp, (void) blocks;
 }
 
 #else

--- a/module/icp/asm-x86_64/sha2/sha256_impl.S
+++ b/module/icp/asm-x86_64/sha2/sha256_impl.S
@@ -71,10 +71,10 @@
 #include <sys/stdint.h>
 #include <sha2/sha2.h>
 
-/* ARGSUSED */
 void
 SHA256TransformBlocks(SHA2_CTX *ctx, const void *in, size_t num)
 {
+	(void) ctx, (void) in, (void) num;
 }
 
 

--- a/module/icp/asm-x86_64/sha2/sha512_impl.S
+++ b/module/icp/asm-x86_64/sha2/sha512_impl.S
@@ -72,10 +72,10 @@
 #include <sys/stdint.h>
 #include <sha2/sha2.h>
 
-/* ARGSUSED */
 void
 SHA512TransformBlocks(SHA2_CTX *ctx, const void *in, size_t num)
 {
+	(void) ctx, (void) in, (void) num;
 }
 
 

--- a/module/icp/core/kcf_mech_tabs.c
+++ b/module/icp/core/kcf_mech_tabs.c
@@ -786,6 +786,6 @@ kcf_get_mech_entry(crypto_mech_type_t mech_type, kcf_mech_entry_t **mep)
 crypto_mech_type_t
 crypto_mech2id_common(char *mechname, boolean_t load_module)
 {
-	crypto_mech_type_t mt = kcf_mech_hash_find(mechname);
-	return (mt);
+	(void) load_module;
+	return (kcf_mech_hash_find(mechname));
 }

--- a/module/icp/core/kcf_prov_lib.c
+++ b/module/icp/core/kcf_prov_lib.c
@@ -40,6 +40,7 @@ int
 crypto_uio_data(crypto_data_t *data, uchar_t *buf, int len, cmd_type_t cmd,
     void *digest_ctx, void (*update)(void))
 {
+	(void) digest_ctx, (void) update;
 	zfs_uio_t *uiop = data->cd_uio;
 	off_t offset = data->cd_offset;
 	size_t length = len;

--- a/module/icp/core/kcf_sched.c
+++ b/module/icp/core/kcf_sched.c
@@ -970,10 +970,10 @@ kcf_enqueue(kcf_areq_node_t *node)
 /*
  * kmem_cache_alloc constructor for sync request structure.
  */
-/* ARGSUSED */
 static int
 kcf_sreq_cache_constructor(void *buf, void *cdrarg, int kmflags)
 {
+	(void) cdrarg, (void) kmflags;
 	kcf_sreq_node_t *sreq = (kcf_sreq_node_t *)buf;
 
 	sreq->sn_type = CRYPTO_SYNCH;
@@ -983,10 +983,10 @@ kcf_sreq_cache_constructor(void *buf, void *cdrarg, int kmflags)
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 kcf_sreq_cache_destructor(void *buf, void *cdrarg)
 {
+	(void) cdrarg;
 	kcf_sreq_node_t *sreq = (kcf_sreq_node_t *)buf;
 
 	mutex_destroy(&sreq->sn_lock);
@@ -996,10 +996,10 @@ kcf_sreq_cache_destructor(void *buf, void *cdrarg)
 /*
  * kmem_cache_alloc constructor for async request structure.
  */
-/* ARGSUSED */
 static int
 kcf_areq_cache_constructor(void *buf, void *cdrarg, int kmflags)
 {
+	(void) cdrarg, (void) kmflags;
 	kcf_areq_node_t *areq = (kcf_areq_node_t *)buf;
 
 	areq->an_type = CRYPTO_ASYNCH;
@@ -1011,10 +1011,10 @@ kcf_areq_cache_constructor(void *buf, void *cdrarg, int kmflags)
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 kcf_areq_cache_destructor(void *buf, void *cdrarg)
 {
+	(void) cdrarg;
 	kcf_areq_node_t *areq = (kcf_areq_node_t *)buf;
 
 	ASSERT(areq->an_refcnt == 0);
@@ -1026,10 +1026,10 @@ kcf_areq_cache_destructor(void *buf, void *cdrarg)
 /*
  * kmem_cache_alloc constructor for kcf_context structure.
  */
-/* ARGSUSED */
 static int
 kcf_context_cache_constructor(void *buf, void *cdrarg, int kmflags)
 {
+	(void) cdrarg, (void) kmflags;
 	kcf_context_t *kctx = (kcf_context_t *)buf;
 
 	kctx->kc_refcnt = 0;
@@ -1038,10 +1038,10 @@ kcf_context_cache_constructor(void *buf, void *cdrarg, int kmflags)
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 kcf_context_cache_destructor(void *buf, void *cdrarg)
 {
+	(void) cdrarg;
 	kcf_context_t *kctx = (kcf_context_t *)buf;
 
 	ASSERT(kctx->kc_refcnt == 0);

--- a/module/icp/io/aes.c
+++ b/module/icp/io/aes.c
@@ -311,10 +311,10 @@ init_keysched(crypto_key_t *key, void *newbie)
 /*
  * KCF software provider control entry points.
  */
-/* ARGSUSED */
 static void
 aes_provider_status(crypto_provider_handle_t provider, uint_t *status)
 {
+	(void) provider;
 	*status = CRYPTO_PROVIDER_READY;
 }
 
@@ -617,11 +617,11 @@ cleanup:
 }
 
 
-/* ARGSUSED */
 static int
 aes_encrypt_update(crypto_ctx_t *ctx, crypto_data_t *plaintext,
     crypto_data_t *ciphertext, crypto_req_handle_t req)
 {
+	(void) req;
 	off_t saved_offset;
 	size_t saved_length, out_len;
 	int ret = CRYPTO_SUCCESS;
@@ -769,11 +769,11 @@ aes_decrypt_update(crypto_ctx_t *ctx, crypto_data_t *ciphertext,
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 aes_encrypt_final(crypto_ctx_t *ctx, crypto_data_t *data,
     crypto_req_handle_t req)
 {
+	(void) req;
 	aes_ctx_t *aes_ctx;
 	int ret;
 
@@ -826,11 +826,11 @@ aes_encrypt_final(crypto_ctx_t *ctx, crypto_data_t *data,
 	return (CRYPTO_SUCCESS);
 }
 
-/* ARGSUSED */
 static int
 aes_decrypt_final(crypto_ctx_t *ctx, crypto_data_t *data,
     crypto_req_handle_t req)
 {
+	(void) req;
 	aes_ctx_t *aes_ctx;
 	int ret;
 	off_t saved_offset;
@@ -929,13 +929,13 @@ aes_decrypt_final(crypto_ctx_t *ctx, crypto_data_t *data,
 	return (CRYPTO_SUCCESS);
 }
 
-/* ARGSUSED */
 static int
 aes_encrypt_atomic(crypto_provider_handle_t provider,
     crypto_session_id_t session_id, crypto_mechanism_t *mechanism,
     crypto_key_t *key, crypto_data_t *plaintext, crypto_data_t *ciphertext,
     crypto_spi_ctx_template_t template, crypto_req_handle_t req)
 {
+	(void) provider, (void) session_id;
 	aes_ctx_t aes_ctx;	/* on the stack */
 	off_t saved_offset;
 	size_t saved_length;
@@ -1065,13 +1065,13 @@ out:
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 aes_decrypt_atomic(crypto_provider_handle_t provider,
     crypto_session_id_t session_id, crypto_mechanism_t *mechanism,
     crypto_key_t *key, crypto_data_t *ciphertext, crypto_data_t *plaintext,
     crypto_spi_ctx_template_t template, crypto_req_handle_t req)
 {
+	(void) provider, (void) session_id;
 	aes_ctx_t aes_ctx;	/* on the stack */
 	off_t saved_offset;
 	size_t saved_length;
@@ -1235,12 +1235,12 @@ out:
 /*
  * KCF software provider context template entry points.
  */
-/* ARGSUSED */
 static int
 aes_create_ctx_template(crypto_provider_handle_t provider,
     crypto_mechanism_t *mechanism, crypto_key_t *key,
     crypto_spi_ctx_template_t *tmpl, size_t *tmpl_size, crypto_req_handle_t req)
 {
+	(void) provider;
 	void *keysched;
 	size_t size;
 	int rv;

--- a/module/icp/io/sha1_mod.c
+++ b/module/icp/io/sha1_mod.c
@@ -227,10 +227,10 @@ sha1_mod_fini(void)
 /*
  * KCF software provider control entry points.
  */
-/* ARGSUSED */
 static void
 sha1_provider_status(crypto_provider_handle_t provider, uint_t *status)
 {
+	(void) provider, (void) status;
 	*status = CRYPTO_PROVIDER_READY;
 }
 
@@ -409,11 +409,11 @@ sha1_digest_final_uio(SHA1_CTX *sha1_ctx, crypto_data_t *digest,
 	return (CRYPTO_SUCCESS);
 }
 
-/* ARGSUSED */
 static int
 sha1_digest(crypto_ctx_t *ctx, crypto_data_t *data, crypto_data_t *digest,
     crypto_req_handle_t req)
 {
+	(void) req;
 	int ret = CRYPTO_SUCCESS;
 
 	ASSERT(ctx->cc_provider_private != NULL);
@@ -483,11 +483,11 @@ sha1_digest(crypto_ctx_t *ctx, crypto_data_t *data, crypto_data_t *digest,
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha1_digest_update(crypto_ctx_t *ctx, crypto_data_t *data,
     crypto_req_handle_t req)
 {
+	(void) req;
 	int ret = CRYPTO_SUCCESS;
 
 	ASSERT(ctx->cc_provider_private != NULL);
@@ -512,11 +512,11 @@ sha1_digest_update(crypto_ctx_t *ctx, crypto_data_t *data,
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha1_digest_final(crypto_ctx_t *ctx, crypto_data_t *digest,
     crypto_req_handle_t req)
 {
+	(void) req;
 	int ret = CRYPTO_SUCCESS;
 
 	ASSERT(ctx->cc_provider_private != NULL);
@@ -561,13 +561,13 @@ sha1_digest_final(crypto_ctx_t *ctx, crypto_data_t *digest,
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha1_digest_atomic(crypto_provider_handle_t provider,
     crypto_session_id_t session_id, crypto_mechanism_t *mechanism,
     crypto_data_t *data, crypto_data_t *digest,
     crypto_req_handle_t req)
 {
+	(void) provider, (void) session_id, (void) req;
 	int ret = CRYPTO_SUCCESS;
 	SHA1_CTX sha1_ctx;
 
@@ -754,10 +754,10 @@ sha1_mac_init(crypto_ctx_t *ctx, crypto_mechanism_t *mechanism,
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha1_mac_update(crypto_ctx_t *ctx, crypto_data_t *data, crypto_req_handle_t req)
 {
+	(void) req;
 	int ret = CRYPTO_SUCCESS;
 
 	ASSERT(ctx->cc_provider_private != NULL);
@@ -783,10 +783,10 @@ sha1_mac_update(crypto_ctx_t *ctx, crypto_data_t *data, crypto_req_handle_t req)
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha1_mac_final(crypto_ctx_t *ctx, crypto_data_t *mac, crypto_req_handle_t req)
 {
+	(void) req;
 	int ret = CRYPTO_SUCCESS;
 	uchar_t digest[SHA1_DIGEST_LENGTH];
 	uint32_t digest_len = SHA1_DIGEST_LENGTH;
@@ -877,13 +877,13 @@ sha1_mac_final(crypto_ctx_t *ctx, crypto_data_t *mac, crypto_req_handle_t req)
 	}								\
 }
 
-/* ARGSUSED */
 static int
 sha1_mac_atomic(crypto_provider_handle_t provider,
     crypto_session_id_t session_id, crypto_mechanism_t *mechanism,
     crypto_key_t *key, crypto_data_t *data, crypto_data_t *mac,
     crypto_spi_ctx_template_t ctx_template, crypto_req_handle_t req)
 {
+	(void) provider, (void) session_id, (void) req;
 	int ret = CRYPTO_SUCCESS;
 	uchar_t digest[SHA1_DIGEST_LENGTH];
 	sha1_hmac_ctx_t sha1_hmac_ctx;
@@ -993,13 +993,13 @@ bail:
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha1_mac_verify_atomic(crypto_provider_handle_t provider,
     crypto_session_id_t session_id, crypto_mechanism_t *mechanism,
     crypto_key_t *key, crypto_data_t *data, crypto_data_t *mac,
     crypto_spi_ctx_template_t ctx_template, crypto_req_handle_t req)
 {
+	(void) provider, (void) session_id, (void) req;
 	int ret = CRYPTO_SUCCESS;
 	uchar_t digest[SHA1_DIGEST_LENGTH];
 	sha1_hmac_ctx_t sha1_hmac_ctx;
@@ -1147,13 +1147,13 @@ bail:
  * KCF software provider context management entry points.
  */
 
-/* ARGSUSED */
 static int
 sha1_create_ctx_template(crypto_provider_handle_t provider,
     crypto_mechanism_t *mechanism, crypto_key_t *key,
     crypto_spi_ctx_template_t *ctx_template, size_t *ctx_template_size,
     crypto_req_handle_t req)
 {
+	(void) provider;
 	sha1_hmac_ctx_t *sha1_hmac_ctx_tmpl;
 	uint_t keylen_in_bytes = CRYPTO_BITS2BYTES(key->ck_length);
 

--- a/module/icp/io/sha2_mod.c
+++ b/module/icp/io/sha2_mod.c
@@ -254,10 +254,10 @@ sha2_mod_fini(void)
 /*
  * KCF software provider control entry points.
  */
-/* ARGSUSED */
 static void
 sha2_provider_status(crypto_provider_handle_t provider, uint_t *status)
 {
+	(void) provider;
 	*status = CRYPTO_PROVIDER_READY;
 }
 
@@ -438,11 +438,11 @@ sha2_digest_final_uio(SHA2_CTX *sha2_ctx, crypto_data_t *digest,
 	return (CRYPTO_SUCCESS);
 }
 
-/* ARGSUSED */
 static int
 sha2_digest(crypto_ctx_t *ctx, crypto_data_t *data, crypto_data_t *digest,
     crypto_req_handle_t req)
 {
+	(void) req;
 	int ret = CRYPTO_SUCCESS;
 	uint_t sha_digest_len;
 
@@ -526,11 +526,11 @@ sha2_digest(crypto_ctx_t *ctx, crypto_data_t *data, crypto_data_t *digest,
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha2_digest_update(crypto_ctx_t *ctx, crypto_data_t *data,
     crypto_req_handle_t req)
 {
+	(void) req;
 	int ret = CRYPTO_SUCCESS;
 
 	ASSERT(ctx->cc_provider_private != NULL);
@@ -555,11 +555,11 @@ sha2_digest_update(crypto_ctx_t *ctx, crypto_data_t *data,
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha2_digest_final(crypto_ctx_t *ctx, crypto_data_t *digest,
     crypto_req_handle_t req)
 {
+	(void) req;
 	int ret = CRYPTO_SUCCESS;
 	uint_t sha_digest_len;
 
@@ -618,13 +618,13 @@ sha2_digest_final(crypto_ctx_t *ctx, crypto_data_t *digest,
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha2_digest_atomic(crypto_provider_handle_t provider,
     crypto_session_id_t session_id, crypto_mechanism_t *mechanism,
     crypto_data_t *data, crypto_data_t *digest,
     crypto_req_handle_t req)
 {
+	(void) provider, (void) session_id, (void) req;
 	int ret = CRYPTO_SUCCESS;
 	SHA2_CTX sha2_ctx;
 	uint32_t sha_digest_len;
@@ -840,11 +840,11 @@ sha2_mac_init(crypto_ctx_t *ctx, crypto_mechanism_t *mechanism,
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha2_mac_update(crypto_ctx_t *ctx, crypto_data_t *data,
     crypto_req_handle_t req)
 {
+	(void) req;
 	int ret = CRYPTO_SUCCESS;
 
 	ASSERT(ctx->cc_provider_private != NULL);
@@ -870,10 +870,10 @@ sha2_mac_update(crypto_ctx_t *ctx, crypto_data_t *data,
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha2_mac_final(crypto_ctx_t *ctx, crypto_data_t *mac, crypto_req_handle_t req)
 {
+	(void) req;
 	int ret = CRYPTO_SUCCESS;
 	uchar_t digest[SHA512_DIGEST_LENGTH];
 	uint32_t digest_len, sha_digest_len;
@@ -983,13 +983,13 @@ sha2_mac_final(crypto_ctx_t *ctx, crypto_data_t *mac, crypto_req_handle_t req)
 	}								\
 }
 
-/* ARGSUSED */
 static int
 sha2_mac_atomic(crypto_provider_handle_t provider,
     crypto_session_id_t session_id, crypto_mechanism_t *mechanism,
     crypto_key_t *key, crypto_data_t *data, crypto_data_t *mac,
     crypto_spi_ctx_template_t ctx_template, crypto_req_handle_t req)
 {
+	(void) provider, (void) session_id, (void) req;
 	int ret = CRYPTO_SUCCESS;
 	uchar_t digest[SHA512_DIGEST_LENGTH];
 	sha2_hmac_ctx_t sha2_hmac_ctx;
@@ -1121,13 +1121,13 @@ bail:
 	return (ret);
 }
 
-/* ARGSUSED */
 static int
 sha2_mac_verify_atomic(crypto_provider_handle_t provider,
     crypto_session_id_t session_id, crypto_mechanism_t *mechanism,
     crypto_key_t *key, crypto_data_t *data, crypto_data_t *mac,
     crypto_spi_ctx_template_t ctx_template, crypto_req_handle_t req)
 {
+	(void) provider, (void) session_id, (void) req;
 	int ret = CRYPTO_SUCCESS;
 	uchar_t digest[SHA512_DIGEST_LENGTH];
 	sha2_hmac_ctx_t sha2_hmac_ctx;
@@ -1301,13 +1301,13 @@ bail:
  * KCF software provider context management entry points.
  */
 
-/* ARGSUSED */
 static int
 sha2_create_ctx_template(crypto_provider_handle_t provider,
     crypto_mechanism_t *mechanism, crypto_key_t *key,
     crypto_spi_ctx_template_t *ctx_template, size_t *ctx_template_size,
     crypto_req_handle_t req)
 {
+	(void) provider;
 	sha2_hmac_ctx_t *sha2_hmac_ctx_tmpl;
 	uint_t keylen_in_bytes = CRYPTO_BITS2BYTES(key->ck_length);
 	uint32_t sha_digest_len, sha_hmac_block_size;

--- a/module/icp/io/skein_mod.c
+++ b/module/icp/io/skein_mod.c
@@ -250,10 +250,10 @@ skein_mod_fini(void)
 /*
  * KCF software provider control entry points.
  */
-/* ARGSUSED */
 static void
 skein_provider_status(crypto_provider_handle_t provider, uint_t *status)
 {
+	(void) provider;
 	*status = CRYPTO_PROVIDER_READY;
 }
 
@@ -462,10 +462,10 @@ skein_digest(crypto_ctx_t *ctx, crypto_data_t *data, crypto_data_t *digest,
  * can push more data). This is used both for digest and MAC operation.
  * Supported input data formats are raw, uio and mblk.
  */
-/*ARGSUSED*/
 static int
 skein_update(crypto_ctx_t *ctx, crypto_data_t *data, crypto_req_handle_t req)
 {
+	(void) req;
 	int error = CRYPTO_SUCCESS;
 
 	ASSERT(SKEIN_CTX(ctx) != NULL);
@@ -491,7 +491,6 @@ skein_update(crypto_ctx_t *ctx, crypto_data_t *data, crypto_req_handle_t req)
  * for digest and MAC operation.
  * Supported output digest formats are raw, uio and mblk.
  */
-/*ARGSUSED*/
 static int
 skein_final(crypto_ctx_t *ctx, crypto_data_t *digest, crypto_req_handle_t req)
 {
@@ -537,15 +536,15 @@ skein_final(crypto_ctx_t *ctx, crypto_data_t *digest, crypto_req_handle_t req)
  * `data' and writing the output to `digest'.
  * Supported input/output formats are raw, uio and mblk.
  */
-/*ARGSUSED*/
 static int
 skein_digest_atomic(crypto_provider_handle_t provider,
     crypto_session_id_t session_id, crypto_mechanism_t *mechanism,
     crypto_data_t *data, crypto_data_t *digest, crypto_req_handle_t req)
 {
-	int		error;
-	skein_ctx_t	skein_ctx;
-	crypto_ctx_t	ctx;
+	(void) provider, (void) session_id, (void) req;
+	int	 error;
+	skein_ctx_t skein_ctx;
+	crypto_ctx_t ctx;
 	SKEIN_CTX_LVALUE(&ctx) = &skein_ctx;
 
 	/* Init */
@@ -640,7 +639,6 @@ errout:
  * The MAC update and final calls are reused from the regular digest code.
  */
 
-/*ARGSUSED*/
 /*
  * Same as skein_digest_atomic, performs an atomic Skein MAC operation in
  * one step. All the same properties apply to the arguments of this
@@ -653,9 +651,10 @@ skein_mac_atomic(crypto_provider_handle_t provider,
     crypto_spi_ctx_template_t ctx_template, crypto_req_handle_t req)
 {
 	/* faux crypto context just for skein_digest_{update,final} */
-	int		error;
-	crypto_ctx_t	ctx;
-	skein_ctx_t	skein_ctx;
+	(void) provider, (void) session_id;
+	int	 error;
+	crypto_ctx_t ctx;
+	skein_ctx_t skein_ctx;
 	SKEIN_CTX_LVALUE(&ctx) = &skein_ctx;
 
 	if (ctx_template != NULL) {
@@ -686,15 +685,15 @@ errout:
  * properties apply to the arguments of this function as to those of
  * skein_mac_init.
  */
-/*ARGSUSED*/
 static int
 skein_create_ctx_template(crypto_provider_handle_t provider,
     crypto_mechanism_t *mechanism, crypto_key_t *key,
     crypto_spi_ctx_template_t *ctx_template, size_t *ctx_template_size,
     crypto_req_handle_t req)
 {
-	int		error;
-	skein_ctx_t	*ctx_tmpl;
+	(void) provider;
+	int	 error;
+	skein_ctx_t *ctx_tmpl;
 
 	ctx_tmpl = kmem_alloc(sizeof (*ctx_tmpl), crypto_kmflag(req));
 	if (ctx_tmpl == NULL)

--- a/module/icp/os/modconf.c
+++ b/module/icp/os/modconf.c
@@ -47,6 +47,7 @@ struct mod_ops mod_cryptoops = {
 static int
 mod_null(struct modlmisc *modl, struct modlinkage *modlp)
 {
+	(void) modl, (void) modlp;
 	return (0);
 }
 
@@ -56,6 +57,7 @@ mod_null(struct modlmisc *modl, struct modlinkage *modlp)
 static int
 mod_infonull(void *modl, struct modlinkage *modlp, int *p0)
 {
+	(void) modl, (void) modlp;
 	*p0 = -1;		/* for modinfo display */
 	return (0);
 }

--- a/module/icp/os/modhash.c
+++ b/module/icp/os/modhash.c
@@ -172,16 +172,16 @@ kmutex_t mh_head_lock;
  * mod_hash_null_valdtor()
  * 	no-op key and value destructors.
  */
-/*ARGSUSED*/
 void
 mod_hash_null_keydtor(mod_hash_key_t key)
 {
+	(void) key;
 }
 
-/*ARGSUSED*/
 void
 mod_hash_null_valdtor(mod_hash_val_t val)
 {
+	(void) val;
 }
 
 /*
@@ -198,10 +198,10 @@ mod_hash_null_valdtor(mod_hash_val_t val)
  *	"Compilers: Principles, Tools & Techniques", by Aho, Sethi, Ullman
  */
 
-/*ARGSUSED*/
 uint_t
 mod_hash_bystr(void *hash_data, mod_hash_key_t key)
 {
+	(void) hash_data;
 	uint_t hash = 0;
 	uint_t g;
 	char *p, *k = (char *)key;
@@ -672,10 +672,10 @@ mod_hash_reserve_nosleep(mod_hash_t *hash, mod_hash_hndl_t *handlep)
 
 }
 
-/*ARGSUSED*/
 void
 mod_hash_cancel(mod_hash_t *hash, mod_hash_hndl_t *handlep)
 {
+	(void) hash;
 	kmem_cache_free(mh_e_cache, *handlep);
 	*handlep = (mod_hash_hndl_t)0;
 }

--- a/module/nvpair/fnvpair.c
+++ b/module/nvpair/fnvpair.c
@@ -82,13 +82,13 @@ fnvlist_pack(nvlist_t *nvl, size_t *sizep)
 	return (packed);
 }
 
-/*ARGSUSED*/
 void
 fnvlist_pack_free(char *pack, size_t size)
 {
 #ifdef _KERNEL
 	kmem_free(pack, size);
 #else
+	(void) size;
 	free(pack);
 #endif
 }

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -576,6 +576,7 @@ nvlist_nv_alloc(int kmflag)
 		return (nv_alloc_pushpage);
 	}
 #else
+	(void) kmflag;
 	return (nv_alloc_nosleep);
 #endif /* _KERNEL */
 }
@@ -2296,10 +2297,11 @@ nvlist_add_nvpair(nvlist_t *nvl, nvpair_t *nvp)
  * the values are taken from nvl in the case of duplicates.
  * Return 0 on success.
  */
-/*ARGSUSED*/
 int
 nvlist_merge(nvlist_t *dst, nvlist_t *nvl, int flag)
 {
+	(void) flag;
+
 	if (nvl == NULL || dst == NULL)
 		return (EINVAL);
 
@@ -2803,10 +2805,10 @@ nvs_native_create(nvstream_t *nvs, nvs_native_t *native, char *buf,
 	}
 }
 
-/*ARGSUSED*/
 static void
 nvs_native_destroy(nvstream_t *nvs)
 {
+	(void) nvs;
 }
 
 static int

--- a/module/nvpair/nvpair_alloc_fixed.c
+++ b/module/nvpair/nvpair_alloc_fixed.c
@@ -85,11 +85,11 @@ nv_fixed_alloc(nv_alloc_t *nva, size_t size)
 	return ((void *)new);
 }
 
-/*ARGSUSED*/
 static void
 nv_fixed_free(nv_alloc_t *nva, void *buf, size_t size)
 {
 	/* don't free memory in the pre-allocated buffer */
+	(void) nva, (void) buf, (void) size;
 }
 
 static void

--- a/module/os/freebsd/zfs/spa_os.c
+++ b/module/os/freebsd/zfs/spa_os.c
@@ -183,7 +183,6 @@ spa_import_rootpool(const char *name, bool checkpointrewind)
 	spa_t *spa;
 	vdev_t *rvd;
 	nvlist_t *config, *nvtop;
-	uint64_t txg;
 	char *pname;
 	int error;
 
@@ -196,7 +195,6 @@ spa_import_rootpool(const char *name, bool checkpointrewind)
 	if (config != NULL) {
 		pname = fnvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME);
 		VERIFY0(strcmp(name, pname));
-		txg = fnvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_TXG);
 
 		if ((spa = spa_lookup(pname)) != NULL) {
 			/*

--- a/module/os/freebsd/zfs/vdev_file.c
+++ b/module/os/freebsd/zfs/vdev_file.c
@@ -286,10 +286,10 @@ vdev_file_io_start(zio_t *zio)
 	    TQ_SLEEP), !=, 0);
 }
 
-/* ARGSUSED */
 static void
 vdev_file_io_done(zio_t *zio)
 {
+	(void) zio;
 }
 
 vdev_ops_t vdev_file_ops = {

--- a/module/os/freebsd/zfs/zfs_racct.c
+++ b/module/os/freebsd/zfs/zfs_racct.c
@@ -37,6 +37,8 @@ zfs_racct_read(uint64_t size, uint64_t iops)
 		racct_add_force(curproc, RACCT_READIOPS, iops);
 		PROC_UNLOCK(curproc);
 	}
+#else
+	(void) size;
 #endif /* RACCT */
 }
 
@@ -51,5 +53,7 @@ zfs_racct_write(uint64_t size, uint64_t iops)
 		racct_add_force(curproc, RACCT_WRITEIOPS, iops);
 		PROC_UNLOCK(curproc);
 	}
+#else
+	(void) size;
 #endif /* RACCT */
 }

--- a/module/os/freebsd/zfs/zfs_znode.c
+++ b/module/os/freebsd/zfs/zfs_znode.c
@@ -571,7 +571,6 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 	dmu_buf_t	*db;
 	timestruc_t	now;
 	uint64_t	gen, obj;
-	int		err;
 	int		bonuslen;
 	int		dnodesize;
 	sa_handle_t	*sa_hdl;
@@ -811,12 +810,11 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 		VERIFY0(zfs_aclset_common(*zpp, acl_ids->z_aclp, cr, tx));
 	}
 	if (!(flag & IS_ROOT_NODE)) {
-		vnode_t *vp;
-
-		vp = ZTOV(*zpp);
+		vnode_t *vp = ZTOV(*zpp);
 		vp->v_vflag |= VV_FORCEINSMQ;
-		err = insmntque(vp, zfsvfs->z_vfs);
+		int err = insmntque(vp, zfsvfs->z_vfs);
 		vp->v_vflag &= ~VV_FORCEINSMQ;
+		(void) err;
 		KASSERT(err == 0, ("insmntque() failed: error %d", err));
 	}
 	kmem_free(sa_attrs, sizeof (sa_bulk_attr_t) * ZPL_END);

--- a/module/os/freebsd/zfs/zio_crypt.c
+++ b/module/os/freebsd/zfs/zio_crypt.c
@@ -1033,7 +1033,6 @@ error:
  * and le_bswap indicates whether a byteswap is needed to get this block
  * into little endian format.
  */
-/* ARGSUSED */
 int
 zio_crypt_do_objset_hmacs(zio_crypt_key_t *key, void *data, uint_t datalen,
     boolean_t should_bswap, uint8_t *portable_mac, uint8_t *local_mac)
@@ -1242,13 +1241,13 @@ zio_crypt_do_indirect_mac_checksum_abd(boolean_t generate, abd_t *abd,
  * It also means we'll only return one zfs_uio_t.
  */
 
-/* ARGSUSED */
 static int
 zio_crypt_init_uios_zil(boolean_t encrypt, uint8_t *plainbuf,
     uint8_t *cipherbuf, uint_t datalen, boolean_t byteswap, zfs_uio_t *puio,
     zfs_uio_t *out_uio, uint_t *enc_len, uint8_t **authbuf, uint_t *auth_len,
     boolean_t *no_crypt)
 {
+	(void) puio;
 	uint8_t *aadbuf = zio_buf_alloc(datalen);
 	uint8_t *src, *dst, *slrp, *dlrp, *blkend, *aadp;
 	iovec_t *dst_iovecs;
@@ -1545,12 +1544,12 @@ zio_crypt_init_uios_dnode(boolean_t encrypt, uint64_t version,
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 zio_crypt_init_uios_normal(boolean_t encrypt, uint8_t *plainbuf,
     uint8_t *cipherbuf, uint_t datalen, zfs_uio_t *puio, zfs_uio_t *out_uio,
     uint_t *enc_len)
 {
+	(void) puio;
 	int ret;
 	uint_t nr_plain = 1, nr_cipher = 2;
 	iovec_t *plain_iovecs = NULL, *cipher_iovecs = NULL;

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -205,6 +205,7 @@ abd_alloc_struct_impl(size_t size)
 	 * In Linux we do not use the size passed in during ABD
 	 * allocation, so we just ignore it.
 	 */
+	(void) size;
 	abd_t *abd = kmem_cache_alloc(abd_cache, KM_PUSHPAGE);
 	ASSERT3P(abd, !=, NULL);
 	ABDSTAT_INCR(abdstat_struct_size, sizeof (abd_t));
@@ -838,6 +839,7 @@ abd_t *
 abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off,
     size_t size)
 {
+	(void) size;
 	int i = 0;
 	struct scatterlist *sg = NULL;
 

--- a/module/os/linux/zfs/arc_os.c
+++ b/module/os/linux/zfs/arc_os.c
@@ -398,11 +398,11 @@ param_set_arc_int(const char *buf, zfs_kernel_param_t *kp)
 }
 
 #ifdef CONFIG_MEMORY_HOTPLUG
-/* ARGSUSED */
 static int
 arc_hotplug_callback(struct notifier_block *self, unsigned long action,
     void *arg)
 {
+	(void) self, (void) arg;
 	uint64_t allmem = arc_all_memory();
 	if (action != MEM_ONLINE)
 		return (NOTIFY_OK);
@@ -458,6 +458,7 @@ arc_available_memory(void)
 int
 arc_memory_throttle(spa_t *spa, uint64_t reserve, uint64_t txg)
 {
+	(void) spa, (void) reserve, (void) txg;
 	return (0);
 }
 

--- a/module/os/linux/zfs/vdev_file.c
+++ b/module/os/linux/zfs/vdev_file.c
@@ -298,10 +298,10 @@ vdev_file_io_start(zio_t *zio)
 	    TQ_SLEEP), !=, TASKQID_INVALID);
 }
 
-/* ARGSUSED */
 static void
 vdev_file_io_done(zio_t *zio)
 {
+	(void) zio;
 }
 
 vdev_ops_t vdev_file_ops = {

--- a/module/os/linux/zfs/zfs_debug.c
+++ b/module/os/linux/zfs/zfs_debug.c
@@ -84,6 +84,7 @@ zfs_dbgmsg_purge(int max_size)
 static int
 zfs_dbgmsg_clear(procfs_list_t *procfs_list)
 {
+	(void) procfs_list;
 	mutex_enter(&zfs_dbgmsgs.pl_lock);
 	zfs_dbgmsg_purge(0);
 	mutex_exit(&zfs_dbgmsgs.pl_lock);

--- a/module/os/linux/zfs/zfs_racct.c
+++ b/module/os/linux/zfs/zfs_racct.c
@@ -28,9 +28,11 @@
 void
 zfs_racct_read(uint64_t size, uint64_t iops)
 {
+	(void) size, (void) iops;
 }
 
 void
 zfs_racct_write(uint64_t size, uint64_t iops)
 {
+	(void) size, (void) iops;
 }

--- a/module/os/linux/zfs/zio_crypt.c
+++ b/module/os/linux/zfs/zio_crypt.c
@@ -1761,6 +1761,7 @@ zio_crypt_init_uios_normal(boolean_t encrypt, uint8_t *plainbuf,
     uint8_t *cipherbuf, uint_t datalen, zfs_uio_t *puio, zfs_uio_t *cuio,
     uint_t *enc_len)
 {
+	(void) encrypt;
 	int ret;
 	uint_t nr_plain = 1, nr_cipher = 2;
 	iovec_t *plain_iovecs = NULL, *cipher_iovecs = NULL;

--- a/module/zcommon/zfs_fletcher.c
+++ b/module/zcommon/zfs_fletcher.c
@@ -226,7 +226,6 @@ static struct fletcher_4_kstat {
 /* Indicate that benchmark has been completed */
 static boolean_t fletcher_4_initialized = B_FALSE;
 
-/*ARGSUSED*/
 void
 fletcher_init(zio_cksum_t *zcp)
 {
@@ -258,11 +257,11 @@ fletcher_2_incremental_native(void *buf, size_t size, void *data)
 	return (0);
 }
 
-/*ARGSUSED*/
 void
 fletcher_2_native(const void *buf, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) ctx_template;
 	fletcher_init(zcp);
 	(void) fletcher_2_incremental_native((void *) buf, size, zcp);
 }
@@ -292,11 +291,11 @@ fletcher_2_incremental_byteswap(void *buf, size_t size, void *data)
 	return (0);
 }
 
-/*ARGSUSED*/
 void
 fletcher_2_byteswap(const void *buf, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) ctx_template;
 	fletcher_init(zcp);
 	(void) fletcher_2_incremental_byteswap((void *) buf, size, zcp);
 }
@@ -460,11 +459,11 @@ fletcher_4_native_impl(const void *buf, uint64_t size, zio_cksum_t *zcp)
 	ops->fini_native(&ctx, zcp);
 }
 
-/*ARGSUSED*/
 void
 fletcher_4_native(const void *buf, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) ctx_template;
 	const uint64_t p2size = P2ALIGN(size, FLETCHER_MIN_SIMD_SIZE);
 
 	ASSERT(IS_P2ALIGNED(size, sizeof (uint32_t)));
@@ -502,11 +501,11 @@ fletcher_4_byteswap_impl(const void *buf, uint64_t size, zio_cksum_t *zcp)
 	ops->fini_byteswap(&ctx, zcp);
 }
 
-/*ARGSUSED*/
 void
 fletcher_4_byteswap(const void *buf, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) ctx_template;
 	const uint64_t p2size = P2ALIGN(size, FLETCHER_MIN_SIMD_SIZE);
 
 	ASSERT(IS_P2ALIGNED(size, sizeof (uint32_t)));

--- a/module/zcommon/zprop_common.c
+++ b/module/zcommon/zprop_common.c
@@ -83,6 +83,7 @@ zfs_mod_supported_prop(const char *name, zfs_type_t type,
  * tree, but this has not been done yet.
  */
 #if defined(_KERNEL) || defined(LIB_ZPOOL_BUILD) || defined(__FreeBSD__)
+	(void) name, (void) type, (void) sfeatures;
 	return (B_TRUE);
 #else
 	return (zfs_mod_supported(type == ZFS_TYPE_POOL ?

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -889,10 +889,10 @@ abd_copy_from_buf_off(abd_t *abd, const void *buf, size_t off, size_t size)
 	    &ba_ptr);
 }
 
-/*ARGSUSED*/
 static int
 abd_zero_off_cb(void *buf, size_t size, void *private)
 {
+	(void) private;
 	(void) memset(buf, 0, size);
 	return (0);
 }
@@ -967,10 +967,10 @@ abd_iterate_func2(abd_t *dabd, abd_t *sabd, size_t doff, size_t soff,
 	return (ret);
 }
 
-/*ARGSUSED*/
 static int
 abd_copy_off_cb(void *dbuf, void *sbuf, size_t size, void *private)
 {
+	(void) private;
 	(void) memcpy(dbuf, sbuf, size);
 	return (0);
 }
@@ -985,10 +985,10 @@ abd_copy_off(abd_t *dabd, abd_t *sabd, size_t doff, size_t soff, size_t size)
 	    abd_copy_off_cb, NULL);
 }
 
-/*ARGSUSED*/
 static int
 abd_cmp_cb(void *bufa, void *bufb, size_t size, void *private)
 {
+	(void) private;
 	return (memcmp(bufa, bufb, size));
 }
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1098,8 +1098,6 @@ static kmem_cache_t *buf_cache;
 static void
 buf_fini(void)
 {
-	int i;
-
 #if defined(_KERNEL)
 	/*
 	 * Large allocations which do not require contiguous pages
@@ -1111,7 +1109,7 @@ buf_fini(void)
 	kmem_free(buf_hash_table.ht_table,
 	    (buf_hash_table.ht_mask + 1) * sizeof (void *));
 #endif
-	for (i = 0; i < BUF_LOCKS; i++)
+	for (int i = 0; i < BUF_LOCKS; i++)
 		mutex_destroy(BUF_HASH_LOCK(i));
 	kmem_cache_destroy(hdr_full_cache);
 	kmem_cache_destroy(hdr_full_crypt_cache);
@@ -1123,10 +1121,10 @@ buf_fini(void)
  * Constructor callback - called when the cache is empty
  * and a new buf is requested.
  */
-/* ARGSUSED */
 static int
 hdr_full_cons(void *vbuf, void *unused, int kmflag)
 {
+	(void) unused, (void) kmflag;
 	arc_buf_hdr_t *hdr = vbuf;
 
 	bzero(hdr, HDR_FULL_SIZE);
@@ -1142,10 +1140,10 @@ hdr_full_cons(void *vbuf, void *unused, int kmflag)
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 hdr_full_crypt_cons(void *vbuf, void *unused, int kmflag)
 {
+	(void) unused;
 	arc_buf_hdr_t *hdr = vbuf;
 
 	hdr_full_cons(vbuf, unused, kmflag);
@@ -1155,10 +1153,10 @@ hdr_full_crypt_cons(void *vbuf, void *unused, int kmflag)
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 hdr_l2only_cons(void *vbuf, void *unused, int kmflag)
 {
+	(void) unused, (void) kmflag;
 	arc_buf_hdr_t *hdr = vbuf;
 
 	bzero(hdr, HDR_L2ONLY_SIZE);
@@ -1167,10 +1165,10 @@ hdr_l2only_cons(void *vbuf, void *unused, int kmflag)
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 buf_cons(void *vbuf, void *unused, int kmflag)
 {
+	(void) unused, (void) kmflag;
 	arc_buf_t *buf = vbuf;
 
 	bzero(buf, sizeof (arc_buf_t));
@@ -1184,10 +1182,10 @@ buf_cons(void *vbuf, void *unused, int kmflag)
  * Destructor callback - called when a cached buf is
  * no longer required.
  */
-/* ARGSUSED */
 static void
 hdr_full_dest(void *vbuf, void *unused)
 {
+	(void) unused;
 	arc_buf_hdr_t *hdr = vbuf;
 
 	ASSERT(HDR_EMPTY(hdr));
@@ -1198,30 +1196,30 @@ hdr_full_dest(void *vbuf, void *unused)
 	arc_space_return(HDR_FULL_SIZE, ARC_SPACE_HDRS);
 }
 
-/* ARGSUSED */
 static void
 hdr_full_crypt_dest(void *vbuf, void *unused)
 {
+	(void) unused;
 	arc_buf_hdr_t *hdr = vbuf;
 
 	hdr_full_dest(vbuf, unused);
 	arc_space_return(sizeof (hdr->b_crypt_hdr), ARC_SPACE_HDRS);
 }
 
-/* ARGSUSED */
 static void
 hdr_l2only_dest(void *vbuf, void *unused)
 {
-	arc_buf_hdr_t *hdr __maybe_unused = vbuf;
+	(void) unused;
+	arc_buf_hdr_t *hdr = vbuf;
 
 	ASSERT(HDR_EMPTY(hdr));
 	arc_space_return(HDR_L2ONLY_SIZE, ARC_SPACE_L2HDRS);
 }
 
-/* ARGSUSED */
 static void
 buf_dest(void *vbuf, void *unused)
 {
+	(void) unused;
 	arc_buf_t *buf = vbuf;
 
 	mutex_destroy(&buf->b_evict_lock);
@@ -1517,11 +1515,11 @@ arc_cksum_compute(arc_buf_t *buf)
 void
 arc_buf_sigsegv(int sig, siginfo_t *si, void *unused)
 {
+	(void) sig, (void) unused;
 	panic("Got SIGSEGV at address: 0x%lx\n", (long)si->si_addr);
 }
 #endif
 
-/* ARGSUSED */
 static void
 arc_buf_unwatch(arc_buf_t *buf)
 {
@@ -1530,10 +1528,11 @@ arc_buf_unwatch(arc_buf_t *buf)
 		ASSERT0(mprotect(buf->b_data, arc_buf_size(buf),
 		    PROT_READ | PROT_WRITE));
 	}
+#else
+	(void) buf;
 #endif
 }
 
-/* ARGSUSED */
 static void
 arc_buf_watch(arc_buf_t *buf)
 {
@@ -1541,6 +1540,8 @@ arc_buf_watch(arc_buf_t *buf)
 	if (arc_watch)
 		ASSERT0(mprotect(buf->b_data, arc_buf_size(buf),
 		    PROT_READ));
+#else
+	(void) buf;
 #endif
 }
 
@@ -1952,7 +1953,7 @@ error:
  * arc_buf_fill().
  */
 static void
-arc_buf_untransform_in_place(arc_buf_t *buf, kmutex_t *hash_lock)
+arc_buf_untransform_in_place(arc_buf_t *buf)
 {
 	arc_buf_hdr_t *hdr = buf->b_hdr;
 
@@ -2056,7 +2057,7 @@ arc_buf_fill(arc_buf_t *buf, spa_t *spa, const zbookmark_phys_t *zb,
 
 			if (hash_lock != NULL)
 				mutex_enter(hash_lock);
-			arc_buf_untransform_in_place(buf, hash_lock);
+			arc_buf_untransform_in_place(buf);
 			if (hash_lock != NULL)
 				mutex_exit(hash_lock);
 
@@ -2342,6 +2343,7 @@ remove_reference(arc_buf_hdr_t *hdr, kmutex_t *hash_lock, void *tag)
 void
 arc_buf_info(arc_buf_t *ab, arc_buf_info_t *abi, int state_index)
 {
+	(void) state_index;
 	arc_buf_hdr_t *hdr = ab->b_hdr;
 	l1arc_buf_hdr_t *l1hdr = NULL;
 	l2arc_buf_hdr_t *l2hdr = NULL;
@@ -4850,10 +4852,11 @@ arc_kmem_reap_soon(void)
 	abd_cache_reap_now();
 }
 
-/* ARGSUSED */
 static boolean_t
 arc_evict_cb_check(void *arg, zthr_t *zthr)
 {
+	(void) arg, (void) zthr;
+
 #ifdef ZFS_DEBUG
 	/*
 	 * This is necessary in order to keep the kstat information
@@ -4893,10 +4896,11 @@ arc_evict_cb_check(void *arg, zthr_t *zthr)
  * Keep arc_size under arc_c by running arc_evict which evicts data
  * from the ARC.
  */
-/* ARGSUSED */
 static void
 arc_evict_cb(void *arg, zthr_t *zthr)
 {
+	(void) arg, (void) zthr;
+
 	uint64_t evicted = 0;
 	fstrans_cookie_t cookie = spl_fstrans_mark();
 
@@ -4933,10 +4937,11 @@ arc_evict_cb(void *arg, zthr_t *zthr)
 	spl_fstrans_unmark(cookie);
 }
 
-/* ARGSUSED */
 static boolean_t
 arc_reap_cb_check(void *arg, zthr_t *zthr)
 {
+	(void) arg, (void) zthr;
+
 	int64_t free_memory = arc_available_memory();
 	static int reap_cb_check_counter = 0;
 
@@ -4980,10 +4985,11 @@ arc_reap_cb_check(void *arg, zthr_t *zthr)
  * target size of the cache (arc_c), causing the arc_evict_cb()
  * to free more buffers.
  */
-/* ARGSUSED */
 static void
 arc_reap_cb(void *arg, zthr_t *zthr)
 {
+	(void) arg, (void) zthr;
+
 	int64_t free_memory;
 	fstrans_cookie_t cookie = spl_fstrans_mark();
 
@@ -5598,11 +5604,12 @@ arc_buf_access(arc_buf_t *buf)
 }
 
 /* a generic arc_read_done_func_t which you can use */
-/* ARGSUSED */
 void
 arc_bcopy_func(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
     arc_buf_t *buf, void *arg)
 {
+	(void) zio, (void) zb, (void) bp;
+
 	if (buf == NULL)
 		return;
 
@@ -5611,11 +5618,11 @@ arc_bcopy_func(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 }
 
 /* a generic arc_read_done_func_t */
-/* ARGSUSED */
 void
 arc_getbuf_func(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
     arc_buf_t *buf, void *arg)
 {
+	(void) zb, (void) bp;
 	arc_buf_t **bufp = arg;
 
 	if (buf == NULL) {
@@ -9678,10 +9685,10 @@ l2arc_hdr_limit_reached(void)
  * This thread feeds the L2ARC at regular intervals.  This is the beating
  * heart of the L2ARC.
  */
-/* ARGSUSED */
 static void
 l2arc_feed_thread(void *unused)
 {
+	(void) unused;
 	callb_cpr_t cpr;
 	l2arc_dev_t *dev;
 	spa_t *spa;

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -860,10 +860,10 @@ struct space_range_arg {
 	uint64_t uncomp;
 };
 
-/* ARGSUSED */
 static int
 space_range_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 {
+	(void) bp_freed, (void) tx;
 	struct space_range_arg *sra = arg;
 
 	if (bp->blk_birth > sra->mintxg && bp->blk_birth <= sra->maxtxg) {
@@ -932,11 +932,11 @@ bpobj_space_range(bpobj_t *bpo, uint64_t mintxg, uint64_t maxtxg,
  * bpobj are designated as free or allocated that information is not preserved
  * in bplists.
  */
-/* ARGSUSED */
 int
 bplist_append_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx)
 {
+	(void) bp_freed, (void) tx;
 	bplist_t *bpl = arg;
 	bplist_append(bpl, bp);
 	return (0);

--- a/module/zfs/bptree.c
+++ b/module/zfs/bptree.c
@@ -147,11 +147,11 @@ bptree_add(objset_t *os, uint64_t obj, blkptr_t *bp, uint64_t birth_txg,
 	dmu_buf_rele(db, FTAG);
 }
 
-/* ARGSUSED */
 static int
 bptree_visit_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
     const zbookmark_phys_t *zb, const dnode_phys_t *dnp, void *arg)
 {
+	(void) zilog, (void) dnp;
 	int err;
 	struct bptree_args *ba = arg;
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -280,10 +280,10 @@ static unsigned long dbuf_metadata_cache_target_bytes(void);
 uint_t dbuf_cache_hiwater_pct = 10;
 uint_t dbuf_cache_lowater_pct = 10;
 
-/* ARGSUSED */
 static int
 dbuf_cons(void *vdb, void *unused, int kmflag)
 {
+	(void) unused, (void) kmflag;
 	dmu_buf_impl_t *db = vdb;
 	bzero(db, sizeof (dmu_buf_impl_t));
 
@@ -296,10 +296,10 @@ dbuf_cons(void *vdb, void *unused, int kmflag)
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 dbuf_dest(void *vdb, void *unused)
 {
+	(void) unused;
 	dmu_buf_impl_t *db = vdb;
 	mutex_destroy(&db->db_mtx);
 	rw_destroy(&db->db_rwlock);
@@ -783,10 +783,10 @@ dbuf_evict_one(void)
  * of the dbuf cache is at or below the maximum size. Once the dbuf is aged
  * out of the cache it is destroyed and becomes eligible for arc eviction.
  */
-/* ARGSUSED */
 static void
 dbuf_evict_thread(void *unused)
 {
+	(void) unused;
 	callb_cpr_t cpr;
 
 	CALLB_CPR_INIT(&cpr, &dbuf_evict_lock, callb_generic_cpr, FTAG);
@@ -1339,6 +1339,7 @@ static void
 dbuf_read_done(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
     arc_buf_t *buf, void *vdb)
 {
+	(void) zb, (void) bp;
 	dmu_buf_impl_t *db = vdb;
 
 	mutex_enter(&db->db_mtx);
@@ -1432,7 +1433,7 @@ dbuf_handle_indirect_hole(dmu_buf_impl_t *db, dnode_t *dn)
  * was taken, ENOENT if no action was taken.
  */
 static int
-dbuf_read_hole(dmu_buf_impl_t *db, dnode_t *dn, uint32_t flags)
+dbuf_read_hole(dmu_buf_impl_t *db, dnode_t *dn)
 {
 	ASSERT(MUTEX_HELD(&db->db_mtx));
 
@@ -1548,7 +1549,7 @@ dbuf_read_impl(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags,
 		goto early_unlock;
 	}
 
-	err = dbuf_read_hole(db, dn, flags);
+	err = dbuf_read_hole(db, dn);
 	if (err == 0)
 		goto early_unlock;
 
@@ -2678,10 +2679,10 @@ dbuf_override_impl(dmu_buf_impl_t *db, const blkptr_t *bp, dmu_tx_t *tx)
 	dl->dr_overridden_by.blk_birth = dr->dr_txg;
 }
 
-/* ARGSUSED */
 void
 dmu_buf_fill_done(dmu_buf_t *dbuf, dmu_tx_t *tx)
 {
+	(void) tx;
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)dbuf;
 	dbuf_states_t old_state;
 	mutex_enter(&db->db_mtx);
@@ -3198,6 +3199,7 @@ static void
 dbuf_issue_final_prefetch_done(zio_t *zio, const zbookmark_phys_t *zb,
     const blkptr_t *iobp, arc_buf_t *abuf, void *private)
 {
+	(void) zio, (void) zb, (void) iobp;
 	dbuf_prefetch_arg_t *dpa = private;
 
 	dbuf_prefetch_fini(dpa, B_TRUE);
@@ -3246,6 +3248,7 @@ static void
 dbuf_prefetch_indirect_done(zio_t *zio, const zbookmark_phys_t *zb,
     const blkptr_t *iobp, arc_buf_t *abuf, void *private)
 {
+	(void) zb, (void) iobp;
 	dbuf_prefetch_arg_t *dpa = private;
 
 	ASSERT3S(dpa->dpa_zb.zb_level, <, dpa->dpa_curlevel);
@@ -4512,10 +4515,10 @@ dbuf_sync_list(list_t *list, int level, dmu_tx_t *tx)
 	}
 }
 
-/* ARGSUSED */
 static void
 dbuf_write_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 {
+	(void) buf;
 	dmu_buf_impl_t *db = vdb;
 	dnode_t *dn;
 	blkptr_t *bp = zio->io_bp;
@@ -4603,7 +4606,6 @@ dbuf_write_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 	dmu_buf_unlock_parent(db, dblt, FTAG);
 }
 
-/* ARGSUSED */
 /*
  * This function gets called just prior to running through the compression
  * stage of the zio pipeline. If we're an indirect block comprised of only
@@ -4614,6 +4616,7 @@ dbuf_write_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 static void
 dbuf_write_children_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 {
+	(void) zio, (void) buf;
 	dmu_buf_impl_t *db = vdb;
 	dnode_t *dn;
 	blkptr_t *bp;
@@ -4657,10 +4660,10 @@ dbuf_write_children_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
  * so this callback allows us to retire dirty space gradually, as the physical
  * i/os complete.
  */
-/* ARGSUSED */
 static void
 dbuf_write_physdone(zio_t *zio, arc_buf_t *buf, void *arg)
 {
+	(void) buf;
 	dmu_buf_impl_t *db = arg;
 	objset_t *os = db->db_objset;
 	dsl_pool_t *dp = dmu_objset_pool(os);
@@ -4679,10 +4682,10 @@ dbuf_write_physdone(zio_t *zio, arc_buf_t *buf, void *arg)
 	dsl_pool_undirty_space(dp, delta, zio->io_txg);
 }
 
-/* ARGSUSED */
 static void
 dbuf_write_done(zio_t *zio, arc_buf_t *buf, void *vdb)
 {
+	(void) buf;
 	dmu_buf_impl_t *db = vdb;
 	blkptr_t *bp_orig = &zio->io_bp_orig;
 	blkptr_t *bp = db->db_blkptr;

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -816,13 +816,14 @@ get_next_chunk(dnode_t *dn, uint64_t *start, uint64_t minimum, uint64_t *l1blks)
  * otherwise return false.
  * Used below in dmu_free_long_range_impl() to enable abort when unmounting
  */
-/*ARGSUSED*/
 static boolean_t
 dmu_objset_zfs_unmounting(objset_t *os)
 {
 #ifdef _KERNEL
 	if (dmu_objset_type(os) == DMU_OST_ZFS)
 		return (zfs_get_vfs_flag_unmounted(os));
+#else
+	(void) os;
 #endif
 	return (B_FALSE);
 }
@@ -1504,10 +1505,10 @@ typedef struct {
 	dmu_tx_t		*dsa_tx;
 } dmu_sync_arg_t;
 
-/* ARGSUSED */
 static void
 dmu_sync_ready(zio_t *zio, arc_buf_t *buf, void *varg)
 {
+	(void) buf;
 	dmu_sync_arg_t *dsa = varg;
 	dmu_buf_t *db = dsa->dsa_zgd->zgd_db;
 	blkptr_t *bp = zio->io_bp;
@@ -1532,10 +1533,10 @@ dmu_sync_late_arrival_ready(zio_t *zio)
 	dmu_sync_ready(zio, NULL, zio->io_private);
 }
 
-/* ARGSUSED */
 static void
 dmu_sync_done(zio_t *zio, arc_buf_t *buf, void *varg)
 {
+	(void) buf;
 	dmu_sync_arg_t *dsa = varg;
 	dbuf_dirty_record_t *dr = dsa->dsa_dr;
 	dmu_buf_impl_t *db = dr->dr_dbuf;
@@ -2276,10 +2277,10 @@ byteswap_uint16_array(void *vbuf, size_t size)
 		buf[i] = BSWAP_16(buf[i]);
 }
 
-/* ARGSUSED */
 void
 byteswap_uint8_array(void *vbuf, size_t size)
 {
+	(void) vbuf, (void) size;
 }
 
 void

--- a/module/zfs/dmu_diff.c
+++ b/module/zfs/dmu_diff.c
@@ -108,11 +108,11 @@ report_dnode(dmu_diffarg_t *da, uint64_t object, dnode_phys_t *dnp)
 	(((uint64_t)dnp->dn_datablkszsec) << (SPA_MINBLOCKSHIFT + \
 	(level) * (dnp->dn_indblkshift - SPA_BLKPTRSHIFT)))
 
-/* ARGSUSED */
 static int
 diff_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
     const zbookmark_phys_t *zb, const dnode_phys_t *dnp, void *arg)
 {
+	(void) zilog;
 	dmu_diffarg_t *da = arg;
 	int err = 0;
 

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -751,9 +751,9 @@ static int
 dmu_objset_own_impl(dsl_dataset_t *ds, dmu_objset_type_t type,
     boolean_t readonly, boolean_t decrypt, void *tag, objset_t **osp)
 {
-	int err;
+	(void) tag;
 
-	err = dmu_objset_from_ds(ds, osp);
+	int err = dmu_objset_from_ds(ds, osp);
 	if (err != 0) {
 		return (err);
 	} else if (type != DMU_OST_ANY && type != (*osp)->os_phys->os_type) {
@@ -1157,7 +1157,6 @@ typedef struct dmu_objset_create_arg {
 	dsl_crypto_params_t *doca_dcp;
 } dmu_objset_create_arg_t;
 
-/*ARGSUSED*/
 static int
 dmu_objset_create_check(void *arg, dmu_tx_t *tx)
 {
@@ -1353,7 +1352,6 @@ typedef struct dmu_objset_clone_arg {
 	proc_t *doca_proc;
 } dmu_objset_clone_arg_t;
 
-/*ARGSUSED*/
 static int
 dmu_objset_clone_check(void *arg, dmu_tx_t *tx)
 {
@@ -1565,10 +1563,10 @@ dmu_objset_sync_dnodes(multilist_sublist_t *list, dmu_tx_t *tx)
 	}
 }
 
-/* ARGSUSED */
 static void
 dmu_objset_write_ready(zio_t *zio, arc_buf_t *abuf, void *arg)
 {
+	(void) abuf;
 	blkptr_t *bp = zio->io_bp;
 	objset_t *os = arg;
 	dnode_phys_t *dnp = &os->os_phys->os_meta_dnode;
@@ -1596,10 +1594,10 @@ dmu_objset_write_ready(zio_t *zio, arc_buf_t *abuf, void *arg)
 		rrw_exit(&os->os_dsl_dataset->ds_bp_rwlock, FTAG);
 }
 
-/* ARGSUSED */
 static void
 dmu_objset_write_done(zio_t *zio, arc_buf_t *abuf, void *arg)
 {
+	(void) abuf;
 	blkptr_t *bp = zio->io_bp;
 	blkptr_t *bp_orig = &zio->io_bp_orig;
 	objset_t *os = arg;

--- a/module/zfs/dmu_redact.c
+++ b/module/zfs/dmu_redact.c
@@ -249,11 +249,11 @@ zfs_get_deleteq(objset_t *os)
  * Third, if there is a deleted object, we need to create a redaction record for
  * all of the blocks in that object.
  */
-/*ARGSUSED*/
 static int
 redact_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
     const zbookmark_phys_t *zb, const struct dnode_phys *dnp, void *arg)
 {
+	(void) spa, (void) zilog;
 	struct redact_thread_arg *rta = arg;
 	struct redact_record *record;
 

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -1097,11 +1097,11 @@ range_alloc(enum type type, uint64_t object, uint64_t start_blkid,
  * This is the callback function to traverse_dataset that acts as a worker
  * thread for dmu_send_impl.
  */
-/*ARGSUSED*/
 static int
 send_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
     const zbookmark_phys_t *zb, const struct dnode_phys *dnp, void *arg)
 {
+	(void) zilog;
 	struct send_thread_arg *sta = arg;
 	struct send_range *record;
 
@@ -2155,6 +2155,7 @@ setup_resume_points(struct dmu_send_params *dspp,
     struct send_merge_thread_arg *smt_arg, boolean_t resuming, objset_t *os,
     redaction_list_t *redact_rl, nvlist_t *nvl)
 {
+	(void) smt_arg;
 	dsl_dataset_t *to_ds = dspp->to_ds;
 	int err = 0;
 

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -560,11 +560,11 @@ traverse_dnode(traverse_data_t *td, const blkptr_t *bp, const dnode_phys_t *dnp,
 	return (err);
 }
 
-/* ARGSUSED */
 static int
 traverse_prefetcher(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
     const zbookmark_phys_t *zb, const dnode_phys_t *dnp, void *arg)
 {
+	(void) zilog, (void) dnp;
 	prefetch_data_t *pfd = arg;
 	int zio_flags = ZIO_FLAG_CANFAIL | ZIO_FLAG_SPECULATIVE;
 	arc_flags_t aflags = ARC_FLAG_NOWAIT | ARC_FLAG_PREFETCH |

--- a/module/zfs/dmu_zfetch.c
+++ b/module/zfs/dmu_zfetch.c
@@ -260,6 +260,7 @@ dmu_zfetch_stream_create(zfetch_t *zf, uint64_t blkid)
 static void
 dmu_zfetch_stream_done(void *arg, boolean_t io_issued)
 {
+	(void) io_issued;
 	zstream_t *zs = arg;
 
 	if (zfs_refcount_remove(&zs->zs_refs, NULL) == 0)

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -108,12 +108,11 @@ dbuf_compare(const void *x1, const void *x2)
 	return (TREE_PCMP(d1, d2));
 }
 
-/* ARGSUSED */
 static int
 dnode_cons(void *arg, void *unused, int kmflag)
 {
+	(void) unused, (void) kmflag;
 	dnode_t *dn = arg;
-	int i;
 
 	rw_init(&dn->dn_struct_rwlock, NULL, RW_NOLOCKDEP, NULL);
 	mutex_init(&dn->dn_mtx, NULL, MUTEX_DEFAULT, NULL);
@@ -139,7 +138,7 @@ dnode_cons(void *arg, void *unused, int kmflag)
 	bzero(&dn->dn_next_blksz[0], sizeof (dn->dn_next_blksz));
 	bzero(&dn->dn_next_maxblkid[0], sizeof (dn->dn_next_maxblkid));
 
-	for (i = 0; i < TXG_SIZE; i++) {
+	for (int i = 0; i < TXG_SIZE; i++) {
 		multilist_link_init(&dn->dn_dirty_link[i]);
 		dn->dn_free_ranges[i] = NULL;
 		list_create(&dn->dn_dirty_records[i],
@@ -174,11 +173,10 @@ dnode_cons(void *arg, void *unused, int kmflag)
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 dnode_dest(void *arg, void *unused)
 {
-	int i;
+	(void) unused;
 	dnode_t *dn = arg;
 
 	rw_destroy(&dn->dn_struct_rwlock);
@@ -190,7 +188,7 @@ dnode_dest(void *arg, void *unused)
 	zfs_refcount_destroy(&dn->dn_tx_holds);
 	ASSERT(!list_link_active(&dn->dn_link));
 
-	for (i = 0; i < TXG_SIZE; i++) {
+	for (int i = 0; i < TXG_SIZE; i++) {
 		ASSERT(!multilist_link_active(&dn->dn_dirty_link[i]));
 		ASSERT3P(dn->dn_free_ranges[i], ==, NULL);
 		list_destroy(&dn->dn_dirty_records[i]);
@@ -889,7 +887,6 @@ dnode_move_impl(dnode_t *odn, dnode_t *ndn)
 	odn->dn_moved = (uint8_t)-1;
 }
 
-/*ARGSUSED*/
 static kmem_cbrc_t
 dnode_move(void *buf, void *newbuf, size_t size, void *arg)
 {

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1621,7 +1621,9 @@ dnode_rele_and_unlock(dnode_t *dn, void *tag, boolean_t evicting)
 	 * other direct or indirect hold on the dnode must first drop the dnode
 	 * handle.
 	 */
+#ifdef ZFS_DEBUG
 	ASSERT(refs > 0 || dnh->dnh_zrlock.zr_owner != curthread);
+#endif
 
 	/* NOTE: the DNODE_DNODE does not have a dn_dbuf */
 	if (refs == 0 && db != NULL) {

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -1203,7 +1203,6 @@ dsl_redaction_list_long_rele(redaction_list_t *rl, void *tag)
 	(void) zfs_refcount_remove(&rl->rl_longholds, tag);
 }
 
-/* ARGSUSED */
 static void
 redaction_list_evict_sync(void *rlu)
 {
@@ -1470,10 +1469,11 @@ dsl_bookmark_next_changed(dsl_dataset_t *head, dsl_dataset_t *origin,
  * Adjust the FBN of any bookmarks that reference this block, whose "next"
  * is the head dataset.
  */
-/* ARGSUSED */
 void
 dsl_bookmark_block_killed(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx)
 {
+	(void) tx;
+
 	/*
 	 * Iterate over bookmarks whose "next" is the head dataset.
 	 */

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -2943,11 +2943,11 @@ typedef struct dsl_dataset_rename_snapshot_arg {
 	dmu_tx_t *ddrsa_tx;
 } dsl_dataset_rename_snapshot_arg_t;
 
-/* ARGSUSED */
 static int
 dsl_dataset_rename_snapshot_check_impl(dsl_pool_t *dp,
     dsl_dataset_t *hds, void *arg)
 {
+	(void) dp;
 	dsl_dataset_rename_snapshot_arg_t *ddrsa = arg;
 	int error;
 	uint64_t val;
@@ -4305,7 +4305,6 @@ typedef struct dsl_dataset_set_qr_arg {
 } dsl_dataset_set_qr_arg_t;
 
 
-/* ARGSUSED */
 static int
 dsl_dataset_set_refquota_check(void *arg, dmu_tx_t *tx)
 {
@@ -4512,7 +4511,6 @@ typedef struct dsl_dataset_set_compression_arg {
 	uint64_t ddsca_value;
 } dsl_dataset_set_compression_arg_t;
 
-/* ARGSUSED */
 static int
 dsl_dataset_set_compression_check(void *arg, dmu_tx_t *tx)
 {

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -699,11 +699,11 @@ struct killarg {
 	dmu_tx_t *tx;
 };
 
-/* ARGSUSED */
 static int
 kill_blkptr(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
     const zbookmark_phys_t *zb, const dnode_phys_t *dnp, void *arg)
 {
+	(void) spa, (void) dnp;
 	struct killarg *ka = arg;
 	dmu_tx_t *tx = ka->tx;
 
@@ -1246,10 +1246,10 @@ dsl_destroy_head(const char *name)
  * inconsistent datasets, even if we encounter an error trying to
  * process one of them.
  */
-/* ARGSUSED */
 int
 dsl_destroy_inconsistent(const char *dsname, void *arg)
 {
+	(void) arg;
 	objset_t *os;
 
 	if (dmu_objset_hold(dsname, FTAG, &os) == 0) {

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -764,6 +764,8 @@ dsl_enforce_ds_ss_limits(dsl_dir_t *dd, zfs_prop_t prop,
 	 */
 	if (secpolicy_zfs_proc(cr, proc) == 0)
 		return (ENFORCE_NEVER);
+#else
+	(void) proc;
 #endif
 
 	if ((obj = dsl_dir_phys(dd)->dd_head_dataset_obj) == 0)
@@ -1896,10 +1898,10 @@ typedef struct dsl_valid_rename_arg {
 	int nest_delta;
 } dsl_valid_rename_arg_t;
 
-/* ARGSUSED */
 static int
 dsl_valid_rename(dsl_pool_t *dp, dsl_dataset_t *ds, void *arg)
 {
+	(void) dp;
 	dsl_valid_rename_arg_t *dvra = arg;
 	char namebuf[ZFS_MAX_DATASET_NAME_LEN];
 
@@ -2396,6 +2398,7 @@ dsl_dir_activity_in_progress(dsl_dir_t *dd, dsl_dataset_t *ds,
 		 * The delete queue is ZPL specific, and libzpool doesn't have
 		 * it. It doesn't make sense to wait for it.
 		 */
+		(void) ds;
 		*in_progress = B_FALSE;
 		break;
 #endif

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -476,8 +476,8 @@ dsl_pool_destroy_obsolete_bpobj(dsl_pool_t *dp, dmu_tx_t *tx)
 }
 
 dsl_pool_t *
-dsl_pool_create(spa_t *spa, nvlist_t *zplprops, dsl_crypto_params_t *dcp,
-    uint64_t txg)
+dsl_pool_create(spa_t *spa, nvlist_t *zplprops __attribute__((unused)),
+    dsl_crypto_params_t *dcp, uint64_t txg)
 {
 	int err;
 	dsl_pool_t *dp = dsl_pool_open_impl(spa, txg);

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -664,6 +664,9 @@ dsl_early_sync_task_verify(dsl_pool_t *dp, uint64_t txg)
 
 	return (B_TRUE);
 }
+#else
+#define	dsl_early_sync_task_verify(dp, txg) \
+	((void) sizeof (dp), (void) sizeof (txg), B_TRUE)
 #endif
 
 void

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -504,10 +504,10 @@ dsl_prop_hascb(dsl_dataset_t *ds)
 	return (!list_is_empty(&ds->ds_prop_cbs));
 }
 
-/* ARGSUSED */
 static int
 dsl_prop_notify_all_cb(dsl_pool_t *dp, dsl_dataset_t *ds, void *arg)
 {
+	(void) arg;
 	dsl_dir_t *dd = ds->ds_dir;
 	dsl_prop_record_t *pr;
 	dsl_prop_cb_record_t *cbr;

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -705,10 +705,10 @@ dsl_scan_sync_state(dsl_scan_t *scn, dmu_tx_t *tx, state_sync_type_t sync_type)
 	}
 }
 
-/* ARGSUSED */
 int
 dsl_scan_setup_check(void *arg, dmu_tx_t *tx)
 {
+	(void) arg;
 	dsl_scan_t *scn = dmu_tx_pool(tx)->dp_scan;
 	vdev_t *rvd = scn->scn_dp->dp_spa->spa_root_vdev;
 
@@ -859,7 +859,6 @@ dsl_scan(dsl_pool_t *dp, pool_scan_func_t func)
 	    dsl_scan_setup_sync, &func, 0, ZFS_SPACE_CHECK_EXTRA_RESERVED));
 }
 
-/* ARGSUSED */
 static void
 dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 {
@@ -1006,10 +1005,10 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 	ASSERT(!dsl_scan_is_running(scn));
 }
 
-/* ARGSUSED */
 static int
 dsl_scan_cancel_check(void *arg, dmu_tx_t *tx)
 {
+	(void) arg;
 	dsl_scan_t *scn = dmu_tx_pool(tx)->dp_scan;
 
 	if (!dsl_scan_is_running(scn))
@@ -1017,10 +1016,10 @@ dsl_scan_cancel_check(void *arg, dmu_tx_t *tx)
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 dsl_scan_cancel_sync(void *arg, dmu_tx_t *tx)
 {
+	(void) arg;
 	dsl_scan_t *scn = dmu_tx_pool(tx)->dp_scan;
 
 	dsl_scan_done(scn, B_FALSE, tx);
@@ -1383,11 +1382,11 @@ typedef struct zil_scan_arg {
 	zil_header_t	*zsa_zh;
 } zil_scan_arg_t;
 
-/* ARGSUSED */
 static int
 dsl_scan_zil_block(zilog_t *zilog, const blkptr_t *bp, void *arg,
     uint64_t claim_txg)
 {
+	(void) zilog;
 	zil_scan_arg_t *zsa = arg;
 	dsl_pool_t *dp = zsa->zsa_dp;
 	dsl_scan_t *scn = dp->dp_scan;
@@ -1414,11 +1413,11 @@ dsl_scan_zil_block(zilog_t *zilog, const blkptr_t *bp, void *arg,
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 dsl_scan_zil_record(zilog_t *zilog, const lr_t *lrc, void *arg,
     uint64_t claim_txg)
 {
+	(void) zilog;
 	if (lrc->lrc_txtype == TX_WRITE) {
 		zil_scan_arg_t *zsa = arg;
 		dsl_pool_t *dp = zsa->zsa_dp;
@@ -1643,6 +1642,7 @@ static void
 dsl_scan_prefetch_cb(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
     arc_buf_t *buf, void *private)
 {
+	(void) zio;
 	scan_prefetch_ctx_t *spc = private;
 	dsl_scan_t *scn = spc->spc_scn;
 	spa_t *spa = scn->scn_dp->dp_spa;
@@ -1702,7 +1702,6 @@ out:
 	scan_prefetch_ctx_rele(spc, scn);
 }
 
-/* ARGSUSED */
 static void
 dsl_scan_prefetch_thread(void *arg)
 {
@@ -2340,7 +2339,6 @@ dsl_scan_ds_clone_swapped(dsl_dataset_t *ds1, dsl_dataset_t *ds2, dmu_tx_t *tx)
 	dsl_scan_sync_state(scn, tx, SYNC_CACHED);
 }
 
-/* ARGSUSED */
 static int
 enqueue_clones_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 {
@@ -2525,10 +2523,10 @@ out:
 	dsl_dataset_rele(ds, FTAG);
 }
 
-/* ARGSUSED */
 static int
 enqueue_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 {
+	(void) arg;
 	dsl_dataset_t *ds;
 	int err;
 	dsl_scan_t *scn = dp->dp_scan;
@@ -2564,16 +2562,15 @@ enqueue_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 	return (0);
 }
 
-/* ARGSUSED */
 void
 dsl_scan_ddt_entry(dsl_scan_t *scn, enum zio_checksum checksum,
     ddt_entry_t *dde, dmu_tx_t *tx)
 {
+	(void) tx;
 	const ddt_key_t *ddk = &dde->dde_key;
 	ddt_phys_t *ddp = dde->dde_phys;
 	blkptr_t bp;
 	zbookmark_phys_t zb = { 0 };
-	int p;
 
 	if (!dsl_scan_is_running(scn))
 		return;
@@ -2592,7 +2589,7 @@ dsl_scan_ddt_entry(dsl_scan_t *scn, enum zio_checksum checksum,
 	if (scn->scn_done_txg != 0)
 		return;
 
-	for (p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
+	for (int p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
 		if (ddp->ddp_phys_birth == 0 ||
 		    ddp->ddp_phys_birth > scn->scn_phys.scn_max_txg)
 			continue;

--- a/module/zfs/dsl_synctask.c
+++ b/module/zfs/dsl_synctask.c
@@ -32,10 +32,10 @@
 
 #define	DST_AVG_BLKSHIFT 14
 
-/* ARGSUSED */
 static int
 dsl_null_checkfunc(void *arg, dmu_tx_t *tx)
 {
+	(void) arg, (void) tx;
 	return (0);
 }
 

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -483,17 +483,17 @@ zfs_zevent_destroy(zfs_zevent_t *ze)
 /*
  * Wrappers for FM nvlist allocators
  */
-/* ARGSUSED */
 static void *
 i_fm_alloc(nv_alloc_t *nva, size_t size)
 {
+	(void) nva;
 	return (kmem_zalloc(size, KM_SLEEP));
 }
 
-/* ARGSUSED */
 static void
 i_fm_free(nv_alloc_t *nva, void *buf, size_t size)
 {
+	(void) nva;
 	kmem_free(buf, size);
 }
 

--- a/module/zfs/gzip.c
+++ b/module/zfs/gzip.c
@@ -83,10 +83,10 @@ gzip_compress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 	return ((size_t)dstlen);
 }
 
-/*ARGSUSED*/
 int
 gzip_decompress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 {
+	(void) n;
 	zlen_t dstlen = d_len;
 
 	ASSERT(d_len >= s_len);

--- a/module/zfs/lz4.c
+++ b/module/zfs/lz4.c
@@ -46,11 +46,11 @@ static int LZ4_compress64kCtx(void *ctx, const char *source, char *dest,
 
 static kmem_cache_t *lz4_cache;
 
-/*ARGSUSED*/
 size_t
 lz4_compress_zfs(void *s_start, void *d_start, size_t s_len,
     size_t d_len, int n)
 {
+	(void) n;
 	uint32_t bufsiz;
 	char *dest = d_start;
 
@@ -74,11 +74,11 @@ lz4_compress_zfs(void *s_start, void *d_start, size_t s_len,
 	return (bufsiz + sizeof (bufsiz));
 }
 
-/*ARGSUSED*/
 int
 lz4_decompress_zfs(void *s_start, void *d_start, size_t s_len,
     size_t d_len, int n)
 {
+	(void) n;
 	const char *src = s_start;
 	uint32_t bufsiz = BE_IN32(src);
 
@@ -463,7 +463,6 @@ LZ4_NbCommonBytes(register U32 val)
 
 /* Compression functions */
 
-/*ARGSUSED*/
 static int
 LZ4_compressCtx(void *ctx, const char *source, char *dest, int isize,
     int osize)
@@ -654,7 +653,6 @@ LZ4_compressCtx(void *ctx, const char *source, char *dest, int isize,
 	HASHLOG64K))
 #define	LZ4_HASH64K_VALUE(p)	LZ4_HASH64K_FUNCTION(A32(p))
 
-/*ARGSUSED*/
 static int
 LZ4_compress64kCtx(void *ctx, const char *source, char *dest, int isize,
     int osize)

--- a/module/zfs/lzjb.c
+++ b/module/zfs/lzjb.c
@@ -45,10 +45,10 @@
 #define	OFFSET_MASK	((1 << (16 - MATCH_BITS)) - 1)
 #define	LEMPEL_SIZE	1024
 
-/*ARGSUSED*/
 size_t
 lzjb_compress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 {
+	(void) n;
 	uchar_t *src = s_start;
 	uchar_t *dst = d_start;
 	uchar_t *cpy;
@@ -100,10 +100,10 @@ lzjb_compress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 	return (dst - (uchar_t *)d_start);
 }
 
-/*ARGSUSED*/
 int
 lzjb_decompress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 {
+	(void) s_len, (void) n;
 	uchar_t *src = s_start;
 	uchar_t *dst = d_start;
 	uchar_t *d_end = (uchar_t *)d_start + d_len;

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -1406,7 +1406,6 @@ metaslab_size_tree_full_load(range_tree_t *rt)
  * Create any block allocator specific components. The current allocators
  * rely on using both a size-ordered range_tree_t and an array of uint64_t's.
  */
-/* ARGSUSED */
 static void
 metaslab_rt_create(range_tree_t *rt, void *arg)
 {
@@ -1431,10 +1430,10 @@ metaslab_rt_create(range_tree_t *rt, void *arg)
 	mrap->mra_floor_shift = metaslab_by_size_min_shift;
 }
 
-/* ARGSUSED */
 static void
 metaslab_rt_destroy(range_tree_t *rt, void *arg)
 {
+	(void) rt;
 	metaslab_rt_arg_t *mrap = arg;
 	zfs_btree_t *size_tree = mrap->mra_bt;
 
@@ -1442,7 +1441,6 @@ metaslab_rt_destroy(range_tree_t *rt, void *arg)
 	kmem_free(mrap, sizeof (*mrap));
 }
 
-/* ARGSUSED */
 static void
 metaslab_rt_add(range_tree_t *rt, range_seg_t *rs, void *arg)
 {
@@ -1456,7 +1454,6 @@ metaslab_rt_add(range_tree_t *rt, range_seg_t *rs, void *arg)
 	zfs_btree_add(size_tree, rs);
 }
 
-/* ARGSUSED */
 static void
 metaslab_rt_remove(range_tree_t *rt, range_seg_t *rs, void *arg)
 {
@@ -1470,7 +1467,6 @@ metaslab_rt_remove(range_tree_t *rt, range_seg_t *rs, void *arg)
 	zfs_btree_remove(size_tree, rs);
 }
 
-/* ARGSUSED */
 static void
 metaslab_rt_vacate(range_tree_t *rt, void *arg)
 {
@@ -2240,6 +2236,8 @@ metaslab_potentially_evict(metaslab_class_t *mc)
 			inuse = spl_kmem_cache_inuse(zfs_btree_leaf_cache);
 		}
 	}
+#else
+	(void) mc;
 #endif
 }
 
@@ -4721,7 +4719,6 @@ metaslab_active_mask_verify(metaslab_t *msp)
 	}
 }
 
-/* ARGSUSED */
 static uint64_t
 metaslab_group_alloc_normal(metaslab_group_t *mg, zio_alloc_list_t *zal,
     uint64_t asize, uint64_t txg, boolean_t want_unique, dva_t *dva, int d,
@@ -5347,11 +5344,11 @@ metaslab_free_concrete(vdev_t *vd, uint64_t offset, uint64_t asize,
 	mutex_exit(&msp->ms_lock);
 }
 
-/* ARGSUSED */
 void
 metaslab_free_impl_cb(uint64_t inner_offset, vdev_t *vd, uint64_t offset,
     uint64_t size, void *arg)
 {
+	(void) inner_offset;
 	boolean_t *checkpoint = arg;
 
 	ASSERT3P(checkpoint, !=, NULL);
@@ -5717,11 +5714,11 @@ typedef struct metaslab_claim_cb_arg_t {
 	int		mcca_error;
 } metaslab_claim_cb_arg_t;
 
-/* ARGSUSED */
 static void
 metaslab_claim_impl_cb(uint64_t inner_offset, vdev_t *vd, uint64_t offset,
     uint64_t size, void *arg)
 {
+	(void) inner_offset;
 	metaslab_claim_cb_arg_t *mcca_arg = arg;
 
 	if (mcca_arg->mcca_error == 0) {
@@ -5973,11 +5970,12 @@ metaslab_fastwrite_unmark(spa_t *spa, const blkptr_t *bp)
 	spa_config_exit(spa, SCL_VDEV, FTAG);
 }
 
-/* ARGSUSED */
 static void
 metaslab_check_free_impl_cb(uint64_t inner, vdev_t *vd, uint64_t offset,
     uint64_t size, void *arg)
 {
+	(void) inner, (void) arg;
+
 	if (vd->vdev_ops == &vdev_indirect_ops)
 		return;
 

--- a/module/zfs/multilist.c
+++ b/module/zfs/multilist.c
@@ -36,6 +36,8 @@ multilist_d2l(multilist_t *ml, void *obj)
 {
 	return ((multilist_node_t *)((char *)obj + ml->ml_offset));
 }
+#else
+#define	multilist_d2l(ml, obj) ((void) sizeof (ml), (void) sizeof (obj), NULL)
 #endif
 
 /*

--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -741,7 +741,6 @@ range_tree_is_empty(range_tree_t *rt)
 	return (range_tree_space(rt) == 0);
 }
 
-/* ARGSUSED */
 void
 rt_btree_create(range_tree_t *rt, void *arg)
 {
@@ -764,35 +763,34 @@ rt_btree_create(range_tree_t *rt, void *arg)
 	zfs_btree_create(size_tree, rt->rt_btree_compare, size);
 }
 
-/* ARGSUSED */
 void
 rt_btree_destroy(range_tree_t *rt, void *arg)
 {
+	(void) rt;
 	zfs_btree_t *size_tree = arg;
 	ASSERT0(zfs_btree_numnodes(size_tree));
 
 	zfs_btree_destroy(size_tree);
 }
 
-/* ARGSUSED */
 void
 rt_btree_add(range_tree_t *rt, range_seg_t *rs, void *arg)
 {
+	(void) rt;
 	zfs_btree_t *size_tree = arg;
 
 	zfs_btree_add(size_tree, rs);
 }
 
-/* ARGSUSED */
 void
 rt_btree_remove(range_tree_t *rt, range_seg_t *rs, void *arg)
 {
+	(void) rt;
 	zfs_btree_t *size_tree = arg;
 
 	zfs_btree_remove(size_tree, rs);
 }
 
-/* ARGSUSED */
 void
 rt_btree_vacate(range_tree_t *rt, void *arg)
 {

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -212,20 +212,20 @@ sa_attr_type_t sa_dummy_zpl_layout[] = { 0 };
 static int sa_legacy_attr_count = ARRAY_SIZE(sa_legacy_attrs);
 static kmem_cache_t *sa_cache = NULL;
 
-/*ARGSUSED*/
 static int
 sa_cache_constructor(void *buf, void *unused, int kmflag)
 {
+	(void) unused, (void) kmflag;
 	sa_handle_t *hdl = buf;
 
 	mutex_init(&hdl->sa_lock, NULL, MUTEX_DEFAULT, NULL);
 	return (0);
 }
 
-/*ARGSUSED*/
 static void
 sa_cache_destructor(void *buf, void *unused)
 {
+	(void) unused;
 	sa_handle_t *hdl = buf;
 	mutex_destroy(&hdl->sa_lock);
 }
@@ -1218,11 +1218,11 @@ sa_attr_iter(objset_t *os, sa_hdr_phys_t *hdr, dmu_object_type_t type,
 	}
 }
 
-/*ARGSUSED*/
 static void
 sa_byteswap_cb(void *hdr, void *attr_addr, sa_attr_type_t attr,
     uint16_t length, int length_idx, boolean_t variable_length, void *userp)
 {
+	(void) hdr, (void) length_idx, (void) variable_length;
 	sa_handle_t *hdl = userp;
 	sa_os_t *sa = hdl->sa_os->os_sa;
 
@@ -1309,10 +1309,10 @@ sa_build_index(sa_handle_t *hdl, sa_buf_type_t buftype)
 	return (0);
 }
 
-/*ARGSUSED*/
 static void
 sa_evict_sync(void *dbu)
 {
+	(void) dbu;
 	panic("evicting sa dbuf\n");
 }
 

--- a/module/zfs/sha256.c
+++ b/module/zfs/sha256.c
@@ -41,11 +41,11 @@ sha_incremental(void *buf, size_t size, void *arg)
 	return (0);
 }
 
-/*ARGSUSED*/
 void
 abd_checksum_SHA256(abd_t *abd, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) ctx_template;
 	int ret;
 	SHA2_CTX ctx;
 	zio_cksum_t tmp;
@@ -78,11 +78,11 @@ bswap:
 	zcp->zc_word[3] = BE_64(tmp.zc_word[3]);
 }
 
-/*ARGSUSED*/
 void
 abd_checksum_SHA512_native(abd_t *abd, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) ctx_template;
 	SHA2_CTX	ctx;
 
 	SHA2Init(SHA512_256, &ctx);
@@ -90,7 +90,6 @@ abd_checksum_SHA512_native(abd_t *abd, uint64_t size,
 	SHA2Final(zcp, &ctx);
 }
 
-/*ARGSUSED*/
 void
 abd_checksum_SHA512_byteswap(abd_t *abd, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2996,6 +2996,8 @@ vdev_count_verify_zaps(vdev_t *vd)
 
 	return (total);
 }
+#else
+#define	vdev_count_verify_zaps(vd) ((void) sizeof (vd), 0)
 #endif
 
 /*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -840,7 +840,6 @@ spa_prop_clear_bootfs(spa_t *spa, uint64_t dsobj, dmu_tx_t *tx)
 	}
 }
 
-/*ARGSUSED*/
 static int
 spa_change_guid_check(void *arg, dmu_tx_t *tx)
 {
@@ -2286,11 +2285,12 @@ int spa_load_verify_shift = 4;
 int spa_load_verify_metadata = B_TRUE;
 int spa_load_verify_data = B_TRUE;
 
-/*ARGSUSED*/
 static int
 spa_load_verify_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
     const zbookmark_phys_t *zb, const dnode_phys_t *dnp, void *arg)
 {
+	(void) zilog, (void) dnp;
+
 	if (zb->zb_level == ZB_DNODE_LEVEL || BP_IS_HOLE(bp) ||
 	    BP_IS_EMBEDDED(bp) || BP_IS_REDACTED(bp))
 		return (0);
@@ -2322,10 +2322,11 @@ spa_load_verify_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 verify_dataset_name_len(dsl_pool_t *dp, dsl_dataset_t *ds, void *arg)
 {
+	(void) dp, (void) arg;
+
 	if (dsl_dataset_namelen(ds) >= ZFS_MAX_DATASET_NAME_LEN)
 		return (SET_ERROR(ENAMETOOLONG));
 
@@ -2455,10 +2456,10 @@ spa_livelist_delete_check(spa_t *spa)
 	return (spa->spa_livelists_to_delete != 0);
 }
 
-/* ARGSUSED */
 static boolean_t
 spa_livelist_delete_cb_check(void *arg, zthr_t *z)
 {
+	(void) z;
 	spa_t *spa = arg;
 	return (spa_livelist_delete_check(spa));
 }
@@ -2550,7 +2551,6 @@ livelist_delete_sync(void *arg, dmu_tx_t *tx)
  * be freed. Then, call a synctask which performs the actual frees and updates
  * the pool-wide livelist data.
  */
-/* ARGSUSED */
 static void
 spa_livelist_delete_cb(void *arg, zthr_t *z)
 {
@@ -2796,7 +2796,6 @@ spa_livelist_condense_cb(void *arg, zthr_t *t)
 		zfs_livelist_condense_zthr_cancel++;
 }
 
-/* ARGSUSED */
 /*
  * Check that there is something to condense but that a condense is not
  * already in progress and that condensing has not been cancelled.
@@ -2804,6 +2803,7 @@ spa_livelist_condense_cb(void *arg, zthr_t *t)
 static boolean_t
 spa_livelist_condense_cb_check(void *arg, zthr_t *z)
 {
+	(void) z;
 	spa_t *spa = arg;
 	if ((spa->spa_to_condense.ds != NULL) &&
 	    (spa->spa_to_condense.syncing == B_FALSE) &&
@@ -9465,6 +9465,7 @@ spa_upgrade(spa_t *spa, uint64_t version)
 static boolean_t
 spa_has_aux_vdev(spa_t *spa, uint64_t guid, spa_aux_vdev_t *sav)
 {
+	(void) spa;
 	int i;
 	uint64_t vdev_guid;
 
@@ -9828,6 +9829,8 @@ spa_event_create(spa_t *spa, vdev_t *vd, nvlist_t *hist_nvl, const char *name)
 		ev = kmem_alloc(sizeof (sysevent_t), KM_SLEEP);
 		ev->resource = resource;
 	}
+#else
+	(void) spa, (void) vd, (void) hist_nvl, (void) name;
 #endif
 	return (ev);
 }
@@ -9840,6 +9843,8 @@ spa_event_post(sysevent_t *ev)
 		zfs_zevent_post(ev->resource, NULL, zfs_zevent_post_cb);
 		kmem_free(ev, sizeof (*ev));
 	}
+#else
+	(void) ev;
 #endif
 }
 

--- a/module/zfs/spa_checkpoint.c
+++ b/module/zfs/spa_checkpoint.c
@@ -380,10 +380,10 @@ spa_checkpoint_discard_is_done(spa_t *spa)
 	return (B_TRUE);
 }
 
-/* ARGSUSED */
 boolean_t
 spa_checkpoint_discard_thread_check(void *arg, zthr_t *zthr)
 {
+	(void) zthr;
 	spa_t *spa = arg;
 
 	if (!spa_feature_is_active(spa, SPA_FEATURE_POOL_CHECKPOINT))
@@ -450,10 +450,10 @@ spa_checkpoint_discard_thread(void *arg, zthr_t *zthr)
 }
 
 
-/* ARGSUSED */
 static int
 spa_checkpoint_check(void *arg, dmu_tx_t *tx)
 {
+	(void) arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 
 	if (!spa_feature_is_enabled(spa, SPA_FEATURE_POOL_CHECKPOINT))
@@ -474,10 +474,10 @@ spa_checkpoint_check(void *arg, dmu_tx_t *tx)
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 spa_checkpoint_sync(void *arg, dmu_tx_t *tx)
 {
+	(void) arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	spa_t *spa = dp->dp_spa;
 	uberblock_t checkpoint = spa->spa_ubsync;
@@ -571,10 +571,10 @@ spa_checkpoint(const char *pool)
 	return (error);
 }
 
-/* ARGSUSED */
 static int
 spa_checkpoint_discard_check(void *arg, dmu_tx_t *tx)
 {
+	(void) arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 
 	if (!spa_feature_is_active(spa, SPA_FEATURE_POOL_CHECKPOINT))
@@ -589,10 +589,10 @@ spa_checkpoint_discard_check(void *arg, dmu_tx_t *tx)
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 spa_checkpoint_discard_sync(void *arg, dmu_tx_t *tx)
 {
+	(void) arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 
 	VERIFY0(zap_remove(spa_meta_objset(spa), DMU_POOL_DIRECTORY_OBJECT,

--- a/module/zfs/spa_errlog.c
+++ b/module/zfs/spa_errlog.c
@@ -252,6 +252,8 @@ spa_get_errlog(spa_t *spa, void *uaddr, size_t *count)
 	mutex_exit(&spa->spa_errlist_lock);
 
 	mutex_exit(&spa->spa_errlog_lock);
+#else
+	(void) spa, (void) uaddr, (void) count;
 #endif
 
 	return (ret);

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -495,6 +495,7 @@ spa_config_tryenter(spa_t *spa, int locks, void *tag, krw_t rw)
 void
 spa_config_enter(spa_t *spa, int locks, const void *tag, krw_t rw)
 {
+	(void) tag;
 	int wlocks_held = 0;
 
 	ASSERT3U(SCL_LOCKS, <, sizeof (wlocks_held) * NBBY);
@@ -528,6 +529,7 @@ spa_config_enter(spa_t *spa, int locks, const void *tag, krw_t rw)
 void
 spa_config_exit(spa_t *spa, int locks, const void *tag)
 {
+	(void) tag;
 	for (int i = SCL_LOCKS - 1; i >= 0; i--) {
 		spa_config_lock_t *scl = &spa->spa_config_lock[i];
 		if (!(locks & (1 << i)))

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -263,11 +263,12 @@ vdev_get_mg(vdev_t *vd, metaslab_class_t *mc)
 		return (vd->vdev_mg);
 }
 
-/* ARGSUSED */
 void
 vdev_default_xlate(vdev_t *vd, const range_seg64_t *logical_rs,
     range_seg64_t *physical_rs, range_seg64_t *remain_rs)
 {
+	(void) vd, (void) remain_rs;
+
 	physical_rs->rs_start = logical_rs->rs_start;
 	physical_rs->rs_end = logical_rs->rs_end;
 }
@@ -1778,6 +1779,7 @@ vdev_uses_zvols(vdev_t *vd)
 static boolean_t
 vdev_default_open_children_func(vdev_t *vd)
 {
+	(void) vd;
 	return (B_TRUE);
 }
 
@@ -2859,6 +2861,8 @@ boolean_t
 vdev_default_need_resilver(vdev_t *vd, const dva_t *dva, size_t psize,
     uint64_t phys_birth)
 {
+	(void) dva, (void) psize;
+
 	/* Set by sequential resilver. */
 	if (phys_birth == TXG_UNKNOWN)
 		return (B_TRUE);
@@ -4308,6 +4312,8 @@ vdev_get_child_stat(vdev_t *cvd, vdev_stat_t *vs, vdev_stat_t *cvs)
 static void
 vdev_get_child_stat_ex(vdev_t *cvd, vdev_stat_ex_t *vsx, vdev_stat_ex_t *cvsx)
 {
+	(void) cvd;
+
 	int t, b;
 	for (t = 0; t < ZIO_TYPES; t++) {
 		for (b = 0; b < ARRAY_SIZE(vsx->vsx_disk_histo[0]); b++)
@@ -4743,6 +4749,7 @@ void
 vdev_space_update(vdev_t *vd, int64_t alloc_delta, int64_t defer_delta,
     int64_t space_delta)
 {
+	(void) defer_delta;
 	int64_t dspace_delta;
 	spa_t *spa = vd->vdev_spa;
 	vdev_t *rvd = spa->spa_root_vdev;

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -2154,6 +2154,7 @@ vdev_draid_config_generate(vdev_t *vd, nvlist_t *nv)
 static int
 vdev_draid_init(spa_t *spa, nvlist_t *nv, void **tsd)
 {
+	(void) spa;
 	uint64_t ndata, nparity, nspares, ngroups;
 	int error;
 
@@ -2382,7 +2383,6 @@ vdev_draid_spare_get_child(vdev_t *vd, uint64_t physical_offset)
 	return (cvd);
 }
 
-/* ARGSUSED */
 static void
 vdev_draid_spare_close(vdev_t *vd)
 {
@@ -2641,10 +2641,10 @@ vdev_draid_spare_io_start(zio_t *zio)
 	zio_execute(zio);
 }
 
-/* ARGSUSED */
 static void
 vdev_draid_spare_io_done(zio_t *zio)
 {
+	(void) zio;
 }
 
 /*

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -637,16 +637,15 @@ spa_condense_indirect_generate_new_mapping(vdev_t *vd,
 	}
 }
 
-/* ARGSUSED */
 static boolean_t
 spa_condense_indirect_thread_check(void *arg, zthr_t *zthr)
 {
+	(void) zthr;
 	spa_t *spa = arg;
 
 	return (spa->spa_condensing_indirect != NULL);
 }
 
-/* ARGSUSED */
 static void
 spa_condense_indirect_thread(void *arg, zthr_t *zthr)
 {
@@ -941,13 +940,12 @@ vdev_obsolete_counts_are_precise(vdev_t *vd, boolean_t *are_precise)
 	return (error);
 }
 
-/* ARGSUSED */
 static void
 vdev_indirect_close(vdev_t *vd)
 {
+	(void) vd;
 }
 
-/* ARGSUSED */
 static int
 vdev_indirect_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
     uint64_t *logical_ashift, uint64_t *physical_ashift)

--- a/module/zfs/vdev_indirect_births.c
+++ b/module/zfs/vdev_indirect_births.c
@@ -38,6 +38,8 @@ vdev_indirect_births_verify(vdev_indirect_births_t *vib)
 
 	return (B_TRUE);
 }
+#else
+#define	vdev_indirect_births_verify(vib) ((void) sizeof (vib), B_TRUE)
 #endif
 
 uint64_t

--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -54,6 +54,8 @@ vdev_indirect_mapping_verify(vdev_indirect_mapping_t *vim)
 
 	return (B_TRUE);
 }
+#else
+#define	vdev_indirect_mapping_verify(vim) ((void) sizeof (vim), B_TRUE)
 #endif
 
 uint64_t

--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -255,10 +255,11 @@ vdev_initialize_write(vdev_t *vd, uint64_t start, uint64_t size, abd_t *data)
  * divisible by sizeof (uint64_t), and buf must be 8-byte aligned. The ABD
  * allocation will guarantee these for us.
  */
-/* ARGSUSED */
 static int
 vdev_initialize_block_fill(void *buf, size_t len, void *unused)
 {
+	(void) unused;
+
 	ASSERT0(len % sizeof (uint64_t));
 #ifdef _ILP32
 	for (uint64_t i = 0; i < len; i += sizeof (uint32_t)) {
@@ -624,6 +625,7 @@ vdev_initialize_stop_wait_impl(vdev_t *vd)
 void
 vdev_initialize_stop_wait(spa_t *spa, list_t *vd_list)
 {
+	(void) spa;
 	vdev_t *vd;
 
 	ASSERT(MUTEX_HELD(&spa_namespace_lock));

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -880,6 +880,8 @@ static uint64_t
 vdev_mirror_rebuild_asize(vdev_t *vd, uint64_t start, uint64_t asize,
     uint64_t max_segment)
 {
+	(void) start;
+
 	uint64_t psize = MIN(P2ROUNDUP(max_segment, 1 << vd->vdev_ashift),
 	    SPA_MAXBLOCKSIZE);
 

--- a/module/zfs/vdev_missing.c
+++ b/module/zfs/vdev_missing.c
@@ -42,7 +42,6 @@
 #include <sys/fs/zfs.h>
 #include <sys/zio.h>
 
-/* ARGSUSED */
 static int
 vdev_missing_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
     uint64_t *ashift, uint64_t *pshift)
@@ -53,6 +52,7 @@ vdev_missing_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	 * VDEV_AUX_BAD_GUID_SUM.  So we pretend to succeed, knowing that we
 	 * will fail the GUID sum check before ever trying to open the pool.
 	 */
+	(void) vd;
 	*psize = 0;
 	*max_psize = 0;
 	*ashift = 0;
@@ -60,13 +60,12 @@ vdev_missing_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 vdev_missing_close(vdev_t *vd)
 {
+	(void) vd;
 }
 
-/* ARGSUSED */
 static void
 vdev_missing_io_start(zio_t *zio)
 {
@@ -74,10 +73,10 @@ vdev_missing_io_start(zio_t *zio)
 	zio_execute(zio);
 }
 
-/* ARGSUSED */
 static void
 vdev_missing_io_done(zio_t *zio)
 {
+	(void) zio;
 }
 
 vdev_ops_t vdev_missing_ops = {

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -648,10 +648,10 @@ vdev_raidz_generate_parity(raidz_map_t *rm)
 	}
 }
 
-/* ARGSUSED */
 static int
 vdev_raidz_reconst_p_func(void *dbuf, void *sbuf, size_t size, void *private)
 {
+	(void) private;
 	uint64_t *dst = dbuf;
 	uint64_t *src = sbuf;
 	int cnt = size / sizeof (src[0]);
@@ -663,11 +663,11 @@ vdev_raidz_reconst_p_func(void *dbuf, void *sbuf, size_t size, void *private)
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 vdev_raidz_reconst_q_pre_func(void *dbuf, void *sbuf, size_t size,
     void *private)
 {
+	(void) private;
 	uint64_t *dst = dbuf;
 	uint64_t *src = sbuf;
 	uint64_t mask;
@@ -681,10 +681,10 @@ vdev_raidz_reconst_q_pre_func(void *dbuf, void *sbuf, size_t size,
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 vdev_raidz_reconst_q_pre_tail_func(void *buf, size_t size, void *private)
 {
+	(void) private;
 	uint64_t *dst = buf;
 	uint64_t mask;
 	int cnt = size / sizeof (dst[0]);
@@ -2496,6 +2496,8 @@ static void
 vdev_raidz_xlate(vdev_t *cvd, const range_seg64_t *logical_rs,
     range_seg64_t *physical_rs, range_seg64_t *remain_rs)
 {
+	(void) remain_rs;
+
 	vdev_t *raidvd = cvd->vdev_parent;
 	ASSERT(raidvd->vdev_ops == &vdev_raidz_ops);
 

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -1820,10 +1820,10 @@ vdev_prop_allocating_off(vdev_t *vd)
 	return (allocating == 0);
 }
 
-/* ARGSUSED */
 static int
 spa_vdev_remove_cancel_check(void *arg, dmu_tx_t *tx)
 {
+	(void) arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 
 	if (spa->spa_vdev_removal == NULL)
@@ -1835,10 +1835,10 @@ spa_vdev_remove_cancel_check(void *arg, dmu_tx_t *tx)
  * Cancel a removal by freeing all entries from the partial mapping
  * and marking the vdev as no longer being removing.
  */
-/* ARGSUSED */
 static void
 spa_vdev_remove_cancel_sync(void *arg, dmu_tx_t *tx)
 {
+	(void) arg;
 	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
 	spa_vdev_removal_t *svr = spa->spa_vdev_removal;
 	vdev_t *vd = vdev_lookup_top(spa, svr->svr_vdev_id);

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -1003,6 +1003,7 @@ vdev_trim_stop_wait_impl(vdev_t *vd)
 void
 vdev_trim_stop_wait(spa_t *spa, list_t *vd_list)
 {
+	(void) spa;
 	vdev_t *vd;
 
 	ASSERT(MUTEX_HELD(&spa_namespace_lock));

--- a/module/zfs/zcp.c
+++ b/module/zfs/zcp.c
@@ -769,10 +769,10 @@ zcp_lua_alloc(void *ud, void *ptr, size_t osize, size_t nsize)
 	}
 }
 
-/* ARGSUSED */
 static void
 zcp_lua_counthook(lua_State *state, lua_Debug *ar)
 {
+	(void) ar;
 	lua_getfield(state, LUA_REGISTRYINDEX, ZCP_RUN_INFO_KEY);
 	zcp_run_info_t *ri = lua_touserdata(state, -1);
 
@@ -974,10 +974,10 @@ zcp_pool_error(zcp_run_info_t *ri, const char *poolname)
  * The txg_wait_synced_sig will continue to wait for the txg to complete
  * after calling this callback.
  */
-/* ARGSUSED */
 static void
 zcp_eval_sig(void *arg, dmu_tx_t *tx)
 {
+	(void) tx;
 	zcp_run_info_t *ri = arg;
 
 	ri->zri_canceled = B_TRUE;

--- a/module/zfs/zcp_synctask.c
+++ b/module/zfs/zcp_synctask.c
@@ -129,10 +129,10 @@ static zcp_synctask_info_t zcp_synctask_destroy_info = {
 	.blocks_modified = 0
 };
 
-/* ARGSUSED */
 static int
 zcp_synctask_destroy(lua_State *state, boolean_t sync, nvlist_t *err_details)
 {
+	(void) err_details;
 	int err;
 	const char *dsname = lua_tostring(state, 1);
 
@@ -251,10 +251,10 @@ static zcp_synctask_info_t zcp_synctask_snapshot_info = {
 	.blocks_modified = 3
 };
 
-/* ARGSUSED */
 static int
 zcp_synctask_snapshot(lua_State *state, boolean_t sync, nvlist_t *err_details)
 {
+	(void) err_details;
 	int err;
 	dsl_dataset_snapshot_arg_t ddsa = { 0 };
 	const char *dsname = lua_tostring(state, 1);
@@ -354,6 +354,7 @@ static int
 zcp_synctask_inherit_prop(lua_State *state, boolean_t sync,
     nvlist_t *err_details)
 {
+	(void) err_details;
 	int err;
 	zcp_inherit_prop_arg_t zipa = { 0 };
 	dsl_props_set_arg_t *dpsa = &zipa.zipa_dpsa;
@@ -396,10 +397,10 @@ static zcp_synctask_info_t zcp_synctask_bookmark_info = {
 	.blocks_modified = 1,
 };
 
-/* ARGSUSED */
 static int
 zcp_synctask_bookmark(lua_State *state, boolean_t sync, nvlist_t *err_details)
 {
+	(void) err_details;
 	int err;
 	const char *source = lua_tostring(state, 1);
 	const char *new = lua_tostring(state, 2);
@@ -443,6 +444,7 @@ static zcp_synctask_info_t zcp_synctask_set_prop_info = {
 static int
 zcp_synctask_set_prop(lua_State *state, boolean_t sync, nvlist_t *err_details)
 {
+	(void) err_details;
 	int err;
 	zcp_set_prop_arg_t args = { 0 };
 

--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -59,7 +59,7 @@
  * read I/Os, there  are basically three 'types' of I/O, which form a roughly
  * layered diagram:
  *
- *      +---------------+
+ * 	+---------------+
  * 	| Aggregate I/O |	No associated logical data or device
  * 	+---------------+
  *              |
@@ -205,7 +205,6 @@ static void zfs_ereport_schedule_cleaner(void);
 /*
  * background task to clean stale recent event nodes.
  */
-/*ARGSUSED*/
 static void
 zfs_ereport_cleaner(void *arg)
 {
@@ -992,10 +991,10 @@ annotate_ecksum(nvlist_t *ereport, zio_bad_cksum_t *info,
 	return (eip);
 }
 #else
-/*ARGSUSED*/
 void
 zfs_ereport_clear(spa_t *spa, vdev_t *vd)
 {
+	(void) spa, (void) vd;
 }
 #endif
 
@@ -1072,6 +1071,8 @@ zfs_ereport_is_valid(const char *subclass, spa_t *spa, vdev_t *vd, zio_t *zio)
 	    (zio != NULL) && (!zio->io_timestamp)) {
 		return (B_FALSE);
 	}
+#else
+	(void) subclass, (void) spa, (void) vd, (void) zio;
 #endif
 	return (B_TRUE);
 }
@@ -1112,6 +1113,9 @@ zfs_ereport_post(const char *subclass, spa_t *spa, vdev_t *vd,
 
 	/* Cleanup is handled by the callback function */
 	rc = zfs_zevent_post(ereport, detector, zfs_zevent_post_cb);
+#else
+	(void) subclass, (void) spa, (void) vd, (void) zb, (void) zio,
+	    (void) state;
 #endif
 	return (rc);
 }
@@ -1141,6 +1145,8 @@ zfs_ereport_start_checksum(spa_t *spa, vdev_t *vd, const zbookmark_phys_t *zb,
 
 	if (zfs_is_ratelimiting_event(FM_EREPORT_ZFS_CHECKSUM, vd))
 		return (SET_ERROR(EBUSY));
+#else
+	(void) zb, (void) offset;
 #endif
 
 	report = kmem_zalloc(sizeof (*report), KM_SLEEP);
@@ -1193,6 +1199,9 @@ zfs_ereport_finish_checksum(zio_cksum_report_t *report, const abd_t *good_data,
 	report->zcr_ereport = report->zcr_detector = NULL;
 	if (info != NULL)
 		kmem_free(info, sizeof (*info));
+#else
+	(void) report, (void) good_data, (void) bad_data,
+	    (void) drop_if_identical;
 #endif
 }
 
@@ -1257,6 +1266,9 @@ zfs_ereport_post_checksum(spa_t *spa, vdev_t *vd, const zbookmark_phys_t *zb,
 		rc = zfs_zevent_post(ereport, detector, zfs_zevent_post_cb);
 		kmem_free(info, sizeof (*info));
 	}
+#else
+	(void) spa, (void) vd, (void) zb, (void) zio, (void) offset,
+	    (void) length, (void) good_data, (void) bad_data, (void) zbc;
 #endif
 	return (rc);
 }
@@ -1321,7 +1333,8 @@ zfs_event_create(spa_t *spa, vdev_t *vd, const char *type, const char *name,
 		while ((elem = nvlist_next_nvpair(aux, elem)) != NULL)
 			(void) nvlist_add_nvpair(resource, elem);
 	}
-
+#else
+	(void) spa, (void) vd, (void) type, (void) name, (void) aux;
 #endif
 	return (resource);
 }
@@ -1336,6 +1349,8 @@ zfs_post_common(spa_t *spa, vdev_t *vd, const char *type, const char *name,
 	resource = zfs_event_create(spa, vd, type, name, aux);
 	if (resource)
 		zfs_zevent_post(resource, NULL, zfs_zevent_post_cb);
+#else
+	(void) spa, (void) vd, (void) type, (void) name, (void) aux;
 #endif
 }
 
@@ -1399,6 +1414,8 @@ zfs_post_state_change(spa_t *spa, vdev_t *vd, uint64_t laststate)
 
 	if (aux)
 		fm_nvlist_destroy(aux, FM_NVA_FREE);
+#else
+	(void) spa, (void) vd, (void) laststate;
 #endif
 }
 

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -432,11 +432,11 @@ done:
 	return (error);
 }
 
-/* ARGSUSED */
 static int
 zil_clear_log_block(zilog_t *zilog, const blkptr_t *bp, void *tx,
     uint64_t first_txg)
 {
+	(void) tx;
 	ASSERT(!BP_IS_HOLE(bp));
 
 	/*
@@ -455,11 +455,11 @@ zil_clear_log_block(zilog_t *zilog, const blkptr_t *bp, void *tx,
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 zil_noop_log_record(zilog_t *zilog, const lr_t *lrc, void *tx,
     uint64_t first_txg)
 {
+	(void) zilog, (void) lrc, (void) tx, (void) first_txg;
 	return (0);
 }
 
@@ -507,11 +507,12 @@ zil_claim_log_record(zilog_t *zilog, const lr_t *lrc, void *tx,
 	return (zil_claim_log_block(zilog, &lr->lr_blkptr, tx, first_txg));
 }
 
-/* ARGSUSED */
 static int
 zil_free_log_block(zilog_t *zilog, const blkptr_t *bp, void *tx,
     uint64_t claim_txg)
 {
+	(void) claim_txg;
+
 	zio_free(zilog->zl_spa, dmu_tx_get_txg(tx), bp);
 
 	return (0);
@@ -911,10 +912,10 @@ zil_claim(dsl_pool_t *dp, dsl_dataset_t *ds, void *txarg)
  * Checksum errors are ok as they indicate the end of the chain.
  * Any other error (no device or read failure) returns an error.
  */
-/* ARGSUSED */
 int
 zil_check_log_chain(dsl_pool_t *dp, dsl_dataset_t *ds, void *tx)
 {
+	(void) dp;
 	zilog_t *zilog;
 	objset_t *os;
 	blkptr_t *bp;
@@ -3127,10 +3128,10 @@ zil_sync(zilog_t *zilog, dmu_tx_t *tx)
 	mutex_exit(&zilog->zl_lock);
 }
 
-/* ARGSUSED */
 static int
 zil_lwb_cons(void *vbuf, void *unused, int kmflag)
 {
+	(void) unused, (void) kmflag;
 	lwb_t *lwb = vbuf;
 	list_create(&lwb->lwb_itxs, sizeof (itx_t), offsetof(itx_t, itx_node));
 	list_create(&lwb->lwb_waiters, sizeof (zil_commit_waiter_t),
@@ -3141,10 +3142,10 @@ zil_lwb_cons(void *vbuf, void *unused, int kmflag)
 	return (0);
 }
 
-/* ARGSUSED */
 static void
 zil_lwb_dest(void *vbuf, void *unused)
 {
+	(void) unused;
 	lwb_t *lwb = vbuf;
 	mutex_destroy(&lwb->lwb_vdev_lock);
 	avl_destroy(&lwb->lwb_vdev_tree);
@@ -3615,10 +3616,11 @@ zil_replay_log_record(zilog_t *zilog, const lr_t *lr, void *zra,
 	return (0);
 }
 
-/* ARGSUSED */
 static int
 zil_incr_blks(zilog_t *zilog, const blkptr_t *bp, void *arg, uint64_t claim_txg)
 {
+	(void) bp, (void) arg, (void) claim_txg;
+
 	zilog->zl_replay_blks++;
 
 	return (0);
@@ -3677,13 +3679,12 @@ zil_replaying(zilog_t *zilog, dmu_tx_t *tx)
 	return (B_FALSE);
 }
 
-/* ARGSUSED */
 int
 zil_reset(const char *osname, void *arg)
 {
-	int error;
+	(void) arg;
 
-	error = zil_suspend(osname, NULL);
+	int error = zil_suspend(osname, NULL);
 	/* EACCES means crypto key not loaded */
 	if ((error == EACCES) || (error == EBUSY))
 		return (SET_ERROR(error));

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -369,6 +369,7 @@ zio_data_buf_free(void *buf, size_t size)
 static void
 zio_abd_free(void *abd, size_t size)
 {
+	(void) size;
 	abd_free((abd_t *)abd);
 }
 
@@ -1072,6 +1073,7 @@ zfs_blkptr_verify(spa_t *spa, const blkptr_t *bp, boolean_t config_held,
 boolean_t
 zfs_dva_valid(spa_t *spa, const dva_t *dva, const blkptr_t *bp)
 {
+	(void) bp;
 	uint64_t vdevid = DVA_GET_VDEV(dva);
 
 	if (vdevid >= spa->spa_root_vdev->vdev_children)
@@ -2143,6 +2145,8 @@ zio_execute_stack_check(zio_t *zio)
 	    !zio_taskq_member(zio, ZIO_TASKQ_ISSUE) &&
 	    !zio_taskq_member(zio, ZIO_TASKQ_ISSUE_HIGH))
 		return (B_TRUE);
+#else
+	(void) zio;
 #endif /* HAVE_LARGE_STACKS */
 
 	return (B_FALSE);
@@ -2555,11 +2559,12 @@ zio_rewrite_gang(zio_t *pio, blkptr_t *bp, zio_gang_node_t *gn, abd_t *data,
 	return (zio);
 }
 
-/* ARGSUSED */
 static zio_t *
 zio_free_gang(zio_t *pio, blkptr_t *bp, zio_gang_node_t *gn, abd_t *data,
     uint64_t offset)
 {
+	(void) gn, (void) data, (void) offset;
+
 	zio_t *zio = zio_free_sync(pio, pio->io_spa, pio->io_txg, bp,
 	    ZIO_GANG_CHILD_FLAGS(pio));
 	if (zio == NULL) {
@@ -2569,11 +2574,11 @@ zio_free_gang(zio_t *pio, blkptr_t *bp, zio_gang_node_t *gn, abd_t *data,
 	return (zio);
 }
 
-/* ARGSUSED */
 static zio_t *
 zio_claim_gang(zio_t *pio, blkptr_t *bp, zio_gang_node_t *gn, abd_t *data,
     uint64_t offset)
 {
+	(void) gn, (void) data, (void) offset;
 	return (zio_claim(pio, pio->io_spa, pio->io_txg, bp,
 	    NULL, NULL, ZIO_GANG_CHILD_FLAGS(pio)));
 }
@@ -3964,7 +3969,6 @@ zio_vsd_default_cksum_finish(zio_cksum_report_t *zcr,
 	zfs_ereport_finish_checksum(zcr, good_buf, zcr->zcr_cbdata, B_FALSE);
 }
 
-/*ARGSUSED*/
 void
 zio_vsd_default_cksum_report(zio_t *zio, zio_cksum_report_t *zcr)
 {

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -91,29 +91,29 @@
  * invocation and passed to the checksum function.
  */
 
-/*ARGSUSED*/
 static void
 abd_checksum_off(abd_t *abd, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) abd, (void) size, (void) ctx_template;
 	ZIO_SET_CHECKSUM(zcp, 0, 0, 0, 0);
 }
 
-/*ARGSUSED*/
 static void
 abd_fletcher_2_native(abd_t *abd, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) ctx_template;
 	fletcher_init(zcp);
 	(void) abd_iterate_func(abd, 0, size,
 	    fletcher_2_incremental_native, zcp);
 }
 
-/*ARGSUSED*/
 static void
 abd_fletcher_2_byteswap(abd_t *abd, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) ctx_template;
 	fletcher_init(zcp);
 	(void) abd_iterate_func(abd, 0, size,
 	    fletcher_2_incremental_byteswap, zcp);
@@ -127,11 +127,11 @@ abd_fletcher_4_impl(abd_t *abd, uint64_t size, zio_abd_checksum_data_t *acdp)
 	fletcher_4_abd_ops.acf_fini(acdp);
 }
 
-/*ARGSUSED*/
 void
 abd_fletcher_4_native(abd_t *abd, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) ctx_template;
 	fletcher_4_ctx_t ctx;
 
 	zio_abd_checksum_data_t acd = {
@@ -144,11 +144,11 @@ abd_fletcher_4_native(abd_t *abd, uint64_t size,
 
 }
 
-/*ARGSUSED*/
 void
 abd_fletcher_4_byteswap(abd_t *abd, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
+	(void) ctx_template;
 	fletcher_4_ctx_t ctx;
 
 	zio_abd_checksum_data_t acd = {

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -74,6 +74,7 @@ uint8_t
 zio_complevel_select(spa_t *spa, enum zio_compress compress, uint8_t child,
     uint8_t parent)
 {
+	(void) spa;
 	uint8_t result;
 
 	if (!ZIO_COMPRESS_HASLEVEL(compress))
@@ -110,10 +111,11 @@ zio_compress_select(spa_t *spa, enum zio_compress child,
 	return (result);
 }
 
-/*ARGSUSED*/
 static int
 zio_compress_zeroed_cb(void *data, size_t len, void *private)
 {
+	(void) private;
+
 	uint64_t *end = (uint64_t *)((char *)data + len);
 	for (uint64_t *word = (uint64_t *)data; word < end; word++)
 		if (*word != 0)


### PR DESCRIPTION
### Motivation and Context
There are **2** unused arguments among us.

### Description
~~Draft because on top of #12835 and #12067, otherwise should be~~ g2g except as indicated below.

The main revelation over my previous attempt at this was making ASSERTs et al do (void)sizeof(args)...: this doesn't ODR-use the arguments, so they get elided as usual, but it marks them as used (and actually verifies that they compile, which is a nice bonus), bringing the total diffstat to just
> 113 files changed, 446 insertions(+), 331 deletions(-)

across 97 commits, which is *more* than fine, imo
These are sequestered to the first two commits.

Commits that start with a `!` are more than purely editorial. In zfs sendrecv, I think this was a bug that I fixed. In arc.c I removed the mutex argument, which the comment says is used but isn't, and is only used by the caller?

In rdwr_efi.c, do we want efi_type() anymore? All it is right now is some #if 0ed Solaris code that returns ENOSYS, and is only applicable for the Solaris blockdev layer. In the Illumos gate, there's a single user: rmformat(1); I recommend a read of the manual as a blast from the past, but, well.

### How Has This Been Tested?
`make -C lib/` builds clean on clang 14 when configured with `-Wall -Wextra -Wno-sign-compare -Wno-missing-field-initializers` in CFLAGS

`git -C lib grep -i argsused` and the equivalent invocations for `include` and `module/{avl,icp,lua,nvpair,spl,unicode,zcommon,zstd}` are empty. The keen-eyed observer will note that this leaves only `module/zfs` and `module/os` (f/s, f/z, and l/z). (Well, and `cstyle.pl`.)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none should apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.co/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by). – needs mass replacing on `;` when ready
