### PR TITLE
Fix trivial calloc(3) arguments order

### DIFF
--- a/cmd/zpool_influxdb/zpool_influxdb.c
+++ b/cmd/zpool_influxdb/zpool_influxdb.c
@@ -818,7 +818,7 @@ main(int argc, char *argv[])
 			break;
 		case 't':
 			tagslen = strlen(optarg) + 2;
-			tags = calloc(tagslen, 1);
+			tags = calloc(1, tagslen);
 			if (tags == NULL) {
 				fprintf(stderr,
 				    "error: cannot allocate memory "

--- a/tests/zfs-tests/cmd/draid/draid.c
+++ b/tests/zfs-tests/cmd/draid/draid.c
@@ -181,7 +181,7 @@ write_map(const char *filename, nvlist_t *allcfgs)
 	 * no locking, it only guarantees the packed nvlist on disk
 	 * is updated atomically and is internally consistent.
 	 */
-	char *tmpname = calloc(MAXPATHLEN, 1);
+	char *tmpname = calloc(1, MAXPATHLEN);
 	if (tmpname == NULL) {
 		free(buf);
 		return (ENOMEM);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Just a trivial fix.

### Description
<!--- Describe your changes in detail -->

calloc(3) takes nmemb first.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
