### PR TITLE
PAM: Add fault tolerance to loading keys and mounting datasets

### DIFF
--- a/contrib/pam_zfs_key/pam_zfs_key.c
+++ b/contrib/pam_zfs_key/pam_zfs_key.c
@@ -389,7 +389,7 @@ decrypt_mount(pam_handle_t *pamh, const char *ds_name,
 	int ret = lzc_load_key(ds_name, B_FALSE, (uint8_t *)key->value,
 	    WRAPPING_KEY_LEN);
 	pw_free(key);
-	if (ret) {
+	if (ret && ret != EEXIST) {
 		pam_syslog(pamh, LOG_ERR, "load_key failed: %d", ret);
 		zfs_close(ds);
 		return (-1);


### PR DESCRIPTION
### Motivation and Context
Several PAM services can fail to provide the appropriate authtok to pam_zfs_key.so for unlocking and mounting a dataset, e.g. `sshd` and `sudo`.  When logging in with an authorized SSH key, the default action is to not prompt for a subsequent password, leaving pam_zfs_key.so with a failed PAM conversation.  With the `sudo -iu <user>` command in its default configuration, the requested password is for the invoking user, not the password of the user being switched to; this means the password to unlock the dataset will not be presented (notably, however, if the invoking user's credentials are cached for `sudo`, then `sudo` actually prompts for the dataset password with a prompt of `[sudo] password for %p: ` -- the `%p` is literal).

Regardless of how, failing to unlock and mount the dataset on the *first* session means that the dataset will remain locked until *every* session is closed and the user starts again from a new "first" session with the appropriate token.  In concert with systemd/systemd#8598 (see #13025), a user (or an admin acting as the user) can accidentally prevent a dataset from unlocking until the machine reboots (or a system administrator removes the right file).

### Description
Instead of attempting to unlock and mount at the start of only the first session, check if the dataset is already unlocked or mounted on every session start and, if not, attempt the necessary actions to unlock or mount it.  This provides fault-tolerance and allows SSH key users to unlock their home directory with `su -c true - $USER` after a successful key-based login.

**Note:** This change comes with performance considerations: checking whether the dataset is already mounted requires iterating through /proc/self/mounts, making the check Ο(_n_) for _n_ mounts.  The prior implementation checked a count value within a file, for far less runtime variability.

Additionally, the PR addresses a related edge case where a dataset's key is already loaded, but the filesystem is not yet mounted.  If pam_zfs_key.so fails to load a key because one already exists, try mounting the filesystem instead of dying with an error because a key - one that didn't need to be loaded - couldn't be loaded.

### How Has This Been Tested?
Test Environment: Fedora 34 Server on VM

1. Setup system with an encrypted dataset for one user; setup pam_zfs_key
2. Log in via SSH key without getting password; verified "Conversation error" in syslog and `keystatus` is `unavailable`
3. Start sub-shell with `su - $USER`; verified `keystatus` is `available`
4. Log in second time via SSH key without getting password; verified `keystatus` is `available`
5. Start second sub-shell from second SSH session with `su - $USER`; verified `keystatus` is `available` and no errors in syslog for this login
6. Exit second sub-shell; verified `keystatus` is `available`
7. Exit second SSH login; verified `keystatus` is `available`
8. Exit first sub-shell; verified `keystatus` is `available`
9. Exit first SSH shell; verified `keystatus` is `unavailable` (from a separate user)
10. Login via SSH key without getting password; verified `keystatus` is `unavailable`
11. Load key via `zfs load-key`; verified `keystatus` is `available` and filesystem is **not** mounted
12. Start sub-shell with `su - $USER`; verified filesystem is mounted

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
