### PR TITLE
spl: Don't check FreeBSD rwlocks for double initialization

### DIFF
--- a/include/os/freebsd/spl/sys/rwlock.h
+++ b/include/os/freebsd/spl/sys/rwlock.h
@@ -48,9 +48,9 @@ typedef enum {
 typedef	struct sx	krwlock_t;
 
 #ifndef OPENSOLARIS_WITNESS
-#define	RW_FLAGS	(SX_DUPOK | SX_NOWITNESS)
+#define	RW_FLAGS	(SX_DUPOK | SX_NEW | SX_NOWITNESS)
 #else
-#define	RW_FLAGS	(SX_DUPOK)
+#define	RW_FLAGS	(SX_DUPOK | SX_NEW)
 #endif
 
 #define	RW_READ_HELD(x)		(rw_read_held((x)))
@@ -60,9 +60,6 @@ typedef	struct sx	krwlock_t;
 #define	rw_init(lock, desc, type, arg)	do {				\
 	const char *_name;						\
 	ASSERT((type) == 0 || (type) == RW_DEFAULT);			\
-	KASSERT(((lock)->lock_object.lo_flags & LO_ALLMASK) !=		\
-	    LO_EXPECTED, ("lock %s already initialized", #lock));	\
-	bzero((lock), sizeof (struct sx));				\
 	for (_name = #lock; *_name != '\0'; _name++) {			\
 		if (*_name >= 'a' && *_name <= 'z')			\
 			break;						\


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The change removes some invariants-checking in rwlock initialization on FreeBSD. This makes it consistent with mutex initialization, while fixing a false-positive report from KMSAN (a sanitizer which catches uses of uninitialized memory).

### Motivation and Context
The change addresses a false-positive KMSAN report seen in our CI:

```
panic: MSan: Uninitialized UMA memory from cache_alloc_retry+0x498
cpuid = 1
time = 1643213424
KDB: stack backtrace:
db_trace_self_wrapper() at db_trace_self_wrapper+0x96/frame 0xfffffe0063df47f0
vpanic() at vpanic+0x5a5/frame 0xfffffe0063df4890
panic() at panic+0x1b3/frame 0xfffffe0063df49a0
__msan_warning() at __msan_warning+0x255/frame 0xfffffe0063df4af0
dnode_cons() at dnode_cons+0x914/frame 0xfffffe0063df4b40
kmem_std_constructor() at kmem_std_constructor+0xc2/frame 0xfffffe0063df4ba0
item_ctor() at item_ctor+0x99d/frame 0xfffffe0063df4c90
cache_alloc_retry() at cache_alloc_retry+0x498/frame 0xfffffe0063df4d50
uma_zalloc_arg() at uma_zalloc_arg+0x76a/frame 0xfffffe0063df4e10
kmem_cache_alloc() at kmem_cache_alloc+0x93/frame 0xfffffe0063df4e60
dnode_create() at dnode_create+0xda/frame 0xfffffe0063df4f20
dnode_special_open() at dnode_special_open+0x133/frame 0xfffffe0063df4fb0
dmu_objset_open_impl() at dmu_objset_open_impl+0x2321/frame 0xfffffe0063df50e0
dmu_objset_create_impl_dnstats() at dmu_objset_create_impl_dnstats+0x358/frame 0xfffffe0063df51e0
dmu_objset_create_impl() at dmu_objset_create_impl+0x71/frame 0xfffffe0063df5230
dsl_pool_create() at dsl_pool_create+0x1cc/frame 0xfffffe0063df5320
spa_create() at spa_create+0x2422/frame 0xfffffe0063df5470
zfs_ioc_pool_create() at zfs_ioc_pool_create+0x4c7/frame 0xfffffe0063df5570
zfsdev_ioctl_common() at zfsdev_ioctl_common+0x2427/frame 0xfffffe0063df56e0
zfsdev_ioctl() at zfsdev_ioctl+0x610/frame 0xfffffe0063df5770
devfs_ioctl() at devfs_ioctl+0x43f/frame 0xfffffe0063df5850
VOP_IOCTL_APV() at VOP_IOCTL_APV+0x117/frame 0xfffffe0063df58d0
vn_ioctl() at vn_ioctl+0x988/frame 0xfffffe0063df5a70
devfs_ioctl_f() at devfs_ioctl_f+0x186/frame 0xfffffe0063df5b30
kern_ioctl() at kern_ioctl+0xe03/frame 0xfffffe0063df5c20
sys_ioctl() at sys_ioctl+0x9ae/frame 0xfffffe0063df5d60
amd64_syscall() at amd64_syscall+0x20eb/frame 0xfffffe0063df5f30
fast_syscall_common() at fast_syscall_common+0xf8/frame 0xfffffe0063df5f30
--- syscall (54, FreeBSD ELF64, sys_ioctl), rip = 0x194d5f3690a, rsp = 0x194ce9d25a8, rbp = 0x194ce9d2610 ---
```

### Description
FreeBSD will by default try to check for double-initialization of locks, in lock_init(). The SPL duplicates this checking for rwlocks and then zeroes the lock structure since FreeBSD's slab allocator's memory trashing triggers false positives from the check in lock_init(); this problem is due to some behaviour in SPL's kmem_cache implementation that is described in the commit log message.

For SPL mutexes this checking is simply not done, nor is it particularly useful in general. Let's disable the checking for rwlocks too. This should have no effect on non-debug builds.

### How Has This Been Tested?
Booted a ZFS-based FreeBSD system with this change, ran some simple manual tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
