### PR TITLE
tests: normalize on use of `sync_pool`

### DIFF
--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -595,7 +595,7 @@ function list_file_blocks # input_file
 	else
 		AWK='awk'
 	fi
-	log_must zpool sync -f
+	sync_all_pools true
 	zdb -dddddd $ds $objnum | $AWK -v pad=$((4<<20)) -v bs=512 '
 	    /^$/ { looking = 0 }
 	    looking {

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3104,6 +3104,7 @@ function datasetcksum
 {
 	typeset cksum
 	sync
+	sync_all_pools
 	cksum=$(zdb -vvv $1 | grep "^Dataset $1 \[" | grep "cksum" \
 		| awk -F= '{print $7}')
 	echo $cksum
@@ -3514,6 +3515,24 @@ function sync_pool #pool <force>
 		log_must zpool sync -f $pool
 	else
 		log_must zpool sync $pool
+	fi
+
+	return 0
+}
+
+#
+# Sync all pools
+#
+# $1 boolean to force uberblock (and config including zpool cache file) update
+#
+function sync_all_pools #<force>
+{
+	typeset force=${1:-false}
+
+	if [[ $force == true ]]; then
+		log_must zpool sync -f
+	else
+		log_must zpool sync
 	fi
 
 	return 0

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_012_pos.ksh
@@ -85,7 +85,7 @@ function check_removal
 		    bs=1M count=$blocks
 		((blocks = blocks + 25))
 	done
-	log_must sync_pool $TESTPOOL
+	sync_pool $TESTPOOL
 	log_must zpool list -v $TESTPOOL
 
 	# Verify the files were written in the special class vdevs
@@ -98,7 +98,7 @@ function check_removal
 	log_must zpool remove $TESTPOOL $CLASS_DISK0
 
 	sleep 5
-	log_must sync_pool $TESTPOOL
+	sync_pool $TESTPOOL
 	sleep 1
 
 	log_must zdb -bbcc $TESTPOOL

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_013_pos.ksh
@@ -53,7 +53,7 @@ log_must zpool list -v $TESTPOOL
 log_must zpool remove $TESTPOOL $CLASS_DISK0
 
 sleep 5
-log_must sync_pool $TESTPOOL
+sync_pool $TESTPOOL
 sleep 1
 
 log_must zdb -bbcc $TESTPOOL

--- a/tests/zfs-tests/tests/functional/arc/dbufstats_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/arc/dbufstats_001_pos.ksh
@@ -75,7 +75,7 @@ log_assert "dbufstats produces correct statistics"
 log_onexit cleanup
 
 log_must file_write -o create -f "$TESTDIR/file" -b 1048576 -c 20 -d R
-log_must zpool sync
+sync_all_pools
 
 log_must eval "kstat dbufs > $DBUFS_FILE"
 log_must eval "kstat dbufstats '' > $DBUFSTATS_FILE"

--- a/tests/zfs-tests/tests/functional/arc/dbufstats_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/arc/dbufstats_002_pos.ksh
@@ -56,7 +56,7 @@ log_assert "dbufs move from mru to mfu list"
 log_onexit cleanup
 
 log_must file_write -o create -f "$TESTDIR/file" -b 1048576 -c 1 -d R
-log_must zpool sync
+sync_all_pools
 
 objid=$(get_objnum "$TESTDIR/file")
 log_note "Object ID for $TESTDIR/file is $objid"

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_written.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_written.ksh
@@ -46,7 +46,7 @@ log_must_program $TESTPOOL - <<-EOF
 EOF
 
 log_must mkdir $dir
-sync
+sync_all_pools
 
 log_must_program $TESTPOOL - <<-EOF
 	ans, setpoint = zfs.get_prop("$fs", "written@$TESTSNAP")

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_block_size_histogram.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_block_size_histogram.ksh
@@ -128,7 +128,7 @@ function histo_populate_test_pool
 	# to the device.  This 'sync' command prevents that from 
 	# happening.
 	####################
-	log_must zpool sync ${pool}
+	sync_pool ${pool}
 }
 function histo_check_test_pool
 {

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_object_range_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_object_range_neg.ksh
@@ -40,7 +40,7 @@ verify_runnable "both"
 verify_disk_count "$DISKS" 2
 default_mirror_setup_noexit $DISKS
 
-log_must zpool sync
+sync_all_pools
 
 set -A bad_flags a b c   e   g h i j k l   n o p q r s t u v w x y   \
                    B C D E F G H I J K L M N O P Q R S T U V W X Y Z \

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_object_range_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_object_range_pos.ksh
@@ -76,7 +76,7 @@ for x in $(seq 0 7); do
 	mkdir $TESTDIR/dir$x
 done
 
-log_must zpool sync
+sync_all_pools
 
 # Get list of all objects, but filter out user/group objects which don't
 # appear when using object or object range arguments

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_recover.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_recover.ksh
@@ -47,7 +47,7 @@ verify_disk_count "$DISKS" 2
 
 default_mirror_setup_noexit $DISKS
 file_write -o create -w -f $init_data -b $blksize -c $write_count
-log_must zpool sync $TESTPOOL
+sync_pool $TESTPOOL
 
 output=$(zdb -r $TESTPOOL/$TESTFS file1 $tmpfile)
 log_must cmp $init_data $tmpfile

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_recover_2.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_recover_2.ksh
@@ -49,7 +49,7 @@ verify_disk_count "$DISKS" 2
 default_mirror_setup_noexit $DISKS
 file_write -o create -w -f $init_data -b $blksize -c $write_count
 log_must echo "zfs" >> $init_data
-log_must zpool sync $TESTPOOL
+sync_pool $TESTPOOL
 
 output=$(zdb -r $TESTPOOL/$TESTFS file1 $tmpfile)
 log_must cmp $init_data $tmpfile

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_002_pos.ksh
@@ -67,7 +67,7 @@ done
 #
 # Sync up the filesystem
 #
-sync
+sync_all_pools
 
 #
 # Verify 'zfs list' can correctly list the space charged

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_clone_livelist_condense_and_disable.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_clone_livelist_condense_and_disable.ksh
@@ -66,7 +66,7 @@ function test_condense
 	# sync between each write to make sure a new entry is created
 	for i in {0..4}; do
 	    log_must mkfile 5m /$TESTPOOL/$TESTCLONE/testfile$i
-	    log_must zpool sync $TESTPOOL
+	    sync_pool $TESTPOOL
 	done
 
 	check_ll_len "5 entries" "Unexpected livelist size"
@@ -74,7 +74,7 @@ function test_condense
 	# sync between each write to allow for a condense of the previous entry
 	for i in {0..4}; do
 	    log_must mkfile 5m /$TESTPOOL/$TESTCLONE/testfile$i
-	    log_must zpool sync $TESTPOOL
+	    sync_pool $TESTPOOL
 	done
 
 	check_ll_len "6 entries" "Condense did not occur"
@@ -91,7 +91,7 @@ function test_deactivated
 
 	log_must mkfile 5m /$TESTPOOL/$TESTCLONE/$TESTFILE0
 	log_must mkfile 5m /$TESTPOOL/$TESTCLONE/$TESTFILE1
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 	# snapshot and clone share 'atestfile', 33 percent
 	check_livelist_gone
 	log_must zfs destroy -R $TESTPOOL/$TESTCLONE
@@ -103,7 +103,7 @@ function test_deactivated
 	log_must mkfile 5m /$TESTPOOL/$TESTCLONE/$TESTFILE0
 	log_must mkfile 5m /$TESTPOOL/$TESTCLONE/$TESTFILE1
 	log_must mkfile 5m /$TESTPOOL/$TESTCLONE/$TESTFILE2
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 	# snapshot and clone share 'atestfile', 25 percent
 	check_livelist_exists $TESTCLONE
 	log_must rm /$TESTPOOL/$TESTCLONE/atestfile

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_clone_livelist_condense_races.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_clone_livelist_condense_races.ksh
@@ -49,11 +49,11 @@ function delete_race
 	set_tunable32 "$1" 0
 	log_must zfs clone $TESTPOOL/$TESTFS1@snap $TESTPOOL/$TESTCLONE
 	for i in {1..5}; do
-		log_must zpool sync $TESTPOOL
+		sync_pool $TESTPOOL
 		log_must mkfile 5m /$TESTPOOL/$TESTCLONE/out
 	done
 	log_must zfs destroy $TESTPOOL/$TESTCLONE
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 	[[ "1" == "$(get_tunable "$1")" ]] || \
 	    log_fail "delete/condense race test failed"
 }
@@ -63,7 +63,7 @@ function export_race
 	set_tunable32 "$1" 0
 	log_must zfs clone $TESTPOOL/$TESTFS1@snap $TESTPOOL/$TESTCLONE
 	for i in {1..5}; do
-		log_must zpool sync $TESTPOOL
+		sync_pool $TESTPOOL
 		log_must mkfile 5m /$TESTPOOL/$TESTCLONE/out
 	done
 	log_must zpool export $TESTPOOL
@@ -78,12 +78,12 @@ function disable_race
 	set_tunable32 "$1" 0
 	log_must zfs clone $TESTPOOL/$TESTFS1@snap $TESTPOOL/$TESTCLONE
 	for i in {1..5}; do
-		log_must zpool sync $TESTPOOL
+		sync_pool $TESTPOOL
 		log_must mkfile 5m /$TESTPOOL/$TESTCLONE/out
 	done
 	# overwrite the file shared with the origin to trigger disable
 	log_must mkfile 100m /$TESTPOOL/$TESTCLONE/atestfile
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 	[[ "1" == "$(get_tunable "$1")" ]] || \
 	    log_fail "disable/condense race test failed"
 	log_must zfs destroy $TESTPOOL/$TESTCLONE
@@ -95,7 +95,7 @@ log_onexit cleanup
 
 log_must zfs create $TESTPOOL/$TESTFS1
 log_must mkfile 100m /$TESTPOOL/$TESTFS1/atestfile
-log_must zpool sync $TESTPOOL
+sync_pool $TESTPOOL
 log_must zfs snapshot $TESTPOOL/$TESTFS1@snap
 
 # Reduce livelist size to trigger condense more easily

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_clone_livelist_dedup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_clone_livelist_dedup.ksh
@@ -54,12 +54,12 @@ function test_dedup
 	# Note: We sync before and after so all dedup blocks belong to the
 	#       same TXG, otherwise they won't look identical to the livelist
 	#       iterator due to their logical birth TXG being different.
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 	log_must cp /$TESTPOOL/$TESTCLONE/data /$TESTPOOL/$TESTCLONE/data-dup-0
 	log_must cp /$TESTPOOL/$TESTCLONE/data /$TESTPOOL/$TESTCLONE/data-dup-1
 	log_must cp /$TESTPOOL/$TESTCLONE/data /$TESTPOOL/$TESTCLONE/data-dup-2
 	log_must cp /$TESTPOOL/$TESTCLONE/data /$TESTPOOL/$TESTCLONE/data-dup-3
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 	check_livelist_exists $TESTCLONE
 
 	# Introduce "double frees"
@@ -67,10 +67,10 @@ function test_dedup
 	#   was what triggered past panics.
 	# Note: Similarly to the previouys step we sync before and after our
 	#       our deletions so all the entries end up in the same TXG.
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 	log_must rm /$TESTPOOL/$TESTCLONE/data-dup-2
 	log_must rm /$TESTPOOL/$TESTCLONE/data-dup-3
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 	check_livelist_exists $TESTCLONE
 
 	log_must zfs destroy $TESTPOOL/$TESTCLONE

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_clone_livelist.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_clone_livelist.ksh
@@ -47,7 +47,7 @@ function cleanup
 function clone_write_file
 {
 	log_must mkfile 1m /$TESTPOOL/$1/$2
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 }
 
 function test_one_empty

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
@@ -153,7 +153,7 @@ function check_livelist_exists
 function check_livelist_gone
 {
 	log_must zpool wait -t free $TESTPOOL
-	zpool sync
+	sync_all_pools
 	zdb -vvvvv $TESTPOOL | grep "Livelist" && \
 		log_fail "zdb found Livelist after the clone is deleted."
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_dev_removal_condense.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_dev_removal_condense.ksh
@@ -65,7 +65,7 @@ log_must zfs clone $TESTPOOL2/$TESTFS@snap $TESTPOOL2/$TESTCLONE
 # Create initial files and pause condense zthr on next execution
 log_must mkfile 10m /$TESTPOOL2/$TESTCLONE/A
 log_must mkfile 1m /$TESTPOOL2/$TESTCLONE/B
-log_must zpool sync $TESTPOOL2
+sync_pool $TESTPOOL2
 set_tunable32 LIVELIST_CONDENSE_SYNC_PAUSE 1
 
 # Add a new dev and remove the old one
@@ -76,15 +76,15 @@ wait_for_removal $TESTPOOL2
 set_tunable32 LIVELIST_CONDENSE_NEW_ALLOC 0
 # Trigger a condense
 log_must mkfile 10m /$TESTPOOL2/$TESTCLONE/A
-log_must zpool sync $TESTPOOL2
+sync_pool $TESTPOOL2
 log_must mkfile 10m /$TESTPOOL2/$TESTCLONE/A
-log_must zpool sync $TESTPOOL2
+sync_pool $TESTPOOL2
 # Write remapped blkptrs which will modify the livelist mid-condense
 log_must mkfile 1m /$TESTPOOL2/$TESTCLONE/B
 
 # Resume condense thr
 set_tunable32 LIVELIST_CONDENSE_SYNC_PAUSE 0
-log_must zpool sync $TESTPOOL2
+sync_pool $TESTPOOL2
 # Check that we've added new ALLOC blkptrs during the condense
 [[ "0" < "$(get_tunable LIVELIST_CONDENSE_NEW_ALLOC)" ]] || \
     log_fail "removal/condense test failed"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_remount.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_remount.ksh
@@ -155,7 +155,7 @@ CRYPT_MNTPFS="$(get_prop mountpoint $TESTFS/crypt)"
 log_must touch $CRYPT_MNTPFS/file.dat
 log_must mount $RO $TESTFS/crypt $CRYPT_MNTPFS
 log_must umount -f $CRYPT_MNTPFS
-zpool sync $TESTPOOL
+sync_pool $TESTPOOL
 
 # 6. Re-import the pool readonly
 log_must zpool export $TESTPOOL

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_004_neg.ksh
@@ -87,7 +87,7 @@ log_must zfs snapshot $inc_snap
 log_must eval "zfs send -i $init_snap $inc_snap > $inc_bkup"
 log_must touch /$TESTDIR/bar
 
-sync
+sync_all_pools
 
 set -A badargs \
     "" "nonexistent-snap" "blah@blah" "-d" "-d nonexistent-dataset" \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_011_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_011_pos.ksh
@@ -65,14 +65,14 @@ origdir=$(get_prop mountpoint $orig)
 #	2. Create two equal-sized large files.
 log_must mkfile 5M $origdir/file1
 log_must mkfile 5M $origdir/file2
-log_must sync
+sync_all_pools
 
 #	3. Snapshot the filesystem.
 log_must zfs snapshot $orig@1
 
 #	4. Remove one of the two large files.
 log_must rm $origdir/file2
-log_must sync
+sync_all_pools
 
 #	5. Create a refquota larger than one file, but smaller than both.
 log_must zfs set refquota=8M $orig

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_common.kshlib
@@ -116,6 +116,7 @@ function setup_snap_env
 			if datasetnonexists $snap; then
 				log_must cp /etc/passwd $fname
 				if is_linux || is_freebsd; then
+					sync_all_pools
 					log_must sync
 				else
 					#

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_007_pos.ksh
@@ -62,9 +62,9 @@ test_pool ()
 	log_must zfs snapshot $POOL/fs@a
 	while true; do
 		log_must find $mntpnt/ -type f -delete
-		sync
+		sync_all_pools
 		log_must mkfiles "$mntpnt/" 4000
-		sync
+		sync_all_pools
 		# check if we started reusing objects
 		object=$(ls -i $mntpnt | sort -n | awk -v object=$object \
 		    '{if ($1 <= object) {exit 1}} END {print $1}')

--- a/tests/zfs-tests/tests/functional/cli_root/zpool/zpool_colors.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool/zpool_colors.ksh
@@ -44,7 +44,7 @@ DISK3="$(echo $DISKS | cut -d' ' -f3)"
 
 log_must dd if=/dev/urandom of=/$TESTDIR/testfile bs=10M count=1
 
-log_must zpool sync
+sync_all_pools
 
 log_must zpool offline -f $TESTPOOL $DISK3
 log_must wait_for_degraded $TESTPOOL

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
@@ -175,7 +175,8 @@ function do_testing #<clear type> <vdevs>
 	esac
 	dd if=/dev/zero of=$fbase.$i seek=512 bs=1024 count=$wcount conv=notrunc \
 			> /dev/null 2>&1
-	log_must sync
+	sync_all_pools
+	log_must sync #ensure the vdev files are written out
 	log_must zpool scrub -w $TESTPOOL1
 
 	check_err $TESTPOOL1 && \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_clear_retained.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_clear_retained.ksh
@@ -111,7 +111,7 @@ log_must zpool create -f -m $MOUNTDIR -o failmode=continue $POOL raidz $VDEV1 $V
 log_must zfs set compression=off recordsize=16k $POOL
 # create a file full of zeros
 log_must mkfile -v $FILESIZE $FILEPATH
-log_must zpool sync $POOL
+sync_pool $POOL
 
 # run once and observe the checksum errors
 damage_and_repair 1

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_duplicates.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_duplicates.ksh
@@ -112,7 +112,7 @@ function do_dup_test
 
 	if [ "$RW" == "write" ] ; then
 		log_must mkfile $FILESIZE $FILEPATH
-		log_must zpool sync $POOL
+		sync_pool $POOL
 	fi
 
 	log_must zinject -c all

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_errors.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_errors.ksh
@@ -96,7 +96,7 @@ function do_test
 
 	if [ "$RW" == "write" ] ; then
 		log_must mkfile $FILESIZE $MOUNTDIR/file
-		log_must zpool sync $POOL
+		sync_pool $POOL
 	else
 		log_must zpool scrub $POOL
 		wait_scrubbed $POOL

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_verify_checksums.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_verify_checksums.ksh
@@ -42,7 +42,7 @@ DISK1=${DISKS%% *}
 
 log_must zpool create -f $TESTPOOL $DISK1
 log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=1M count=30
-log_must sync
+sync_all_pools
 
 log_must zpool initialize $TESTPOOL
 
@@ -52,7 +52,7 @@ log_must zdb -cc $TESTPOOL
     log_fail "Initializing did not start"
 
 log_must dd if=/dev/urandom of=/$TESTPOOL/file2 bs=1M count=30
-log_must sync
+sync_all_pools
 
 log_must zdb -cc $TESTPOOL
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_removed.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_removed.ksh
@@ -49,12 +49,12 @@ log_must truncate -s $SPA_MINDEVSIZE $DEVICE2 $DEVICE3 $DEVICE4 $DEVICE5
 
 log_must zpool create -f $TESTPOOL $DEVICE1 $DEVICE2 \
     log $DEVICE3 cache $DEVICE4 spare $DEVICE5
-log_must zpool sync
+sync_all_pools
 
 # Remove each type of vdev and verify the label can be cleared.
 for dev in $DEVICE5 $DEVICE4 $DEVICE3 $DEVICE2; do
 	log_must zpool remove $TESTPOOL $dev
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL true
 	log_must zpool labelclear $dev
 	log_mustnot zdb -lq $dev
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_online/zpool_online_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_online/zpool_online_001_pos.ksh
@@ -77,7 +77,7 @@ for disk in $DISKLIST; do
 	i=0
 	while [[ $i -lt ${#args[*]} ]]; do
 
-		log_must sync_pool $TESTPOOL
+		sync_pool $TESTPOOL
 		log_must zpool offline $TESTPOOL $disk
 		check_state $TESTPOOL $disk "offline"
 		if [[ $? != 0 ]]; then

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_001_pos.ksh
@@ -55,6 +55,7 @@ log_must zpool reopen
 log_must check_state $TESTPOOL "$REMOVED_DISK_ID" "unavail"
 # Write some data to the pool
 log_must generate_random_file /$TESTPOOL/data $SMALL_FILE_SIZE
+sync_pool $TESTPOOL
 # 4. "Plug back" disk.
 insert_disk $REMOVED_DISK $scsi_host
 # 5. Reopen a pool and verify if removed disk is marked online again.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_002_pos.ksh
@@ -55,6 +55,7 @@ log_must zpool reopen $TESTPOOL
 log_must check_state $TESTPOOL "$REMOVED_DISK_ID" "unavail"
 # Write some data to the pool
 log_must generate_random_file /$TESTPOOL/data $SMALL_FILE_SIZE
+sync_pool $TESTPOOL
 # 4. "Plug back" disk.
 insert_disk $REMOVED_DISK $scsi_host
 # 5. Reopen a pool and verify if removed disk is marked online again.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_003_pos.ksh
@@ -64,6 +64,7 @@ log_must check_state $TESTPOOL "$REMOVED_DISK_ID" "unavail"
 # 3. Write a test file to the pool and calculate its checksum.
 TESTFILE=/$TESTPOOL/data
 log_must generate_random_file /$TESTPOOL/data $LARGE_FILE_SIZE
+sync_pool $TESTPOOL
 TESTFILE_MD5=$(md5digest $TESTFILE)
 
 # 4. Execute scrub.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_004_pos.ksh
@@ -62,6 +62,7 @@ log_must zpool reopen -n $TESTPOOL
 log_must check_state $TESTPOOL "$REMOVED_DISK_ID" "unavail"
 # 3. Write test file to pool.
 log_must generate_random_file /$TESTPOOL/data $LARGE_FILE_SIZE
+sync_pool $TESTPOOL
 # 4. Execute scrub.
 # add delay to I/O requests for remaining disk in pool
 log_must zinject -d $DISK2 -D125:1 $TESTPOOL

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_005_pos.ksh
@@ -60,6 +60,7 @@ log_must zpool reopen $TESTPOOL
 log_must check_state $TESTPOOL "$REMOVED_DISK_ID" "unavail"
 # 3. Write test file to pool.
 log_must generate_random_file /$TESTPOOL/data $LARGE_FILE_SIZE
+sync_pool $TESTPOOL
 # 4. "Plug back" disk.
 insert_disk $REMOVED_DISK $scsi_host
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_resilver/zpool_resilver_restart.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_resilver/zpool_resilver_restart.ksh
@@ -58,12 +58,12 @@ mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
 
 # 1. Write some data and detach the first drive so it has resilver work to do
 log_must file_write -b 524288 -c 1024 -o create -d 0 -f $mntpnt/biggerfile1
-log_must sync
+sync_all_pools
 log_must zpool detach $TESTPOOL $DISK2
 
 # 2. Repeat the process with a second disk
 log_must file_write -b 524288 -c 1024 -o create -d 0 -f $mntpnt/biggerfile2
-log_must sync
+sync_all_pools
 log_must zpool detach $TESTPOOL $DISK3
 
 # 3. Reattach the drives, causing the second drive's resilver to be deferred

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_002_pos.ksh
@@ -61,7 +61,7 @@ log_assert "Verify scrub, scrub -p, and scrub -s show the right status."
 # Create 1G of additional data
 mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
 log_must file_write -b 1048576 -c 1024 -o create -d 0 -f $mntpnt/biggerfile
-log_must sync
+sync_all_pools
 
 log_must set_tunable32 SCAN_SUSPEND_PROGRESS 1
 log_must zpool scrub $TESTPOOL

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_multiple_copies.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_multiple_copies.ksh
@@ -50,7 +50,7 @@ log_assert "Scrubs and self healing must work with additional copies"
 log_must zfs create -o copies=3 $TESTPOOL/$TESTFS2
 typeset mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS2)
 log_must mkfile 10m $mntpnt/file
-log_must zpool sync $TESTPOOL
+sync_pool $TESTPOOL
 
 log_must zinject -a -t data -C 0,1 -e io $mntpnt/file
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_resilver.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_resilver.ksh
@@ -66,7 +66,7 @@ function zpool_split #disk_to_be_offline/online
 	# Create 2G of additional data
 	mntpnt=$(get_prop mountpoint $TESTPOOL)
 	log_must file_write -b 2097152 -c 1024 -o create -d 0 -f $mntpnt/biggerfile
-	log_must sync
+	sync_all_pools
 
 	# temporarily prevent resilvering progress, so it will not finish too early
 	log_must set_tunable32 SCAN_SUSPEND_PROGRESS 1

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_partial.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_partial.ksh
@@ -66,7 +66,7 @@ log_must mkdir "$TESTDIR"
 log_must truncate -s $LARGESIZE "$LARGEFILE"
 log_must zpool create $TESTPOOL "$LARGEFILE"
 log_must mkfile $(( floor(LARGESIZE * 0.80) )) /$TESTPOOL/file
-log_must zpool sync
+sync_all_pools
 
 new_size=$(du -B1 "$LARGEFILE" | cut -f1)
 log_must test $new_size -le $LARGESIZE
@@ -89,7 +89,7 @@ log_must set_tunable64 TRIM_METASLAB_SKIP 1
 log_must zpool trim $TESTPOOL
 log_must set_tunable64 TRIM_METASLAB_SKIP 0
 
-log_must zpool sync
+sync_all_pools
 while [[ "$(trim_progress $TESTPOOL $LARGEFILE)" -lt "100" ]]; do
 	sleep 0.5
 done
@@ -102,7 +102,7 @@ log_must test $new_size -gt $LARGESIZE
 # space usage of the new metaslabs.
 log_must zpool trim $TESTPOOL
 
-log_must zpool sync
+sync_all_pools
 while [[ "$(trim_progress $TESTPOOL $LARGEFILE)" -lt "100" ]]; do
 	sleep 0.5
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_verify_checksums.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_verify_checksums.ksh
@@ -54,14 +54,14 @@ log_must truncate -s $LARGESIZE "$LARGEFILE"
 log_must zpool create $TESTPOOL "$LARGEFILE"
 
 log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=1048576 count=64
-log_must zpool sync
+sync_all_pools
 log_must zpool trim $TESTPOOL
 
 [[ -z "$(trim_progress $TESTPOOL $DISK1)" ]] && \
     log_fail "Trimming did not start"
 
 log_must dd if=/dev/urandom of=/$TESTPOOL/file2 bs=1048576 count=64
-log_must zpool sync
+sync_all_pools
 
 log_must zpool export $TESTPOOL
 log_must zdb -e -p "$TESTDIR" -cc $TESTPOOL

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_wait/scan/zpool_wait_replace_cancel.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_wait/scan/zpool_wait_replace_cancel.ksh
@@ -41,7 +41,7 @@ function cleanup
 	    log_must zpool detach $TESTPOOL $DISK2
 	get_disklist $TESTPOOL | grep $DISK3 >/dev/null && \
 	    log_must zpool detach $TESTPOOL $DISK3
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 }
 
 typeset pid

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_wait/zpool_wait_freeing.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_wait/zpool_wait_freeing.ksh
@@ -104,7 +104,7 @@ log_must zfs clone "$SNAP" "$CLONE"
 for i in {1..50}; do
 	log_must dd if=/dev/urandom of="/$CLONE/testfile$i" bs=1k count=512
 	# Force each new file to be tracked by a new livelist
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 done
 log_must zfs destroy "$CLONE"
 test_wait

--- a/tests/zfs-tests/tests/functional/deadman/deadman_sync.ksh
+++ b/tests/zfs-tests/tests/functional/deadman/deadman_sync.ksh
@@ -70,7 +70,7 @@ log_must file_write -b 1048576 -c 8 -o create -d 0 -f $mntpnt/file
 sleep 10
 
 log_must zinject -c all
-log_must zpool sync
+sync_all_pools
 
 # Log txg sync times for reference and the zpool event summary.
 if is_freebsd; then

--- a/tests/zfs-tests/tests/functional/deadman/deadman_zio.ksh
+++ b/tests/zfs-tests/tests/functional/deadman/deadman_zio.ksh
@@ -83,7 +83,7 @@ log_must zinject -d $DISK1 -D10000:1 $TESTPOOL
 log_must eval "dd if=/$mntpnt/file1 of=/dev/null bs=1048576 &"
 sleep 10
 log_must zinject -c all
-log_must zpool sync
+sync_all_pools
 wait
 
 # 5. Verify a "deadman" event is posted.  The first appears after 5

--- a/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
+++ b/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
@@ -483,7 +483,7 @@ function verify_userprop
 	typeset stamp=${perm}.${user}.$RANDOM
 
 	user_run $user zfs set "$user:ts=$stamp" $dtst
-	zpool sync ${dtst%%/*}
+	sync_pool ${dtst%%/*}
 	if [[ $stamp != $(get_prop "$user:ts" $dtst) ]]; then
 		return 1
 	fi

--- a/tests/zfs-tests/tests/functional/events/events_common.kshlib
+++ b/tests/zfs-tests/tests/functional/events/events_common.kshlib
@@ -110,7 +110,7 @@ function run_and_verify
 	log_must eval "$fullcmd"
 
 	# Collect the new events and verify there are some.
-	log_must zpool sync -f
+	sync_all_pools true
 	log_must eval "zpool events >$TMP_EVENTS 2>/dev/null"
 	log_must eval "zpool events -v > $TMP_EVENTS_FULL 2>/dev/null"
 

--- a/tests/zfs-tests/tests/functional/fault/auto_offline_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_offline_001_pos.ksh
@@ -102,7 +102,7 @@ do
 	# 2. Simulate physical removal of one device
 	remove_disk $removedev
 	log_must mkfile 1m $mntpnt/file
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 
 	# 3. Verify the device is unavailable.
 	log_must wait_vdev_state $TESTPOOL $removedev "UNAVAIL"
@@ -134,7 +134,7 @@ do
 	# 2. Simulate physical removal of one device
 	remove_disk $removedev
 	log_must mkfile 1m $mntpnt/file
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 
 	# 3. Verify the device is handled by the spare.
 	log_must wait_hotspare_state $TESTPOOL $sparedev "INUSE"
@@ -171,7 +171,7 @@ do
 	# 3. Simulate physical removal of one device
 	remove_disk $removedev
 	log_must mkfile 1m $mntpnt/file
-	log_must zpool sync $TESTPOOL
+	sync_pool $TESTPOOL
 
 	# 4. Verify the device is unavailable
 	log_must wait_vdev_state $TESTPOOL $removedev "UNAVAIL"

--- a/tests/zfs-tests/tests/functional/fault/decompress_fault.ksh
+++ b/tests/zfs-tests/tests/functional/fault/decompress_fault.ksh
@@ -45,7 +45,7 @@ log_must set_tunable64 COMPRESSED_ARC_ENABLED 0
 log_must zfs create -o compression=on $TESTPOOL/fs
 mntpt=$(get_prop mountpoint $TESTPOOL/fs)
 write_compressible $mntpt 32m 1 1024k "testfile"
-log_must sync
+sync_all_pools
 log_must zfs umount $TESTPOOL/fs
 log_must zfs mount $TESTPOOL/fs
 log_must zinject -a -t data -e decompress -f 20 $mntpt/testfile.0

--- a/tests/zfs-tests/tests/functional/fault/zpool_status_-s.ksh
+++ b/tests/zfs-tests/tests/functional/fault/zpool_status_-s.ksh
@@ -64,7 +64,7 @@ log_must set_tunable64 SLOW_IO_EVENTS_PER_SECOND 1000
 # Create 20ms IOs
 log_must zinject -d $DISK -D20:100 $TESTPOOL
 log_must mkfile 1048576 /$TESTPOOL/testfile
-log_must zpool sync $TESTPOOL
+sync_pool $TESTPOOL
 
 log_must zinject -c all
 SLOW_IOS=$(zpool status -sp | grep "$DISK" | awk '{print $6}')

--- a/tests/zfs-tests/tests/functional/features/async_destroy/async_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/features/async_destroy/async_destroy_001_pos.ksh
@@ -66,7 +66,7 @@ log_must dd bs=1024k count=128 if=/dev/zero of=/$TEST_FS/file
 #
 log_must set_tunable64 ASYNC_BLOCK_MAX_BLOCKS 100
 
-log_must sync
+sync_all_pools
 log_must zfs destroy $TEST_FS
 
 #

--- a/tests/zfs-tests/tests/functional/log_spacemap/log_spacemap_import_logs.ksh
+++ b/tests/zfs-tests/tests/functional/log_spacemap/log_spacemap_import_logs.ksh
@@ -63,9 +63,9 @@ log_must zpool create -o cachefile=none -f $LOGSM_POOL $TESTDISK
 log_must zfs create $LOGSM_POOL/fs
 
 log_must dd if=/dev/urandom of=/$LOGSM_POOL/fs/00 bs=128k count=10
-log_must sync
+sync_all_pools
 log_must dd if=/dev/urandom of=/$LOGSM_POOL/fs/00 bs=128k count=10
-log_must sync
+sync_all_pools
 
 log_must set_tunable64 KEEP_LOG_SPACEMAPS_AT_EXPORT 1
 log_must zpool export $LOGSM_POOL

--- a/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
@@ -71,7 +71,7 @@ for fails in $(seq $MMP_FAIL_INTERVALS_MIN $((MMP_FAIL_INTERVALS_MIN*2))); do
 	for interval in $(seq $MMP_INTERVAL_MIN 200 $MMP_INTERVAL_DEFAULT); do
 		log_must set_tunable64 MULTIHOST_FAIL_INTERVALS $fails
 		log_must set_tunable64 MULTIHOST_INTERVAL $interval
-		log_must sync_pool $TESTPOOL
+		sync_pool $TESTPOOL
 		typeset mmp_fail=$(zdb $TESTPOOL 2>/dev/null |
 		    awk '/mmp_fail/ {print $NF}')
 		if [ $fails -ne $mmp_fail ]; then

--- a/tests/zfs-tests/tests/functional/no_space/enospc_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/no_space/enospc_002_pos.ksh
@@ -56,7 +56,7 @@ for i in $(seq 100); do
 	(( $ret != $ENOSPC )) && \
 	    log_fail "file.$i returned: $ret rather than ENOSPC."
 
-	log_must zpool sync -f
+	sync_all_pools true
 done
 
 log_mustnot_expect space zfs create $TESTPOOL/$TESTFS/subfs

--- a/tests/zfs-tests/tests/functional/online_offline/online_offline_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/online_offline/online_offline_001_pos.ksh
@@ -90,7 +90,8 @@ for disk in $DISKLIST; do
 done
 
 log_must kill $killpid
-sync
+sync_all_pools
+log_must sync
 
 typeset dir=$(get_device_dir $DISKS)
 verify_filesys "$TESTPOOL" "$TESTPOOL/$TESTFS" "$dir"

--- a/tests/zfs-tests/tests/functional/online_offline/online_offline_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/online_offline/online_offline_002_neg.ksh
@@ -129,7 +129,8 @@ while [[ $i -lt ${#disks[*]} ]]; do
 done
 
 log_must kill $killpid
-sync
+sync_all_pools
+log_must sync
 
 typeset dir=$(get_device_dir $DISKS)
 verify_filesys "$TESTPOOL" "$TESTPOOL/$TESTFS" "$dir"

--- a/tests/zfs-tests/tests/functional/online_offline/online_offline_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/online_offline/online_offline_003_neg.ksh
@@ -76,6 +76,6 @@ for i in 0 1 2; do
 done
 
 log_must kill $killpid
-sync
+sync_all_pools
 
 log_pass

--- a/tests/zfs-tests/tests/functional/procfs/procfs_list_basic.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/procfs_list_basic.ksh
@@ -65,7 +65,7 @@ log_must zfs create $FS
 for i in {1..20}; do
 	log_must zfs snapshot "$FS@testsnapshot$i"
 done
-log_must zpool sync $TESTPOOL
+sync_pool $TESTPOOL
 
 #
 # Read the debug message file in small chunks to make sure that the read is

--- a/tests/zfs-tests/tests/functional/procfs/procfs_list_concurrent_readers.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/procfs_list_concurrent_readers.ksh
@@ -60,7 +60,7 @@ log_must zfs create $FS
 for i in {1..20}; do
 	log_must zfs snapshot "$FS@testsnapshot$i"
 done
-log_must zpool sync $TESTPOOL
+sync_pool $TESTPOOL
 
 msgs1=$(mktemp) || log_fail
 msgs2=$(mktemp) || log_fail

--- a/tests/zfs-tests/tests/functional/procfs/procfs_list_stale_read.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/procfs_list_stale_read.ksh
@@ -50,7 +50,7 @@ function cleanup
 function sync_n
 {
 	for i in {1..$1}; do
-		log_must zpool sync $TESTPOOL
+		sync_pool $TESTPOOL
 	done
 	return 0
 }

--- a/tests/zfs-tests/tests/functional/projectquota/projectquota_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectquota_006_pos.ksh
@@ -65,7 +65,7 @@ mkmount_writable $QFS
 log_must user_run $PUSER mkdir $PRJDIR
 log_must chattr +P -p $PRJID1 $PRJDIR
 log_must user_run $PUSER mkfile 100m $PRJDIR/qf
-sync
+sync_all_pools
 
 log_note "set projectquota at a smaller size than it current usage"
 log_must zfs set projectquota@$PRJID1=90m $QFS

--- a/tests/zfs-tests/tests/functional/projectquota/projectquota_common.kshlib
+++ b/tests/zfs-tests/tests/functional/projectquota/projectquota_common.kshlib
@@ -51,7 +51,7 @@ function cleanup_projectquota
 	[[ -d $PRJDIR1 ]] && log_must rm -rf $PRJDIR1
 	[[ -d $PRJDIR2 ]] && log_must rm -rf $PRJDIR2
 	[[ -d $PRJDIR3 ]] && log_must rm -rf $PRJDIR3
-	sync
+	sync_all_pools
 
 	return 0
 }

--- a/tests/zfs-tests/tests/functional/projectquota/projectspace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectspace_001_pos.ksh
@@ -70,7 +70,7 @@ mkmount_writable $QFS
 log_must user_run $PUSER mkdir $PRJDIR
 log_must chattr +P -p $PRJID1 $PRJDIR
 log_must user_run $PUSER mkfile 50m $PRJDIR/qf
-sync
+sync_all_pools
 
 log_must zfs snapshot $snap_fs
 

--- a/tests/zfs-tests/tests/functional/projectquota/projectspace_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectspace_002_pos.ksh
@@ -63,7 +63,7 @@ mkmount_writable $QFS
 log_must user_run $PUSER mkdir $PRJDIR
 log_must chattr +P -p $PRJID1 $PRJDIR
 log_must user_run $PUSER mkfile 50m $PRJDIR/qf
-sync
+sync_all_pools
 
 typeset snapfs=$QFS@snap
 

--- a/tests/zfs-tests/tests/functional/refquota/refquota_007_neg.ksh
+++ b/tests/zfs-tests/tests/functional/refquota/refquota_007_neg.ksh
@@ -53,7 +53,7 @@ log_must mkfile 20M $mntpnt/$TESTFILE
 log_must zfs snapshot $FS@snap20M
 log_must rm $mntpnt/$TESTFILE
 
-log_must sync
+sync_all_pools
 
 log_must zfs set refquota=10M $FS
 log_mustnot zfs rollback $FS@snap20M

--- a/tests/zfs-tests/tests/functional/removal/removal.kshlib
+++ b/tests/zfs-tests/tests/functional/removal/removal.kshlib
@@ -69,7 +69,7 @@ function attempt_during_removal # pool disk callback [args]
 	# We want to make sure that the removal started
 	# before issuing the callback.
 	#
-	sync
+	sync_pool $pool
 	log_must is_pool_removing $pool
 
 	log_must $callback "$@"

--- a/tests/zfs-tests/tests/functional/removal/remove_expanded.ksh
+++ b/tests/zfs-tests/tests/functional/removal/remove_expanded.ksh
@@ -79,7 +79,7 @@ log_must wait_for_removal $TESTPOOL
 # Run sync once to ensure that the config actually changed.
 #
 log_must zpool add $TESTPOOL $DISK2
-log_must sync
+sync_all_pools
 
 #
 # Ensure that zdb does not find any problems with this.

--- a/tests/zfs-tests/tests/functional/replacement/rebuild_multiple.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/rebuild_multiple.ksh
@@ -73,7 +73,7 @@ log_must zfs create $TESTPOOL1/$TESTFS
 
 mntpnt=$(get_prop mountpoint $TESTPOOL1/$TESTFS)
 log_must dd if=/dev/urandom of=$mntpnt/file bs=1M count=32
-log_must zpool sync $TESTPOOL1
+sync_pool $TESTPOOL1
 
 log_must set_tunable32 SCAN_SUSPEND_PROGRESS 1
 
@@ -99,7 +99,7 @@ log_must zfs create $TESTPOOL1/$TESTFS
 
 mntpnt=$(get_prop mountpoint $TESTPOOL1/$TESTFS)
 log_must dd if=/dev/urandom of=$mntpnt/file bs=1M count=32
-log_must zpool sync $TESTPOOL1
+sync_pool $TESTPOOL1
 
 log_must set_tunable32 SCAN_SUSPEND_PROGRESS 1
 

--- a/tests/zfs-tests/tests/functional/replacement/resilver_restart_001.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/resilver_restart_001.ksh
@@ -153,9 +153,9 @@ do
 	# offline then online a vdev to introduce a new DTL range after current
 	# scan, which should restart (or defer) the resilver
 	log_must zpool offline $TESTPOOL1 ${VDEV_FILES[2]}
-	log_must zpool sync $TESTPOOL1
+	sync_pool $TESTPOOL1
 	log_must zpool online $TESTPOOL1 ${VDEV_FILES[2]}
-	log_must zpool sync $TESTPOOL1
+	sync_pool $TESTPOOL1
 
 	# there should now be 2 resilver starts w/o defer, 1 with defer
 	verify_restarts ' after offline/online' "${RESTARTS[1]}" "${VDEVS[1]}"
@@ -177,8 +177,8 @@ do
 	log_must is_pool_resilvered $TESTPOOL1
 
 	# wait for a few txg's to see if a resilver happens
-	log_must zpool sync $TESTPOOL1
-	log_must zpool sync $TESTPOOL1
+	sync_pool $TESTPOOL1
+	sync_pool $TESTPOOL1
 
 	# there should now be 2 resilver starts
 	verify_restarts ' after resilver' "${RESTARTS[3]}" "${VDEVS[3]}"

--- a/tests/zfs-tests/tests/functional/replacement/resilver_restart_002.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/resilver_restart_002.ksh
@@ -73,7 +73,7 @@ log_must zpool attach $TESTPOOL1 ${VDEV_FILES[0]} $SPARE_VDEV_FILE
 log_note "waiting for read errors to start showing up"
 for iter in {0..59}
 do
-	zpool sync $TESTPOOL1
+	sync_pool $TESTPOOL1
 	err=$(zpool status $TESTPOOL1 | grep ${VDEV_FILES[0]} | awk '{print $3}')
 	(( $err > 0 )) && break
 	sleep 1
@@ -92,8 +92,8 @@ done
 (( $finish == 0 )) && log_fail "resilver took too long to finish"
 
 # wait a few syncs to ensure that zfs does not restart the resilver
-log_must zpool sync $TESTPOOL1
-log_must zpool sync $TESTPOOL1
+sync_pool $TESTPOOL1
+sync_pool $TESTPOOL1
 
 # check if resilver was restarted
 start=$(zpool events | grep "sysevent.fs.zfs.resilver_start" | wc -l)

--- a/tests/zfs-tests/tests/functional/replacement/scrub_cancel.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/scrub_cancel.ksh
@@ -60,7 +60,7 @@ log_must zfs create $TESTPOOL1/$TESTFS
 
 mntpnt=$(get_prop mountpoint $TESTPOOL1/$TESTFS)
 log_must dd if=/dev/urandom of=$mntpnt/file bs=1M count=64
-log_must zpool sync $TESTPOOL1
+sync_pool $TESTPOOL1
 
 # Request a healing or sequential resilver
 for replace_mode in "healing" "sequential"; do

--- a/tests/zfs-tests/tests/functional/rsend/send-wR_encrypted_zvol.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-wR_encrypted_zvol.ksh
@@ -88,7 +88,7 @@ for ((i = 1; i <= $snap_count; i++)); do
 		log_must cp $mntpnt/file $mntpnt/file$j
 	done
 
-	log_must sync
+	sync_all_pools
 	log_must mount $remount_ro $zdev $mntpnt
 	log_must zfs snap $TESTPOOL/$TESTVOL@snap$i
 	log_must mount $remount_rw $zdev $mntpnt

--- a/tests/zfs-tests/tests/functional/rsend/send_encrypted_files.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_encrypted_files.ksh
@@ -97,7 +97,7 @@ log_must zfs snapshot $TESTPOOL/$TESTFS2@snap1
 for i in {1..1000}; do
 	log_must rm /$TESTPOOL/$TESTFS2/dir/file-$i
 done
-sync
+sync_all_pools
 
 log_must zfs snapshot $TESTPOOL/$TESTFS2@snap2
 expected_cksum=$(recursive_cksum /$TESTPOOL/$TESTFS2)

--- a/tests/zfs-tests/tests/functional/rsend/send_encrypted_truncated_files.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_encrypted_truncated_files.ksh
@@ -100,7 +100,7 @@ log_must truncate -s 131072 /$TESTPOOL/$TESTFS2/truncated
 log_must truncate -s 393216 /$TESTPOOL/$TESTFS2/truncated2
 log_must rm -f /$TESTPOOL/$TESTFS2/truncated3
 log_must rm -f /$TESTPOOL/$TESTFS2/truncated4
-log_must zpool sync $TESTPOOL
+sync_pool $TESTPOOL
 log_must zfs umount $TESTPOOL/$TESTFS2
 log_must zfs mount $TESTPOOL/$TESTFS2
 log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS2/truncated3 \

--- a/tests/zfs-tests/tests/functional/slog/slog_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_014_pos.ksh
@@ -58,7 +58,7 @@ for type in "mirror" "raidz" "raidz2"; do
                 # Ensure the file has been synced out before attempting to
                 # corrupt its contents.
                 #
-                sync
+                sync_all_pools
 
 		#
 		# Corrupt a pool device to make the pool DEGRADED

--- a/tests/zfs-tests/tests/functional/slog/slog_replay_volume.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_replay_volume.ksh
@@ -102,7 +102,7 @@ else
 	log_must mount $VOLUME $MNTPNT
 	FSTYPE=$NEWFS_DEFAULT_FS
 fi
-log_must zpool sync
+sync_all_pools
 
 #
 # 2. Freeze TESTVOL

--- a/tests/zfs-tests/tests/functional/snapshot/rollback_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/rollback_001_pos.ksh
@@ -93,6 +93,7 @@ while [[ $i -le $COUNT ]]; do
 
         (( i = i + 1 ))
 done
+sync_pool $TESTPOOL
 
 #
 # Now rollback to latest snapshot

--- a/tests/zfs-tests/tests/functional/snapshot/rollback_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/rollback_003_pos.ksh
@@ -82,6 +82,7 @@ log_must zfs rollback $SNAPPOOL
 log_mustnot zfs snapshot $SNAPPOOL
 
 log_must touch /$TESTPOOL/$TESTFILE
+sync_pool $TESTPOOL
 
 log_must zfs rollback $SNAPPOOL
 log_must zfs create $TESTPOOL/$TESTFILE

--- a/tests/zfs-tests/tests/functional/trim/autotrim_integrity.ksh
+++ b/tests/zfs-tests/tests/functional/trim/autotrim_integrity.ksh
@@ -73,7 +73,7 @@ for type in "" "mirror" "raidz" "draid"; do
 		filesize=$((4096 + ((RANDOM * 691) % 131072) ))
 		log_must rm -rf $dir
 		log_must fill_fs $dir 10 10 $filesize 1 R
-		zpool sync
+		sync_all_pools
 	done
 	log_must du -hs /$TESTPOOL
 

--- a/tests/zfs-tests/tests/functional/trim/autotrim_trim_integrity.ksh
+++ b/tests/zfs-tests/tests/functional/trim/autotrim_trim_integrity.ksh
@@ -74,7 +74,7 @@ for type in "" "mirror" "raidz" "raidz2" "draid" "draid2"; do
 		filesize=$((4096 + ((RANDOM * 691) % 131072) ))
 		log_must rm -rf $dir
 		log_must fill_fs $dir 10 10 $filesize 1 R
-		zpool sync
+		sync_all_pools
 
 		if [[ $((n % 4)) -eq 0 ]]; then
 			log_must timeout 120 zpool trim -w $TESTPOOL

--- a/tests/zfs-tests/tests/functional/trim/trim.kshlib
+++ b/tests/zfs-tests/tests/functional/trim/trim.kshlib
@@ -91,7 +91,7 @@ function wait_trim_io # pool type txgs
 			return
 		fi
 
-		zpool sync -f
+		sync_all_pools true
 		((i = i + 1))
 	done
 

--- a/tests/zfs-tests/tests/functional/trim/trim_integrity.ksh
+++ b/tests/zfs-tests/tests/functional/trim/trim_integrity.ksh
@@ -72,7 +72,7 @@ for type in "" "mirror" "raidz" "draid"; do
 		filesize=$((4096 + ((RANDOM * 691) % 131072) ))
 		log_must rm -rf $dir
 		log_must fill_fs $dir 10 10 $filesize 1 R
-		zpool sync
+		sync_all_pools
 	done
 	log_must du -hs /$TESTPOOL
 

--- a/tests/zfs-tests/tests/functional/truncate/truncate_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/truncate/truncate_002_pos.ksh
@@ -58,7 +58,7 @@ log_must dd if=/dev/urandom of=$srcfile bs=1024k count=1
 log_onexit cleanup
 log_must cp $srcfile $TESTDIR/$TESTFILE
 log_must cp /dev/null $TESTDIR/$TESTFILE
-log_must sync
+sync_all_pools
 if [[ -s $TESTDIR/$TESTFILE ]]; then
 	log_note "$(ls -l $TESTDIR/$TESTFILE)"
 	log_fail "testfile not truncated"

--- a/tests/zfs-tests/tests/functional/userquota/groupspace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/groupspace_001_pos.ksh
@@ -65,7 +65,7 @@ log_must zfs set groupquota@$QGROUP=500m $QFS
 mkmount_writable $QFS
 log_must user_run $QUSER1 mkfile 50m $QFILE
 
-sync
+sync_all_pools
 
 log_must zfs snapshot $snap_fs
 

--- a/tests/zfs-tests/tests/functional/userquota/groupspace_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/groupspace_002_pos.ksh
@@ -57,7 +57,7 @@ log_must zfs set groupquota@$QGROUP=500m $QFS
 mkmount_writable $QFS
 log_must user_run $QUSER1 mkfile 100m $QFILE
 
-sync
+sync_all_pools
 
 typeset snapfs=$QFS@snap
 

--- a/tests/zfs-tests/tests/functional/userquota/groupspace_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/groupspace_003_pos.ksh
@@ -78,7 +78,7 @@ log_must zfs set xattr=sa $QFS
 log_must user_run $QUSER1 mkfiles ${QFILE}_1 $user1_cnt
 log_must user_run $QUSER2 mkfiles ${QFILE}_2 $user2_cnt
 ((grp_cnt = user1_cnt + user2_cnt))
-sync_pool
+sync_all_pools
 
 typeset snapfs=$QFS@snap
 

--- a/tests/zfs-tests/tests/functional/userquota/userquota_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userquota_007_pos.ksh
@@ -63,7 +63,7 @@ log_must zfs get groupquota@$QGROUP $QFS
 log_note "write some data to the $QFS"
 mkmount_writable $QFS
 log_must user_run $QUSER1 mkfile 100m $QFILE
-sync
+sync_all_pools
 
 log_note "set user|group quota at a smaller size than it current usage"
 log_must zfs set userquota@$QUSER1=90m $QFS

--- a/tests/zfs-tests/tests/functional/userquota/userquota_common.kshlib
+++ b/tests/zfs-tests/tests/functional/userquota/userquota_common.kshlib
@@ -48,7 +48,7 @@ function cleanup_quota
 
 	[[ -f $QFILE ]] && log_must rm -f $QFILE
 	[[ -f $OFILE ]] && log_must rm -f $OFILE
-	sync
+	sync_all_pools
 
 	return 0
 }

--- a/tests/zfs-tests/tests/functional/userquota/userspace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userspace_001_pos.ksh
@@ -64,7 +64,7 @@ typeset snap_fs=$QFS@snap
 log_must zfs set userquota@$QUSER1=100m $QFS
 mkmount_writable $QFS
 log_must user_run $QUSER1 mkfile 50m $QFILE
-sync
+sync_all_pools
 
 log_must zfs snapshot $snap_fs
 

--- a/tests/zfs-tests/tests/functional/userquota/userspace_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userspace_002_pos.ksh
@@ -59,7 +59,7 @@ log_must zfs set userquota@$QUSER1=100m $QFS
 mkmount_writable $QFS
 
 log_must user_run $QUSER1 mkfile 50m $QFILE
-sync
+sync_all_pools
 
 typeset snapfs=$QFS@snap
 

--- a/tests/zfs-tests/tests/functional/userquota/userspace_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userspace_003_pos.ksh
@@ -79,7 +79,7 @@ log_must zfs set xattr=sa $QFS
 
 log_must user_run $QUSER1 mkfiles ${QFILE}_1 $user1_cnt
 log_must user_run $QUSER2 mkfiles ${QFILE}_2 $user2_cnt
-sync_pool
+sync_all_pools
 
 typeset snapfs=$QFS@snap
 

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_005_pos.ksh
@@ -41,7 +41,7 @@ orig_top=$(get_top_vd_zap $DISK $conf)
 orig_leaf=$(get_leaf_vd_zap $DISK $conf)
 assert_zap_common $TESTPOOL $DISK "top" $orig_top
 assert_zap_common $TESTPOOL $DISK "leaf" $orig_leaf
-log_must zpool sync
+sync_all_pools
 
 # Export the pool.
 log_must zpool export $TESTPOOL

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
@@ -84,7 +84,7 @@ while (( 1 )); do
 done
 
 if is_linux || is_freebsd ; then
-	log_must sync
+	sync_all_pools
 else
 	log_must lockfs -f $TESTDIR
 fi


### PR DESCRIPTION
Signed-off-by: Allan Jude <allan@klarasystems.com>
Sponsored-by: Zededa Inc.

### Motivation and Context
Instead of using 3-4 different ways to quiesce the pool during tests, standardize on the function built into the test framework `sync_pool`

### Description
A number of tests require a `zpool sync` to ensure that the expected outcome of the previous commands is realized (eg: space freed by rm'ing a file) before checking for the results

### How Has This Been Tested?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
