### PR TITLE
Ask libtool to stop hiding some errors

### DIFF
--- a/lib/libavl/Makefile.am
+++ b/lib/libavl/Makefile.am
@@ -5,6 +5,8 @@ VPATH = $(top_srcdir)/module/avl/
 # Includes kernel code, generate warnings for large stack frames
 AM_CFLAGS += $(FRAME_LARGER_THAN)
 AM_CFLAGS += -fvisibility=hidden
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 noinst_LTLIBRARIES = libavl.la
 

--- a/lib/libefi/Makefile.am
+++ b/lib/libefi/Makefile.am
@@ -2,6 +2,8 @@ include $(top_srcdir)/config/Rules.am
 
 AM_CFLAGS += $(LIBUUID_CFLAGS) $(ZLIB_CFLAGS)
 AM_CFLAGS += -fvisibility=hidden
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 noinst_LTLIBRARIES = libefi.la
 

--- a/lib/libicp/Makefile.am
+++ b/lib/libicp/Makefile.am
@@ -6,6 +6,8 @@ VPATH = \
 
 # Includes kernel code, generate warnings for large stack frames
 AM_CFLAGS += $(FRAME_LARGER_THAN)
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 noinst_LTLIBRARIES = libicp.la
 

--- a/lib/libnvpair/Makefile.am
+++ b/lib/libnvpair/Makefile.am
@@ -8,6 +8,8 @@ VPATH = \
 # and required CFLAGS for libtirpc
 AM_CFLAGS += $(FRAME_LARGER_THAN) $(LIBTIRPC_CFLAGS)
 AM_CFLAGS += -fvisibility=hidden
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 # wchar_t is undefined-signedness, but we compare to >=0; this warns with unsigned wchar_t
 libnvpair_json.$(OBJEXT): CFLAGS += -Wno-type-limits

--- a/lib/libshare/Makefile.am
+++ b/lib/libshare/Makefile.am
@@ -3,6 +3,8 @@ include $(top_srcdir)/config/Rules.am
 DEFAULT_INCLUDES += -I$(srcdir)
 
 AM_CFLAGS += -fvisibility=hidden
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 noinst_LTLIBRARIES = libshare.la
 

--- a/lib/libspl/Makefile.am
+++ b/lib/libspl/Makefile.am
@@ -2,6 +2,9 @@ include $(top_srcdir)/config/Rules.am
 
 SUBDIRS = include
 
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
+
 noinst_LTLIBRARIES = libspl_assert.la libspl.la
 
 libspl_assert_la_SOURCES = \

--- a/lib/libtpool/Makefile.am
+++ b/lib/libtpool/Makefile.am
@@ -1,8 +1,12 @@
 include $(top_srcdir)/config/Rules.am
 
 AM_CFLAGS += -fvisibility=hidden
+
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61118
 AM_CFLAGS += $(NO_CLOBBERED)
+
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 noinst_LTLIBRARIES = libtpool.la
 

--- a/lib/libunicode/Makefile.am
+++ b/lib/libunicode/Makefile.am
@@ -5,6 +5,9 @@ VPATH = $(top_srcdir)/module/unicode
 # Includes kernel code, generate warnings for large stack frames
 AM_CFLAGS += $(FRAME_LARGER_THAN)
 
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
+
 noinst_LTLIBRARIES = libunicode.la
 
 KERNEL_C = \

--- a/lib/libuutil/Makefile.am
+++ b/lib/libuutil/Makefile.am
@@ -1,5 +1,8 @@
 include $(top_srcdir)/config/Rules.am
 
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
+
 lib_LTLIBRARIES = libuutil.la
 
 include $(top_srcdir)/config/Abigail.am

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -8,6 +8,8 @@ VPATH = \
 # Suppress unused but set variable warnings often due to ASSERTs
 AM_CFLAGS += $(LIBCRYPTO_CFLAGS) $(ZLIB_CFLAGS)
 AM_CFLAGS += -fvisibility=hidden
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 pkgconfig_DATA = libzfs.pc
 

--- a/lib/libzfs_core/Makefile.am
+++ b/lib/libzfs_core/Makefile.am
@@ -3,6 +3,8 @@ include $(top_srcdir)/config/Rules.am
 pkgconfig_DATA = libzfs_core.pc
 
 AM_CFLAGS += -fvisibility=hidden
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 lib_LTLIBRARIES = libzfs_core.la
 

--- a/lib/libzfsbootenv/Makefile.am
+++ b/lib/libzfsbootenv/Makefile.am
@@ -3,6 +3,8 @@ include $(top_srcdir)/config/Rules.am
 pkgconfig_DATA = libzfsbootenv.pc
 
 AM_CFLAGS += -fvisibility=hidden
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 lib_LTLIBRARIES = libzfsbootenv.la
 

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -24,6 +24,9 @@ AM_CFLAGS += $(ZLIB_CFLAGS)
 
 AM_CFLAGS += -DLIB_ZPOOL_BUILD
 
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
+
 lib_LTLIBRARIES = libzpool.la
 
 USER_C = \

--- a/lib/libzstd/Makefile.am
+++ b/lib/libzstd/Makefile.am
@@ -5,6 +5,8 @@ VPATH = $(top_srcdir)/module/zstd
 # -fno-tree-vectorize is set for gcc in zstd/common/compiler.h
 # Set it for other compilers, too.
 AM_CFLAGS += -fno-tree-vectorize
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 noinst_LTLIBRARIES = libzstd.la
 

--- a/lib/libzutil/Makefile.am
+++ b/lib/libzutil/Makefile.am
@@ -2,6 +2,8 @@ include $(top_srcdir)/config/Rules.am
 
 AM_CFLAGS += $(LIBBLKID_CFLAGS) $(LIBUDEV_CFLAGS)
 AM_CFLAGS += -fvisibility=hidden
+# See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54020
+AM_CFLAGS += -no-suppress
 
 DEFAULT_INCLUDES += -I$(srcdir)
 


### PR DESCRIPTION
### Motivation and Context
Curiously, for #13083, it did not print the actual error encountered for me, on Fedora 35 or Debian 11, it just printed something like this, even with V=1 (though V=1 prints the full command it ran):
```
Making all in libzpool
make[3]: Entering directory '/home/rich/zfs_heregoes/lib/libzpool'
  CC       dsl_dataset.lo
make[3]: *** [Makefile:1354: dsl_dataset.lo] Error 1
make[3]: Leaving directory '/home/rich/zfs_heregoes/lib/libzpool'
```
as opposed to:
```
../../module/zfs/dsl_dataset.c: In function ‘get_receive_resume_token_impl’:
../../module/zfs/dsl_dataset.c:2394:17: error: ‘redact_snaps’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 2394 |                 fnvlist_add_uint64_array(token_nv, "redact_snaps",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2395 |                     redact_snaps, num_redact_snaps);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../module/zfs/dsl_dataset.c:2394:17: error: ‘num_redact_snaps’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
cc1: all warnings being treated as errors
```

After a bit of staring into the abyss, I found it was libtool eating the error output.

In theory, this flag should make it sometimes kick out errors twice. In practice, I'm okay with getting some twice if it means getting some more than 0 times.

(If someone has a better way to accomplish this, I'm all ears, but from reading the "libtool" script, this seems to be the only flag that influences the behavior...)

### Description
Shoves -no-suppress into AM_CPPFLAGS for lib/ - AM_LIBTOOLFLAGS puts it too early in the invocation, LTCFLAGS did not do what I might have hoped, and AM_CPPFLAGS globally breaks all of our cmd/ compiles.

### How Has This Been Tested?
Well, it correctly bombs printing that error now, and if you fix the error, it successfully built for me.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
