### PR TITLE
Add ShellCheck's `--enable=all` inside `etc/`

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,9 +1,10 @@
 include $(top_srcdir)/config/Shellcheck.am
 
 SUBDIRS = zfs sudoers.d
-SHELLCHECKDIRS = zfs
+SHELLCHECKDIRS = default $(ZFS_INIT_SYSV) zfs
+SHELLCHECK_OPTS = --enable=all
+
 if BUILD_LINUX
-SHELLCHECKDIRS += default $(ZFS_INIT_SYSV)
 SUBDIRS += default $(ZFS_INIT_SYSTEMD) $(ZFS_INIT_SYSV) $(ZFS_MODULE_LOAD)
 endif
 DIST_SUBDIRS = default init.d zfs systemd modules-load.d sudoers.d

--- a/etc/default/Makefile.am
+++ b/etc/default/Makefile.am
@@ -5,4 +5,5 @@ initconf_SCRIPTS = zfs
 
 SUBSTFILES += $(initconf_SCRIPTS)
 
-SHELLCHECK_SHELL = sh
+SHELLCHECK_SHELL = dash
+SHELLCHECK_OPTS = --enable=all

--- a/etc/default/zfs.in
+++ b/etc/default/zfs.in
@@ -1,4 +1,5 @@
 # OpenZFS userland configuration.
+# shellcheck disable=SC2154
 
 # NOTE: This file is intended for sysv init and initramfs.
 # Changing some of these settings may not make any difference on

--- a/etc/init.d/Makefile.am
+++ b/etc/init.d/Makefile.am
@@ -7,4 +7,5 @@ init_SCRIPTS = zfs-import zfs-load-key zfs-mount zfs-share zfs-zed
 
 SUBSTFILES += $(init_SCRIPTS)
 
-SHELLCHECK_SHELL = dash # local variables
+SHELLCHECK_SHELL = dash
+SHELLCHECK_OPTS = --enable=all

--- a/etc/init.d/zfs-import.in
+++ b/etc/init.d/zfs-import.in
@@ -1,4 +1,5 @@
 #!@DEFAULT_INIT_SHELL@
+# shellcheck disable=SC2154
 #
 # zfs-import    This script will import ZFS pools
 #

--- a/etc/init.d/zfs-load-key.in
+++ b/etc/init.d/zfs-load-key.in
@@ -1,4 +1,5 @@
 #!@DEFAULT_INIT_SHELL@
+# shellcheck disable=SC2154
 #
 # zfs-load-key  This script will load/unload the zfs filesystems keys.
 #

--- a/etc/init.d/zfs-mount.in
+++ b/etc/init.d/zfs-mount.in
@@ -1,4 +1,5 @@
 #!@DEFAULT_INIT_SHELL@
+# shellcheck disable=SC2154
 #
 # zfs-mount     This script will mount/umount the zfs filesystems.
 #
@@ -68,7 +69,7 @@ do_mount()
 	check_boolean "$DO_OVERLAY_MOUNTS" && overlay=O
 
 	zfs_action "Mounting ZFS filesystem(s)" \
-	    "$ZFS" mount -a$verbose$overlay "$MOUNT_EXTRA_OPTIONS"
+	    "$ZFS" mount "-a$verbose$overlay" "$MOUNT_EXTRA_OPTIONS"
 
 	# Require each volume/filesystem to have 'noauto' and no fsck
 	# option. This shouldn't really be necessary, as long as one

--- a/etc/init.d/zfs-share.in
+++ b/etc/init.d/zfs-share.in
@@ -1,4 +1,5 @@
 #!@DEFAULT_INIT_SHELL@
+# shellcheck disable=SC2154
 #
 # zfs-share     This script will network share zfs filesystems and volumes.
 #

--- a/etc/init.d/zfs-zed.in
+++ b/etc/init.d/zfs-zed.in
@@ -1,4 +1,5 @@
 #!@DEFAULT_INIT_SHELL@
+# shellcheck disable=SC2154
 #
 # zfs-zed
 #

--- a/etc/zfs/Makefile.am
+++ b/etc/zfs/Makefile.am
@@ -15,4 +15,5 @@ pkgsysconf_SCRIPTS = \
 
 SUBSTFILES += $(pkgsysconf_SCRIPTS)
 
-SHELLCHECK_SHELL = dash # local variables
+SHELLCHECK_OPTS = --enable=all
+SHELLCHECK_SHELL = dash

--- a/etc/zfs/zfs-functions.in
+++ b/etc/zfs/zfs-functions.in
@@ -46,6 +46,7 @@ elif type success > /dev/null 2>&1 ; then
 
 	zfs_log_begin_msg() { printf "%s" "$1 "; }
 	zfs_log_end_msg() {
+		# shellcheck disable=SC2154
 		zfs_set_ifs "$OLD_IFS"
 		if [ "$1" -eq 0 ]; then
 			success
@@ -119,12 +120,12 @@ zfs_action()
 	$CMD
 	ret=$?
 	if [ "$ret" -eq 0 ]; then
-		zfs_log_end_msg $ret
+		zfs_log_end_msg "$ret"
 	else
-		zfs_log_failure_msg $ret
+		zfs_log_failure_msg "$ret"
 	fi
 
-	return $ret
+	return "$ret"
 }
 
 # Returns


### PR DESCRIPTION
### Motivation and Context
Strengthen static code analysis for shell scripts.

### Description
Add ShellCheck's `--enable=all` inside `etc/`

### How Has This Been Tested?
$ make shellcheck

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
