### PR TITLE
zfs_prune: delay next prune if nothing pruned

### DIFF
--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
@@ -135,6 +135,7 @@ struct zfsvfs {
 	avl_tree_t	*z_hold_trees;	/* znode hold trees */
 	kmutex_t	*z_hold_locks;	/* znode hold locks */
 	taskqid_t	z_drain_task;	/* task id for the unlink drain task */
+	clock_t		z_next_prune;	/* don't prune before this time */
 };
 
 #define	ZFS_TEARDOWN_INIT(zfsvfs)		\

--- a/include/sys/dataset_kstats.h
+++ b/include/sys/dataset_kstats.h
@@ -38,6 +38,8 @@ typedef struct dataset_sum_stats_t {
 	wmsum_t dss_nread;
 	wmsum_t dss_nunlinks;
 	wmsum_t dss_nunlinked;
+	wmsum_t dss_prunes;
+	wmsum_t dss_prunes_skipped;
 } dataset_sum_stats_t;
 
 typedef struct dataset_kstat_values {
@@ -56,6 +58,16 @@ typedef struct dataset_kstat_values {
 	 * entry is removed from the unlinked set
 	 */
 	kstat_named_t dkv_nunlinked;
+	/*
+	 * nprune is initialized to zero on mount and is incremented when a
+	 * prune is performed
+	 */
+	kstat_named_t dkv_prunes;
+	/*
+	 * nprune_delayed is initialized to zero on mount and is incremented
+	 * when a prune is delayed
+	 */
+	kstat_named_t dkv_prunes_skipped;
 } dataset_kstat_values_t;
 
 typedef struct dataset_kstats {
@@ -71,5 +83,8 @@ void dataset_kstats_update_read_kstats(dataset_kstats_t *, int64_t);
 
 void dataset_kstats_update_nunlinks_kstat(dataset_kstats_t *, int64_t);
 void dataset_kstats_update_nunlinked_kstat(dataset_kstats_t *, int64_t);
+
+void dataset_kstats_update_prunes_kstat(dataset_kstats_t *);
+void dataset_kstats_update_prunes_skipped_kstat(dataset_kstats_t *);
 
 #endif /* _SYS_DATASET_KSTATS_H */

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -680,6 +680,25 @@ Minimum time "prescient prefetched" blocks are locked in the ARC.
 These blocks are meant to be prefetched fairly aggressively ahead of
 the code that may use them.
 .
+.It Sy zfs_arc_prune_skip_ms Ns = Ns Sy 2000 Ns ms Po 2s Pc Pq ulong
+If nothing is able to be pruned from a superblock, skip pruning the
+superblock for some milliseconds to avoid continually trying to do
+something that can't be done.
+Under pressure, this can save thousands of scans a second per superblock.
+The delay time isn't critical, it needs to be long enough to avoid
+excessive useless work, and short enough that skipping the prune on this
+particular superblock isn't going to cause problems.
+.Pp
+The parameter can be set to 0 (zero) to disable the delay,
+and only applies on Linux.
+.Pp
+The number of prunes and delayed prune attempts will be available in the
+.Va prunes
+and
+.Va prunes_skipped
+fields of
+.Pa /proc/spl/kstat/zfs/ Ns Ao Ar pool Ac Ns Pa /objset-0x Ns Aq Ar objset .
+.
 .It Sy zfs_arc_prune_task_threads Ns = Ns Sy 1 Pq int
 Number of arc_prune threads.
 .Fx

--- a/module/zfs/dataset_kstats.c
+++ b/module/zfs/dataset_kstats.c
@@ -37,6 +37,8 @@ static dataset_kstat_values_t empty_dataset_kstats = {
 	{ "nread",	KSTAT_DATA_UINT64 },
 	{ "nunlinks",	KSTAT_DATA_UINT64 },
 	{ "nunlinked",	KSTAT_DATA_UINT64 },
+	{ "prunes",	KSTAT_DATA_UINT64 },
+	{ "prunes_skipped",	KSTAT_DATA_UINT64 },
 };
 
 static int
@@ -61,6 +63,10 @@ dataset_kstats_update(kstat_t *ksp, int rw)
 	    wmsum_value(&dk->dk_sums.dss_nunlinks);
 	dkv->dkv_nunlinked.value.ui64 =
 	    wmsum_value(&dk->dk_sums.dss_nunlinked);
+	dkv->dkv_prunes.value.ui64 =
+	    wmsum_value(&dk->dk_sums.dss_prunes);
+	dkv->dkv_prunes_skipped.value.ui64 =
+	    wmsum_value(&dk->dk_sums.dss_prunes_skipped);
 
 	return (0);
 }
@@ -146,6 +152,8 @@ dataset_kstats_create(dataset_kstats_t *dk, objset_t *objset)
 	wmsum_init(&dk->dk_sums.dss_nread, 0);
 	wmsum_init(&dk->dk_sums.dss_nunlinks, 0);
 	wmsum_init(&dk->dk_sums.dss_nunlinked, 0);
+	wmsum_init(&dk->dk_sums.dss_prunes, 0);
+	wmsum_init(&dk->dk_sums.dss_prunes_skipped, 0);
 }
 
 void
@@ -168,6 +176,8 @@ dataset_kstats_destroy(dataset_kstats_t *dk)
 	wmsum_fini(&dk->dk_sums.dss_nread);
 	wmsum_fini(&dk->dk_sums.dss_nunlinks);
 	wmsum_fini(&dk->dk_sums.dss_nunlinked);
+	wmsum_fini(&dk->dk_sums.dss_prunes);
+	wmsum_fini(&dk->dk_sums.dss_prunes_skipped);
 }
 
 void
@@ -212,4 +222,22 @@ dataset_kstats_update_nunlinked_kstat(dataset_kstats_t *dk, int64_t delta)
 		return;
 
 	wmsum_add(&dk->dk_sums.dss_nunlinked, delta);
+}
+
+void
+dataset_kstats_update_prunes_kstat(dataset_kstats_t *dk)
+{
+	if (dk->dk_kstats == NULL)
+		return;
+
+	wmsum_add(&dk->dk_sums.dss_prunes, 1);
+}
+
+void
+dataset_kstats_update_prunes_skipped_kstat(dataset_kstats_t *dk)
+{
+	if (dk->dk_kstats == NULL)
+		return;
+
+	wmsum_add(&dk->dk_sums.dss_prunes_skipped, 1);
 }


### PR DESCRIPTION
### Motivation and Context

A mounted filesystem can have zfs_prune called on it thousands of
times a second under memory pressure. This is wasted CPU cycles if
there is nothing to prune (e.g. an otherwise unused filesystem).
This can be particularly painful if there are a large number of
mounted but unused filesystems (e.g. thousands of snapshots
mounted, the vast majority of which are very infrequently
accessed). This can result in "arc_prune storms" where the system
CPU can be completely swamped by arc_prune thread processing.

### Description

We can vastly reduce these wasted CPU cycles by delaying trying to
prune a filesystem for which nothing could be pruned the previous
time.

Signed-off-by: Chris Dunlop <chris@onthe.net.au>

### How Has This Been Tested?

Has been in production for 4 months and has removed our arc_prune
storms (in conjunction with reducing the number of threads to 1
#9966 and resetting sc.nr_to_scan #12433).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
