### PR TITLE
Add nomount option to pam_zfs_key for autofs integration

### DIFF
--- a/contrib/pam_zfs_key/pam_zfs_key.c
+++ b/contrib/pam_zfs_key/pam_zfs_key.c
@@ -388,14 +388,14 @@ decrypt_mount(pam_handle_t *pamh, const char *ds_name,
 		zfs_close(ds);
 		return (-1);
 	}
-        if (do_mount) {
-                ret = zfs_mount(ds, NULL, 0);
-                if (ret) {
-                        pam_syslog(pamh, LOG_ERR, "mount failed: %d", ret);
-                        zfs_close(ds);
-                        return (-1);
-                }
-        }
+	if (do_mount) {
+		ret = zfs_mount(ds, NULL, 0);
+		if (ret) {
+			pam_syslog(pamh, LOG_ERR, "mount failed: %d", ret);
+			zfs_close(ds);
+			return (-1);
+		}
+	}
 	zfs_close(ds);
 	return (0);
 }
@@ -433,23 +433,23 @@ typedef struct {
 	uid_t uid;
 	const char *username;
 	int unmount_and_unload;
-        int mount;
+	int mount;
 } zfs_key_config_t;
 
-#define HOMES_PARAM "homes="
-#define HOMES_PARAM_LEN (sizeof(HOMES_PARAM) - 1)
+#define	HOMES_PARAM	"homes="
+#define	HOMES_PARAM_LEN	(sizeof (HOMES_PARAM) - 1)
 
-#define RUNSTATEDIR_PARAM "runstatedir="
-#define RUNSTATEDIR_PARAM_LEN (sizeof(RUNSTATEDIR_PARAM) - 1)
+#define	RUNSTATEDIR_PARAM	"runstatedir="
+#define	RUNSTATEDIR_PARAM_LEN	(sizeof (RUNSTATEDIR_PARAM) - 1)
 
-#define NOUNMOUNT_PARAM "nounmount"
-#define NOUNMOUNT_PARAM_LEN (sizeof(NOUNMOUNT_PARAM) - 1)
+#define	NOUNMOUNT_PARAM		"nounmount"
+#define	NOUNMOUNT_PARAM_LEN	(sizeof (NOUNMOUNT_PARAM) - 1)
 
-#define NOMOUNT_PARAM "nomount"
-#define NOMOUNT_PARAM_LEN (sizeof(NOUNMOUNT_PARAM) - 1)
+#define	NOMOUNT_PARAM		"nomount"
+#define	NOMOUNT_PARAM_LEN	(sizeof (NOUNMOUNT_PARAM) - 1)
 
-#define PROP_MOUNTPOINT_PARAM "prop_mountpoint"
-#define PROP_MOUNTPOINT_PARAM_LEN (sizeof(PROP_MOUNTPOINT_PARAM) - 1)
+#define	PROP_MOUNTPOINT_PARAM		"prop_mountpoint"
+#define	PROP_MOUNTPOINT_PARAM_LEN	(sizeof (PROP_MOUNTPOINT_PARAM) - 1)
 
 static int
 zfs_key_config_load(pam_handle_t *pamh, zfs_key_config_t *config,
@@ -483,19 +483,19 @@ zfs_key_config_load(pam_handle_t *pamh, zfs_key_config_t *config,
 	config->uid = entry->pw_uid;
 	config->username = name;
 	config->unmount_and_unload = 1;
-        config->mount = 1;
+	config->mount = 1;
 	config->dsname = NULL;
 	config->homedir = NULL;
 	for (int c = 0; c < argc; c++) {
 		if (strncmp(argv[c], HOMES_PARAM, HOMES_PARAM_LEN) == 0) {
 			free(config->homes_prefix);
 			config->homes_prefix =
-                          strdup(argv[c] + HOMES_PARAM_LEN);
+			    strdup(argv[c] + HOMES_PARAM_LEN);
 		} else if (strncmp(argv[c], RUNSTATEDIR_PARAM,
-                                   RUNSTATEDIR_PARAM_LEN) == 0) {
+		    RUNSTATEDIR_PARAM_LEN) == 0) {
 			free(config->runstatedir);
 			config->runstatedir =
-                          strdup(argv[c] + RUNSTATEDIR_PARAM_LEN);
+			    strdup(argv[c] + RUNSTATEDIR_PARAM_LEN);
 		} else if (strcmp(argv[c], NOUNMOUNT_PARAM) == 0) {
 			config->unmount_and_unload = 0;
 		} else if (strcmp(argv[c], NOMOUNT_PARAM) == 0) {
@@ -504,10 +504,9 @@ zfs_key_config_load(pam_handle_t *pamh, zfs_key_config_t *config,
 		} else if (strcmp(argv[c], "prop_mountpoint") == 0) {
 			config->homedir = strdup(entry->pw_dir);
 		} else {
-                        pam_syslog(pamh, LOG_NOTICE,
-                                   "ignored argument: %s", argv[c]);
-                }
-
+			pam_syslog(pamh, LOG_NOTICE,
+			    "ignored argument: %s", argv[c]);
+		}
 	}
 
 	return (0);


### PR DESCRIPTION
This adds a "nomount" option to the pam_zfs_key module, which will prevent both mounting and unmounting of the filesystems, but will still load the keys.  The idea behind this is to load the keys, but allow autofs to do the actual mounting.

### Motivation and Context

The idea behind this change is that it will facilitate interaction with autofs or a similar system.  The keys will be loaded by the pam_zfs_key module, but autofs will do the work of mounting and unmounting the filesystems (and unloading the keys once the user logs out).  This is necessary on some systems to ensure that the filesystems are unmounted and keys are unloaded.


### Description

This adds a "nomount" option to the pam_zfs_keys module.  It also refactors the argument parsing somewhat, to minimize the possibility of errors resulting from future changes.  The nomount option will prevent the mounting of filesystems, but will still load the keys.  The nomount option also implies the nounmount option, and will prevent attempts to unmount the filesystems and unload the keys.  Users are expected to guarantee that the filesystems are unmounted and the keys are unloaded through other means.

### How Has This Been Tested?

Changes were tested on a FreeBSD system with encrypted ZFS datasets, both with and without the nomount flag specified.  Additionally, extra logging statements were added to verify the correct workflows were happening.

A user's home directory was encrypted, and then the user logged in with the pam_zfs_key module activated, and mount was used to verify that the home directory was mounted (this verifies existing functionality).  Following this, the nounmonut flag was specified, the procedure was repeated, and mount was checked after the user had logged out to ensure that the home directory was still mounted.  Finally, the nomount flag was specified, the user logged in, and mount was used to verify that the home directory was not mounted, and the home directory was then manually mounted from the command line to ensure that the key was loaded.  After the user had logged out, mount was checked to ensure that the home directory had not been unmounted.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly. (No documentation for pam_zfs_key)
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. (No tests for pam_zfs_key)
- [ ] I have run the ZFS Test Suite with this change applied. (Does not modify core ZFS functionality)
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
