### PR TITLE
Misc. cleanups from #12928 pt. 2

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3218,11 +3218,9 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 	 * Loading keys is best effort. We don't want to return immediately
 	 * if it fails but we do want to give the error to the caller.
 	 */
-	if (flags & ZFS_IMPORT_LOAD_KEYS) {
-		ret = zfs_crypto_attempt_load_keys(g_zfs, name);
-		if (ret != 0)
+	if (flags & ZFS_IMPORT_LOAD_KEYS &&
+	    zfs_crypto_attempt_load_keys(g_zfs, name) != 0)
 			ret = 1;
-	}
 
 	if (zpool_get_state(zhp) != POOL_STATE_UNAVAIL &&
 	    !(flags & ZFS_IMPORT_ONLY) &&
@@ -3272,7 +3270,7 @@ import_pools(nvlist_t *pools, nvlist_t *props, char *mntopts, int flags,
 			if (first)
 				first = B_FALSE;
 			else if (!do_all)
-				(void) printf("\n");
+				(void) putchar('\n');
 
 			if (do_all) {
 				err |= do_import(config, NULL, mntopts,
@@ -3723,9 +3721,8 @@ zpool_do_import(int argc, char **argv)
 	if (argc == 0 && geteuid() != 0) {
 		(void) fprintf(stderr, gettext("cannot "
 		    "discover pools: permission denied\n"));
-		if (searchdirs != NULL)
-			free(searchdirs);
 
+		free(searchdirs);
 		nvlist_free(props);
 		nvlist_free(policy);
 		return (1);

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3039,9 +3039,8 @@ show_import(nvlist_t *config, boolean_t report_error)
 				    ZPOOL_CONFIG_MMP_HOSTID);
 
 			(void) printf(gettext(" action: The pool must be "
-			    "exported from %s (hostid=%lx)\n\tbefore it "
-			    "can be safely imported.\n"), hostname,
-			    (unsigned long) hostid);
+			    "exported from %s (hostid=%"PRIx64")\n\tbefore it "
+			    "can be safely imported.\n"), hostname, hostid);
 			break;
 		case ZPOOL_STATUS_HOSTID_REQUIRED:
 			(void) printf(gettext(" action: Set a unique system "
@@ -3170,9 +3169,9 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 
 			(void) fprintf(stderr, gettext("cannot import '%s': "
 			    "pool is imported on %s (hostid: "
-			    "0x%lx)\nExport the pool on the other system, "
-			    "then run 'zpool import'.\n"),
-			    name, hostname, (unsigned long) hostid);
+			    "0x%"PRIx64")\nExport the pool on the other "
+			    "system, then run 'zpool import'.\n"),
+			    name, hostname, hostid);
 		} else if (mmp_state == MMP_STATE_NO_HOSTID) {
 			(void) fprintf(stderr, gettext("Cannot import '%s': "
 			    "pool has the multihost property on and the\n"
@@ -3197,10 +3196,10 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 
 			(void) fprintf(stderr, gettext("cannot import '%s': "
 			    "pool was previously in use from another system.\n"
-			    "Last accessed by %s (hostid=%lx) at %s"
+			    "Last accessed by %s (hostid=%"PRIx64") at %s"
 			    "The pool can be imported, use 'zpool import -f' "
 			    "to import the pool.\n"), name, hostname,
-			    (unsigned long)hostid, ctime(&timestamp));
+			    hostid, ctime(&timestamp));
 		}
 
 		return (1);

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3136,7 +3136,7 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 {
 	int ret = 0;
 	zpool_handle_t *zhp;
-	char *name;
+	const char *name;
 	uint64_t version;
 
 	name = fnvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME);
@@ -3157,7 +3157,7 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 			    ZPOOL_CONFIG_MMP_STATE);
 
 		if (mmp_state == MMP_STATE_ACTIVE) {
-			char *hostname = "<unknown>";
+			const char *hostname = "<unknown>";
 			uint64_t hostid = 0;
 
 			if (nvlist_exists(nvinfo, ZPOOL_CONFIG_MMP_HOSTNAME))
@@ -3179,8 +3179,8 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 			    "system's hostid is not set. Set a unique hostid "
 			    "with the zgenhostid(8) command.\n"), name);
 		} else {
-			char *hostname = "<unknown>";
-			uint64_t timestamp = 0;
+			const char *hostname = "<unknown>";
+			time_t timestamp = 0;
 			uint64_t hostid = 0;
 
 			if (nvlist_exists(config, ZPOOL_CONFIG_HOSTNAME))
@@ -3200,7 +3200,7 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 			    "Last accessed by %s (hostid=%lx) at %s"
 			    "The pool can be imported, use 'zpool import -f' "
 			    "to import the pool.\n"), name, hostname,
-			    (unsigned long)hostid, ctime((time_t *)&timestamp));
+			    (unsigned long)hostid, ctime(&timestamp));
 		}
 
 		return (1);
@@ -3210,7 +3210,7 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 		return (1);
 
 	if (newname != NULL)
-		name = (char *)newname;
+		name = newname;
 
 	if ((zhp = zpool_open_canfail(g_zfs, name)) == NULL)
 		return (1);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -553,8 +553,8 @@ _LIBZFS_H int zfs_crypto_create(libzfs_handle_t *, char *, nvlist_t *,
     nvlist_t *, boolean_t stdin_available, uint8_t **, uint_t *);
 _LIBZFS_H int zfs_crypto_clone_check(libzfs_handle_t *, zfs_handle_t *, char *,
     nvlist_t *);
-_LIBZFS_H int zfs_crypto_attempt_load_keys(libzfs_handle_t *, char *);
-_LIBZFS_H int zfs_crypto_load_key(zfs_handle_t *, boolean_t, char *);
+_LIBZFS_H int zfs_crypto_attempt_load_keys(libzfs_handle_t *, const char *);
+_LIBZFS_H int zfs_crypto_load_key(zfs_handle_t *, boolean_t, const char *);
 _LIBZFS_H int zfs_crypto_unload_key(zfs_handle_t *);
 _LIBZFS_H int zfs_crypto_rewrap(zfs_handle_t *, nvlist_t *, boolean_t);
 

--- a/lib/libspl/os/linux/zone.c
+++ b/lib/libspl/os/linux/zone.c
@@ -26,7 +26,7 @@
 #include <zone.h>
 
 zoneid_t
-getzoneid()
+getzoneid(void)
 {
 	return (GLOBAL_ZONEID);
 }

--- a/lib/libtpool/thread_pool.c
+++ b/lib/libtpool/thread_pool.c
@@ -108,8 +108,7 @@ job_cleanup(void *arg)
 	tpool_active_t **activepp;
 
 	pthread_mutex_lock(&tpool->tp_mutex);
-	/* CSTYLED */
-	for (activepp = &tpool->tp_active;; activepp = &activep->tpa_next) {
+	for (activepp = &tpool->tp_active; ; activepp = &activep->tpa_next) {
 		activep = *activepp;
 		if (activep->tpa_tid == my_tid) {
 			*activepp = activep->tpa_next;

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -345,7 +345,7 @@ changelist_rename(prop_changelist_t *clp, const char *src, const char *dst)
  * unshare all the datasets in the list.
  */
 int
-changelist_unshare(prop_changelist_t *clp, zfs_share_proto_t *proto)
+changelist_unshare(prop_changelist_t *clp, const zfs_share_proto_t *proto)
 {
 	prop_changenode_t *cn;
 	uu_avl_walk_t *walk;

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -685,7 +685,7 @@ end:
  */
 static int
 get_key_material(libzfs_handle_t *hdl, boolean_t do_verify, boolean_t newkey,
-    zfs_keyformat_t keyformat, char *keylocation, const char *fsname,
+    zfs_keyformat_t keyformat, const char *keylocation, const char *fsname,
     uint8_t **km_out, size_t *kmlen_out, boolean_t *can_retry_out)
 {
 	int ret;
@@ -1240,7 +1240,7 @@ out:
  * filesystem and all of its children.
  */
 int
-zfs_crypto_attempt_load_keys(libzfs_handle_t *hdl, char *fsname)
+zfs_crypto_attempt_load_keys(libzfs_handle_t *hdl, const char *fsname)
 {
 	int ret;
 	zfs_handle_t *zhp = NULL;
@@ -1275,7 +1275,8 @@ error:
 }
 
 int
-zfs_crypto_load_key(zfs_handle_t *zhp, boolean_t noop, char *alt_keylocation)
+zfs_crypto_load_key(zfs_handle_t *zhp, boolean_t noop,
+    const char *alt_keylocation)
 {
 	int ret, attempts = 0;
 	char errbuf[1024];
@@ -1283,7 +1284,7 @@ zfs_crypto_load_key(zfs_handle_t *zhp, boolean_t noop, char *alt_keylocation)
 	uint64_t keyformat = ZFS_KEYFORMAT_NONE;
 	char prop_keylocation[MAXNAMELEN];
 	char prop_encroot[MAXNAMELEN];
-	char *keylocation = NULL;
+	const char *keylocation = NULL;
 	uint8_t *key_material = NULL, *key_data = NULL;
 	size_t key_material_len;
 	boolean_t is_encroot, can_retry = B_FALSE, correctible = B_FALSE;

--- a/lib/libzfs/libzfs_impl.h
+++ b/lib/libzfs/libzfs_impl.h
@@ -189,7 +189,7 @@ extern void changelist_remove(prop_changelist_t *, const char *);
 extern void changelist_free(prop_changelist_t *);
 extern prop_changelist_t *changelist_gather(zfs_handle_t *, zfs_prop_t, int,
     int);
-extern int changelist_unshare(prop_changelist_t *, zfs_share_proto_t *);
+extern int changelist_unshare(prop_changelist_t *, const zfs_share_proto_t *);
 extern int changelist_haszonedchild(prop_changelist_t *);
 
 extern void remove_mountpoint(zfs_handle_t *);
@@ -240,14 +240,13 @@ typedef struct differ_info {
 	int datafd;
 } differ_info_t;
 
-extern proto_table_t proto_table[PROTO_END];
-
 extern int do_mount(zfs_handle_t *zhp, const char *mntpt, char *opts,
     int flags);
 extern int do_unmount(zfs_handle_t *zhp, const char *mntpt, int flags);
 extern int zfs_mount_delegation_check(void);
-extern int zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto);
-extern int zfs_unshare_proto(zfs_handle_t *, const char *, zfs_share_proto_t *);
+extern int zfs_share_proto(zfs_handle_t *zhp, const zfs_share_proto_t *proto);
+extern int zfs_unshare_proto(zfs_handle_t *, const char *,
+    const zfs_share_proto_t *);
 extern int unshare_one(libzfs_handle_t *hdl, const char *name,
     const char *mountpoint, zfs_share_proto_t proto);
 extern boolean_t zfs_is_mountable(zfs_handle_t *zhp, char *buf, size_t buflen,
@@ -259,7 +258,7 @@ extern int zpool_relabel_disk(libzfs_handle_t *hdl, const char *path,
     const char *msg);
 extern int find_shares_object(differ_info_t *di);
 extern void libzfs_set_pipe_max(int infd);
-extern void zfs_commit_proto(zfs_share_proto_t *);
+extern void zfs_commit_proto(const zfs_share_proto_t *);
 
 #ifdef	__cplusplus
 }

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -102,21 +102,21 @@ static zfs_share_type_t zfs_is_shared_proto(zfs_handle_t *, char **,
  * The share protocols table must be in the same order as the zfs_share_proto_t
  * enum in libzfs_impl.h
  */
-proto_table_t proto_table[PROTO_END] = {
+static const proto_table_t proto_table[PROTO_END] = {
 	{ZFS_PROP_SHARENFS, "nfs", EZFS_SHARENFSFAILED, EZFS_UNSHARENFSFAILED},
 	{ZFS_PROP_SHARESMB, "smb", EZFS_SHARESMBFAILED, EZFS_UNSHARESMBFAILED},
 };
 
-static zfs_share_proto_t nfs_only[] = {
+static const zfs_share_proto_t nfs_only[] = {
 	PROTO_NFS,
 	PROTO_END
 };
 
-static zfs_share_proto_t smb_only[] = {
+static const zfs_share_proto_t smb_only[] = {
 	PROTO_SMB,
 	PROTO_END
 };
-static zfs_share_proto_t share_all_proto[] = {
+static const zfs_share_proto_t share_all_proto[] = {
 	PROTO_NFS,
 	PROTO_SMB,
 	PROTO_END
@@ -706,7 +706,7 @@ boolean_t
 zfs_is_shared(zfs_handle_t *zhp)
 {
 	zfs_share_type_t rc = 0;
-	zfs_share_proto_t *curr_proto;
+	const zfs_share_proto_t *curr_proto;
 
 	if (ZFS_IS_VOLUME(zhp))
 		return (B_FALSE);
@@ -762,12 +762,12 @@ is_shared(const char *mountpoint, zfs_share_proto_t proto)
  * on "libshare" to do the dirty work for us.
  */
 int
-zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
+zfs_share_proto(zfs_handle_t *zhp, const zfs_share_proto_t *proto)
 {
 	char mountpoint[ZFS_MAXPROPLEN];
 	char shareopts[ZFS_MAXPROPLEN];
 	char sourcestr[ZFS_MAXPROPLEN];
-	zfs_share_proto_t *curr_proto;
+	const zfs_share_proto_t *curr_proto;
 	zprop_source_t sourcetype;
 	int err = 0;
 
@@ -872,12 +872,11 @@ zfs_parse_options(char *options, zfs_share_proto_t proto)
 }
 
 void
-zfs_commit_proto(zfs_share_proto_t *proto)
+zfs_commit_proto(const zfs_share_proto_t *proto)
 {
-	zfs_share_proto_t *curr_proto;
-	for (curr_proto = proto; *curr_proto != PROTO_END; curr_proto++) {
+	const zfs_share_proto_t *curr_proto;
+	for (curr_proto = proto; *curr_proto != PROTO_END; curr_proto++)
 		sa_commit_shares(proto_table[*curr_proto].p_name);
-	}
 }
 
 void
@@ -932,7 +931,7 @@ zfs_shareall(zfs_handle_t *zhp)
  */
 int
 zfs_unshare_proto(zfs_handle_t *zhp, const char *mountpoint,
-    zfs_share_proto_t *proto)
+    const zfs_share_proto_t *proto)
 {
 	libzfs_handle_t *hdl = zhp->zfs_hdl;
 	struct mnttab entry;
@@ -944,7 +943,7 @@ zfs_unshare_proto(zfs_handle_t *zhp, const char *mountpoint,
 
 	if (mountpoint != NULL || ((zfs_get_type(zhp) == ZFS_TYPE_FILESYSTEM) &&
 	    libzfs_mnttab_find(hdl, zfs_get_name(zhp), &entry) == 0)) {
-		zfs_share_proto_t *curr_proto;
+		const zfs_share_proto_t *curr_proto;
 
 		if (mountpoint == NULL)
 			mntpt = zfs_strdup(zhp->zfs_hdl, entry.mnt_mountp);
@@ -984,7 +983,7 @@ zfs_unshare_smb(zfs_handle_t *zhp, const char *mountpoint)
  * Same as zfs_unmountall(), but for NFS and SMB unshares.
  */
 static int
-zfs_unshareall_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
+zfs_unshareall_proto(zfs_handle_t *zhp, const zfs_share_proto_t *proto)
 {
 	prop_changelist_t *clp;
 	int ret;
@@ -1616,7 +1615,7 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	 * Walk through and first unshare everything.
 	 */
 	for (i = 0; i < used; i++) {
-		zfs_share_proto_t *curr_proto;
+		const zfs_share_proto_t *curr_proto;
 		for (curr_proto = share_all_proto; *curr_proto != PROTO_END;
 		    curr_proto++) {
 			if (is_shared(sets[i].mountpoint, *curr_proto) &&

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1352,7 +1352,7 @@ zfs_mount_task(void *arg)
 	    sizeof (mountpoint), NULL, NULL, 0, B_FALSE) == 0);
 
 	if (mp->mnt_func(handles[idx], mp->mnt_data) != 0)
-		return;
+		goto out;
 
 	/*
 	 * We dispatch tasks to mount filesystems with mountpoints underneath
@@ -1373,6 +1373,8 @@ zfs_mount_task(void *arg)
 		zfs_dispatch_mount(mp->mnt_hdl, handles, num_handles, i,
 		    mp->mnt_func, mp->mnt_data, mp->mnt_tp);
 	}
+
+out:
 	free(mp);
 }
 

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2030,7 +2030,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 	nvlist_t *nv = NULL;
 	nvlist_t *nvinfo = NULL;
 	nvlist_t *missing = NULL;
-	char *thename;
+	const char *thename;
 	char *origname;
 	int ret;
 	int error = 0;
@@ -2047,7 +2047,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 			return (zfs_error_fmt(hdl, EZFS_INVALIDNAME,
 			    dgettext(TEXT_DOMAIN, "cannot import '%s'"),
 			    newname));
-		thename = (char *)newname;
+		thename = newname;
 	} else {
 		thename = origname;
 	}


### PR DESCRIPTION
### Motivation and Context
What I Noticed In https://github.com/openzfs/zfs/pull/12928#issuecomment-1010519412, Part Two. I just need to stop staring at the fucking thing before I go insane. As far as I can tell there's no leak. As far as I can tell, also
```
+53784 -53784  NO TPOOL
+53784 -53784  YES TPOOL, NO DISPATCH
+60960 -42944  YES TPOOL, YES DISPATCH
+53784 -53784  YES TPOOL, FAKE DISPATCH
+60960 -53912  YES TPOOL, YES DISPATCH, BUMP ALLOC
+60960 -42944  YES TPOOL, YES DISPATCH, NO BUMP ALLOC
```
somehow there is one. Barring something fundamental, I don't know what I could possibly be missing and why allocating in the other thread would lose this. See the VM link in that thread if you want to curse yourself with this.

<details>
<summary>Working diff on top of this, in case I want to come back to it.</summary>

```diff
diff --git a/lib/libnvpair/nvpair_alloc_system.c b/lib/libnvpair/nvpair_alloc_system.c
index 9771f58f6..5806a6283 100644
--- a/lib/libnvpair/nvpair_alloc_system.c
+++ b/lib/libnvpair/nvpair_alloc_system.c
@@ -29,17 +29,21 @@
 #include <rpc/types.h>
 #include <sys/kmem.h>
 #include <sys/nvpair.h>
+#include <stdio.h>
 
 static void *
 nv_alloc_sys(nv_alloc_t *nva, size_t size)
 {
-	return (kmem_alloc(size, (int)(uintptr_t)nva->nva_arg));
+	void * ret = (kmem_alloc(size, (int)(uintptr_t)nva->nva_arg));
+  printf("alloc: %p (%zu)\n", ret, size);
+  return ret;
 }
 
 static void
 nv_free_sys(nv_alloc_t *nva, void *buf, size_t size)
 {
 	(void) nva;
+  printf("free: %p (%zu)\n", buf, size);
 	kmem_free(buf, size);
 }
 
diff --git a/lib/libtpool/thread_pool.c b/lib/libtpool/thread_pool.c
index 58b706dde..b3ff14d31 100644
--- a/lib/libtpool/thread_pool.c
+++ b/lib/libtpool/thread_pool.c
@@ -399,7 +399,9 @@ tpool_create(uint_t min_threads, uint_t max_threads, uint_t linger,
 
 	return (tpool);
 }
-
+static void do_nothing(void *_) {
+	printf("do_nothing(%p)\n", _);
+}
 /*
  * Dispatch a work request to the thread pool.
  * If there are idle workers, awaken one.
@@ -419,6 +421,7 @@ tpool_dispatch(tpool_t *tpool, void (*func)(void *), void *arg)
 	job->tpj_next = NULL;
 	job->tpj_func = func;
 	job->tpj_arg = arg;
+	// job->tpj_func = do_nothing;
 
 	pthread_mutex_lock(&tpool->tp_mutex);
 
@@ -438,6 +441,7 @@ tpool_dispatch(tpool_t *tpool, void (*func)(void *), void *arg)
 	}
 
 	pthread_mutex_unlock(&tpool->tp_mutex);
+	// func(arg);
 	return (0);
 }
 
diff --git a/lib/libzfs/libzfs_mount.c b/lib/libzfs/libzfs_mount.c
index 8bde57051..e11224d7e 100644
--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1267,6 +1267,7 @@ zfs_dispatch_mount(libzfs_handle_t *hdl, zfs_handle_t **handles,
 	mnt_param->mnt_data = data;
 
 	(void) tpool_dispatch(tp, zfs_mount_task, (void*)mnt_param);
+	// zfs_mount_task(mnt_param);
 }
 
 /*
@@ -1334,6 +1335,9 @@ zfs_mount_task(void *arg)
 	verify(zfs_prop_get(handles[idx], ZFS_PROP_MOUNTPOINT, mountpoint,
 	    sizeof (mountpoint), NULL, NULL, 0, B_FALSE) == 0);
 
+// printf("skipping: %p (%d): %s\n", handles[idx], idx, mountpoint);
+// goto out;
+printf("not-skipping: %p (%d): %s\n", handles[idx], idx, mountpoint);
 	if (mp->mnt_func(handles[idx], mp->mnt_data) != 0)
 		goto out;
 
@@ -1410,6 +1414,7 @@ zfs_foreach_mountpoint(libzfs_handle_t *hdl, zfs_handle_t **handles,
 	 * Issue the callback function for each dataset using a parallel
 	 * algorithm that uses a thread pool to manage threads.
 	 */
+	// tpool_t *tp = NULL;
 	tpool_t *tp = tpool_create(1, mount_tp_nthr, 0, NULL);
 
 	/*
diff --git a/lib/libzfs/libzfs_pool.c b/lib/libzfs/libzfs_pool.c
index 88c7ee74b..5aeac1ebb 100644
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -84,36 +84,36 @@ zpool_get_all_props(zpool_handle_t *zhp)
 
 	while (zfs_ioctl(hdl, ZFS_IOC_POOL_GET_PROPS, &zc) != 0) {
 		if (errno == ENOMEM) {
-			if (zcmd_expand_dst_nvlist(hdl, &zc) != 0) {
-				zcmd_free_nvlists(&zc);
-				return (-1);
-			}
-		} else {
-			zcmd_free_nvlists(&zc);
-			return (-1);
-		}
+			if (zcmd_expand_dst_nvlist(hdl, &zc) != 0)
+				goto err;
+		} else
+			goto err;
 	}
 
-	if (zcmd_read_dst_nvlist(hdl, &zc, &zhp->zpool_props) != 0) {
-		zcmd_free_nvlists(&zc);
-		return (-1);
-	}
+printf("reE: before: %p\n", zhp->zpool_props);
+	if (zcmd_read_dst_nvlist(hdl, &zc, &zhp->zpool_props) != 0)
+		goto err;
+printf("reE: after : %p\n", zhp->zpool_props);
 
+printf("ok : free: %p\n", &zc.zc_nvlist_dst);
 	zcmd_free_nvlists(&zc);
-
 	return (0);
+err:
+printf("err: free: %p\n", &zc.zc_nvlist_dst);
+	zcmd_free_nvlists(&zc);
+	return (-1);
 }
 
 int
 zpool_props_refresh(zpool_handle_t *zhp)
 {
-	nvlist_t *old_props;
-
-	old_props = zhp->zpool_props;
+	nvlist_t *old_props = zhp->zpool_props;
 
+printf("in : refr: %p\n", old_props);
 	if (zpool_get_all_props(zhp) != 0)
 		return (-1);
 
+printf("out: refr: %p\n", old_props);
 	nvlist_free(old_props);
 	return (0);
 }
@@ -151,9 +151,9 @@ zpool_get_prop_int(zpool_handle_t *zhp, zpool_prop_t prop, zprop_source_t *src)
 	uint64_t value;
 	zprop_source_t source;
 
-	if (zhp->zpool_props == NULL && zpool_get_all_props(zhp)) {
+	if (zhp->zpool_props == NULL && zpool_props_refresh(zhp)) {
 		/*
-		 * zpool_get_all_props() has most likely failed because
+		 * zpool_props_refresh() has most likely failed because
 		 * the pool is faulted, but if all we need is the top level
 		 * vdev's guid then get it from the zhp config nvlist.
 		 */
diff --git a/module/nvpair/nvpair.c b/module/nvpair/nvpair.c
index 8230cca20..365a1d984 100644
--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -598,14 +598,17 @@ nvlist_xalloc(nvlist_t **nvlp, uint_t nvflag, nv_alloc_t *nva)
 	if (nvlp == NULL || nva == NULL)
 		return (EINVAL);
 
+// printf("xalloc: pre: %p: %p\n", nvlp, *nvlp);
 	if ((priv = nv_priv_alloc(nva)) == NULL)
 		return (ENOMEM);
+// printf("xalloc: pri: %p: %p; priv=%p\n", nvlp, *nvlp, priv);
 
 	if ((*nvlp = nv_mem_zalloc(priv,
 	    NV_ALIGN(sizeof (nvlist_t)))) == NULL) {
 		nv_mem_free(priv, priv, sizeof (nvpriv_t));
 		return (ENOMEM);
 	}
+printf("xalloc: %p, %p\n", *nvlp, priv);
 
 	nvlist_init(*nvlp, nvflag, priv);
 
```

</details>


### Description
See individual commits.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
