### PR TITLE
tests: explicitly strip whitespace for broken wc(1) implementations

### DIFF
--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_012_pos.ksh
@@ -34,6 +34,7 @@ function file_in_special_vdev # <dataset> <inode>
 	typeset dataset="$1"
 	typeset inum="$2"
 	typeset num_normal=$(echo $ZPOOL_DISKS | wc -w)
+	num_normal=${num_normal##* }
 
 	zdb -dddddd $dataset $inum | awk -v d=$num_normal '{
 # find DVAs from string "offset level dva" only for L0 (data) blocks

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_clear.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_clear.ksh
@@ -44,6 +44,7 @@ done
 # wait a bit to allow the kernel module to process new events
 zpool_events_settle
 EVENTS_NUM=$(zpool events -H | wc -l)
+EVENTS_NUM=${EVENTS_NUM##* }
 
 # 3. Verify 'zpool events -c' successfully clear new events
 CLEAR_OUTPUT=$(zpool events -c)

--- a/tests/zfs-tests/tests/functional/mv_files/mv_files_common.kshlib
+++ b/tests/zfs-tests/tests/functional/mv_files/mv_files_common.kshlib
@@ -115,7 +115,7 @@ function mv_files
 function count_files
 {
         typeset -i file_num
-        file_num=$(find $1 -type f -print | wc -l)
+        file_num=$(find $1 -type f -print | wc -l | tr -d ' ')
         (( file_num != $2 )) && \
                 log_fail "The file number of target directory"\
                         "$2 is not equal to that of the source "\


### PR DESCRIPTION
### Motivation and Context
https://github.com/openzfs/zfs/pull/12979#issuecomment-1024513829

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
