### PR TITLE
Fix string/index variables being unflexed by default

### DIFF
--- a/module/zcommon/zprop_common.c
+++ b/module/zcommon/zprop_common.c
@@ -136,7 +136,7 @@ zprop_register_string(int prop, const char *name, const char *def,
     const char *colname, const struct zfs_mod_supported_features *sfeatures)
 {
 	zprop_register_impl(prop, name, PROP_TYPE_STRING, 0, def, attr,
-	    objset_types, values, colname, B_FALSE, B_TRUE, B_FALSE, NULL,
+	    objset_types, values, colname, B_FALSE, B_TRUE, B_TRUE, NULL,
 	    sfeatures);
 
 }
@@ -159,7 +159,7 @@ zprop_register_index(int prop, const char *name, uint64_t def,
     const struct zfs_mod_supported_features *sfeatures)
 {
 	zprop_register_impl(prop, name, PROP_TYPE_INDEX, def, NULL, attr,
-	    objset_types, values, colname, B_FALSE, B_TRUE, B_FALSE, idx_tbl,
+	    objset_types, values, colname, B_FALSE, B_TRUE, B_TRUE, idx_tbl,
 	    sfeatures);
 }
 


### PR DESCRIPTION
### Motivation and Context
Fix #13125

### Description
I got the status backward (B_FALSE for fixed, rather than B_TRUE for flex); before:
```
  $ zfs get mountpoint tarta-zoot -r
  NAME                                 PROPERTY    VALUE       SOURCE
  tarta-zoot                           mountpoint  /           local
  tarta-zoot/PAGEFILE.SYS              mountpoint  -           -
  tarta-zoot/etc                       mountpoint  /etc        inherited from tarta-zoot
  tarta-zoot/home                      mountpoint  /home       inherited from tarta-zoot
  tarta-zoot/home/xspon                mountpoint  /home/xspon  inherited from tarta-zoot
  tarta-zoot/home/nabijaczleweli       mountpoint  /home/nabijaczleweli  inherited from tarta-zoot
  tarta-zoot/home/nabijaczleweli/tftp  mountpoint  /home/nabijaczleweli/tftp  inherited from tarta-zoot
  tarta-zoot/home/root                 mountpoint  /root       local
```
after:
```
  $ zfs get mountpoint tarta-zoot -r
  NAME                                 PROPERTY    VALUE                      SOURCE
  tarta-zoot                           mountpoint  /                          local
  tarta-zoot/PAGEFILE.SYS              mountpoint  -                          -
  tarta-zoot/etc                       mountpoint  /etc                       inherited from tarta-zoot
  tarta-zoot/home                      mountpoint  /home                      inherited from tarta-zoot
  tarta-zoot/home/xspon                mountpoint  /home/xspon                inherited from tarta-zoot
  tarta-zoot/home/nabijaczleweli       mountpoint  /home/nabijaczleweli       inherited from tarta-zoot
  tarta-zoot/home/nabijaczleweli/tftp  mountpoint  /home/nabijaczleweli/tftp  inherited from tarta-zoot
  tarta-zoot/home/root                 mountpoint  /root                      local
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. — none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
