### PR TITLE
ZTS: Fix send_partial_dataset.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -583,24 +583,22 @@ function churn_files
 #
 function mess_send_file
 {
+	typeset -i minsize=2072
 	file=$1
 
 	filesize=$(stat_size $file)
+	if [ $filesize -lt $minsize ]; then
+		log_fail "Send file too small: $filesize < $minsize"
+	fi
 
-	offset=$(($RANDOM * $RANDOM % $filesize))
-
-	# The random offset might truncate the send stream to be
-	# smaller than the DRR_BEGIN record. If this happens, then
-	# the receiving system won't have enough info to create the
-	# partial dataset at all. We use zstream dump to check for
-	# this and retry in this case.
+	# Truncate the send stream at a random offset after the DRR_BEGIN
+	# record (beyond 2072 bytes), any smaller than this and the receiving
+	# system won't have enough info to create the partial dataset at all.
+	# We use zstream dump to verify there is an intact DRR_BEGIN record.
+	offset=$(((($RANDOM * $RANDOM) % ($filesize - $minsize)) + $minsize))
 	nr_begins=$(head -c $offset $file | zstream dump | \
 	    grep DRR_BEGIN | awk '{ print $5 }')
-	while [ "$nr_begins" -eq 0 ]; do
-		offset=$(($RANDOM * $RANDOM % $filesize))
-		nr_begins=$(head -c $offset $file | zstream dump | \
-		    grep DRR_BEGIN | awk '{ print $5 }')
-	done
+	log_must test "$nr_begins" -eq 1
 
 	if (($RANDOM % 7 <= 1)); then
 		#


### PR DESCRIPTION
### Motivation and Context

Observed CI failure:

http://build.zfsonlinux.org/builders/CentOS%208%20x86_64%20%28TEST%29/builds/7575/steps/shell_4/logs/summary

### Description

The send_partial_dataset test verifies that partial send streams
 can be resumed.  This test may occasionally fail with a "token is
 corrupt" error if the `mess_send_file` truncates a send stream
 below the size of the DRR_BEGIN record.  Update this function to
 set a minimum size to ensure there is at least an intact DDR_BEGIN
 record which allows for the receiving dataset to be created.

[edit] Updated PR with a fix for the test case rather than an exception.

### How Has This Been Tested?

Modified the test case to intentionally truncate the send stream
in the middle of the DDR_BEGIN record to reproduce the failure.
Then updated the test to truncate after the minimum size and
confirmed the test behaved as intended.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
