### PR TITLE
Add explicit timeout to test in order to collect artifacts on timeout

### DIFF
--- a/.github/workflows/zfs-tests-functional.yml
+++ b/.github/workflows/zfs-tests-functional.yml
@@ -64,6 +64,7 @@ jobs:
     - name: Tests
       run: |
         /usr/share/zfs/zfs-tests.sh -vR -s 3G
+      timeout-minutes: 330
     - name: Prepare artifacts
       if: failure()
       run: |

--- a/.github/workflows/zfs-tests-sanity.yml
+++ b/.github/workflows/zfs-tests-sanity.yml
@@ -60,6 +60,7 @@ jobs:
     - name: Tests
       run: |
         /usr/share/zfs/zfs-tests.sh -vR -s 3G -r sanity
+      timeout-minutes: 330
     - name: Prepare artifacts
       if: failure()
       run: |


### PR DESCRIPTION
### Motivation and Context
A PR I'm working on turned out to cause an astonishing number of tests to overrun their timeouts, and in turn, blow the default GH action timeout.

Unfortunately, if we die from the entire action timing out, we don't run the artifact collection and upload step.

### Description
Add a slightly shorter than the full 6h timeout for the test step of the workflow - if that fails, it counts as a failure, and we collect as usual.

### How Has This Been Tested?
[It collected](https://github.com/rincebrain/zfs/actions/runs/1729441130).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
