### PR TITLE
ZTS: Retry in import_rewind_config_changed.ksh

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -222,8 +222,6 @@ maybe = {
     'cli_root/zfs_unshare/setup': ['SKIP', share_reason],
     'cli_root/zpool_add/zpool_add_004_pos': ['FAIL', known_reason],
     'cli_root/zpool_destroy/zpool_destroy_001_pos': ['SKIP', '6145'],
-    'cli_root/zpool_import/import_rewind_config_changed':
-        ['FAIL', rewind_reason],
     'cli_root/zpool_import/zpool_import_missing_003_pos': ['SKIP', '6839'],
     'cli_root/zpool_initialize/zpool_initialize_import_export':
         ['FAIL', '11948'],


### PR DESCRIPTION
### Motivation and Context

This ZTS failure was one of the most frequently observed
by the CI.  It needed to be resolved or disabled.

### Description

As explained by the disclaimer in the test case,

    "This test can fail since nothing guarantees that old
    MOS blocks aren't overwritten."

This behavior is expected and correct, but results in a
flaky test case which is problematic for the CI.  The best
we can do to resolve this is to retry the sub-test which
failed when the MOS blocks have clearly been overwriten.

When testing failures were rare enough that a single retry
should normally be sufficient.  However, we allow up to
five for good measure.

### How Has This Been Tested?

Locally verified that only the known failure scenarios were
observed, and when they occurred only a single retry was
required under normal circumstances.

```sh
$ ./scripts/zfs-tests.sh -t tests/functional/cli_root/zpool_import/import_rewind_config_changed.ksh -I 10
Test: functional/cli_root/zpool_import/setup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/import_rewind_config_changed.ksh (run as root) [01:26] [PASS]
Test: functional/cli_root/zpool_import/cleanup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/setup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/import_rewind_config_changed.ksh (run as root) [01:32] [PASS]
Test: functional/cli_root/zpool_import/cleanup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/setup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/import_rewind_config_changed.ksh (run as root) [01:32] [PASS]
Test: functional/cli_root/zpool_import/cleanup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/setup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/import_rewind_config_changed.ksh (run as root) [01:26] [PASS]
Test: functional/cli_root/zpool_import/cleanup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/setup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/import_rewind_config_changed.ksh (run as root) [01:26] [PASS]
Test: functional/cli_root/zpool_import/cleanup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/setup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/import_rewind_config_changed.ksh (run as root) [01:26] [PASS]
Test: functional/cli_root/zpool_import/cleanup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/setup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/import_rewind_config_changed.ksh (run as root) [01:25] [PASS]
Test: functional/cli_root/zpool_import/cleanup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/setup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/import_rewind_config_changed.ksh (run as root) [01:37] [PASS]
Test: functional/cli_root/zpool_import/cleanup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/setup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/import_rewind_config_changed.ksh (run as root) [01:26] [PASS]
Test: functional/cli_root/zpool_import/cleanup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/setup (run as root) [00:00] [PASS]
Test: functional/cli_root/zpool_import/import_rewind_config_changed.ksh (run as root) [01:26] [PASS]
Test: functional/cli_root/zpool_import/cleanup (run as root) [00:00] [PASS]

Results Summary
PASS      30

Running Time:   00:15:00
Percent passed: 100.0%
Log directory:  /var/tmp/test_results/20220218T153331

Tests with results other than PASS that are expected:

Tests with result of PASS that are unexpected:

Tests with results other than PASS that are unexpected:


$ grep Retry /var/tmp/test_results/current/log
15:35:11.67 NOTE: Retry 1 / 5 for test_add_vdevs()
15:37:34.98 NOTE: Retry 1 / 5 for test_attach_vdev()
15:44:57.94 NOTE: Retry 1 / 5 for test_attach_vdev()
15:45:03.62 NOTE: Retry 2 / 5 for test_attach_vdev()
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
