### PR TITLE
ZTS: Fix refreserv_raidz.ksh

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -294,7 +294,6 @@ elif sys.platform.startswith('linux'):
         'mmp/mmp_active_import': ['FAIL', known_reason],
         'mmp/mmp_exported_import': ['FAIL', known_reason],
         'mmp/mmp_inactive_import': ['FAIL', known_reason],
-        'refreserv/refreserv_raidz': ['FAIL', known_reason],
         'snapshot/rollback_003_pos': ['FAIL', known_reason],
         'zvol/zvol_misc/zvol_misc_snapdev': ['FAIL', '12621'],
         'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', known_reason],

--- a/tests/zfs-tests/tests/functional/refreserv/refreserv_raidz.ksh
+++ b/tests/zfs-tests/tests/functional/refreserv/refreserv_raidz.ksh
@@ -110,7 +110,7 @@ for parity in 1 2 3; do
 			block_device_wait "/dev/zvol/$vol"
 			log_must dd if=/dev/zero of=/dev/zvol/$vol \
 			    bs=1024k count=$volsize
-			sync
+			sync_pool $TESTPOOL
 
 			ref=$(zfs get -Hpo value referenced "$vol")
 			refres=$(zfs get -Hpo value refreservation "$vol")


### PR DESCRIPTION
### Motivation and Context

Issue #12848.  Plus it's a long standing test failure which needed
to be investigated and resolved.   As expected, it was caused by a
flaw in the test case.

### Description

The `rerefreserv_raidz` test was failing on Linux because the sync being
issued doesn't guarantee pool sync.  Switch to using the sync_pool
function and remove the ZTS exception for Linux.

### How Has This Been Tested?

The test case would reliably fail on Linux prior to this change.  After the
change it passes reliably.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
