### PR TITLE
Remove VERIFY() in vdev_props_set_sync()

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -5476,7 +5476,10 @@ vdev_props_set_sync(void *arg, dmu_tx_t *tx)
 	vdev_guid = fnvlist_lookup_uint64(nvp, ZPOOL_VDEV_PROPS_SET_VDEV);
 	nvprops = fnvlist_lookup_nvlist(nvp, ZPOOL_VDEV_PROPS_SET_PROPS);
 	vd = spa_lookup_by_guid(spa, vdev_guid, B_TRUE);
-	VERIFY(vd != NULL);
+
+	/* this vdev could get removed while waiting for this sync task */
+	if (vd == NULL)
+		return;
 
 	mutex_enter(&spa->spa_props_lock);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Replace the VERIFY(vd != NULL) in vdev_props_set_sync() with a vd check that simply returns if vd is NULL
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is possible to enter vdev_props_set_sync() with a vdev guid that is not present in the pool, thus triggering the VERIFY().
### Description
<!--- Describe your changes in detail -->
If a vdev remove is in progress it is possible to get a race between an attempt to set a vdev property on the removing vdev and the remove operation:
1. Start device removal of devA
2. Set prep allocating to **false** on devA
   => trigger sync task
3. Device removal completes
4. Enter sync task (vdev_props_set_sync) and panic at VERIFY(vd != NULL)

It seem entirely reasonable to simply return from the sync task if the passed in vdev guid is no longer present in the pool. This gives the equivalent result to the race running the other way: the property set completes just before the vdev remove completes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Internal test suite that triggered this panic no longer triggers after fix.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
