### PR TITLE
Extract zpool.8 and zfs.8 examples into zpool-*.8 and zfs-*.8

### DIFF
--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -464,12 +464,7 @@ If no options are specified, all information about the named pool will be
 displayed at default verbosity.
 .
 .Sh EXAMPLES
-.Bl -tag -width Ds
-.It Xo
-.Sy Example 1 :
-Display the configuration of imported pool
-.Ar rpool
-.Xc
+.Ss Example 1 : No Display the configuration of imported pool Ar rpool
 .Bd -literal
 .No # Nm zdb Fl C Ar rpool
 MOS Configuration:
@@ -477,22 +472,16 @@ MOS Configuration:
         name: 'rpool'
  …
 .Ed
-.It Xo
-.Sy Example 2 :
-Display basic dataset information about
-.Ar rpool
-.Xc
+.
+.Ss Example 2 : No Display basic dataset information about Ar rpool
 .Bd -literal
 .No # Nm zdb Fl d Ar rpool
 Dataset mos [META], ID 0, cr_txg 4, 26.9M, 1051 objects
 Dataset rpool/swap [ZVOL], ID 59, cr_txg 356, 486M, 2 objects
  …
 .Ed
-.It Xo
-.Sy Example 3 :
-Display basic information about object 0 in
-.Ar rpool/export/home
-.Xc
+.
+.Ss Example 3 : No Display basic information about object 0 in Ar rpool/export/home
 .Bd -literal
 .No # Nm zdb Fl d Ar rpool/export/home 0
 Dataset rpool/export/home [ZPL], ID 137, cr_txg 1546, 32K, 8 objects
@@ -500,11 +489,8 @@ Dataset rpool/export/home [ZPL], ID 137, cr_txg 1546, 32K, 8 objects
     Object  lvl   iblk   dblk  dsize  lsize   %full  type
          0    7    16K    16K  15.0K    16K   25.00  DMU dnode
 .Ed
-.It Xo
-.Sy Example 4 :
-Display the predicted effect of enabling deduplication on
-.Ar rpool
-.Xc
+.
+.Ss Example 4 : No Display the predicted effect of enabling deduplication on Ar rpool
 .Bd -literal
 .No # Nm zdb Fl S Ar rpool
 Simulated DDT histogram:
@@ -518,7 +504,6 @@ refcnt   blocks   LSIZE   PSIZE   DSIZE   blocks   LSIZE   PSIZE   DSIZE
  …
 dedup = 1.11, compress = 1.80, copies = 1.00, dedup * compress / copies = 2.00
 .Ed
-.El
 .
 .Sh SEE ALSO
 .Xr zfs 8 ,

--- a/man/man8/zfs-allow.8
+++ b/man/man8/zfs-allow.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd May 27, 2021
+.Dd March 16, 2022
 .Dt ZFS-ALLOW 8
 .Os
 .
@@ -384,3 +384,109 @@ Removes permissions from a permission set.
 If no permissions are specified, then all permissions are removed, thus removing
 the set entirely.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 17, 18, 19, 20 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Delegating ZFS Administration Permissions on a ZFS Dataset
+The following example shows how to set permissions so that user
+.Ar cindys
+can create, destroy, mount, and take snapshots on
+.Ar tank/cindys .
+The permissions on
+.Ar tank/cindys
+are also displayed.
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm allow Sy cindys create , Ns Sy destroy , Ns Sy mount , Ns Sy snapshot Ar tank/cindys
+.No # Nm zfs Cm allow Ar tank/cindys
+---- Permissions on tank/cindys --------------------------------------
+Local+Descendent permissions:
+        user cindys create,destroy,mount,snapshot
+.Ed
+.Pp
+Because the
+.Ar tank/cindys
+mount point permission is set to 755 by default, user
+.Ar cindys
+will be unable to mount file systems under
+.Ar tank/cindys .
+Add an ACE similar to the following syntax to provide mount point access:
+.Dl # Cm chmod No A+user: Ns Ar cindys Ns :add_subdirectory:allow Ar /tank/cindys
+.
+.Ss Example 2 : No Delegating Create Time Permissions on a ZFS Dataset
+The following example shows how to grant anyone in the group
+.Ar staff
+to create file systems in
+.Ar tank/users .
+This syntax also allows staff members to destroy their own file systems, but not
+destroy anyone else's file system.
+The permissions on
+.Ar tank/users
+are also displayed.
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm allow Ar staff Sy create , Ns Sy mount Ar tank/users
+.No # Nm zfs Cm allow Fl c Sy destroy Ar tank/users
+.No # Nm zfs Cm allow Ar tank/users
+---- Permissions on tank/users ---------------------------------------
+Permission sets:
+        destroy
+Local+Descendent permissions:
+        group staff create,mount
+.Ed
+.
+.Ss Example 3 : No Defining and Granting a Permission Set on a ZFS Dataset
+The following example shows how to define and grant a permission set on the
+.Ar tank/users
+file system.
+The permissions on
+.Ar tank/users
+are also displayed.
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm allow Fl s No @ Ns Ar pset Sy create , Ns Sy destroy , Ns Sy snapshot , Ns Sy mount Ar tank/users
+.No # Nm zfs Cm allow staff No @ Ns Ar pset tank/users
+.No # Nm zfs Cm allow Ar tank/users
+---- Permissions on tank/users ---------------------------------------
+Permission sets:
+        @pset create,destroy,mount,snapshot
+Local+Descendent permissions:
+        group staff @pset
+.Ed
+.
+.Ss Example 4 : No Delegating Property Permissions on a ZFS Dataset
+The following example shows to grant the ability to set quotas and reservations
+on the
+.Ar users/home
+file system.
+The permissions on
+.Ar users/home
+are also displayed.
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm allow Ar cindys Sy quota , Ns Sy reservation Ar users/home
+.No # Nm zfs Cm allow Ar users/home
+---- Permissions on users/home ---------------------------------------
+Local+Descendent permissions:
+        user cindys quota,reservation
+cindys% zfs set quota=10G users/home/marks
+cindys% zfs get quota users/home/marks
+NAME              PROPERTY  VALUE  SOURCE
+users/home/marks  quota     10G    local
+.Ed
+.
+.Ss Example 5 : No Removing ZFS Delegated Permissions on a ZFS Dataset
+The following example shows how to remove the snapshot permission from the
+.Ar staff
+group on the
+.Sy tank/users
+file system.
+The permissions on
+.Sy tank/users
+are also displayed.
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm unallow Ar staff Sy snapshot Ar tank/users
+.No # Nm zfs Cm allow Ar tank/users
+---- Permissions on tank/users ---------------------------------------
+Permission sets:
+        @pset create,destroy,mount,snapshot
+Local+Descendent permissions:
+        group staff @pset
+.Ed

--- a/man/man8/zfs-bookmark.8
+++ b/man/man8/zfs-bookmark.8
@@ -30,7 +30,7 @@
 .\" Copyright 2019 Joyent, Inc.
 .\" Copyright (c) 2019, 2020 by Christian Schwarz. All Rights Reserved.
 .\"
-.Dd May 27, 2021
+.Dd March 16, 2022
 .Dt ZFS-BOOKMARK 8
 .Os
 .
@@ -60,6 +60,14 @@ See
 for details on ZFS feature flags and the
 .Sy bookmarks
 feature.
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 23 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Creating a bookmark
+The following example create a bookmark to a snapshot.
+This bookmark can then be used instead of snapshot in send streams.
+.Dl # Nm zfs Cm bookmark Ar rpool Ns @ Ns Ar snapshot rpool Ns # Ns Ar bookmark
 .
 .Sh SEE ALSO
 .Xr zfs-destroy 8 ,

--- a/man/man8/zfs-clone.8
+++ b/man/man8/zfs-clone.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd May 27, 2021
+.Dd March 16, 2022
 .Dt ZFS-CLONE 8
 .Os
 .
@@ -64,6 +64,32 @@ property inherited from their parent.
 If the target filesystem or volume already exists, the operation completes
 successfully.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 9, 10 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Creating a ZFS Clone
+The following command creates a writable file system whose initial contents are
+the same as
+.Ar pool/home/bob@yesterday .
+.Dl # Nm zfs Cm clone Ar pool/home/bob@yesterday pool/clone
+.
+.Ss Example 2 : No Promoting a ZFS Clone
+The following commands illustrate how to test out changes to a file system, and
+then replace the original file system with the changed one, using clones, clone
+promotion, and renaming:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm create Ar pool/project/production
+  populate /pool/project/production with data
+.No # Nm zfs Cm snapshot Ar pool/project/production Ns @ Ns Ar today
+.No # Nm zfs Cm clone Ar pool/project/production@today pool/project/beta
+  make changes to /pool/project/beta and test them
+.No # Nm zfs Cm promote Ar pool/project/beta
+.No # Nm zfs Cm rename Ar pool/project/production pool/project/legacy
+.No # Nm zfs Cm rename Ar pool/project/beta pool/project/production
+  once the legacy version is no longer needed, it can be destroyed
+.No # Nm zfs Cm destroy Ar pool/project/legacy
+.Ed
 .
 .Sh SEE ALSO
 .Xr zfs-promote 8 ,

--- a/man/man8/zfs-create.8
+++ b/man/man8/zfs-create.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd December 1, 2020
+.Dd March 16, 2022
 .Dt ZFS-CREATE 8
 .Os
 .
@@ -242,6 +242,39 @@ enable the swap area using the
 .Xr swapon 8
 command.
 Swapping to files on ZFS filesystems is not supported.
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 1, 10 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Creating a ZFS File System Hierarchy
+The following commands create a file system named
+.Ar pool/home
+and a file system named
+.Ar pool/home/bob .
+The mount point
+.Pa /export/home
+is set for the parent file system, and is automatically inherited by the child
+file system.
+.Dl # Nm zfs Cm create Ar pool/home
+.Dl # Nm zfs Cm set Sy mountpoint Ns = Ns Ar /export/home pool/home
+.Dl # Nm zfs Cm create Ar pool/home/bob
+.
+.Ss Example 2 : No Promoting a ZFS Clone
+The following commands illustrate how to test out changes to a file system, and
+then replace the original file system with the changed one, using clones, clone
+promotion, and renaming:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm create Ar pool/project/production
+  populate /pool/project/production with data
+.No # Nm zfs Cm snapshot Ar pool/project/production Ns @ Ns Ar today
+.No # Nm zfs Cm clone Ar pool/project/production@today pool/project/beta
+  make changes to /pool/project/beta and test them
+.No # Nm zfs Cm promote Ar pool/project/beta
+.No # Nm zfs Cm rename Ar pool/project/production pool/project/legacy
+.No # Nm zfs Cm rename Ar pool/project/beta pool/project/production
+  once the legacy version is no longer needed, it can be destroyed
+.No # Nm zfs Cm destroy Ar pool/project/legacy
+.Ed
 .
 .Sh SEE ALSO
 .Xr zfs-destroy 8 ,

--- a/man/man8/zfs-destroy.8
+++ b/man/man8/zfs-destroy.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd June 30, 2019
+.Dd March 16, 2022
 .Dt ZFS-DESTROY 8
 .Os
 .
@@ -172,6 +172,54 @@ behavior for mounted file systems in use.
 .Xc
 The given bookmark is destroyed.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 3, 10, 15 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Creating and Destroying Multiple Snapshots
+The following command creates snapshots named
+.Ar yesterday No of Ar pool/home
+and all of its descendent file systems.
+Each snapshot is mounted on demand in the
+.Pa .zfs/snapshot
+directory at the root of its file system.
+The second command destroys the newly created snapshots.
+.Dl # Nm zfs Cm snapshot Fl r Ar pool/home Ns @ Ns Ar yesterday
+.Dl # Nm zfs Cm destroy Fl r Ar pool/home Ns @ Ns Ar yesterday
+.
+.Ss Example 2 : No Promoting a ZFS Clone
+The following commands illustrate how to test out changes to a file system, and
+then replace the original file system with the changed one, using clones, clone
+promotion, and renaming:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm create Ar pool/project/production
+  populate /pool/project/production with data
+.No # Nm zfs Cm snapshot Ar pool/project/production Ns @ Ns Ar today
+.No # Nm zfs Cm clone Ar pool/project/production@today pool/project/beta
+  make changes to /pool/project/beta and test them
+.No # Nm zfs Cm promote Ar pool/project/beta
+.No # Nm zfs Cm rename Ar pool/project/production pool/project/legacy
+.No # Nm zfs Cm rename Ar pool/project/beta pool/project/production
+  once the legacy version is no longer needed, it can be destroyed
+.No # Nm zfs Cm destroy Ar pool/project/legacy
+.Ed
+.
+.Ss Example 3 : No Performing a Rolling Snapshot
+The following example shows how to maintain a history of snapshots with a
+consistent naming scheme.
+To keep a week's worth of snapshots, the user destroys the oldest snapshot,
+renames the remaining snapshots, and then creates a new snapshot, as follows:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm destroy Fl r Ar pool/users@7daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@6daysago No @ Ns Ar 7daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@5daysago No @ Ns Ar 6daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@4daysago No @ Ns Ar 5daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@3daysago No @ Ns Ar 4daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@2daysago No @ Ns Ar 3daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@yesterday No @ Ns Ar 2daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@today No @ Ns Ar yesterday
+.No # Nm zfs Cm snapshot Fl r Ar pool/users Ns @ Ns Ar today
+.Ed
 .
 .Sh SEE ALSO
 .Xr zfs-create 8 ,

--- a/man/man8/zfs-diff.8
+++ b/man/man8/zfs-diff.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd May 29, 2021
+.Dd March 16, 2022
 .Dt ZFS-DIFF 8
 .Os
 .
@@ -97,6 +97,25 @@ Do not
 .Sy \e0 Ns Ar ooo Ns -escape
 non-ASCII paths.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 22 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Showing the differences between a snapshot and a ZFS Dataset
+The following example shows how to see what has changed between a prior
+snapshot of a ZFS dataset and its current state.
+The
+.Fl F
+option is used to indicate type information for the files affected.
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm diff Fl F Ar tank/test@before tank/test
+M       /       /tank/test/
+M       F       /tank/test/linked      (+1)
+R       F       /tank/test/oldname -> /tank/test/newname
+-       F       /tank/test/deleted
++       F       /tank/test/created
+M       F       /tank/test/modified
+.Ed
 .
 .Sh SEE ALSO
 .Xr zfs-snapshot 8

--- a/man/man8/zfs-list.8
+++ b/man/man8/zfs-list.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd May 27, 2021
+.Dd March 16, 2022
 .Dt ZFS-LIST 8
 .Os
 .
@@ -156,6 +156,27 @@ For example, specifying
 .Fl t Sy snapshot
 displays only snapshots.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 5 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Listing ZFS Datasets
+The following command lists all active file systems and volumes in the system.
+Snapshots are displayed if
+.Sy listsnaps Ns = Ns Sy on .
+The default is
+.Sy off .
+See
+.Xr zpoolprops 7
+for more information on pool properties.
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm list
+NAME                      USED  AVAIL  REFER  MOUNTPOINT
+pool                      450K   457G    18K  /pool
+pool/home                 315K   457G    21K  /export/home
+pool/home/anne             18K   457G    18K  /export/home/anne
+pool/home/bob             276K   457G   276K  /export/home/bob
+.Ed
 .
 .Sh SEE ALSO
 .Xr zfsprops 7 ,

--- a/man/man8/zfs-promote.8
+++ b/man/man8/zfs-promote.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd June 30, 2019
+.Dd March 16, 2022
 .Dt ZFS-PROMOTE 8
 .Os
 .
@@ -58,6 +58,26 @@ The promoted clone must not have any conflicting snapshot names of its own.
 The
 .Nm zfs Cm rename
 subcommand can be used to rename any conflicting snapshots.
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 10 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Promoting a ZFS Clone
+The following commands illustrate how to test out changes to a file system, and
+then replace the original file system with the changed one, using clones, clone
+promotion, and renaming:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm create Ar pool/project/production
+  populate /pool/project/production with data
+.No # Nm zfs Cm snapshot Ar pool/project/production Ns @ Ns Ar today
+.No # Nm zfs Cm clone Ar pool/project/production@today pool/project/beta
+  make changes to /pool/project/beta and test them
+.No # Nm zfs Cm promote Ar pool/project/beta
+.No # Nm zfs Cm rename Ar pool/project/production pool/project/legacy
+.No # Nm zfs Cm rename Ar pool/project/beta pool/project/production
+  once the legacy version is no longer needed, it can be destroyed
+.No # Nm zfs Cm destroy Ar pool/project/legacy
+.Ed
 .
 .Sh SEE ALSO
 .Xr zfs-clone 8 ,

--- a/man/man8/zfs-receive.8
+++ b/man/man8/zfs-receive.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd February 16, 2020
+.Dd March 16, 2022
 .Dt ZFS-RECEIVE 8
 .Os
 .
@@ -394,6 +394,48 @@ Abort an interrupted
 .Nm zfs Cm receive Fl s ,
 deleting its saved partially received state.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 12, 13 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Remotely Replicating ZFS Data
+The following commands send a full stream and then an incremental stream to a
+remote machine, restoring them into
+.Em poolB/received/fs@a
+and
+.Em poolB/received/fs@b ,
+respectively.
+.Em poolB
+must contain the file system
+.Em poolB/received ,
+and must not initially contain
+.Em poolB/received/fs .
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm send Ar pool/fs@a |
+.No "   " Nm ssh Ar host Nm zfs Cm receive Ar poolB/received/fs Ns @ Ns Ar a
+.No # Nm zfs Cm send Fl i Ar a pool/fs@b |
+.No "   " Nm ssh Ar host Nm zfs Cm receive Ar poolB/received/fs
+.Ed
+.
+.Ss Example 2 : No Using the Nm zfs Cm receive Fl d No Option
+The following command sends a full stream of
+.Ar poolA/fsA/fsB@snap
+to a remote machine, receiving it into
+.Ar poolB/received/fsA/fsB@snap .
+The
+.Ar fsA/fsB@snap
+portion of the received snapshot's name is determined from the name of the sent
+snapshot.
+.Ar poolB
+must contain the file system
+.Ar poolB/received .
+If
+.Ar poolB/received/fsA
+does not exist, it is created as an empty file system.
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm send Ar poolA/fsA/fsB@snap |
+.No "   " Nm ssh Ar host Nm zfs Cm receive Fl d Ar poolB/received
+.Ed
 .
 .Sh SEE ALSO
 .Xr zfs-send 8 ,

--- a/man/man8/zfs-rename.8
+++ b/man/man8/zfs-rename.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd September 1, 2020
+.Dd March 16, 2022
 .Dt ZFS-RENAME 8
 .Os
 .
@@ -121,3 +121,40 @@ the file system is not unmounted even if this option is not given.
 Recursively rename the snapshots of all descendent datasets.
 Snapshots are the only dataset that can be renamed recursively.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 10, 15 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Promoting a ZFS Clone
+The following commands illustrate how to test out changes to a file system, and
+then replace the original file system with the changed one, using clones, clone
+promotion, and renaming:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm create Ar pool/project/production
+  populate /pool/project/production with data
+.No # Nm zfs Cm snapshot Ar pool/project/production Ns @ Ns Ar today
+.No # Nm zfs Cm clone Ar pool/project/production@today pool/project/beta
+  make changes to /pool/project/beta and test them
+.No # Nm zfs Cm promote Ar pool/project/beta
+.No # Nm zfs Cm rename Ar pool/project/production pool/project/legacy
+.No # Nm zfs Cm rename Ar pool/project/beta pool/project/production
+  once the legacy version is no longer needed, it can be destroyed
+.No # Nm zfs Cm destroy Ar pool/project/legacy
+.Ed
+.
+.Ss Example 2 : No Performing a Rolling Snapshot
+The following example shows how to maintain a history of snapshots with a
+consistent naming scheme.
+To keep a week's worth of snapshots, the user destroys the oldest snapshot,
+renames the remaining snapshots, and then creates a new snapshot, as follows:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm destroy Fl r Ar pool/users@7daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@6daysago No @ Ns Ar 7daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@5daysago No @ Ns Ar 6daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@4daysago No @ Ns Ar 5daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@3daysago No @ Ns Ar 4daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@2daysago No @ Ns Ar 3daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@yesterday No @ Ns Ar 2daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@today No @ Ns Ar yesterday
+.No # Nm zfs Cm snapshot Fl r Ar pool/users Ns @ Ns Ar today
+.Ed

--- a/man/man8/zfs-rollback.8
+++ b/man/man8/zfs-rollback.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd May 27, 2021
+.Dd March 16, 2022
 .Dt ZFS-ROLLBACK 8
 .Os
 .
@@ -70,6 +70,17 @@ option to force an unmount of any clone file systems that are to be destroyed.
 .It Fl r
 Destroy any snapshots and bookmarks more recent than the one specified.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 8 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 8 : No Rolling Back a ZFS File System
+The following command reverts the contents of
+.Ar pool/home/anne
+to the snapshot named
+.Ar yesterday ,
+deleting all intermediate snapshots:
+.Dl # Nm zfs Cm rollback Fl r Ar pool/home/anne Ns @ Ns Ar yesterday
 .
 .Sh SEE ALSO
 .Xr zfs-snapshot 8

--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd April 15, 2021
+.Dd March 16, 2022
 .Dt ZFS-SEND 8
 .Os
 .
@@ -647,6 +647,48 @@ to and received on the target server; these snapshots are identical to the
 ones on the source, and are ready to be used, while the parent snapshot on the
 target contains none of the username and password data present on the source,
 because it was removed by the redacted send operation.
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 12, 13 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Remotely Replicating ZFS Data
+The following commands send a full stream and then an incremental stream to a
+remote machine, restoring them into
+.Em poolB/received/fs@a
+and
+.Em poolB/received/fs@b ,
+respectively.
+.Em poolB
+must contain the file system
+.Em poolB/received ,
+and must not initially contain
+.Em poolB/received/fs .
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm send Ar pool/fs@a |
+.No "   " Nm ssh Ar host Nm zfs Cm receive Ar poolB/received/fs Ns @ Ns Ar a
+.No # Nm zfs Cm send Fl i Ar a pool/fs@b |
+.No "   " Nm ssh Ar host Nm zfs Cm receive Ar poolB/received/fs
+.Ed
+.
+.Ss Example 2 : No Using the Nm zfs Cm receive Fl d No Option
+The following command sends a full stream of
+.Ar poolA/fsA/fsB@snap
+to a remote machine, receiving it into
+.Ar poolB/received/fsA/fsB@snap .
+The
+.Ar fsA/fsB@snap
+portion of the received snapshot's name is determined from the name of the sent
+snapshot.
+.Ar poolB
+must contain the file system
+.Ar poolB/received .
+If
+.Ar poolB/received/fsA
+does not exist, it is created as an empty file system.
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm send Ar poolA/fsA/fsB@snap |
+.No "   " Nm ssh Ar host Nm zfs Cm receive Fl d Ar poolB/received
+.Ed
 .
 .Sh SEE ALSO
 .Xr zfs-bookmark 8 ,

--- a/man/man8/zfs-set.8
+++ b/man/man8/zfs-set.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd June 2, 2021
+.Dd March 16, 2022
 .Dt ZFS-SET 8
 .Os
 .
@@ -176,6 +176,132 @@ if the
 option was not specified.
 .El
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 1, 4, 6, 7, 11, 14, 16 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Creating a ZFS File System Hierarchy
+The following commands create a file system named
+.Ar pool/home
+and a file system named
+.Ar pool/home/bob .
+The mount point
+.Pa /export/home
+is set for the parent file system, and is automatically inherited by the child
+file system.
+.Dl # Nm zfs Cm create Ar pool/home
+.Dl # Nm zfs Cm set Sy mountpoint Ns = Ns Ar /export/home pool/home
+.Dl # Nm zfs Cm create Ar pool/home/bob
+.
+.Ss Example 2 : No Disabling and Enabling File System Compression
+The following command disables the
+.Sy compression
+property for all file systems under
+.Ar pool/home .
+The next command explicitly enables
+.Sy compression
+for
+.Ar pool/home/anne .
+.Dl # Nm zfs Cm set Sy compression Ns = Ns Sy off Ar pool/home
+.Dl # Nm zfs Cm set Sy compression Ns = Ns Sy on Ar pool/home/anne
+.
+.Ss Example 3 : No Setting a Quota on a ZFS File System
+The following command sets a quota of 50 Gbytes for
+.Ar pool/home/bob :
+.Dl # Nm zfs Cm set Sy quota Ns = Ns Ar 50G pool/home/bob
+.
+.Ss Example 4 : No Listing ZFS Properties
+The following command lists all properties for
+.Ar pool/home/bob :
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm get Sy all Ar pool/home/bob
+NAME           PROPERTY              VALUE                  SOURCE
+pool/home/bob  type                  filesystem             -
+pool/home/bob  creation              Tue Jul 21 15:53 2009  -
+pool/home/bob  used                  21K                    -
+pool/home/bob  available             20.0G                  -
+pool/home/bob  referenced            21K                    -
+pool/home/bob  compressratio         1.00x                  -
+pool/home/bob  mounted               yes                    -
+pool/home/bob  quota                 20G                    local
+pool/home/bob  reservation           none                   default
+pool/home/bob  recordsize            128K                   default
+pool/home/bob  mountpoint            /pool/home/bob         default
+pool/home/bob  sharenfs              off                    default
+pool/home/bob  checksum              on                     default
+pool/home/bob  compression           on                     local
+pool/home/bob  atime                 on                     default
+pool/home/bob  devices               on                     default
+pool/home/bob  exec                  on                     default
+pool/home/bob  setuid                on                     default
+pool/home/bob  readonly              off                    default
+pool/home/bob  zoned                 off                    default
+pool/home/bob  snapdir               hidden                 default
+pool/home/bob  acltype               off                    default
+pool/home/bob  aclmode               discard                default
+pool/home/bob  aclinherit            restricted             default
+pool/home/bob  canmount              on                     default
+pool/home/bob  xattr                 on                     default
+pool/home/bob  copies                1                      default
+pool/home/bob  version               4                      -
+pool/home/bob  utf8only              off                    -
+pool/home/bob  normalization         none                   -
+pool/home/bob  casesensitivity       sensitive              -
+pool/home/bob  vscan                 off                    default
+pool/home/bob  nbmand                off                    default
+pool/home/bob  sharesmb              off                    default
+pool/home/bob  refquota              none                   default
+pool/home/bob  refreservation        none                   default
+pool/home/bob  primarycache          all                    default
+pool/home/bob  secondarycache        all                    default
+pool/home/bob  usedbysnapshots       0                      -
+pool/home/bob  usedbydataset         21K                    -
+pool/home/bob  usedbychildren        0                      -
+pool/home/bob  usedbyrefreservation  0                      -
+.Ed
+.Pp
+The following command gets a single property value:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm get Fl H o Sy value compression Ar pool/home/bob
+on
+.Ed
+.Pp
+The following command lists all properties with local settings for
+.Ar pool/home/bob :
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm get Fl r s Sy local Fl o Sy name , Ns Sy property , Ns Sy value all Ar pool/home/bob
+NAME           PROPERTY              VALUE
+pool/home/bob  quota                 20G
+pool/home/bob  compression           on
+.Ed
+.
+.Ss Example 5 : No Inheriting ZFS Properties
+The following command causes
+.Ar pool/home/bob No and Ar pool/home/anne
+to inherit the
+.Sy checksum
+property from their parent.
+.Dl # Nm zfs Cm inherit Sy checksum Ar pool/home/bob pool/home/anne
+.
+.Ss Example 6 : No Setting User Properties
+The following example sets the user-defined
+.Ar com.example : Ns Ar department
+property for a dataset:
+.Dl # Nm zfs Cm set Ar com.example : Ns Ar department Ns = Ns Ar 12345 tank/accounting
+.
+.Ss Example 7 : No Setting sharenfs Property Options on a ZFS File System
+The following commands show how to set
+.Sy sharenfs
+property options to enable read-write
+access for a set of IP addresses and to enable root access for system
+.Qq neo
+on the
+.Ar tank/home
+file system:
+.Dl # Nm zfs Cm set Sy sharenfs Ns = Ns ' Ns Ar rw Ns =@123.123.0.0/16:[::1],root= Ns Ar neo Ns ' tank/home
+.Pp
+If you are using DNS for host name resolution,
+specify the fully-qualified hostname.
 .
 .Sh SEE ALSO
 .Xr zfsprops 7 ,

--- a/man/man8/zfs-snapshot.8
+++ b/man/man8/zfs-snapshot.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd May 27, 2021
+.Dd March 16, 2022
 .Dt ZFS-SNAPSHOT 8
 .Os
 .
@@ -64,6 +64,64 @@ for details.
 .It Fl r
 Recursively create snapshots of all descendent datasets
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 2, 3, 10, 15 from zfs.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Creating a ZFS Snapshot
+The following command creates a snapshot named
+.Ar yesterday .
+This snapshot is mounted on demand in the
+.Pa .zfs/snapshot
+directory at the root of the
+.Ar pool/home/bob
+file system.
+.Dl # Nm zfs Cm snapshot Ar pool/home/bob Ns @ Ns Ar yesterday
+.
+.Ss Example 2 : No Creating and Destroying Multiple Snapshots
+The following command creates snapshots named
+.Ar yesterday No of Ar pool/home
+and all of its descendent file systems.
+Each snapshot is mounted on demand in the
+.Pa .zfs/snapshot
+directory at the root of its file system.
+The second command destroys the newly created snapshots.
+.Dl # Nm zfs Cm snapshot Fl r Ar pool/home Ns @ Ns Ar yesterday
+.Dl # Nm zfs Cm destroy Fl r Ar pool/home Ns @ Ns Ar yesterday
+.
+.Ss Example 3 : No Promoting a ZFS Clone
+The following commands illustrate how to test out changes to a file system, and
+then replace the original file system with the changed one, using clones, clone
+promotion, and renaming:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm create Ar pool/project/production
+  populate /pool/project/production with data
+.No # Nm zfs Cm snapshot Ar pool/project/production Ns @ Ns Ar today
+.No # Nm zfs Cm clone Ar pool/project/production@today pool/project/beta
+  make changes to /pool/project/beta and test them
+.No # Nm zfs Cm promote Ar pool/project/beta
+.No # Nm zfs Cm rename Ar pool/project/production pool/project/legacy
+.No # Nm zfs Cm rename Ar pool/project/beta pool/project/production
+  once the legacy version is no longer needed, it can be destroyed
+.No # Nm zfs Cm destroy Ar pool/project/legacy
+.Ed
+.
+.Ss Example 4 : No Performing a Rolling Snapshot
+The following example shows how to maintain a history of snapshots with a
+consistent naming scheme.
+To keep a week's worth of snapshots, the user destroys the oldest snapshot,
+renames the remaining snapshots, and then creates a new snapshot, as follows:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm destroy Fl r Ar pool/users@7daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@6daysago No @ Ns Ar 7daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@5daysago No @ Ns Ar 6daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@4daysago No @ Ns Ar 5daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@3daysago No @ Ns Ar 4daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@2daysago No @ Ns Ar 3daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@yesterday No @ Ns Ar 2daysago
+.No # Nm zfs Cm rename Fl r Ar pool/users@today No @ Ns Ar yesterday
+.No # Nm zfs Cm snapshot Fl r Ar pool/users Ns @ Ns Ar today
+.Ed
 .
 .Sh SEE ALSO
 .Xr zfs-bookmark 8 ,

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -301,6 +301,7 @@ if invalid command line options were specified.
 .Sh EXAMPLES
 .\" Examples 17, 18, 19, 20, 21 are shared with zfs-allow.8.
 .\" Examples 1, 4, 6, 14, 16 are shared with zfs-set.8.
+.\" Examples 23 are shared with zfs-bookmark.8.
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a ZFS File System Hierarchy
 The following commands create a file system named

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -299,6 +299,8 @@ if an error occurs, and
 if invalid command line options were specified.
 .
 .Sh EXAMPLES
+.\" Examples 17, 18, 19, 20, 21 are shared with zfs-allow.8.
+.\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a ZFS File System Hierarchy
 The following commands create a file system named
 .Ar pool/home

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -299,7 +299,8 @@ if an error occurs, and
 if invalid command line options were specified.
 .
 .Sh EXAMPLES
-.\" Examples 1, 4, 6, 14, 16 are shared with zfs-set.8.
+.\" Examples 1, 4, 6, 7, 11, 14, 16 are shared with zfs-set.8.
+.\" Examples 3, 10, 15 are shared with zfs-destroy.8.
 .\" Examples 5 are shared with zfs-list.8.
 .\" Examples 8 are shared with zfs-rollback.8.
 .\" Examples 9, 10 are shared with zfs-clone.8.

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -301,6 +301,7 @@ if invalid command line options were specified.
 .Sh EXAMPLES
 .\" Examples 1, 4, 6, 14, 16 are shared with zfs-set.8.
 .\" Examples 5 are shared with zfs-list.8.
+.\" Examples 9, 10 are shared with zfs-clone.8.
 .\" Examples 12, 13 are shared with zfs-send.8.
 .\" Examples 12, 13 are also shared with zfs-receive.8.
 .\" Examples 17, 18, 19, 20, 21 are shared with zfs-allow.8.

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -36,7 +36,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd June 30, 2019
+.Dd March 16, 2022
 .Dt ZFS 8
 .Os
 .
@@ -299,9 +299,7 @@ if an error occurs, and
 if invalid command line options were specified.
 .
 .Sh EXAMPLES
-.Bl -tag -width ""
-.
-.It Sy Example 1 : No Creating a ZFS File System Hierarchy
+.Ss Example 1 : No Creating a ZFS File System Hierarchy
 The following commands create a file system named
 .Ar pool/home
 and a file system named
@@ -314,7 +312,7 @@ file system.
 .Dl # Nm zfs Cm set Sy mountpoint Ns = Ns Ar /export/home pool/home
 .Dl # Nm zfs Cm create Ar pool/home/bob
 .
-.It Sy Example 2 : No Creating a ZFS Snapshot
+.Ss Example 2 : No Creating a ZFS Snapshot
 The following command creates a snapshot named
 .Ar yesterday .
 This snapshot is mounted on demand in the
@@ -324,7 +322,7 @@ directory at the root of the
 file system.
 .Dl # Nm zfs Cm snapshot Ar pool/home/bob Ns @ Ns Ar yesterday
 .
-.It Sy Example 3 : No Creating and Destroying Multiple Snapshots
+.Ss Example 3 : No Creating and Destroying Multiple Snapshots
 The following command creates snapshots named
 .Ar yesterday No of Ar pool/home
 and all of its descendent file systems.
@@ -335,7 +333,7 @@ The second command destroys the newly created snapshots.
 .Dl # Nm zfs Cm snapshot Fl r Ar pool/home Ns @ Ns Ar yesterday
 .Dl # Nm zfs Cm destroy Fl r Ar pool/home Ns @ Ns Ar yesterday
 .
-.It Sy Example 4 : No Disabling and Enabling File System Compression
+.Ss Example 4 : No Disabling and Enabling File System Compression
 The following command disables the
 .Sy compression
 property for all file systems under
@@ -347,7 +345,7 @@ for
 .Dl # Nm zfs Cm set Sy compression Ns = Ns Sy off Ar pool/home
 .Dl # Nm zfs Cm set Sy compression Ns = Ns Sy on Ar pool/home/anne
 .
-.It Sy Example 5 : No Listing ZFS Datasets
+.Ss Example 5 : No Listing ZFS Datasets
 The following command lists all active file systems and volumes in the system.
 Snapshots are displayed if
 .Sy listsnaps Ns = Ns Sy on .
@@ -365,12 +363,12 @@ pool/home/anne             18K   457G    18K  /export/home/anne
 pool/home/bob             276K   457G   276K  /export/home/bob
 .Ed
 .
-.It Sy Example 6 : No Setting a Quota on a ZFS File System
+.Ss Example 6 : No Setting a Quota on a ZFS File System
 The following command sets a quota of 50 Gbytes for
 .Ar pool/home/bob :
 .Dl # Nm zfs Cm set Sy quota Ns = Ns Ar 50G pool/home/bob
 .
-.It Sy Example 7 : No Listing ZFS Properties
+.Ss Example 7 : No Listing ZFS Properties
 The following command lists all properties for
 .Ar pool/home/bob :
 .Bd -literal -compact -offset Ds
@@ -435,7 +433,7 @@ pool/home/bob  quota                 20G
 pool/home/bob  compression           on
 .Ed
 .
-.It Sy Example 8 : No Rolling Back a ZFS File System
+.Ss Example 8 : No Rolling Back a ZFS File System
 The following command reverts the contents of
 .Ar pool/home/anne
 to the snapshot named
@@ -443,13 +441,13 @@ to the snapshot named
 deleting all intermediate snapshots:
 .Dl # Nm zfs Cm rollback Fl r Ar pool/home/anne Ns @ Ns Ar yesterday
 .
-.It Sy Example 9 : No Creating a ZFS Clone
+.Ss Example 9 : No Creating a ZFS Clone
 The following command creates a writable file system whose initial contents are
 the same as
 .Ar pool/home/bob@yesterday .
 .Dl # Nm zfs Cm clone Ar pool/home/bob@yesterday pool/clone
 .
-.It Sy Example 10 : No Promoting a ZFS Clone
+.Ss Example 10 : No Promoting a ZFS Clone
 The following commands illustrate how to test out changes to a file system, and
 then replace the original file system with the changed one, using clones, clone
 promotion, and renaming:
@@ -466,7 +464,7 @@ promotion, and renaming:
 .No # Nm zfs Cm destroy Ar pool/project/legacy
 .Ed
 .
-.It Sy Example 11 : No Inheriting ZFS Properties
+.Ss Example 11 : No Inheriting ZFS Properties
 The following command causes
 .Ar pool/home/bob No and Ar pool/home/anne
 to inherit the
@@ -474,7 +472,7 @@ to inherit the
 property from their parent.
 .Dl # Nm zfs Cm inherit Sy checksum Ar pool/home/bob pool/home/anne
 .
-.It Sy Example 12 : No Remotely Replicating ZFS Data
+.Ss Example 12 : No Remotely Replicating ZFS Data
 The following commands send a full stream and then an incremental stream to a
 remote machine, restoring them into
 .Em poolB/received/fs@a
@@ -493,7 +491,7 @@ and must not initially contain
 .No "   " Nm ssh Ar host Nm zfs Cm receive Ar poolB/received/fs
 .Ed
 .
-.It Sy Example 13 : No Using the Nm zfs Cm receive Fl d No Option
+.Ss Example 13 : No Using the Nm zfs Cm receive Fl d No Option
 The following command sends a full stream of
 .Ar poolA/fsA/fsB@snap
 to a remote machine, receiving it into
@@ -513,13 +511,13 @@ does not exist, it is created as an empty file system.
 .No "   " Nm ssh Ar host Nm zfs Cm receive Fl d Ar poolB/received
 .Ed
 .
-.It Sy Example 14 : No Setting User Properties
+.Ss Example 14 : No Setting User Properties
 The following example sets the user-defined
 .Ar com.example : Ns Ar department
 property for a dataset:
 .Dl # Nm zfs Cm set Ar com.example : Ns Ar department Ns = Ns Ar 12345 tank/accounting
 .
-.It Sy Example 15 : No Performing a Rolling Snapshot
+.Ss Example 15 : No Performing a Rolling Snapshot
 The following example shows how to maintain a history of snapshots with a
 consistent naming scheme.
 To keep a week's worth of snapshots, the user destroys the oldest snapshot,
@@ -536,7 +534,7 @@ renames the remaining snapshots, and then creates a new snapshot, as follows:
 .No # Nm zfs Cm snapshot Fl r Ar pool/users Ns @ Ns Ar today
 .Ed
 .
-.It Sy Example 16 : No Setting sharenfs Property Options on a ZFS File System
+.Ss Example 16 : No Setting sharenfs Property Options on a ZFS File System
 The following commands show how to set
 .Sy sharenfs
 property options to enable read-write
@@ -550,7 +548,7 @@ file system:
 If you are using DNS for host name resolution,
 specify the fully-qualified hostname.
 .
-.It Sy Example 17 : No Delegating ZFS Administration Permissions on a ZFS Dataset
+.Ss Example 17 : No Delegating ZFS Administration Permissions on a ZFS Dataset
 The following example shows how to set permissions so that user
 .Ar cindys
 can create, destroy, mount, and take snapshots on
@@ -575,7 +573,7 @@ will be unable to mount file systems under
 Add an ACE similar to the following syntax to provide mount point access:
 .Dl # Cm chmod No A+user: Ns Ar cindys Ns :add_subdirectory:allow Ar /tank/cindys
 .
-.It Sy Example 18 : No Delegating Create Time Permissions on a ZFS Dataset
+.Ss Example 18 : No Delegating Create Time Permissions on a ZFS Dataset
 The following example shows how to grant anyone in the group
 .Ar staff
 to create file systems in
@@ -596,7 +594,7 @@ Local+Descendent permissions:
         group staff create,mount
 .Ed
 .
-.It Sy Example 19 : No Defining and Granting a Permission Set on a ZFS Dataset
+.Ss Example 19 : No Defining and Granting a Permission Set on a ZFS Dataset
 The following example shows how to define and grant a permission set on the
 .Ar tank/users
 file system.
@@ -614,7 +612,7 @@ Local+Descendent permissions:
         group staff @pset
 .Ed
 .
-.It Sy Example 20 : No Delegating Property Permissions on a ZFS Dataset
+.Ss Example 20 : No Delegating Property Permissions on a ZFS Dataset
 The following example shows to grant the ability to set quotas and reservations
 on the
 .Ar users/home
@@ -634,7 +632,7 @@ NAME              PROPERTY  VALUE  SOURCE
 users/home/marks  quota     10G    local
 .Ed
 .
-.It Sy Example 21 : No Removing ZFS Delegated Permissions on a ZFS Dataset
+.Ss Example 21 : No Removing ZFS Delegated Permissions on a ZFS Dataset
 The following example shows how to remove the snapshot permission from the
 .Ar staff
 group on the
@@ -653,7 +651,7 @@ Local+Descendent permissions:
         group staff @pset
 .Ed
 .
-.It Sy Example 22 : No Showing the differences between a snapshot and a ZFS Dataset
+.Ss Example 22 : No Showing the differences between a snapshot and a ZFS Dataset
 The following example shows how to see what has changed between a prior
 snapshot of a ZFS dataset and its current state.
 The
@@ -669,12 +667,12 @@ R       F       /tank/test/oldname -> /tank/test/newname
 M       F       /tank/test/modified
 .Ed
 .
-.It Sy Example 23 : No Creating a bookmark
+.Ss Example 23 : No Creating a bookmark
 The following example create a bookmark to a snapshot.
 This bookmark can then be used instead of snapshot in send streams.
 .Dl # Nm zfs Cm bookmark Ar rpool Ns @ Ns Ar snapshot rpool Ns # Ns Ar bookmark
 .
-.It Sy Example 24 : No Setting Sy sharesmb No Property Options on a ZFS File System
+.Ss Example 24 : No Setting Sy sharesmb No Property Options on a ZFS File System
 The following example show how to share SMB filesystem through ZFS.
 Note that a user and their password must be given.
 .Dl # Nm smbmount Ar //127.0.0.1/share_tmp /mnt/tmp Fl o No user=workgroup/turbo,password=obrut,uid=1000
@@ -701,7 +699,6 @@ in case you need to modify any options of the share afterwards.
 Do note that any changes done with the
 .Xr net 8
 command will be undone if the share is ever unshared (like via a reboot).
-.El
 .
 .Sh ENVIRONMENT VARIABLES
 .Bl -tag -width "ZFS_MOUNT_HELPER"

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -305,6 +305,7 @@ if invalid command line options were specified.
 .\" Examples 5 are shared with zfs-list.8.
 .\" Examples 8 are shared with zfs-rollback.8.
 .\" Examples 9, 10 are shared with zfs-clone.8.
+.\" Examples 10 are also shared with zfs-promote.8.
 .\" Examples 12, 13 are shared with zfs-send.8.
 .\" Examples 12, 13 are also shared with zfs-receive.8.
 .\" Examples 17, 18, 19, 20, 21 are shared with zfs-allow.8.

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -299,11 +299,13 @@ if an error occurs, and
 if invalid command line options were specified.
 .
 .Sh EXAMPLES
-.\" Examples 17, 18, 19, 20, 21 are shared with zfs-allow.8.
 .\" Examples 1, 4, 6, 14, 16 are shared with zfs-set.8.
+.\" Examples 12, 13 are shared with zfs-send.8.
+.\" Examples 12, 13 are also shared with zfs-receive.8.
+.\" Examples 17, 18, 19, 20, 21 are shared with zfs-allow.8.
 .\" Examples 22 are shared with zfs-diff.8.
 .\" Examples 23 are shared with zfs-bookmark.8.
-.\" Make sure to update them bidirectionally
+.\" Make sure to update them omnidirectionally
 .Ss Example 1 : No Creating a ZFS File System Hierarchy
 The following commands create a file system named
 .Ar pool/home

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -300,6 +300,7 @@ if invalid command line options were specified.
 .
 .Sh EXAMPLES
 .\" Examples 1, 4, 6, 7, 11, 14, 16 are shared with zfs-set.8.
+.\" Examples 1, 10 are shared with zfs-create.8.
 .\" Examples 3, 10, 15 are shared with zfs-destroy.8.
 .\" Examples 5 are shared with zfs-list.8.
 .\" Examples 8 are shared with zfs-rollback.8.

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -300,6 +300,7 @@ if invalid command line options were specified.
 .
 .Sh EXAMPLES
 .\" Examples 1, 4, 6, 14, 16 are shared with zfs-set.8.
+.\" Examples 5 are shared with zfs-list.8.
 .\" Examples 12, 13 are shared with zfs-send.8.
 .\" Examples 12, 13 are also shared with zfs-receive.8.
 .\" Examples 17, 18, 19, 20, 21 are shared with zfs-allow.8.

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -301,6 +301,7 @@ if invalid command line options were specified.
 .Sh EXAMPLES
 .\" Examples 1, 4, 6, 7, 11, 14, 16 are shared with zfs-set.8.
 .\" Examples 1, 10 are shared with zfs-create.8.
+.\" Examples 2, 3, 10, 15 are also shared with zfs-snapshot.8.
 .\" Examples 3, 10, 15 are shared with zfs-destroy.8.
 .\" Examples 5 are shared with zfs-list.8.
 .\" Examples 8 are shared with zfs-rollback.8.

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -307,6 +307,7 @@ if invalid command line options were specified.
 .\" Examples 8 are shared with zfs-rollback.8.
 .\" Examples 9, 10 are shared with zfs-clone.8.
 .\" Examples 10 are also shared with zfs-promote.8.
+.\" Examples 10, 15 also are shared with zfs-rename.8.
 .\" Examples 12, 13 are shared with zfs-send.8.
 .\" Examples 12, 13 are also shared with zfs-receive.8.
 .\" Examples 17, 18, 19, 20, 21 are shared with zfs-allow.8.

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -301,6 +301,7 @@ if invalid command line options were specified.
 .Sh EXAMPLES
 .\" Examples 1, 4, 6, 14, 16 are shared with zfs-set.8.
 .\" Examples 5 are shared with zfs-list.8.
+.\" Examples 8 are shared with zfs-rollback.8.
 .\" Examples 9, 10 are shared with zfs-clone.8.
 .\" Examples 12, 13 are shared with zfs-send.8.
 .\" Examples 12, 13 are also shared with zfs-receive.8.

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -301,6 +301,7 @@ if invalid command line options were specified.
 .Sh EXAMPLES
 .\" Examples 17, 18, 19, 20, 21 are shared with zfs-allow.8.
 .\" Examples 1, 4, 6, 14, 16 are shared with zfs-set.8.
+.\" Examples 22 are shared with zfs-diff.8.
 .\" Examples 23 are shared with zfs-bookmark.8.
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a ZFS File System Hierarchy

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -300,6 +300,7 @@ if invalid command line options were specified.
 .
 .Sh EXAMPLES
 .\" Examples 17, 18, 19, 20, 21 are shared with zfs-allow.8.
+.\" Examples 1, 4, 6, 14, 16 are shared with zfs-set.8.
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a ZFS File System Hierarchy
 The following commands create a file system named

--- a/man/man8/zpool-add.8
+++ b/man/man8/zpool-add.8
@@ -25,7 +25,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd May 27, 2021
+.Dd March 16, 2022
 .Dt ZPOOL-ADD 8
 .Os
 .
@@ -92,6 +92,29 @@ manual page for a list of valid properties that can be set.
 The only property supported at the moment is
 .Sy ashift .
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 5, 13 from zpool.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Adding a Mirror to a ZFS Storage Pool
+The following command adds two mirrored disks to the pool
+.Ar tank ,
+assuming the pool is already made up of two-way mirrors.
+The additional space is immediately available to any datasets within the pool.
+.Dl # Nm zpool Cm add Ar tank Sy mirror Pa sda sdb
+.
+.Ss Example 2 : No Adding Cache Devices to a ZFS Pool
+The following command adds two disks for use as cache devices to a ZFS storage
+pool:
+.Dl # Nm zpool Cm add Ar pool Sy cache Pa sdc sdd
+.Pp
+Once added, the cache devices gradually fill with content from main memory.
+Depending on the size of your cache devices, it could take over an hour for
+them to fill.
+Capacity and reads can be monitored using the
+.Cm iostat
+subcommand as follows:
+.Dl # Nm zpool Cm iostat Fl v Ar pool 5
 .
 .Sh SEE ALSO
 .Xr zpool-attach 8 ,

--- a/man/man8/zpool-create.8
+++ b/man/man8/zpool-create.8
@@ -27,7 +27,7 @@
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\" Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
 .\"
-.Dd June 2, 2021
+.Dd March 16, 2022
 .Dt ZPOOL-CREATE 8
 .Os
 .
@@ -204,6 +204,38 @@ to handle name space collisions when creating pools for other systems,
 such as virtual machines or physical machines whose pools live on network
 block devices.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 1, 2, 3, 4, 11, 12 from zpool.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Creating a RAID-Z Storage Pool
+The following command creates a pool with a single raidz root vdev that
+consists of six disks:
+.Dl # Nm zpool Cm create Ar tank Sy raidz Pa sda sdb sdc sdd sde sdf
+.
+.Ss Example 2 : No Creating a Mirrored Storage Pool
+The following command creates a pool with two mirrors, where each mirror
+contains two disks:
+.Dl # Nm zpool Cm create Ar tank Sy mirror Pa sda sdb Sy mirror Pa sdc sdd
+.
+.Ss Example 3 : No Creating a ZFS Storage Pool by Using Partitions
+The following command creates a non-redundant pool using two disk partitions:
+.Dl # Nm zpool Cm create Ar tank Pa sda1 sdb2
+.
+.Ss Example 4 : No Creating a ZFS Storage Pool by Using Files
+The following command creates a non-redundant pool using files.
+While not recommended, a pool based on files can be useful for experimental
+purposes.
+.Dl # Nm zpool Cm create Ar tank Pa /path/to/file/a /path/to/file/b
+.
+.Ss Example 5 : No Managing Hot Spares
+The following command creates a new pool with an available hot spare:
+.Dl # Nm zpool Cm create Ar tank Sy mirror Pa sda sdb Sy spare Pa sdc
+.
+.Ss Example 6 : No Creating a ZFS Pool with Mirrored Separate Intent Logs
+The following command creates a ZFS storage pool consisting of two, two-way
+mirrors and mirrored log devices:
+.Dl # Nm zpool Cm create Ar pool Sy mirror Pa sda sdb Sy mirror Pa sdc sdd Sy log mirror Pa sde sdf
 .
 .Sh SEE ALSO
 .Xr zpool-destroy 8 ,

--- a/man/man8/zpool-destroy.8
+++ b/man/man8/zpool-destroy.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd May 31, 2021
+.Dd March 16, 2022
 .Dt ZPOOL-DESTROY 8
 .Os
 .
@@ -46,3 +46,12 @@ This command tries to unmount any active datasets before destroying the pool.
 .It Fl f
 Forcefully unmount all active datasets.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 7 from zpool.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Destroying a ZFS Storage Pool
+The following command destroys the pool
+.Ar tank
+and any datasets contained within:
+.Dl # Nm zpool Cm destroy Fl f Ar tank

--- a/man/man8/zpool-export.8
+++ b/man/man8/zpool-export.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd February 16, 2020
+.Dd March 16, 2022
 .Dt ZPOOL-EXPORT 8
 .Os
 .
@@ -67,6 +67,15 @@ This command will forcefully export the pool even if it has a shared spare that
 is currently being used.
 This may lead to potential data corruption.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 8 from zpool.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Exporting a ZFS Storage Pool
+The following command exports the devices in pool
+.Ar tank
+so that they can be relocated or later imported:
+.Dl # Nm zpool Cm export Ar tank
 .
 .Sh SEE ALSO
 .Xr zpool-import 8

--- a/man/man8/zpool-import.8
+++ b/man/man8/zpool-import.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd August 9, 2019
+.Dd March 16, 2022
 .Dt ZPOOL-IMPORT 8
 .Os
 .
@@ -403,6 +403,30 @@ Will also set
 when not explicitly specified.
 .El
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 9 from zpool.8
+.\" Make sure to update them bidirectionally
+.Ss Example 9 : No Importing a ZFS Storage Pool
+The following command displays available pools, and then imports the pool
+.Ar tank
+for use on the system.
+The results from this command are similar to the following:
+.Bd -literal -compact -offset Ds
+.No # Nm zpool Cm import
+  pool: tank
+    id: 15451357997522795478
+ state: ONLINE
+action: The pool can be imported using its name or numeric identifier.
+config:
+
+        tank        ONLINE
+          mirror    ONLINE
+            sda     ONLINE
+            sdb     ONLINE
+
+.No # Nm zpool Cm import Ar tank
+.Ed
 .
 .Sh SEE ALSO
 .Xr zpool-export 8 ,

--- a/man/man8/zpool-iostat.8
+++ b/man/man8/zpool-iostat.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd May 27, 2021
+.Dd March 16, 2022
 .Dt ZPOOL-IOSTAT 8
 .Os
 .
@@ -257,6 +257,46 @@ entries in the queues.
 If you specify an interval,
 the measurements will be sampled from the end of the interval.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 13, 16 from zpool.8
+.\" Make sure to update them bidirectionally
+.Ss Example 13 : No Adding Cache Devices to a ZFS Pool
+The following command adds two disks for use as cache devices to a ZFS storage
+pool:
+.Dl # Nm zpool Cm add Ar pool Sy cache Pa sdc sdd
+.Pp
+Once added, the cache devices gradually fill with content from main memory.
+Depending on the size of your cache devices, it could take over an hour for
+them to fill.
+Capacity and reads can be monitored using the
+.Cm iostat
+subcommand as follows:
+.Dl # Nm zpool Cm iostat Fl v Ar pool 5
+.
+.Ss Example 16 : No Adding output columns
+Additional columns can be added to the
+.Nm zpool Cm status No and Nm zpool Cm iostat No output with Fl c .
+.Bd -literal -compact -offset Ds
+.No # Nm zpool Cm status Fl c Pa vendor , Ns Pa model , Ns Pa size
+   NAME     STATE  READ WRITE CKSUM vendor  model        size
+   tank     ONLINE 0    0     0
+   mirror-0 ONLINE 0    0     0
+   U1       ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+   U10      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+   U11      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+   U12      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+   U13      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+   U14      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+
+.No # Nm zpool Cm iostat Fl vc Pa size
+              capacity     operations     bandwidth
+pool        alloc   free   read  write   read  write  size
+----------  -----  -----  -----  -----  -----  -----  ----
+rpool       14.6G  54.9G      4     55   250K  2.69M
+  sda1      14.6G  54.9G      4     55   250K  2.69M   70G
+----------  -----  -----  -----  -----  -----  -----  ----
+.Ed
 .
 .Sh SEE ALSO
 .Xr iostat 1 ,

--- a/man/man8/zpool-list.8
+++ b/man/man8/zpool-list.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd August 9, 2019
+.Dd March 16, 2022
 .Dt ZPOOL-LIST 8
 .Os
 .
@@ -106,6 +106,40 @@ Verbose statistics.
 Reports usage statistics for individual vdevs within the pool, in addition to
 the pool-wide statistics.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 6, 15 from zpool.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Listing Available ZFS Storage Pools
+The following command lists all available pools on the system.
+In this case, the pool
+.Ar zion
+is faulted due to a missing device.
+The results from this command are similar to the following:
+.Bd -literal -compact -offset Ds
+.No # Nm zpool Cm list
+NAME    SIZE  ALLOC   FREE  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
+rpool  19.9G  8.43G  11.4G         -    33%    42%  1.00x  ONLINE  -
+tank   61.5G  20.0G  41.5G         -    48%    32%  1.00x  ONLINE  -
+zion       -      -      -         -      -      -      -  FAULTED -
+.Ed
+.
+.Ss Example 2 : No Displaying expanded space on a device
+The following command displays the detailed information for the pool
+.Ar data .
+This pool is comprised of a single raidz vdev where one of its devices
+increased its capacity by 10GB.
+In this example, the pool will not be able to utilize this extra capacity until
+all the devices under the raidz vdev have been expanded.
+.Bd -literal -compact -offset Ds
+.No # Nm zpool Cm list Fl v Ar data
+NAME         SIZE  ALLOC   FREE  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
+data        23.9G  14.6G  9.30G         -    48%    61%  1.00x  ONLINE  -
+  raidz1    23.9G  14.6G  9.30G         -    48%
+    sda         -      -      -         -      -
+    sdb         -      -      -       10G      -
+    sdc         -      -      -         -      -
+.Ed
 .
 .Sh SEE ALSO
 .Xr zpool-import 8 ,

--- a/man/man8/zpool-remove.8
+++ b/man/man8/zpool-remove.8
@@ -26,12 +26,14 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd August 9, 2019
+.Dd March 16, 2022
 .Dt ZPOOL-REMOVE 8
 .Os
+.
 .Sh NAME
 .Nm zpool-remove
 .Nd remove devices from ZFS storage pool
+.
 .Sh SYNOPSIS
 .Nm zpool
 .Cm remove
@@ -41,6 +43,7 @@
 .Cm remove
 .Fl s
 .Ar pool
+.
 .Sh DESCRIPTION
 .Bl -tag -width Ds
 .It Xo
@@ -102,6 +105,45 @@ Waits until the removal has completed before returning.
 .Xc
 Stops and cancels an in-progress removal of a top-level vdev.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 14 from zpool.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Removing a Mirrored top-level (Log or Data) Device
+The following commands remove the mirrored log device
+.Sy mirror-2
+and mirrored top-level data device
+.Sy mirror-1 .
+.Pp
+Given this configuration:
+.Bd -literal -compact -offset Ds
+  pool: tank
+ state: ONLINE
+ scrub: none requested
+config:
+
+         NAME        STATE     READ WRITE CKSUM
+         tank        ONLINE       0     0     0
+           mirror-0  ONLINE       0     0     0
+             sda     ONLINE       0     0     0
+             sdb     ONLINE       0     0     0
+           mirror-1  ONLINE       0     0     0
+             sdc     ONLINE       0     0     0
+             sdd     ONLINE       0     0     0
+         logs
+           mirror-2  ONLINE       0     0     0
+             sde     ONLINE       0     0     0
+             sdf     ONLINE       0     0     0
+.Ed
+.Pp
+The command to remove the mirrored log
+.Ar mirror-2 No is:
+.Dl # Nm zpool Cm remove Ar tank mirror-2
+.Pp
+The command to remove the mirrored data
+.Ar mirror-1 No is:
+.Dl # Nm zpool Cm remove Ar tank mirror-1
+.
 .Sh SEE ALSO
 .Xr zpool-add 8 ,
 .Xr zpool-detach 8 ,

--- a/man/man8/zpool-scrub.8
+++ b/man/man8/zpool-scrub.8
@@ -97,10 +97,8 @@ again.
 Wait until scrub has completed before returning.
 .El
 .Sh EXAMPLES
-.Bl -tag -width "Exam"
-.It Sy Example 1 : Status of pool with ongoing scrub:
-Output:
-.Bd -literal -compact -offset Ds
+.Ss Example 1 : No Status of pool with ongoing scrub:
+.Bd -literal -compact
 .No # Nm zpool Cm status
   ...
   scan: scrub in progress since Sun Jul 25 16:07:49 2021
@@ -108,14 +106,10 @@ Output:
         0B repaired, 16.91% done, 00:00:04 to go
   ...
 .Ed
-Where:
-.Bl -dash -offset indent
-.It
-Metadata which references 403M of file data has been
+.Pp
+Where metadata which references 403M of file data has been
 scanned at 100M/s, and 68.4M of that file data has been
 scrubbed sequentially at 10.0M/s.
-.El
-.El
 .Sh PERIODIC SCRUB
 On machines using systemd, scrub timers can be enabled on per-pool basis.
 .Nm weekly

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd June 2, 2021
+.Dd March 16, 2022
 .Dt ZPOOL-STATUS 8
 .Os
 .
@@ -123,6 +123,33 @@ Only display status for pools that are exhibiting errors or are otherwise
 unavailable.
 Warnings about pools not using the latest on-disk format will not be included.
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 16 from zpool.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Adding output columns
+Additional columns can be added to the
+.Nm zpool Cm status No and Nm zpool Cm iostat No output with Fl c .
+.Bd -literal -compact -offset Ds
+.No # Nm zpool Cm status Fl c Pa vendor , Ns Pa model , Ns Pa size
+   NAME     STATE  READ WRITE CKSUM vendor  model        size
+   tank     ONLINE 0    0     0
+   mirror-0 ONLINE 0    0     0
+   U1       ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+   U10      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+   U11      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+   U12      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+   U13      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+   U14      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
+
+.No # Nm zpool Cm iostat Fl vc Pa size
+              capacity     operations     bandwidth
+pool        alloc   free   read  write   read  write  size
+----------  -----  -----  -----  -----  -----  -----  ----
+rpool       14.6G  54.9G      4     55   250K  2.69M
+  sda1      14.6G  54.9G      4     55   250K  2.69M   70G
+----------  -----  -----  -----  -----  -----  -----  ----
+.Ed
 .
 .Sh SEE ALSO
 .Xr zpool-events 8 ,

--- a/man/man8/zpool-upgrade.8
+++ b/man/man8/zpool-upgrade.8
@@ -27,7 +27,7 @@
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\" Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
 .\"
-.Dd August 9, 2019
+.Dd March 16, 2022
 .Dt ZPOOL-UPGRADE 8
 .Os
 .
@@ -101,6 +101,17 @@ This option can only be used to increase the version number up to the last
 supported legacy version number.
 .El
 .El
+.
+.Sh EXAMPLES
+.\" These are, respectively, examples 10 from zpool.8
+.\" Make sure to update them bidirectionally
+.Ss Example 1 : No Upgrading All ZFS Storage Pools to the Current Version
+The following command upgrades all ZFS Storage pools to the current version of
+the software:
+.Bd -literal -compact -offset Ds
+.No # Nm zpool Cm upgrade Fl a
+This system is currently running ZFS version 2.
+.Ed
 .
 .Sh SEE ALSO
 .Xr zpool-features 7 ,

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -234,6 +234,7 @@ Invalid command line options were specified.
 .\" Examples 5, 13 are shared with zpool-add.8.
 .\" Examples 6, 15 are shared with zpool-list.8.
 .\" Examples 7 are shared with zpool-destroy.8.
+.\" Examples 8 are shared with zpool-export.8.
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a RAID-Z Storage Pool
 The following command creates a pool with a single raidz root vdev that

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd June 2, 2021
+.Dd March 16, 2022
 .Dt ZPOOL 8
 .Os
 .
@@ -230,6 +230,8 @@ Invalid command line options were specified.
 .El
 .
 .Sh EXAMPLES
+.\" Examples 1, 2, 3, 4, 11, 12 are shared with zpool-create.8.
+.\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a RAID-Z Storage Pool
 The following command creates a pool with a single raidz root vdev that
 consists of six disks:

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -242,11 +242,11 @@ contains two disks:
 .Dl # Nm zpool Cm create Ar tank Sy mirror Pa sda sdb Sy mirror Pa sdc sdd
 .
 .It Sy Example 3 : No Creating a ZFS Storage Pool by Using Partitions
-The following command creates an unmirrored pool using two disk partitions:
+The following command creates a non-redundant pool using two disk partitions:
 .Dl # Nm zpool Cm create Ar tank Pa sda1 sdb2
 .
 .It Sy Example 4 : No Creating a ZFS Storage Pool by Using Files
-The following command creates an unmirrored pool using files.
+The following command creates a non-redundant pool using files.
 While not recommended, a pool based on files can be useful for experimental
 purposes.
 .Dl # Nm zpool Cm create Ar tank Pa /path/to/file/a /path/to/file/b

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -231,6 +231,7 @@ Invalid command line options were specified.
 .
 .Sh EXAMPLES
 .\" Examples 1, 2, 3, 4, 11, 12 are shared with zpool-create.8.
+.\" Examples 5, 13 are shared with zpool-add.8.
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a RAID-Z Storage Pool
 The following command creates a pool with a single raidz root vdev that

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -237,6 +237,7 @@ Invalid command line options were specified.
 .\" Examples 8 are shared with zpool-export.8.
 .\" Examples 9 are shared with zpool-import.8.
 .\" Examples 10 are shared with zpool-upgrade.8.
+.\" Examples 14 are shared with zpool-remove.8.
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a RAID-Z Storage Pool
 The following command creates a pool with a single raidz root vdev that

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -238,7 +238,9 @@ Invalid command line options were specified.
 .\" Examples 9 are shared with zpool-import.8.
 .\" Examples 10 are shared with zpool-upgrade.8.
 .\" Examples 14 are shared with zpool-remove.8.
-.\" Make sure to update them bidirectionally
+.\" Examples 16 are shared with zpool-status.8.
+.\" Examples 13, 16 are also shared with zpool-iostat.8.
+.\" Make sure to update them omnidirectionally
 .Ss Example 1 : No Creating a RAID-Z Storage Pool
 The following command creates a pool with a single raidz root vdev that
 consists of six disks:

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -235,6 +235,7 @@ Invalid command line options were specified.
 .\" Examples 6, 15 are shared with zpool-list.8.
 .\" Examples 7 are shared with zpool-destroy.8.
 .\" Examples 8 are shared with zpool-export.8.
+.\" Examples 9 are shared with zpool-import.8.
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a RAID-Z Storage Pool
 The following command creates a pool with a single raidz root vdev that

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -234,29 +234,29 @@ Invalid command line options were specified.
 .It Sy Example 1 : No Creating a RAID-Z Storage Pool
 The following command creates a pool with a single raidz root vdev that
 consists of six disks:
-.Dl # Nm zpool Cm create Ar tank Sy raidz Ar sda sdb sdc sdd sde sdf
+.Dl # Nm zpool Cm create Ar tank Sy raidz Pa sda sdb sdc sdd sde sdf
 .
 .It Sy Example 2 : No Creating a Mirrored Storage Pool
 The following command creates a pool with two mirrors, where each mirror
 contains two disks:
-.Dl # Nm zpool Cm create Ar tank Sy mirror Ar sda sdb Sy mirror Ar sdc sdd
+.Dl # Nm zpool Cm create Ar tank Sy mirror Pa sda sdb Sy mirror Pa sdc sdd
 .
 .It Sy Example 3 : No Creating a ZFS Storage Pool by Using Partitions
 The following command creates an unmirrored pool using two disk partitions:
-.Dl # Nm zpool Cm create Ar tank sda1 sdb2
+.Dl # Nm zpool Cm create Ar tank Pa sda1 sdb2
 .
 .It Sy Example 4 : No Creating a ZFS Storage Pool by Using Files
 The following command creates an unmirrored pool using files.
 While not recommended, a pool based on files can be useful for experimental
 purposes.
-.Dl # Nm zpool Cm create Ar tank /path/to/file/a /path/to/file/b
+.Dl # Nm zpool Cm create Ar tank Pa /path/to/file/a /path/to/file/b
 .
 .It Sy Example 5 : No Adding a Mirror to a ZFS Storage Pool
 The following command adds two mirrored disks to the pool
 .Ar tank ,
 assuming the pool is already made up of two-way mirrors.
 The additional space is immediately available to any datasets within the pool.
-.Dl # Nm zpool Cm add Ar tank Sy mirror Ar sda sdb
+.Dl # Nm zpool Cm add Ar tank Sy mirror Pa sda sdb
 .
 .It Sy Example 6 : No Listing Available ZFS Storage Pools
 The following command lists all available pools on the system.
@@ -315,28 +315,28 @@ This system is currently running ZFS version 2.
 .
 .It Sy Example 11 : No Managing Hot Spares
 The following command creates a new pool with an available hot spare:
-.Dl # Nm zpool Cm create Ar tank Sy mirror Ar sda sdb Sy spare Ar sdc
+.Dl # Nm zpool Cm create Ar tank Sy mirror Pa sda sdb Sy spare Pa sdc
 .Pp
 If one of the disks were to fail, the pool would be reduced to the degraded
 state.
 The failed device can be replaced using the following command:
-.Dl # Nm zpool Cm replace Ar tank sda sdd
+.Dl # Nm zpool Cm replace Ar tank Pa sda sdd
 .Pp
 Once the data has been resilvered, the spare is automatically removed and is
 made available for use should another device fail.
 The hot spare can be permanently removed from the pool using the following
 command:
-.Dl # Nm zpool Cm remove Ar tank sdc
+.Dl # Nm zpool Cm remove Ar tank Pa sdc
 .
 .It Sy Example 12 : No Creating a ZFS Pool with Mirrored Separate Intent Logs
 The following command creates a ZFS storage pool consisting of two, two-way
 mirrors and mirrored log devices:
-.Dl # Nm zpool Cm create Ar pool Sy mirror Ar sda sdb Sy mirror Ar sdc sdd Sy log mirror Ar sde sdf
+.Dl # Nm zpool Cm create Ar pool Sy mirror Pa sda sdb Sy mirror Pa sdc sdd Sy log mirror Pa sde sdf
 .
 .It Sy Example 13 : No Adding Cache Devices to a ZFS Pool
 The following command adds two disks for use as cache devices to a ZFS storage
 pool:
-.Dl # Nm zpool Cm add Ar pool Sy cache Ar sdc sdd
+.Dl # Nm zpool Cm add Ar pool Sy cache Pa sdc sdd
 .Pp
 Once added, the cache devices gradually fill with content from main memory.
 Depending on the size of your cache devices, it could take over an hour for
@@ -402,7 +402,7 @@ data        23.9G  14.6G  9.30G         -    48%    61%  1.00x  ONLINE  -
 Additional columns can be added to the
 .Nm zpool Cm status No and Nm zpool Cm iostat No output with Fl c .
 .Bd -literal -compact -offset Ds
-.No # Nm zpool Cm status Fl c Ar vendor , Ns Ar model , Ns Ar size
+.No # Nm zpool Cm status Fl c Pa vendor , Ns Pa model , Ns Pa size
    NAME     STATE  READ WRITE CKSUM vendor  model        size
    tank     ONLINE 0    0     0
    mirror-0 ONLINE 0    0     0
@@ -413,7 +413,7 @@ Additional columns can be added to the
    U13      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
    U14      ONLINE 0    0     0     SEAGATE ST8000NM0075 7.3T
 
-.No # Nm zpool Cm iostat Fl vc Ar size
+.No # Nm zpool Cm iostat Fl vc Pa size
               capacity     operations     bandwidth
 pool        alloc   free   read  write   read  write  size
 ----------  -----  -----  -----  -----  -----  -----  ----

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -232,6 +232,8 @@ Invalid command line options were specified.
 .Sh EXAMPLES
 .\" Examples 1, 2, 3, 4, 11, 12 are shared with zpool-create.8.
 .\" Examples 5, 13 are shared with zpool-add.8.
+.\" Examples 6, 15 are shared with zpool-list.8.
+.\" Examples 7 are shared with zpool-destroy.8.
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a RAID-Z Storage Pool
 The following command creates a pool with a single raidz root vdev that

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -236,6 +236,7 @@ Invalid command line options were specified.
 .\" Examples 7 are shared with zpool-destroy.8.
 .\" Examples 8 are shared with zpool-export.8.
 .\" Examples 9 are shared with zpool-import.8.
+.\" Examples 10 are shared with zpool-upgrade.8.
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a RAID-Z Storage Pool
 The following command creates a pool with a single raidz root vdev that

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -230,35 +230,34 @@ Invalid command line options were specified.
 .El
 .
 .Sh EXAMPLES
-.Bl -tag -width "Exam"
-.It Sy Example 1 : No Creating a RAID-Z Storage Pool
+.Ss Example 1 : No Creating a RAID-Z Storage Pool
 The following command creates a pool with a single raidz root vdev that
 consists of six disks:
 .Dl # Nm zpool Cm create Ar tank Sy raidz Pa sda sdb sdc sdd sde sdf
 .
-.It Sy Example 2 : No Creating a Mirrored Storage Pool
+.Ss Example 2 : No Creating a Mirrored Storage Pool
 The following command creates a pool with two mirrors, where each mirror
 contains two disks:
 .Dl # Nm zpool Cm create Ar tank Sy mirror Pa sda sdb Sy mirror Pa sdc sdd
 .
-.It Sy Example 3 : No Creating a ZFS Storage Pool by Using Partitions
+.Ss Example 3 : No Creating a ZFS Storage Pool by Using Partitions
 The following command creates a non-redundant pool using two disk partitions:
 .Dl # Nm zpool Cm create Ar tank Pa sda1 sdb2
 .
-.It Sy Example 4 : No Creating a ZFS Storage Pool by Using Files
+.Ss Example 4 : No Creating a ZFS Storage Pool by Using Files
 The following command creates a non-redundant pool using files.
 While not recommended, a pool based on files can be useful for experimental
 purposes.
 .Dl # Nm zpool Cm create Ar tank Pa /path/to/file/a /path/to/file/b
 .
-.It Sy Example 5 : No Adding a Mirror to a ZFS Storage Pool
+.Ss Example 5 : No Adding a Mirror to a ZFS Storage Pool
 The following command adds two mirrored disks to the pool
 .Ar tank ,
 assuming the pool is already made up of two-way mirrors.
 The additional space is immediately available to any datasets within the pool.
 .Dl # Nm zpool Cm add Ar tank Sy mirror Pa sda sdb
 .
-.It Sy Example 6 : No Listing Available ZFS Storage Pools
+.Ss Example 6 : No Listing Available ZFS Storage Pools
 The following command lists all available pools on the system.
 In this case, the pool
 .Ar zion
@@ -272,19 +271,19 @@ tank   61.5G  20.0G  41.5G         -    48%    32%  1.00x  ONLINE  -
 zion       -      -      -         -      -      -      -  FAULTED -
 .Ed
 .
-.It Sy Example 7 : No Destroying a ZFS Storage Pool
+.Ss Example 7 : No Destroying a ZFS Storage Pool
 The following command destroys the pool
 .Ar tank
 and any datasets contained within:
 .Dl # Nm zpool Cm destroy Fl f Ar tank
 .
-.It Sy Example 8 : No Exporting a ZFS Storage Pool
+.Ss Example 8 : No Exporting a ZFS Storage Pool
 The following command exports the devices in pool
 .Ar tank
 so that they can be relocated or later imported:
 .Dl # Nm zpool Cm export Ar tank
 .
-.It Sy Example 9 : No Importing a ZFS Storage Pool
+.Ss Example 9 : No Importing a ZFS Storage Pool
 The following command displays available pools, and then imports the pool
 .Ar tank
 for use on the system.
@@ -305,7 +304,7 @@ config:
 .No # Nm zpool Cm import Ar tank
 .Ed
 .
-.It Sy Example 10 : No Upgrading All ZFS Storage Pools to the Current Version
+.Ss Example 10 : No Upgrading All ZFS Storage Pools to the Current Version
 The following command upgrades all ZFS Storage pools to the current version of
 the software:
 .Bd -literal -compact -offset Ds
@@ -313,7 +312,7 @@ the software:
 This system is currently running ZFS version 2.
 .Ed
 .
-.It Sy Example 11 : No Managing Hot Spares
+.Ss Example 11 : No Managing Hot Spares
 The following command creates a new pool with an available hot spare:
 .Dl # Nm zpool Cm create Ar tank Sy mirror Pa sda sdb Sy spare Pa sdc
 .Pp
@@ -328,12 +327,12 @@ The hot spare can be permanently removed from the pool using the following
 command:
 .Dl # Nm zpool Cm remove Ar tank Pa sdc
 .
-.It Sy Example 12 : No Creating a ZFS Pool with Mirrored Separate Intent Logs
+.Ss Example 12 : No Creating a ZFS Pool with Mirrored Separate Intent Logs
 The following command creates a ZFS storage pool consisting of two, two-way
 mirrors and mirrored log devices:
 .Dl # Nm zpool Cm create Ar pool Sy mirror Pa sda sdb Sy mirror Pa sdc sdd Sy log mirror Pa sde sdf
 .
-.It Sy Example 13 : No Adding Cache Devices to a ZFS Pool
+.Ss Example 13 : No Adding Cache Devices to a ZFS Pool
 The following command adds two disks for use as cache devices to a ZFS storage
 pool:
 .Dl # Nm zpool Cm add Ar pool Sy cache Pa sdc sdd
@@ -346,7 +345,7 @@ Capacity and reads can be monitored using the
 subcommand as follows:
 .Dl # Nm zpool Cm iostat Fl v Ar pool 5
 .
-.It Sy Example 14 : No Removing a Mirrored top-level (Log or Data) Device
+.Ss Example 14 : No Removing a Mirrored top-level (Log or Data) Device
 The following commands remove the mirrored log device
 .Sy mirror-2
 and mirrored top-level data device
@@ -381,7 +380,7 @@ The command to remove the mirrored data
 .Ar mirror-1 No is:
 .Dl # Nm zpool Cm remove Ar tank mirror-1
 .
-.It Sy Example 15 : No Displaying expanded space on a device
+.Ss Example 15 : No Displaying expanded space on a device
 The following command displays the detailed information for the pool
 .Ar data .
 This pool is comprised of a single raidz vdev where one of its devices
@@ -398,7 +397,7 @@ data        23.9G  14.6G  9.30G         -    48%    61%  1.00x  ONLINE  -
     sdc         -      -      -         -      -
 .Ed
 .
-.It Sy Example 16 : No Adding output columns
+.Ss Example 16 : No Adding output columns
 Additional columns can be added to the
 .Nm zpool Cm status No and Nm zpool Cm iostat No output with Fl c .
 .Bd -literal -compact -offset Ds
@@ -421,7 +420,6 @@ rpool       14.6G  54.9G      4     55   250K  2.69M
   sda1      14.6G  54.9G      4     55   250K  2.69M   70G
 ----------  -----  -----  -----  -----  -----  -----  ----
 .Ed
-.El
 .
 .Sh ENVIRONMENT VARIABLES
 .Bl -tag -compact -width "ZPOOL_IMPORT_UDEV_TIMEOUT_MS"
@@ -432,7 +430,7 @@ to dump core on exit for the purposes of running
 .Sy ::findleaks .
 .It Sy ZFS_COLOR
 Use ANSI color in
-.Nm zpool status
+.Nm zpool Cm status
 output.
 .It Sy ZPOOL_IMPORT_PATH
 The search path for devices or files to use with the pool.
@@ -449,7 +447,7 @@ The maximum time in milliseconds that
 will wait for an expected device to be available.
 .It Sy ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE
 If set, suppress warning about non-native vdev ashift in
-.Nm zpool status .
+.Nm zpool Cm status .
 The value is not used, only the presence or absence of the variable matters.
 .It Sy ZPOOL_VDEV_NAME_GUID
 Cause
@@ -481,7 +479,7 @@ NVP value is present in the pool's config.
 For example, a pool that originated on illumos platform would have a
 .Sy devid
 value in the config and
-.Nm zpool status
+.Nm zpool Cm status
 would fail when listing the config.
 This would also be true for future Linux-based pools.
 .Pp
@@ -497,12 +495,12 @@ by setting
 .Pp
 .It Sy ZPOOL_SCRIPTS_AS_ROOT
 Allow a privileged user to run
-.Nm zpool status/iostat Fl c .
+.Nm zpool Cm status Ns / Ns Cm iostat Fl c .
 Normally, only unprivileged users are allowed to run
 .Fl c .
 .It Sy ZPOOL_SCRIPTS_PATH
 The search path for scripts when running
-.Nm zpool status/iostat Fl c .
+.Nm zpool Cm status Ns / Ns Cm iostat Fl c .
 This is a colon-separated list of directories and overrides the default
 .Pa ~/.zpool.d
 and
@@ -510,7 +508,7 @@ and
 search paths.
 .It Sy ZPOOL_SCRIPTS_ENABLED
 Allow a user to run
-.Nm zpool status/iostat Fl c .
+.Nm zpool Cm status Ns / Ns Cm iostat Fl c .
 If
 .Sy ZPOOL_SCRIPTS_ENABLED
 is not set, it is assumed that the user is allowed to run


### PR DESCRIPTION
### Motivation and Context
Supersedes #13140. Includes @behlendorf's review comments therefrom.

### How Has This Been Tested?
Looks alright I think. The only undistributed example is from zfs.8:
```
.Ss Example 24 : No Setting Sy sharesmb No Property Options on a ZFS File System
The following example show how to share SMB filesystem through ZFS.
Note that a user and their password must be given.
.Dl # Nm smbmount Ar //127.0.0.1/share_tmp /mnt/tmp Fl o No user=workgroup/turbo,password=obrut,uid=1000
.Pp
Minimal
.Pa /etc/samba/smb.conf
configuration is required, as follows.
.Pp
Samba will need to bind to the loopback interface for the ZFS utilities to
communicate with Samba.
This is the default behavior for most Linux distributions.
.Pp
Samba must be able to authenticate a user.
This can be done in a number of ways
.Pq Xr passwd 5 , LDAP , Xr smbpasswd 5 , &c.\& .
How to do this is outside the scope of this document – refer to
.Xr smb.conf 5
for more information.
.Pp
See the
.Sx USERSHARES
section for all configuration options,
in case you need to modify any options of the share afterwards.
Do note that any changes done with the
.Xr net 8
command will be undone if the share is ever unshared (like via a reboot).
```

Since it doesn't mention any subcommand, so dunno.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – likewise
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
