### PR TITLE
zfs-recv.8 fixes, libzfs-sendrecv followup

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -5023,11 +5023,10 @@ static boolean_t
 zfs_receive_checkprops(libzfs_handle_t *hdl, nvlist_t *props,
     const char *errbuf)
 {
-	nvpair_t *nvp;
+	nvpair_t *nvp = NULL;
 	zfs_prop_t prop;
 	const char *name;
 
-	nvp = NULL;
 	while ((nvp = nvlist_next_nvpair(props, nvp)) != NULL) {
 		name = nvpair_name(nvp);
 		prop = zfs_name_to_prop(name);
@@ -5086,7 +5085,7 @@ zfs_receive_impl(libzfs_handle_t *hdl, const char *tosnap,
 
 	/* check cmdline props, raise an error if they cannot be received */
 	if (!zfs_receive_checkprops(hdl, cmdprops, errbuf))
-		return (-1);
+		return (zfs_error(hdl, EZFS_BADPROP, errbuf));
 
 	if (flags->isprefix &&
 	    !zfs_dataset_exists(hdl, tosnap, ZFS_TYPE_DATASET)) {

--- a/man/man8/zfs-receive.8
+++ b/man/man8/zfs-receive.8
@@ -319,7 +319,7 @@ received as an encryption root, specify encryption properties in the same
 manner as is required for
 .Nm zfs Cm create .
 For instance:
-.Dl # Nm zfs Cm send Pa tank/test@snap1 | Nm zfs Cm recv Fl o Sy encryption Ns = Ns Sy on Fl o Sy keyformat=passphrase Fl o Sy keylocation Ns = Ns Pa file:///path/to/keyfile
+.Dl # Nm zfs Cm send Pa tank/test@snap1 | Nm zfs Cm recv Fl o Sy encryption Ns = Ns Sy on Fl o Sy keyformat Ns = Ns Sy passphrase Fl o Sy keylocation Ns = Ns Pa file:///path/to/keyfile
 .Pp
 Note that
 .Fl o Sy keylocation Ns = Ns Sy prompt

--- a/man/man8/zfs-receive.8
+++ b/man/man8/zfs-receive.8
@@ -329,7 +329,7 @@ Once the receive has completed, you can use
 .Nm zfs Cm set
 to change this setting after the fact.
 Similarly, you can receive a dataset as an encrypted child by specifying
-.Op Fl x Ar encryption
+.Fl x Sy encryption
 to force the property to be inherited.
 Overriding encryption properties (except for
 .Sy keylocation )


### PR DESCRIPTION
### Description
See individual commit messages. Fixes #13100.

### How Has This Been Tested?
```
$ sudo env LD_LIBRARY_PATH="/home/nabijaczleweli/store/code/zfs/lib/libzfs/.libs:/home/nabijaczleweli/store/code/zfs/lib/libzfs_core/.libs:/home/nabijaczleweli/store/code/zfs/lib/libnvpair/.libs:/home/nabijaczleweli/store/code/zfs/lib/libuutil/.libs:$LD_LIBRARY_PATH" ./cmd/zfs/.libs/zfs recv -x encryption -x encryptionroot -x keylocation -x keyformat -ev tarta-zoot < pre-make
cannot receive: cannot receive: invalid property 'encryptionroot'
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
