### PR TITLE
Fix building with clang and lld

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -601,9 +601,15 @@ dnl #
 dnl # Used internally by ZFS_LINUX_TEST_{COMPILE,MODPOST}
 dnl #
 AC_DEFUN([ZFS_LINUX_COMPILE], [
+	AC_ARG_VAR([KERNEL_CC], [C compiler for
+		building kernel modules])
+	AC_ARG_VAR([KERNEL_LD], [Linker for
+		building kernel modules])
+	AC_ARG_VAR([KERNEL_LLVM], [Binary option to
+		build kernel modules with LLVM/CLANG toolchain])
 	AC_TRY_COMMAND([
 	    KBUILD_MODPOST_NOFINAL="$5" KBUILD_MODPOST_WARN="$6"
-	    make modules -k -j$TEST_JOBS -C $LINUX_OBJ $ARCH_UM
+	    make modules -k -j$TEST_JOBS ${KERNEL_CC:+CC=$KERNEL_CC} ${KERNEL_LD:+LD=$KERNEL_LD} ${KERNEL_LLVM:+LLVM=$KERNEL_LLVM} -C $LINUX_OBJ $ARCH_UM
 	    M=$PWD/$1 >$1/build.log 2>&1])
 	AS_IF([AC_TRY_COMMAND([$2])], [$3], [$4])
 ])

--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -371,6 +371,9 @@ AC_DEFUN([ZFS_AC_RPM], [
 		RPM_DEFINE_KMOD=${RPM_DEFINE_KMOD}' --define "kernels $(LINUX_VERSION)"'
 		RPM_DEFINE_KMOD=${RPM_DEFINE_KMOD}' --define "ksrc $(LINUX)"'
 		RPM_DEFINE_KMOD=${RPM_DEFINE_KMOD}' --define "kobj $(LINUX_OBJ)"'
+		RPM_DEFINE_KMOD=${RPM_DEFINE_KMOD}' --define "kernel_cc KERNEL_CC=$(KERNEL_CC)"'
+		RPM_DEFINE_KMOD=${RPM_DEFINE_KMOD}' --define "kernel_ld KERNEL_LD=$(KERNEL_LD)"'
+		RPM_DEFINE_KMOD=${RPM_DEFINE_KMOD}' --define "kernel_llvm KERNEL_LLVM=$(KERNEL_LLVM)"'
 	])
 
 	RPM_DEFINE_DKMS=''

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -52,7 +52,9 @@ FMAKE = env -u MAKEFLAGS make $(FMAKEFLAGS)
 
 modules-Linux:
 	list='$(SUBDIR_TARGETS)'; for td in $$list; do $(MAKE) -C $$td; done
-	$(MAKE) -C @LINUX_OBJ@ M="$$PWD" @KERNEL_MAKE@ CONFIG_ZFS=m modules
+	$(MAKE) -C @LINUX_OBJ@ $(if @KERNEL_CC@,CC=@KERNEL_CC@) \
+		$(if @KERNEL_LD@,LD=@KERNEL_LD@) $(if @KERNEL_LLVM@,LLVM=@KERNEL_LLVM@) \
+		M="$$PWD" @KERNEL_MAKE@ CONFIG_ZFS=m modules
 
 modules-FreeBSD:
 	+$(FMAKE)

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -140,7 +140,10 @@ for kernel_version in %{?kernel_versions}; do
         --with-linux=%{ksrc} \
         --with-linux-obj=%{kobj} \
         %{debug} \
-        %{debuginfo}
+        %{debuginfo} \
+        %{?kernel_cc} \
+        %{?kernel_ld} \
+        %{?kernel_llvm}
     make %{?_smp_mflags}
     cd ..
 done

--- a/rpm/redhat/zfs-kmod.spec.in
+++ b/rpm/redhat/zfs-kmod.spec.in
@@ -69,7 +69,10 @@ fi
         --with-linux=%{ksrc} \
         --with-linux-obj=%{kobj} \
         %{debug} \
-        %{debuginfo}
+        %{debuginfo} \
+        %{?kernel_cc} \
+        %{?kernel_ld} \
+        %{?kernel_llvm}
 make %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Explicitly pass CC and LD when building modules to prevent kbuild from defaulting to gcc and ld.bfd.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[Fixes 10107](https://github.com/openzfs/zfs/issues/10107)
### Description
<!--- Describe your changes in detail -->
When building `sys-fs/zfs-kmod-9999` on Gentoo Linux, configure fails with:
```
configure: error: 
        *** Unable to build an empty module.
```
config.log shows:
```
configure:16388: clang -c -march=native -O2 -pipe -Werror -Wbool-compare  conftest.c >&5
error: unknown warning option '-Wbool-compare' [-Werror,-Wunknown-warning-option]
```
build/conftest/build.log shows:
```
make: Entering directory '/usr/src/linux-5.16.3-gentoo'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: clang version 13.0.0
  You are using:           x86_64-pc-linux-gnu-gcc (Gentoo Hardened 11.2.1_p20220115 p4) 11.2.1 20220115
  CC [M]  /var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/build/conftest/conftest.o
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-Qunused-arguments’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-mretpoline-external-thunk’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-mno-global-merge’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-ftrivial-auto-var-init=zero’
make[1]: *** [scripts/Makefile.build:287: /var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/build/conftest/conftest.o] Error 1
make[1]: Target '__build' not remade because of errors.
make: *** [Makefile:1846: /var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/build/conftest] Error 2
make: Target 'modules' not remade because of errors.
make: Leaving directory '/usr/src/linux-5.16.3-gentoo'
```
The offending code is from config/kernel.m4:
```
dnl #
dnl # ZFS_LINUX_COMPILE
dnl #
dnl # $1 - build dir
dnl # $2 - test command
dnl # $3 - pass command
dnl # $4 - fail command
dnl # $5 - set KBUILD_MODPOST_NOFINAL='yes'
dnl # $6 - set KBUILD_MODPOST_WARN='yes'
dnl #
dnl # Used internally by ZFS_LINUX_TEST_{COMPILE,MODPOST}
dnl #
AC_DEFUN([ZFS_LINUX_COMPILE], [
	AC_TRY_COMMAND([
	    KBUILD_MODPOST_NOFINAL="$5" KBUILD_MODPOST_WARN="$6"
	    make modules -k -j$TEST_JOBS -C $LINUX_OBJ $ARCH_UM
	    M=$PWD/$1 >$1/build.log 2>&1])
	AS_IF([AC_TRY_COMMAND([$2])], [$3], [$4])
])
```
kbuild doesn't parse CC, LD, et al., from the environment but expects the to be explicitly passed to `make`.

Similarly, the build fails to compile, with 
```
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-Qunused-arguments’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-Qunused-arguments’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-Qunused-arguments’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-mretpoline-external-thunk’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-mretpoline-external-thunk’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-mretpoline-external-thunk’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-mno-global-merge’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-mno-global-merge’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-mno-global-merge’
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-ftrivial-auto-var-init=zero’
make[5]: *** [scripts/Makefile.build:287: /var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/module/avl/avl.o] Error 1
make[4]: *** [scripts/Makefile.build:549: /var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/module/avl] Error 2
make[4]: *** Waiting for unfinished jobs....
x86_64-pc-linux-gnu-gcc: error: unrecognized command-line option ‘-ftrivial-auto-var-init=zero’
make[5]: *** [scripts/Makefile.build:287: /var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/module/spl/../os/linux/spl/spl-atomic.o] Error 1
make[4]: *** [scripts/Makefile.build:549: /var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/module/spl] Error 2
```
The offending code is from module/Makefile.in:
```
modules-Linux:
	list='$(SUBDIR_TARGETS)'; for td in $$list; do $(MAKE) -C $$td; done
	$(MAKE) -C @LINUX_OBJ@ M="$$PWD" @KERNEL_MAKE@ CONFIG_ZFS=m modules
```

Again, this is resolved by explicitly passing `CC` and `LD`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Tested using `/etc/portage/patches/sys-fs/zfs-kmod-9999/zfs-kmod-9999-clang.patch`:

```
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -604,7 +604,7 @@
 	AC_TRY_COMMAND([
 	    KBUILD_MODPOST_NOFINAL="$5" KBUILD_MODPOST_WARN="$6"
 	    make modules -k -j$TEST_JOBS -C $LINUX_OBJ $ARCH_UM
-	    M=$PWD/$1 >$1/build.log 2>&1])
+	    CC="$CC" LD="$LD" M=$PWD/$1 >$1/build.log 2>&1])
 	AS_IF([AC_TRY_COMMAND([$2])], [$3], [$4])
 ])
```
and `/etc/portage/patches/sys-fs/zfs-kmod-9999/zfs-kmod-9999-clang2.patch`:
```
--- zfs-kmod-9999/module/Makefile.in.old	2022-01-30 01:51:53.977190277 -0500
+++ zfs-kmod-9999/module/Makefile.in	2022-01-30 02:19:35.827239919 -0500
@@ -52,7 +52,7 @@
 
 modules-Linux:
 	list='$(SUBDIR_TARGETS)'; for td in $$list; do $(MAKE) -C $$td; done
-	$(MAKE) -C @LINUX_OBJ@ M="$$PWD" @KERNEL_MAKE@ CONFIG_ZFS=m modules
+	$(MAKE) -C @LINUX_OBJ@ CC="$(CC)" LD="$(LD)" M="$$PWD" @KERNEL_MAKE@ CONFIG_ZFS=m modules
 
 modules-FreeBSD:
 	+$(FMAKE)
```

then `ebuild /var/db/repos/local/sys-fs/zfs-kmod/zfs-kmod-9999.ebuild merge`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
