### PR TITLE
libzfs: sendrecv: fix unused, remove argsused

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3101,7 +3101,7 @@ created_before(libzfs_handle_t *hdl, avl_tree_t *avl,
  */
 static int
 recv_fix_encryption_hierarchy(libzfs_handle_t *hdl, const char *top_zfs,
-    nvlist_t *stream_nv, avl_tree_t *stream_avl)
+    nvlist_t *stream_nv)
 {
 	int err;
 	nvpair_t *fselem = NULL;
@@ -3728,7 +3728,7 @@ zfs_receive_package(libzfs_handle_t *hdl, int fd, const char *destname,
 
 	if (raw && softerr == 0 && *top_zfs != NULL) {
 		softerr = recv_fix_encryption_hierarchy(hdl, *top_zfs,
-		    stream_nv, stream_avl);
+		    stream_nv);
 	}
 
 out:
@@ -4991,7 +4991,7 @@ zfs_receive_checkprops(libzfs_handle_t *hdl, nvlist_t *props,
 		if (prop == ZPROP_INVAL) {
 			if (!zfs_prop_user(name)) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "invalid property '%s'"), name);
+				    "%s: invalid property '%s'"), errbuf, name);
 				return (B_FALSE);
 			}
 			continue;
@@ -5015,7 +5015,7 @@ zfs_receive_checkprops(libzfs_handle_t *hdl, nvlist_t *props,
 		if (zfs_prop_readonly(prop) || prop == ZFS_PROP_VERSION ||
 		    prop == ZFS_PROP_VOLSIZE) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "invalid property '%s'"), name);
+			    "%s: invalid property '%s'"), errbuf, name);
 			return (B_FALSE);
 		}
 	}
@@ -5041,9 +5041,8 @@ zfs_receive_impl(libzfs_handle_t *hdl, const char *tosnap,
 	    "cannot receive"));
 
 	/* check cmdline props, raise an error if they cannot be received */
-	if (!zfs_receive_checkprops(hdl, cmdprops, errbuf)) {
-		return (zfs_error(hdl, EZFS_BADPROP, errbuf));
-	}
+	if (!zfs_receive_checkprops(hdl, cmdprops, errbuf))
+		return (-1);
 
 	if (flags->isprefix &&
 	    !zfs_dataset_exists(hdl, tosnap, ZFS_TYPE_DATASET)) {


### PR DESCRIPTION
### Motivation and Context
https://github.com/openzfs/zfs/pull/12844#pullrequestreview-838833079

### Description
I think I fixed an error string location bug here?

### How Has This Been Tested?
Builds.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
