### PR TITLE
ztest: Fix ASSERT in ztest_objset_destroy_cb()

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -4273,7 +4273,15 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 	 * Destroy the dataset.
 	 */
 	if (strchr(name, '@') != NULL) {
-		VERIFY0(dsl_destroy_snapshot(name, B_TRUE));
+		error = dsl_destroy_snapshot(name, B_TRUE);
+		if (error != ECHRNG) {
+			/*
+			 * The program was executed, but encountered a runtime
+			 * error, such as insufficient slop, or a hold on the
+			 * dataset.
+			 */
+			ASSERT0(error);
+		}
 	} else {
 		error = dsl_destroy_head(name);
 		if (error == ENOSPC) {


### PR DESCRIPTION
### Motivation and Context

Resolves a reasonably frequent `ztest` failure observed which can
result in incorrect CI failures.

### Description

The `dsl_destroy_snapshot()` call in `ztest_objset_destroy_cb()` may
encounter a runtime error when the pool is out of space.  This is
similar to the error handling for the `dsl_destroy_head()` case,
but since `dsl_destroy_snapshot()` is implemented as a channel
program `ECHRNG` is returned instead of `ENOSPC`. `ECHRNG` may also 
be returned instead of `EBUSY` if there is a hold on the snapshot. 

### How Has This Been Tested?

Locally reproduced and instrumented `zcp_eval()` to log the
error returned by `dsl_sync_task_sig()` before it was overwritten
with the generic `ECHRNG`.

I've left `zloop` running with the extra instrumentation to verify
these are the only cases observed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
