### PR TITLE
`checkabi`/`storeabi` relevant only to x86_64

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -138,20 +138,10 @@ SHELLCHECKSCRIPTS = autogen.sh
 
 PHONY += checkabi storeabi
 
-checklibabiversion:
-	libabiversion=`abidw -v | $(SED) 's/[^0-9]//g'`; \
-	if test $$libabiversion -lt "200"; then \
-        /bin/echo -e "\n" \
-        "*** Please use libabigail 2.0.0 version or newer;\n" \
-        "*** otherwise results are not consistent!\n" \
-        "(or see https://github.com/openzfs/libabigail-docker )\n"; \
-        exit 1; \
-    fi;
-
-checkabi: checklibabiversion lib
+checkabi: lib
 	$(MAKE) -C lib checkabi
 
-storeabi: checklibabiversion lib
+storeabi: lib
 	$(MAKE) -C lib storeabi
 
 PHONY += mancheck

--- a/config/Abigail.am
+++ b/config/Abigail.am
@@ -12,9 +12,24 @@
 # a mechanism for suppressing harmless warnings.
 #
 
-PHONY += checkabi storeabi
+PHONY += checkabi storeabi check_libabi_version allow_libabi_only_for_x86_64
 
-checkabi:
+check_libabi_version:
+	libabiversion=`abidw -v | $(SED) 's/[^0-9]//g'`; \
+	if test $$libabiversion -lt "200"; then \
+		/bin/echo -e "\n" \
+		    "*** Please use libabigail 2.0.0 version or newer;\n" \
+		    "*** otherwise results are not consistent!\n" \
+		    "(or see https://github.com/openzfs/libabigail-docker )\n"; \
+		exit 1; \
+	fi;
+
+allow_libabi_only_for_x86_64:
+	echo '*** ABI definitions provided apply only to x86_64 architecture'
+	echo '*** Skipping `checkabi`/`storeabi` target and assuming success.'
+
+if TARGET_CPU_X86_64
+checkabi: check_libabi_version
 	for lib in $(lib_LTLIBRARIES) ; do \
 		abidiff --no-unreferenced-symbols \
 		    --headers-dir1 ../../include \
@@ -22,7 +37,7 @@ checkabi:
 		    $${lib%.la}.abi .libs/$${lib%.la}.so ; \
 	done
 
-storeabi:
+storeabi: check_libabi_version
 	cd .libs ; \
 	for lib in $(lib_LTLIBRARIES) ; do \
 		abidw --no-show-locs \
@@ -31,3 +46,7 @@ storeabi:
 		--type-id-style hash \
 		$${lib%.la}.so > ../$${lib%.la}.abi ; \
 	done
+else
+checkabi: allow_libabi_only_for_x86_64
+storeabi: allow_libabi_only_for_x86_64
+endif


### PR DESCRIPTION
### Motivation and Context
Close #11345.

### Description
Avoid checking ABI on x86_64 architectures.

### How Has This Been Tested?
no testing was done

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
