### PR TITLE
Add workaround for broken Linux pipes

### DIFF
--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -615,9 +615,10 @@ max_pipe_buffer(int infd)
 	 * And since the problem is in waking up the writer, there's nothing
 	 * we can do about it from here.
 	 *
-	 * So we add this workaround for people who get bitten.
+	 * So if people want to, they can set this, but they
+	 * may regret it...
 	 */
-	if (getenv("ZFS_NO_PIPE_MAX") != NULL)
+	if (getenv("ZFS_SET_PIPE_MAX") == NULL)
 		return (cur);
 	if (cur < max && fcntl(infd, F_SETPIPE_SZ, max) != -1)
 		cur = max;

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -725,6 +725,14 @@ to use
 to mount ZFS datasets.
 This option is provided for backwards compatibility with older ZFS versions.
 .El
+.Bl -tag -width "ZFS_SET_PIPE_MAX"
+.It Sy ZFS_SET_PIPE_MAX
+Tells
+.Nm zfs
+to set the maximum pipe size for sends/recieves.
+Disabled by default on Linux
+due to an unfixed deadlock in Linux's pipe size handling code.
+.El
 .
 .Sh INTERFACE STABILITY
 .Sy Committed .


### PR DESCRIPTION
### Motivation and Context
I couldn't stop hitting #13232 on my Pi 4 when I wanted to benchmark some things.

### Description
Adds an env variable, ZFS_NO_PIPE_MAX, which disables the problematic F_SETPIPE_SZ.

This should be documented somewhere, but I wasn't sure where - `zfs(8)`? `zfs-recv(8)`? `zpool(8)`?

### How Has This Been Tested?
WIthout this change, running dd [send stream] | zfs recv on my Pi 4 hangs at least once every 5 times, often more frequently; with this change and no env variable set, same thing; with it set, it hasn't hung in 1024 runs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
