### PR TITLE
[2.1] get_key_material_https: removed bogus free() call

### DIFF
--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -606,7 +606,6 @@ get_key_material_https(libzfs_handle_t *hdl, const char *uri,
 kfdok:
 	if ((key = fdopen(kfd, "r+")) == NULL) {
 		ret = errno;
-		free(path);
 		(void) close(kfd);
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 		    "Couldn't reopen temporary file: %s"), strerror(ret));


### PR DESCRIPTION
### Motivation and Context
This is, potentially, like, a big problem on kernels without O_TMPFILE (< 3.11, which is, haha, the oldest thing we support) and a slightly smaller one on other systems where the fdopen() allocation could fail.

### Description
Clean cherry-pick of #13198.

Targeting this at 2.1-release like #13196. Dunno if that's Proper.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
