### PR TITLE
ZTS: Log test name to /dev/kmsg on Linux

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -39,6 +39,7 @@ VERBOSE="no"
 QUIET=""
 CLEANUP="yes"
 CLEANUPALL="no"
+KMSG=""
 LOOPBACK="yes"
 STACK_TRACER="no"
 FILESIZE="4G"
@@ -326,6 +327,7 @@ OPTIONS:
 	-q          Quiet test-runner output
 	-x          Remove all testpools, dm, lo, and files (unsafe)
 	-k          Disable cleanup after test failure
+	-K          Log test names to /dev/kmsg
 	-f          Use files only, disables block device tests
 	-S          Enable stack tracer (negative performance impact)
 	-c          Only create and populate constrained path
@@ -357,7 +359,7 @@ $0 -x
 EOF
 }
 
-while getopts 'hvqxkfScRmn:d:s:r:?t:T:u:I:' OPTION; do
+while getopts 'hvqxkKfScRmn:d:s:r:?t:T:u:I:' OPTION; do
 	case $OPTION in
 	h)
 		usage
@@ -374,6 +376,9 @@ while getopts 'hvqxkfScRmn:d:s:r:?t:T:u:I:' OPTION; do
 		;;
 	k)
 		CLEANUP="no"
+		;;
+	K)
+		KMSG="yes"
 		;;
 	f)
 		LOOPBACK="no"
@@ -705,6 +710,7 @@ REPORT_FILE=$(mktemp_file zts-report)
 msg "${TEST_RUNNER}" \
     "${QUIET:+-q}" \
     "${KMEMLEAK:+-m}" \
+    "${KMSG:+-K}" \
     "-c \"${RUNFILES}\"" \
     "-T \"${TAGS}\"" \
     "-i \"${STF_SUITE}\"" \
@@ -712,6 +718,7 @@ msg "${TEST_RUNNER}" \
 { ${TEST_RUNNER} \
     ${QUIET:+-q} \
     ${KMEMLEAK:+-m} \
+    ${KMSG:+-K} \
     -c "${RUNFILES}" \
     -T "${TAGS}" \
     -i "${STF_SUITE}" \

--- a/tests/test-runner/bin/test-runner.py.in
+++ b/tests/test-runner/bin/test-runner.py.in
@@ -34,6 +34,7 @@ from subprocess import Popen
 from subprocess import check_output
 from threading import Timer
 from time import time, CLOCK_MONOTONIC
+from os.path import exists
 
 BASEDIR = '/var/tmp/test_results'
 TESTDIR = '/usr/share/zfs/'
@@ -256,7 +257,7 @@ User: %s
 
         return out.lines, err.lines
 
-    def run(self, dryrun, kmemleak):
+    def run(self, dryrun, kmemleak, kmsg):
         """
         This is the main function that runs each individual test.
         Determine whether or not the command requires sudo, and modify it
@@ -274,6 +275,18 @@ User: %s
             os.umask(old)
         except OSError as e:
             fail('%s' % e)
+
+        """
+        Log each test we run to /dev/kmsg (on Linux), so if there's a kernel
+        warning we'll be able to match it up to a particular test.
+        """
+        if kmsg is True and exists("/dev/kmsg"):
+            try:
+                kp = Popen([SUDO, "sh", "-c",
+                            f"echo ZTS run {self.pathname} > /dev/kmsg"])
+                kp.wait()
+            except Exception:
+                pass
 
         self.result.starttime = monotonic_time()
 
@@ -459,14 +472,14 @@ Tags: %s
 
         cont = True
         if len(pretest.pathname):
-            pretest.run(options.dryrun, False)
+            pretest.run(options.dryrun, False, options.kmsg)
             cont = pretest.result.result == 'PASS'
             pretest.log(options)
 
         if cont:
-            test.run(options.dryrun, options.kmemleak)
+            test.run(options.dryrun, options.kmemleak, options.kmsg)
             if test.result.result == 'KILLED' and len(failsafe.pathname):
-                failsafe.run(options.dryrun, False)
+                failsafe.run(options.dryrun, False, options.kmsg)
                 failsafe.log(options, suppress_console=True)
         else:
             test.skip()
@@ -474,7 +487,7 @@ Tags: %s
         test.log(options)
 
         if len(posttest.pathname):
-            posttest.run(options.dryrun, False)
+            posttest.run(options.dryrun, False, options.kmsg)
             posttest.log(options)
 
 
@@ -577,7 +590,7 @@ Tags: %s
 
         cont = True
         if len(pretest.pathname):
-            pretest.run(options.dryrun, False)
+            pretest.run(options.dryrun, False, options.kmsg)
             cont = pretest.result.result == 'PASS'
             pretest.log(options)
 
@@ -590,9 +603,9 @@ Tags: %s
             failsafe = Cmd(self.failsafe, outputdir=odir, timeout=self.timeout,
                            user=self.failsafe_user, identifier=self.identifier)
             if cont:
-                test.run(options.dryrun, options.kmemleak)
+                test.run(options.dryrun, options.kmemleak, options.kmsg)
                 if test.result.result == 'KILLED' and len(failsafe.pathname):
-                    failsafe.run(options.dryrun, False)
+                    failsafe.run(options.dryrun, False, options.kmsg)
                     failsafe.log(options, suppress_console=True)
             else:
                 test.skip()
@@ -600,7 +613,7 @@ Tags: %s
             test.log(options)
 
         if len(posttest.pathname):
-            posttest.run(options.dryrun, False)
+            posttest.run(options.dryrun, False, options.kmsg)
             posttest.log(options)
 
 
@@ -1060,6 +1073,8 @@ def parse_args():
     parser.add_option('-i', action='callback', callback=options_cb,
                       default=TESTDIR, dest='testdir', type='string',
                       metavar='testdir', help='Specify a test directory.')
+    parser.add_option('-K', action='store_true', default=False, dest='kmsg',
+                      help='Log tests names to /dev/kmsg')
     parser.add_option('-m', action='callback', callback=kmemleak_cb,
                       default=False, dest='kmemleak',
                       help='Enable kmemleak reporting (Linux only)')


### PR DESCRIPTION
### Motivation and Context
Easily match a kernel warning to a particular test

### Description
Log each test we run to /dev/kmsg (on Linux), so if there's a kernel warning we'll be able to match it up to a particular test

### How Has This Been Tested?
Ran locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
