### PR TITLE
libspl: cast to uintptr_t instead of !!ing

### DIFF
--- a/include/os/freebsd/spl/sys/debug.h
+++ b/include/os/freebsd/spl/sys/debug.h
@@ -133,14 +133,20 @@ void spl_dumpstack(void);
  */
 #ifdef NDEBUG
 
-#define	ASSERT(x)		((void) sizeof (!!(x)))
-#define	ASSERT3B(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT3S(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT3U(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT3P(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT0(x)		((void) sizeof (!!(x)))
-#define	IMPLY(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
-#define	EQUIV(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
+#define	ASSERT(x)		((void) sizeof ((uintptr_t)(x)))
+#define	ASSERT3B(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT3S(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT3U(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT3P(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT0(x)		((void) sizeof ((uintptr_t)(x)))
+#define	IMPLY(A, B)							\
+	((void) sizeof ((uintptr_t)(A)), (void) sizeof ((uintptr_t)(B)))
+#define	EQUIV(A, B)		\
+	((void) sizeof ((uintptr_t)(A)), (void) sizeof ((uintptr_t)(B)))
 
 /*
  * Debugging enabled (--enable-debug)

--- a/include/os/linux/spl/sys/debug.h
+++ b/include/os/linux/spl/sys/debug.h
@@ -133,14 +133,20 @@ void spl_dumpstack(void);
  */
 #ifdef NDEBUG
 
-#define	ASSERT(x)		((void) sizeof (!!(x)))
-#define	ASSERT3B(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT3S(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT3U(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT3P(x,y,z)		((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT0(x)		((void) sizeof (!!(x)))
-#define	IMPLY(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
-#define	EQUIV(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
+#define	ASSERT(x)		((void) sizeof ((uintptr_t)(x)))
+#define	ASSERT3B(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT3S(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT3U(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT3P(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT0(x)		((void) sizeof ((uintptr_t)(x)))
+#define	IMPLY(A, B)							\
+	((void) sizeof ((uintptr_t)(A)), (void) sizeof ((uintptr_t)(B)))
+#define	EQUIV(A, B)		\
+	((void) sizeof ((uintptr_t)(A)), (void) sizeof ((uintptr_t)(B)))
 
 /*
  * Debugging enabled (--enable-debug)

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -120,15 +120,21 @@ do {									\
 	__compile_time_assertion__ ## y[(x) ? 1 : -1]
 
 #ifdef NDEBUG
-#define	ASSERT3B(x, y, z)	((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT3S(x, y, z)	((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT3U(x, y, z)	((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT3P(x, y, z)	((void) sizeof (!!(x)), (void) sizeof (!!(z)))
-#define	ASSERT0(x)		((void) sizeof (!!(x)))
-#define	ASSERT(x)		((void) sizeof (!!(x)))
-#define	assert(x)		((void) sizeof (!!(x)))
-#define	IMPLY(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
-#define	EQUIV(A, B)		((void) sizeof (!!(A)), (void) sizeof (!!(B)))
+#define	ASSERT3B(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT3S(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT3U(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT3P(x, y, z)						\
+	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
+#define	ASSERT0(x)		((void) sizeof ((uintptr_t)(x)))
+#define	ASSERT(x)		((void) sizeof ((uintptr_t)(x)))
+#define	assert(x)		((void) sizeof ((uintptr_t)(x)))
+#define	IMPLY(A, B)							\
+	((void) sizeof ((uintptr_t)(A)), (void) sizeof ((uintptr_t)(B)))
+#define	EQUIV(A, B)							\
+	((void) sizeof ((uintptr_t)(A)), (void) sizeof ((uintptr_t)(B)))
 #else
 #define	ASSERT3B	VERIFY3B
 #define	ASSERT3S	VERIFY3S


### PR DESCRIPTION
### Motivation and Context
Extracted from #12993. 
https://github.com/openzfs/zfs/pull/12986#issuecomment-1020580466

### Description
See commit message.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
