### PR TITLE
zpool-create.8: add examples of `zpool create` from zpool.8

### DIFF
--- a/man/man8/zpool-create.8
+++ b/man/man8/zpool-create.8
@@ -66,15 +66,17 @@ The pool names
 .Sy mirror ,
 .Sy raidz ,
 .Sy draid ,
-.Sy spare
+.Sy spare ,
+.Sy special ,
 and
 .Sy log
 are reserved, as are names beginning with
 .Sy mirror ,
 .Sy raidz ,
 .Sy draid ,
+.Sy spare ,
 and
-.Sy spare .
+.Sy special .
 The
 .Ar vdev
 specification is described in the
@@ -205,7 +207,40 @@ such as virtual machines or physical machines whose pools live on network
 block devices.
 .El
 .
+.Sh EXAMPLES
+.Bl -tag -width "Exam"
+.It Sy Example 1 : No Creating a RAID-Z Storage Pool
+The following command creates a pool with a single raidz root vdev that
+consists of six disks:
+.Dl # Nm zpool Cm create Ar tank Sy raidz Ar sda sdb sdc sdd sde sdf
+.
+.It Sy Example 2 : No Creating a Mirrored Storage Pool
+The following command creates a pool with two mirrors, where each mirror
+contains two disks:
+.Dl # Nm zpool Cm create Ar tank Sy mirror Ar sda sdb Sy mirror Ar sdc sdd
+.
+.It Sy Example 3 : No Creating a ZFS Storage Pool by Using Partitions
+The following command creates an unmirrored pool using two disk partitions:
+.Dl # Nm zpool Cm create Ar tank sda1 sdb2
+.
+.It Sy Example 4 : No Creating a ZFS Storage Pool by Using Files
+The following command creates an unmirrored pool using files.
+While not recommended, a pool based on files can be useful for experimental
+purposes.
+.Dl # Nm zpool Cm create Ar tank /path/to/file/a /path/to/file/b
+.
+.It Sy Example 5 : No Creating a ZFS Storage Pool with a Hot Spare
+The following command creates a new pool with an available hot spare:
+.Dl # Nm zpool Cm create Ar tank Sy mirror Ar sda sdb Sy spare Ar sdc
+.
+.It Sy Example 6 : No Creating a ZFS Pool with Mirrored Separate Intent Logs
+The following command creates a ZFS storage pool consisting of two, two-way
+mirrors and mirrored log devices:
+.Dl # Nm zpool Cm create Ar pool Sy mirror Ar sda sdb Sy mirror Ar sdc sdd Sy log mirror Ar sde sdf
+.
 .Sh SEE ALSO
+.Xr zpool 8 ,
+.Xr zpoolconcepts 7 ,
 .Xr zpool-destroy 8 ,
 .Xr zpool-export 8 ,
 .Xr zpool-import 8


### PR DESCRIPTION
- add mention of "special" vdev type
- and cross-references to zpool.8 and zpoolconcepts.7

### Motivation and Context
While explaining to somehow that they might consider using a special allocation class vdev, they pointed out that the type is not mentioned in the zpool-create man page.

I did notice that someone has already fixed the issue with the cross-reference to zpoolconcepts in that opening paragraph, but I've also added a cross reference to the 'see also' section at the end of the man page.

I also copied the relevant (to zpool create) examples from the zpool man page, to populate an examples section for the zpool-create man page.

### Description
Added a few words to the man page, and copied some examples from the zpool.8 man page. I left the examples there as well, where they are part of a broader set of examples (zpool create/add/attach/remove, etc)

### How Has This Been Tested?
Eyeballing the output

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
