### PR TITLE
Linux 5.17 compat: PDE_DATA() renamed to pde_data()

### DIFF
--- a/config/kernel-pde-data.m4
+++ b/config/kernel-pde-data.m4
@@ -1,20 +1,22 @@
 dnl #
-dnl # 3.10 API change,
-dnl # PDE is replaced by PDE_DATA
+dnl # 5.17 API: PDE_DATA() renamed to pde_data(),
+dnl # 359745d78351c6f5442435f81549f0207ece28aa ("proc: remove PDE_DATA() completely")
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_PDE_DATA], [
 	ZFS_LINUX_TEST_SRC([pde_data], [
 		#include <linux/proc_fs.h>
 	], [
-		PDE_DATA(NULL);
+		pde_data(NULL);
 	])
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_PDE_DATA], [
-	AC_MSG_CHECKING([whether PDE_DATA() is available])
-	ZFS_LINUX_TEST_RESULT_SYMBOL([pde_data], [PDE_DATA], [], [
+	AC_MSG_CHECKING([whether pde_data() is lowercase])
+	ZFS_LINUX_TEST_RESULT([pde_data], [
 		AC_MSG_RESULT(yes)
-	],[
-		ZFS_LINUX_TEST_ERROR([PDE_DATA])
+		AC_DEFINE(SPL_PDE_DATA, pde_data, [pde_data() is pde_data()])
+	], [
+		AC_MSG_RESULT(no)
+		AC_DEFINE(SPL_PDE_DATA, PDE_DATA, [pde_data() is PDE_DATA()])
 	])
 ])

--- a/module/os/linux/spl/spl-kstat.c
+++ b/module/os/linux/spl/spl-kstat.c
@@ -418,7 +418,7 @@ proc_kstat_open(struct inode *inode, struct file *filp)
 		return (rc);
 
 	f = filp->private_data;
-	f->private = PDE_DATA(inode);
+	f->private = SPL_PDE_DATA(inode);
 
 	return (0);
 }

--- a/module/os/linux/spl/spl-procfs-list.c
+++ b/module/os/linux/spl/spl-procfs-list.c
@@ -175,7 +175,7 @@ procfs_list_open(struct inode *inode, struct file *filp)
 
 	struct seq_file *f = filp->private_data;
 	procfs_list_cursor_t *cursor = f->private;
-	cursor->procfs_list = PDE_DATA(inode);
+	cursor->procfs_list = SPL_PDE_DATA(inode);
 	cursor->cached_node = NULL;
 	cursor->cached_pos = 0;
 


### PR DESCRIPTION
### Motivation and Context
#13004

### How Has This Been Tested?
Local build for pre-5.17, CI for 5.17.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
