### PR TITLE
mkfile: fsync() before closing the file

### DIFF
--- a/tests/zfs-tests/cmd/mkfile/mkfile.c
+++ b/tests/zfs-tests/cmd/mkfile/mkfile.c
@@ -247,6 +247,17 @@ main(int argc, char **argv)
 				continue;
 			}
 		}
+		if (fsync(fd) < 0) {
+			saverr = errno;
+			(void) fprintf(stderr, gettext(
+			    "Error encountered when fsyncing %s: %s\n"),
+			    argv[1], strerror(saverr));
+			(void) close(fd);
+			errors++;
+			argv++;
+			argc--;
+			continue;
+		}
 		if (close(fd) < 0) {
 			saverr = errno;
 			(void) fprintf(stderr, gettext(


### PR DESCRIPTION

Signed-off-by: Allan Jude <allan@klarasystems.com>

### Motivation and Context
Many tests in the test suite assume that space will be consumed
after mkfile has run, but it infact may not have actually been
written out yet. Adding a call to fsync() ensures that when
mkfile exits, the expected impact on the pool is realized.

### Description
Call `fsync()` before `close()` in mkfile (used by the zfs-tests)

### How Has This Been Tested?
After this, the `refquota/refquota_003_pos` and other tests no longer fail in https://github.com/openzfs/zfs/pull/12773

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
