### PR TITLE
Upstream: rename fallthrough to zfs_fallthrough

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -390,7 +390,7 @@ main(int argc, char **argv)
 				return (MOUNT_SYSERR);
 			}
 #endif
-			fallthrough;
+			zfs_fallthrough;
 		default:
 			(void) fprintf(stderr, gettext("filesystem "
 			    "'%s' can not be mounted: %s\n"), dataset,

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -4655,7 +4655,7 @@ dump_path_impl(objset_t *os, uint64_t obj, char *name, uint64_t *retobj)
 	case DMU_OT_DIRECTORY_CONTENTS:
 		if (s != NULL && *(s + 1) != '\0')
 			return (dump_path_impl(os, child_obj, s + 1, retobj));
-		fallthrough;
+		zfs_fallthrough;
 	case DMU_OT_PLAIN_FILE_CONTENTS:
 		if (retobj != NULL) {
 			*retobj = child_obj;

--- a/cmd/zpool_influxdb/zpool_influxdb.c
+++ b/cmd/zpool_influxdb/zpool_influxdb.c
@@ -118,7 +118,7 @@ escape_string(const char *s)
 		case '=':
 		case '\\':
 			*d++ = '\\';
-			fallthrough;
+			zfs_fallthrough;
 		default:
 			*d = *c;
 		}

--- a/include/os/freebsd/linux/compiler.h
+++ b/include/os/freebsd/linux/compiler.h
@@ -67,7 +67,7 @@
 #define	__always_inline			inline
 #define	noinline			__noinline
 #define	____cacheline_aligned		__aligned(CACHE_LINE_SIZE)
-#define	fallthrough			__attribute__((__fallthrough__))
+#define	zfs_fallthrough			__attribute__((__fallthrough__))
 
 #if !defined(_KERNEL) && !defined(_STANDALONE)
 #define	likely(x)			__builtin_expect(!!(x), 1)

--- a/include/os/linux/kernel/linux/compiler_compat.h
+++ b/include/os/linux/kernel/linux/compiler_compat.h
@@ -28,11 +28,11 @@
 
 #include <linux/compiler.h>
 
-#if !defined(fallthrough)
+#if !defined(zfs_fallthrough)
 #if defined(HAVE_IMPLICIT_FALLTHROUGH)
-#define	fallthrough		__attribute__((__fallthrough__))
+#define	zfs_fallthrough		__attribute__((__fallthrough__))
 #else
-#define	fallthrough		((void)0)
+#define	zfs_fallthrough		((void)0)
 #endif
 #endif
 

--- a/lib/libspl/include/sys/feature_tests.h
+++ b/lib/libspl/include/sys/feature_tests.h
@@ -30,11 +30,11 @@
 #define	____cacheline_aligned
 #define	__NORETURN		__attribute__((__noreturn__))
 
-#if !defined(fallthrough) && !defined(_LIBCPP_VERSION)
+#if !defined(zfs_fallthrough) && !defined(_LIBCPP_VERSION)
 #if defined(HAVE_IMPLICIT_FALLTHROUGH)
-#define	fallthrough		__attribute__((__fallthrough__))
+#define	zfs_fallthrough		__attribute__((__fallthrough__))
 #else
-#define	fallthrough		((void)0)
+#define	zfs_fallthrough		((void)0)
 #endif
 #endif
 

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1363,7 +1363,7 @@ badlabel:
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
-			fallthrough;
+			zfs_fallthrough;
 		}
 
 		case ZFS_PROP_SHARESMB:
@@ -3783,7 +3783,7 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 			if (type == ZFS_TYPE_VOLUME)
 				return (zfs_error(hdl, EZFS_VOLTOOBIG,
 				    errbuf));
-			fallthrough;
+			zfs_fallthrough;
 #endif
 		default:
 			return (zfs_standard_error(hdl, errno, errbuf));

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -316,7 +316,7 @@ zpool_get_prop(zpool_handle_t *zhp, zpool_prop_t prop, char *buf,
 				    len);
 				break;
 			}
-			fallthrough;
+			zfs_fallthrough;
 		default:
 			(void) strlcpy(buf, "-", len);
 			break;
@@ -407,7 +407,7 @@ zpool_get_prop(zpool_handle_t *zhp, zpool_prop_t prop, char *buf,
 				(void) snprintf(buf, len, "-");
 				break;
 			}
-			fallthrough;
+			zfs_fallthrough;
 		default:
 			(void) snprintf(buf, len, "%llu", (u_longlong_t)intval);
 		}

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -4947,7 +4947,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 				(void) zfs_error(hdl, EZFS_BUSY, errbuf);
 				break;
 			}
-			fallthrough;
+			zfs_fallthrough;
 		default:
 			(void) zfs_standard_error(hdl, ioctl_errno, errbuf);
 		}

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -600,8 +600,8 @@ zfs_setprop_error(libzfs_handle_t *hdl, zfs_prop_t prop, int err,
 			(void) zfs_error(hdl, EZFS_VOLTOOBIG, errbuf);
 			break;
 		}
+		zfs_fallthrough;
 #endif
-		fallthrough;
 	default:
 		(void) zfs_standard_error(hdl, err, errbuf);
 	}

--- a/lib/libzfsbootenv/lzbe_device.c
+++ b/lib/libzfsbootenv/lzbe_device.c
@@ -63,7 +63,7 @@ lzbe_set_boot_device(const char *pool, lzbe_flags_t flag, const char *device)
 			/* Drop this nvlist */
 			fnvlist_free(nv);
 		}
-		fallthrough;
+		zfs_fallthrough;
 	case lzbe_replace:
 		nv = fnvlist_alloc();
 		break;

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -1032,11 +1032,11 @@ zpool_read_label(int fd, nvlist_t **config, int *num_labels)
 					// This shouldn't be possible to
 					// encounter, die if we do.
 					ASSERT(B_FALSE);
-					fallthrough;
+					zfs_fallthrough;
 				case EOPNOTSUPP:
 				case ENOSYS:
 					do_slow = B_TRUE;
-					fallthrough;
+					zfs_fallthrough;
 				case 0:
 				default:
 					(void) aio_return(&aiocbs[l]);

--- a/module/icp/core/kcf_prov_tabs.c
+++ b/module/icp/core/kcf_prov_tabs.c
@@ -378,7 +378,7 @@ kcf_provider_zero_refcnt(kcf_provider_desc_t *desc)
 			mutex_exit(&desc->pd_lock);
 			break;
 		}
-		fallthrough;
+		zfs_fallthrough;
 
 	case CRYPTO_HW_PROVIDER:
 	case CRYPTO_LOGICAL_PROVIDER:

--- a/module/icp/io/aes.c
+++ b/module/icp/io/aes.c
@@ -952,7 +952,7 @@ aes_encrypt_atomic(crypto_provider_handle_t provider,
 	case AES_GMAC_MECH_INFO_TYPE:
 		if (plaintext->cd_length != 0)
 			return (CRYPTO_ARGUMENTS_BAD);
-		fallthrough;
+		zfs_fallthrough;
 	case AES_GCM_MECH_INFO_TYPE:
 		length_needed = plaintext->cd_length + aes_ctx.ac_tag_len;
 		break;

--- a/module/lua/lgc.c
+++ b/module/lua/lgc.c
@@ -675,7 +675,7 @@ static void freeobj (lua_State *L, GCObject *o) {
     case LUA_TUSERDATA: luaM_freemem(L, o, sizeudata(gco2u(o))); break;
     case LUA_TSHRSTR:
       G(L)->strt.nuse--;
-      fallthrough;
+      zfs_fallthrough;
     case LUA_TLNGSTR: {
       luaM_freemem(L, o, sizestring(gco2ts(o)));
       break;

--- a/module/lua/llex.c
+++ b/module/lua/llex.c
@@ -476,7 +476,7 @@ static int llex (LexState *ls, SemInfo *seminfo) {
         else if (!lisdigit(ls->current)) return '.';
         /* else go through */
       }
-        fallthrough;
+        zfs_fallthrough;
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {
         read_numeral(ls, seminfo);

--- a/module/lua/lstrlib.c
+++ b/module/lua/lstrlib.c
@@ -500,7 +500,7 @@ static const char *match (MatchState *ms, const char *s, const char *p) {
             }
             case '+':  /* 1 or more repetitions */
               s++;  /* 1 match already done */
-              fallthrough;
+              zfs_fallthrough;
             case '*':  /* 0 or more repetitions */
               s = max_expand(ms, s, p, ep);
               break;

--- a/module/lua/ltable.c
+++ b/module/lua/ltable.c
@@ -491,7 +491,7 @@ const TValue *luaH_get (Table *t, const TValue *key) {
         return luaH_getint(t, k);  /* use specialized version */
       /* else go through */
     }
-      fallthrough;
+      zfs_fallthrough;
     default: {
       Node *n = mainposition(t, key);
       do {  /* check whether `key' is somewhere in the chain */

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -269,7 +269,7 @@ zfs_ace_fuid_size(void *acep)
 		    entry_type == OWNING_GROUP ||
 		    entry_type == ACE_EVERYONE)
 			return (sizeof (zfs_ace_hdr_t));
-		fallthrough;
+		zfs_fallthrough;
 	default:
 		return (sizeof (zfs_ace_t));
 	}
@@ -2153,7 +2153,7 @@ zfs_zaccess_aces_check(znode_t *zp, uint32_t *working_mode,
 			break;
 		case OWNING_GROUP:
 			who = gowner;
-			fallthrough;
+			zfs_fallthrough;
 		case ACE_IDENTIFIER_GROUP:
 			checkit = zfs_groupmember(zfsvfs, who, cr);
 			break;

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -966,7 +966,7 @@ zfs_lookup(vnode_t *dvp, const char *nm, vnode_t **vpp,
 				cnp->cn_flags |= SAVENAME;
 				break;
 			}
-			fallthrough;
+			zfs_fallthrough;
 		case DELETE:
 			if (error == 0)
 				cnp->cn_flags |= SAVENAME;

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -269,7 +269,7 @@ zfs_ace_fuid_size(void *acep)
 		    entry_type == OWNING_GROUP ||
 		    entry_type == ACE_EVERYONE)
 			return (sizeof (zfs_ace_hdr_t));
-		fallthrough;
+		zfs_fallthrough;
 	default:
 		return (sizeof (zfs_ace_t));
 	}
@@ -2317,7 +2317,7 @@ zfs_zaccess_aces_check(znode_t *zp, uint32_t *working_mode,
 			break;
 		case OWNING_GROUP:
 			who = gowner;
-			fallthrough;
+			zfs_fallthrough;
 		case ACE_IDENTIFIER_GROUP:
 			checkit = zfs_groupmember(zfsvfs, who, cr);
 			break;

--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -430,7 +430,7 @@ zfs_inode_set_ops(zfsvfs_t *zfsvfs, struct inode *ip)
 	case S_IFBLK:
 		(void) sa_lookup(ITOZ(ip)->z_sa_hdl, SA_ZPL_RDEV(zfsvfs), &rdev,
 		    sizeof (rdev));
-		fallthrough;
+		zfs_fallthrough;
 	case S_IFIFO:
 	case S_IFSOCK:
 		init_special_inode(ip, ip->i_mode, rdev);

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -1066,10 +1066,10 @@ abd_raidz_gen_iterate(abd_t **cabds, abd_t *dabd,
 		switch (parity) {
 			case 3:
 				len = MIN(caiters[2].iter_mapsize, len);
-				fallthrough;
+				zfs_fallthrough;
 			case 2:
 				len = MIN(caiters[1].iter_mapsize, len);
-				fallthrough;
+				zfs_fallthrough;
 			case 1:
 				len = MIN(caiters[0].iter_mapsize, len);
 		}
@@ -1179,11 +1179,11 @@ abd_raidz_rec_iterate(abd_t **cabds, abd_t **tabds,
 			case 3:
 				len = MIN(xiters[2].iter_mapsize, len);
 				len = MIN(citers[2].iter_mapsize, len);
-				fallthrough;
+				zfs_fallthrough;
 			case 2:
 				len = MIN(xiters[1].iter_mapsize, len);
 				len = MIN(citers[1].iter_mapsize, len);
-				fallthrough;
+				zfs_fallthrough;
 			case 1:
 				len = MIN(xiters[0].iter_mapsize, len);
 				len = MIN(citers[0].iter_mapsize, len);

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -749,7 +749,7 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		ASSERT(err == 0 || err == ENOENT);
 		err = zap_remove(mos, zapobj, inheritstr, tx);
 		ASSERT(err == 0 || err == ENOENT);
-		fallthrough;
+		zfs_fallthrough;
 	case (ZPROP_SRC_NONE | ZPROP_SRC_RECEIVED):
 		/*
 		 * remove propname$recvd

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -9729,7 +9729,7 @@ spa_activity_in_progress(spa_t *spa, zpool_wait_activity_t activity,
 	case ZPOOL_WAIT_RESILVER:
 		if ((*in_progress = vdev_rebuild_active(spa->spa_root_vdev)))
 			break;
-		fallthrough;
+		zfs_fallthrough;
 	case ZPOOL_WAIT_SCRUB:
 	{
 		boolean_t scanning, paused, is_scrub;

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -1324,7 +1324,7 @@ vdev_label_read_bootenv(vdev_t *rvd, nvlist_t *bootenv)
 				nvlist_free(config);
 				break;
 			}
-			fallthrough;
+			zfs_fallthrough;
 		default:
 			/* Check for FreeBSD zfs bootonce command string */
 			buf = abd_to_buf(abd);

--- a/module/zfs/vdev_raidz_math_scalar.c
+++ b/module/zfs/vdev_raidz_math_scalar.c
@@ -142,7 +142,7 @@ static const struct {
 		a.b[6] = mul_lt[a.b[6]];				\
 		a.b[5] = mul_lt[a.b[5]];				\
 		a.b[4] = mul_lt[a.b[4]];				\
-		fallthrough;						\
+		zfs_fallthrough;					\
 	case 4:								\
 		a.b[3] = mul_lt[a.b[3]];				\
 		a.b[2] = mul_lt[a.b[2]];				\

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -362,7 +362,7 @@ zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 		zfsvfs->z_fuid_replay = zfs_replay_fuids(fuidstart,
 		    (void *)&name, lracl->lr_fuidcnt, lracl->lr_domcnt,
 		    lr->lr_uid, lr->lr_gid);
-		fallthrough;
+		zfs_fallthrough;
 	case TX_CREATE_ACL_ATTR:
 		if (name == NULL) {
 			lrattr = (lr_attr_t *)(caddr_t)(lracl + 1);
@@ -394,7 +394,7 @@ zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 		zfsvfs->z_fuid_replay = zfs_replay_fuids(fuidstart,
 		    (void *)&name, lracl->lr_fuidcnt, lracl->lr_domcnt,
 		    lr->lr_uid, lr->lr_gid);
-		fallthrough;
+		zfs_fallthrough;
 	case TX_MKDIR_ACL_ATTR:
 		if (name == NULL) {
 			lrattr = (lr_attr_t *)(caddr_t)(lracl + 1);
@@ -519,7 +519,7 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 		    zfs_replay_fuid_domain(start, &start,
 		    lr->lr_uid, lr->lr_gid);
 		name = (char *)start;
-		fallthrough;
+		zfs_fallthrough;
 
 	case TX_CREATE:
 		if (name == NULL)
@@ -537,7 +537,7 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 		    zfs_replay_fuid_domain(start, &start,
 		    lr->lr_uid, lr->lr_gid);
 		name = (char *)start;
-		fallthrough;
+		zfs_fallthrough;
 
 	case TX_MKDIR:
 		if (name == NULL)

--- a/tests/zfs-tests/cmd/mkbusy/mkbusy.c
+++ b/tests/zfs-tests/cmd/mkbusy/mkbusy.c
@@ -136,7 +136,7 @@ main(int argc, char *argv[])
 		switch (sbuf.st_mode & S_IFMT) {
 			case S_IFDIR:
 				isdir = B_TRUE;
-				fallthrough;
+				zfs_fallthrough;
 			case S_IFLNK:
 			case S_IFCHR:
 			case S_IFBLK:


### PR DESCRIPTION
literal "fallthrough" can not be used.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


### Description
<!--- Describe your changes in detail -->

Unfortunately macOS has obj-C keyword "fallthrough" in the OS headers.
Changing to use `zfs_fallthrough`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
