### PR TITLE
Fix get_key_material_https bogus free call

### DIFF
--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -614,7 +614,6 @@ get_key_material_https(libzfs_handle_t *hdl, const char *uri,
 kfdok:
 	if ((key = fdopen(kfd, "r+")) == NULL) {
 		ret = errno;
-		free(path);
 		(void) close(kfd);
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 		    "Couldn't reopen temporary file: %s"), strerror(ret));


### PR DESCRIPTION
### Motivation and Context

This trivial change fixes a bogus `free` call in get_key_material_https error code path.

### Description

The get_key_material_https function error code path had a bogus `free` call, either resulting in double-free or `free` of uninitialized pointer.

### How Has This Been Tested?

Built on linux amd64 & test suite ran.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly. (doesn't apply, trivial change)
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. (doesn't apply, trivial change)
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
