### PR TITLE
cmd: zpool: clear: document flags

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -352,7 +352,7 @@ get_usage(zpool_help_t idx)
 		return (gettext("\tattach [-fsw] [-o property=value] "
 		    "<pool> <device> <new-device>\n"));
 	case HELP_CLEAR:
-		return (gettext("\tclear [-nF] <pool> [device]\n"));
+		return (gettext("\tclear [-F [-nX]] <pool> [device]\n"));
 	case HELP_CREATE:
 		return (gettext("\tcreate [-fnd] [-o property=value] ... \n"
 		    "\t    [-O file-system-property=value] ... \n"
@@ -7002,7 +7002,7 @@ zpool_do_offline(int argc, char **argv)
 }
 
 /*
- * zpool clear <pool> [device]
+ * zpool clear [-F [-nX]] <pool> [device]
  *
  * Clear all errors associated with a pool or a particular device.
  */

--- a/man/man8/zpool-clear.8
+++ b/man/man8/zpool-clear.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd May 27, 2021
+.Dd December 29, 2021
 .Dt ZPOOL-CLEAR 8
 .Os
 .
@@ -36,6 +36,7 @@
 .Sh SYNOPSIS
 .Nm zpool
 .Cm clear
+.Op Fl F Op Fl nX
 .Ar pool
 .Oo Ar device Oc Ns …
 .
@@ -52,8 +53,30 @@ Pools with
 enabled which have been suspended cannot be resumed.
 While the pool was suspended, it may have been imported on
 another host, and resuming I/O could result in pool damage.
+.Pp
+.
+.Bl -tag -width Ds -compact
+.It Fl F
+Force import by rewinding
+.Pq no further than Sy 2 No transactions past the last uberblock sync .
+.\" ^ TXG_DEFER_SIZE inlined here
+.
+.It Fl n
+Dry-run rewind: show how far back time needs to be rewound.
+.
+.It Fl X
+eXtreme rewind: try going back to the initial transaction if possible.
+.Pp
+These options pose obvious potential for data loss, and
+.Fl X
+may induce catastrophic pool failure.
+Confer with
+.Xr zpool-import 8
+so as to their applicability.
+.El
 .
 .Sh SEE ALSO
 .Xr zdb 8 ,
+.Xr zpool-import 8 ,
 .Xr zpool-reopen 8 ,
 .Xr zpool-status 8


### PR DESCRIPTION
### Motivation and Context
I cleared a disk after pulling it and got `-nF` in the usage string, unsupported by the manual!

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
