### PR TITLE
Make zfs_max_recordsize default to 16M

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1464,15 +1464,15 @@ feature uses to estimate incoming log blocks.
 .It Sy zfs_max_logsm_summary_length Ns = Ns Sy 10 Pq ulong
 Maximum number of rows allowed in the summary of the spacemap log.
 .
-.It Sy zfs_max_recordsize Ns = Ns Sy 1048576 Po 1MB Pc Pq int
+.It Sy zfs_max_recordsize Ns = Ns Sy 16777216 Po 16MB Pc Pq int
 We currently support block sizes from
 .Em 512B No to Em 16MB .
 The benefits of larger blocks, and thus larger I/O,
 need to be weighed against the cost of COWing a giant block to modify one byte.
 Additionally, very large blocks can have an impact on I/O latency,
 and also potentially on the memory allocator.
-Therefore, we do not allow the recordsize to be set larger than this tunable.
-Larger blocks can be created by changing it,
+Therefore, we formerly forbade creating blocks larger than 1M.
+Larger blocks could be created by changing it,
 and pools with larger blocks can always be imported and used,
 regardless of this setting.
 .

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -77,8 +77,15 @@
  * (former default: 1MB).  Larger blocks could be created by changing this
  * tunable, and pools with larger blocks could always be imported and used,
  * regardless of this setting.
+ *
+ * We do, however, still limit it by default to 1M on x86_32, because Linux's
+ * 3/1 memory split doesn't leave much room for 16M chunks.
  */
+#ifdef _ILP32
+int zfs_max_recordsize =  1 * 1024 * 1024;
+#else
 int zfs_max_recordsize = 16 * 1024 * 1024;
+#endif
 static int zfs_allow_redacted_dataset_mount = 0;
 
 #define	SWITCH64(x, y) \
@@ -4964,13 +4971,7 @@ dsl_dataset_oldest_snapshot(spa_t *spa, uint64_t head_ds, uint64_t min_txg,
 	return (0);
 }
 
-#if defined(_LP64)
-#define	RECORDSIZE_PERM ZMOD_RW
-#else
-/* Limited to 1M on 32-bit platforms due to lack of virtual address space */
-#define	RECORDSIZE_PERM ZMOD_RD
-#endif
-ZFS_MODULE_PARAM(zfs, zfs_, max_recordsize, INT, RECORDSIZE_PERM,
+ZFS_MODULE_PARAM(zfs, zfs_, max_recordsize, INT, ZMOD_RW,
 	"Max allowed record size");
 
 ZFS_MODULE_PARAM(zfs, zfs_, allow_redacted_dataset_mount, INT, ZMOD_RW,

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -73,12 +73,12 @@
  * The SPA supports block sizes up to 16MB.  However, very large blocks
  * can have an impact on i/o latency (e.g. tying up a spinning disk for
  * ~300ms), and also potentially on the memory allocator.  Therefore,
- * we do not allow the recordsize to be set larger than zfs_max_recordsize
- * (default 1MB).  Larger blocks can be created by changing this tunable,
- * and pools with larger blocks can always be imported and used, regardless
- * of this setting.
+ * we did not allow the recordsize to be set larger than zfs_max_recordsize
+ * (former default: 1MB).  Larger blocks could be created by changing this
+ * tunable, and pools with larger blocks could always be imported and used,
+ * regardless of this setting.
  */
-int zfs_max_recordsize = 1 * 1024 * 1024;
+int zfs_max_recordsize = 16 * 1024 * 1024;
 static int zfs_allow_redacted_dataset_mount = 0;
 
 #define	SWITCH64(x, y) \

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -166,15 +166,6 @@ zio_init(void)
 		cflags = (zio_exclude_metadata || size > zio_buf_debug_limit) ?
 		    KMC_NODEBUG : 0;
 
-#if defined(_ILP32) && defined(_KERNEL)
-		/*
-		 * Cache size limited to 1M on 32-bit platforms until ARC
-		 * buffers no longer require virtual address space.
-		 */
-		if (size > zfs_max_recordsize)
-			break;
-#endif
-
 		while (!ISP2(p2))
 			p2 &= p2 - 1;
 

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_011_neg.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_011_neg.ksh
@@ -35,7 +35,7 @@ log_must disk_setup
 log_must zpool create $TESTPOOL raidz $ZPOOL_DISKS special mirror \
 	$CLASS_DISK0 $CLASS_DISK1
 
-for value in 256 1025 2097152
+for value in 256 1025 33554432
 do
 	log_mustnot zfs set special_small_blocks=$value $TESTPOOL
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_008_neg.ksh
@@ -56,7 +56,7 @@ set -A args "ab" "-?" "-cV" "-Vc" "-c -V" "c" "V" "--c" "-e" "-s" \
     "-blah" "-cV 12k" "-s -cV 1P" "-sc" "-Vs 5g" "-o" "--o" "-O" "--O" \
     "-o QuOta=none" "-o quota=non" "-o quota=abcd" "-o quota=0" "-o quota=" \
     "-o ResErVaTi0n=none" "-o reserV=none" "-o reservation=abcd" "-o reserv=" \
-    "-o recorDSize=64k" "-o recordsize=2048K" "-o recordsize=2M" \
+    "-o recorDSize=64k" "-o recordsize=32768K" "-o recordsize=32M" \
     "-o recordsize=256" "-o recsize=" "-o recsize=zero" "-o recordsize=0" \
     "-o mountPoint=/tmp/tmpfile$$" "-o mountpoint=non0" "-o mountpoint=" \
     "-o mountpoint=LEGACY" "-o mounpoint=none" \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_001_neg.ksh
@@ -78,7 +78,7 @@ while (( i < ${#dataset[@]} )); do
 		(( j += 1 ))
 	done
 	# Additional recordsize
-	set_n_check_prop "2048K" "recordsize" "${dataset[i]}" false
+	set_n_check_prop "32768K" "recordsize" "${dataset[i]}" false
 	set_n_check_prop "128B" "recordsize" "${dataset[i]}" false
 	(( i += 1 ))
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_023_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_023_neg.ksh
@@ -52,7 +52,7 @@ log_onexit cleanup
 
 set -A args "QuOta=none" "quota=non" "quota=abcd" "quota=0" "quota=" \
     "ResErVaTi0n=none" "reserV=none" "reservation=abcd" "reserv=" \
-    "recorDSize=64k" "recordsize=2M" "recordsize=2048K" \
+    "recorDSize=64k" "recordsize=32M" "recordsize=32768K" \
     "recordsize=256" "recsize=" "recsize=zero" "recordsize=0" \
     "mountPoint=/tmp/tmpfile$$" "mountpoint=non0" "mountpoint=" \
     "mountpoint=LEGACY" "mounpoint=none" \


### PR DESCRIPTION
### Motivation and Context
In [#12830](https://github.com/openzfs/zfs/issues/12830#issuecomment-991391604), @behlendorf said he thought there was no reason to not change the default at this point, after I opened a bug about the default interacting poorly with cases of larger blocks.

It's April, that still hasn't changed, and I remembered it, so here we go.

(I'm open to suggestions for better things to do with the big block comment and description in `zfs(4)`, I just took a quick pass.)

### Description
s/1M/16M/

### How Has This Been Tested?
Passed `-r sanity`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
