### PR TITLE
zed: Fix mpath autoreplace on Centos 7

### DIFF
--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -613,27 +613,24 @@ zfs_get_underlying_path(const char *dev_name)
 /*
  * A disk is considered a multipath whole disk when:
  *	DEVNAME key value has "dm-"
- *	MPATH_DEVICE_READY is present
- *	DM_UUID key exists
+ *	DM_UUID key exists and starts with 'mpath-'
  *	ID_PART_TABLE_TYPE key does not exist or is not gpt
  *	ID_FS_LABEL key does not exist (disk isn't labeled)
  */
 static boolean_t
 is_mpath_udev_sane(struct udev_device *dev)
 {
-	const char *devname, *type, *uuid, *label, *mpath_ready;
+	const char *devname, *type, *uuid, *label;
 
 	devname = udev_device_get_property_value(dev, "DEVNAME");
 	type = udev_device_get_property_value(dev, "ID_PART_TABLE_TYPE");
 	uuid = udev_device_get_property_value(dev, "DM_UUID");
 	label = udev_device_get_property_value(dev, "ID_FS_LABEL");
-	mpath_ready = udev_device_get_property_value(dev, "MPATH_DEVICE_READY");
 
 	if ((devname != NULL && strncmp(devname, "/dev/dm-", 8) == 0) &&
 	    ((type == NULL) || (strcmp(type, "gpt") != 0)) &&
-	    (uuid != NULL) &&
-	    (label == NULL) &&
-	    (mpath_ready != NULL && strncmp(mpath_ready, "1", 1) == 0)) {
+	    ((uuid != NULL) && (strncmp(uuid, "mpath-", 6) == 0)) &&
+	    (label == NULL)) {
 		return (B_TRUE);
 	}
 


### PR DESCRIPTION


### Motivation and Context
Fix multipath autoreplace on Centos 7

### Description
A prior commit included a udev check for MPATH_DEVICE_READY to determine if a path was multipath when doing an autoreplace:

f2f6c18 zed: Misc multipath autoreplace fixes

However, MPATH_DEVICE_READY is not provided udev on Centos 7 (but is on Centos 8).

This patch instead looks for 'mpath-' in the UUID, which works on both Centos 7 and 8.


### How Has This Been Tested?
Tested autoreplace with a JBOD on both Centos 7 and Centos 8.  Saw that old code didn't autoreaplace on Centos 7, and then saw it working with this PR.  Also tested autoreplace with an additional JBOD type on Centos 8.
  
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
