### PR TITLE
libzfs: Convert to fnvpair functions

### DIFF
--- a/lib/libzfs/libzfs_config.c
+++ b/lib/libzfs/libzfs_config.c
@@ -193,7 +193,7 @@ namespace_reload(libzfs_handle_t *hdl)
 			return (-1);
 		}
 
-		verify(nvpair_value_nvlist(elem, &child) == 0);
+		child = fnvpair_value_nvlist(elem);
 		if (nvlist_dup(child, &cn->cn_config, 0) != 0) {
 			free(cn->cn_name);
 			free(cn);

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -48,7 +48,6 @@ pool_active(libzfs_handle_t *hdl, const char *name, uint64_t guid,
     boolean_t *isactive)
 {
 	zpool_handle_t *zhp;
-	uint64_t theguid;
 
 	if (zpool_open_silent(hdl, name, &zhp) != 0)
 		return (-1);
@@ -58,8 +57,8 @@ pool_active(libzfs_handle_t *hdl, const char *name, uint64_t guid,
 		return (0);
 	}
 
-	verify(nvlist_lookup_uint64(zhp->zpool_config, ZPOOL_CONFIG_POOL_GUID,
-	    &theguid) == 0);
+	uint64_t theguid = fnvlist_lookup_uint64(zhp->zpool_config,
+	    ZPOOL_CONFIG_POOL_GUID);
 
 	zpool_close(zhp);
 
@@ -239,12 +238,10 @@ zpool_clear_label(int fd)
 static boolean_t
 find_guid(nvlist_t *nv, uint64_t guid)
 {
-	uint64_t tmp;
 	nvlist_t **child;
 	uint_t c, children;
 
-	verify(nvlist_lookup_uint64(nv, ZPOOL_CONFIG_GUID, &tmp) == 0);
-	if (tmp == guid)
+	if (fnvlist_lookup_uint64(nv, ZPOOL_CONFIG_GUID) == guid)
 		return (B_TRUE);
 
 	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN,
@@ -268,18 +265,16 @@ find_aux(zpool_handle_t *zhp, void *data)
 {
 	aux_cbdata_t *cbp = data;
 	nvlist_t **list;
-	uint_t i, count;
-	uint64_t guid;
-	nvlist_t *nvroot;
+	uint_t count;
 
-	verify(nvlist_lookup_nvlist(zhp->zpool_config, ZPOOL_CONFIG_VDEV_TREE,
-	    &nvroot) == 0);
+	nvlist_t *nvroot = fnvlist_lookup_nvlist(zhp->zpool_config,
+	    ZPOOL_CONFIG_VDEV_TREE);
 
 	if (nvlist_lookup_nvlist_array(nvroot, cbp->cb_type,
 	    &list, &count) == 0) {
-		for (i = 0; i < count; i++) {
-			verify(nvlist_lookup_uint64(list[i],
-			    ZPOOL_CONFIG_GUID, &guid) == 0);
+		for (uint_t i = 0; i < count; i++) {
+			uint64_t guid = fnvlist_lookup_uint64(list[i],
+			    ZPOOL_CONFIG_GUID);
 			if (guid == cbp->cb_guid) {
 				cbp->cb_zhp = zhp;
 				return (1);
@@ -320,16 +315,12 @@ zpool_in_use(libzfs_handle_t *hdl, int fd, pool_state_t *state, char **namestr,
 	if (config == NULL)
 		return (0);
 
-	verify(nvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_STATE,
-	    &stateval) == 0);
-	verify(nvlist_lookup_uint64(config, ZPOOL_CONFIG_GUID,
-	    &vdev_guid) == 0);
+	stateval = fnvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_STATE);
+	vdev_guid = fnvlist_lookup_uint64(config, ZPOOL_CONFIG_GUID);
 
 	if (stateval != POOL_STATE_SPARE && stateval != POOL_STATE_L2CACHE) {
-		verify(nvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME,
-		    &name) == 0);
-		verify(nvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_GUID,
-		    &guid) == 0);
+		name = fnvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME);
+		guid = fnvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_GUID);
 	}
 
 	switch (stateval) {
@@ -378,10 +369,8 @@ zpool_in_use(libzfs_handle_t *hdl, int fd, pool_state_t *state, char **namestr,
 			if ((zhp = zpool_open_canfail(hdl, name)) != NULL &&
 			    (pool_config = zpool_get_config(zhp, NULL))
 			    != NULL) {
-				nvlist_t *nvroot;
-
-				verify(nvlist_lookup_nvlist(pool_config,
-				    ZPOOL_CONFIG_VDEV_TREE, &nvroot) == 0);
+				nvlist_t *nvroot = fnvlist_lookup_nvlist(
+				    pool_config, ZPOOL_CONFIG_VDEV_TREE);
 				ret = find_guid(nvroot, vdev_guid);
 			} else {
 				ret = B_FALSE;

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -296,9 +296,9 @@ zpool_in_use(libzfs_handle_t *hdl, int fd, pool_state_t *state, char **namestr,
     boolean_t *inuse)
 {
 	nvlist_t *config;
-	char *name;
+	char *name = NULL;
 	boolean_t ret;
-	uint64_t guid, vdev_guid;
+	uint64_t guid = 0, vdev_guid;
 	zpool_handle_t *zhp;
 	nvlist_t *pool_config;
 	uint64_t stateval, isspare;

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1199,10 +1199,8 @@ zcmd_write_nvlist_com(libzfs_handle_t *hdl, uint64_t *outnv, uint64_t *outlen,
     nvlist_t *nvl)
 {
 	char *packed;
-	size_t len;
 
-	verify(nvlist_size(nvl, &len, NV_ENCODE_NATIVE) == 0);
-
+	size_t len = fnvlist_size(nvl);
 	if ((packed = zfs_alloc(hdl, len)) == NULL)
 		return (-1);
 

--- a/lib/libzfs/os/linux/libzfs_pool_os.c
+++ b/lib/libzfs/os/linux/libzfs_pool_os.c
@@ -224,10 +224,8 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, const char *name)
 	    dgettext(TEXT_DOMAIN, "cannot label '%s'"), name);
 
 	if (zhp) {
-		nvlist_t *nvroot;
-
-		verify(nvlist_lookup_nvlist(zhp->zpool_config,
-		    ZPOOL_CONFIG_VDEV_TREE, &nvroot) == 0);
+		nvlist_t *nvroot = fnvlist_lookup_nvlist(zhp->zpool_config,
+		    ZPOOL_CONFIG_VDEV_TREE);
 
 		if (zhp->zpool_start_block == 0)
 			start_block = find_start_block(nvroot);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve readability.  No functional change intended.

### Description
<!--- Describe your changes in detail -->
Straightforward conversion from manually verified `nvpair` functions to internally verified `fnvpair` functions. In some places I made small style adjustments as well. The changes cover all of `lib/libzfs`. A few `nvpair` uses remain so as to not change existing behavior, usually with regard to error handling. NB there is no `fnvlist_lookup_nvlist_array`.

For some reason I started seeing CI build failures with GCC erroring out on a variable it couldn't tell had been set before use. I have a commit to fix that as well, but I want to try to reproduce it in the OpenZFS CI before I throw in a hack for something that may have been a fluke.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS sanity passed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
