### PR TITLE
zfs(8): add requirements towards fs names

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -245,7 +245,7 @@ option reverted to the received value if one exists.
 Displays space consumed by, and quotas on, each user, group, or project
 in the specified filesystem or snapshot.
 .It Xr zfs-project 8
-List, set, or clear project ID and/or inherit flag on the file(s) or directories.
+List, set, or clear project ID and/or inherit flag on the files or directories.
 .El
 .
 .Ss Mountpoints
@@ -282,7 +282,8 @@ Add or change an encryption key on the specified dataset.
 .It Xr zfs-load-key 8
 Load the key for the specified encrypted dataset, enabling access.
 .It Xr zfs-unload-key 8
-Unload a key for the specified dataset, removing the ability to access the dataset.
+Unload a key for the specified dataset,
+removing the ability to access the dataset.
 .El
 .
 .Ss Channel Programs
@@ -605,7 +606,7 @@ mount point permission is set to 755 by default, user
 will be unable to mount file systems under
 .Ar tank/cindys .
 Add an ACE similar to the following syntax to provide mount point access:
-.Dl # Cm chmod No A+user: Ns Ar cindys Ns :add_subdirectory:allow Ar /tank/cindys
+.Dl # Cm chmod No A+user : Ns Ar cindys Ns :add_subdirectory:allow Ar /tank/cindys
 .
 .Ss Example 18 : No Delegating Create Time Permissions on a ZFS Dataset
 The following example shows how to grant anyone in the group

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -57,13 +57,32 @@ The
 .Nm
 command configures ZFS datasets within a ZFS storage pool, as described in
 .Xr zpool 8 .
-A dataset is identified by a unique path within the ZFS namespace.
-For example:
-.Dl pool/{filesystem,volume,snapshot}
+A dataset is identified by a unique path within the ZFS namespace:
 .Pp
-where the maximum length of a dataset name is
-.Sy MAXNAMELEN Pq 256B
-and the maximum amount of nesting allowed in a path is 50 levels deep.
+.D1 Ar pool Ns Oo Sy / Ns Ar component Oc Ns Sy / Ns Ar component
+.Pp
+for example:
+.Pp
+.Dl rpool/var/log
+.Pp
+The maximum length of a dataset name is
+.Sy ZFS_MAX_DATASET_NAME_LEN No - 1
+ASCII characters (currently 255) satisfying
+.Sy [A-Za-z_.:/ -] .
+Additionally snapshots are allowed to contain a single
+.Sy @
+character, while bookmarks are allowed to contain a single
+.Sy #
+character.
+.Sy /
+is used as separator between components.
+The maximum amount of nesting allowed in a path is
+.Sy zfs_max_dataset_nesting
+levels deep.
+ZFS tunables
+.Pq Sy zfs_*
+are explained in
+.Xr zfs 4 .
 .Pp
 A dataset can be one of the following:
 .Bl -tag -offset Ds -width "file system"


### PR DESCRIPTION
### Motivation and Context
#13310

### Description
Provide explicit requirements towards file system naming convention
in OpenZFS man pages.

Mitigates #13310

### How Has This Been Tested?
$ man ./man/man8/zfs.8

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
