### PR TITLE
Revert "zfs list: Allow more fields in ZFS_ITER_SIMPLE mode"

### DIFF
--- a/cmd/zfs/zfs_iter.c
+++ b/cmd/zfs/zfs_iter.c
@@ -144,20 +144,19 @@ zfs_callback(zfs_handle_t *zhp, void *data)
 		    (cb->cb_types &
 		    (ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME))) &&
 		    zfs_get_type(zhp) == ZFS_TYPE_FILESYSTEM) {
-			(void) zfs_iter_filesystems(zhp, cb->cb_flags,
-			    zfs_callback, data);
+			(void) zfs_iter_filesystems(zhp, zfs_callback, data);
 		}
 
 		if (((zfs_get_type(zhp) & (ZFS_TYPE_SNAPSHOT |
 		    ZFS_TYPE_BOOKMARK)) == 0) && include_snaps) {
-			(void) zfs_iter_snapshots(zhp, cb->cb_flags,
+			(void) zfs_iter_snapshots(zhp,
+			    (cb->cb_flags & ZFS_ITER_SIMPLE) != 0,
 			    zfs_callback, data, 0, 0);
 		}
 
 		if (((zfs_get_type(zhp) & (ZFS_TYPE_SNAPSHOT |
 		    ZFS_TYPE_BOOKMARK)) == 0) && include_bmarks) {
-			(void) zfs_iter_bookmarks(zhp, cb->cb_flags,
-			    zfs_callback, data);
+			(void) zfs_iter_bookmarks(zhp, zfs_callback, data);
 		}
 
 		cb->cb_depth--;
@@ -213,58 +212,11 @@ zfs_free_sort_columns(zfs_sort_column_t *sc)
 	}
 }
 
-/*
- * Return true if all of the properties to be sorted are populated by
- * dsl_dataset_fast_stat(). Note that sc == NULL (no sort) means we
- * don't need any extra properties, so returns true.
- */
-boolean_t
-zfs_sort_only_by_fast(const zfs_sort_column_t *sc)
+int
+zfs_sort_only_by_name(const zfs_sort_column_t *sc)
 {
-	while (sc != NULL) {
-		switch (sc->sc_prop) {
-		case ZFS_PROP_NAME:
-		case ZFS_PROP_GUID:
-		case ZFS_PROP_CREATETXG:
-		case ZFS_PROP_NUMCLONES:
-		case ZFS_PROP_INCONSISTENT:
-		case ZFS_PROP_REDACTED:
-		case ZFS_PROP_ORIGIN:
-			break;
-		default:
-			return (B_FALSE);
-		}
-		sc = sc->sc_next;
-	}
-
-	return (B_TRUE);
-}
-
-boolean_t
-zfs_list_only_by_fast(const zprop_list_t *p)
-{
-	if (p == NULL) {
-		/* NULL means 'all' so we can't use simple mode */
-		return (B_FALSE);
-	}
-
-	while (p != NULL) {
-		switch (p->pl_prop) {
-		case ZFS_PROP_NAME:
-		case ZFS_PROP_GUID:
-		case ZFS_PROP_CREATETXG:
-		case ZFS_PROP_NUMCLONES:
-		case ZFS_PROP_INCONSISTENT:
-		case ZFS_PROP_REDACTED:
-		case ZFS_PROP_ORIGIN:
-			break;
-		default:
-			return (B_FALSE);
-		}
-		p = p->pl_next;
-	}
-
-	return (B_TRUE);
+	return (sc != NULL && sc->sc_next == NULL &&
+	    sc->sc_prop == ZFS_PROP_NAME);
 }
 
 static int

--- a/cmd/zfs/zfs_iter.h
+++ b/cmd/zfs/zfs_iter.h
@@ -40,13 +40,19 @@ typedef struct zfs_sort_column {
 	boolean_t		sc_reverse;
 } zfs_sort_column_t;
 
+#define	ZFS_ITER_RECURSE	   (1 << 0)
+#define	ZFS_ITER_ARGS_CAN_BE_PATHS (1 << 1)
+#define	ZFS_ITER_PROP_LISTSNAPS    (1 << 2)
+#define	ZFS_ITER_DEPTH_LIMIT	   (1 << 3)
+#define	ZFS_ITER_RECVD_PROPS	   (1 << 4)
+#define	ZFS_ITER_LITERAL_PROPS	   (1 << 5)
+#define	ZFS_ITER_SIMPLE		   (1 << 6)
+
 int zfs_for_each(int, char **, int options, zfs_type_t,
     zfs_sort_column_t *, zprop_list_t **, int, zfs_iter_f, void *);
 int zfs_add_sort_column(zfs_sort_column_t **, const char *, boolean_t);
 void zfs_free_sort_columns(zfs_sort_column_t *);
-boolean_t zfs_sort_only_by_fast(const zfs_sort_column_t *);
-boolean_t zfs_list_only_by_fast(const zprop_list_t *);
-
+int zfs_sort_only_by_name(const zfs_sort_column_t *);
 
 #ifdef	__cplusplus
 }

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -1536,7 +1536,7 @@ destroy_print_snapshots(zfs_handle_t *fs_zhp, destroy_cbdata_t *cb)
 	int err;
 	assert(cb->cb_firstsnap == NULL);
 	assert(cb->cb_prevsnap == NULL);
-	err = zfs_iter_snapshots_sorted(fs_zhp, 0, destroy_print_cb, cb, 0, 0);
+	err = zfs_iter_snapshots_sorted(fs_zhp, destroy_print_cb, cb, 0, 0);
 	if (cb->cb_firstsnap != NULL) {
 		uint64_t used = 0;
 		if (err == 0) {
@@ -1562,7 +1562,7 @@ snapshot_to_nvl_cb(zfs_handle_t *zhp, void *arg)
 	if (!cb->cb_doclones && !cb->cb_defer_destroy) {
 		cb->cb_target = zhp;
 		cb->cb_first = B_TRUE;
-		err = zfs_iter_dependents(zhp, 0, B_TRUE,
+		err = zfs_iter_dependents(zhp, B_TRUE,
 		    destroy_check_dependent, cb);
 	}
 
@@ -1580,8 +1580,7 @@ gather_snapshots(zfs_handle_t *zhp, void *arg)
 	destroy_cbdata_t *cb = arg;
 	int err = 0;
 
-	err = zfs_iter_snapspec(zhp, 0, cb->cb_snapspec,
-	    snapshot_to_nvl_cb, cb);
+	err = zfs_iter_snapspec(zhp, cb->cb_snapspec, snapshot_to_nvl_cb, cb);
 	if (err == ENOENT)
 		err = 0;
 	if (err != 0)
@@ -1594,7 +1593,7 @@ gather_snapshots(zfs_handle_t *zhp, void *arg)
 	}
 
 	if (cb->cb_recurse)
-		err = zfs_iter_filesystems(zhp, 0, gather_snapshots, cb);
+		err = zfs_iter_filesystems(zhp, gather_snapshots, cb);
 
 out:
 	zfs_close(zhp);
@@ -1619,7 +1618,7 @@ destroy_clones(destroy_cbdata_t *cb)
 			 * false while destroying the clones.
 			 */
 			cb->cb_defer_destroy = B_FALSE;
-			err = zfs_iter_dependents(zhp, 0, B_FALSE,
+			err = zfs_iter_dependents(zhp, B_FALSE,
 			    destroy_callback, cb);
 			cb->cb_defer_destroy = defer;
 			zfs_close(zhp);
@@ -1830,7 +1829,7 @@ zfs_do_destroy(int argc, char **argv)
 		 */
 		cb.cb_first = B_TRUE;
 		if (!cb.cb_doclones &&
-		    zfs_iter_dependents(zhp, 0, B_TRUE, destroy_check_dependent,
+		    zfs_iter_dependents(zhp, B_TRUE, destroy_check_dependent,
 		    &cb) != 0) {
 			rv = 1;
 			goto out;
@@ -1841,7 +1840,7 @@ zfs_do_destroy(int argc, char **argv)
 			goto out;
 		}
 		cb.cb_batchedsnaps = fnvlist_alloc();
-		if (zfs_iter_dependents(zhp, 0, B_FALSE, destroy_callback,
+		if (zfs_iter_dependents(zhp, B_FALSE, destroy_callback,
 		    &cb) != 0) {
 			rv = 1;
 			goto out;
@@ -3706,6 +3705,13 @@ zfs_do_list(int argc, char **argv)
 		fields = default_fields;
 
 	/*
+	 * If we are only going to list snapshot names and sort by name,
+	 * then we can use faster version.
+	 */
+	if (strcmp(fields, "name") == 0 && zfs_sort_only_by_name(sortcol))
+		flags |= ZFS_ITER_SIMPLE;
+
+	/*
 	 * If "-o space" and no types were specified, don't display snapshots.
 	 */
 	if (strcmp(fields, "space") == 0 && types_specified == B_FALSE)
@@ -3731,15 +3737,6 @@ zfs_do_list(int argc, char **argv)
 		usage(B_FALSE);
 
 	cb.cb_first = B_TRUE;
-
-	/*
-	 * If we are only going to list and sort by properties that are "fast"
-	 * then we can use "simple" mode and avoid populating the properties
-	 * nvlist.
-	 */
-	if (zfs_list_only_by_fast(cb.cb_proplist) &&
-	    zfs_sort_only_by_fast(sortcol))
-		flags |= ZFS_ITER_SIMPLE;
 
 	ret = zfs_for_each(argc, argv, flags, types, sortcol, &cb.cb_proplist,
 	    limit, list_callback, &cb);
@@ -4051,7 +4048,7 @@ rollback_check(zfs_handle_t *zhp, void *data)
 		}
 
 		if (cbp->cb_recurse) {
-			if (zfs_iter_dependents(zhp, 0, B_TRUE,
+			if (zfs_iter_dependents(zhp, B_TRUE,
 			    rollback_check_dependent, cbp) != 0) {
 				zfs_close(zhp);
 				return (-1);
@@ -4150,10 +4147,10 @@ zfs_do_rollback(int argc, char **argv)
 	if (cb.cb_create > 0)
 		min_txg = cb.cb_create;
 
-	if ((ret = zfs_iter_snapshots(zhp, 0, rollback_check, &cb,
+	if ((ret = zfs_iter_snapshots(zhp, B_FALSE, rollback_check, &cb,
 	    min_txg, 0)) != 0)
 		goto out;
-	if ((ret = zfs_iter_bookmarks(zhp, 0, rollback_check, &cb)) != 0)
+	if ((ret = zfs_iter_bookmarks(zhp, rollback_check, &cb)) != 0)
 		goto out;
 
 	if ((ret = cb.cb_error) != 0)
@@ -4295,7 +4292,7 @@ zfs_snapshot_cb(zfs_handle_t *zhp, void *arg)
 	free(name);
 
 	if (sd->sd_recursive)
-		rv = zfs_iter_filesystems(zhp, 0, zfs_snapshot_cb, sd);
+		rv = zfs_iter_filesystems(zhp, zfs_snapshot_cb, sd);
 	zfs_close(zhp);
 	return (rv);
 }
@@ -6281,7 +6278,7 @@ zfs_do_allow_unallow_impl(int argc, char **argv, boolean_t un)
 
 		if (un && opts.recursive) {
 			struct deleg_perms data = { un, update_perm_nvl };
-			if (zfs_iter_filesystems(zhp, 0, set_deleg_perms,
+			if (zfs_iter_filesystems(zhp, set_deleg_perms,
 			    &data) != 0)
 				goto cleanup0;
 		}
@@ -6644,7 +6641,7 @@ get_one_dataset(zfs_handle_t *zhp, void *data)
 	/*
 	 * Iterate over any nested datasets.
 	 */
-	if (zfs_iter_filesystems(zhp, 0, get_one_dataset, data) != 0) {
+	if (zfs_iter_filesystems(zhp, get_one_dataset, data) != 0) {
 		zfs_close(zhp);
 		return (1);
 	}

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -8807,7 +8807,7 @@ check_unsupp_fs(zfs_handle_t *zhp, void *unsupp_fs)
 		(*count)++;
 	}
 
-	zfs_iter_filesystems(zhp, 0, check_unsupp_fs, unsupp_fs);
+	zfs_iter_filesystems(zhp, check_unsupp_fs, unsupp_fs);
 
 	zfs_close(zhp);
 

--- a/contrib/pam_zfs_key/pam_zfs_key.c
+++ b/contrib/pam_zfs_key/pam_zfs_key.c
@@ -534,7 +534,7 @@ zfs_key_config_get_dataset(zfs_key_config_t *config)
 			return (NULL);
 		}
 
-		(void) zfs_iter_filesystems(zhp, 0, find_dsname_by_prop_value,
+		(void) zfs_iter_filesystems(zhp, find_dsname_by_prop_value,
 		    config);
 		zfs_close(zhp);
 		char *dsname = config->dsname;

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -644,27 +644,19 @@ _LIBZFS_H void zprop_print_one_property(const char *, zprop_get_cbdata_t *,
 /*
  * Iterator functions.
  */
-#define	ZFS_ITER_RECURSE		(1 << 0)
-#define	ZFS_ITER_ARGS_CAN_BE_PATHS	(1 << 1)
-#define	ZFS_ITER_PROP_LISTSNAPS		(1 << 2)
-#define	ZFS_ITER_DEPTH_LIMIT		(1 << 3)
-#define	ZFS_ITER_RECVD_PROPS		(1 << 4)
-#define	ZFS_ITER_LITERAL_PROPS		(1 << 5)
-#define	ZFS_ITER_SIMPLE			(1 << 6)
-
 typedef int (*zfs_iter_f)(zfs_handle_t *, void *);
 _LIBZFS_H int zfs_iter_root(libzfs_handle_t *, zfs_iter_f, void *);
-_LIBZFS_H int zfs_iter_children(zfs_handle_t *, int, zfs_iter_f, void *);
-_LIBZFS_H int zfs_iter_dependents(zfs_handle_t *, int, boolean_t, zfs_iter_f,
+_LIBZFS_H int zfs_iter_children(zfs_handle_t *, zfs_iter_f, void *);
+_LIBZFS_H int zfs_iter_dependents(zfs_handle_t *, boolean_t, zfs_iter_f,
     void *);
-_LIBZFS_H int zfs_iter_filesystems(zfs_handle_t *, int, zfs_iter_f, void *);
-_LIBZFS_H int zfs_iter_snapshots(zfs_handle_t *, int, zfs_iter_f, void *,
+_LIBZFS_H int zfs_iter_filesystems(zfs_handle_t *, zfs_iter_f, void *);
+_LIBZFS_H int zfs_iter_snapshots(zfs_handle_t *, boolean_t, zfs_iter_f, void *,
     uint64_t, uint64_t);
-_LIBZFS_H int zfs_iter_snapshots_sorted(zfs_handle_t *, int, zfs_iter_f, void *,
+_LIBZFS_H int zfs_iter_snapshots_sorted(zfs_handle_t *, zfs_iter_f, void *,
     uint64_t, uint64_t);
-_LIBZFS_H int zfs_iter_snapspec(zfs_handle_t *, int, const char *, zfs_iter_f,
+_LIBZFS_H int zfs_iter_snapspec(zfs_handle_t *, const char *, zfs_iter_f,
     void *);
-_LIBZFS_H int zfs_iter_bookmarks(zfs_handle_t *, int, zfs_iter_f, void *);
+_LIBZFS_H int zfs_iter_bookmarks(zfs_handle_t *, zfs_iter_f, void *);
 _LIBZFS_H int zfs_iter_mounted(zfs_handle_t *, zfs_iter_f, void *);
 
 typedef struct get_all_cb {

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -4025,14 +4025,13 @@
   <abi-instr address-size='64' path='libzfs_iter.c' language='LANG_C99'>
     <function-decl name='zfs_iter_filesystems' mangled-name='zfs_iter_filesystems' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_iter_snapshots' mangled-name='zfs_iter_snapshots' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
+      <parameter type-id='c19b74c3' name='simple'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <parameter type-id='9c313c2d' name='min_txg'/>
@@ -4041,14 +4040,12 @@
     </function-decl>
     <function-decl name='zfs_iter_bookmarks' mangled-name='zfs_iter_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_bookmarks'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_iter_snapshots_sorted' mangled-name='zfs_iter_snapshots_sorted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_sorted'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='d8e49ab9' name='callback'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <parameter type-id='9c313c2d' name='min_txg'/>
@@ -4057,7 +4054,6 @@
     </function-decl>
     <function-decl name='zfs_iter_snapspec' mangled-name='zfs_iter_snapspec' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapspec'>
       <parameter type-id='9200a744' name='fs_zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='80f4b756' name='spec_orig'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='arg'/>
@@ -4065,14 +4061,12 @@
     </function-decl>
     <function-decl name='zfs_iter_children' mangled-name='zfs_iter_children' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_children'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_iter_dependents' mangled-name='zfs_iter_dependents' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_dependents'>
       <parameter type-id='9200a744' name='zhp'/>
-      <parameter type-id='95e97e5e' name='flags'/>
       <parameter type-id='c19b74c3' name='allowrecursion'/>
       <parameter type-id='d8e49ab9' name='func'/>
       <parameter type-id='eaa32e2f' name='data'/>

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -551,7 +551,7 @@ change_one(zfs_handle_t *zhp, void *data)
 		}
 
 		if (!clp->cl_alldependents)
-			ret = zfs_iter_children(zhp, 0, change_one, data);
+			ret = zfs_iter_children(zhp, change_one, data);
 
 		/*
 		 * If we added the handle to the changelist, we will re-use it
@@ -721,11 +721,11 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 			return (NULL);
 		}
 	} else if (clp->cl_alldependents) {
-		if (zfs_iter_dependents(zhp, 0, B_TRUE, change_one, clp) != 0) {
+		if (zfs_iter_dependents(zhp, B_TRUE, change_one, clp) != 0) {
 			changelist_free(clp);
 			return (NULL);
 		}
-	} else if (zfs_iter_children(zhp, 0, change_one, clp) != 0) {
+	} else if (zfs_iter_children(zhp, change_one, clp) != 0) {
 		changelist_free(clp);
 		return (NULL);
 	}

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -1228,7 +1228,7 @@ load_keys_cb(zfs_handle_t *zhp, void *arg)
 		cb->cb_numfailed++;
 
 out:
-	(void) zfs_iter_filesystems(zhp, 0, load_keys_cb, cb);
+	(void) zfs_iter_filesystems(zhp, load_keys_cb, cb);
 	zfs_close(zhp);
 
 	/* always return 0, since this function is best effort */

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -104,7 +104,7 @@ top:
  * Iterate over all child filesystems
  */
 int
-zfs_iter_filesystems(zfs_handle_t *zhp, int flags, zfs_iter_f func, void *data)
+zfs_iter_filesystems(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 {
 	zfs_cmd_t zc = {"\0"};
 	zfs_handle_t *nzhp;
@@ -113,24 +113,19 @@ zfs_iter_filesystems(zfs_handle_t *zhp, int flags, zfs_iter_f func, void *data)
 	if (zhp->zfs_type != ZFS_TYPE_FILESYSTEM)
 		return (0);
 
-	if ((flags & ZFS_ITER_SIMPLE) == ZFS_ITER_SIMPLE)
-		zc.zc_simple = B_TRUE;
-
 	if (zcmd_alloc_dst_nvlist(zhp->zfs_hdl, &zc, 0) != 0)
 		return (-1);
 
 	while ((ret = zfs_do_list_ioctl(zhp, ZFS_IOC_DATASET_LIST_NEXT,
 	    &zc)) == 0) {
-		if (zc.zc_simple)
-			nzhp = make_dataset_simple_handle_zc(zhp, &zc);
-		else
-			nzhp = make_dataset_handle_zc(zhp->zfs_hdl, &zc);
 		/*
 		 * Silently ignore errors, as the only plausible explanation is
 		 * that the pool has since been removed.
 		 */
-		if (nzhp == NULL)
+		if ((nzhp = make_dataset_handle_zc(zhp->zfs_hdl,
+		    &zc)) == NULL) {
 			continue;
+		}
 
 		if ((ret = func(nzhp, data)) != 0) {
 			zcmd_free_nvlists(&zc);
@@ -145,7 +140,7 @@ zfs_iter_filesystems(zfs_handle_t *zhp, int flags, zfs_iter_f func, void *data)
  * Iterate over all snapshots
  */
 int
-zfs_iter_snapshots(zfs_handle_t *zhp, int flags, zfs_iter_f func,
+zfs_iter_snapshots(zfs_handle_t *zhp, boolean_t simple, zfs_iter_f func,
     void *data, uint64_t min_txg, uint64_t max_txg)
 {
 	zfs_cmd_t zc = {"\0"};
@@ -157,7 +152,7 @@ zfs_iter_snapshots(zfs_handle_t *zhp, int flags, zfs_iter_f func,
 	    zhp->zfs_type == ZFS_TYPE_BOOKMARK)
 		return (0);
 
-	zc.zc_simple = (flags & ZFS_ITER_SIMPLE) != 0;
+	zc.zc_simple = simple;
 
 	if (zcmd_alloc_dst_nvlist(zhp->zfs_hdl, &zc, 0) != 0)
 		return (-1);
@@ -182,7 +177,7 @@ zfs_iter_snapshots(zfs_handle_t *zhp, int flags, zfs_iter_f func,
 	while ((ret = zfs_do_list_ioctl(zhp, ZFS_IOC_SNAPSHOT_LIST_NEXT,
 	    &zc)) == 0) {
 
-		if (zc.zc_simple)
+		if (simple)
 			nzhp = make_dataset_simple_handle_zc(zhp, &zc);
 		else
 			nzhp = make_dataset_handle_zc(zhp->zfs_hdl, &zc);
@@ -204,9 +199,8 @@ zfs_iter_snapshots(zfs_handle_t *zhp, int flags, zfs_iter_f func,
  * Iterate over all bookmarks
  */
 int
-zfs_iter_bookmarks(zfs_handle_t *zhp, int flags, zfs_iter_f func, void *data)
+zfs_iter_bookmarks(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 {
-	(void) flags;
 	zfs_handle_t *nzhp;
 	nvlist_t *props = NULL;
 	nvlist_t *bmarks = NULL;
@@ -312,8 +306,8 @@ zfs_snapshot_compare(const void *larg, const void *rarg)
 }
 
 int
-zfs_iter_snapshots_sorted(zfs_handle_t *zhp, int flags, zfs_iter_f callback,
-    void *data, uint64_t min_txg, uint64_t max_txg)
+zfs_iter_snapshots_sorted(zfs_handle_t *zhp, zfs_iter_f callback, void *data,
+    uint64_t min_txg, uint64_t max_txg)
 {
 	int ret = 0;
 	zfs_node_t *node;
@@ -323,7 +317,7 @@ zfs_iter_snapshots_sorted(zfs_handle_t *zhp, int flags, zfs_iter_f callback,
 	avl_create(&avl, zfs_snapshot_compare,
 	    sizeof (zfs_node_t), offsetof(zfs_node_t, zn_avlnode));
 
-	ret = zfs_iter_snapshots(zhp, flags, zfs_sort_snaps, &avl, min_txg,
+	ret = zfs_iter_snapshots(zhp, B_FALSE, zfs_sort_snaps, &avl, min_txg,
 	    max_txg);
 
 	for (node = avl_first(&avl); node != NULL; node = AVL_NEXT(&avl, node))
@@ -386,7 +380,7 @@ snapspec_cb(zfs_handle_t *zhp, void *arg)
  * return ENOENT at the end.
  */
 int
-zfs_iter_snapspec(zfs_handle_t *fs_zhp, int flags, const char *spec_orig,
+zfs_iter_snapspec(zfs_handle_t *fs_zhp, const char *spec_orig,
     zfs_iter_f func, void *arg)
 {
 	char *buf, *comma_separated, *cp;
@@ -426,7 +420,7 @@ zfs_iter_snapspec(zfs_handle_t *fs_zhp, int flags, const char *spec_orig,
 				}
 			}
 
-			err = zfs_iter_snapshots_sorted(fs_zhp, flags,
+			err = zfs_iter_snapshots_sorted(fs_zhp,
 			    snapspec_cb, &ssa, 0, 0);
 			if (ret == 0)
 				ret = err;
@@ -463,14 +457,14 @@ zfs_iter_snapspec(zfs_handle_t *fs_zhp, int flags, const char *spec_orig,
  * and as close as possible.
  */
 int
-zfs_iter_children(zfs_handle_t *zhp, int flags, zfs_iter_f func, void *data)
+zfs_iter_children(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 {
 	int ret;
 
-	if ((ret = zfs_iter_snapshots(zhp, flags, func, data, 0, 0)) != 0)
+	if ((ret = zfs_iter_snapshots(zhp, B_FALSE, func, data, 0, 0)) != 0)
 		return (ret);
 
-	return (zfs_iter_filesystems(zhp, flags, func, data));
+	return (zfs_iter_filesystems(zhp, func, data));
 }
 
 
@@ -481,7 +475,6 @@ typedef struct iter_stack_frame {
 
 typedef struct iter_dependents_arg {
 	boolean_t first;
-	int flags;
 	boolean_t allowrecursion;
 	iter_stack_frame_t *stack;
 	zfs_iter_f func;
@@ -531,10 +524,9 @@ iter_dependents_cb(zfs_handle_t *zhp, void *arg)
 		isf.zhp = zhp;
 		isf.next = ida->stack;
 		ida->stack = &isf;
-		err = zfs_iter_filesystems(zhp, ida->flags,
-		    iter_dependents_cb, ida);
+		err = zfs_iter_filesystems(zhp, iter_dependents_cb, ida);
 		if (err == 0)
-			err = zfs_iter_snapshots(zhp, ida->flags,
+			err = zfs_iter_snapshots(zhp, B_FALSE,
 			    iter_dependents_cb, ida, 0, 0);
 		ida->stack = isf.next;
 	}
@@ -548,11 +540,10 @@ iter_dependents_cb(zfs_handle_t *zhp, void *arg)
 }
 
 int
-zfs_iter_dependents(zfs_handle_t *zhp, int flags, boolean_t allowrecursion,
+zfs_iter_dependents(zfs_handle_t *zhp, boolean_t allowrecursion,
     zfs_iter_f func, void *data)
 {
 	iter_dependents_arg_t ida;
-	ida.flags = flags;
 	ida.allowrecursion = allowrecursion;
 	ida.stack = NULL;
 	ida.func = func;

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1127,7 +1127,7 @@ zfs_iter_cb(zfs_handle_t *zhp, void *data)
 	}
 
 	libzfs_add_handle(cbp, zhp);
-	if (zfs_iter_filesystems(zhp, 0, zfs_iter_cb, cbp) != 0) {
+	if (zfs_iter_filesystems(zhp, zfs_iter_cb, cbp) != 0) {
 		zfs_close(zhp);
 		return (-1);
 	}
@@ -1474,7 +1474,7 @@ zpool_enable_datasets(zpool_handle_t *zhp, const char *mntopts, int flags)
 	 * over all child filesystems.
 	 */
 	libzfs_add_handle(&cb, zfsp);
-	if (zfs_iter_filesystems(zfsp, 0, zfs_iter_cb, &cb) != 0)
+	if (zfs_iter_filesystems(zfsp, zfs_iter_cb, &cb) != 0)
 		goto out;
 
 	/*

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -597,7 +597,7 @@ send_iterate_fs(zfs_handle_t *zhp, void *arg)
 			min_txg = fromsnap_txg;
 		if (!sd->replicate && tosnap_txg != 0)
 			max_txg = tosnap_txg;
-		(void) zfs_iter_snapshots_sorted(zhp, 0, send_iterate_snap, sd,
+		(void) zfs_iter_snapshots_sorted(zhp, send_iterate_snap, sd,
 		    min_txg, max_txg);
 	} else {
 		char snapname[MAXPATHLEN] = { 0 };
@@ -640,7 +640,7 @@ send_iterate_fs(zfs_handle_t *zhp, void *arg)
 
 	/* iterate over children */
 	if (sd->recursive)
-		rv = zfs_iter_filesystems(zhp, 0, send_iterate_fs, sd);
+		rv = zfs_iter_filesystems(zhp, send_iterate_fs, sd);
 
 out:
 	sd->parent_fromsnap_guid = parent_fromsnap_guid_save;
@@ -1212,7 +1212,7 @@ dump_filesystem(zfs_handle_t *zhp, void *arg)
 		if (!sdd->replicate && sdd->tosnap != NULL)
 			max_txg = get_snap_txg(zhp->zfs_hdl, zhp->zfs_name,
 			    sdd->tosnap);
-		rv = zfs_iter_snapshots_sorted(zhp, 0, dump_snapshot, arg,
+		rv = zfs_iter_snapshots_sorted(zhp, dump_snapshot, arg,
 		    min_txg, max_txg);
 	} else {
 		char snapname[MAXPATHLEN] = { 0 };
@@ -2959,9 +2959,9 @@ guid_to_name_cb(zfs_handle_t *zhp, void *arg)
 		return (EEXIST);
 	}
 
-	err = zfs_iter_children(zhp, 0, guid_to_name_cb, gtnd);
+	err = zfs_iter_children(zhp, guid_to_name_cb, gtnd);
 	if (err != EEXIST && gtnd->bookmark_ok)
-		err = zfs_iter_bookmarks(zhp, 0, guid_to_name_cb, gtnd);
+		err = zfs_iter_bookmarks(zhp, guid_to_name_cb, gtnd);
 	zfs_close(zhp);
 	return (err);
 }
@@ -3015,10 +3015,9 @@ guid_to_name_redact_snaps(libzfs_handle_t *hdl, const char *parent,
 			continue;
 		int err = guid_to_name_cb(zfs_handle_dup(zhp), &gtnd);
 		if (err != EEXIST)
-			err = zfs_iter_children(zhp, 0, guid_to_name_cb, &gtnd);
+			err = zfs_iter_children(zhp, guid_to_name_cb, &gtnd);
 		if (err != EEXIST && bookmark_ok)
-			err = zfs_iter_bookmarks(zhp, 0, guid_to_name_cb,
-			    &gtnd);
+			err = zfs_iter_bookmarks(zhp, guid_to_name_cb, &gtnd);
 		zfs_close(zhp);
 		if (err == EEXIST)
 			return (0);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2044,7 +2044,7 @@ zfs_ioc_objset_stats_impl(zfs_cmd_t *zc, objset_t *os)
 
 	dmu_objset_fast_stat(os, &zc->zc_objset_stats);
 
-	if (!zc->zc_simple && zc->zc_nvlist_dst != 0 &&
+	if (zc->zc_nvlist_dst != 0 &&
 	    (error = dsl_prop_get_all(os, &nv)) == 0) {
 		dmu_objset_stats(os, nv);
 		/*
@@ -2331,7 +2331,6 @@ zfs_ioc_snapshot_list_next(zfs_cmd_t *zc)
 		}
 
 		if (zc->zc_simple) {
-			dsl_dataset_fast_stat(ds, &zc->zc_objset_stats);
 			dsl_dataset_rele(ds, FTAG);
 			break;
 		}


### PR DESCRIPTION

### Motivation and Context
As discussed in #12937, we should back out this commit until we can fix the user/kernel incompatibility issue

### Description
This is a simple revert, no conflicts occurred.

### How Has This Been Tested?
Build and unit tests passed, and the incompatibility is no longer present

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
