### PR TITLE
cstyle: remove unused -o

### DIFF
--- a/man/man1/cstyle.1
+++ b/man/man1/cstyle.1
@@ -30,7 +30,6 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl chpvCP
-.Op Fl o Ar construct Ns Op , Ns Ar construct Ns …
 .Oo Ar file Oc Ns …
 .Sh DESCRIPTION
 .Nm
@@ -91,16 +90,6 @@ types
 etc.
 This detects any use of the deprecated types.
 Used as part of the putback checks.
-.It Fl o Ar construct Ns Op , Ns Ar construct Ns …
-Available constructs include:
-.Bl -tag -compact -width "doxygen"
-.It Sy doxygen
-Allow doxygen-style block comments
-.Pq Sy /** No and Sy /*!\& .
-.It Sy splint
-Allow splint-style lint comments
-.Pq Sy /*@ Ns ... Ns Sy @*/ .
-.El
 .El
 .
 .Sh CONTINUATION CHECKING


### PR DESCRIPTION
### Motivation and Context
All it does is additional handling for allowing doxygen- and embedding in splint(?)-style comments, which we don't use, and don't call cstyle with any -o options anyway.

### How Has This Been Tested?
```
$ git grep -ie splint -e doxygen; echo $?
1
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
