### PR TITLE
Fix test-runner on FreeBSD

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -706,9 +706,9 @@ msg "${TEST_RUNNER} ${QUIET:+-q}" \
     -T "${TAGS}" \
     -i "${STF_SUITE}" \
     -I "${ITERATIONS}" \
-    2>&1 ; echo $? > $EVILRES; )| tee "$RESULTS_FILE"
+    2>&1 ; echo $? > "$EVILRES"; )| tee "$RESULTS_FILE"
 
-RUNRESULT=$(cat $EVILRES)
+RUNRESULT=$(cat "$EVILRES")
 
 #
 # Analyze the results.
@@ -753,7 +753,7 @@ if [ -n "$SINGLETEST" ]; then
 fi
 
 # If the test runner errored out, we probably care.
-if [ $RUNRESULT -ne "0" ]; then
+if [ "$RUNRESULT" -ne "0" ]; then
        RESULT=$RUNRESULT
 fi
 

--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -695,21 +695,20 @@ fi
 #
 # Run all the tests as specified.
 #
-set -o pipefail
+EVILRES=$(mktemp -u -t test-runner-error)
 msg "${TEST_RUNNER} ${QUIET:+-q}" \
     "-c \"${RUNFILES}\"" \
     "-T \"${TAGS}\"" \
     "-i \"${STF_SUITE}\"" \
     "-I \"${ITERATIONS}\""
-${TEST_RUNNER} ${QUIET:+-q} \
+(${TEST_RUNNER} ${QUIET:+-q} \
     -c "${RUNFILES}" \
     -T "${TAGS}" \
     -i "${STF_SUITE}" \
     -I "${ITERATIONS}" \
-    2>&1 | tee "$RESULTS_FILE"
+    2>&1 ; echo $? > $EVILRES; )| tee "$RESULTS_FILE"
 
-RUNRESULT=$?
-set +o pipefail
+RUNRESULT=$(cat $EVILRES)
 
 #
 # Analyze the results.

--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -695,6 +695,7 @@ fi
 #
 # Run all the tests as specified.
 #
+set -o pipefail
 msg "${TEST_RUNNER} ${QUIET:+-q}" \
     "-c \"${RUNFILES}\"" \
     "-T \"${TAGS}\"" \
@@ -706,6 +707,10 @@ ${TEST_RUNNER} ${QUIET:+-q} \
     -i "${STF_SUITE}" \
     -I "${ITERATIONS}" \
     2>&1 | tee "$RESULTS_FILE"
+
+RUNRESULT=$?
+set +o pipefail
+
 #
 # Analyze the results.
 #
@@ -746,6 +751,11 @@ rm -f "$RESULTS_FILE" "$REPORT_FILE"
 
 if [ -n "$SINGLETEST" ]; then
 	rm -f "$RUNFILES" >/dev/null 2>&1
+fi
+
+# If the test runner errored out, we probably care.
+if [ $RUNRESULT -ne "0" ]; then
+       RESULT=$RUNRESULT
 fi
 
 exit "${RESULT}"

--- a/tests/test-runner/bin/test-runner.py.in
+++ b/tests/test-runner/bin/test-runner.py.in
@@ -32,7 +32,11 @@ from select import select
 from subprocess import PIPE
 from subprocess import Popen
 from threading import Timer
-from time import time, CLOCK_MONOTONIC_RAW
+# CLOCK_MONOTONIC_RAW is only on Linux and macOS
+try:
+  from time import CLOCK_MONOTONIC_RAW as CLOCK_MONO
+except:
+  from time import CLOCK_MONOTONIC as CLOCK_MONO
 
 BASEDIR = '/var/tmp/test_results'
 TESTDIR = '/usr/share/zfs/'
@@ -59,7 +63,7 @@ clock_gettime.argtypes = [ctypes.c_int, ctypes.POINTER(timespec)]
 
 def monotonic_time():
     t = timespec()
-    if clock_gettime(CLOCK_MONOTONIC_RAW, ctypes.pointer(t)) != 0:
+    if clock_gettime(CLOCK_MONO, ctypes.pointer(t)) != 0:
         errno_ = ctypes.get_errno()
         raise OSError(errno_, os.strerror(errno_))
     return t.tv_sec + t.tv_nsec * 1e-9

--- a/tests/test-runner/bin/test-runner.py.in
+++ b/tests/test-runner/bin/test-runner.py.in
@@ -32,11 +32,12 @@ from select import select
 from subprocess import PIPE
 from subprocess import Popen
 from threading import Timer
+from time import time
 # CLOCK_MONOTONIC_RAW is only on Linux and macOS
 try:
-  from time import CLOCK_MONOTONIC_RAW as CLOCK_MONO
-except:
-  from time import CLOCK_MONOTONIC as CLOCK_MONO
+    from time import CLOCK_MONOTONIC_RAW as CLOCK_MONO
+except ImportError:
+    from time import CLOCK_MONOTONIC as CLOCK_MONO
 
 BASEDIR = '/var/tmp/test_results'
 TESTDIR = '/usr/share/zfs/'


### PR DESCRIPTION
### Motivation and Context
CLOCK_MONOTONIC_RAW is only a thing on Linux and macOS. I'm not
actually sure why the previous hardcoding of a constant didn't
error out, but when we removed it, it sure does now.

~(Separately, should figure out why it's returning success when erroring out in under a second in the CI, but wanted to get this in before possibly going down a rabbit hole like that...)~ Ah, zfs-tests.sh doesn't actually care if the test-runner dies in a fire, it just cares what the results collector returns...let's fix that.

### Description
Fallback to CLOCK_MONOTONIC if CLOCK_MONOTONIC_RAW doesn't exist.

Return the error code if test-runner.py errored, even if zts-results didn't.

### How Has This Been Tested?
Didn't run on my 13-RELEASE VM before, runs now.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
