### PR TITLE
RPM: Add missing BuildRequires for PAM component

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -117,10 +117,15 @@ BuildRequires:  ncompress
 BuildRequires:  libtirpc-devel
 %endif
 
+%if %{with pam}
+BuildRequires:  pam-devel
+%endif
+
 Requires:       openssl
 %if 0%{?_systemd}
 BuildRequires: systemd
 %endif
+
 %endif
 
 %if 0%{?_systemd}


### PR DESCRIPTION
### Motivation and Context
When the optional PAM binaries are included in a build, ./configure will look for security/pam_modules.h and - if it doesn't find it - recommend the user install `libpam0g-dev`.  On Red Hat systems, `pam-devel` is the package that supplies this requirement; `libpam0g-dev` does not exist.

By encoding this requirement in the spec file, we give packagers more appropriate (and timely) recommendations for completing the build.

### Description
Adds a `BuildRequires:` line to the spec file, but only if the PAM module is being built (i.e. `-D 'with_pam 1`) is given while building.

### How Has This Been Tested?
Test Environment: Fedora 34 Server in a VM

Steps:
1. Downloaded zfs v2.1.2 source package from official repository
2. Extracted SPECS/ and SOURCES/
3. Installed dependencies with `dnf builddep zfs.spec`
4. Built with `rpmbuild -bb zfs.spec`, confirmed successful build
5. Built with `rpmbuild -bb zfs.spec -D 'with_pam 1'`, confirmed build failed
6. Applied this patch to zfs.spec
7. Built with `rpmbuild -bb zfs.spec -D 'with_pam 1'`, confirmed missing dependency listed
8. Installed dependencies with `dnf builddep zfs.spec -D 'with_pam 1'`
9. Built with `rpmbuild -bb zfs.spec -D 'with_pam 1'`, confirmed successful build

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
