### PR TITLE
Do not run zfsexpandknoweldge if zfs_devs function is present in dracut

### DIFF
--- a/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
+++ b/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
@@ -57,6 +57,12 @@ array_contains () {
 }
 
 check() {
+    # https://github.com/dracutdevs/dracut/pull/1711 provides a zfs_devs
+    # function to detect the physical devices backing zfs pools. If this
+    # function exists in the version of dracut this module is being called
+    # from, then it does not need to run.
+    type zfs_devs >/dev/null 2>&1 && return 1
+
     local mp
     local dev
     local blockdevs


### PR DESCRIPTION
PR 1711 (https://github.com/dracutdevs/dracut/pull/1711) adds a zfs_devs
function to dracut to detect the physical devices backing zfs pools. If
this function exists in the version of dracut this module is being
called from, then it does not need to run.

Signed-off-by: Savyasachee Jha hi@savyasacheejha.com

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Copying in from [this issue](https://github.com/openzfs/zfs/issues/13117):

The openzfs project currently provides the module zfsexpandknowledge which adds zfs devices to dracut's host_devs array and enumerates their filesystem types in the host_fs_types array. Support for every other filesystem is provided by dracut themselves. Ideally the functionality provided by this module should be available upstream (downstream?) with other filesystems where it can take advantage of dracut's existing filesystem logic. It is provided by https://github.com/dracutdevs/dracut/pull/1711 which I opened a short while ago. It has been approved by one dracut maintainer and is awaiting reviews by the others.

### Description
This PR adds a small check for the presence of the `zfs_devs` function. This function is defined in the PR submitted to the dracut project. If this function is present, then dracut can detect the physical devices backing zpools without the need for the `zfsexpandknowledge` module to be run, and so this module is skipped.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
It has been tested on a debian machine (along with the corresponding dracut changes, of course) and has been seen to cause no change in behaviour apart from a loss of verbosity on the command line.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

It's not really a performance enhancement per se, but it does lead to more efficiency in a dracut-based initramfs.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
