### PR TITLE
Fix dracut. Document it.

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -9,13 +9,10 @@ check() {
 	for tool in "zgenhostid" "zpool" "zfs" "mount.zfs"; do
 		command -v "${tool}" >/dev/null || return 1
 	done
-
-	return 0
 }
 
 depends() {
 	echo udev-rules
-	return 0
 }
 
 installkernel() {
@@ -39,7 +36,6 @@ install() {
 		{ dfatal "Failed to install essential binaries"; exit 1; }
 
 	# Adapted from https://github.com/zbm-dev/zfsbootmenu
-
 	if ! ldd "$(command -v zpool)" | grep -qF 'libgcc_s.so'; then
 		# On systems with gcc-config (Gentoo, Funtoo, etc.), use it to find libgcc_s
 		if command -v gcc-config >/dev/null; then
@@ -79,7 +75,6 @@ install() {
 	fi
 
 	if dracut_module_included "systemd"; then
-
 		inst_simple "${systemdsystemunitdir}/zfs-import.target"
 		systemctl -q --root "${initdir}" add-wants initrd.target zfs-import.target
 

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -20,6 +20,42 @@ fi
 info "ZFS: No sysroot.mount exists or zfs-generator did not extend it."
 info "ZFS: Mounting root with the traditional mount-zfs.sh instead."
 
+# ask_for_password tries prompt cmd
+#
+# Wraps around plymouth ask-for-password and adds fallback to tty password ask
+# if plymouth is not present.
+ask_for_password() {
+    tries="$1"
+    prompt="$2"
+    cmd="$3"
+
+    {
+        flock -s 9
+
+        # Prompt for password with plymouth, if installed and running.
+        if plymouth --ping 2>/dev/null; then
+            plymouth ask-for-password \
+                --prompt "$prompt" --number-of-tries="$tries" | \
+                eval "$cmd"
+            ret=$?
+        else
+            i=1
+            while [ "$i" -le "$tries" ]; do
+                printf "%s [%i/%i]:" "$prompt" "$i" "$tries" >&2
+                eval "$cmd" && ret=0 && break
+                ret=$?
+                i=$((i+1))
+                printf '\n' >&2
+            done
+            unset i
+        fi
+    } 9>/.console_lock
+
+    [ "$ret" -ne 0 ] && echo "Wrong password" >&2
+    return "$ret"
+}
+
+
 # Delay until all required block devices are present.
 modprobe zfs 2>/dev/null
 udevadm settle
@@ -45,31 +81,39 @@ fi
 ZFS_DATASET="${ZFS_DATASET:-${root}}"
 ZFS_POOL="${ZFS_DATASET%%/*}"
 
-if import_pool "${ZFS_POOL}" ; then
-	# Load keys if we can or if we need to
-	if [ "$(zpool list -H -o feature@encryption "${ZFS_POOL}")" = 'active' ]; then
-		# if the root dataset has encryption enabled
-		ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${ZFS_DATASET}")"
-		if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
-			KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
-			# if the key needs to be loaded
-			if [ "$KEYSTATUS" = "unavailable" ]; then
-				# decrypt them
-				ask_for_password \
-					5 \
-					"Encrypted ZFS password for ${ENCRYPTIONROOT}: " \
-					"zfs load-key '${ENCRYPTIONROOT}'"
-			fi
+
+if ! zpool get -Ho name "${ZFS_POOL}" > /dev/null 2>&1; then
+    info "ZFS: Importing pool ${ZFS_POOL}..."
+    # shellcheck disable=SC2086
+    if ! zpool import -N ${ZPOOL_IMPORT_OPTS} "${ZFS_POOL}"; then
+        warn "ZFS: Unable to import pool ${ZFS_POOL}"
+        rootok=0
+        return 1
+    fi
+fi
+
+# Load keys if we can or if we need to
+if [ "$(zpool get -Ho value feature@encryption "${ZFS_POOL}")" = 'active' ]; then
+	# if the root dataset has encryption enabled
+	ENCRYPTIONROOT="$(zfs get -Ho value encryptionroot "${ZFS_DATASET}")"
+	if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
+		KEYSTATUS="$(zfs get -Ho value keystatus "${ENCRYPTIONROOT}")"
+		# if the key needs to be loaded
+		if [ "$KEYSTATUS" = "unavailable" ]; then
+			# decrypt them
+			ask_for_password \
+				5 \
+				"Encrypted ZFS password for ${ENCRYPTIONROOT}: " \
+				"zfs load-key '${ENCRYPTIONROOT}'"
 		fi
-	fi
-	# Let us tell the initrd to run on shutdown.
-	# We have a shutdown hook to run
-	# because we imported the pool.
-	info "ZFS: Mounting dataset ${ZFS_DATASET}..."
-	if mount_dataset "${ZFS_DATASET}" ; then
-		ROOTFS_MOUNTED=yes
-		return 0
 	fi
 fi
 
-rootok=0
+# Let us tell the initrd to run on shutdown.
+# We have a shutdown hook to run
+# because we imported the pool.
+info "ZFS: Mounting dataset ${ZFS_DATASET}..."
+if ! mount_dataset "${ZFS_DATASET}"; then
+  rootok=0
+  return 1
+fi

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -3,40 +3,29 @@
 
 . /lib/dracut-zfs-lib.sh
 
-ZFS_DATASET=""
-ZFS_POOL=""
-
-case "${root}" in
-	zfs:*) ;;
-	*) return ;;
-esac
+decode_root_args || return 0
 
 GENERATOR_FILE=/run/systemd/generator/sysroot.mount
 GENERATOR_EXTENSION=/run/systemd/generator/sysroot.mount.d/zfs-enhancement.conf
 
-if [ -e "$GENERATOR_FILE" ] && [ -e "$GENERATOR_EXTENSION" ] ; then
-	# If the ZFS sysroot.mount flag exists, the initial RAM disk configured
-	# it to mount ZFS on root.  In that case, we bail early.  This flag
-	# file gets created by the zfs-generator program upon successful run.
-	info "ZFS: There is a sysroot.mount and zfs-generator has extended it."
-	info "ZFS: Delegating root mount to sysroot.mount."
-	# Let us tell the initrd to run on shutdown.
-	# We have a shutdown hook to run
-	# because we imported the pool.
+if [ -e "$GENERATOR_FILE" ] && [ -e "$GENERATOR_EXTENSION" ]; then
+	# We're under systemd and dracut-zfs-generator ran to completion.
+	info "ZFS: Delegating root mount to sysroot.mount at al."
+
 	# We now prevent Dracut from running this thing again.
-	for zfsmounthook in "$hookdir"/mount/*zfs* ; do
-		if [ -f "$zfsmounthook" ] ; then
-			rm -f "$zfsmounthook"
-		fi
-	done
+	rm -f "$hookdir"/mount/*zfs*
 	return
 fi
+
 info "ZFS: No sysroot.mount exists or zfs-generator did not extend it."
 info "ZFS: Mounting root with the traditional mount-zfs.sh instead."
 
 # Delay until all required block devices are present.
 modprobe zfs 2>/dev/null
 udevadm settle
+
+ZFS_DATASET=
+ZFS_POOL=
 
 if [ "${root}" = "zfs:AUTO" ] ; then
 	if ! ZFS_DATASET="$(find_bootfs)" ; then
@@ -53,7 +42,7 @@ if [ "${root}" = "zfs:AUTO" ] ; then
 	info "ZFS: Using ${ZFS_DATASET} as root."
 fi
 
-ZFS_DATASET="${ZFS_DATASET:-${root#zfs:}}"
+ZFS_DATASET="${ZFS_DATASET:-${root}}"
 ZFS_POOL="${ZFS_DATASET%%/*}"
 
 if import_pool "${ZFS_POOL}" ; then

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -28,10 +28,10 @@ ZFS_DATASET=
 ZFS_POOL=
 
 if [ "${root}" = "zfs:AUTO" ] ; then
-	if ! ZFS_DATASET="$(find_bootfs)" ; then
+	if ! ZFS_DATASET="$(zpool get -Ho value bootfs | grep -m1 -vFx -)"; then
 		# shellcheck disable=SC2086
 		zpool import -N -a ${ZPOOL_IMPORT_OPTS}
-		if ! ZFS_DATASET="$(find_bootfs)" ; then
+		if ! ZFS_DATASET="$(zpool get -Ho value bootfs | grep -m1 -vFx -)"; then
 			warn "ZFS: No bootfs attribute found in importable pools."
 			zpool export -aF
 

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -93,6 +93,7 @@ if ! zpool get -Ho name "${ZFS_POOL}" > /dev/null 2>&1; then
 fi
 
 # Load keys if we can or if we need to
+# TODO: for_relevant_root_children like in zfs-load-key.sh.in
 if [ "$(zpool get -Ho value feature@encryption "${ZFS_POOL}")" = 'active' ]; then
 	# if the root dataset has encryption enabled
 	ENCRYPTIONROOT="$(zfs get -Ho value encryptionroot "${ZFS_DATASET}")"

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -56,9 +56,9 @@ if import_pool "${ZFS_POOL}" ; then
 			if [ "$KEYSTATUS" = "unavailable" ]; then
 				# decrypt them
 				ask_for_password \
-					--tries 5 \
-					--prompt "Encrypted ZFS password for ${ENCRYPTIONROOT}: " \
-					--cmd "zfs load-key '${ENCRYPTIONROOT}'"
+					5 \
+					"Encrypted ZFS password for ${ENCRYPTIONROOT}: " \
+					"zfs load-key '${ENCRYPTIONROOT}'"
 			fi
 		fi
 	fi

--- a/contrib/dracut/90zfs/parse-zfs.sh.in
+++ b/contrib/dracut/90zfs/parse-zfs.sh.in
@@ -29,18 +29,15 @@ case "${root}" in
 		info "ZFS: Enabling autodetection of bootfs after udev settles."
 		;;
 
-	ZFS=*|zfs:*|FILESYSTEM=*)
+	ZFS=*|zfs:*)
 		# root is explicit ZFS root.  Parse it now.  We can handle
 		# a root=... param in any of the following formats:
 		# root=ZFS=rpool/ROOT
 		# root=zfs:rpool/ROOT
-		# root=zfs:FILESYSTEM=rpool/ROOT
-		# root=FILESYSTEM=rpool/ROOT
 		# root=ZFS=pool+with+space/ROOT+WITH+SPACE (translates to root=ZFS=pool with space/ROOT WITH SPACE)
 
 		# Strip down to just the pool/fs
 		root="${root#zfs:}"
-		root="${root#FILESYSTEM=}"
 		root="zfs:${root#ZFS=}"
 		# switch + with spaces because kernel cmdline does not allow us to quote parameters
 		root=$(echo "$root" | tr '+' ' ')

--- a/contrib/dracut/90zfs/parse-zfs.sh.in
+++ b/contrib/dracut/90zfs/parse-zfs.sh.in
@@ -1,7 +1,8 @@
 #!/bin/sh
 # shellcheck disable=SC2034,SC2154
 
-. /lib/dracut-lib.sh
+# shellcheck source=zfs-lib.sh.in
+. /lib/dracut-zfs-lib.sh
 
 # Let the command line override our host id.
 spl_hostid=$(getarg spl_hostid=)
@@ -15,46 +16,20 @@ else
 	warn "ZFS: Pools may not import correctly."
 fi
 
-wait_for_zfs=0
-case "${root}" in
-	""|zfs|zfs:)
-		# We'll take root unset, root=zfs, or root=zfs:
-		# No root set, so we want to read the bootfs attribute.  We
-		# can't do that until udev settles so we'll set dummy values
-		# and hope for the best later on.
-		root="zfs:AUTO"
-		rootok=1
-		wait_for_zfs=1
+if decode_root_args; then
+	if [ "$root" = "zfs:AUTO" ]; then
+		info "ZFS: Boot dataset autodetected from bootfs=."
+	else
+		info "ZFS: Boot dataset is ${root}."
+	fi
 
-		info "ZFS: Enabling autodetection of bootfs after udev settles."
-		;;
-
-	ZFS=*|zfs:*)
-		# root is explicit ZFS root.  Parse it now.  We can handle
-		# a root=... param in any of the following formats:
-		# root=ZFS=rpool/ROOT
-		# root=zfs:rpool/ROOT
-		# root=ZFS=pool+with+space/ROOT+WITH+SPACE (translates to root=ZFS=pool with space/ROOT WITH SPACE)
-
-		# Strip down to just the pool/fs
-		root="${root#zfs:}"
-		root="zfs:${root#ZFS=}"
-		# switch + with spaces because kernel cmdline does not allow us to quote parameters
-		root=$(echo "$root" | tr '+' ' ')
-		rootok=1
-		wait_for_zfs=1
-
-		info "ZFS: Set ${root} as bootfs."
-		;;
-
-	*)
-		info "ZFS: no ZFS-on-root"
-esac
-
-# Make sure Dracut is happy that we have a root and will wait for ZFS
-# modules to settle before mounting.
-if [ "${wait_for_zfs}" -eq 1 ]; then
-	ln -s /dev/null /dev/root 2>/dev/null
-	initqueuedir="${hookdir}/initqueue/finished"
-	echo '[ -e /dev/zfs ]' > "${initqueuedir}/zfs.sh"
+	rootok=1
+	# Make sure Dracut is happy that we have a root and will wait for ZFS
+	# modules to settle before mounting.
+	if [ -n "${wait_for_zfs}" ]; then
+		ln -s null /dev/root
+		echo '[ -e /dev/zfs ]' > "${hookdir}/initqueue/finished/zfs.sh"
+	fi
+else
+	info "ZFS: no ZFS-on-root."
 fi

--- a/contrib/dracut/90zfs/parse-zfs.sh.in
+++ b/contrib/dracut/90zfs/parse-zfs.sh.in
@@ -59,8 +59,5 @@ esac
 if [ "${wait_for_zfs}" -eq 1 ]; then
 	ln -s /dev/null /dev/root 2>/dev/null
 	initqueuedir="${hookdir}/initqueue/finished"
-	test -d "${initqueuedir}" || {
-		initqueuedir="${hookdir}/initqueue-finished"
-	}
 	echo '[ -e /dev/zfs ]' > "${initqueuedir}/zfs.sh"
 fi

--- a/contrib/dracut/90zfs/zfs-env-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-env-bootfs.service.in
@@ -8,7 +8,7 @@ Before=zfs-import.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "exec systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | grep -m1 -v '^-$')"
+ExecStart=/bin/sh -c "exec systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | grep -m1 -vFx -)"
 
 [Install]
 WantedBy=zfs-import.target

--- a/contrib/dracut/90zfs/zfs-generator.sh.in
+++ b/contrib/dracut/90zfs/zfs-generator.sh.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC2016,SC1004
+# shellcheck disable=SC2016,SC1004,SC2154
 
 grep -wq debug /proc/cmdline && debug=1
 [ -n "$debug" ] && echo "zfs-generator: starting" >> /dev/kmsg
@@ -10,36 +10,16 @@ GENERATOR_DIR="$1"
     exit 1
 }
 
-[ -f /lib/dracut-lib.sh ] && dracutlib=/lib/dracut-lib.sh
-[ -f /usr/lib/dracut/modules.d/99base/dracut-lib.sh ] && dracutlib=/usr/lib/dracut/modules.d/99base/dracut-lib.sh
-command -v getarg >/dev/null 2>&1 || {
-    [ -n "$debug" ] && echo "zfs-generator: loading Dracut library from $dracutlib" >> /dev/kmsg
-    . "$dracutlib"
-}
-
+# shellcheck source=zfs-lib.sh.in
 . /lib/dracut-zfs-lib.sh
+decode_root_args || exit 0
 
-[ -z "$root" ]       && root=$(getarg root=)
-[ -z "$rootfstype" ] && rootfstype=$(getarg rootfstype=)
-[ -z "$rootflags" ]  && rootflags=$(getarg rootflags=)
-
-# If root is not ZFS= or zfs: or rootfstype is not zfs
-# then we are not supposed to handle it.
-[ "${root##zfs:}" = "${root}" ] &&
-	[ "${root##ZFS=}" = "${root}" ] &&
-	[ "$rootfstype" != "zfs" ] &&
-	exit 0
-
+[ -z "${rootflags}" ] && rootflags=$(getarg rootflags=)
 case ",${rootflags}," in
 	*,zfsutil,*) ;;
 	,,)	rootflags=zfsutil ;;
 	*)	rootflags="zfsutil,${rootflags}" ;;
 esac
-
-if [ "${root}" != "zfs:AUTO" ]; then
-  root="${root##zfs:}"
-  root="${root##ZFS=}"
-fi
 
 [ -n "$debug" ] && echo "zfs-generator: writing extension for sysroot.mount to $GENERATOR_DIR/sysroot.mount.d/zfs-enhancement.conf" >> /dev/kmsg
 
@@ -89,7 +69,7 @@ else
   _zfs_generator_cb() {
       dset="${1}"
       mpnt="${2}"
-      unit="sysroot$(echo "$mpnt" | tr '/' '-').mount"
+      unit="$(systemd-escape --suffix=mount -p "/sysroot${mpnt}")"
 
       {
           echo "[Unit]"

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -2,20 +2,6 @@
 # shellcheck disable=SC2034
 
 command -v getarg >/dev/null || . /lib/dracut-lib.sh || . /usr/lib/dracut/modules.d/99base/dracut-lib.sh
-command -v getargbool >/dev/null || {
-    # Compatibility with older Dracut versions.
-    # With apologies to the Dracut developers.
-    getargbool() {
-        _default="$1"; shift
-        ! _b=$(getarg "$@") && [ -z "$_b" ] && _b="$_default"
-        if [ -n "$_b" ]; then
-            [ "$_b" = "0" ] && return 1
-            [ "$_b" = "no" ] && return 1
-            [ "$_b" = "off" ] && return 1
-        fi
-        return 0
-    }
-}
 
 TAB="	"
 

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -27,31 +27,6 @@ if getargbool 0 zfs_force -y zfs.force -y zfsforce ; then
     ZPOOL_IMPORT_OPTS="${ZPOOL_IMPORT_OPTS} -f"
 fi
 
-# find_bootfs
-#   returns the first dataset with the bootfs attribute.
-find_bootfs() {
-    IFS="${NEWLINE}"
-    for dataset in $(zpool list -H -o bootfs); do
-        case "${dataset}" in
-            "" | "-")
-                continue
-                ;;
-            "no pools available")
-                IFS="${OLDIFS}"
-                return 1
-                ;;
-            *)
-                IFS="${OLDIFS}"
-                echo "${dataset}"
-                return 0
-                ;;
-        esac
-    done
-
-    IFS="${OLDIFS}"
-    return 1
-}
-
 # import_pool POOL
 #   imports the given zfs pool if it isn't imported already.
 import_pool() {

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2034
 
 command -v getarg >/dev/null || . /lib/dracut-lib.sh || . /usr/lib/dracut/modules.d/99base/dracut-lib.sh
 command -v getargbool >/dev/null || {
@@ -16,33 +17,13 @@ command -v getargbool >/dev/null || {
     }
 }
 
-OLDIFS="${IFS}"
-NEWLINE="
-"
 TAB="	"
 
-ZPOOL_IMPORT_OPTS=""
-if getargbool 0 zfs_force -y zfs.force -y zfsforce ; then
+ZPOOL_IMPORT_OPTS=
+if getargbool 0 zfs_force -y zfs.force -y zfsforce; then
     warn "ZFS: Will force-import pools if necessary."
-    ZPOOL_IMPORT_OPTS="${ZPOOL_IMPORT_OPTS} -f"
+    ZPOOL_IMPORT_OPTS=-f
 fi
-
-# import_pool POOL
-#   imports the given zfs pool if it isn't imported already.
-import_pool() {
-    pool="${1}"
-
-    if ! zpool list -H "${pool}" > /dev/null 2>&1; then
-        info "ZFS: Importing pool ${pool}..."
-        # shellcheck disable=SC2086
-        if ! zpool import -N ${ZPOOL_IMPORT_OPTS} "${pool}" ; then
-            warn "ZFS: Unable to import pool ${pool}"
-            return 1
-        fi
-    fi
-
-    return 0
-}
 
 _mount_dataset_cb() {
     # shellcheck disable=SC2154
@@ -95,41 +76,6 @@ for_relevant_root_children() {
             done
             exit "${_ret}"
         )
-}
-
-# ask_for_password tries prompt cmd
-#
-# Wraps around plymouth ask-for-password and adds fallback to tty password ask
-# if plymouth is not present.
-ask_for_password() {
-    tries="$1"
-    prompt="$2"
-    cmd="$3"
-
-    {
-        flock -s 9
-
-        # Prompt for password with plymouth, if installed and running.
-        if plymouth --ping 2>/dev/null; then
-            plymouth ask-for-password \
-                --prompt "$prompt" --number-of-tries="$tries" | \
-                eval "$cmd"
-            ret=$?
-        else
-            i=1
-            while [ "$i" -le "$tries" ]; do
-                printf "%s [%i/%i]:" "$prompt" "$i" "$tries" >&2
-                eval "$cmd" && ret=0 && break
-                ret=$?
-                i=$((i+1))
-                printf '\n' >&2
-            done
-            unset i
-        fi
-    } 9>/.console_lock
-
-    [ "$ret" -ne 0 ] && echo "Wrong password" >&2
-    return "$ret"
 }
 
 # Parse root=, rootfstype=, return them decoded and normalised to zfs:AUTO for auto, plain dset for explicit

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-command -v getarg >/dev/null || . /lib/dracut-lib.sh
+command -v getarg >/dev/null || . /lib/dracut-lib.sh || . /usr/lib/dracut/modules.d/99base/dracut-lib.sh
 command -v getargbool >/dev/null || {
     # Compatibility with older Dracut versions.
     # With apologies to the Dracut developers.
@@ -161,7 +161,9 @@ ask_for_password() {
         shift
     done
 
-    { flock -s 9;
+    {
+        flock -s 9
+
         # Prompt for password with plymouth, if installed and running.
         if plymouth --ping 2>/dev/null; then
             plymouth ask-for-password \
@@ -190,4 +192,59 @@ ask_for_password() {
 
     [ "$ret" -ne 0 ] && echo "Wrong password" >&2
     return "$ret"
+}
+
+# Parse root=, rootfstype=, return them decoded and normalised to zfs:AUTO for auto, plain dset for explicit
+#
+# True if ZFS-on-root, false if we shouldn't
+#
+# Supported values:
+#   root=
+#   root=zfs
+#   root=zfs:
+#   root=zfs:AUTO
+#
+#   root=ZFS=data/set
+#   root=zfs:data/set
+#   root=zfs:ZFS=data/set (as a side-effect; allowed but undocumented)
+#
+#   rootfstype=zfs AND root=data/set <=> root=data/set
+#   rootfstype=zfs AND root=         <=> root=zfs:AUTO
+#
+# '+'es in explicit dataset decoded to ' 's.
+decode_root_args() {
+    if [ -n "$rootfstype" ]; then
+        [ "$rootfstype" = zfs ]
+        return
+    fi
+
+    root=$(getarg root=)
+    rootfstype=$(getarg rootfstype=)
+
+    # shellcheck disable=SC2249
+    case "$root" in
+        ""|zfs|zfs:|zfs:AUTO)
+            root=zfs:AUTO
+            rootfstype=zfs
+            return 0
+            ;;
+
+        ZFS=*|zfs:*)
+            root="${root#zfs:}"
+            root="${root#ZFS=}"
+            root=$(echo "$root" | tr '+' ' ')
+            rootfstype=zfs
+            return 0
+            ;;
+    esac
+
+    if [ "$rootfstype" = "zfs" ]; then
+        case "$root" in
+            "") root=zfs:AUTO ;;
+            *)  root=$(echo "$root" | tr '+' ' ') ;;
+        esac
+        return 0
+    fi
+
+    return 1
 }

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -122,44 +122,14 @@ for_relevant_root_children() {
         )
 }
 
-# ask_for_password
+# ask_for_password tries prompt cmd
 #
 # Wraps around plymouth ask-for-password and adds fallback to tty password ask
 # if plymouth is not present.
-#
-# --cmd command
-#   Command to execute. Required.
-# --prompt prompt
-#   Password prompt. Note that function already adds ':' at the end.
-#   Recommended.
-# --tries n
-#   How many times repeat command on its failure.  Default is 3.
-# --ply-[cmd|prompt|tries]
-#   Command/prompt/tries specific for plymouth password ask only.
-# --tty-[cmd|prompt|tries]
-#   Command/prompt/tries specific for tty password ask only.
-# --tty-echo-off
-#   Turn off input echo before tty command is executed and turn on after.
-#   It's useful when password is read from stdin.
 ask_for_password() {
-    ply_tries=3
-    tty_tries=3
-    while [ "$#" -gt 0 ]; do
-        case "$1" in
-            --cmd) ply_cmd="$2"; tty_cmd="$2"; shift;;
-            --ply-cmd) ply_cmd="$2"; shift;;
-            --tty-cmd) tty_cmd="$2"; shift;;
-            --prompt) ply_prompt="$2"; tty_prompt="$2"; shift;;
-            --ply-prompt) ply_prompt="$2"; shift;;
-            --tty-prompt) tty_prompt="$2"; shift;;
-            --tries) ply_tries="$2"; tty_tries="$2"; shift;;
-            --ply-tries) ply_tries="$2"; shift;;
-            --tty-tries) tty_tries="$2"; shift;;
-            --tty-echo-off) tty_echo_off=yes;;
-            *) echo "ask_for_password(): wrong opt '$1'" >&2;;
-        esac
-        shift
-    done
+    tries="$1"
+    prompt="$2"
+    cmd="$3"
 
     {
         flock -s 9
@@ -167,26 +137,19 @@ ask_for_password() {
         # Prompt for password with plymouth, if installed and running.
         if plymouth --ping 2>/dev/null; then
             plymouth ask-for-password \
-                --prompt "$ply_prompt" --number-of-tries="$ply_tries" | \
-                eval "$ply_cmd"
+                --prompt "$prompt" --number-of-tries="$tries" | \
+                eval "$cmd"
             ret=$?
         else
-            if [ "$tty_echo_off" = yes ]; then
-                stty_orig="$(stty -g)"
-                stty -echo
-            fi
-
             i=1
-            while [ "$i" -le "$tty_tries" ]; do
-                [ -n "$tty_prompt" ] && \
-                    printf "%s [%i/%i]:" "$tty_prompt" "$i" "$tty_tries" >&2
-                eval "$tty_cmd" && ret=0 && break
+            while [ "$i" -le "$tries" ]; do
+                printf "%s [%i/%i]:" "$prompt" "$i" "$tries" >&2
+                eval "$cmd" && ret=0 && break
                 ret=$?
                 i=$((i+1))
-                [ -n "$tty_prompt" ] && printf '\n' >&2
+                printf '\n' >&2
             done
             unset i
-            [ "$tty_echo_off" = yes ] && stty "$stty_orig"
         fi
     } 9>/.console_lock
 

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -20,42 +20,38 @@ if [ "$BOOTFS" = "zfs:AUTO" ]; then
     BOOTFS="$(zpool get -Ho value bootfs | grep -m1 -vFx -)"
 fi
 
-# if pool encryption is active and the zfs command understands '-o encryption'
-if [ "$(zpool list -H -o feature@encryption "${BOOTFS%%/*}")" = 'active' ]; then
-    # if the root dataset has encryption enabled
-    ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${BOOTFS}")"
-    if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
-        KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
-        # continue only if the key needs to be loaded
-        [ "$KEYSTATUS" = "unavailable" ] || exit 0
+[ "$(zpool get -Ho value feature@encryption "${BOOTFS%%/*}")" = 'active' ] || return 0
 
-        KEYLOCATION="$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")"
-        case "${KEYLOCATION%%://*}" in
-            prompt)
-                for _ in 1 2 3; do
-                    systemd-ask-password --no-tty "Encrypted ZFS password for ${BOOTFS}" | zfs load-key "${ENCRYPTIONROOT}" && break
-                done
-                ;;
-            http*)
-                systemctl start network-online.target
-                zfs load-key "${ENCRYPTIONROOT}"
-                ;;
-            file)
-                KEYFILE="${KEYLOCATION#file://}"
-                [ -r "${KEYFILE}" ] || udevadm settle
-                [ -r "${KEYFILE}" ] || {
-                    info "Waiting for key ${KEYFILE} for ${ENCRYPTIONROOT}..."
-                    for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-                        sleep 0.5s
-                        [ -r "${KEYFILE}" ] && break
-                    done
-                }
-                [ -r "${KEYFILE}" ] || warn "Key ${KEYFILE} for ${ENCRYPTIONROOT} hasn't appeared. Trying anyway."
-                zfs load-key "${ENCRYPTIONROOT}"
-                ;;
-            *)
-                zfs load-key "${ENCRYPTIONROOT}"
-                ;;
-        esac
-    fi
-fi
+ENCRYPTIONROOT="$(zfs get -Ho value encryptionroot "${BOOTFS}")"
+[ "${ENCRYPTIONROOT}" = "-" ] && return 0
+
+[ "$(zfs get -Ho value keystatus "${ENCRYPTIONROOT}")" = "unavailable" ] || return 0
+
+KEYLOCATION="$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")"
+case "${KEYLOCATION%%://*}" in
+    prompt)
+        for _ in 1 2 3; do
+            systemd-ask-password --no-tty "Encrypted ZFS password for ${BOOTFS}" | zfs load-key "${ENCRYPTIONROOT}" && break
+        done
+        ;;
+    http*)
+        systemctl start network-online.target
+        zfs load-key "${ENCRYPTIONROOT}"
+        ;;
+    file)
+        KEYFILE="${KEYLOCATION#file://}"
+        [ -r "${KEYFILE}" ] || udevadm settle
+        [ -r "${KEYFILE}" ] || {
+            info "ZFS: Waiting for key ${KEYFILE} for ${ENCRYPTIONROOT}..."
+            for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+                sleep 0.5s
+                [ -r "${KEYFILE}" ] && break
+            done
+        }
+        [ -r "${KEYFILE}" ] || warn "ZFS: Key ${KEYFILE} for ${ENCRYPTIONROOT} hasn't appeared. Trying anyway."
+        zfs load-key "${ENCRYPTIONROOT}"
+        ;;
+    *)
+        zfs load-key "${ENCRYPTIONROOT}"
+        ;;
+esac

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -4,32 +4,20 @@
 # only run this on systemd systems, we handle the decrypt in mount-zfs.sh in the mount hook otherwise
 [ -e /bin/systemctl ] || [ -e /usr/bin/systemctl ] || return 0
 
-# This script only gets executed on systemd systems, see mount-zfs.sh for non-systemd systems
+# shellcheck source=zfs-lib.sh.in
+. /lib/dracut-zfs-lib.sh
 
-# import the libs now that we know the pool imported
-[ -f /lib/dracut-lib.sh ] && dracutlib=/lib/dracut-lib.sh
-[ -f /usr/lib/dracut/modules.d/99base/dracut-lib.sh ] && dracutlib=/usr/lib/dracut/modules.d/99base/dracut-lib.sh
-# shellcheck source=./lib-zfs.sh.in
-. "$dracutlib"
-
-# load the kernel command line vars
-[ -z "$root" ] && root="$(getarg root=)"
-# If root is not ZFS= or zfs: or rootfstype is not zfs then we are not supposed to handle it.
-[ "${root##zfs:}" = "${root}" ] && [ "${root##ZFS=}" = "${root}" ] && [ "$rootfstype" != "zfs" ] && exit 0
+decode_root_args || return 0
 
 # There is a race between the zpool import and the pre-mount hooks, so we wait for a pool to be imported
-while [ "$(zpool list -H)" = "" ]; do
-    systemctl is-failed --quiet zfs-import-cache.service zfs-import-scan.service && exit 1
+while ! systemctl is-active --quiet zfs-import.target; do
+    systemctl is-failed --quiet zfs-import-cache.service zfs-import-scan.service && return 1
     sleep 0.1s
 done
 
-# run this after import as zfs-import-cache/scan service is confirmed good
-# we do not overwrite the ${root} variable, but create a new one, BOOTFS, to hold the dataset
-if [ "${root}" = "zfs:AUTO" ] ; then
-    BOOTFS="$(zpool list -H -o bootfs | awk '$1 != "-" {print; exit}')"
-else
-    BOOTFS="${root##zfs:}"
-    BOOTFS="${BOOTFS##ZFS=}"
+BOOTFS="$root"
+if [ "$BOOTFS" = "zfs:AUTO" ]; then
+    BOOTFS="$(zpool get -Ho value bootfs | grep -m1 -vFx -)"
 fi
 
 # if pool encryption is active and the zfs command understands '-o encryption'

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -22,36 +22,43 @@ fi
 
 [ "$(zpool get -Ho value feature@encryption "${BOOTFS%%/*}")" = 'active' ] || return 0
 
-ENCRYPTIONROOT="$(zfs get -Ho value encryptionroot "${BOOTFS}")"
-[ "${ENCRYPTIONROOT}" = "-" ] && return 0
+_load_key_cb() {
+    dataset="$1"
 
-[ "$(zfs get -Ho value keystatus "${ENCRYPTIONROOT}")" = "unavailable" ] || return 0
+    ENCRYPTIONROOT="$(zfs get -Ho value encryptionroot "${dataset}")"
+    [ "${ENCRYPTIONROOT}" = "-" ] && return 0
 
-KEYLOCATION="$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")"
-case "${KEYLOCATION%%://*}" in
-    prompt)
-        for _ in 1 2 3; do
-            systemd-ask-password --no-tty "Encrypted ZFS password for ${BOOTFS}" | zfs load-key "${ENCRYPTIONROOT}" && break
-        done
-        ;;
-    http*)
-        systemctl start network-online.target
-        zfs load-key "${ENCRYPTIONROOT}"
-        ;;
-    file)
-        KEYFILE="${KEYLOCATION#file://}"
-        [ -r "${KEYFILE}" ] || udevadm settle
-        [ -r "${KEYFILE}" ] || {
-            info "ZFS: Waiting for key ${KEYFILE} for ${ENCRYPTIONROOT}..."
-            for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-                sleep 0.5s
-                [ -r "${KEYFILE}" ] && break
+    [ "$(zfs get -Ho value keystatus "${ENCRYPTIONROOT}")" = "unavailable" ] || return 0
+
+    KEYLOCATION="$(zfs get -Ho value keylocation "${ENCRYPTIONROOT}")"
+    case "${KEYLOCATION%%://*}" in
+        prompt)
+            for _ in 1 2 3; do
+                systemd-ask-password --no-tty "Encrypted ZFS password for ${dataset}" | zfs load-key "${ENCRYPTIONROOT}" && break
             done
-        }
-        [ -r "${KEYFILE}" ] || warn "ZFS: Key ${KEYFILE} for ${ENCRYPTIONROOT} hasn't appeared. Trying anyway."
-        zfs load-key "${ENCRYPTIONROOT}"
-        ;;
-    *)
-        zfs load-key "${ENCRYPTIONROOT}"
-        ;;
-esac
+            ;;
+        http*)
+            systemctl start network-online.target
+            zfs load-key "${ENCRYPTIONROOT}"
+            ;;
+        file)
+            KEYFILE="${KEYLOCATION#file://}"
+            [ -r "${KEYFILE}" ] || udevadm settle
+            [ -r "${KEYFILE}" ] || {
+                info "ZFS: Waiting for key ${KEYFILE} for ${ENCRYPTIONROOT}..."
+                for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+                    sleep 0.5s
+                    [ -r "${KEYFILE}" ] && break
+                done
+            }
+            [ -r "${KEYFILE}" ] || warn "ZFS: Key ${KEYFILE} for ${ENCRYPTIONROOT} hasn't appeared. Trying anyway."
+            zfs load-key "${ENCRYPTIONROOT}"
+            ;;
+        *)
+            zfs load-key "${ENCRYPTIONROOT}"
+            ;;
+    esac
+}
+
+_load_key_cb "$BOOTFS"
+for_relevant_root_children "$BOOTFS" _load_key_cb

--- a/contrib/dracut/90zfs/zfs-needshutdown.sh.in
+++ b/contrib/dracut/90zfs/zfs-needshutdown.sh.in
@@ -2,7 +2,7 @@
 
 command -v getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-if zpool list 2>&1 | grep -q 'no pools available' ; then
+if [ -z "$(zpool get -Ho value name)" ]; then
     info "ZFS: No active pools, no need to export anything."
 else
     info "ZFS: There is an active pool, will export it."

--- a/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
@@ -1,14 +1,12 @@
 [Unit]
 Description=Rollback bootfs just before it is mounted
 Requisite=zfs-import.target
-After=zfs-import.target zfs-snapshot-bootfs.service
+After=zfs-import.target dracut-pre-mount.service zfs-snapshot-bootfs.service
 Before=dracut-mount.service
 DefaultDependencies=no
 ConditionKernelCommandLine=bootfs.rollback
 
 [Service]
-# ${BOOTFS} should have been set by zfs-env-bootfs.service
 Type=oneshot
-ExecStartPre=/bin/test -n ${BOOTFS}
-ExecStart=/bin/sh -c '. /lib/dracut-lib.sh; SNAPNAME="$(getarg bootfs.rollback)"; exec @sbindir@/zfs rollback -Rf "${BOOTFS}@${SNAPNAME:-%v}"'
+ExecStart=/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS" SNAPNAME="$(getarg bootfs.rollback)"; exec @sbindir@/zfs rollback -Rf "$root@${SNAPNAME:-%v}"'
 RemainAfterExit=yes

--- a/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in
@@ -1,14 +1,12 @@
 [Unit]
 Description=Snapshot bootfs just before it is mounted
 Requisite=zfs-import.target
-After=zfs-import.target
+After=zfs-import.target dracut-pre-mount.service
 Before=dracut-mount.service
 DefaultDependencies=no
 ConditionKernelCommandLine=bootfs.snapshot
 
 [Service]
-# ${BOOTFS} should have been set by zfs-env-bootfs.service
 Type=oneshot
-ExecStartPre=/bin/test -n ${BOOTFS}
-ExecStart=-/bin/sh -c '. /lib/dracut-lib.sh; SNAPNAME="$(getarg bootfs.snapshot)"; exec @sbindir@/zfs snapshot "${BOOTFS}@${SNAPNAME:-%v}"'
+ExecStart=/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS" SNAPNAME="$(getarg bootfs.snapshot)"; exec @sbindir@/zfs snapshot "$root@${SNAPNAME:-%v}"'
 RemainAfterExit=yes

--- a/contrib/dracut/README.md
+++ b/contrib/dracut/README.md
@@ -15,6 +15,8 @@ Encrypted datasets have keys loaded automatically or prompted for.
 
 If the root dataset contains children with `mountpoint=`s of `/etc`, `/bin`, `/lib*`, or `/usr`, they're mounted too.
 
+For complete documentation, see `dracut.zfs(7)`.
+
 ## cmdline
 1. `root=`                    | Root dataset is…                                         |
    ---------------------------|----------------------------------------------------------|

--- a/contrib/dracut/README.md
+++ b/contrib/dracut/README.md
@@ -16,18 +16,18 @@ Encrypted datasets have keys loaded automatically or prompted for.
 If the root dataset contains children with `mountpoint=`s of `/etc`, `/bin`, `/lib*`, or `/usr`, they're mounted too.
 
 ## cmdline
-1. `root=`            | Root dataset is…                                         | Pools imported |
-   -------------------|----------------------------------------------------------|----------------|
-   *(empty)*          | the first `bootfs=` after `zpool import -aN`             | all            |
-   `zfs:AUTO`         | *(as above, but overriding other autoselection methods)* | all            |
-   `ZFS=pool/dataset` | `pool/dataset`                                           | `pool`         |
-   `zfs:pool/dataset` | *(as above)*                                             | `pool`         |
+1. `root=`                    | Root dataset is…                                         |
+   ---------------------------|----------------------------------------------------------|
+   *(empty)*                  | the first `bootfs=` after `zpool import -aN`             |
+   `zfs:AUTO`, `zfs:`, `zfs`  | *(as above, but overriding other autoselection methods)* |
+   `ZFS=pool/dataset`         | `pool/dataset`                                           |
+   `zfs:pool/dataset`         | *(as above)*                                             |
 
    All `+`es are replaced with spaces (i.e. to boot from `root pool/data set`, pass `root=zfs:root+pool/data+set`).
 
    The dataset can be at any depth, including being the pool's root dataset (i.e. `root=zfs:pool`).
 
-   `rootfstype=zfs` is mostly equivalent to `root=zfs:AUTO`.
+   `rootfstype=zfs` is equivalent to `root=zfs:AUTO`, `rootfstype=zfs root=pool/dataset` is equivalent to `root=zfs:pool/dataset`.
 
 2. `spl_hostid`: passed to `zgenhostid -f`, useful to override the `/etc/hostid` file baked into the initrd.
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -15,6 +15,7 @@ dist_man_MANS = \
 	man4/spl.4 \
 	man4/zfs.4 \
 	\
+	man7/dracut.zfs.7 \
 	man7/zpool-features.7 \
 	man7/zfsconcepts.7 \
 	man7/zfsprops.7 \

--- a/man/man7/dracut.zfs.7
+++ b/man/man7/dracut.zfs.7
@@ -1,0 +1,278 @@
+.\" SPDX-License-Identifier: 0BSD
+.\"
+.Dd April 4, 2022
+.Dt DRACUT.ZFS 7
+.Os
+.
+.Sh NAME
+.Nm dracut.zfs
+.Nd overview of ZFS dracut hooks
+.
+.Sh SYNOPSIS
+.Bd -literal -compact
+                      parse-zfs.sh \(-> dracut-cmdline.service
+                          |                     \(da
+                          |                     …
+                          |                     \(da
+                          \e\(em\(em\(em\(em\(em\(em\(em\(em\(-> dracut-initqueue.service
+                                                |                      zfs-import-opts.sh
+   zfs-load-module.service                      \(da                          |       |
+     |                  |                sysinit.target                    \(da       |
+     \(da                  |                       |        zfs-import-scan.service   \(da
+zfs-import-scan.service \(da                       \(da           | zfs-import-cache.service
+     |   zfs-import-cache.service         basic.target      |     |
+     \e__________________|                       |           \(da     \(da
+                        \(da                       |     zfs-load-key.sh
+     zfs-env-bootfs.service                     |         |
+                        \(da                       \(da         \(da
+                 zfs-import.target \(-> dracut-pre-mount.service
+                        |          \(ua            |
+                        | dracut-zfs-generator  |
+                        |  ____________________/|
+                        |/                      \(da
+                        |                   sysroot.mount \(<-\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em dracut-zfs-generator
+                        |                       |                                        \(da   |
+                        |                       \(da            sysroot-{usr,etc,lib,&c.}.mount |
+                        |             initrd-root-fs.target \(<-\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em or                 \(da
+                        |                       |              zfs-nonroot-necessities.service
+                        |                       \(da                                 |
+                        \(da             dracut-mount.service                        |
+       zfs-snapshot-bootfs.service              |                                 |
+                        |                       \(da                                 |
+                        \(da                       …                                 |
+       zfs-rollback-bootfs.service              |                                 |
+                        |                       \(da                                 |
+                        |               sysroot-usr.mount \(<-\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em/
+                        |                       |
+                        |                       \(da
+                        |                initrd-fs.target
+                        \e______________________ |
+                                               \e|
+                                                \(da
+        export-zfs.sh                      initrd.target
+              |                                 |
+              \(da                                 \(da
+   dracut-shutdown.service                      …
+                                                |
+                                                \(da
+                 zfs-needshutdown.sh \(-> initrd-cleanup.service
+.Ed
+.Pp
+Compare
+.Xr dracut.bootup 7
+for the full flowchart.
+.
+.Sh DESCRIPTION
+Under dracut, booting with
+.No ZFS-on- Ns Pa /
+is facilitated by a number of hooks in the
+.Nm 90zfs
+module.
+.Pp
+Booting into a ZFS dataset requires
+.Sy mountpoint Ns = Ns Pa /
+to be set on the dataset containing the root filesystem (henceforth "the boot dataset") and at the very least either the
+.Sy bootfs
+property to be set to that dataset, or the
+.Sy root=
+kernel cmdline (or dracut drop-in) argument to specify it.
+.Pp
+All children of the boot dataset with
+.Sy canmount Ns = Ns Sy on
+with
+.Sy mountpoint Ns s
+matching
+.Pa /etc , /bin , /lib , /lib?? , /libx32 , No and Pa /usr
+globs are deemed essential and will be mounted as well.
+.Pp
+.Xr zfs-mount-generator 8
+is recommended for proper functioning of the system afterward (correct mount properties, remounting, &c.).
+.
+.Sh CMDLINE
+.Ss Standard
+.Bl -tag -compact -width ".Sy root=zfs:AUTO , root=zfs: , root=zfs , Op Sy root="
+.It Sy root=zfs:\& Ns Ar dataset , Sy root=ZFS= Ns Ar dataset
+Use
+.Ar dataset
+as the boot dataset.
+All pluses
+.Pq Sq +
+are replaced with spaces
+.Pq Sq \  .
+.
+.It Sy root=zfs:AUTO , root=zfs:\& , root=zfs , Op Sy root=
+After import, search for the first pool with the
+.Sy bootfs
+property set, use its value as-if specified as the
+.Ar dataset
+above.
+.
+.It Sy rootfstype=zfs root= Ns Ar dataset
+Equivalent to
+.Sy root=zfs:\& Ns Ar dataset .
+.
+.It Sy rootfstype=zfs Op Sy root=
+Equivalent to
+.Sy root=zfs:AUTO .
+.
+.It Sy rootflags= Ns Ar flags
+Mount the boot dataset with
+.Fl o Ar flags ;
+cf.\&
+.Sx Temporary Mount Point Properties
+in
+.Xr zfsprops 7 .
+These properties will not last, since all filesystems will be re-mounted from the real root.
+.
+.It Sy debug
+If specified,
+.Nm dracut-zfs-generator
+logs to the journal.
+.El
+.Pp
+Be careful about setting neither
+.Sy rootfstype=zfs
+nor
+.Sy root=zfs:\& Ns Ar dataset
+\(em other automatic boot selection methods, like
+.Nm systemd-gpt-auto-generator
+and
+.Nm systemd-fstab-generator
+might take precedent.
+.
+.Ss ZFS-specific
+.Bl -tag -compact -width ".Sy bootfs.snapshot Ns Op Sy = Ns Ar snapshot-name"
+.It Sy bootfs.snapshot Ns Op Sy = Ns Ar snapshot-name
+Execute
+.Nm zfs Cm snapshot Ar boot-dataset Ns Sy @ Ns Ar snapshot-name
+before pivoting to the real root.
+.Ar snapshot-name
+defaults to the current kernel release.
+.
+.It Sy bootfs.rollback Ns Op Sy = Ns Ar snapshot-name
+Execute
+.Nm zfs Cm snapshot Fl Rf Ar boot-dataset Ns Sy @ Ns Ar snapshot-name
+before pivoting to the real root.
+.Ar snapshot-name
+defaults to the current kernel release.
+.
+.It Sy spl_hostid= Ns Ar host-id
+Use
+.Xr zgenhostid 8
+to set the host ID to
+.Ar host-id ;
+otherwise,
+.Pa /etc/hostid
+inherited from the real root is used.
+.
+.It Sy zfs_force , zfs.force , zfsforce
+Appends
+.Fl f
+to all
+.Nm zpool Cm import
+invocations; primarily useful in conjunction with
+.Sy spl_hostid= ,
+or if no host ID was inherited.
+.El
+.
+.Sh FILES
+.Bl -tag -width 0
+.It Pa parse-zfs.sh Pq Sy cmdline
+Processes
+.Sy spl_hostid= .
+If
+.Sy root=
+matches a known pattern, above, provides
+.Pa /dev/root
+and delays the initqueue until
+.Xr zfs 4
+is loaded,
+.
+.It Pa zfs-import-opts.sh Pq Nm systemd No environment generator
+Turns
+.Sy zfs_force , zfs.force , No or Sy zfsforce
+into
+.Ev ZPOOL_IMPORT_OPTS Ns = Ns Fl f
+for
+.Pa zfs-import-scan.service
+or
+.Pa zfs-import-cache.service .
+.
+.It Pa zfs-load-key.sh Pq Sy pre-mount
+Loads encryption keys for the boot dataset and its essential descendants.
+.Bl -tag -compact -offset 4n -width ".Sy keylocation Ns = Ns Sy https:// Ns Ar URL , Sy keylocation Ns = Ns Sy http:// Ns Ar URL"
+.It Sy keylocation Ns = Ns Sy prompt
+Is prompted for via
+.Nm systemd-ask-password
+thrice.
+.
+.It Sy keylocation Ns = Ns Sy https:// Ns Ar URL , Sy keylocation Ns = Ns Sy http:// Ns Ar URL
+.Pa network-online.target
+is started before loading.
+.
+.It Sy keylocation Ns = Ns Sy file:// Ns Ar path
+If
+.Ar path
+doesn't exist,
+.Nm udevadm No is Cm settle Ns d .
+If it still doesn't, it's waited for for up to
+.Sy 10 Ns s .
+.El
+.
+.It Pa zfs-env-bootfs.service Pq Nm systemd No service
+After pool import, sets
+.Ev BOOTFS Ns =
+in the systemd environment to the first non-null
+.Sy bootfs
+value in iteration order.
+.
+.It Pa dracut-zfs-generator Pq Nm systemd No generator
+Generates
+.Pa sysroot.mount Pq using Sy rootflags= , No if any .
+If an explicit boot dataset was specified, also generates essential mountpoints
+.Pq Pa sysroot-etc.mount , sysroot-bin.mount , No &c.\& ,
+otherwise generates
+.Pa zfs-nonroot-necessities.service
+which mounts them explicitly after
+.Pa /sysroot
+using
+.Ev BOOTFS Ns = .
+.
+.It Pa zfs-snapshot-bootfs.service , zfs-rollback-bootfs.service Pq Nm systemd No services
+Consume
+.Sy bootfs.snapshot
+and
+.Sy bootfs.rollback
+as described in
+.Sx CMDLINE  .
+Use
+.Ev BOOTFS Ns =
+if no explicit boot dataset was specified.
+.
+.It Pa zfs-needshutdown.sh Pq Sy cleanup
+If any pools were imported, signals that shutdown hooks are required.
+.
+.It Pa export-zfs.sh Pq Sy shutdown
+Forcibly exports all pools.
+.
+.It Pa /etc/hostid , /etc/zfs/zpool.cache , /etc/zfs/vdev_id.conf Pq regular files
+Included verbatim, hostonly.
+.
+.It Pa mount-zfs.sh Pq Sy mount
+Does nothing on
+.Nm systemd
+systems
+.Pq if Pa dracut-zfs-generator No succeeded .
+Otherwise, loads encryption key for the boot dataset from the console or via plymouth.
+It may not work at all!
+.El
+.
+.Sh SEE ALSO
+.Xr dracut.bootup 7 ,
+.Xr zfsprops 7 ,
+.Xr zpoolprops 7 ,
+.Xr dracut-shutdown.service 8 ,
+.Xr systemd-fstab-generator 8 ,
+.Xr systemd-gpt-auto-generator 8 ,
+.Xr zfs-mount-generator 8 ,
+.Xr zgenhostid 8


### PR DESCRIPTION
### Motivation and Context
@behlendorf: as promised in https://github.com/openzfs/zfs/pull/13017#issuecomment-1036394027

### Description
Uh, well. In order to write documentation I had to actually test whether the magic half of dracut was depending on, well, worked. Turns out it didn't. Which, well, means it didn't. Which explains why it's consistently kinda nondescriptly ass and we keep (kept?) getting people whose basic setups were failing. It's honestly a miracle and an incredible accident this'd worked at all.

Also, the non-systemd path (`zfs-mount.sh`) needs either removing or fixing; I haven't the slightest how you'd adjust network key loading. I don't even know *if* it works because I don't have a system or even distribution I could test it with. Well, I'm not building Gentoo I guess?

### How Has This Been Tested?
Thoroughly. See commit messages. As far as the new manual goes, here's the dracut.bootup(7)-style flowchart:
![image](https://user-images.githubusercontent.com/6709544/161648153-fc442e3d-0d2e-43b4-8a2e-078507635f2c.png)
![image](https://user-images.githubusercontent.com/6709544/161648180-b5302c39-f9ce-4024-ae69-903767f2c11e.png)

And PDF: [job_1958-stdin___jaczleweli_PDF.pdf](https://github.com/openzfs/zfs/files/8414026/job_1958-stdin___jaczleweli_PDF.pdf) (I don't usually target postscript in ZFS manuals, but, well, this looks shockingly alright in landscape)

Closes #13291

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
