### PR TITLE
Use literal `xgetbv` instead of bitbanging it

### DIFF
--- a/config/toolchain-simd.m4
+++ b/config/toolchain-simd.m4
@@ -27,6 +27,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_TOOLCHAIN_SIMD], [
 			ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVE
 			ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVEOPT
 			ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVES
+			ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XGETBV
 			;;
 	esac
 ])
@@ -484,6 +485,26 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVES], [
 	]])], [
 		AC_MSG_RESULT([yes])
 		AC_DEFINE([HAVE_XSAVES], 1, [Define if host toolchain supports XSAVES])
+	], [
+		AC_MSG_RESULT([no])
+	])
+])
+
+dnl #
+dnl # ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XGETBV
+dnl #
+AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XGETBV], [
+	AC_MSG_CHECKING([whether host toolchain supports XGETBV])
+
+	AC_LINK_IFELSE([AC_LANG_SOURCE([
+	[
+		void main()
+		{
+		  __asm__ __volatile__("xgetbv");
+		}
+	]])], [
+		AC_MSG_RESULT([yes])
+		AC_DEFINE([HAVE_XGETBV], 1, [Define if host toolchain supports XGETBV])
 	], [
 		AC_MSG_RESULT([no])
 	])

--- a/include/os/freebsd/spl/sys/simd_x86.h
+++ b/include/os/freebsd/spl/sys/simd_x86.h
@@ -55,6 +55,9 @@
  * Only call this function if CPUID indicates that AVX feature is
  * supported by the CPU, otherwise it might be an illegal instruction.
  */
+#ifndef HAVE_XGETBV
+#error "xgetbv assembler support required"
+#endif
 static inline uint64_t
 xgetbv(uint32_t index)
 {

--- a/include/os/freebsd/spl/sys/simd_x86.h
+++ b/include/os/freebsd/spl/sys/simd_x86.h
@@ -59,8 +59,7 @@ static inline uint64_t
 xgetbv(uint32_t index)
 {
 	uint32_t eax, edx;
-	/* xgetbv - instruction byte code */
-	__asm__ __volatile__(".byte 0x0f; .byte 0x01; .byte 0xd0"
+	__asm__ __volatile__("xgetbv"
 	    : "=a" (eax), "=d" (edx)
 	    : "c" (index));
 

--- a/include/os/linux/kernel/linux/simd_x86.h
+++ b/include/os/linux/kernel/linux/simd_x86.h
@@ -410,6 +410,9 @@ out:
  * Only call this function if CPUID indicates that AVX feature is
  * supported by the CPU, otherwise it might be an illegal instruction.
  */
+#ifndef HAVE_XGETBV
+#error "xgetbv assembler support required"
+#endif
 static inline uint64_t
 zfs_xgetbv(uint32_t index)
 {

--- a/include/os/linux/kernel/linux/simd_x86.h
+++ b/include/os/linux/kernel/linux/simd_x86.h
@@ -414,8 +414,7 @@ static inline uint64_t
 zfs_xgetbv(uint32_t index)
 {
 	uint32_t eax, edx;
-	/* xgetbv - instruction byte code */
-	__asm__ __volatile__(".byte 0x0f; .byte 0x01; .byte 0xd0"
+	__asm__ __volatile__("xgetbv"
 	    : "=a" (eax), "=d" (edx)
 	    : "c" (index));
 

--- a/lib/libspl/include/sys/simd.h
+++ b/lib/libspl/include/sys/simd.h
@@ -142,8 +142,7 @@ static inline uint64_t
 xgetbv(uint32_t index)
 {
 	uint32_t eax, edx;
-	/* xgetbv - instruction byte code */
-	__asm__ __volatile__(".byte 0x0f; .byte 0x01; .byte 0xd0"
+	__asm__ __volatile__("xgetbv"
 	    : "=a" (eax), "=d" (edx)
 	    : "c" (index));
 

--- a/lib/libspl/include/sys/simd.h
+++ b/lib/libspl/include/sys/simd.h
@@ -138,6 +138,9 @@ static const cpuid_feature_desc_t cpuid_features[] = {
  * Only call this function if CPUID indicates that AVX feature is
  * supported by the CPU, otherwise it might be an illegal instruction.
  */
+#ifndef HAVE_XGETBV
+#error "xgetbv assembler support required"
+#endif
 static inline uint64_t
 xgetbv(uint32_t index)
 {


### PR DESCRIPTION
### Motivation and Context
Dunno. Don't like that it's just .byte directives

### How Has This Been Tested?
Builds On My Machine™.

Also, are we sure we need three separate identical xgetbvs?

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none should apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
