### PR TITLE
ZTS: Fix zpool_expand_001_pos

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -283,8 +283,6 @@ if sys.platform.startswith('freebsd'):
 elif sys.platform.startswith('linux'):
     maybe.update({
         'cli_root/zfs_rename/zfs_rename_002_pos': ['FAIL', known_reason],
-        'cli_root/zpool_expand/zpool_expand_001_pos': ['FAIL', known_reason],
-        'cli_root/zpool_expand/zpool_expand_005_pos': ['FAIL', known_reason],
         'cli_root/zpool_reopen/zpool_reopen_003_pos': ['FAIL', known_reason],
         'fault/auto_spare_shared': ['FAIL', '11889'],
         'io/io_uring': ['SKIP', 'io_uring support required'],

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh
@@ -72,7 +72,7 @@ log_onexit cleanup
 
 log_assert "zpool can be autoexpanded after set autoexpand=on on vdev expansion"
 
-for type in " " mirror raidz draid; do
+for type in " " mirror raidz draid:1s; do
 	log_note "Setting up loopback, scsi_debug, and file vdevs"
 	log_must truncate -s $org_size $FILE_LO
 	DEV1=$(losetup -f)
@@ -144,7 +144,7 @@ for type in " " mirror raidz draid; do
 			if [[ $? -ne 0 ]] ; then
 				log_fail "pool $TESTPOOL1 has not expanded"
 			fi
-		elif [[ $type == "draid" ]]; then
+		elif [[ $type == "draid:1s" ]]; then
 			typeset expansion_size=$((2*($exp_size-$org_size)))
 			zpool history -il $TESTPOOL1 | \
 			    grep "pool '$TESTPOOL1' size:" | \


### PR DESCRIPTION
### Motivation and Context

Cut down the exception list by fixing faulty tests.  

### Description

The dRAID section of the `zpool_expand_001_pos` test would reliably fail
because the calculated expansion size assumed the dRAID top-level vdev
was created with a distributed spare.  Create the vdev as expected to
resolve the test failure.

This test case flaw was accidentally caused by changing the default
number of dRAID distributed spares from one to zero while dRAID was
being developed.

Additionally, remove `zpool_expand_005_pos` from the list of possible
faulty tests.  It appears to be passing consistently in my testing.

### How Has This Been Tested?

```
$ ./scripts/zfs-tests.sh -T zpool_expand
Test (Linux): tests/functional/cli_root/zpool_expand/setup (run as root) [00:00] [PASS]
Test (Linux): tests/functional/cli_root/zpool_expand/zpool_expand_001_pos (run as root) [01:01] [PASS]
Test (Linux): tests/functional/cli_root/zpool_expand/zpool_expand_002_pos (run as root) [00:41] [PASS]
Test (Linux): tests/functional/cli_root/zpool_expand/zpool_expand_003_neg (run as root) [01:15] [PASS]
Test (Linux): tests/functional/cli_root/zpool_expand/zpool_expand_004_pos (run as root) [00:10] [PASS]
Test (Linux): tests/functional/cli_root/zpool_expand/zpool_expand_005_pos (run as root) [00:17] [PASS]
Test (Linux): tests/functional/cli_root/zpool_expand/cleanup (run as root) [00:00] [PASS]

Results Summary
PASS       7

Running Time:   00:03:28
Percent passed: 100.0%
Log directory:  /var/tmp/test_results/20220211T154305
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
