### PR TITLE
zfs-test/mmap_seek: fix build on musl

### DIFF
--- a/tests/zfs-tests/cmd/mmap_seek/mmap_seek.c
+++ b/tests/zfs-tests/cmd/mmap_seek/mmap_seek.c
@@ -29,7 +29,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/sysmacros.h>
 #include <errno.h>
+#ifdef __linux__
+#include <linux/fs.h>
+#endif
 
 static void
 seek_data(int fd, off_t offset, off_t expected)


### PR DESCRIPTION
it needs linux/fs.h for SEEK_DATA and friends



Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
zfs-2.1.2 fails to build on musl targets because of this change that added new test:
https://github.com/openzfs/zfs/commit/de198f2d9507b6dcf3d0d8f037ba33940208733e

### Description
without linux/fs.h:

```
mmap_seek.c
mmap_seek.c: In function 'seek_data':
mmap_seek.c:37:40: error: 'SEEK_DATA' undeclared (first use in this function); did you mean 'SEEK_SET'?
   37 |  off_t data_offset = lseek(fd, offset, SEEK_DATA);
```

also it needs sys/sysmacros.h for P2ROUNDUP
without it:

```
make[5]: Entering directory '/var/tmp/portage/sys-fs/zfs-2.1.2-r1/work/zfs-2.1.2/tests/zfs-tests/cmd/mmap_seek'
powerpc64-gentoo-linux-musl-gcc -DHAVE_CONFIG_H -include ../../../../zfs_config.h -I../../../../include -I../../../../include -I../../../../module/icp/include -I../../../../lib/libspl/include -I../../../../lib/libspl/include/os/linu
x   -D_GNU_SOURCE -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DLIBEXECDIR=\"/usr/libexec\" -DRUNSTATEDIR=\"/var/run\" -DSBINDIR=\"/sbin\" -DSYSCONFDIR=\"/etc\" -DPKGDATADIR=\"/usr/share/zfs\" -UDEBUG -DNDEBUG  -DTEXT_
DOMAIN=\"zfs-linux-user\"   -std=gnu99 -Wall -Wstrict-prototypes -Wmissing-prototypes -fno-strict-aliasing -fno-omit-frame-pointer -Wimplicit-fallthrough    -Wno-format-zero-length  -O2 -pipe -frecord-gcc-switches -fdiagnostics-show
-option -c -o mmap_seek.o mmap_seek.c
mmap_seek.c: In function 'main':
mmap_seek.c:122:19: warning: implicit declaration of function 'P2ROUNDUP' [-Wimplicit-function-declaration]
  122 |  seek_hole(fd, 0, P2ROUNDUP(file_size / 2, block_size));
      |                   ^~~~~~~~~
/bin/sh ../../../../libtool  --tag=CC --silent  --mode=link powerpc64-gentoo-linux-musl-gcc -std=gnu99 -Wall -Wstrict-prototypes -Wmissing-prototypes -fno-strict-aliasing -fno-omit-frame-pointer -Wimplicit-fallthrough    -Wno-format
-zero-length  -O2 -pipe -frecord-gcc-switches -fdiagnostics-show-option    -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -o mmap_seek mmap_seek.o
/usr/lib/gcc/powerpc64-gentoo-linux-musl/10.3.0/../../../../powerpc64-gentoo-linux-musl/bin/ld: mmap_seek.o: in function `main':
mmap_seek.c:(.text.startup+0x1b8): undefined reference to `P2ROUNDUP'
/usr/lib/gcc/powerpc64-gentoo-linux-musl/10.3.0/../../../../powerpc64-gentoo-linux-musl/bin/ld: mmap_seek.c:(.text.startup+0x1d8): undefined reference to `P2ROUNDUP'
/usr/lib/gcc/powerpc64-gentoo-linux-musl/10.3.0/../../../../powerpc64-gentoo-linux-musl/bin/ld: mmap_seek.c:(.text.startup+0x21c): undefined reference to `P2ROUNDUP'
collect2: error: ld returned 1 exit status
make[5]: *** [Makefile:754: mmap_seek] Error 1
```
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I applied my change and it now builds fine.
I have NOT tested if the test-suite actually works after it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
