### PR TITLE
config: Linux 5.18: detect 4-argument `bio_alloc()`, genhd.h removal

### DIFF
--- a/config/kernel-add-disk.m4
+++ b/config/kernel-add-disk.m4
@@ -3,16 +3,15 @@ dnl # 5.16 API change
 dnl # add_disk grew a must-check return code
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_ADD_DISK], [
-
 	ZFS_LINUX_TEST_SRC([add_disk_ret], [
-		#include <linux/genhd.h>
+		#include <linux/blkdev.h>
 	], [
 		struct gendisk *disk = NULL;
 		int err = add_disk(disk);
 		err = err;
 	])
-
 ])
+
 AC_DEFUN([ZFS_AC_KERNEL_ADD_DISK], [
 	AC_MSG_CHECKING([whether add_disk() returns int])
 	ZFS_LINUX_TEST_RESULT([add_disk_ret],

--- a/config/kernel-revalidate-disk-size.m4
+++ b/config/kernel-revalidate-disk-size.m4
@@ -8,14 +8,14 @@ dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_REVALIDATE_DISK], [
 
 	ZFS_LINUX_TEST_SRC([revalidate_disk_size], [
-		#include <linux/genhd.h>
+		#include <linux/blkdev.h>
 	], [
 		struct gendisk *disk = NULL;
 		(void) revalidate_disk_size(disk, false);
 	])
 
 	ZFS_LINUX_TEST_SRC([revalidate_disk], [
-		#include <linux/genhd.h>
+		#include <linux/blkdev.h>
 	], [
 		struct gendisk *disk = NULL;
 		(void) revalidate_disk(disk);

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -563,6 +563,10 @@ vdev_submit_bio(struct bio *bio)
 	current->bio_list = bio_list;
 }
 
+#ifdef HAVE_BIO_ALLOC_4ARG
+#define	bio_alloc(gfp_mask, nr_iovecs) bio_alloc(NULL, nr_iovecs, 0, gfp_mask)
+#endif
+
 static int
 __vdev_disk_physio(struct block_device *bdev, zio_t *zio,
     size_t io_size, uint64_t io_offset, int rw, int flags)

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -906,7 +906,7 @@ zvol_alloc(dev_t dev, const char *name)
 	if (volmode == ZFS_VOLMODE_DEV) {
 		/*
 		 * ZFS_VOLMODE_DEV disable partitioning on ZVOL devices: set
-		 * gendisk->minors = 1 as noted in include/linux/genhd.h.
+		 * gendisk->minors = 1 as noted in include/linux/blkdev.h.
 		 * Also disable extended partition numbers (GENHD_FL_EXT_DEVT)
 		 * and suppresses partition scanning (GENHD_FL_NO_PART_SCAN)
 		 * setting gendisk->flags accordingly.


### PR DESCRIPTION
### Motivation and Context
http://build.zfsonlinux.org/builders/Kernel.org%20Built-in%20x86_64%20%28BUILD%29/builds/44753/steps/shell_1/logs/make:
```
In file included from ./include/linux/umh.h:4:0,
                 from ./include/linux/kmod.h:9,
                 from ./include/linux/module.h:17,
                 from ./include/zfs/os/linux/spl/sys/atomic.h:27,
                 from ./include/zfs/sys/zfs_context.h:45,
                 from fs/zfs/zfs/../os/linux/zfs/vdev_disk.c:29:
fs/zfs/zfs/../os/linux/zfs/vdev_disk.c: In function ‘__vdev_disk_physio’:
./include/linux/gfp.h:329:18: warning: passing argument 1 of ‘bio_alloc’ makes pointer from integer without a cast [-Wint-conversion]
 #define GFP_NOIO (__GFP_RECLAIM)
                  ^
fs/zfs/zfs/../os/linux/zfs/vdev_disk.c:630:29: note: in expansion of macro ‘GFP_NOIO’
   dr->dr_bio[i] = bio_alloc(GFP_NOIO, bio_max_segs(
                             ^~~~~~~~
In file included from ./include/linux/blkdev.h:17:0,
                 from ./include/zfs/os/linux/spl/sys/uio.h:30,
                 from ./include/zfs/os/linux/spl/sys/sunddi.h:28,
                 from ./include/zfs/sys/zfs_context.h:68,
                 from fs/zfs/zfs/../os/linux/zfs/vdev_disk.c:29:
./include/linux/bio.h:423:27: note: expected ‘struct block_device *’ but argument is of type ‘unsigned int’
 static inline struct bio *bio_alloc(struct block_device *bdev,
                           ^~~~~~~~~
fs/zfs/zfs/../os/linux/zfs/vdev_disk.c:630:19: error: too few arguments to function ‘bio_alloc’
   dr->dr_bio[i] = bio_alloc(GFP_NOIO, bio_max_segs(
                   ^~~~~~~~~
In file included from ./include/linux/blkdev.h:17:0,
                 from ./include/zfs/os/linux/spl/sys/uio.h:30,
                 from ./include/zfs/os/linux/spl/sys/sunddi.h:28,
                 from ./include/zfs/sys/zfs_context.h:68,
                 from fs/zfs/zfs/../os/linux/zfs/vdev_disk.c:29:
./include/linux/bio.h:423:27: note: declared here
 static inline struct bio *bio_alloc(struct block_device *bdev,
                           ^~~~~~~~~
In file included from ./include/linux/umh.h:4:0,
                 from ./include/linux/kmod.h:9,
                 from ./include/linux/module.h:17,
                 from ./include/zfs/os/linux/spl/sys/atomic.h:27,
                 from ./include/zfs/sys/zfs_context.h:45,
                 from fs/zfs/zfs/../os/linux/zfs/vdev_disk.c:29:
fs/zfs/zfs/../os/linux/zfs/vdev_disk.c: In function ‘vdev_disk_io_flush’:
./include/linux/gfp.h:329:18: warning: passing argument 1 of ‘bio_alloc’ makes pointer from integer without a cast [-Wint-conversion]
 #define GFP_NOIO (__GFP_RECLAIM)
                  ^
fs/zfs/zfs/../os/linux/zfs/vdev_disk.c:709:18: note: in expansion of macro ‘GFP_NOIO’
  bio = bio_alloc(GFP_NOIO, 0);
                  ^~~~~~~~
In file included from ./include/linux/blkdev.h:17:0,
                 from ./include/zfs/os/linux/spl/sys/uio.h:30,
                 from ./include/zfs/os/linux/spl/sys/sunddi.h:28,
                 from ./include/zfs/sys/zfs_context.h:68,
                 from fs/zfs/zfs/../os/linux/zfs/vdev_disk.c:29:
./include/linux/bio.h:423:27: note: expected ‘struct block_device *’ but argument is of type ‘unsigned int’
 static inline struct bio *bio_alloc(struct block_device *bdev,
                           ^~~~~~~~~
fs/zfs/zfs/../os/linux/zfs/vdev_disk.c:709:8: error: too few arguments to function ‘bio_alloc’
  bio = bio_alloc(GFP_NOIO, 0);
        ^~~~~~~~~
In file included from ./include/linux/blkdev.h:17:0,
                 from ./include/zfs/os/linux/spl/sys/uio.h:30,
                 from ./include/zfs/os/linux/spl/sys/sunddi.h:28,
                 from ./include/zfs/sys/zfs_context.h:68,
                 from fs/zfs/zfs/../os/linux/zfs/vdev_disk.c:29:
./include/linux/bio.h:423:27: note: declared here
 static inline struct bio *bio_alloc(struct block_device *bdev,
                           ^~~~~~~~~
scripts/Makefile.build:288: recipe for target 'fs/zfs/zfs/../os/linux/zfs/vdev_disk.o' failed
make[3]: *** [fs/zfs/zfs/../os/linux/zfs/vdev_disk.o] Error 1
scripts/Makefile.build:550: recipe for target 'fs/zfs/zfs' failed
make[2]: *** [fs/zfs/zfs] Error 2
scripts/Makefile.build:550: recipe for target 'fs/zfs' failed
make[1]: *** [fs/zfs] Error 2
Makefile:1831: recipe for target 'fs' failed
make: *** [fs] Error 2
make: *** Waiting for unfinished jobs....
```

### Description
In 07888c665b405b1cd3577ddebfeb74f4717a84c4 ("block: pass a block_device and opf to bio_alloc")
```c
bio_alloc(gfp_t gfp_mask, unsigned short nr_iovecs)
```
became
```c
bio_alloc(struct block_device *bdev, unsigned short nr_vecs, unsigned int opf, gfp_t gfp_mask)
```
and
> NULL/0 can be passed, both for the
> passthrough case on a raw request_queue and to temporarily avoid
> refactoring some nasty code.

### How Has This Been Tested?
Not.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
