### PR TITLE
libspl: ASSERT*: !! for sizeof

### DIFF
--- a/include/os/freebsd/spl/sys/debug.h
+++ b/include/os/freebsd/spl/sys/debug.h
@@ -133,14 +133,14 @@ void spl_dumpstack(void);
  */
 #ifdef NDEBUG
 
-#define	ASSERT(x)		((void)sizeof(x))
-#define	ASSERT3B(x,y,z)		((void)sizeof(x), (void)sizeof(z))
-#define	ASSERT3S(x,y,z)		((void)sizeof(x), (void)sizeof(z))
-#define	ASSERT3U(x,y,z)		((void)sizeof(x), (void)sizeof(z))
-#define	ASSERT3P(x,y,z)		((void)sizeof(x), (void)sizeof(z))
-#define	ASSERT0(x)		((void)sizeof(x))
-#define	IMPLY(A, B)		((void)sizeof(A), (void)sizeof(B))
-#define	EQUIV(A, B)		((void)sizeof(A), (void)sizeof(B))
+#define	ASSERT(x)		((void) sizeof (!!(x)))
+#define	ASSERT3B(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT3S(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT3U(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT3P(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT0(x)		((void) sizeof (!!(x)))
+#define	IMPLY(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
+#define	EQUIV(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
 
 /*
  * Debugging enabled (--enable-debug)

--- a/include/os/linux/spl/sys/debug.h
+++ b/include/os/linux/spl/sys/debug.h
@@ -133,14 +133,14 @@ void spl_dumpstack(void);
  */
 #ifdef NDEBUG
 
-#define	ASSERT(x)		((void)sizeof(x))
-#define	ASSERT3B(x,y,z)		((void)sizeof(x), (void)sizeof(z))
-#define	ASSERT3S(x,y,z)		((void)sizeof(x), (void)sizeof(z))
-#define	ASSERT3U(x,y,z)		((void)sizeof(x), (void)sizeof(z))
-#define	ASSERT3P(x,y,z)		((void)sizeof(x), (void)sizeof(z))
-#define	ASSERT0(x)		((void)sizeof(x))
-#define	IMPLY(A, B)		((void)sizeof(A), (void)sizeof(B))
-#define	EQUIV(A, B)		((void)sizeof(A), (void)sizeof(B))
+#define	ASSERT(x)		((void) sizeof (!!(x)))
+#define	ASSERT3B(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT3S(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT3U(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT3P(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT0(x)		((void) sizeof (!!(x)))
+#define	IMPLY(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
+#define	EQUIV(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
 
 /*
  * Debugging enabled (--enable-debug)

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -120,15 +120,15 @@ do {									\
 	__compile_time_assertion__ ## y[(x) ? 1 : -1]
 
 #ifdef NDEBUG
-#define	ASSERT3B(x, y, z)	((void) sizeof (x), (void) sizeof (z))
-#define	ASSERT3S(x, y, z)	((void) sizeof (x), (void) sizeof (z))
-#define	ASSERT3U(x, y, z)	((void) sizeof (x), (void) sizeof (z))
-#define	ASSERT3P(x, y, z)	((void) sizeof (x), (void) sizeof (z))
-#define	ASSERT0(x)		((void) sizeof (x))
-#define	ASSERT(x)		((void) sizeof (x))
-#define	assert(x)		((void) sizeof (x))
-#define	IMPLY(A, B)		((void) sizeof (A), (void) sizeof (B))
-#define	EQUIV(A, B)		((void) sizeof (A), (void) sizeof (B))
+#define	ASSERT3B(x, y, z)	((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT3S(x, y, z)	((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT3U(x, y, z)	((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT3P(x, y, z)	((void) sizeof (!!(x)), (void) sizeof (!!(z)))
+#define	ASSERT0(x)		((void) sizeof (!!(x)))
+#define	ASSERT(x)		((void) sizeof (!!(x)))
+#define	assert(x)		((void) sizeof (!!(x)))
+#define	IMPLY(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
+#define	EQUIV(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
 #else
 #define	ASSERT3B	VERIFY3B
 #define	ASSERT3S	VERIFY3S


### PR DESCRIPTION
### Motivation and Context
#12984

### How Has This Been Tested?
Not.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
