### PR TITLE
man: speling

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -110,7 +110,7 @@ A value of
 disables this feature.
 .
 .It Sy l2arc_exclude_special Ns = Ns Sy 0 Ns | Ns 1 Pq int
-Controls whether buffers present on special vdevs are eligibile for caching
+Controls whether buffers present on special vdevs are eligible for caching
 into L2ARC.
 If set to 1, exclude dbufs on special vdevs from being cached to L2ARC.
 .
@@ -1142,7 +1142,7 @@ Maximum number of blocks freed in a single TXG.
 Maximum number of dedup blocks freed in a single TXG.
 .
 .It Sy zfs_override_estimate_recordsize Ns = Ns Sy 0 Pq ulong
-If nonzer, override record size calculation for
+If nonzero, override record size calculation for
 .Nm zfs Cm send
 estimates.
 .
@@ -1256,7 +1256,7 @@ For non-interactive I/O (scrub, resilver, removal, initialize and rebuild),
 the number of concurrently-active I/O operations is limited to
 .Sy zfs_*_min_active ,
 unless the vdev is "idle".
-When there are no interactive I/O operatinons active (synchronous or otherwise),
+When there are no interactive I/O operations active (synchronous or otherwise),
 and
 .Sy zfs_vdev_nia_delay
 operations have completed since the last interactive operation,

--- a/man/man7/vdevprops.7
+++ b/man/man7/vdevprops.7
@@ -68,7 +68,7 @@ Percentage of vdev space used
 .It Sy state
 state of this vdev such as online, faulted, or offline
 .It Sy guid
-globaly unique id of this vdev
+globally unique id of this vdev
 .It Sy asize
 The allocable size of this vdev
 .It Sy psize

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -905,7 +905,7 @@ ratio; for example, 8kB blocks on disks with 4kB disk sectors must compress to 1
 or less of their original size.
 .It Xo
 .Sy context Ns = Ns Sy none Ns | Ns
-.Ar SELinux-User : Ns Ar SElinux-Role : Ns Ar Selinux-Type : Ns Ar Sensitivity-Level
+.Ar SELinux-User : Ns Ar SELinux-Role : Ns Ar SELinux-Type : Ns Ar Sensitivity-Level
 .Xc
 This flag sets the SELinux context for all files in the file system under
 a mount point for that file system.
@@ -914,7 +914,7 @@ See
 for more information.
 .It Xo
 .Sy fscontext Ns = Ns Sy none Ns | Ns
-.Ar SELinux-User : Ns Ar SElinux-Role : Ns Ar Selinux-Type : Ns Ar Sensitivity-Level
+.Ar SELinux-User : Ns Ar SELinux-Role : Ns Ar SELinux-Type : Ns Ar Sensitivity-Level
 .Xc
 This flag sets the SELinux context for the file system file system being
 mounted.
@@ -923,7 +923,7 @@ See
 for more information.
 .It Xo
 .Sy defcontext Ns = Ns Sy none Ns | Ns
-.Ar SELinux-User : Ns Ar SElinux-Role : Ns Ar Selinux-Type : Ns Ar Sensitivity-Level
+.Ar SELinux-User : Ns Ar SELinux-Role : Ns Ar SELinux-Type : Ns Ar Sensitivity-Level
 .Xc
 This flag sets the SELinux default context for unlabeled files.
 See
@@ -931,7 +931,7 @@ See
 for more information.
 .It Xo
 .Sy rootcontext Ns = Ns Sy none Ns | Ns
-.Ar SELinux-User : Ns Ar SElinux-Role : Ns Ar Selinux-Type : Ns Ar Sensitivity-Level
+.Ar SELinux-User : Ns Ar SELinux-Role : Ns Ar SELinux-Type : Ns Ar Sensitivity-Level
 .Xc
 This flag sets the SELinux context for the root inode of the file system.
 See

--- a/man/man8/zfs-load-key.8
+++ b/man/man8/zfs-load-key.8
@@ -200,7 +200,7 @@ if supported by your hardware, otherwise
 .Bl -tag -width "-r"
 .It Fl l
 Ensures the key is loaded before attempting to change the key.
-This is effectively equivalent to runnin
+This is effectively equivalent to running
 .Nm zfs Cm load-key Ar filesystem ; Nm zfs Cm change-key Ar filesystem
 .It Fl o Ar property Ns = Ns Ar value
 Allows the user to set encryption key properties

--- a/man/man8/zgenhostid.8
+++ b/man/man8/zgenhostid.8
@@ -80,7 +80,7 @@ be an 8-digit-long hexadecimal number, optionally prefixed by
 .Dl # Nm Qq $ Ns Pq Nm hostid
 .It Record a custom hostid Po Ar 0xdeadbeef Pc in Pa /etc/hostid
 .Dl # Nm Ar deadbeef
-.It Record a custom hostid Po Ar 0x01234567 Pc in Pa /tmp/hostid No and ovewrite the file if it exists
+.It Record a custom hostid Po Ar 0x01234567 Pc in Pa /tmp/hostid No and overwrite the file if it exists
 .Dl # Nm Fl f o Ar /tmp/hostid 0x01234567
 .El
 .

--- a/man/man8/zpool-attach.8
+++ b/man/man8/zpool-attach.8
@@ -79,7 +79,7 @@ The only property supported at the moment is
 The
 .Ar new_device
 is reconstructed sequentially to restore redundancy as quickly as possible.
-Checksums are not verfied during sequential reconstruction so a scrub is
+Checksums are not verified during sequential reconstruction so a scrub is
 started when the resilver completes.
 Sequential reconstruction is not supported for raidz configurations.
 .It Fl w

--- a/man/man8/zpool-events.8
+++ b/man/man8/zpool-events.8
@@ -68,7 +68,7 @@ Print the entire payload for each event.
 .El
 .
 .Sh EVENTS
-Theese are the different event subclasses.
+These are the different event subclasses.
 The full event name would be
 .Sy ereport.fs.zfs.\& Ns Em SUBCLASS ,
 but only the last part is listed here.
@@ -136,7 +136,7 @@ Issued when the ashift alignment requirement has increased.
 .It Sy vdev.remove
 Issued when a vdev is detached from a mirror (or a spare detached from a
 vdev where it have been used to replace a failed drive - only works if
-the original drive have been readded).
+the original drive have been re-added).
 .It Sy vdev.clear
 Issued when clearing device errors in a pool.
 Such as running

--- a/man/man8/zpool-replace.8
+++ b/man/man8/zpool-replace.8
@@ -85,7 +85,7 @@ The only property supported at the moment is
 The
 .Ar new-device
 is reconstructed sequentially to restore redundancy as quickly as possible.
-Checksums are not verfied during sequential reconstruction so a scrub is
+Checksums are not verified during sequential reconstruction so a scrub is
 started when the resilver completes.
 Sequential reconstruction is not supported for raidz configurations.
 .It Fl w


### PR DESCRIPTION
### Motivation and Context

Spelling fixes

### How Has This Been Tested?

`Aspell` with a localised dictionary

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
