### PR TITLE
Introduce write throttle smoothing

### DIFF
--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -64,6 +64,8 @@ extern int zfs_dirty_data_max_percent;
 extern int zfs_dirty_data_max_max_percent;
 extern int zfs_delay_min_dirty_percent;
 extern unsigned long zfs_delay_scale;
+extern unsigned long zfs_smoothing_scale;
+extern unsigned long zfs_smoothing_write;
 
 /* These macros are for indexing into the zfs_all_blkstats_t. */
 #define	DMU_OT_DEFERRED	DMU_OT_NONE
@@ -115,6 +117,7 @@ typedef struct dsl_pool {
 	kcondvar_t dp_spaceavail_cv;
 	uint64_t dp_dirty_pertxg[TXG_SIZE];
 	uint64_t dp_dirty_total;
+	hrtime_t dp_last_smooth;
 	uint64_t dp_long_free_dirty_pertxg[TXG_SIZE];
 	uint64_t dp_mos_used_delta;
 	uint64_t dp_mos_compressed_delta;

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -15,7 +15,7 @@
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
 .\"
-.Dd June 1, 2021
+.Dd January 8, 2021
 .Dt ZFS 4
 .Os
 .
@@ -943,6 +943,21 @@ This will smoothly handle between ten times and a tenth of this number.
 .No See Sx ZFS TRANSACTION DELAY .
 .Pp
 .Sy zfs_delay_scale No \(mu Sy zfs_dirty_data_max Em must No be smaller than Sy 2^64 .
+.
+.It Sy zfs_smoothing_write Ns = Ns Sy 0 Ns s Pq ulong
+This controls for how many seconds smoothing should be applied.
+The smoothing mechanism is used to add additional transaction delays
+after the amount of dirty data drops below
+.Sy zfs_delay_min_dirty_percent .
+This mechanism may be used to avoid stalls and uneven performance during
+heavy write workloads
+.
+.It Sy zfs_smoothing_scale Ns = Ns Sy 100000 Pq int
+Similar to
+.Sy zfs_delay_scale ,
+but for write smoothing.
+This variable controls the scale of smoothing curve.
+Larger values cause longer delays for a given amount of dirty data.
 .
 .It Sy zfs_disable_ivset_guid_check Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Disables requirement for IVset GUIDs to be present and match when doing a raw


### PR DESCRIPTION
To avoid stalls and uneven performance during heavy write workloads,
continue to apply the write throttling even when the amount of dirty data
has temporarily dipped below `zfs_delay_min_dirty_percent` for up to
`zfs_write_smoothing` seconds.

Sponsored by: Zededa Inc.

### Motivation and Context
Consider a case where new data is written to the ZFS dirty buffers at the rate that the backing storage cannot keep up with. ZFS allows writing data at full speed until the amount of dirty data in memory reach the threshold (`zfs_delay_min_dirty_percent`, default is 60%). When this point is reached, ZFS starts to apply artificial delays. The applied delays scales based on the amount of dirty data and is described by the formula:
```
delay_ns = zfs_delay_scale * (amount_of_dirty_data - delay_min_bytes) / (zfs_dirty_data_max - amount_of_dirty_data)
```

While data is added at a somewhat consistent rate, data is drained from the dirty buffers in large swaths as each transaction group is flushed to disk. This can result in the amount of dirty data dropping below the 60% threshold again, resulting in no delay being applied, and ZFS accepts data at full speed.

This causes applications to experience significant changes in write throughput depending on the amount of dirty data, especially on very heavy write workloads. The behavior is noticeable because the delay is applied only when the threshold is exceeded.

### Description
The idea is to continue to apply the write throttle (adding delay to every write) for a short time even after the amount of dirty data has fallen below the threshold. The smoothing mechanism continues to be applied for `zfs_write_smoothing` seconds after the last time when the amount of dirty data was above the threshold. Thanks to this, applications will not be able to burst writes again if the backing storage is still possibly unable to keep up with the level of incoming writes. 
The additional delay will be applied only when the backing storage has been overloaded within the last few seconds.

The original delaying algorithm works as before.

The formula used for the smoothing algorithm is as follow:
```
delay_ns = zfs_delay_scale * (amount_of_dirty_data) / ((zfs_dirty_data_max - amount_of_dirty_data));
```

The characteristic of this formula is shown in the Figure below in yellow color. It’s more aggressive than the previous one because when the dirty data exceeds the threshold, we apply the previous formula.

![smoothed_write_throttle](https://user-images.githubusercontent.com/1096028/146411949-a41bc884-28d4-4d5d-aeb6-c58a58c95df8.png)


### How Has This Been Tested?
We performed several tests using the fio utility. We observed the amount of dirty data during these tests and applied delays. Both those observation was done using eBPF.
Example of eBPF to observe the change in the amount of data buffers:
```
bpftrace -e ‘kprobe:dsl_pool_dirty_delta {@val[tid] = (int8 *)arg0 + 0x248;} kretprobe:dsl_pool_dirty_delta {printf(“%lld %lld\n”, nsecs, *(uint64 *)@val[tid]); delete(@val[tid]); }’
```

To observe the applied delay:
```
bpftrace -e ‘kprobe:dmu_tx_assign { @time[tid] = 0 } kprobe:dmu_tx_wait { @tmp[tid] = nsecs } kretprobe:dmu_tx_wait /@tmp[tid]/ { @time[tid] += nsecs - @tmp
[tid] } kretprobe:dmu_tx_assign { @ns = hist(@time[tid]); delete(@time[tid]) } END { clear(@time); clear(@tmp); }’
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

