### PR TITLE
ZTS: Fix vdev_zaps_004_pos.ksh

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -259,7 +259,6 @@ maybe = {
     'upgrade/upgrade_projectquota_001_pos': ['SKIP', project_id_reason],
     'user_namespace/setup': ['SKIP', user_ns_reason],
     'userquota/setup': ['SKIP', exec_reason],
-    'vdev_zaps/vdev_zaps_004_pos': ['FAIL', '6935'],
     'zvol/zvol_ENOSPC/zvol_ENOSPC_001_pos': ['FAIL', '5848'],
     'pam/setup': ['SKIP', "pamtester might be not available"],
 }

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_004_pos.ksh
@@ -50,6 +50,7 @@ assert_zap_common $TESTPOOL $DISK "top" $orig_top
 
 disk2=$(echo $DISKS | awk '{print $2}')
 log_must zpool attach $TESTPOOL $DISK $disk2
+log_must zpool wait -t resilver $TESTPOOL
 log_must zdb -PC $TESTPOOL > $conf
 
 # Ensure top-level ZAP was transferred successfully.


### PR DESCRIPTION
### Motivation and Context

Address a long time occasional CI failure.

http://build.zfsonlinux.org/builders/CentOS%208%20x86_64%20%28TEST%29/builds/7233/steps/shell_4/logs/summary

```sh
Test: /usr/share/zfs/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_004_pos (run as root) [00:04] [FAIL]
17:22:09.36 ASSERTION: Per-vdev ZAPs are transferred properly on attach/detach
17:22:09.65 SUCCESS: zpool create -f testpool loop0
17:22:13.02 SUCCESS: zpool attach testpool loop0 loop1
17:22:13.65
```

### Description

When attaching a vdev to a mirror wait for the resilver to complete
before invoking `zdb` to inspect the pool.  This ensures the pool is
essentially idle which allows `zdb` to open the imported pool reliably.

Additional analysis can be found in the original issue #6935.

### How Has This Been Tested?

Locally ran the updated test in a test loop for 1000 iterations without
observing any failures.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
