### PR TITLE
Make better use of dracut functions when building initramfs

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -20,59 +20,30 @@ depends() {
 
 installkernel() {
 	instmods zfs
-	instmods zcommon
-	instmods znvpair
-	instmods zavl
-	instmods zunicode
-	instmods zlua
-	instmods icp
-	instmods spl
-	instmods zlib_deflate
-	instmods zlib_inflate
 }
 
 install() {
-	inst_rules @udevruledir@/90-zfs.rules
-	inst_rules @udevruledir@/69-vdev.rules
-	inst_rules @udevruledir@/60-zvol.rules
-	dracut_install hostid
-	dracut_install grep
-	dracut_install @sbindir@/zgenhostid
-	dracut_install @sbindir@/zfs
-	dracut_install @sbindir@/zpool
-	# Workaround for https://github.com/openzfs/zfs/issues/4749 by
-	# ensuring libgcc_s.so(.1) is included
-	if ldd @sbindir@/zpool | grep -qF 'libgcc_s.so'; then
-		# Dracut will have already tracked and included it
-		:;
-	elif command -v gcc-config >/dev/null 2>&1; then
-		# On systems with gcc-config (Gentoo, Funtoo, etc.):
-		# Use the current profile to resolve the appropriate path
-		s="$(gcc-config -c)"
-		dracut_install "/usr/lib/gcc/${s%-*}/${s##*-}/libgcc_s.so"*
-	elif [ "$(echo /usr/lib/libgcc_s.so*)" != "/usr/lib/libgcc_s.so*" ]; then
-		# Try a simple path first
-		dracut_install /usr/lib/libgcc_s.so*
-	elif [ "$(echo /lib*/libgcc_s.so*)" != "/lib*/libgcc_s.so*" ]; then
-		# SUSE
-		dracut_install /lib*/libgcc_s.so*
-	else
-		# Fallback: Guess the path and include all matches
-		dracut_install /usr/lib*/gcc/**/libgcc_s.so*
-	fi
-	# shellcheck disable=SC2050
-	if [ @LIBFETCH_DYNAMIC@ -gt 0 ]; then
-		for d in $libdirs; do
-			[ -e "$d/@LIBFETCH_SONAME@" ] && dracut_install "$d/@LIBFETCH_SONAME@"
-		done
-	fi
-	dracut_install @mounthelperdir@/mount.zfs
-	dracut_install @udevdir@/vdev_id
-	dracut_install awk
-	dracut_install cut
-	dracut_install tr
-	dracut_install head
-	dracut_install @udevdir@/zvol_id
+	inst_rules \
+		@udevruledir@/90-zfs.rules \
+		@udevruledir@/69-vdev.rules \
+		@udevruledir@/60-zvol.rules
+	
+	dracut_install \
+		@sbindir@/zgenhostid \
+		@sbindir@/zfs \
+		@sbindir@/zpool \
+		@udevdir@/vdev_id \
+		@udevdir@/zvol_id \
+		@mounthelperdir@/mount.zfs \
+		hostid \
+		grep \
+		awk \
+		tr \
+		cut \
+		head
+		
+	inst_libdir_file "libgcc_s.so*"
+	
 	inst_hook cmdline 95 "${moddir}/parse-zfs.sh"
 	if [ -n "$systemdutildir" ] ; then
 		inst_script "${moddir}/zfs-generator.sh" "$systemdutildir"/system-generators/dracut-zfs-generator
@@ -103,6 +74,9 @@ install() {
 	fi
 
 	if dracut_module_included "systemd"; then
+
+		dracut_install systemd-ask-password systemd-tty-ask-password-agent
+
 		mkdir -p "${initdir}/$systemdsystemunitdir/zfs-import.target.wants"
 		for _service in "zfs-import-scan.service" "zfs-import-cache.service" ; do
 			dracut_install "@systemdunitdir@/$_service"
@@ -115,9 +89,6 @@ install() {
 		inst "${moddir}"/zfs-env-bootfs.service "${systemdsystemunitdir}"/zfs-env-bootfs.service
 		ln -s ../zfs-env-bootfs.service "${initdir}/${systemdsystemunitdir}/zfs-import.target.wants"/zfs-env-bootfs.service
 		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/zfs-env-bootfs.service
-
-		dracut_install systemd-ask-password
-		dracut_install systemd-tty-ask-password-agent
 
 		mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
 		dracut_install @systemdunitdir@/zfs-import.target

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -23,20 +23,13 @@ installkernel() {
 }
 
 install() {
-	for i in "90-zfs.rules" "69-vdev.rules" "60-zvol.rules"; do
-		if ! dracut_install "@udevdir@/$i"; then
-			dfatal "Failed to install udev rule: $i"
-			exit 1
-		fi
-	done
+	inst_rules 90-zfs.rules 69-vdev.rules 60-zvol.rules
 	
 	inst_multiple \
-		@sbindir@/zgenhostid \
-		@sbindir@/zfs \
-		@sbindir@/zpool \
-		@udevdir@/vdev_id \
-		@udevdir@/zvol_id \
-		@mounthelperdir@/mount.zfs \
+		zgenhostid \
+		zfs \
+		zpool \
+		mount.zfs \
 		hostid \
 		grep \
 		awk \

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -19,16 +19,18 @@ depends() {
 }
 
 installkernel() {
-	instmods zfs
+	instmods -c zfs
 }
 
 install() {
-	inst_rules \
-		@udevruledir@/90-zfs.rules \
-		@udevruledir@/69-vdev.rules \
-		@udevruledir@/60-zvol.rules
+	for i in "90-zfs.rules" "69-vdev.rules" "60-zvol.rules"; do
+		if ! dracut_install "@udevdir@/$i"; then
+			dfatal "Failed to install udev rule: $i"
+			exit 1
+		fi
+	done
 	
-	dracut_install \
+	inst_multiple \
 		@sbindir@/zgenhostid \
 		@sbindir@/zfs \
 		@sbindir@/zpool \
@@ -40,10 +42,25 @@ install() {
 		awk \
 		tr \
 		cut \
-		head
-		
-	inst_libdir_file "libgcc_s.so*"
+		head ||
+		{ dfatal "Failed to install essential binaries"; exit 1; }
 	
+	# Lines 71-90 adapted from
+	# https://github.com/zbm-dev/zfsbootmenu/blob/9a03eab2b75647170bdc383903735a694ecd0ed6/dracut/module-setup.sh#L71
+	
+	if ! ldd "$( command -v zpool )" | grep -qF 'libgcc_s.so'; then
+		# On systems with gcc-config (Gentoo, Funtoo, etc.), use it to find libgcc_s
+		if command -v gcc-config >/dev/null 2>&1; then
+			dracut_install "/usr/lib/gcc/$(s=$(gcc-config -c); echo "${s%-*}/${s##*-}")/libgcc_s.so.1" ||
+				{ dfatal "Unable to install libgcc_s.so"; exit 1; }
+			# Otherwise, use dracut's library installation function to find the right one
+		elif ! inst_libdir_file "libgcc_s.so*"; then
+			# If all else fails, just try looking for some gcc arch directory
+			dracut_install /usr/lib/gcc/*/*/libgcc_s.so* ||
+				{ dfatal "Unable to install libgcc_s.so"; exit 1; }
+		fi
+	fi
+
 	inst_hook cmdline 95 "${moddir}/parse-zfs.sh"
 	if [ -n "$systemdutildir" ] ; then
 		inst_script "${moddir}/zfs-generator.sh" "$systemdutildir"/system-generators/dracut-zfs-generator
@@ -75,7 +92,10 @@ install() {
 
 	if dracut_module_included "systemd"; then
 
-		dracut_install systemd-ask-password systemd-tty-ask-password-agent
+		dracut_install \
+			systemd-ask-password \
+			systemd-tty-ask-password-agent ||
+			{ dfatal "Failed to install essential systemd binaries"; exit 1; }
 
 		mkdir -p "${initdir}/$systemdsystemunitdir/zfs-import.target.wants"
 		for _service in "zfs-import-scan.service" "zfs-import-cache.service" ; do

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -6,8 +6,8 @@ check() {
 	[ "${1}" = "-d" ] && return 0
 
 	# Verify the zfs tool chain
-	for tool in "@sbindir@/zgenhostid" "@sbindir@/zpool" "@sbindir@/zfs" "@mounthelperdir@/mount.zfs" ; do
-		test -x "$tool" || return 1
+	for tool in "zgenhostid" "zpool" "zfs" "mount.zfs"; do
+		command -v "${tool}" >/dev/null || return 1
 	done
 
 	return 0
@@ -38,90 +38,69 @@ install() {
 		head ||
 		{ dfatal "Failed to install essential binaries"; exit 1; }
 	
-	# Lines 71-90 adapted from
-	# https://github.com/zbm-dev/zfsbootmenu/blob/9a03eab2b75647170bdc383903735a694ecd0ed6/dracut/module-setup.sh#L71
+	# Adapted from https://github.com/zbm-dev/zfsbootmenu
 	
-	if ! ldd "$( command -v zpool )" | grep -qF 'libgcc_s.so'; then
+	if ! ldd "$(command -v zpool)" | grep -qF 'libgcc_s.so'; then
 		# On systems with gcc-config (Gentoo, Funtoo, etc.), use it to find libgcc_s
-		if command -v gcc-config >/dev/null 2>&1; then
-			dracut_install "/usr/lib/gcc/$(s=$(gcc-config -c); echo "${s%-*}/${s##*-}")/libgcc_s.so.1" ||
+		if command -v gcc-config >/dev/null; then
+			inst_simple "/usr/lib/gcc/$(s=$(gcc-config -c); echo "${s%-*}/${s##*-}")/libgcc_s.so.1" ||
 				{ dfatal "Unable to install libgcc_s.so"; exit 1; }
 			# Otherwise, use dracut's library installation function to find the right one
 		elif ! inst_libdir_file "libgcc_s.so*"; then
 			# If all else fails, just try looking for some gcc arch directory
-			dracut_install /usr/lib/gcc/*/*/libgcc_s.so* ||
+			inst_simple /usr/lib/gcc/*/*/libgcc_s.so* ||
 				{ dfatal "Unable to install libgcc_s.so"; exit 1; }
 		fi
 	fi
 
 	inst_hook cmdline 95 "${moddir}/parse-zfs.sh"
-	if [ -n "$systemdutildir" ] ; then
-		inst_script "${moddir}/zfs-generator.sh" "$systemdutildir"/system-generators/dracut-zfs-generator
+	if [ -n "${systemdutildir}" ]; then
+		inst_script "${moddir}/zfs-generator.sh" "${systemdutildir}/system-generators/dracut-zfs-generator"
 	fi
 	inst_hook pre-mount 90 "${moddir}/zfs-load-key.sh"
 	inst_hook mount 98 "${moddir}/mount-zfs.sh"
 	inst_hook cleanup 99 "${moddir}/zfs-needshutdown.sh"
 	inst_hook shutdown 20 "${moddir}/export-zfs.sh"
 
-	inst_simple "${moddir}/zfs-lib.sh" "/lib/dracut-zfs-lib.sh"
-	if [ -e @sysconfdir@/zfs/zpool.cache ]; then
-		inst @sysconfdir@/zfs/zpool.cache
-		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @sysconfdir@/zfs/zpool.cache
-	fi
+	inst_script "${moddir}/zfs-lib.sh" "/lib/dracut-zfs-lib.sh"
 
-	if [ -e @sysconfdir@/zfs/vdev_id.conf ]; then
-		inst @sysconfdir@/zfs/vdev_id.conf
-		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @sysconfdir@/zfs/vdev_id.conf
-	fi
+	# -H ensures they are marked host-only
+	# -o ensures there is no error upon absence of these files
+	inst_multiple -o -H \
+		"@sysconfdir@/zfs/zpool.cache" \
+		"@sysconfdir@/zfs/vdev_id.conf"
 
 	# Synchronize initramfs and system hostid
-	if [ -f @sysconfdir@/hostid ]; then
-		inst @sysconfdir@/hostid
-		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @sysconfdir@/hostid
-	elif HOSTID="$(hostid 2>/dev/null)" && [ "${HOSTID}" != "00000000" ]; then
-		zgenhostid -o "${initdir}@sysconfdir@/hostid" "${HOSTID}"
-		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @sysconfdir@/hostid
+	if ! inst_simple -H @sysconfdir@/hostid; then
+		if HOSTID="$(hostid 2>/dev/null)" && [ "${HOSTID}" != "00000000" ]; then
+			zgenhostid -o "${initdir}@sysconfdir@/hostid" "${HOSTID}"
+			mark_hostonly @sysconfdir@/hostid
+		fi
 	fi
 
 	if dracut_module_included "systemd"; then
 
-		dracut_install \
-			systemd-ask-password \
-			systemd-tty-ask-password-agent ||
-			{ dfatal "Failed to install essential systemd binaries"; exit 1; }
-
-		mkdir -p "${initdir}/$systemdsystemunitdir/zfs-import.target.wants"
-		for _service in "zfs-import-scan.service" "zfs-import-cache.service" ; do
-			dracut_install "@systemdunitdir@/$_service"
-			if ! [ -L "${initdir}/$systemdsystemunitdir/zfs-import.target.wants/$_service" ]; then
-				ln -sf "../$_service" "${initdir}/$systemdsystemunitdir/zfs-import.target.wants/$_service"
-				type mark_hostonly >/dev/null 2>&1 && mark_hostonly "@systemdunitdir@/$_service"
-			fi
+		inst_simple "${systemdsystemunitdir}/zfs-import.target"
+		systemctl -q --root "${initdir}" add-wants initrd.target zfs-import.target
+		
+		inst_simple "${moddir}/zfs-env-bootfs.service" "${systemdsystemunitdir}/zfs-env-bootfs.service"
+		systemctl -q --root "${initdir}" add-wants zfs-import.target zfs-env-bootfs.service
+		
+		for _service in \
+			"zfs-import-scan.service" \
+			"zfs-import-cache.service" \
+			"zfs-load-module.service"; do
+			inst_simple "${systemdsystemunitdir}/${_service}"
+			systemctl -q --root "${initdir}" add-wants zfs-import.target "${_service}"
+		done
+		
+		for _service in \
+			"zfs-snapshot-bootfs.service" \
+			"zfs-rollback-bootfs.service"; do
+			inst_simple "${moddir}/${_service}" "${systemdsystemunitdir}/${_service}"
+			systemctl -q --root "${initdir}" add-wants initrd.target "${_service}"
 		done
 
-		inst "${moddir}"/zfs-env-bootfs.service "${systemdsystemunitdir}"/zfs-env-bootfs.service
-		ln -s ../zfs-env-bootfs.service "${initdir}/${systemdsystemunitdir}/zfs-import.target.wants"/zfs-env-bootfs.service
-		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/zfs-env-bootfs.service
-
-		mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
-		dracut_install @systemdunitdir@/zfs-import.target
-		if ! [ -L "${initdir}/$systemdsystemunitdir/initrd.target.wants"/zfs-import.target ]; then
-			ln -s ../zfs-import.target "${initdir}/$systemdsystemunitdir/initrd.target.wants"/zfs-import.target
-			type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/zfs-import.target
-		fi
-
-		for _service in zfs-snapshot-bootfs.service zfs-rollback-bootfs.service ; do
-			inst "${moddir}/$_service" "${systemdsystemunitdir}/$_service"
-			if ! [ -L "${initdir}/$systemdsystemunitdir/initrd.target.wants/$_service" ]; then
-				ln -s "../$_service" "${initdir}/$systemdsystemunitdir/initrd.target.wants/$_service"
-			fi
-		done
-
-		# There isn't a pkg-config variable for this,
-		# and dracut doesn't automatically resolve anything this'd be next to
-		local systemdsystemenvironmentgeneratordir
-		systemdsystemenvironmentgeneratordir="$(pkg-config --variable=prefix systemd || echo "/usr")/lib/systemd/system-environment-generators"
-		mkdir -p "${initdir}/${systemdsystemenvironmentgeneratordir}"
-		inst "${moddir}"/import-opts-generator.sh "${systemdsystemenvironmentgeneratordir}"/zfs-import-opts.sh
+		inst_simple "${moddir}/import-opts-generator.sh" "${systemdutildir}/system-environment-generators/zfs-import-opts.sh"
 	fi
 }


### PR DESCRIPTION
Setting up the module involves multiple redundant calls to a bunch of
dracut functions wheich can be combined into one. Additionally, the mass
of code required to load libgcc_s.so* can be replaced with one dracut
function. This has the additional effect of removing the error:

```
dracut-install: ERROR: installing '/usr/lib/gcc/*/*/libgcc_s.so*'
dracut: FAILED: /usr/lib/dracut/dracut-install -D /var/tmp/dracut.ELz0Yb/initramfs -a /usr/lib/gcc/*/*/libgcc_s.so*
```

Which is seen on debian bullseye when using version 2.1.2-1~bpo11+1 from
the backports repository.

Signed-off-by: Savyasachee Jha <hi@savyasacheejha.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
I made this change because I kept getting the error (mostly cosmetic, but annoying):

```
dracut-install: ERROR: installing '/usr/lib/gcc/*/*/libgcc_s.so*'
dracut: FAILED: /usr/lib/dracut/dracut-install -D /var/tmp/dracut.ELz0Yb/initramfs -a /usr/lib/gcc/*/*/libgcc_s.so*
```

whenever I could build a new initramfs on debian bullseye using `dracut`. This caused no issues in booting but seeing that error message all the time was jarring.

### Description
The `module-setup.sh.in` file defines how zfs modules are setup in the initramfs and pulls in all the required dependencies. The script (in master) calls the `instmods`, `inst_rules` and `dracut_install` functions once for each module, rule and binary which are to be added to the initramfs respectively. Since each function is capable of installing multiple files, I have reduced the number of function calls to just one each.

In addition, there is a long if-else statement to find `libgcc_s.so*` on the filesystem and install it into the initramfs. Dracut has a function `inst_libdir_file` which does this quite well, so I replaced the if-else statements with one call to `inst_libdir_file`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

I have tested this on Debian stable, Fedora 35, and Arch Linux using zfs 2.1.2 by building the initramfs using this change and booting into the system. No changes were observed in terms of booting - the systems booted perfectly well with no errors. The upside was that the cosmetic error seen in Debian described above went away.

This change should not affect any other areas of code.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Since this does not touch the core zfs files, I did not run the test suite or add any tests. I also do not believe this change requires any addition to the documentation.