### PR TITLE
Fix erroneous zstreamdump warning

### DIFF
--- a/cmd/zstream/zstream_dump.c
+++ b/cmd/zstream/zstream_dump.c
@@ -297,6 +297,7 @@ zstream_do_dump(int argc, char *argv[])
 
 	fletcher_4_init();
 	while (read_hdr(drr, &zc)) {
+		uint64_t featureflags = 0;
 
 		/*
 		 * If this is the first DMU record being processed, check for
@@ -361,6 +362,9 @@ zstream_do_dump(int argc, char *argv[])
 				drrb->drr_fromguid =
 				    BSWAP_64(drrb->drr_fromguid);
 			}
+
+			featureflags =
+			    DMU_GET_FEATUREFLAGS(drrb->drr_versioninfo);
 
 			(void) printf("BEGIN record\n");
 			(void) printf("\thdrtype = %lld\n",
@@ -461,7 +465,8 @@ zstream_do_dump(int argc, char *argv[])
 				    BSWAP_64(drro->drr_maxblkid);
 			}
 
-			if (drro->drr_bonuslen > drro->drr_raw_bonuslen) {
+			if (featureflags & DMU_BACKUP_FEATURE_RAW &&
+			    drro->drr_bonuslen > drro->drr_raw_bonuslen) {
 				(void) fprintf(stderr,
 				    "Warning: Object %llu has bonuslen = "
 				    "%u > raw_bonuslen = %u\n\n",


### PR DESCRIPTION

### Motivation and Context
When using zstream dump on a normal send stream that contains objects with bonus buffers, you get something like the following warning: `Warning: Object 34 has bonuslen = 176 > raw_bonuslen = 0`. This is because we always compare the bonuslen to the raw_bonuslen, but we only set the raw_bonuslen for raw sends.

### Description
We check the featureflags to see if this is a raw send before doing the bonuslen check.

### How Has This Been Tested?
Tested on a send stream created without raw send, verified that no warning was erroneously printed. Passes zfs test suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
