### PR TITLE
support incremental receive of clone streams (DRR_FLAG_CLONE)

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -4755,7 +4755,7 @@ zfs_do_receive(int argc, char **argv)
 		nomem();
 
 	/* check options */
-	while ((c = getopt(argc, argv, ":o:x:dehMnuvFsA")) != -1) {
+	while ((c = getopt(argc, argv, ":o:x:CdehMnuvFsA")) != -1) {
 		switch (c) {
 		case 'o':
 			if (!parseprop(props, optarg)) {
@@ -4786,6 +4786,9 @@ zfs_do_receive(int argc, char **argv)
 				usage(B_FALSE);
 			}
 			flags.istail = B_TRUE;
+			break;
+		case 'C':
+			flags.allow_clone_as_incremental = B_TRUE;
 			break;
 		case 'h':
 			flags.skipholds = B_TRUE;

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -829,6 +829,8 @@ typedef struct recvflags {
 
 	/* force unmount while recv snapshot (private) */
 	boolean_t forceunmount;
+
+	boolean_t allow_clone_as_incremental;
 } recvflags_t;
 
 _LIBZFS_H int zfs_receive(libzfs_handle_t *, const char *, nvlist_t *,

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -111,8 +111,8 @@ _LIBZFS_CORE_H int lzc_receive_one(const char *, nvlist_t *, const char *,
     uint64_t *, uint64_t *, uint64_t *, nvlist_t **);
 _LIBZFS_CORE_H int lzc_receive_with_cmdprops(const char *, nvlist_t *,
     nvlist_t *, uint8_t *, uint_t, const char *, boolean_t, boolean_t,
-    boolean_t, int, const struct dmu_replay_record *, int, uint64_t *,
-    uint64_t *, uint64_t *, nvlist_t **);
+    boolean_t, boolean_t, int, const struct dmu_replay_record *, int,
+    uint64_t *, uint64_t *, uint64_t *, nvlist_t **);
 _LIBZFS_CORE_H int lzc_send_space(const char *, const char *,
     enum lzc_send_flags, uint64_t *);
 _LIBZFS_CORE_H int lzc_send_space_resume_redacted(const char *, const char *,

--- a/include/sys/dmu_recv.h
+++ b/include/sys/dmu_recv.h
@@ -78,7 +78,7 @@ typedef struct dmu_recv_cookie {
 } dmu_recv_cookie_t;
 
 int dmu_recv_begin(char *, char *, dmu_replay_record_t *,
-    boolean_t, boolean_t, nvlist_t *, nvlist_t *, char *,
+    boolean_t, boolean_t, nvlist_t *, nvlist_t *, char *, boolean_t,
     dmu_recv_cookie_t *, zfs_file_t *, offset_t *);
 int dmu_recv_stream(dmu_recv_cookie_t *, offset_t *);
 int dmu_recv_end(dmu_recv_cookie_t *, void *);

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -824,7 +824,8 @@ tests = ['rootpool_002_neg', 'rootpool_003_neg', 'rootpool_007_pos']
 tags = ['functional', 'rootpool']
 
 [tests/functional/rsend]
-tests = ['recv_dedup', 'recv_dedup_encrypted_zvol', 'rsend_001_pos',
+tests = [ 'recv_clone_as_incremental', 'recv_dedup',
+    'recv_dedup_encrypted_zvol', 'rsend_001_pos',
     'rsend_002_pos', 'rsend_003_pos', 'rsend_004_pos', 'rsend_005_pos',
     'rsend_006_pos', 'rsend_007_pos', 'rsend_008_pos', 'rsend_009_pos',
     'rsend_010_pos', 'rsend_011_pos', 'rsend_012_pos', 'rsend_013_pos',

--- a/tests/zfs-tests/tests/functional/rsend/Makefile.am
+++ b/tests/zfs-tests/tests/functional/rsend/Makefile.am
@@ -2,6 +2,7 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/rsend
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
+	recv_clone_as_incremental.ksh \
 	recv_dedup.ksh \
 	recv_dedup_encrypted_zvol.ksh \
 	rsend_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/rsend/recv_clone_as_incremental.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/recv_clone_as_incremental.ksh
@@ -1,0 +1,38 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2022 by Christian Schwarz. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/rsend/rsend.kshlib
+
+#
+# DESCRIPTION:
+# Verifies that, with and only with the recv -c flag, we can
+# receive a clone stream as an incremental stream into an existing
+# dataset
+#
+
+verify_runnable "both"
+
+log_onexit cleanup_pool $POOL2
+
+log_must eval "zfs send $POOL@psnap | zfs recv $POOL2/recv@psnap"
+log_mustnot eval "zfs send -i $POOL@psnap $POOL/pclone@init | zfs recv $POOL2/recv@init"
+log_must eval "zfs send -i $POOL@psnap $POOL/pclone@init | zfs recv -C $POOL2/recv@init"
+
+log_pass


### PR DESCRIPTION
If an incremental send is from parent to clone snapshot, we set
DRR_FLAG_CLONE. Example: zfs send -i tank/parentfs@a tank/clone@b
will have the flag set, given the following hierarchy:

  tank/parentfs@a
  tank/clone           origin=tank/parentfs@a
  tank/clone@b

There is no difference to an incremental send/recv within the same
dataset. But since the user pereceives the clone as another dataset,
we want it to behave more like an initial replication.
Hence, we forbid receiving into an existing dataset.
Users who do wish to receive @b into an existing dataset can
do so by receiving into a clone, promoting the clone, destroying
the existing dataset, and renaming the clone to the original name.
However, this has several UX & operational disadvantages, so we
provide drba->drba_allow_clone_as_incremental (= recv -C) to allow
receiving clone streams into existing datasets.

Alternative Design:
I also considered the option of simply removing the checks for
DRR_FLAG_CLONE, making recv of a clone stream into an existing
filesystem "just work" by default.
However, that approach was discarded because
"we just don’t want to add more sharp edges to the user interface".

fixes https://github.com/openzfs/zfs/issues/13094

Signed-off-by: Christian Schwarz <me@cschwarz.com>

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
