### PR TITLE
ZTS: Fix zpool_reopen_[1-5] on Fedora 35

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen.shlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen.shlib
@@ -68,11 +68,11 @@ function wait_for_action #pool timeout function
 {
 	typeset pool=$1
 	typeset -i timeout=$2
-	typeset func=$3
+	typeset funct=$3
 
 	while [ $timeout -gt 0 ]; do
 		(( --timeout ))
-		if ( $func $pool ); then
+		if ( $funct $pool ); then
 			return 0
 		fi
 		sleep 1


### PR DESCRIPTION

### Motivation and Context
Fix  `zpool_reopen_[1-5]` tests on Fedora 35

### Description
The `zpool_reopen_[1-5]` tests are failing Fedora 35:
```
zpool_reopen_001_pos.ksh[64]: log_must[67]: log_pos[270]: wait_for_resilver_end[98]: wait_for_action: line 71: func: is read only
```
Renaming 'func' -> 'funct' fixes the issue.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [d] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
