### PR TITLE
Disable --enable-asan and --enable-ubsan in CI

### DIFF
--- a/.github/workflows/zfs-tests-functional.yml
+++ b/.github/workflows/zfs-tests-functional.yml
@@ -32,7 +32,7 @@ jobs:
         sh autogen.sh
     - name: Configure
       run: |
-        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan
+        ./configure --enable-debug --enable-debuginfo
     - name: Make
       run: |
         make --no-print-directory -s pkg-utils pkg-kmod

--- a/.github/workflows/zfs-tests-sanity.yml
+++ b/.github/workflows/zfs-tests-sanity.yml
@@ -28,7 +28,7 @@ jobs:
         sh autogen.sh
     - name: Configure
       run: |
-        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan
+        ./configure --enable-debug --enable-debuginfo
     - name: Make
       run: |
         make --no-print-directory -s pkg-utils pkg-kmod

--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -28,7 +28,7 @@ jobs:
         sh autogen.sh
     - name: Configure
       run: |
-        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan
+        ./configure --enable-debug --enable-debuginfo
     - name: Make
       run: |
         make --no-print-directory -s pkg-utils pkg-kmod


### PR DESCRIPTION
### Motivation and Context

After this change the GitHub actions CI builders have detected
leaks in some of the ZTS support utilities and test cases.  This results
in these CI builds always failing.  Disable the use of these checks
for now to keep the CI happy.

https://github.com/openzfs/zfs/actions/runs/1794167045

@szubersk thanks for working on these changes, but it looks like
we're going to need to briefly disable them.  I'm not sure how we
missed this in the original PR CI runs.  Would you mind taking a
look in to this.

### Description

For the moment disable the use of `--enable-asan` and `--enable-ubsan`
in the GitHub actions CI workflows.  This functionality can be
re-enabled after the detected issues have been resolved.

### How Has This Been Tested?

Pending verification from the CI that disabling these new checks
resolves the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
