### PR TITLE
Linux: Implement FS_IOC_GETVERSION

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,6 +213,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/cmd/file_trunc/Makefile
 	tests/zfs-tests/cmd/file_write/Makefile
 	tests/zfs-tests/cmd/get_diff/Makefile
+	tests/zfs-tests/cmd/getversion/Makefile
 	tests/zfs-tests/cmd/largest_file/Makefile
 	tests/zfs-tests/cmd/libzfs_input_check/Makefile
 	tests/zfs-tests/cmd/mkbusy/Makefile
@@ -388,6 +389,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/snapshot/Makefile
 	tests/zfs-tests/tests/functional/snapused/Makefile
 	tests/zfs-tests/tests/functional/sparse/Makefile
+	tests/zfs-tests/tests/functional/stat/Makefile
 	tests/zfs-tests/tests/functional/suid/Makefile
 	tests/zfs-tests/tests/functional/threadsappend/Makefile
 	tests/zfs-tests/tests/functional/tmpfile/Makefile

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -817,6 +817,14 @@ zpl_fallocate(struct file *filp, int mode, loff_t offset, loff_t len)
 	    mode, offset, len);
 }
 
+static int
+zpl_ioctl_getversion(struct file *filp, void __user *arg)
+{
+	uint32_t generation = file_inode(filp)->i_generation;
+
+	return (copy_to_user(arg, &generation, sizeof (generation)));
+}
+
 #define	ZFS_FL_USER_VISIBLE	(FS_FL_USER_VISIBLE | ZFS_PROJINHERIT_FL)
 #define	ZFS_FL_USER_MODIFIABLE	(FS_FL_USER_MODIFIABLE | ZFS_PROJINHERIT_FL)
 
@@ -989,6 +997,8 @@ static long
 zpl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	switch (cmd) {
+	case FS_IOC_GETVERSION:
+		return (zpl_ioctl_getversion(filp, (void *)arg));
 	case FS_IOC_GETFLAGS:
 		return (zpl_ioctl_getflags(filp, (void *)arg));
 	case FS_IOC_SETFLAGS:
@@ -1007,6 +1017,9 @@ static long
 zpl_compat_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	switch (cmd) {
+	case FS_IOC32_GETVERSION:
+		cmd = FS_IOC_GETVERSION;
+		break;
 	case FS_IOC32_GETFLAGS:
 		cmd = FS_IOC_GETFLAGS;
 		break;

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -874,6 +874,10 @@ tags = ['functional', 'snapused']
 tests = ['sparse_001_pos']
 tags = ['functional', 'sparse']
 
+[tests/functional/stat]
+tests = ['stat_001_pos']
+tags = ['functional', 'stat']
+
 [tests/functional/suid]
 tests = ['suid_write_to_suid', 'suid_write_to_sgid', 'suid_write_to_suid_sgid',
     'suid_write_to_none']

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -32,6 +32,7 @@ SUBDIRS = \
 
 if BUILD_LINUX
 SUBDIRS += \
+	getversion \
 	randfree_file \
 	user_ns_exec \
 	xattrtest

--- a/tests/zfs-tests/cmd/getversion/.gitignore
+++ b/tests/zfs-tests/cmd/getversion/.gitignore
@@ -1,0 +1,1 @@
+/getversion

--- a/tests/zfs-tests/cmd/getversion/Makefile.am
+++ b/tests/zfs-tests/cmd/getversion/Makefile.am
@@ -1,0 +1,6 @@
+include $(top_srcdir)/config/Rules.am
+
+pkgexecdir = $(datadir)/@PACKAGE@/zfs-tests/bin
+
+pkgexec_PROGRAMS = getversion
+getversion_SOURCES = getversion.c

--- a/tests/zfs-tests/cmd/getversion/getversion.c
+++ b/tests/zfs-tests/cmd/getversion/getversion.c
@@ -1,0 +1,48 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2021 iXsystems, Inc.
+ */
+
+/*
+ * FreeBSD and macOS expose file generation number through stat(2) and stat(1).
+ * Linux exposes it instead through an ioctl.
+ */
+
+#include <sys/ioctl.h>
+#include <sys/fcntl.h>
+#include <linux/fs.h>
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int
+main(int argc, const char * const argv[])
+{
+	if (argc != 2)
+		errx(EXIT_FAILURE, "usage: %s filename", argv[0]);
+
+	int fd = open(argv[1], O_RDONLY);
+	if (fd == -1)
+		err(EXIT_FAILURE, "failed to open %s", argv[1]);
+
+	int gen = 0;
+	if (ioctl(fd, FS_IOC_GETVERSION, &gen) == -1)
+		err(EXIT_FAILURE, "FS_IOC_GETVERSION failed");
+
+	(void) close(fd);
+
+	(void) printf("%d\n", gen);
+
+	return (EXIT_SUCCESS);
+}

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -201,6 +201,7 @@ export ZFSTEST_FILES='badsend
     file_trunc
     file_write
     get_diff
+    getversion
     largest_file
     libzfs_input_check
     mkbusy

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -4051,6 +4051,20 @@ function stat_crtime #<path>
 	esac
 }
 
+function stat_generation #<path>
+{
+	typeset path=$1
+
+	case $(uname) in
+	Linux)
+		getversion "${path}"
+		;;
+	*)
+		stat -f %v "${path}"
+		;;
+	esac
+}
+
 # Run a command as if it was being run in a TTY.
 #
 # Usage:

--- a/tests/zfs-tests/tests/functional/Makefile.am
+++ b/tests/zfs-tests/tests/functional/Makefile.am
@@ -73,6 +73,7 @@ SUBDIRS = \
 	snapshot \
 	snapused \
 	sparse \
+	stat \
 	suid \
 	threadsappend \
 	trim \

--- a/tests/zfs-tests/tests/functional/stat/Makefile.am
+++ b/tests/zfs-tests/tests/functional/stat/Makefile.am
@@ -1,0 +1,8 @@
+include $(top_srcdir)/config/Rules.am
+
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/stat
+
+dist_pkgdata_SCRIPTS = \
+	cleanup.ksh \
+	setup.ksh \
+	stat_001_pos.ksh

--- a/tests/zfs-tests/tests/functional/stat/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/stat/cleanup.ksh
@@ -1,0 +1,34 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/stat/setup.ksh
+++ b/tests/zfs-tests/tests/functional/stat/setup.ksh
@@ -1,0 +1,36 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+
+default_setup ${DISK}

--- a/tests/zfs-tests/tests/functional/stat/stat_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/stat/stat_001_pos.ksh
@@ -1,0 +1,57 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2021 iXsystems, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# Ensure znode generation number is accessible.
+#
+# STRATEGY:
+#	1) Create a file
+#	2) Verify that the znode generation number can be obtained
+#	3) Verify that the znode generation number is not empty
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	rm -f ${TESTFILE}
+}
+
+log_onexit cleanup
+
+log_assert "Ensure znode generation number is accessible."
+
+TESTFILE=${TESTDIR}/${TESTFILE0}
+
+log_must touch ${TESTFILE}
+log_must stat_generation ${TESTFILE}
+log_must test $(stat_generation ${TESTFILE}) -ne 0
+
+log_pass "Successfully obtained file znode generation number."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Provide access to file generation number on Linux.
FreeBSD and macOS already provide it through stat(2), but Linux provides it through an ioctl.

### Description
<!--- Describe your changes in detail -->
Implement the FS_IOC_GETVERSION ioctl for Linux.
Add test coverage.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
A small C program "getversion" is used to perform the FS_IOC_GETVERSION ioctl on Linux, and a test case verifies the command works and retrieves a nonzero value. On FreeBSD the test invokes stat(1) instead.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
