### PR TITLE
Temporarily exclude known-failing tests

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -193,6 +193,10 @@ elif sys.platform.startswith('linux'):
         'casenorm/sensitive_formd_lookup': ['FAIL', '7633'],
         'casenorm/sensitive_formd_delete': ['FAIL', '7633'],
         'removal/removal_with_zdb': ['SKIP', known_reason],
+        'cli_root/zpool_import/import_rewind_device_replaced':
+            ['FAIL', '12848'],
+        'mmp/mmp_inactive_import': ['FAIL', '12848'],
+        'no_space/enospc_002_pos': ['FAIL', '12848'],
     })
 
 
@@ -294,8 +298,6 @@ elif sys.platform.startswith('linux'):
         'mmp/mmp_active_import': ['FAIL', known_reason],
         'mmp/mmp_exported_import': ['FAIL', known_reason],
         'mmp/mmp_inactive_import': ['FAIL', known_reason],
-        'refreserv/refreserv_raidz': ['FAIL', known_reason],
-        'snapshot/rollback_003_pos': ['FAIL', known_reason],
         'zvol/zvol_misc/zvol_misc_snapdev': ['FAIL', '12621'],
         'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', known_reason],
     })


### PR DESCRIPTION
### Motivation and Context
Make the 20.04 runner not report failure every time until #12848 is resolved.

### Description
"Yes, we know these might fail, don't scream about it."

### How Has This Been Tested?
Not even slightly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
