### PR TITLE
man: fix ellipses, -X in zfs-send.8

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -315,8 +315,8 @@ get_usage(zfs_help_t idx)
 	case HELP_ROLLBACK:
 		return (gettext("\trollback [-rRf] <snapshot>\n"));
 	case HELP_SEND:
-		return (gettext("\tsend [-DnPpRvLecwhb] "
-		    "[-X dataset[,dataset]...] "
+		return (gettext("\tsend [-DLPbcehnpsvw] "
+		    "[-R [-X dataset[,dataset]...]] "
 		    "[-[i|I] snapshot] <snapshot>\n"
 		    "\tsend [-DnvPLecw] [-i snapshot|bookmark] "
 		    "<filesystem|volume|snapshot>\n"
@@ -4318,73 +4318,27 @@ usage:
 	return (-1);
 }
 
+/*
+ * Array of prefixes to exclude –
+ * a linear search, even if executed for each dataset,
+ * is plenty good enough.
+ */
 typedef struct zfs_send_exclude_arg {
 	size_t count;
-	char **list;
+	const char **list;
 } zfs_send_exclude_arg_t;
 
-/*
- * This function creates the zfs_send_exclude_arg_t
- * object described above; it can be called multiple
- * times, and the input can be comma-separated.
- * This is NOT the most efficient data layout; however,
- * I couldn't think of a non-pathological case where
- * it should have more than a couple dozen instances
- * of excludes. If that turns out to be used in
- * practice, we might want to instead use a tree.
- */
-static void
-add_dataset_excludes(char *exclude, zfs_send_exclude_arg_t *context)
-{
-	char *tok;
-	while ((tok = strsep(&exclude, ",")) != NULL) {
-		if (!zfs_name_valid(tok, ZFS_TYPE_DATASET) ||
-		    strchr(tok, '/') == NULL) {
-			(void) fprintf(stderr, gettext("-X %s: "
-			    "not a valid non-root dataset name.\n"), tok);
-			usage(B_FALSE);
-		}
-		context->list = safe_realloc(context->list,
-		    (sizeof (char *)) * (context->count + 1));
-		context->list[context->count++] = tok;
-	}
-}
-
-static void
-free_dataset_excludes(zfs_send_exclude_arg_t *exclude_list)
-{
-	free(exclude_list->list);
-}
-
-/*
- * This is the call back used by zfs_send to
- * determine if a dataset should be skipped.
- * As stated above, this is not the most efficient
- * data structure to use, but as long as the
- * number of excluded datasets is relatively
- * small (a couple of dozen or so), it won't
- * have a big impact on performance on modern
- * processors. Since it's excluding hierarchies,
- * we'd probably want to move to a more complex
- * tree structure in that case.
- */
 static boolean_t
 zfs_do_send_exclude(zfs_handle_t *zhp, void *context)
 {
-	zfs_send_exclude_arg_t *exclude = context;
+	zfs_send_exclude_arg_t *excludes = context;
 	const char *name = zfs_get_name(zhp);
 
-	for (size_t indx = 0; indx < exclude->count; indx++) {
-		char *exclude_name = exclude->list[indx];
-		size_t len = strlen(exclude_name);
-		/* If it's shorter, it can't possibly match */
-		if (strlen(name) < len)
-			continue;
-		if (strncmp(name, exclude_name, len) == 0 &&
-		    (name[len] == '/' || name[len] == '\0' ||
-		    name[len] == '@')) {
+	for (size_t i = 0; i < excludes->count; ++i) {
+		size_t len = strlen(excludes->list[i]);
+		if (strncmp(name, excludes->list[i], len) == 0 &&
+		    memchr(name[len], "/@", sizeof ("/@")))
 			return (B_FALSE);
-		}
 	}
 
 	return (B_TRUE);
@@ -4405,11 +4359,11 @@ zfs_do_send(int argc, char **argv)
 	int c, err;
 	nvlist_t *dbgnv = NULL;
 	char *redactbook = NULL;
-	zfs_send_exclude_arg_t exclude_context = { 0 };
+	zfs_send_exclude_arg_t excludes = { 0 };
 
 	struct option long_options[] = {
 		{"replicate",	no_argument,		NULL, 'R'},
-		{"skip-missing",	no_argument,		NULL, 's'},
+		{"skip-missing",	no_argument,	NULL, 's'},
 		{"redact",	required_argument,	NULL, 'd'},
 		{"props",	no_argument,		NULL, 'p'},
 		{"parsable",	no_argument,		NULL, 'P'},
@@ -4433,7 +4387,18 @@ zfs_do_send(int argc, char **argv)
 	    long_options, NULL)) != -1) {
 		switch (c) {
 		case 'X':
-			add_dataset_excludes(optarg, &exclude_context);
+			for (char *ds; (ds = strsep(&optarg, ",")) != NULL; ) {
+				if (!zfs_name_valid(ds, ZFS_TYPE_DATASET) ||
+				    strchr(ds, '/') == NULL) {
+					(void) fprintf(stderr, gettext("-X %s: "
+					    "not a valid non-root dataset name"
+					    ".\n"), ds);
+					usage(B_FALSE);
+				}
+				excludes.list = safe_realloc(excludes.list,
+				    sizeof (char *) * (excludes.count + 1));
+				excludes.list[excludes.count++] = ds;
+			}
 			break;
 		case 'i':
 			if (fromname)
@@ -4544,7 +4509,7 @@ zfs_do_send(int argc, char **argv)
 	if (flags.parsable && flags.verbosity == 0)
 		flags.verbosity = 1;
 
-	if (exclude_context.count > 0 && !flags.replicate) {
+	if (excludes.count > 0 && !flags.replicate) {
 		(void) fprintf(stderr, gettext("Cannot specify "
 		    "dataset exclusion (-X) on a non-recursive "
 		    "send.\n"));
@@ -4733,10 +4698,8 @@ zfs_do_send(int argc, char **argv)
 		flags.doall = B_TRUE;
 
 	err = zfs_send(zhp, fromname, toname, &flags, STDOUT_FILENO,
-	    exclude_context.count > 0 ? zfs_do_send_exclude : NULL,
-	    &exclude_context, flags.verbosity >= 3 ? &dbgnv : NULL);
-
-	free_dataset_excludes(&exclude_context);
+	    excludes.count > 0 ? zfs_do_send_exclude : NULL,
+	    &excludes, flags.verbosity >= 3 ? &dbgnv : NULL);
 
 	if (flags.verbosity >= 3 && dbgnv != NULL) {
 		/*
@@ -4748,8 +4711,9 @@ zfs_do_send(int argc, char **argv)
 		dump_nvlist(dbgnv, 0);
 		nvlist_free(dbgnv);
 	}
-	zfs_close(zhp);
 
+	zfs_close(zhp);
+	free(excludes.list);
 	return (err != 0);
 }
 

--- a/man/man1/cstyle.1
+++ b/man/man1/cstyle.1
@@ -30,7 +30,6 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl chpvCP
-.Op Fl o Ar construct Ns Op , Ns Ar construct Ns …
 .Oo Ar file Oc Ns …
 .Sh DESCRIPTION
 .Nm
@@ -91,16 +90,6 @@ types
 etc.
 This detects any use of the deprecated types.
 Used as part of the putback checks.
-.It Fl o Ar construct Ns Op , Ns Ar construct Ns …
-Available constructs include:
-.Bl -tag -compact -width "doxygen"
-.It Sy doxygen
-Allow doxygen-style block comments
-.Pq Sy /** No and Sy /*!\& .
-.It Sy splint
-Allow splint-style lint comments
-.Pq Sy /*@ Ns ... Ns Sy @*/ .
-.El
 .El
 .
 .Sh CONTINUATION CHECKING

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -388,7 +388,7 @@ privilege with
 can access everyone's usage.
 .Pp
 The
-.Sy userused Ns @ Ns Ar ...
+.Sy userused Ns @ Ns Ar …
 properties are not displayed by
 .Nm zfs Cm get Sy all .
 The user's name must be appended after the
@@ -872,14 +872,17 @@ This is done using
 .Sy zstd-fast- Ns Ar N ,
 where
 .Ar N
-is an integer in [1-9,10,20,30,...,100,500,1000] which maps to a negative
+is an integer in
+.Bq Sy 1 Ns - Ns Sy 10 , 20 , 30 , No … , Sy 100 , 500 , 1000
+which maps to a negative
 .Sy zstd
 level.
-The lower the level the faster the compression -
-.Ar 1000 No provides the fastest compression and lowest compression ratio.
+The lower the level the faster the compression \(em
+.Sy 1000
+provides the fastest compression and lowest compression ratio.
 .Sy zstd-fast
 is equivalent to
-.Sy zstd-fast-1 .
+.Sy zstd-fast- Ns Ar 1 .
 .Pp
 The
 .Sy zle
@@ -1315,7 +1318,7 @@ can get and set everyone's quota.
 This property is not available on volumes, on file systems before version 4, or
 on pools before version 15.
 The
-.Sy userquota@ Ns Ar ...
+.Sy userquota@ Ns Ar …
 properties are not displayed by
 .Nm zfs Cm get Sy all .
 The user's name must be appended after the

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -75,7 +75,7 @@ Custom
 .Ev $PATH
 for zedlets to use.
 Normally zedlets run in a locked-down environment, with hardcoded paths to the ZFS commands
-.Pq Ev $ZFS , $ZPOOL , $ZED , ... ,
+.Pq Ev $ZFS , $ZPOOL , $ZED , … ,
 and a hard-coded
 .Ev $PATH .
 This is done for security reasons.

--- a/man/man8/zfs-allow.8
+++ b/man/man8/zfs-allow.8
@@ -215,19 +215,19 @@ send	subcommand
 share	subcommand	Allows sharing file systems over NFS or SMB protocols
 snapshot	subcommand	Must also have the \fBmount\fR ability
 
-groupquota	other	Allows accessing any \fBgroupquota@\fI...\fR property
-groupobjquota	other	Allows accessing any \fBgroupobjquota@\fI...\fR property
-groupused	other	Allows reading any \fBgroupused@\fI...\fR property
-groupobjused	other	Allows reading any \fBgroupobjused@\fI...\fR property
+groupquota	other	Allows accessing any \fBgroupquota@\fI…\fR property
+groupobjquota	other	Allows accessing any \fBgroupobjquota@\fI…\fR property
+groupused	other	Allows reading any \fBgroupused@\fI…\fR property
+groupobjused	other	Allows reading any \fBgroupobjused@\fI…\fR property
 userprop	other	Allows changing any user property
-userquota	other	Allows accessing any \fBuserquota@\fI...\fR property
-userobjquota	other	Allows accessing any \fBuserobjquota@\fI...\fR property
-userused	other	Allows reading any \fBuserused@\fI...\fR property
-userobjused	other	Allows reading any \fBuserobjused@\fI...\fR property
-projectobjquota	other	Allows accessing any \fBprojectobjquota@\fI...\fR property
-projectquota	other	Allows accessing any \fBprojectquota@\fI...\fR property
-projectobjused	other	Allows reading any \fBprojectobjused@\fI...\fR property
-projectused	other	Allows reading any \fBprojectused@\fI...\fR property
+userquota	other	Allows accessing any \fBuserquota@\fI…\fR property
+userobjquota	other	Allows accessing any \fBuserobjquota@\fI…\fR property
+userused	other	Allows reading any \fBuserused@\fI…\fR property
+userobjused	other	Allows reading any \fBuserobjused@\fI…\fR property
+projectobjquota	other	Allows accessing any \fBprojectobjquota@\fI…\fR property
+projectquota	other	Allows accessing any \fBprojectquota@\fI…\fR property
+projectobjused	other	Allows reading any \fBprojectobjused@\fI…\fR property
+projectused	other	Allows reading any \fBprojectused@\fI…\fR property
 
 aclinherit	property
 aclmode	property

--- a/man/man8/zfs-program.8
+++ b/man/man8/zfs-program.8
@@ -96,16 +96,17 @@ argv = args["argv"]
 -- argv == {1="arg1", 2="arg2", ...}
 .Ed
 .Pp
-If invoked from the libZFS interface, an arbitrary argument list can be
+If invoked from the libzfs interface, an arbitrary argument list can be
 passed to the channel program, which is accessible via the same
-"..." syntax in Lua:
+.Qq Li ...
+syntax in Lua:
 .Bd -literal -compact -offset indent
 args = ...
 -- args == {"foo"="bar", "baz"={...}, ...}
 .Ed
 .Pp
 Note that because Lua arrays are 1-indexed, arrays passed to Lua from the
-libZFS interface will have their indices incremented by 1.
+libzfs interface will have their indices incremented by 1.
 That is, the element
 in
 .Va arr[0]
@@ -166,7 +167,7 @@ See the
 section below for function-specific details on error return codes.
 .
 .Ss Lua to C Value Conversion
-When invoking a channel program via the libZFS interface, it is necessary to
+When invoking a channel program via the libzfs interface, it is necessary to
 translate arguments and return values from Lua values to their C equivalents,
 and vice-versa.
 .Pp

--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -40,7 +40,7 @@
 .Nm zfs
 .Cm send
 .Op Fl DLPRbcehnpsvw
-.Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns ...
+.Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
 .Op Oo Fl I Ns | Ns Fl i Oc Ar snapshot
 .Ar snapshot
 .Nm zfs
@@ -74,7 +74,7 @@
 .Nm zfs
 .Cm send
 .Op Fl DLPRbcehnpvw
-.Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns ...
+.Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
 .Op Oo Fl I Ns | Ns Fl i Oc Ar snapshot
 .Ar snapshot
 .Xc
@@ -142,7 +142,7 @@ If the
 flag is used to send encrypted datasets, then
 .Fl w
 must also be specified.
-.It Fl X , -exclude Ar dataset Ns Oo , Ns Ar dataset Oc Ns ...
+.It Fl X , -exclude Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
 When the
 .Fl R
 flag is given,

--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -39,8 +39,8 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm send
-.Op Fl DLPRbcehnpsvw
-.Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
+.Op Fl DLPbcehnpsvw
+.Op Fl R Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
 .Op Oo Fl I Ns | Ns Fl i Oc Ar snapshot
 .Ar snapshot
 .Nm zfs
@@ -73,8 +73,8 @@
 .It Xo
 .Nm zfs
 .Cm send
-.Op Fl DLPRbcehnpvw
-.Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
+.Op Fl DLPbcehnpsvw
+.Op Fl R Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
 .Op Oo Fl I Ns | Ns Fl i Oc Ar snapshot
 .Ar snapshot
 .Xc
@@ -143,22 +143,15 @@ flag is used to send encrypted datasets, then
 .Fl w
 must also be specified.
 .It Fl X , -exclude Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
-When the
-.Fl R
-flag is given,
+With
+.Fl R ,
 .Fl X
-can be used to specify a list of datasets to be excluded from the
-data stream.
-The
-.Fl X
-option can be used multiple times, or the list of datasets can be
-specified as a comma-separated list, or both.
-.Ar dataset
-must not be the pool's root dataset, and all descendant datasets of
-.Ar dataset
-will be excluded from the send stream.
-Requires
-.Fl R .
+specifies a set of datasets (and, hence, their descendants),
+to be excluded from the send stream.
+The root dataset may not be excluded.
+.Fl X Ar a Fl X Ar b
+is equivalent to
+.Fl X Ar a Ns , Ns Ar b .
 .It Fl e , -embed
 Generate a more compact stream by using
 .Sy WRITE_EMBEDDED

--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -58,7 +58,7 @@ use Getopt::Std;
 use strict;
 
 my $usage =
-"usage: cstyle [-cghpvCP] [-o constructs] file ...
+"usage: cstyle [-cghpvCP] file ...
 	-c	check continuation indentation inside functions
 	-g	print github actions' workflow commands
 	-h	perform heuristic checks that are sometimes wrong
@@ -66,15 +66,11 @@ my $usage =
 	-v	verbose
 	-C	don't check anything in header block comments
 	-P	check for use of non-POSIX types
-	-o constructs
-		allow a comma-separated list of optional constructs:
-		    doxygen	allow doxygen-style block comments (/** /*!)
-		    splint	allow splint-style lint comments (/*@ ... @*/)
 ";
 
 my %opts;
 
-if (!getopts("cgho:pvCP", \%opts)) {
+if (!getopts("cghpvCP", \%opts)) {
 	print $usage;
 	exit 2;
 }
@@ -87,23 +83,6 @@ my $verbose = $opts{'v'};
 my $ignore_hdr_comment = $opts{'C'};
 my $check_posix_types = $opts{'P'};
 
-my $doxygen_comments = 0;
-my $splint_comments = 0;
-
-if (defined($opts{'o'})) {
-	for my $x (split /,/, $opts{'o'}) {
-		if ($x eq "doxygen") {
-			$doxygen_comments = 1;
-		} elsif ($x eq "splint") {
-			$splint_comments = 1;
-		} else {
-			print "cstyle: unrecognized construct \"$x\"\n";
-			print $usage;
-			exit 2;
-		}
-	}
-}
-
 my ($filename, $line, $prev);		# shared globals
 
 my $fmt;
@@ -115,12 +94,7 @@ if ($verbose) {
 	$fmt = "%s: %d: %s\n";
 }
 
-if ($doxygen_comments) {
-	# doxygen comments look like "/*!" or "/**"; allow them.
-	$hdr_comment_start = qr/^\s*\/\*[\!\*]?$/;
-} else {
-	$hdr_comment_start = qr/^\s*\/\*$/;
-}
+$hdr_comment_start = qr/^\s*\/\*$/;
 
 # Note, following must be in single quotes so that \s and \w work right.
 my $typename = '(int|char|short|long|unsigned|float|double' .
@@ -145,8 +119,6 @@ my $lint_re = qr/\/\*(?:
 	FALLTHRU|FALLTHROUGH|LINTED.*?|PRINTFLIKE[0-9]*|
 	PROTOLIB[0-9]*|SCANFLIKE[0-9]*|CSTYLED.*?
     )\*\//x;
-
-my $splint_re = qr/\/\*@.*?@\*\//x;
 
 my $warlock_re = qr/\/\*\s*(?:
 	VARIABLES\ PROTECTED\ BY|
@@ -536,12 +508,10 @@ line: while (<$filehandle>) {
 		next line;
 	}
 
-	if ((/[^(]\/\*\S/ || /^\/\*\S/) &&
-	    !(/$lint_re/ || ($splint_comments && /$splint_re/))) {
+	if ((/[^(]\/\*\S/ || /^\/\*\S/) && !/$lint_re/) {
 		err("missing blank after open comment");
 	}
-	if (/\S\*\/[^)]|\S\*\/$/ &&
-	    !(/$lint_re/ || ($splint_comments && /$splint_re/))) {
+	if (/\S\*\/[^)]|\S\*\/$/ && !/$lint_re/) {
 		err("missing blank before close comment");
 	}
 	if (/\/\/\S/) {		# C++ comments


### PR DESCRIPTION
### Motivation and Context
The synopses were wrong and the description was horrendously verbose; minor optimisation; also `...` pruning (and some things I noticed could be improved therein).

### How Has This Been Tested?
Looks alright I think.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
