### PR TITLE
Silence some complaints from valgrind

### DIFF
--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -1193,10 +1193,10 @@ dsl_crypto_key_sync(dsl_crypto_key_t *dck, dmu_tx_t *tx)
 {
 	zio_crypt_key_t *key = &dck->dck_key;
 	dsl_wrapping_key_t *wkey = dck->dck_wkey;
-	uint8_t keydata[MASTER_KEY_MAX_LEN];
-	uint8_t hmac_keydata[SHA512_HMAC_KEYLEN];
-	uint8_t iv[WRAPPING_IV_LEN];
-	uint8_t mac[WRAPPING_MAC_LEN];
+	uint8_t keydata[MASTER_KEY_MAX_LEN] = {0};
+	uint8_t hmac_keydata[SHA512_HMAC_KEYLEN] = {0};
+	uint8_t iv[WRAPPING_IV_LEN] = {0};
+	uint8_t mac[WRAPPING_MAC_LEN] = {0};
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT3U(key->zk_crypt, <, ZIO_CRYPT_FUNCTIONS);

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1706,6 +1706,15 @@ zio_write_compress(zio_t *zio)
 	if (compress != ZIO_COMPRESS_OFF &&
 	    !(zio->io_flags & ZIO_FLAG_RAW_COMPRESS)) {
 		void *cbuf = zio_buf_alloc(lsize);
+		/*
+		 * Both the crypto code and LZ4 code have bad habits of reading
+		 * uninited bytes sometimes.
+		 *
+		 * So to stop valgrind screaming to the point of uselessness,
+		 * zero them all.
+		 */
+		memset(cbuf, 0, lsize);
+
 		psize = zio_compress_data(compress, zio->io_abd, cbuf, lsize,
 		    zp->zp_complevel);
 		if (psize == 0 || psize >= lsize) {


### PR DESCRIPTION
### Motivation and Context
Without this, valgrind is effectively useless in most cases, as
it floods with messages about zio writes trying to read uninited
buffers, and about the old LZ4 compressor doing the same.

It'd be nice to fix the logic that involves doing that if possible,
but for now, this at least reduces it to a small handful of messages
beyond whatever new code you're introducing.

### Description
Inited the biggest offendersin valgrind flooding output.

### How Has This Been Tested?
Ran it for a few days debugging other things, no problems found from it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
