### PR TITLE
Support root= being set in dracut embedded cmdline better^Udracut and manual cleanups

### DIFF
--- a/contrib/dracut/90zfs/export-zfs.sh.in
+++ b/contrib/dracut/90zfs/export-zfs.sh.in
@@ -1,10 +1,8 @@
 #!/bin/sh
 
-. /lib/dracut-zfs-lib.sh
-
 _do_zpool_export() {
 	info "ZFS: Exporting ZFS storage pools..."
-	errs=$(export_all -F 2>&1)
+	errs=$(zpool export -aF 2>&1)
 	ret=$?
 	echo "${errs}" | vwarn
 	if [ "${ret}" -ne 0 ]; then

--- a/contrib/dracut/90zfs/export-zfs.sh.in
+++ b/contrib/dracut/90zfs/export-zfs.sh.in
@@ -3,28 +3,22 @@
 . /lib/dracut-zfs-lib.sh
 
 _do_zpool_export() {
-	ret=0
-	errs=""
-	final="${1}"
-
 	info "ZFS: Exporting ZFS storage pools..."
 	errs=$(export_all -F 2>&1)
 	ret=$?
-	[ -z "${errs}" ] || echo "${errs}" | vwarn
-	if [ "x${ret}" != "x0" ]; then
+	echo "${errs}" | vwarn
+	if [ "${ret}" -ne 0 ]; then
 		info "ZFS: There was a problem exporting pools."
 	fi
 
-	if [ "x${final}" != "x" ]; then
+	if [ -n "$1" ]; then
 		info "ZFS: pool list"
 		zpool list 2>&1 | vinfo
 	fi
 
-	return "${ret}"
+	return "$ret"
 }
 
 if command -v zpool >/dev/null; then
 	_do_zpool_export "${1}"
-else
-	:
 fi

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -44,7 +44,7 @@ if [ "${root}" = "zfs:AUTO" ] ; then
 		zpool import -N -a ${ZPOOL_IMPORT_OPTS}
 		if ! ZFS_DATASET="$(find_bootfs)" ; then
 			warn "ZFS: No bootfs attribute found in importable pools."
-			export_all -F
+			zpool export -aF
 
 			rootok=0
 			return 1

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -122,22 +122,6 @@ for_relevant_root_children() {
         )
 }
 
-# export_all OPTS
-#   exports all imported zfs pools.
-export_all() {
-    ret=0
-
-    IFS="${NEWLINE}"
-    for pool in $(zpool list -H -o name) ; do
-        if zpool list -H "${pool}" > /dev/null 2>&1; then
-            zpool export "${pool}" "$@" || ret=$?
-        fi
-    done
-    IFS="${OLDIFS}"
-
-    return "${ret}"
-}
-
 # ask_for_password
 #
 # Wraps around plymouth ask-for-password and adds fallback to tty password ask

--- a/contrib/dracut/README.md
+++ b/contrib/dracut/README.md
@@ -27,6 +27,8 @@ If the root dataset contains children with `mountpoint=`s of `/etc`, `/bin`, `/l
 
    The dataset can be at any depth, including being the pool's root dataset (i.e. `root=zfs:pool`).
 
+   `rootfstype=zfs` is mostly equivalent to `root=zfs:AUTO`.
+
 2. `spl_hostid`: passed to `zgenhostid -f`, useful to override the `/etc/hostid` file baked into the initrd.
 
 3. `bootfs.snapshot`, `bootfs.snapshot=snapshot-name`: enables `zfs-snapshot-bootfs.service`,

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -30,13 +30,13 @@
 .Op Fl t Ar txg
 .Op Fl U Ar cache
 .Op Fl x Ar dumpdir
-.Op Ar poolname Ns Op / Ns Ar dataset | objset ID
+.Op Ar poolname Ns Op / Ns Ar dataset Ns | Ns Ar objset-ID
 .Op Ar object Ns | Ns Ar range Ns …
 .Nm
 .Op Fl AdiPv
 .Op Fl e Oo Fl V Oc Oo Fl p Ar path Oc Ns …
 .Op Fl U Ar cache
-.Ar poolname Ns Op Ar / Ns Ar dataset | objset ID
+.Ar poolname Ns Op Ar / Ns Ar dataset Ns | Ns Ar objset-ID
 .Op Ar object Ns | Ns Ar range Ns …
 .Nm
 .Fl C
@@ -84,7 +84,7 @@ some amount of consistency checking.
 It is a not a general purpose tool and options
 .Pq and facilities
 may change.
-This is not a
+It is not a
 .Xr fsck 8
 utility.
 .Pp
@@ -140,9 +140,9 @@ size, and object count.
 See
 .Fl N
 for determining if
-.Op Ar poolname Ns Op / Ns Ar dataset | objset ID
+.Ar poolname Ns Op / Ns Ar dataset Ns | Ns Ar objset-ID
 is to use the specified
-.Op Ar dataset | objset ID
+.Ar dataset Ns | Ns Ar objset-ID
 as a string (dataset name) or a number (objset ID) when
 datasets have numeric names.
 .Pp
@@ -198,7 +198,7 @@ compression ratio
 inflation due to the zfs copies property
 .Pq Sy copies ,
 and an overall effective ratio
-.Pq Sy dedup No * Sy compress No / Sy copies .
+.Pq Sy dedup No \(mu Sy compress No / Sy copies .
 .It Fl DD
 Display a histogram of deduplication statistics, showing the allocated
 .Pq physically present on disk
@@ -287,9 +287,9 @@ Display every spacemap record.
 Same as
 .Fl d
 but force zdb to interpret the
-.Op Ar dataset | objset ID
+.Op Ar dataset Ns | Ns Ar objset-ID
 in
-.Op Ar poolname Ns Op / Ns Ar dataset | objset ID
+.Op Ar poolname Ns Op / Ns Ar dataset Ns | Ns Ar objset-ID
 as a numeric objset ID.
 .It Fl O Ar dataset path
 Look up the specified
@@ -410,7 +410,7 @@ The default value is 200.
 This option affects the performance of the
 .Fl c
 option.
-.It Fl o , -option Ns = Ns Ar var Ns = Ns Ar value …
+.It Fl o , -option Ns = Ns Ar var Ns = Ns Ar value Ns …
 Set the given global libzpool variable to the provided value.
 The value must be an unsigned 32-bit integer.
 Currently only little-endian systems are supported to avoid accidentally setting


### PR DESCRIPTION
### Motivation and Context
#13088

### Description
See individual commits. ~~All but the top~~ NFC.

### How Has This Been Tested?
~~Not. I don't currently have a system I could test this on.~~ See above.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
