### PR TITLE
WIP: Punt zfs_dbgmsg into zcommon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,7 @@ AC_CONFIG_FILES([
 	module/lua/Makefile
 	module/nvpair/Makefile
 	module/os/linux/spl/Makefile
+	module/os/linux/zcommon/Makefile
 	module/os/linux/zfs/Makefile
 	module/spl/Makefile
 	module/unicode/Makefile

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -4,6 +4,7 @@ VPATH = \
 	$(top_srcdir)/module/zfs \
 	$(top_srcdir)/module/zcommon \
 	$(top_srcdir)/module/lua \
+	$(top_srcdir)/module/os/linux/zcommon \
 	$(top_srcdir)/module/os/linux/zfs \
 	$(top_srcdir)/lib/libzpool
 

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -826,6 +826,7 @@ kernel_init(int mode)
 	(void) snprintf(hw_serial, sizeof (hw_serial), "%ld",
 	    (mode & SPA_MODE_WRITE) ? get_system_hostid() : 0);
 
+	zfs_dbgmsg_init();
 	random_init();
 
 	VERIFY0(uname(&hw_utsname));
@@ -854,6 +855,7 @@ kernel_fini(void)
 	system_taskq_fini();
 
 	random_fini();
+	zfs_dbgmsg_fini();
 }
 
 uid_t

--- a/module/os/linux/zcommon/Makefile.in
+++ b/module/os/linux/zcommon/Makefile.in
@@ -1,0 +1,9 @@
+#
+# Linux specific sources included from module/zcommon/Makefile.in
+#
+
+# Suppress unused-value warnings in sparc64 architecture headers
+ccflags-$(CONFIG_SPARC64) += -Wno-unused-value
+
+$(MODULE)-objs += ../os/linux/zcommon/zfs_debug.o
+$(MODULE)-objs += ../os/linux/zcommon/trace.o

--- a/module/os/linux/zcommon/trace.c
+++ b/module/os/linux/zcommon/trace.c
@@ -39,16 +39,5 @@
 #ifdef _KERNEL
 #define	CREATE_TRACE_POINTS
 #include <sys/trace.h>
-#include <sys/trace_acl.h>
-#include <sys/trace_arc.h>
-#include <sys/trace_dbuf.h>
-#include <sys/trace_dmu.h>
-#include <sys/trace_dnode.h>
-#include <sys/trace_multilist.h>
-#include <sys/trace_rrwlock.h>
-#include <sys/trace_txg.h>
-#include <sys/trace_vdev.h>
-#include <sys/trace_zil.h>
-#include <sys/trace_zio.h>
-#include <sys/trace_zrlock.h>
+#include <sys/trace_dbgmsg.h>
 #endif

--- a/module/os/linux/zcommon/zfs_debug.c
+++ b/module/os/linux/zcommon/zfs_debug.c
@@ -37,6 +37,18 @@ static procfs_list_t zfs_dbgmsgs;
 static int zfs_dbgmsg_size = 0;
 int zfs_dbgmsg_maxsize = 4<<20; /* 4MB */
 
+#ifdef ZFS_DEBUG
+/*
+ * Everything except dprintf, set_error, spa, and indirect_remap is on
+ * by default in debug builds.
+ */
+int zfs_flags = ~(ZFS_DEBUG_DPRINTF | ZFS_DEBUG_SET_ERROR |
+    ZFS_DEBUG_INDIRECT_REMAP);
+#else
+int zfs_flags = 0;
+#endif
+
+
 /*
  * Internal ZFS debug messages are enabled by default.
  *
@@ -110,7 +122,6 @@ zfs_dbgmsg_fini(void)
 {
 	procfs_list_uninstall(&zfs_dbgmsgs);
 	zfs_dbgmsg_purge(0);
-
 	/*
 	 * TODO - decide how to make this permanent
 	 */
@@ -255,3 +266,10 @@ MODULE_PARM_DESC(zfs_dbgmsg_enable, "Enable ZFS debug message log");
 module_param(zfs_dbgmsg_maxsize, int, 0644);
 MODULE_PARM_DESC(zfs_dbgmsg_maxsize, "Maximum ZFS debug log size");
 #endif
+
+EXPORT_SYMBOL(zfs_dbgmsg_enable);
+EXPORT_SYMBOL(__dprintf);
+EXPORT_SYMBOL(__set_error);
+EXPORT_SYMBOL(zfs_dbgmsg_init);
+EXPORT_SYMBOL(zfs_dbgmsg_fini);
+EXPORT_SYMBOL(zfs_flags);

--- a/module/os/linux/zfs/Makefile.in
+++ b/module/os/linux/zfs/Makefile.in
@@ -18,7 +18,6 @@ $(MODULE)-objs += ../os/linux/zfs/vdev_disk.o
 $(MODULE)-objs += ../os/linux/zfs/vdev_file.o
 $(MODULE)-objs += ../os/linux/zfs/zfs_acl.o
 $(MODULE)-objs += ../os/linux/zfs/zfs_ctldir.o
-$(MODULE)-objs += ../os/linux/zfs/zfs_debug.o
 $(MODULE)-objs += ../os/linux/zfs/zfs_dir.o
 $(MODULE)-objs += ../os/linux/zfs/zfs_file_os.o
 $(MODULE)-objs += ../os/linux/zfs/zfs_ioctl_os.o

--- a/module/zcommon/Makefile.in
+++ b/module/zcommon/Makefile.in
@@ -1,6 +1,9 @@
 ifneq ($(KBUILD_EXTMOD),)
 src = @abs_srcdir@
 obj = @abs_builddir@
+mfdir = $(obj)
+else
+mfdir = $(srctree)/$(src)
 endif
 
 MODULE := zcommon
@@ -26,3 +29,5 @@ $(MODULE)-$(CONFIG_X86) += zfs_fletcher_intel.o
 $(MODULE)-$(CONFIG_X86) += zfs_fletcher_sse.o
 $(MODULE)-$(CONFIG_X86) += zfs_fletcher_avx512.o
 $(MODULE)-$(CONFIG_ARM64) += zfs_fletcher_aarch64_neon.o
+
+include $(mfdir)/../os/linux/zcommon/Makefile

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -1009,6 +1009,7 @@ EXPORT_SYMBOL(zfs_kfpu_fpregs);
 static int __init
 zcommon_init(void)
 {
+	zfs_dbgmsg_init();
 	int error = kfpu_init();
 	if (error)
 		return (error);
@@ -1023,6 +1024,7 @@ zcommon_fini(void)
 {
 	fletcher_4_fini();
 	kfpu_fini();
+	zfs_dbgmsg_fini();
 }
 
 module_init_early(zcommon_init);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2287,7 +2287,6 @@ void
 dmu_init(void)
 {
 	abd_init();
-	zfs_dbgmsg_init();
 	sa_cache_init();
 	dmu_objset_init();
 	dnode_init();
@@ -2309,7 +2308,6 @@ dmu_fini(void)
 	dnode_fini();
 	dmu_objset_fini();
 	sa_cache_fini();
-	zfs_dbgmsg_fini();
 	abd_fini();
 }
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -244,16 +244,10 @@ static avl_tree_t spa_l2cache_avl;
 
 spa_mode_t spa_mode_global = SPA_MODE_UNINIT;
 
-#ifdef ZFS_DEBUG
 /*
- * Everything except dprintf, set_error, spa, and indirect_remap is on
- * by default in debug builds.
+ * dprintf and zfs_flags and friends have been moved to zcommon/zfs_prop.c.
  */
-int zfs_flags = ~(ZFS_DEBUG_DPRINTF | ZFS_DEBUG_SET_ERROR |
-    ZFS_DEBUG_INDIRECT_REMAP);
-#else
-int zfs_flags = 0;
-#endif
+extern int zfs_flags;
 
 /*
  * zfs_recover can be set to nonzero to attempt to recover from

--- a/tests/zfs-tests/tests/functional/checksum/Makefile.am
+++ b/tests/zfs-tests/tests/functional/checksum/Makefile.am
@@ -1,7 +1,7 @@
 include $(top_srcdir)/config/Rules.am
 
 LDADD = \
-	$(abs_top_builddir)/lib/libicp/libicp.la \
+	$(abs_top_builddir)/lib/libzpool/libzpool.la \
 	$(abs_top_builddir)/lib/libspl/libspl_assert.la
 
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/checksum


### PR DESCRIPTION
(WIP because I just want to see if the CI screams anywhere about this...)

e: Oh, I didn't mark it as draft on creation. Oops.

### Motivation and Context
It's much more useful to be able to call zfs_dbgmsg from anything
that depends on zcommon - zzstd, icp...

(Using it from icp means that people can't link libicp on its own, which is unfortunate, but since the only consumer in our tree that did that is the checksum tests in the test suite, I think it's an acceptable tradeoff...if anybody really minds this, I imagine you could implement weak symbols for the dbgmsg family in libicp that stub it out and get overridden if you have libzpool instead.)

(I tried punting it into SPL, but that would involve reimplementing a whole bunch in userland because you no longer get libzpool/kernel.c if you're in libspl...oh well, if someone really wants to call it from SPL, they can do it.)

### Description
`git mv module/os/linux/{zfs,zcommon}/zfs_debug.c` and then cleanup of fallout.

(FreeBSD never had a problem with this, since it shoves everything into one module anyway...)

### How Has This Been Tested?
This branch? It built.

The branch I pulled these changes out of, I've been running tests on and using this for a couple weeks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
