### PR TITLE
FreeBSD: fix world build after 143476ce8

### DIFF
--- a/lib/libspl/include/sys/feature_tests.h
+++ b/lib/libspl/include/sys/feature_tests.h
@@ -30,7 +30,7 @@
 #define	____cacheline_aligned
 #define	__NORETURN		__attribute__((__noreturn__))
 
-#if !defined(fallthrough)
+#if !defined(fallthrough) && !defined(_LIBCPP_VERSION)
 #if defined(HAVE_IMPLICIT_FALLTHROUGH)
 #define	fallthrough		__attribute__((__fallthrough__))
 #else


### PR DESCRIPTION
### Motivation and Context
This fix has been included in FreeBSD since the merge of 143476ce8 but I forgot to submit it upstream.

### Description
Do not redefine the fallthrough macro when building with libcpp.

### How Has This Been Tested?
Included in FreeBSD main for over 2 months.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).