### PR TITLE
-Wunused-but-set-variable post-increments found by new Clang trunk (number 3 will shock you!)

### DIFF
--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -137,10 +137,10 @@ zpool_clear_label(int fd)
 	struct stat64 statbuf;
 	int l;
 	vdev_label_t *label;
-	l2arc_dev_hdr_phys_t *l2dhdr;
+	l2arc_dev_hdr_phys_t *l2dhdr = NULL;
 	uint64_t size;
-	int labels_cleared = 0, header_cleared = 0;
-	boolean_t clear_l2arc_header = B_FALSE;
+	int labels_cleared = 0;
+	boolean_t clear_l2arc_header = B_FALSE, header_cleared = B_FALSE;
 
 	if (fstat64_blk(fd, &statbuf) == -1)
 		return (0);
@@ -210,18 +210,18 @@ zpool_clear_label(int fd)
 	}
 
 	/* Clear the L2ARC header. */
-	if (clear_l2arc_header) {
-		memset(l2dhdr, 0, sizeof (l2arc_dev_hdr_phys_t));
-		if (pwrite64(fd, l2dhdr, sizeof (l2arc_dev_hdr_phys_t),
-		    VDEV_LABEL_START_SIZE) == sizeof (l2arc_dev_hdr_phys_t)) {
-			header_cleared++;
-		}
-	}
+	if (clear_l2arc_header &&
+	    pwrite64(fd, l2dhdr, sizeof (l2arc_dev_hdr_phys_t),
+		VDEV_LABEL_START_SIZE) == sizeof (l2arc_dev_hdr_phys_t))
+			header_cleared = B_TRUE;
 
 	free(label);
 	free(l2dhdr);
 
 	if (labels_cleared == 0)
+		return (-1);
+
+	if (clear_l2arc_header && !header_cleared)
 		return (-1);
 
 	return (0);

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -138,8 +138,8 @@ zpool_clear_label(int fd)
 	int l;
 	vdev_label_t *label;
 	uint64_t size;
-	int labels_cleared = 0;
-	boolean_t clear_l2arc_header = B_FALSE, header_cleared = B_FALSE;
+	boolean_t labels_cleared = B_FALSE, clear_l2arc_header = B_FALSE,
+	    header_cleared = B_FALSE;
 
 	if (fstat64_blk(fd, &statbuf) == -1)
 		return (0);
@@ -198,9 +198,8 @@ zpool_clear_label(int fd)
 		size_t label_size = sizeof (vdev_label_t) - (2 * VDEV_PAD_SIZE);
 
 		if (pwrite64(fd, label, label_size, label_offset(size, l) +
-		    (2 * VDEV_PAD_SIZE)) == label_size) {
-			labels_cleared++;
-		}
+		    (2 * VDEV_PAD_SIZE)) == label_size)
+			labels_cleared = B_TRUE;
 	}
 
 	if (clear_l2arc_header) {
@@ -214,10 +213,7 @@ zpool_clear_label(int fd)
 
 	free(label);
 
-	if (labels_cleared == 0)
-		return (-1);
-
-	if (clear_l2arc_header && !header_cleared)
+	if (!labels_cleared || (clear_l2arc_header && !header_cleared))
 		return (-1);
 
 	return (0);

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -2251,7 +2251,6 @@ spa_vdev_remove_top_check(vdev_t *vd)
 	 * and not be raidz or draid.
 	 */
 	vdev_t *rvd = spa->spa_root_vdev;
-	int num_indirect = 0;
 	for (uint64_t id = 0; id < rvd->vdev_children; id++) {
 		vdev_t *cvd = rvd->vdev_child[id];
 
@@ -2267,8 +2266,6 @@ spa_vdev_remove_top_check(vdev_t *vd)
 		if (cvd->vdev_ashift != 0 &&
 		    cvd->vdev_alloc_bias == VDEV_BIAS_NONE)
 			ASSERT3U(cvd->vdev_ashift, ==, spa->spa_max_ashift);
-		if (cvd->vdev_ops == &vdev_indirect_ops)
-			num_indirect++;
 		if (!vdev_is_concrete(cvd))
 			continue;
 		if (vdev_get_nparity(cvd) != 0)

--- a/tests/zfs-tests/cmd/draid.c
+++ b/tests/zfs-tests/cmd/draid.c
@@ -1312,14 +1312,11 @@ static int
 draid_merge(int argc, char *argv[])
 {
 	char filename[MAXPATHLEN] = {0};
-	int c, error, total_merged = 0, verbose = 0;
+	int c, error, total_merged = 0;
 	nvlist_t *allcfgs;
 
-	while ((c = getopt(argc, argv, ":v")) != -1) {
+	while ((c = getopt(argc, argv, ":")) != -1) {
 		switch (c) {
-		case 'v':
-			verbose++;
-			break;
 		case ':':
 			(void) fprintf(stderr,
 			    "missing argument for '%c' option\n", optopt);


### PR DESCRIPTION
### Description
We provide no API for draid, it did nothing, and was undocumented.

`num_indirect` is a left-over from the original a1d477c24c; it's unused there as well.

`zpool_clear_label()` contains a bug-fix (since I assume *failing to clear the L2ARC label* should be an error) an optimisation, and a clean-up to match the bug-fix. The bug-fix is separate for backports.

### How Has This Been Tested?
Builds.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
