### PR TITLE
WIP: Native NFSv4-style ZFS ACL support for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@
 modules.order
 Makefile
 Makefile.in
+nfs41acl.h
+nfs41acl_xdr.c
 *.patch
 *.orig
 *.tmp

--- a/Makefile.am
+++ b/Makefile.am
@@ -122,6 +122,7 @@ cstyle:
 	$(AM_V_at)find $(top_srcdir) -name build -prune \
 		-o -type f -name '*.[hc]' \
 		! -name 'zfs_config.*' ! -name '*.mod.c' \
+		! -name 'nfs41acl_xdr.c' ! -name 'nfs41acl.h' \
 		! -name 'opt_global.h' ! -name '*_if*.h' \
 		! -name 'zstd_compat_wrapper.h' \
 		! -path './module/zstd/lib/*' \

--- a/include/os/linux/spl/rpc/xdr.h
+++ b/include/os/linux/spl/rpc/xdr.h
@@ -22,6 +22,7 @@
 #define	_SPL_RPC_XDR_H
 
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 
 typedef int bool_t;
 

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -91,7 +91,12 @@ zpl_chmod_acl(struct inode *ip)
 }
 #endif /* CONFIG_FS_POSIX_ACL */
 
+#if defined(HAVE_IOPS_PERMISSION_USERNS)
+extern int zpl_permission(struct user_namespace *userns, struct inode *ip,
+    int mask);
+#else
 extern int zpl_permission(struct inode *ip, int mask);
+#endif
 
 extern xattr_handler_t *zpl_xattr_handlers[];
 

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -91,6 +91,8 @@ zpl_chmod_acl(struct inode *ip)
 }
 #endif /* CONFIG_FS_POSIX_ACL */
 
+extern int zpl_permission(struct inode *ip, int mask);
+
 extern xattr_handler_t *zpl_xattr_handlers[];
 
 /* zpl_ctldir.c */

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -413,6 +413,7 @@ ZFS_OBJS_OS := \
 	abd_os.o \
 	arc_os.o \
 	mmp_os.o \
+	nfs41acl_xdr.o \
 	policy.o \
 	qat.o \
 	qat_compress.o \

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -53,6 +53,16 @@ FMAKE = env -u MAKEFLAGS make $(FMAKEFLAGS)
 modules-Linux:
 	mkdir -p $(sort $(dir $(spl-objs) $(spl-)))
 	mkdir -p $(sort $(dir $(zfs-objs) $(zfs-)))
+	@# Generate the nfs41acl XDR header.
+	rpcgen -h "@abs_srcdir@/os/linux/zfs/nfs41acl.x" > "@abs_srcdir@/os/linux/zfs/nfs41acl.h"
+	sed -i "/\<rpc\/rpc.h\>/c\\#include \<rpc\/xdr.h\>" "@abs_srcdir@/os/linux/zfs/nfs41acl.h"
+	sed -i "9i #include <sys/sysmacros.h>" "@abs_srcdir@/os/linux/zfs/nfs41acl.h"
+	@# Generate the nfs41acl XDR code.
+	rpcgen -c "@abs_srcdir@/os/linux/zfs/nfs41acl.x" > "@abs_srcdir@/os/linux/zfs/nfs41acl_xdr.c"
+	sed -i "5i #pragma GCC diagnostic push" "@abs_srcdir@/os/linux/zfs/nfs41acl_xdr.c"
+	sed -i "6i #pragma GCC diagnostic ignored \"-Wunused-variable\"" "@abs_srcdir@/os/linux/zfs/nfs41acl_xdr.c"
+	echo "#pragma GCC diagnostic pop" >> "@abs_srcdir@/os/linux/zfs/nfs41acl_xdr.c"
+	@# Build the kernel modules.
 	$(MAKE) -C @LINUX_OBJ@ $(if @KERNEL_CC@,CC=@KERNEL_CC@) \
 		$(if @KERNEL_LD@,LD=@KERNEL_LD@) $(if @KERNEL_LLVM@,LLVM=@KERNEL_LLVM@) \
 		M="$$PWD" @KERNEL_MAKE@ CONFIG_ZFS=m modules
@@ -161,7 +171,7 @@ cppcheck-FreeBSD:
 cppcheck: cppcheck-@ac_system@
 
 distdir:
-	cd @srcdir@ && find . -name '*.[chS]' -exec sh -c 'for f; do mkdir -p $$distdir/$${f%/*}; cp @srcdir@/$$f $$distdir/$$f; done' _ {} +
+	cd @srcdir@ && find . -name '*.[chxS]' -exec sh -c 'for f; do mkdir -p $$distdir/$${f%/*}; cp @srcdir@/$$f $$distdir/$$f; done' _ {} +
 	cp @srcdir@/Makefile.bsd $$distdir/Makefile.bsd
 
 gen-zstd-symbols:

--- a/module/os/linux/zfs/nfs41acl.x
+++ b/module/os/linux/zfs/nfs41acl.x
@@ -1,0 +1,74 @@
+const ACE4_ACCESS_ALLOWED_ACE_TYPE      = 0x00000000;
+const ACE4_ACCESS_DENIED_ACE_TYPE       = 0x00000001;
+const ACE4_SYSTEM_AUDIT_ACE_TYPE        = 0x00000002;
+const ACE4_SYSTEM_ALARM_ACE_TYPE        = 0x00000003;
+
+typedef u_int acetype4;
+
+const ACE4_FILE_INHERIT_ACE             = 0x00000001;
+const ACE4_DIRECTORY_INHERIT_ACE        = 0x00000002;
+const ACE4_NO_PROPAGATE_INHERIT_ACE     = 0x00000004;
+const ACE4_INHERIT_ONLY_ACE             = 0x00000008;
+const ACE4_SUCCESSFUL_ACCESS_ACE_FLAG   = 0x00000010;
+const ACE4_FAILED_ACCESS_ACE_FLAG       = 0x00000020;
+const ACE4_IDENTIFIER_GROUP             = 0x00000040;
+const ACE4_INHERITED_ACE                = 0x00000080;
+
+typedef u_int aceflag4;
+
+const ACEI4_SPECIAL_WHO                  = 0x00000001;
+
+typedef u_int aceiflag4;
+
+const ACE4_SPECIAL_OWNER                = 1;
+const ACE4_SPECIAL_GROUP                = 2;
+const ACE4_SPECIAL_EVERYONE             = 3;
+const ACE4_SPECIAL_INTERACTIVE          = 4;
+const ACE4_SPECIAL_NETWORK              = 5;
+const ACE4_SPECIAL_DIALUP               = 6;
+const ACE4_SPECIAL_BATCH                = 7;
+const ACE4_SPECIAL_ANONYMOUS            = 8;
+const ACE4_SPECIAL_AUTHENTICATED        = 9;
+const ACE4_SPECIAL_SERVICE              = 10;
+
+const ACE4_READ_DATA            = 0x00000001;
+const ACE4_LIST_DIRECTORY       = 0x00000001;
+const ACE4_WRITE_DATA           = 0x00000002;
+const ACE4_ADD_FILE             = 0x00000002;
+const ACE4_APPEND_DATA          = 0x00000004;
+const ACE4_ADD_SUBDIRECTORY     = 0x00000004;
+const ACE4_READ_NAMED_ATTRS     = 0x00000008;
+const ACE4_WRITE_NAMED_ATTRS    = 0x00000010;
+const ACE4_EXECUTE              = 0x00000020;
+const ACE4_DELETE_CHILD         = 0x00000040;
+const ACE4_READ_ATTRIBUTES      = 0x00000080;
+const ACE4_WRITE_ATTRIBUTES     = 0x00000100;
+const ACE4_WRITE_RETENTION      = 0x00000200;
+const ACE4_WRITE_RETENTION_HOLD = 0x00000400;
+
+const ACE4_DELETE               = 0x00010000;
+const ACE4_READ_ACL             = 0x00020000;
+const ACE4_WRITE_ACL            = 0x00040000;
+const ACE4_WRITE_OWNER          = 0x00080000;
+const ACE4_SYNCHRONIZE          = 0x00100000;
+
+typedef u_int acemask4;
+
+struct nfsace4i {
+        acetype4        type;
+        aceflag4        flag;
+        aceiflag4       iflag;
+        acemask4        access_mask;
+        u_int           who;
+};
+
+const ACL4_AUTO_INHERIT         = 0x00000001;
+const ACL4_PROTECTED            = 0x00000002;
+const ACL4_DEFAULTED            = 0x00000004;
+
+typedef u_int aclflag4;
+
+struct nfsacl41i {
+        aclflag4        na41_flag;
+        nfsace4i        na41_aces<>;
+};

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -353,12 +353,17 @@ acltype_changed_cb(void *arg, uint64_t newval)
 	zfsvfs_t *zfsvfs = arg;
 
 	switch (newval) {
-	case ZFS_ACLTYPE_NFSV4:
 	case ZFS_ACLTYPE_OFF:
 		zfsvfs->z_acl_type = ZFS_ACLTYPE_OFF;
 		zfsvfs->z_sb->s_flags &= ~SB_POSIXACL;
+#ifdef SB_NFSV4ACL
+		zfsvfs->z_sb->s_flags &= ~SB_NFSV4ACL;
+#endif
 		break;
 	case ZFS_ACLTYPE_POSIX:
+#ifdef SB_NFSV4ACL
+		zfsvfs->z_sb->s_flags &= ~SB_NFSV4ACL;
+#endif
 #ifdef CONFIG_FS_POSIX_ACL
 		zfsvfs->z_acl_type = ZFS_ACLTYPE_POSIX;
 		zfsvfs->z_sb->s_flags |= SB_POSIXACL;
@@ -366,6 +371,13 @@ acltype_changed_cb(void *arg, uint64_t newval)
 		zfsvfs->z_acl_type = ZFS_ACLTYPE_OFF;
 		zfsvfs->z_sb->s_flags &= ~SB_POSIXACL;
 #endif /* CONFIG_FS_POSIX_ACL */
+		break;
+	case ZFS_ACLTYPE_NFSV4:
+		zfsvfs->z_acl_type = ZFS_ACLTYPE_NFSV4;
+		zfsvfs->z_sb->s_flags &= ~SB_POSIXACL;
+#ifdef SB_NFSV4ACL
+		zfsvfs->z_sb->s_flags |= SB_NFSV4ACL;
+#endif
 		break;
 	default:
 		break;

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -753,6 +753,7 @@ const struct inode_operations zpl_inode_operations = {
 #endif /* HAVE_SET_ACL */
 	.get_acl	= zpl_get_acl,
 #endif /* CONFIG_FS_POSIX_ACL */
+	.permission	= zpl_permission,
 };
 
 const struct inode_operations zpl_dir_inode_operations = {
@@ -786,6 +787,7 @@ const struct inode_operations zpl_dir_inode_operations = {
 #endif /* HAVE_SET_ACL */
 	.get_acl	= zpl_get_acl,
 #endif /* CONFIG_FS_POSIX_ACL */
+	.permission	= zpl_permission,
 };
 
 const struct inode_operations zpl_symlink_inode_operations = {
@@ -825,6 +827,7 @@ const struct inode_operations zpl_special_inode_operations = {
 #endif /* HAVE_SET_ACL */
 	.get_acl	= zpl_get_acl,
 #endif /* CONFIG_FS_POSIX_ACL */
+	.permission	= zpl_permission,
 };
 
 dentry_operations_t zpl_dentry_operations = {

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -229,6 +229,9 @@ __zpl_show_options(struct seq_file *seq, zfsvfs_t *zfsvfs)
 	case ZFS_ACLTYPE_POSIX:
 		seq_puts(seq, ",posixacl");
 		break;
+	case ZFS_ACLTYPE_NFSV4:
+		seq_puts(seq, ",nfs4acl");
+		break;
 	default:
 		seq_puts(seq, ",noacl");
 		break;

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -1449,7 +1449,11 @@ static xattr_handler_t zpl_xattr_acl_default_handler = {
 #endif /* CONFIG_FS_POSIX_ACL */
 
 int
+#if defined(HAVE_IOPS_PERMISSION_USERNS)
+zpl_permission(struct user_namespace *userns, struct inode *ip, int mask)
+#else
 zpl_permission(struct inode *ip, int mask)
+#endif
 {
 	int to_check = 0, i, ret;
 	cred_t *cr = NULL;
@@ -1462,7 +1466,11 @@ zpl_permission(struct inode *ip, int mask)
 	 */
 	if ((ITOZSB(ip)->z_acl_type != ZFS_ACLTYPE_NFSV4) ||
 	    ((ITOZ(ip)->z_pflags & ZFS_ACL_TRIVIAL && GENERIC_MASK(mask)))) {
+#if defined(HAVE_IOPS_PERMISSION_USERNS)
+		return (generic_permission(userns, ip, mask));
+#else
 		return (generic_permission(ip, mask));
+#endif
 	}
 
 	for (i = 0; i < ARRAY_SIZE(mask2zfs); i++) {
@@ -1476,7 +1484,11 @@ zpl_permission(struct inode *ip, int mask)
 	 * NFSv4 ACE. Pass back to default kernel permissions check.
 	 */
 	if (to_check == 0) {
+#if defined(HAVE_IOPS_PERMISSION_USERNS)
+		return (generic_permission(userns, ip, mask));
+#else
 		return (generic_permission(ip, mask));
+#endif
 	}
 
 	/*

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -107,7 +107,8 @@ static const struct {
 #endif
 };
 
-#define	GENERIC_MASK(mask) ((mask & ~(MAY_READ | MAY_WRITE | MAY_EXEC)) == 0)
+#define	POSIX_MASKS	(MAY_READ|MAY_WRITE|MAY_EXEC|MAY_OPEN)
+#define	GENERIC_MASK(mask) ((mask & ~POSIX_MASKS) == 0)
 
 enum xattr_permission {
 	XAPERM_DENY,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ZFS on Linux has so far not supported the native ZFS ACL type because the Linux kernel lacks support for NFSv4-style ACLs. Instead, ZFS on Linux implemented a new POSIX ACL type. The ACL types are not interchangeable, so existing pools with ACLs on illumos or FreeBSD cannot be used on Linux without loss of those ACLs, and conversely a pool created on Linux with POSIX ACLs cannot use those ACLs on other platforms where only the native ZFS NFSv4-style ACLs are implemented.

See also: #9709 

### Description
<!--- Describe your changes in detail -->
We have implemented NFSv4 ACLs for Linux in ZFS. This is mostly functional with a stock Linux kernel, and we have patches for the kernel to fix the few mishandled edge cases that exist.

Details in the commit messages for now, I'm just getting this PR open early for some initial test coverage across the broad range of Linux distros in the OpenZFS CI.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
We have a suite of tests in TrueNAS that test this functionality. I intend to port what I can of these tests to ZTS for regular testing outside of our internal infrastructure.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
