### PR TITLE
Fix gcc warning in kfpu_begin()

### DIFF
--- a/include/os/linux/kernel/linux/simd_x86.h
+++ b/include/os/linux/kernel/linux/simd_x86.h
@@ -318,13 +318,13 @@ kfpu_begin(void)
 #if defined(HAVE_XSAVES)
 	if (static_cpu_has(X86_FEATURE_XSAVES)) {
 		kfpu_do_xsave("xsaves", &state->xsave, ~0);
-		goto out;
+		return;
 	}
 #endif
 #if defined(HAVE_XSAVEOPT)
 	if (static_cpu_has(X86_FEATURE_XSAVEOPT)) {
 		kfpu_do_xsave("xsaveopt", &state->xsave, ~0);
-		goto out;
+		return;
 	}
 #endif
 	if (static_cpu_has(X86_FEATURE_XSAVE)) {
@@ -334,7 +334,6 @@ kfpu_begin(void)
 	} else {
 		kfpu_save_fsave(&state->fsave);
 	}
-out:
 }
 #endif /* defined(HAVE_KERNEL_FPU_XSAVE_INTERNAL) */
 


### PR DESCRIPTION
### Motivation and Context

Resolve a CI build failure on CentOS 8 Stream.  I'm not sure why
this warning wasn't encountered in the original PR, I presume it's
due to recently updated packages in CentOS 8 Stream.

http://build.zfsonlinux.org/builders/CentOS%20Stream%208%20x86_64%20%28TEST%29/builds/3980/steps/shell_1/logs/make

### Description

Observed when building on CentOS 8 Stream.  Remove the `out`
label at the end of the function and instead return.

    linux/simd_x86.h: In function 'kfpu_begin':
    linux/simd_x86.h:337:1: error: label at end of compound statement

### How Has This Been Tested?

It has not.  Just submitted to the CI to verify it resolves the warning.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
