### PR TITLE
RPM: Split out pam_zfs_key into separate package

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -62,6 +62,7 @@ deb-utils: deb-local rpm-utils-initramfs
 	pkg8=$${name}-dracut-$${version}.noarch.rpm; \
 	pkg9=$${name}-initramfs-$${version}.$${arch}.rpm; \
 	pkg10=`ls python*-pyzfs-$${version}* | tail -1`; \
+	pkg11=pam_zfs_key-$${version}.$${arch}.rpm; \
 ## Arguments need to be passed to dh_shlibdeps. Alien provides no mechanism
 ## to do this, so we install a shim onto the path which calls the real
 ## dh_shlibdeps with the required arguments.
@@ -77,10 +78,10 @@ deb-utils: deb-local rpm-utils-initramfs
 	env PATH=$${path_prepend}:$${PATH} \
 	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch \
 	    $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \
-	    $$pkg8 $$pkg9 $$pkg10 || exit 1; \
+	    $$pkg8 $$pkg9 $$pkg10 $$pkg11 || exit 1; \
 	$(RM) $${path_prepend}/dh_shlibdeps; \
 	rmdir $${path_prepend}; \
 	$(RM) $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \
-	    $$pkg8 $$pkg9 $$pkg10;
+	    $$pkg8 $$pkg9 $$pkg10 $$pkg11;
 
 deb: deb-kmod deb-dkms deb-utils

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -118,10 +118,6 @@ BuildRequires:  ncompress
 BuildRequires:  libtirpc-devel
 %endif
 
-%if %{with pam}
-BuildRequires:  pam-devel
-%endif
-
 Requires:       openssl
 %if 0%{?_systemd}
 BuildRequires: systemd
@@ -326,6 +322,19 @@ This package contains a initramfs module used to construct an initramfs
 image which is ZFS aware.
 %endif
 
+%if %{with pam}
+%package -n pam_zfs_key
+Summary:        PAM module for encrypted ZFS datasets
+
+%if 0%{?rhel}%{?centos}%{?fedora}%{?suse_version}
+BuildRequires:  pam-devel
+%endif
+
+%description -n pam_zfs_key
+This package contains the pam_zfs_key PAM module, which provides
+support for unlocking datasets on user login.
+%endif
+
 %prep
 %if %{with debug}
     %define debug --enable-debug
@@ -508,10 +517,6 @@ systemctl --system daemon-reload >/dev/null || true
 %config(noreplace) %{_sysconfdir}/%{name}/zpool.d/*
 %config(noreplace) %{_sysconfdir}/%{name}/vdev_id.conf.*.example
 %attr(440, root, root) %config(noreplace) %{_sysconfdir}/sudoers.d/*
-%if %{with pam}
-%{_libdir}/security/*
-%{_datadir}/pam-configs/*
-%endif
 
 %files -n libzpool5
 %{_libdir}/libzpool.so.*
@@ -560,4 +565,10 @@ systemctl --system daemon-reload >/dev/null || true
 # Since we're not building the initramfs package,
 # ignore those files.
 %exclude /usr/share/initramfs-tools
+%endif
+
+%if %{with pam}
+%files -n pam_zfs_key
+%{_libdir}/security/*
+%{_datadir}/pam-configs/*
 %endif


### PR DESCRIPTION
### Motivation and Context
The RPM packages provided at `http://download.zfsonlinux.org/fedora/$releasever/$basearch/` do not include the `pam_zfs_key` PAM module.  To get this feature, the `zfs` source RPM may be rebuilt `--with pam`; however, this approach requires rebuilding the `zfs` RPM for every minor version update.

The PAM module is stable and does not need to be rebuilt for every version of ZFS.  By splitting it out into a separate RPM, it can be built and installed much less frequently on a system that receives regular ZFS updates from the official channels.

### Description
Create a separate `pam_zfs_key` package for the PAM module components, an optional addition to the deliverables, in much the same way as the Python bindings are released as a separate `python#-pyzfs` package.

The module's name follows Fedora precedent for RPM packages providing PAM modules.

### How Has This Been Tested?
Test Environment: Fedora 34 Server on VM

Steps:
1. Installed `zfs` RPM from upstream Yum repository
2. Downloaded `zfs` source RPM from upstream Yum repository, apply patch, and build new RPM (`--with pam`)
3. Installed `pam_zfs_key` RPM package
4. Configured system to use pam_zfs_key.so PAM module
5. Rebooted and logged in
6. Verified pam_zfs_key.so PAM module performed as expected

Further steps checking for regression of #13001:
1. Uninstalled `pam-devel` RPM
2. Built patched RPM without `--with pam`
3. Verified no `pam_zfs_key` RPM was created
4. Built patched RPM `--with pam`
5. Verified RPM build failure from missing dependency

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
