### PR TITLE
module: zfs: arc: hdr_full_crypt_dest: drop unevaulated-only variable

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1204,11 +1204,11 @@ hdr_full_dest(void *vbuf, void *unused)
 static void
 hdr_full_crypt_dest(void *vbuf, void *unused)
 {
-	(void) unused;
-	arc_buf_hdr_t *hdr = vbuf;
+	(void) vbuf, (void) unused;
 
 	hdr_full_dest(vbuf, unused);
-	arc_space_return(sizeof (hdr->b_crypt_hdr), ARC_SPACE_HDRS);
+	arc_space_return(sizeof (((arc_buf_hdr_t *)NULL)->b_crypt_hdr),
+	    ARC_SPACE_HDRS);
 }
 
 static void


### PR DESCRIPTION
### Motivation and Context
#13194

### Description
Doesn't fix #13194

### How Has This Been Tested?
Builds

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
