### PR TITLE
dsl_dir_tempreserve_impl: remove unused `deferred` variable

### DIFF
--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1322,7 +1322,6 @@ top_of_function:
 	 * we're very close to full, this will allow a steady trickle of
 	 * removes to get through.
 	 */
-	uint64_t deferred = 0;
 	if (dd->dd_parent == NULL) {
 		uint64_t avail = dsl_pool_unreserved_space(dd->dd_pool,
 		    (netfree) ?
@@ -1342,7 +1341,7 @@ top_of_function:
 	 */
 	if (used_on_disk + est_inflight >= quota) {
 		if (est_inflight > 0 || used_on_disk < quota ||
-		    (retval == ENOSPC && used_on_disk < quota + deferred))
+		    (retval == ENOSPC && used_on_disk < quota))
 			retval = ERESTART;
 		dprintf_dd(dd, "failing: used=%lluK inflight = %lluK "
 		    "quota=%lluK tr=%lluK err=%d\n",


### PR DESCRIPTION
The following commit moved the users of `unused` into functino
dsl_pool_unreserved_space:

    commit d2734cce68cf740e015312314415f9034c67851c
    Author: Serapheim Dimitropoulos <serapheim.dimitro@delphix.com>
    Date:   Fri Dec 16 14:11:29 2016 -0800

        OpenZFS 9166 - zfs storage pool checkpoint

Signed-off-by: Christian Schwarz <christian.schwarz@nutanix.com>
