### PR TITLE
Pick #12138 and parts of #12829 into 2.1.5

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7672,7 +7672,7 @@ zfs_do_diff(int argc, char **argv)
 	int c;
 	struct sigaction sa;
 
-	while ((c = getopt(argc, argv, "FHt")) != -1) {
+	while ((c = getopt(argc, argv, "FHth")) != -1) {
 		switch (c) {
 		case 'F':
 			flags |= ZFS_DIFF_CLASSIFY;
@@ -7682,6 +7682,9 @@ zfs_do_diff(int argc, char **argv)
 			break;
 		case 't':
 			flags |= ZFS_DIFF_TIMESTAMP;
+			break;
+		case 'h':
+			flags |= ZFS_DIFF_NO_MANGLE;
 			break;
 		default:
 			(void) fprintf(stderr,

--- a/etc/systemd/system-generators/zfs-mount-generator.c
+++ b/etc/systemd/system-generators/zfs-mount-generator.c
@@ -27,9 +27,6 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/stat.h>
-#include <sys/wait.h>
-#include <sys/mman.h>
-#include <semaphore.h>
 #include <stdbool.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -44,25 +41,16 @@
 #include <errno.h>
 #include <libzfs.h>
 
+/*
+ * For debugging only.
+ *
+ * Free statics with trivial life-times,
+ * but saved line filenames are replaced with a static string.
+ */
+#define	FREE_STATICS false
+
+#define	nitems(arr) (sizeof (arr) / sizeof (*arr))
 #define	STRCMP ((int(*)(const void *, const void *))&strcmp)
-#define	PID_T_CMP ((int(*)(const void *, const void *))&pid_t_cmp)
-
-static int
-pid_t_cmp(const pid_t *lhs, const pid_t *rhs)
-{
-	/*
-	 * This is always valid, quoth sys_types.h(7posix):
-	 * > blksize_t, pid_t, and ssize_t shall be signed integer types.
-	 */
-	return (*lhs - *rhs);
-}
-
-#define	EXIT_ENOMEM() \
-	do { \
-		fprintf(stderr, PROGNAME "[%d]: " \
-		    "not enough memory (L%d)!\n", getpid(), __LINE__); \
-		_exit(1); \
-	} while (0)
 
 
 #define	PROGNAME "zfs-mount-generator"
@@ -80,20 +68,11 @@ pid_t_cmp(const pid_t *lhs, const pid_t *rhs)
 #define	URI_REGEX_S "^\\([A-Za-z][A-Za-z0-9+.\\-]*\\):\\/\\/\\(.*\\)$"
 static regex_t uri_regex;
 
-static char *argv0;
-
 static const char *destdir = "/tmp";
 static int destdir_fd = -1;
 
 static void *known_pools = NULL; /* tsearch() of C strings */
-static struct {
-	sem_t noauto_not_on_sem;
-
-	sem_t noauto_names_sem;
-	size_t noauto_names_len;
-	size_t noauto_names_max;
-	char noauto_names[][NAME_MAX];
-} *noauto_files;
+static void *noauto_files = NULL; /* tsearch() of C strings */
 
 
 static char *
@@ -103,8 +82,12 @@ systemd_escape(const char *input, const char *prepend, const char *append)
 	size_t applen = strlen(append);
 	size_t prelen = strlen(prepend);
 	char *ret = malloc(4 * len + prelen + applen + 1);
-	if (!ret)
-		EXIT_ENOMEM();
+	if (!ret) {
+		fprintf(stderr, PROGNAME "[%d]: "
+		    "out of memory to escape \"%s%s%s\"!\n",
+		    getpid(), prepend, input, append);
+		return (NULL);
+	}
 
 	memcpy(ret, prepend, prelen);
 	char *out = ret + prelen;
@@ -166,8 +149,12 @@ systemd_escape_path(char *input, const char *prepend, const char *append)
 {
 	if (strcmp(input, "/") == 0) {
 		char *ret;
-		if (asprintf(&ret, "%s-%s", prepend, append) == -1)
-			EXIT_ENOMEM();
+		if (asprintf(&ret, "%s-%s", prepend, append) == -1) {
+			fprintf(stderr, PROGNAME "[%d]: "
+			    "out of memory to escape \"%s%s%s\"!\n",
+			    getpid(), prepend, input, append);
+			ret = NULL;
+		}
 		return (ret);
 	} else {
 		/*
@@ -209,6 +196,10 @@ fopenat(int dirfd, const char *pathname, int flags,
 static int
 line_worker(char *line, const char *cachefile)
 {
+	int ret = 0;
+	void *tofree_all[8];
+	void **tofree = tofree_all;
+
 	char *toktmp;
 	/* BEGIN CSTYLED */
 	const char *dataset                     = strtok_r(line, "\t", &toktmp);
@@ -240,10 +231,8 @@ line_worker(char *line, const char *cachefile)
 	if (p_nbmand == NULL) {
 		fprintf(stderr, PROGNAME "[%d]: %s: not enough tokens!\n",
 		    getpid(), dataset);
-		return (1);
+		goto err;
 	}
-
-	strncpy(argv0, dataset, strlen(argv0));
 
 	/* Minimal pre-requisites to mount a ZFS dataset */
 	const char *after = "zfs-import.target";
@@ -280,28 +269,31 @@ line_worker(char *line, const char *cachefile)
 
 
 	if (strcmp(p_encroot, "-") != 0) {
-		char *keyloadunit =
+		char *keyloadunit = *(tofree++) =
 		    systemd_escape(p_encroot, "zfs-load-key@", ".service");
+		if (keyloadunit == NULL)
+			goto err;
 
 		if (strcmp(dataset, p_encroot) == 0) {
 			const char *keymountdep = NULL;
 			bool is_prompt = false;
+			bool need_network = false;
 
 			regmatch_t uri_matches[3];
 			if (regexec(&uri_regex, p_keyloc,
-			    sizeof (uri_matches) / sizeof (*uri_matches),
-			    uri_matches, 0) == 0) {
+			    nitems(uri_matches), uri_matches, 0) == 0) {
+				p_keyloc[uri_matches[1].rm_eo] = '\0';
 				p_keyloc[uri_matches[2].rm_eo] = '\0';
+				const char *scheme =
+				    &p_keyloc[uri_matches[1].rm_so];
 				const char *path =
 				    &p_keyloc[uri_matches[2].rm_so];
 
-				/*
-				 * Assumes all URI keylocations need
-				 * the mount for their path;
-				 * http://, for example, wouldn't
-				 * (but it'd need network-online.target et al.)
-				 */
-				keymountdep = path;
+				if (strcmp(scheme, "https") == 0 ||
+				    strcmp(scheme, "http") == 0)
+					need_network = true;
+				else
+					keymountdep = path;
 			} else {
 				if (strcmp(p_keyloc, "prompt") != 0)
 					fprintf(stderr, PROGNAME "[%d]: %s: "
@@ -321,7 +313,7 @@ line_worker(char *line, const char *cachefile)
 				    "couldn't open %s under %s: %s\n",
 				    getpid(), dataset, keyloadunit, destdir,
 				    strerror(errno));
-				return (1);
+				goto err;
 			}
 
 			fprintf(keyloadunit_f,
@@ -335,20 +327,22 @@ line_worker(char *line, const char *cachefile)
 			    "After=%s\n",
 			    dataset, cachefile, wants, after);
 
+			if (need_network)
+				fprintf(keyloadunit_f,
+				    "Wants=network-online.target\n"
+				    "After=network-online.target\n");
+
 			if (p_systemd_requires)
 				fprintf(keyloadunit_f,
 				    "Requires=%s\n", p_systemd_requires);
 
-			if (p_systemd_requiresmountsfor || keymountdep) {
-				fprintf(keyloadunit_f, "RequiresMountsFor=");
-				if (p_systemd_requiresmountsfor)
-					fprintf(keyloadunit_f,
-					    "%s ", p_systemd_requiresmountsfor);
-				if (keymountdep)
-					fprintf(keyloadunit_f,
-					    "'%s'", keymountdep);
-				fprintf(keyloadunit_f, "\n");
-			}
+			if (p_systemd_requiresmountsfor)
+				fprintf(keyloadunit_f,
+				    "RequiresMountsFor=%s\n",
+				    p_systemd_requiresmountsfor);
+			if (keymountdep)
+				fprintf(keyloadunit_f,
+				    "RequiresMountsFor='%s'\n", keymountdep);
 
 			/* BEGIN CSTYLED */
 			fprintf(keyloadunit_f,
@@ -393,9 +387,13 @@ line_worker(char *line, const char *cachefile)
 		if (after[0] == '\0')
 			after = keyloadunit;
 		else if (asprintf(&toktmp, "%s %s", after, keyloadunit) != -1)
-			after = toktmp;
-		else
-			EXIT_ENOMEM();
+			after = *(tofree++) = toktmp;
+		else {
+			fprintf(stderr, PROGNAME "[%d]: %s: "
+			    "out of memory to generate after=\"%s %s\"!\n",
+			    getpid(), dataset, after, keyloadunit);
+			goto err;
+		}
 	}
 
 
@@ -404,12 +402,12 @@ line_worker(char *line, const char *cachefile)
 	    strcmp(p_systemd_ignore, "off") == 0) {
 		/* ok */
 	} else if (strcmp(p_systemd_ignore, "on") == 0)
-		return (0);
+		goto end;
 	else {
 		fprintf(stderr, PROGNAME "[%d]: %s: "
 		    "invalid org.openzfs.systemd:ignore=%s\n",
 		    getpid(), dataset, p_systemd_ignore);
-		return (1);
+		goto err;
 	}
 
 	/* Check for canmount */
@@ -418,21 +416,21 @@ line_worker(char *line, const char *cachefile)
 	} else if (strcmp(p_canmount, "noauto") == 0)
 		noauto = true;
 	else if (strcmp(p_canmount, "off") == 0)
-		return (0);
+		goto end;
 	else {
 		fprintf(stderr, PROGNAME "[%d]: %s: invalid canmount=%s\n",
 		    getpid(), dataset, p_canmount);
-		return (1);
+		goto err;
 	}
 
 	/* Check for legacy and blank mountpoints */
 	if (strcmp(p_mountpoint, "legacy") == 0 ||
 	    strcmp(p_mountpoint, "none") == 0)
-		return (0);
+		goto end;
 	else if (p_mountpoint[0] != '/') {
 		fprintf(stderr, PROGNAME "[%d]: %s: invalid mountpoint=%s\n",
 		    getpid(), dataset, p_mountpoint);
-		return (1);
+		goto err;
 	}
 
 	/* Escape the mountpoint per systemd policy */
@@ -442,7 +440,7 @@ line_worker(char *line, const char *cachefile)
 		fprintf(stderr,
 		    PROGNAME "[%d]: %s: abnormal simplified mountpoint: %s\n",
 		    getpid(), dataset, p_mountpoint);
-		return (1);
+		goto err;
 	}
 
 
@@ -552,8 +550,7 @@ line_worker(char *line, const char *cachefile)
 	 * 	files if we're sure they were created by us. (see 5.)
 	 * 2.	We handle files differently based on canmount.
 	 * 	Units with canmount=on always have precedence over noauto.
-	 * 	This is enforced by the noauto_not_on_sem semaphore,
-	 * 	which is only unlocked when the last canmount=on process exits.
+	 * 	This is enforced by processing these units before all others.
 	 * 	It is important to use p_canmount and not noauto here,
 	 * 	since we categorise by canmount while other properties,
 	 * 	e.g. org.openzfs.systemd:wanted-by, also modify noauto.
@@ -561,7 +558,7 @@ line_worker(char *line, const char *cachefile)
 	 * 	Additionally, we use noauto_files to track the unit file names
 	 * 	(which are the systemd-escaped mountpoints) of all (exclusively)
 	 * 	noauto datasets that had a file created.
-	 * 4.	If the file to be created is found in the tracking array,
+	 * 4.	If the file to be created is found in the tracking tree,
 	 * 	we do NOT create it.
 	 * 5.	If a file exists for a noauto dataset,
 	 * 	we check whether the file name is in the array.
@@ -571,29 +568,14 @@ line_worker(char *line, const char *cachefile)
 	 * 	further noauto datasets creating a file for this path again.
 	 */
 
-	{
-		sem_t *our_sem = (strcmp(p_canmount, "on") == 0) ?
-		    &noauto_files->noauto_names_sem :
-		    &noauto_files->noauto_not_on_sem;
-		while (sem_wait(our_sem) == -1 && errno == EINTR)
-			;
-	}
-
 	struct stat stbuf;
 	bool already_exists = fstatat(destdir_fd, mountfile, &stbuf, 0) == 0;
+	bool is_known = tfind(mountfile, &noauto_files, STRCMP) != NULL;
 
-	bool is_known = false;
-	for (size_t i = 0; i < noauto_files->noauto_names_len; ++i) {
-		if (strncmp(
-		    noauto_files->noauto_names[i], mountfile, NAME_MAX) == 0) {
-			is_known = true;
-			break;
-		}
-	}
-
+	*(tofree++) = (void *)mountfile;
 	if (already_exists) {
 		if (is_known) {
-			/* If it's in $noauto_files, we must be noauto too */
+			/* If it's in noauto_files, we must be noauto too */
 
 			/* See 5 */
 			errno = 0;
@@ -614,43 +596,31 @@ line_worker(char *line, const char *cachefile)
 		}
 
 		/* File exists: skip current dataset */
-		if (strcmp(p_canmount, "on") == 0)
-			sem_post(&noauto_files->noauto_names_sem);
-		return (0);
+		goto end;
 	} else {
 		if (is_known) {
 			/* See 4 */
-			if (strcmp(p_canmount, "on") == 0)
-				sem_post(&noauto_files->noauto_names_sem);
-			return (0);
+			goto end;
 		} else if (strcmp(p_canmount, "noauto") == 0) {
-			if (noauto_files->noauto_names_len ==
-			    noauto_files->noauto_names_max)
+			if (tsearch(mountfile, &noauto_files, STRCMP) == NULL)
 				fprintf(stderr, PROGNAME "[%d]: %s: "
-				    "noauto dataset limit (%zu) reached! "
-				    "Not tracking %s. Please report this to "
-				    "https://github.com/openzfs/zfs\n",
-				    getpid(), dataset,
-				    noauto_files->noauto_names_max, mountfile);
-			else {
-				strncpy(noauto_files->noauto_names[
-				    noauto_files->noauto_names_len],
-				    mountfile, NAME_MAX);
-				++noauto_files->noauto_names_len;
-			}
+				    "out of memory for noauto datasets! "
+				    "Not tracking %s.\n",
+				    getpid(), dataset, mountfile);
+			else
+				/* mountfile escaped to noauto_files */
+				*(--tofree) = NULL;
 		}
 	}
 
 
 	FILE *mountfile_f = fopenat(destdir_fd, mountfile,
 	    O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, "w", 0644);
-	if (strcmp(p_canmount, "on") == 0)
-		sem_post(&noauto_files->noauto_names_sem);
 	if (!mountfile_f) {
 		fprintf(stderr,
 		    PROGNAME "[%d]: %s: couldn't open %s under %s: %s\n",
 		    getpid(), dataset, mountfile, destdir, strerror(errno));
-		return (1);
+		goto err;
 	}
 
 	fprintf(mountfile_f,
@@ -699,12 +669,17 @@ line_worker(char *line, const char *cachefile)
 	(void) fclose(mountfile_f);
 
 	if (!requiredby && !wantedby)
-		return (0);
+		goto end;
 
 	/* Finally, create the appropriate dependencies */
 	char *linktgt;
-	if (asprintf(&linktgt, "../%s", mountfile) == -1)
-		EXIT_ENOMEM();
+	if (asprintf(&linktgt, "../%s", mountfile) == -1) {
+		fprintf(stderr, PROGNAME "[%d]: %s: "
+		    "out of memory for dependents of %s!\n",
+		    getpid(), dataset, mountfile);
+		goto err;
+	}
+	*(tofree++) = linktgt;
 
 	char *dependencies[][2] = {
 		{"wants", wantedby},
@@ -719,8 +694,14 @@ line_worker(char *line, const char *cachefile)
 		    reqby;
 		    reqby = strtok_r(NULL, " ", &toktmp)) {
 			char *depdir;
-			if (asprintf(&depdir, "%s.%s", reqby, (*dep)[0]) == -1)
-				EXIT_ENOMEM();
+			if (asprintf(
+			    &depdir, "%s.%s", reqby, (*dep)[0]) == -1) {
+				fprintf(stderr, PROGNAME "[%d]: %s: "
+				    "out of memory for dependent dir name "
+				    "\"%s.%s\"!\n",
+				    getpid(), dataset, reqby, (*dep)[0]);
+				continue;
+			}
 
 			(void) mkdirat(destdir_fd, depdir, 0755);
 			int depdir_fd = openat(destdir_fd, depdir,
@@ -746,7 +727,24 @@ line_worker(char *line, const char *cachefile)
 		}
 	}
 
-	return (0);
+end:
+	if (tofree >= tofree_all + nitems(tofree_all)) {
+		/*
+		 * This won't happen as-is:
+		 * we've got 8 slots and allocate 4 things at most.
+		 */
+		fprintf(stderr,
+		    PROGNAME "[%d]: %s: need to free %zu > %zu!\n",
+		    getpid(), dataset, tofree - tofree_all, nitems(tofree_all));
+		ret = tofree - tofree_all;
+	}
+
+	while (tofree-- != tofree_all)
+		free(*tofree);
+	return (ret);
+err:
+	ret = 1;
+	goto end;
 }
 
 
@@ -780,12 +778,11 @@ main(int argc, char **argv)
 		if (kmfd >= 0) {
 			(void) dup2(kmfd, STDERR_FILENO);
 			(void) close(kmfd);
+
+			setlinebuf(stderr);
 		}
 	}
 
-	uint8_t debug = 0;
-
-	argv0 = argv[0];
 	switch (argc) {
 	case 1:
 		/* Use default */
@@ -844,33 +841,9 @@ main(int argc, char **argv)
 		}
 	}
 
-	{
-		/*
-		 * We could just get a gigabyte here and Not Care,
-		 * but if vm.overcommit_memory=2, then MAP_NORESERVE is ignored
-		 * and we'd try (and likely fail) to rip it out of swap
-		 */
-		noauto_files = mmap(NULL, 4 * 1024 * 1024,
-		    PROT_READ | PROT_WRITE,
-		    MAP_SHARED | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
-		if (noauto_files == MAP_FAILED) {
-			fprintf(stderr,
-			    PROGNAME "[%d]: couldn't allocate IPC region: %s\n",
-			    getpid(), strerror(errno));
-			_exit(1);
-		}
-
-		sem_init(&noauto_files->noauto_not_on_sem, true, 0);
-		sem_init(&noauto_files->noauto_names_sem, true, 1);
-		noauto_files->noauto_names_len = 0;
-		/* Works out to 16447ish, *well* enough */
-		noauto_files->noauto_names_max =
-		    (4 * 1024 * 1024 - sizeof (*noauto_files)) / NAME_MAX;
-	}
-
+	bool debug = false;
 	char *line = NULL;
 	size_t linelen = 0;
-	struct timespec time_start = {};
 	{
 		const char *dbgenv = getenv("ZFS_DEBUG");
 		if (dbgenv)
@@ -879,7 +852,7 @@ main(int argc, char **argv)
 			FILE *cmdline = fopen("/proc/cmdline", "re");
 			if (cmdline != NULL) {
 				if (getline(&line, &linelen, cmdline) >= 0)
-					debug = strstr(line, "debug") ? 2 : 0;
+					debug = strstr(line, "debug");
 				(void) fclose(cmdline);
 			}
 		}
@@ -888,19 +861,17 @@ main(int argc, char **argv)
 			dup2(STDERR_FILENO, STDOUT_FILENO);
 	}
 
-	size_t forked_canmount_on = 0;
-	size_t forked_canmount_not_on = 0;
-	size_t canmount_on_pids_len = 128;
-	pid_t *canmount_on_pids =
-	    malloc(canmount_on_pids_len * sizeof (*canmount_on_pids));
-	if (canmount_on_pids == NULL)
-		canmount_on_pids_len = 0;
-
+	struct timespec time_start = {};
 	if (debug)
 		clock_gettime(CLOCK_MONOTONIC_RAW, &time_start);
 
-	ssize_t read;
-	pid_t pid;
+	struct line {
+		char *line;
+		const char *fname;
+		struct line *next;
+	} *lines_canmount_not_on = NULL;
+
+	int ret = 0;
 	struct dirent *cachent;
 	while ((cachent = readdir(fslist_dir)) != NULL) {
 		if (strcmp(cachent->d_name, ".") == 0 ||
@@ -916,129 +887,67 @@ main(int argc, char **argv)
 			continue;
 		}
 
+		const char *filename = FREE_STATICS ? "(elided)" : NULL;
+
+		ssize_t read;
 		while ((read = getline(&line, &linelen, cachefile)) >= 0) {
 			line[read - 1] = '\0'; /* newline */
 
-			switch (pid = fork()) {
-			case -1:
-				fprintf(stderr,
-				    PROGNAME "[%d]: couldn't fork for %s: %s\n",
-				    getpid(), line, strerror(errno));
-				break;
-			case 0: /* child */
-				_exit(line_worker(line, cachent->d_name));
-			default: { /* parent */
-				char *tmp;
-				char *dset = strtok_r(line, "\t", &tmp);
-				strtok_r(NULL, "\t", &tmp);
-				char *canmount = strtok_r(NULL, "\t", &tmp);
-				bool canmount_on =
-				    canmount && strncmp(canmount, "on", 2) == 0;
+			char *canmount = line;
+			canmount += strcspn(canmount, "\t");
+			canmount += strspn(canmount, "\t");
+			canmount += strcspn(canmount, "\t");
+			canmount += strspn(canmount, "\t");
+			bool canmount_on = strncmp(canmount, "on", 2) == 0;
 
-				if (debug >= 2)
-					printf(PROGNAME ": forked %d, "
-					    "canmount_on=%d, dataset=%s\n",
-					    (int)pid, canmount_on, dset);
+			if (canmount_on)
+				ret |= line_worker(line, cachent->d_name);
+			else {
+				if (filename == NULL)
+					filename =
+					    strdup(cachent->d_name) ?: "(?)";
 
-				if (canmount_on &&
-				    forked_canmount_on ==
-				    canmount_on_pids_len) {
-					size_t new_len =
-					    (canmount_on_pids_len ?: 16) * 2;
-					void *new_pidlist =
-					    realloc(canmount_on_pids,
-					    new_len *
-					    sizeof (*canmount_on_pids));
-					if (!new_pidlist) {
-						fprintf(stderr,
-						    PROGNAME "[%d]: "
-						    "out of memory! "
-						    "Mount ordering may be "
-						    "affected.\n", getpid());
-						continue;
-					}
-
-					canmount_on_pids = new_pidlist;
-					canmount_on_pids_len = new_len;
+				struct line *l = calloc(1, sizeof (*l));
+				char *nl = strdup(line);
+				if (l == NULL || nl == NULL) {
+					fprintf(stderr, PROGNAME "[%d]: "
+					    "out of memory for \"%s\" in %s\n",
+					    getpid(), line, cachent->d_name);
+					free(l);
+					free(nl);
+					continue;
 				}
-
-				if (canmount_on) {
-					canmount_on_pids[forked_canmount_on] =
-					    pid;
-					++forked_canmount_on;
-				} else
-					++forked_canmount_not_on;
-				break;
-			}
+				l->line = nl;
+				l->fname = filename;
+				l->next = lines_canmount_not_on;
+				lines_canmount_not_on = l;
 			}
 		}
 
-		(void) fclose(cachefile);
+		fclose(cachefile);
 	}
 	free(line);
 
-	if (forked_canmount_on == 0) {
-		/* No canmount=on processes to finish, so don't deadlock here */
-		for (size_t i = 0; i < forked_canmount_not_on; ++i)
-			sem_post(&noauto_files->noauto_not_on_sem);
-	} else {
-		/* Likely a no-op, since we got these from a narrow fork loop */
-		qsort(canmount_on_pids, forked_canmount_on,
-		    sizeof (*canmount_on_pids), PID_T_CMP);
-	}
+	while (lines_canmount_not_on) {
+		struct line *l = lines_canmount_not_on;
+		lines_canmount_not_on = l->next;
 
-	int status, ret = 0;
-	struct rusage usage;
-	size_t forked_canmount_on_max = forked_canmount_on;
-	while ((pid = wait4(-1, &status, 0, &usage)) != -1) {
-		ret |= WEXITSTATUS(status) | WTERMSIG(status);
-
-		if (forked_canmount_on != 0) {
-			if (bsearch(&pid, canmount_on_pids,
-			    forked_canmount_on_max, sizeof (*canmount_on_pids),
-			    PID_T_CMP))
-				--forked_canmount_on;
-
-			if (forked_canmount_on == 0) {
-				/*
-				 * All canmount=on processes have finished,
-				 * let all the lower-priority ones finish now
-				 */
-				for (size_t i = 0;
-				    i < forked_canmount_not_on; ++i)
-					sem_post(
-					    &noauto_files->noauto_not_on_sem);
-			}
+		ret |= line_worker(l->line, l->fname);
+		if (FREE_STATICS) {
+			free(l->line);
+			free(l);
 		}
-
-		if (debug >= 2)
-			printf(PROGNAME ": %d done, user=%llu.%06us, "
-			    "system=%llu.%06us, maxrss=%ldB, ex=0x%x\n",
-			    (int)pid,
-			    (unsigned long long) usage.ru_utime.tv_sec,
-			    (unsigned int) usage.ru_utime.tv_usec,
-			    (unsigned long long) usage.ru_stime.tv_sec,
-			    (unsigned int) usage.ru_stime.tv_usec,
-			    usage.ru_maxrss * 1024, status);
 	}
 
 	if (debug) {
 		struct timespec time_end = {};
 		clock_gettime(CLOCK_MONOTONIC_RAW, &time_end);
 
+		struct rusage usage;
 		getrusage(RUSAGE_SELF, &usage);
 		printf(
 		    "\n"
-		    PROGNAME ": self    : "
-		    "user=%llu.%06us, system=%llu.%06us, maxrss=%ldB\n",
-		    (unsigned long long) usage.ru_utime.tv_sec,
-		    (unsigned int) usage.ru_utime.tv_usec,
-		    (unsigned long long) usage.ru_stime.tv_sec,
-		    (unsigned int) usage.ru_stime.tv_usec,
-		    usage.ru_maxrss * 1024);
-
-		getrusage(RUSAGE_CHILDREN, &usage);
-		printf(PROGNAME ": children: "
+		    PROGNAME ": "
 		    "user=%llu.%06us, system=%llu.%06us, maxrss=%ldB\n",
 		    (unsigned long long) usage.ru_utime.tv_sec,
 		    (unsigned int) usage.ru_utime.tv_usec,
@@ -1068,7 +977,7 @@ main(int argc, char **argv)
 		    time_init.tv_nsec / 1000000000;
 		time_init.tv_nsec %= 1000000000;
 
-		printf(PROGNAME ": wall    : "
+		printf(PROGNAME ": "
 		    "total=%llu.%09llus = "
 		    "init=%llu.%09llus + real=%llu.%09llus\n",
 		    (unsigned long long) time_init.tv_sec,
@@ -1077,7 +986,15 @@ main(int argc, char **argv)
 		    (unsigned long long) time_start.tv_nsec,
 		    (unsigned long long) time_end.tv_sec,
 		    (unsigned long long) time_end.tv_nsec);
+
+		fflush(stdout);
 	}
 
+	if (FREE_STATICS) {
+		closedir(fslist_dir);
+		tdestroy(noauto_files, free);
+		tdestroy(known_pools, free);
+		regfree(&uri_regex);
+	}
 	_exit(ret);
 }

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -795,9 +795,10 @@ extern int zfs_receive(libzfs_handle_t *, const char *, nvlist_t *,
     recvflags_t *, int, avl_tree_t *);
 
 typedef enum diff_flags {
-	ZFS_DIFF_PARSEABLE = 0x1,
-	ZFS_DIFF_TIMESTAMP = 0x2,
-	ZFS_DIFF_CLASSIFY = 0x4
+	ZFS_DIFF_PARSEABLE = 1 << 0,
+	ZFS_DIFF_TIMESTAMP = 1 << 1,
+	ZFS_DIFF_CLASSIFY = 1 << 2,
+	ZFS_DIFF_NO_MANGLE = 1 << 3
 } diff_flags_t;
 
 extern int zfs_show_diffs(zfs_handle_t *, int, const char *, const char *,

--- a/include/libzfs_impl.h
+++ b/include/libzfs_impl.h
@@ -234,6 +234,7 @@ typedef struct differ_info {
 	boolean_t scripted;
 	boolean_t classify;
 	boolean_t timestamped;
+	boolean_t no_mangle;
 	uint64_t shares;
 	int zerr;
 	int cleanupfd;

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -122,9 +122,9 @@ stream_bytes(FILE *fp, const char *string)
 
 	while ((c = *string++) != '\0') {
 		if (c > ' ' && c != '\\' && c < '\177') {
-			(void) fprintf(fp, "%c", c);
+			(void) fputc(c, fp);
 		} else {
-			(void) fprintf(fp, "\\%04o", (uint8_t)c);
+			(void) fprintf(fp, "\\%04hho", (uint8_t)c);
 		}
 	}
 }

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -176,8 +176,13 @@ print_what(FILE *fp, mode_t what)
 static void
 print_cmn(FILE *fp, differ_info_t *di, const char *file)
 {
-	stream_bytes(fp, di->dsmnt);
-	stream_bytes(fp, file);
+	if (!di->no_mangle) {
+		stream_bytes(fp, di->dsmnt);
+		stream_bytes(fp, file);
+	} else {
+		(void) fputs(di->dsmnt, fp);
+		(void) fputs(file, fp);
+	}
 }
 
 static void
@@ -752,6 +757,7 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 	di.scripted = (flags & ZFS_DIFF_PARSEABLE);
 	di.classify = (flags & ZFS_DIFF_CLASSIFY);
 	di.timestamped = (flags & ZFS_DIFF_TIMESTAMP);
+	di.no_mangle = (flags & ZFS_DIFF_NO_MANGLE);
 
 	di.outputfd = outfd;
 	di.datafd = pipefd[0];

--- a/man/man8/zfs-diff.8
+++ b/man/man8/zfs-diff.8
@@ -39,7 +39,7 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm diff
-.Op Fl FHt
+.Op Fl FHth
 .Ar snapshot Ar snapshot Ns | Ns Ar filesystem
 .
 .Sh DESCRIPTION
@@ -92,6 +92,10 @@ Give more parsable tab-separated output, without header lines and without
 arrows.
 .It Fl t
 Display the path's inode change time as the first column of output.
+.It Fl h
+Do not
+.Sy \e0 Ns Ar ooo Ns -escape
+non-ASCII paths.
 .El
 .
 .Sh SEE ALSO

--- a/man/man8/zfs-mount-generator.8.in
+++ b/man/man8/zfs-mount-generator.8.in
@@ -142,22 +142,11 @@ ZEDLET, if enabled
 .Pq see Xr zed 8 .
 .
 .Sh ENVIRONMENT
-The
+If the
 .Sy ZFS_DEBUG
-environment variable can either be
-.Sy 0
-(default),
-.Sy 1
-(print summary accounting information at the end), or at least
-.Sy 2
-(print accounting information for each subprocess as it finishes).
-.
-If not present,
-.Pa /proc/cmdline
-is additionally checked for
-.Qq debug ,
-in which case the debug level is set to
-.Sy 2 .
+environment variable is nonzero
+.Pq or unset and Pa /proc/cmdline No contains Qq Sy debug ,
+print summary accounting information at the end.
 .
 .Sh EXAMPLES
 To begin, enable tracking for the pool:

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -178,7 +178,7 @@ tags = ['functional', 'cli_root', 'zfs_destroy']
 
 [tests/functional/cli_root/zfs_diff]
 tests = ['zfs_diff_changes', 'zfs_diff_cliargs', 'zfs_diff_timestamp',
-    'zfs_diff_types', 'zfs_diff_encrypted']
+    'zfs_diff_types', 'zfs_diff_encrypted', 'zfs_diff_mangle']
 tags = ['functional', 'cli_root', 'zfs_diff']
 
 [tests/functional/cli_root/zfs_get]

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/Makefile.am
@@ -8,6 +8,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_diff_changes.ksh \
 	zfs_diff_cliargs.ksh \
 	zfs_diff_encrypted.ksh \
+	zfs_diff_mangle.ksh \
 	zfs_diff_timestamp.ksh \
 	zfs_diff_types.ksh
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_cliargs.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_cliargs.ksh
@@ -39,8 +39,8 @@ function cleanup
 log_assert "'zfs diff' should only work with supported options."
 log_onexit cleanup
 
-typeset goodopts=("" "-F" "-H" "-t" "-FH" "-Ft" "-Ht" "-FHt")
-typeset badopts=("-f" "-h" "-h" "-T" "-Fx" "-Ho" "-tT" "-")
+typeset goodopts=("" "-h" "-t" "-th" "-H" "-Hh" "-Ht" "-Hth" "-F" "-Fh" "-Ft" "-Fth" "-FH" "-FHh" "-FHt" "-FHth")
+typeset badopts=("-f" "-T" "-Fx" "-Ho" "-tT" "-")
 
 DATASET="$TESTPOOL/$TESTFS"
 TESTSNAP1="$DATASET@snap1"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_mangle.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_mangle.ksh
@@ -1,0 +1,48 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs diff' escapes filenames as expected, 'zfs diff -h' doesn't
+#
+# STRATEGY:
+# 1. Prepare a dataset
+# 2. Create some files
+# 3. verify 'zfs diff' mangles them and 'zfs diff -h' doesn't
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zfs destroy -r "$DATASET"
+}
+
+log_assert "'zfs diff' mangles filenames, 'zfs diff -h' doesn't"
+log_onexit cleanup
+
+DATASET="$TESTPOOL/$TESTFS/fs"
+TESTSNAP1="$DATASET@snap1"
+
+# 1. Prepare a dataset
+log_must zfs create "$DATASET"
+MNTPOINT="$(get_prop mountpoint "$DATASET")"
+log_must zfs snapshot "$TESTSNAP1"
+
+printf '%c\t'"$MNTPOINT/"'%s\n' M '' + 'śmieszny żupan'                       + 'достопримечательности'                                                                                                                                                                                              | sort > "$MNTPOINT/śmieszny żupan"
+printf '%c\t'"$MNTPOINT/"'%s\n' M '' + '\0305\0233mieszny\0040\0305\0274upan' + '\0320\0264\0320\0276\0321\0201\0321\0202\0320\0276\0320\0277\0321\0200\0320\0270\0320\0274\0320\0265\0321\0207\0320\0260\0321\0202\0320\0265\0320\0273\0321\0214\0320\0275\0320\0276\0321\0201\0321\0202\0320\0270' | sort > "$MNTPOINT/достопримечательности"
+log_must diff -u <(zfs diff -h "$TESTSNAP1" | grep -vF '<xattrdir>' | sort) "$MNTPOINT/śmieszny żupan"
+log_must diff -u <(zfs diff    "$TESTSNAP1" | grep -vF '<xattrdir>' | sort) "$MNTPOINT/достопримечательности"
+
+log_pass "'zfs diff' mangles filenames, 'zfs diff -h' doesn't"


### PR DESCRIPTION
### Motivation and Context
Commit 1 is `zfs diff -h`, commit 2 is format safety also from #12138.

Commit 3 is zfs-mount-generator serialisation and keylocation=https:// handling from #12829 (originally merged as a single commit). This is additionally Good To Have considering 2.1.3 pulled keylocation=https:// in, so, as it stands, z-m-g kinda just falls over and generates `RequiresMountsFor=key.server/file` for kl=https://key.server/file, which is Bad™.
And without it z-m-g is liable to go medieval on the CPU with a lot of datasets (see message).

All clean cherry-picks, added Upstream-commit: trailers.

### How Has This Been Tested?
I've been running all of them backported into 2.1.2 for however long 2.1.2's been out.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
