### PR TITLE
zpool-import.8: newpool is Ar, not Sy

### DIFF
--- a/man/man8/zpool-import.8
+++ b/man/man8/zpool-import.8
@@ -386,7 +386,8 @@ For more details
 about pool recovery mode, see the
 .Fl X
 option, above.
-WARNING: This option can be extremely hazardous to the
+.Em WARNING :
+This option can be extremely hazardous to the
 health of your pool and should only be used as a last resort.
 .It Fl t
 Used with

--- a/man/man8/zpool-import.8
+++ b/man/man8/zpool-import.8
@@ -390,9 +390,9 @@ WARNING: This option can be extremely hazardous to the
 health of your pool and should only be used as a last resort.
 .It Fl t
 Used with
-.Sy newpool .
+.Ar newpool .
 Specifies that
-.Sy newpool
+.Ar newpool
 is temporary.
 Temporary pool names last until export.
 Ensures that the original pool name will be used


### PR DESCRIPTION
### Motivation and Context
Broken since original wording in 26b42f3f9d03f85cc7966dc2fe4dfe9216601b0e:
```
Used with "\fBnewpool\fR". Specifies that "\fBnewpool\fR" is temporary. Temporary pool names last until export. Ensures that the original pool name will be used in all label updates and therefore is retained upon export.
```
Didn't see it when doing the big conversion, since it was already mdoc.

### Description
See commit messages.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
