### PR TITLE
Fix directory detection in `dkms.mkconf`

### DIFF
--- a/scripts/dkms.mkconf
+++ b/scripts/dkms.mkconf
@@ -29,22 +29,14 @@ PRE_BUILD="configure
   --prefix=/usr
   --with-config=kernel
   --with-linux=\$(
-    case \`lsb_release -is\` in
-      (Debian|Devuan)
-        if [[ -e \${kernel_source_dir/%build/source} ]]
-        then
-          echo \${kernel_source_dir/%build/source}
-        else
-          # A kpkg exception for Proxmox 2.0
-          echo \${kernel_source_dir}
-        fi
-      ;;
-      (*)
-        echo \${kernel_source_dir}
-      ;;
-    esac
+    if [ -e "\${kernel_source_dir/%build/source}" ]
+    then
+      echo "\${kernel_source_dir/%build/source}"
+    else
+      echo "\${kernel_source_dir}"
+    fi
   )
-  --with-linux-obj=\${kernel_source_dir}
+  --with-linux-obj="\${kernel_source_dir}"
   \$(
     [[ -n \"\${ICP_ROOT}\" ]] && \\
     {


### PR DESCRIPTION
### Motivation and Context
#11449

### Description
Fix `zfs-dkms` installation on Debian-derived distributions by
aligning the directory detection logic to #13096.
Fix #11449

### How Has This Been Tested?
`apt install -y zfs-dkms`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
