### PR TITLE
libefi: remove efi_type()

### DIFF
--- a/include/sys/efi_partition.h
+++ b/include/sys/efi_partition.h
@@ -369,7 +369,6 @@ _SYS_EFI_PARTITION_H int efi_alloc_and_read(int, struct dk_gpt **);
 _SYS_EFI_PARTITION_H int efi_write(int, struct dk_gpt *);
 _SYS_EFI_PARTITION_H int efi_rescan(int);
 _SYS_EFI_PARTITION_H void efi_free(struct dk_gpt *);
-_SYS_EFI_PARTITION_H int efi_type(int);
 _SYS_EFI_PARTITION_H void efi_err_check(struct dk_gpt *);
 _SYS_EFI_PARTITION_H int efi_use_whole_disk(int fd);
 #endif

--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -1541,34 +1541,6 @@ efi_free(struct dk_gpt *ptr)
 	free(ptr);
 }
 
-/*
- * Input: File descriptor
- * Output: 1 if disk has an EFI label, or > 2TB with no VTOC or legacy MBR.
- * Otherwise 0.
- */
-int
-efi_type(int fd)
-{
-#if 0
-	struct vtoc vtoc;
-	struct extvtoc extvtoc;
-
-	if (ioctl(fd, DKIOCGEXTVTOC, &extvtoc) == -1) {
-		if (errno == ENOTSUP)
-			return (1);
-		else if (errno == ENOTTY) {
-			if (ioctl(fd, DKIOCGVTOC, &vtoc) == -1)
-				if (errno == ENOTSUP)
-					return (1);
-		}
-	}
-	return (0);
-#else
-	(void) fd;
-	return (ENOSYS);
-#endif
-}
-
 void
 efi_err_check(struct dk_gpt *vtoc)
 {

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -168,7 +168,6 @@
     <elf-symbol name='efi_err_check' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_rescan' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='efi_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_use_whole_disk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_write' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='entity_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -843,10 +842,6 @@
     <function-decl name='efi_free' mangled-name='efi_free' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_free'>
       <parameter type-id='0d8119a8' name='ptr'/>
       <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='efi_type' mangled-name='efi_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_type'>
-      <parameter type-id='95e97e5e' name='fd'/>
-      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='efi_err_check' mangled-name='efi_err_check' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_err_check'>
       <parameter type-id='0d8119a8' name='vtoc'/>


### PR DESCRIPTION
### Motivation and Context
As noted in #12844:
> All it is right now is some #if 0ed Solaris code that returns ENOSYS, and is only applicable for the Solaris blockdev layer. In the Illumos gate, there's a single user: rmformat(1); I recommend a read of the manual as a blast from the past, but, well

It never was anything but: imported in 5c36312909256a886495b56fb0cd75ebaa25615b (Fri Oct 9 15:37:29 2009 -0700), commented out in d603ed6c278f9c25b17ba8e75e9bce6e5d715ac0 (Thu Aug 26 11:56:53 2010 -0700), which says
```
    This topic branch contains all the changes needed to integrate the user
    side zfs tools with Linux style devices.  Primarily this includes fixing
    up the Solaris libefi library to be Linux friendly, and integrating with
    the libblkid library which is provided by e2fsprogs.
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
