### PR TITLE
Fix snapshot automounting in mount namespaces/bind mount/...

### DIFF
--- a/include/os/linux/spl/sys/Makefile.am
+++ b/include/os/linux/spl/sys/Makefile.am
@@ -21,6 +21,7 @@ KERNEL_H = \
 	kstat.h \
 	list.h \
 	mod_os.h \
+	mount.h \
 	mutex.h \
 	param.h \
 	processor.h \

--- a/include/os/linux/spl/sys/mount.h
+++ b/include/os/linux/spl/sys/mount.h
@@ -1,0 +1,26 @@
+/*
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _SPL_MOUNT_H
+#define	_SPL_MOUNT_H
+
+#include <sys/vfs.h>
+
+void spl_add_mount_to_expire(spl_mount *mnt, int delay_in_seconds);
+
+#endif /* SPL_MOUNT_H */

--- a/include/os/linux/spl/sys/vfs.h
+++ b/include/os/linux/spl/sys/vfs.h
@@ -31,6 +31,7 @@
 #include <linux/xattr.h>
 #include <linux/security.h>
 #include <linux/seq_file.h>
+#include <sys/types.h>
 
 #define	MAXFIDSZ	64
 
@@ -46,5 +47,7 @@ typedef struct spl_fid {
 
 #define	fid_len		un._fid.len
 #define	fid_data	un._fid.data
+
+typedef struct vfsmount spl_mount;
 
 #endif /* SPL_ZFS_H */

--- a/include/os/linux/zfs/sys/zfs_ctldir.h
+++ b/include/os/linux/zfs/sys/zfs_ctldir.h
@@ -74,7 +74,8 @@ extern int zfsctl_snapdir_remove(struct inode *dip, const char *name,
     cred_t *cr, int flags);
 extern int zfsctl_snapdir_mkdir(struct inode *dip, const char *dirname,
     vattr_t *vap, struct inode **ipp, cred_t *cr, int flags);
-extern int zfsctl_snapshot_mount(struct path *path, int flags);
+extern int zfsctl_snapshot_mount(struct path *path, int flags,
+    struct vfsmount **mount);
 extern int zfsctl_snapshot_unmount(const char *snapname, int flags);
 extern int zfsctl_snapshot_unmount_delay(spa_t *spa, uint64_t objsetid,
     int delay);

--- a/module/os/linux/spl/Makefile.in
+++ b/module/os/linux/spl/Makefile.in
@@ -6,6 +6,7 @@ $(MODULE)-objs += ../os/linux/spl/spl-generic.o
 $(MODULE)-objs += ../os/linux/spl/spl-kmem.o
 $(MODULE)-objs += ../os/linux/spl/spl-kmem-cache.o
 $(MODULE)-objs += ../os/linux/spl/spl-kstat.o
+$(MODULE)-objs += ../os/linux/spl/spl-mount.o
 $(MODULE)-objs += ../os/linux/spl/spl-proc.o
 $(MODULE)-objs += ../os/linux/spl/spl-procfs-list.o
 $(MODULE)-objs += ../os/linux/spl/spl-taskq.o

--- a/module/os/linux/spl/spl-mount.c
+++ b/module/os/linux/spl/spl-mount.c
@@ -1,0 +1,58 @@
+/*
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Solaris Porting Layer (SPL) Automount expiration Implementation.
+ */
+
+#include <sys/mount.h>
+
+static LIST_HEAD(spl_automount_list);
+
+static void
+spl_mount_expire(struct work_struct *data);
+static DECLARE_DELAYED_WORK(spl_automount_task, spl_mount_expire);
+
+static int last_delay_in_seconds = 0;
+
+static void
+spl_mount_expire(struct work_struct *data)
+{
+	struct list_head *list = &spl_automount_list;
+	printk("performing mount expiry expire");
+	mark_mounts_for_expiry(list);
+	if (!list_empty(list)) {
+		printk("Rescheduling in %d seconds", last_delay_in_seconds);
+		schedule_delayed_work(&spl_automount_task,
+		    READ_ONCE(last_delay_in_seconds) * HZ);
+	} else {
+		printk("No need for rescheduling.");
+	}
+}
+
+void
+spl_add_mount_to_expire(spl_mount *mnt, int delay_in_seconds)
+{
+	printk("scheduling! expire in %d", delay_in_seconds);
+	if (last_delay_in_seconds != delay_in_seconds) {
+		cancel_delayed_work(&spl_automount_task);
+	}
+	last_delay_in_seconds = delay_in_seconds;
+	mnt_set_expiry(mnt, &spl_automount_list);
+	printk("scheduling expire in %d", delay_in_seconds);
+	schedule_delayed_work(&spl_automount_task, delay_in_seconds * HZ);
+}
+EXPORT_SYMBOL(spl_add_mount_to_expire);

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -726,6 +726,37 @@ zfsctl_snapshot_name(zfsvfs_t *zfsvfs, const char *snap_name, int len,
  * Returns full path in full_path: "/pool/dataset/.zfs/snapshot/snap_name/"
  */
 static int
+zfsctl_snapshot_path(struct path *path, int len, char *full_path)
+{
+	char *path_buffer, *path_ptr;
+	int path_len, error = 0;
+
+	path_buffer = kmem_alloc(len, KM_SLEEP);
+
+	path_ptr = d_path(path, path_buffer, len);
+	if (IS_ERR(path_ptr)) {
+		error = -PTR_ERR(path_ptr);
+		goto out;
+	}
+
+	path_len = path_buffer + len - 1 - path_ptr;
+	if (path_len > len) {
+		error = SET_ERROR(EFAULT);
+		goto out;
+	}
+
+	memcpy(full_path, path_ptr, path_len);
+	full_path[path_len] = '\0';
+out:
+	kmem_free(path_buffer, len);
+
+	return (error);
+}
+
+/*
+ * Returns full path in full_path: "/pool/dataset/.zfs/snapshot/snap_name/"
+ */
+static int
 zfsctl_snapshot_path_objset(zfsvfs_t *zfsvfs, uint64_t objsetid,
     int path_len, char *full_path)
 {
@@ -1084,13 +1115,9 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	if (error)
 		goto error;
 
-	/*
-	 * Construct a mount point path from sb of the ctldir inode and dirent
-	 * name, instead of from d_path(), so that chroot'd process doesn't fail
-	 * on mount.zfs(8).
-	 */
-	snprintf(full_path, MAXPATHLEN, "%s/.zfs/snapshot/%s",
-	    zfsvfs->z_vfs->vfs_mntpoint, dname(dentry));
+	error = zfsctl_snapshot_path(path, MAXPATHLEN, full_path);
+	if (error)
+		goto error;
 
 	/*
 	 * Multiple concurrent automounts of a snapshot are never allowed.

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -1090,8 +1090,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	 * on mount.zfs(8).
 	 */
 	snprintf(full_path, MAXPATHLEN, "%s/.zfs/snapshot/%s",
-	    zfsvfs->z_vfs->vfs_mntpoint ? zfsvfs->z_vfs->vfs_mntpoint : "",
-	    dname(dentry));
+	    zfsvfs->z_vfs->vfs_mntpoint, dname(dentry));
 
 	/*
 	 * Multiple concurrent automounts of a snapshot are never allowed.

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -71,12 +71,14 @@
  * as that used by the parent zfsvfs_t to make NFS happy.
  */
 
+#include <linux/fs_context.h>
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/time.h>
 #include <sys/sysmacros.h>
 #include <sys/pathname.h>
 #include <sys/vfs.h>
+#include <sys/mount.h>
 #include <sys/zfs_ctldir.h>
 #include <sys/zfs_ioctl.h>
 #include <sys/zfs_vfsops.h>
@@ -722,6 +724,8 @@ zfsctl_snapshot_name(zfsvfs_t *zfsvfs, const char *snap_name, int len,
 	return (0);
 }
 
+#define	USE_FC_MOUNT
+#if defined(USE_FC_MOUNT)
 /*
  * Returns full path in full_path: "/pool/dataset/.zfs/snapshot/snap_name/"
  */
@@ -752,7 +756,7 @@ out:
 
 	return (error);
 }
-
+#endif
 /*
  * Returns full path in full_path: "/pool/dataset/.zfs/snapshot/snap_name/"
  */
@@ -1085,24 +1089,24 @@ zfsctl_snapshot_unmount(const char *snapname, int flags)
 
 	return (error);
 }
-
 int
-zfsctl_snapshot_mount(struct path *path, int flags)
+zfsctl_snapshot_mount(struct path *path, int flags, struct vfsmount **mnt_out)
 {
 	struct dentry *dentry = path->dentry;
 	struct inode *ip = dentry->d_inode;
 	zfsvfs_t *zfsvfs;
 	zfsvfs_t *snap_zfsvfs;
-	zfs_snapentry_t *se;
+	int error;
 	char *full_name, *full_path;
+#if !defined(USE_FC_MOUNT)
+	zfs_snapentry_t *se;
 	char *argv[] = { "/usr/bin/env", "mount", "-t", "zfs", "-n", NULL, NULL,
 	    NULL };
 	char *envp[] = { NULL };
-	int error;
 	struct path spath;
-
+#endif
 	if (ip == NULL)
-		return (SET_ERROR(EISDIR));
+		return (-SET_ERROR(EISDIR));
 
 	zfsvfs = ITOZSB(ip);
 	ZFS_ENTER(zfsvfs);
@@ -1110,14 +1114,19 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	full_name = kmem_zalloc(ZFS_MAX_DATASET_NAME_LEN, KM_SLEEP);
 	full_path = kmem_zalloc(MAXPATHLEN, KM_SLEEP);
 
-	error = zfsctl_snapshot_name(zfsvfs, dname(dentry),
+	error = -zfsctl_snapshot_name(zfsvfs, dname(dentry),
 	    ZFS_MAX_DATASET_NAME_LEN, full_name);
 	if (error)
 		goto error;
 
-	error = zfsctl_snapshot_path(path, MAXPATHLEN, full_path);
-	if (error)
-		goto error;
+	/*
+	 * Construct a mount point path from sb of the ctldir inode and dirent
+	 * name, instead of from d_path(), so that chroot'd process doesn't fail
+	 * on mount.zfs(8).
+	 */
+	snprintf(full_path, MAXPATHLEN, "%s/.zfs/snapshot/%s",
+	    zfsvfs->z_vfs->vfs_mntpoint ? zfsvfs->z_vfs->vfs_mntpoint : "",
+	    dname(dentry));
 
 	/*
 	 * Multiple concurrent automounts of a snapshot are never allowed.
@@ -1128,6 +1137,53 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 		goto error;
 	}
 
+#if defined(USE_FC_MOUNT)
+	(void) &zfsctl_snapshot_alloc; // For now..
+	error = -zfsctl_snapshot_path(path, MAXPATHLEN, full_path);
+	if (error)
+		goto error;
+
+	struct fs_context *fc;
+	struct vfsmount *mnt = NULL;
+	fc = fs_context_for_submount(&zpl_fs_type, dentry);
+	if (IS_ERR(fc)) {
+		zfs_dbgmsg("error-fc: %p", ERR_CAST(fc));
+	} else {
+		vfs_parse_fs_string(fc, "source", full_name, strlen(full_name));
+		mnt = fc_mount(fc);
+
+		if (IS_ERR(mnt)) {
+			zfs_dbgmsg("error-mnt: %p", ERR_CAST(mnt));
+		}
+		zfs_dbgmsg("mnt %p", mnt);
+		zfs_dbgmsg("put_fc %p", fc);
+		put_fs_context(fc);
+	}
+
+	if (!mnt || IS_ERR(mnt)) {
+		error = PTR_ERR(mnt);
+		goto error;
+	} else {
+		zfs_dbgmsg("yielding vfsmount %p", mnt);
+		mnt->mnt_flags |= MNT_SHRINKABLE;
+		mntget(mnt);
+		printk("adding mount to expiry list with timeout %d.",
+		    zfs_expire_snapshot);
+		spl_add_mount_to_expire(mnt, zfs_expire_snapshot);
+		printk("done!");
+		*mnt_out = mnt;
+	}
+
+	snap_zfsvfs = ITOZSB(mnt->mnt_root->d_inode);
+	snap_zfsvfs->z_parent = zfsvfs;
+
+	kmem_free(full_name, ZFS_MAX_DATASET_NAME_LEN);
+	kmem_free(full_path, MAXPATHLEN);
+
+	ZFS_EXIT(zfsvfs);
+
+	return (0);
+#else
 	/*
 	 * Attempt to mount the snapshot from user space.  Normally this
 	 * would be done using the vfs_kern_mount() function, however that
@@ -1148,7 +1204,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 		if (!(error & MOUNT_BUSY << 8)) {
 			zfs_dbgmsg("Unable to automount %s error=%d",
 			    full_path, error);
-			error = SET_ERROR(EISDIR);
+			error = -SET_ERROR(EISDIR);
 		} else {
 			/*
 			 * EBUSY, this could mean a concurrent mount, or the
@@ -1184,6 +1240,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 		rw_exit(&zfs_snapshot_lock);
 	}
 	path_put(&spath);
+#endif
 error:
 	kmem_free(full_name, ZFS_MAX_DATASET_NAME_LEN);
 	kmem_free(full_path, MAXPATHLEN);

--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -170,8 +170,8 @@ static struct vfsmount *
 zpl_snapdir_automount(struct path *path)
 {
 	int error;
-
-	error = -zfsctl_snapshot_mount(path, 0);
+	struct vfsmount *ret = NULL;
+	error = zfsctl_snapshot_mount(path, 0, &ret);
 	if (error)
 		return (ERR_PTR(error));
 
@@ -182,7 +182,7 @@ zpl_snapdir_automount(struct path *path)
 	 * to the name space.  If we returned the new mount here it would be
 	 * added again to the vfsmount list resulting in list corruption.
 	 */
-	return (NULL);
+	return (ret);
 }
 
 /*

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -121,7 +121,7 @@ tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
 tags = ['functional', 'mmp']
 
 [tests/functional/mount:Linux]
-tests = ['umount_unlinked_drain']
+tests = ['umount_unlinked_drain', 'mount_chroot', 'mount_bind', 'mount_ns', 'mount_ns_pivot', 'mount_autoshrink']
 tags = ['functional', 'mount']
 
 [tests/functional/pam:Linux]

--- a/tests/zfs-tests/tests/functional/mount/mount_autoshrink.ksh
+++ b/tests/zfs-tests/tests/functional/mount/mount_autoshrink.ksh
@@ -1,0 +1,44 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2020 by Felix Dörre. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mount/mount_common
+
+dir=$TESTDIR.autoshrink
+fs=$TESTPOOL/$TESTFS.autoshrink
+
+log_must mkdir -p "$dir"
+log_must zfs create -o mountpoint=$dir $fs
+
+function cleanup {
+    zfs destroy -r "$fs"
+    rm -R "$dir"
+}
+
+log_onexit cleanup
+
+log_must touch "$dir/testfile"
+log_must zfs snap ${fs}@snap
+
+log_must ls ${dir}/.zfs/snapshot/snap/testfile
+log_must umount ${dir}
+
+log_must zfs mount ${fs}
+log_must ls ${dir}/.zfs/snapshot/snap/testfile
+log_must zfs umount ${fs}
+
+log_pass "All ZFS file systems would have been unmounted"

--- a/tests/zfs-tests/tests/functional/mount/mount_bind.ksh
+++ b/tests/zfs-tests/tests/functional/mount/mount_bind.ksh
@@ -1,0 +1,122 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2020 by Felix Dörre. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mount/mount_common
+
+bind=$TESTDIR.bind
+fs=$TESTPOOL/$TESTFS.bind
+old_expiry=$(cat /sys/module/zfs/parameters/zfs_expire_snapshot)
+
+log_must mkdir -p ${bind}1
+log_must mkdir -p ${bind}2
+log_must zfs create -o mountpoint=${bind}1 $fs
+
+function cleanup {
+    zfs destroy -r "$fs"
+    printf "%s" "${old_expiry}" > /sys/module/zfs/parameters/zfs_expire_snapshot
+}
+
+log_onexit cleanup
+
+log_must touch ${bind}1/testfile
+log_must zfs snap ${fs}@snap
+
+
+function testbind {
+    if [[ $unmount_type == auto ]]; then
+	printf "%s" "1" > /sys/module/zfs/parameters/zfs_expire_snapshot
+    fi
+    
+
+    # Scenario 1: regular bind-mount
+    log_must mount --bind ${bind}1 ${bind}2
+    log_must ls ${bind}1/.zfs/snapshot/snap/testfile
+    log_must ls ${bind}2/.zfs/snapshot/snap/testfile
+    snapshots_mounted 2
+    unmount_automounted ${bind}1/.zfs/snapshot/snap
+    snapshots_mounted 0
+
+    log_must ls ${bind}2/.zfs/snapshot/snap/testfile
+    log_must ls ${bind}1/.zfs/snapshot/snap/testfile
+    snapshots_mounted 2
+    unmount_automounted ${bind}1/.zfs/snapshot/snap
+    snapshots_mounted 0
+
+    log_must umount ${bind}1
+    log_mustnot ls ${bind}1/.zfs/snapshot/snap/testfile
+    log_must ls ${bind}2/.zfs/snapshot/snap/testfile
+    snapshots_mounted 1
+    unmount_automounted ${bind}2/.zfs/snapshot/snap
+    snapshots_mounted 0
+
+    # cleanup
+    log_must umount ${bind}2
+    log_must zfs mount ${fs}
+    
+    # Scenario 2: mark the second bind-mount as "private"
+    log_must mount --bind --make-private ${bind}1 ${bind}2
+
+    log_must ls ${bind}2/.zfs/snapshot/snap/testfile
+    # TODO this currently is a limitation, but not desired
+    log_mustnot ls ${bind}1/.zfs/snapshot/snap/testfile
+    unmount_automounted ${bind}2/.zfs/snapshot/snap
+    snapshots_mounted 0
+
+    # And symmetric
+    log_must ls ${bind}1/.zfs/snapshot/snap/testfile
+    # TODO this currently is a limitation, but not desired
+    log_mustnot ls ${bind}2/.zfs/snapshot/snap/testfile
+    unmount_automounted ${bind}1/.zfs/snapshot/snap
+    snapshots_mounted 0
+
+    log_must umount ${bind}2
+
+    # Scenario 3: bind-mount and remove the original one
+    log_must mount --bind --make-private ${bind}1 ${bind}2
+    log_must umount ${bind}1
+    log_must ls ${bind}2/.zfs/snapshot/snap/testfile
+    log_mustnot test -f ${bind}1/.zfs/snapshot/snap/testfile
+    unmount_automounted ${bind}2/.zfs/snapshot/snap
+    snapshots_mounted 0
+
+    log_must umount ${bind}2
+    log_must zfs mount ${fs}
+    
+    # Scenario 4: bind-mount when auto-mounted snapshot is in place
+    log_must ls ${bind}1/.zfs/snapshot/snap/testfile
+    log_must mount --bind ${bind}1 ${bind}2
+    snapshots_mounted 1
+    # TODO this is a limitation, but not desired
+    log_mustnot ls ${bind}2/.zfs/snapshot/snap/testfile
+    snapshots_mounted 1
+
+    unmount_automounted ${bind}1/.zfs/snapshot/snap
+    snapshots_mounted 0
+    # now we are back to Scenario 1, so no reason for more tests
+    log_must umount ${bind}2
+
+    printf "%s" "${old_expiry}" > /sys/module/zfs/parameters/zfs_expire_snapshot
+}
+
+unmount_type=manual
+testbind
+unmount_type=auto
+testbind
+
+mount | grep zfs
+log_pass "All ZFS file systems would have been unmounted"

--- a/tests/zfs-tests/tests/functional/mount/mount_chroot.ksh
+++ b/tests/zfs-tests/tests/functional/mount/mount_chroot.ksh
@@ -1,0 +1,75 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2020 by Felix Dörre. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mount/mount_common
+
+chroot=$TESTDIR.chroot
+fs=$TESTPOOL/$TESTFS.chroot
+
+log_must mkdir -p $chroot/dataset
+log_must zfs create -o mountpoint=$chroot/dataset $fs
+old_expiry=$(cat /sys/module/zfs/parameters/zfs_expire_snapshot)
+
+function cleanup {
+    zfs destroy -r "$fs"
+    rm -R "$chroot"
+    printf "%s" "${old_expiry}" > /sys/module/zfs/parameters/zfs_expire_snapshot
+    mount | grep zfs
+}
+
+log_onexit cleanup
+
+function test_chroot {
+    local mountpoint=$1
+    local dir=${chroot}$2
+    local chroot_outer=$2
+    local mountpoint_inner=$3
+    [[ $unmount_type == auto ]] && printf "2" > /sys/module/zfs/parameters/zfs_expire_snapshot
+
+    log_must mkdir -p "$dir/bin"
+    log_must cp /bin/busybox "$dir/bin"
+    log_must ln -s /bin/busybox "$dir/bin/sh"
+    log_must ln -s /bin/busybox "$dir/bin/ls"
+    log_must touch "${mountpoint}/testfile"
+    log_must zfs snap ${fs}@snap
+    log_mustnot eval "mount | grep @"
+
+    log_must /usr/sbin/chroot ${dir} /bin/ls ${mountpoint_inner}/.zfs/snapshot/snap/testfile
+    log_must ls ${mountpoint}/.zfs/snapshot/snap/testfile
+    log_must eval "mount | grep @"
+    unmount_automounted ${mountpoint}/.zfs/snapshot/snap
+    log_mustnot eval "mount | grep @"
+
+    log_must ls ${mountpoint}/.zfs/snapshot/snap/testfile
+    log_must /usr/sbin/chroot ${dir} /bin/ls ${mountpoint_inner}/.zfs/snapshot/snap/testfile
+    log_must eval "mount | grep @"
+
+    unmount_automounted ${mountpoint}/.zfs/snapshot/snap
+    log_must zfs destroy ${fs}@snap
+    log_must rm -r "$dir/bin"
+
+    printf "%s" "${old_expiry}" > /sys/module/zfs/parameters/zfs_expire_snapshot
+}
+
+unmount_type=manual
+test_chroot "$chroot/dataset" "/dataset" ""
+test_chroot "$chroot/dataset" "" "/dataset"
+unmount_type=auto
+test_chroot "$chroot/dataset" "" "/dataset"
+
+log_pass "All ZFS file systems would have been unmounted"

--- a/tests/zfs-tests/tests/functional/mount/mount_common
+++ b/tests/zfs-tests/tests/functional/mount/mount_common
@@ -1,0 +1,21 @@
+function snaps_outside {
+    mount | grep -F "$fs@" | wc -l
+}
+
+function snapshots_mounted {
+	 assert $(snaps_outside) == "$1"
+}
+
+unmount_type=manual
+function unmount_automounted {
+    if [[ $unmount_type == auto ]]; then
+	for i in {0..10}; do
+	    if ! mount | grep -q " on $1 type zfs"; then
+		break;
+	    fi
+	    log_must sleep 1
+	done
+    else
+	log_must umount "$1"
+    fi
+}

--- a/tests/zfs-tests/tests/functional/mount/mount_ns.ksh
+++ b/tests/zfs-tests/tests/functional/mount/mount_ns.ksh
@@ -1,0 +1,108 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2020 by Felix Dörre. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mount/mount_common
+
+mountpoint=$TESTDIR.ns
+fs=$TESTPOOL/$TESTFS.ns
+
+log_must zfs create -o mountpoint=${mountpoint} $fs
+mntns=0
+old_expiry=$(cat /sys/module/zfs/parameters/zfs_expire_snapshot)
+
+function cleanup {
+    (( mntns != 0 )) && kill $mntns
+    zfs destroy -r "$fs"
+    printf "%s" "${old_expiry}" > /sys/module/zfs/parameters/zfs_expire_snapshot
+}
+
+log_onexit cleanup
+
+log_must touch ${mountpoint}/testfile
+log_must zfs snap ${fs}@snap
+
+function snaps_inside {
+    /usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt mount | grep -F "$fs@" | wc -l
+}
+
+/usr/bin/unshare -m bash -c "while :; do sleep 5; done" &
+mntns=$!
+assert $(snaps_outside) == 0
+assert $(snaps_inside) == 0
+
+log_must ls ${mountpoint}/.zfs/snapshot/snap/testfile
+assert $(snaps_outside) == 1
+assert $(snaps_inside) == 0
+log_must umount ${mountpoint}/.zfs/snapshot/snap
+assert $(snaps_outside) == 0
+assert $(snaps_inside) == 0
+
+log_must /usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt ls ${mountpoint}/.zfs/snapshot/snap/testfile
+assert $(snaps_outside) == 0
+assert $(snaps_inside) == 1
+
+# TODO this is not desired behavior
+log_mustnot ls ${mountpoint}/.zfs/snapshot/snap/testfile
+assert $(snaps_outside) == 0
+assert $(snaps_inside) == 1
+
+log_must /usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt umount ${mountpoint}/.zfs/snapshot/snap
+assert $(snaps_outside) == 0
+assert $(snaps_inside) == 0
+
+kill ${mntns}
+mntns=0
+assert $(snaps_outside) == 0
+
+# And now the same, but this time the snapshot is automounted before we fork of the mount ns
+printf "%s" "5" > /sys/module/zfs/parameters/zfs_expire_snapshot
+
+# Just quickly verify that auto unmounting works
+log_must ls ${mountpoint}/.zfs/snapshot/snap/testfile
+assert $(snaps_outside) == 1
+mount | grep zfs
+unmount_type=auto
+unmount_automounted ${mountpoint}/.zfs/snapshot/snap
+mount | grep zfs
+printf "should have expired now, checking...\n"
+assert $(snaps_outside) == 0
+
+
+log_must ls ${mountpoint}/.zfs/snapshot/snap/testfile
+/usr/bin/unshare -m bash -c "while :; do sleep 5; done" &
+mntns=$!
+mount | grep -F "$fs@"
+/usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt mount | grep -F "$fs@"
+assert $(snaps_outside) == 1
+assert $(snaps_inside) == 1
+
+# now expire all mounts
+sleep 15
+printf "outer\n"
+mount | grep -F "$fs@"
+printf "inner\n"
+/usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt mount | grep -F "$fs@"
+assert $(snaps_outside) == 0
+# TODO this is undesired
+assert $(snaps_inside) == 0
+#log_must /usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt umount /var/tmp/testdir.ns/.zfs/snapshot/snap
+
+assert $(snaps_outside) == 0
+assert $(snaps_inside) == 0
+
+log_pass "All ZFS file systems would have been unmounted"

--- a/tests/zfs-tests/tests/functional/mount/mount_ns_pivot.ksh
+++ b/tests/zfs-tests/tests/functional/mount/mount_ns_pivot.ksh
@@ -1,0 +1,82 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2020 by Felix Dörre. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mount/mount_common
+
+mountpoint=$TESTDIR.ns_pivot
+fs=$TESTPOOL/$TESTFS.ns_pivot
+
+log_must zfs create -o mountpoint=${mountpoint} $fs
+mntns=0
+old_expiry=$(cat /sys/module/zfs/parameters/zfs_expire_snapshot)
+
+function cleanup {
+    (( mntns != 0 )) && kill $mntns
+    zfs destroy -r "$fs"
+    printf "%s" "${old_expiry}" > /sys/module/zfs/parameters/zfs_expire_snapshot
+}
+
+log_onexit cleanup
+
+log_must mkdir "${mountpoint}/bin"
+log_must mkdir "${mountpoint}/mnt"
+log_must mkdir "${mountpoint}/proc"
+log_must cp /bin/busybox ${mountpoint}/bin/busybox
+log_must ln -s /bin/busybox ${mountpoint}/bin/sh
+log_must ln -s /bin/busybox ${mountpoint}/bin/mount
+log_must ln -s /bin/busybox ${mountpoint}/bin/umount
+log_must ln -s /bin/busybox ${mountpoint}/bin/ls
+log_must ln -s /bin/busybox ${mountpoint}/bin/pivot_root
+log_must zfs snap ${fs}@snap
+
+function snaps_inside {
+    /usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt /bin/mount | grep -F "$fs@" | wc -l
+}
+
+/usr/bin/unshare -m $STF_SUITE/tests/functional/mount/mount_ns_pivot_init "${mountpoint}" &
+mntns=$!
+echo ${mountns}
+while ! [[ -e ${mountpoint}/ready ]]; do
+    sleep 1
+done
+assert $(snaps_outside) == 0
+assert $(snaps_inside) == 0
+
+/usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt /bin/ls /.zfs/snapshot/snap/bin/busybox
+assert $(snaps_outside) == 0
+assert $(snaps_inside) == 1
+
+/usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt /bin/umount /.zfs/snapshot/snap
+assert $(snaps_outside) == 0
+assert $(snaps_inside) == 0
+
+printf "5" > /sys/module/zfs/parameters/zfs_expire_snapshot
+
+/usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt /bin/ls /.zfs/snapshot/snap/bin/busybox
+assert $(snaps_outside) == 0
+assert $(snaps_inside) == 1
+for i in {0..20}; do
+    (( $(snaps_inside) == 0 )) && break
+    sleep 1
+done
+assert $(snaps_outside) == 0
+# TODO this is undesired.
+assert $(snaps_inside) == 0
+#/usr/bin/nsenter --mount=/proc/${mntns}/ns/mnt /bin/umount /.zfs/snapshot/snap
+
+log_pass "All ZFS file systems would have been unmounted"

--- a/tests/zfs-tests/tests/functional/mount/mount_ns_pivot_init
+++ b/tests/zfs-tests/tests/functional/mount/mount_ns_pivot_init
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2020 by Felix Dörre. All rights reserved.
+#
+
+$1/bin/pivot_root "$1" "$1/mnt"
+cd /
+/bin/busybox cat > /newinit <<"EOF"
+/bin/busybox mount -t proc none /proc
+/bin/busybox cat /proc/self/mounts | /bin/busybox sed 's/[^ ]* \([^ ]*\) .*/\1/' | /bin/busybox grep '^/mnt\(/\|$\)' | /bin/busybox sort -r | xargs umount
+/bin/busybox mount
+/bin/busybox touch /ready
+exec /bin/busybox sleep 60
+EOF
+exec /bin/sh /newinit

--- a/tests/zfs-tests/tests/functional/mount/umount_unlinked_drain.ksh
+++ b/tests/zfs-tests/tests/functional/mount/umount_unlinked_drain.ksh
@@ -58,6 +58,7 @@ function unlinked_size_is
 		else
 			iters=0
 		fi
+		sleep 0.5
 		last_usize=$usize
 	done
 


### PR DESCRIPTION
### Motivation and Context
The auto-mounts for snapshots in the `.zfs` directory working on linux are a pretty big hack, even invoking the `mount` executable from kernel. This required follow up hacks to fix up problems that resulted from this handling including problems occurring if the visible location of a zfs mountpoint was moved using `pivot_root`. Because the `mount` executable is always executed in the primary `init`'s mount-ns/chroot snapshot automounts currently doesn't work at all in mount namespaces or on bind-mounts.

### State

The new testcases show the provided improved functionality and additionally document the points where the new behavior still might leave things to be desired. The new code still requires some cleanup (e.g. removing/cleaning up debug output, removing code hidden with the `USE_FC_MOUNT` macro, removing the `USE_FC_MOUNT` macro).

I'm opening this pull request now, to get feedback if the functionality as demonstrated by the new test cases is good/consistent enough for this change to get merged as an intermediate stage, leaving debugging/fixing the remaining corner cases for a future pull request. This would help me figure out if cleaning up the code at the current stage is worth the effort or if I need to continue debugging further first.

### Description
Several new mount-testcases testing the auto-mounting/unmounting of snapshots in various scenarios: `'mount_chroot', 'mount_bind', 'mount_ns', 'mount_ns_pivot', 'mount_autoshrink'`
An addition to the SPL allowing to register mount-points for auto-expiry after a specified time.
Changes to the auto-mount code to not use the mount binary anymore but directly automount the snapshots.

### How Has This Been Tested?
The new mount testcases run through with the code as it is now.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
