### PR TITLE
Notice if the test-runner dies

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -700,12 +700,14 @@ msg "${TEST_RUNNER} ${QUIET:+-q}" \
     "-T \"${TAGS}\"" \
     "-i \"${STF_SUITE}\"" \
     "-I \"${ITERATIONS}\""
-${TEST_RUNNER} ${QUIET:+-q} \
+{ ${TEST_RUNNER} ${QUIET:+-q} \
     -c "${RUNFILES}" \
     -T "${TAGS}" \
     -i "${STF_SUITE}" \
     -I "${ITERATIONS}" \
-    2>&1 | tee "$RESULTS_FILE"
+    2>&1; echo $? >"$REPORT_FILE"; } | tee "$RESULTS_FILE"
+read -r RUNRESULT <"$REPORT_FILE"
+
 #
 # Analyze the results.
 #
@@ -720,13 +722,14 @@ if [ "$RESULT" -eq "2" ] && [ -n "$RERUN" ]; then
 	for test_name in $MAYBES; do
 		grep "$test_name " "$TEMP_RESULTS_FILE" >>"$TEST_LIST"
 	done
-	${TEST_RUNNER} ${QUIET:+-q} \
+	{ ${TEST_RUNNER} ${QUIET:+-q} \
 	    -c "${RUNFILES}" \
 	    -T "${TAGS}" \
 	    -i "${STF_SUITE}" \
 	    -I "${ITERATIONS}" \
 	    -l "${TEST_LIST}" \
-	    2>&1 | tee "$RESULTS_FILE"
+	    2>&1; echo $? >"$REPORT_FILE"; } | tee "$RESULTS_FILE"
+	read -r RUNRESULT <"$REPORT_FILE"
 	#
 	# Analyze the results.
 	#
@@ -748,4 +751,4 @@ if [ -n "$SINGLETEST" ]; then
 	rm -f "$RUNFILES" >/dev/null 2>&1
 fi
 
-exit "${RESULT}"
+[ "$RUNRESULT" -gt 3 ] && exit "$RUNRESULT" || exit "$RESULT"


### PR DESCRIPTION
### Description
The Other Bit™ of #12990. Rich seems to've lost interest, I think there's still a point to landing this for now. Nevertheless, just like #12995, this is authored by him (which seems to've been lost on merge?).

Decided to cannibalise `$REPORT_FILE` for the duration between finishing the test and starting the reporter instead of making another temp file.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI will hopefully
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
