### PR TITLE
config: libfetch: unquote @LIBFETCH_SONAME@ subst

### DIFF
--- a/config/user-libfetch.m4
+++ b/config/user-libfetch.m4
@@ -32,7 +32,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBFETCH], [
 		have_libfetch=1
 		LIBFETCH_IS_FETCH=1
 		LIBFETCH_DYNAMIC=1
-		LIBFETCH_SONAME='"libfetch.so.6"'
+		LIBFETCH_SONAME="libfetch.so.6"
 		LIBFETCH_LIBS="-ldl"
 		AC_MSG_RESULT([fetch(3)])
 	], [])
@@ -45,7 +45,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBFETCH], [
 			LIBFETCH_IS_LIBCURL=1
 			if test "$(curl-config --built-shared)" = "yes"; then
 				LIBFETCH_DYNAMIC=1
-				LIBFETCH_SONAME='"libcurl.so.4"'
+				LIBFETCH_SONAME="libcurl.so.4"
 				LIBFETCH_LIBS="-ldl"
 				AC_MSG_RESULT([libcurl])
 			else
@@ -67,5 +67,5 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBFETCH], [
 	AC_DEFINE_UNQUOTED([LIBFETCH_IS_FETCH], [$LIBFETCH_IS_FETCH], [libfetch is fetch(3)])
 	AC_DEFINE_UNQUOTED([LIBFETCH_IS_LIBCURL], [$LIBFETCH_IS_LIBCURL], [libfetch is libcurl])
 	AC_DEFINE_UNQUOTED([LIBFETCH_DYNAMIC], [$LIBFETCH_DYNAMIC], [whether the chosen libfetch is to be loaded at run-time])
-	AC_DEFINE_UNQUOTED([LIBFETCH_SONAME], [$LIBFETCH_SONAME], [soname of chosen libfetch])
+	AC_DEFINE_UNQUOTED([LIBFETCH_SONAME], ["$LIBFETCH_SONAME"], [soname of chosen libfetch])
 ])

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -61,9 +61,9 @@ install() {
 		dracut_install /usr/lib*/gcc/**/libgcc_s.so*
 	fi
 	# shellcheck disable=SC2050
-	if [ @LIBFETCH_DYNAMIC@ != 0 ]; then
+	if [ @LIBFETCH_DYNAMIC@ -gt 0 ]; then
 		for d in $libdirs; do
-			[ -e "$d/"@LIBFETCH_SONAME@ ] && dracut_install "$d/"@LIBFETCH_SONAME@
+			[ -e "$d/@LIBFETCH_SONAME@" ] && dracut_install "$d/@LIBFETCH_SONAME@"
 		done
 	fi
 	dracut_install @mounthelperdir@/mount.zfs

--- a/contrib/initramfs/hooks/zfs.in
+++ b/contrib/initramfs/hooks/zfs.in
@@ -30,8 +30,8 @@ find /lib/ -type f -name "libgcc_s.so.[1-9]" | while read -r libgcc; do
 done
 
 # shellcheck disable=SC2050
-if [ @LIBFETCH_DYNAMIC@ != 0 ]; then
-	find /lib/ -name @LIBFETCH_SONAME@ | while read -r libfetch; do
+if [ @LIBFETCH_DYNAMIC@ -gt 0 ]; then
+	find /lib/ -name "@LIBFETCH_SONAME@" | while read -r libfetch; do
 		copy_exec "$libfetch"
 	done
 fi


### PR DESCRIPTION
### Motivation and Context
153f7c9f72082d7ef5ee27fcbec1bcb94ba88151, https://github.com/openzfs/zfs/pull/12835#discussion_r776833743, and friends

### Description
`@LIBFETCH_SONAME@` is no longer quoted. The C define still is, obviously.

### How Has This Been Tested?
libzfs builds, new use sites:
```sh
if [ 1 -gt 0 ]; then
	find /lib/ -name "libcurl.so.4" | while read -r libfetch; do
		copy_exec "$libfetch"
	done
fi

if [ 1 -gt 0 ]; then
	for d in $libdirs; do
		[ -e "$d/libcurl.so.4" ] && dracut_install "$d/libcurl.so.4"
	done
fi
```

If no libfetch, or static, this becomes
```sh
if [ 0 -gt 0 ]; then
	find /lib/ -name "" | while read -r libfetch; do
		copy_exec "$libfetch"
	done
fi

if [ 0 -gt 0 ]; then
	for d in $libdirs; do
		[ -e "$d/" ] && dracut_install "$d/"
	done
fi
```
instead, which works as-expected and elicits no further warnings.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
