### PR TITLE
The first arg of submit_bio is used for block dump

### DIFF
--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -446,7 +446,7 @@ vdev_submit_bio_impl(struct bio *bio)
 #ifdef HAVE_1ARG_SUBMIT_BIO
 	(void) submit_bio(bio);
 #else
-	(void) submit_bio(0, bio);
+	(void) submit_bio(bio_data_dir(bio), bio);
 #endif
 }
 


### PR DESCRIPTION
Because some kernel version of submit_bio use the first argument for block dump function. We could use the result of bio_data_dir instead of 0.

Signed-off-by: Finix Yan <yancw@info2soft.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When enable block dump by "echo 1 > /proc/sys/vm/block_dump"
I got "[47410.364655] z_wr_int(17446): READ block 1348575456 on nvme0n1p1 (8 sectors)"
But from iostat it shows this block device only has WRITE operation. 

I notice that submit_bio of kernel 3.10 use the first argument "rw" for statistic. 

void submit_bio(int rw, struct bio *bio)
{
.......
if (unlikely(block_dump)) {
    char b[BDEVNAME_SIZE];
    printk(KERN_DEBUG "%s(%d): %s block %Lu on %s (%u sectors)\n",
    current->comm, task_pid_nr(current),
    (rw & WRITE) ? "WRITE" : "READ",
    (unsigned long long)bio->bi_sector,
    bdevname(bio->bi_bdev, b),
    count);
    }
}

The output of block dump always reports READ instead of WRITE because rw is passed 0.

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
