### PR TITLE
lz4: Cherrypick fix for CVE-2021-3520

### DIFF
--- a/module/zfs/lz4.c
+++ b/module/zfs/lz4.c
@@ -541,7 +541,7 @@ LZ4_decompress_generic(
                  const size_t dictSize         /* note : = 0 if noDict */
                  )
 {
-    if (src == NULL) { return -1; }
+    if ((src == NULL) || (outputSize < 0)) { return -1; }
 
     {   const BYTE* ip = (const BYTE*) src;
         const BYTE* const iend = ip + srcSize;


### PR DESCRIPTION
### Motivation and Context
I went to look seriously at integrating a compressor update, and what do I find but a [bug requesting a new release due to fixing some sanitizer issues and a CVE](https://github.com/lz4/lz4/issues/1037).

Clearly the life lesson is to always sync code from git tip, not stable releases. _/s_

### Description
I'd rather wait for a 1.9.4 and sync from that if the sanitizer issues mentioned cause anyone headaches (I'm sorry if your tree is now full of error messages #12928), but a size check to close a CVE seems like a reasonable change unlikely to break people.

### How Has This Been Tested?
It built.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
