### PR TITLE
Fix `zpool history` sometimes fails without reporting any error

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4439,17 +4439,17 @@ int
 zpool_get_history(zpool_handle_t *zhp, nvlist_t **nvhisp, uint64_t *off,
     boolean_t *eof)
 {
+	libzfs_handle_t *hdl = zhp->zpool_hdl;
 	char *buf;
 	int buflen = 128 * 1024;
 	nvlist_t **records = NULL;
 	uint_t numrecords = 0;
-	int err, i;
+	int err = 0, i;
 	uint64_t start = *off;
 
-	buf = malloc(buflen);
-	if (buf == NULL)
-		return (ENOMEM);
-	/* process about 1MB a time */
+	buf = zfs_alloc(hdl, buflen);
+
+	/* process about 1MiB a time */
 	while (*off - start < 1024 * 1024) {
 		uint64_t bytes_read = buflen;
 		uint64_t leftover;
@@ -4464,8 +4464,12 @@ zpool_get_history(zpool_handle_t *zhp, nvlist_t **nvhisp, uint64_t *off,
 		}
 
 		if ((err = zpool_history_unpack(buf, bytes_read,
-		    &leftover, &records, &numrecords)) != 0)
+		    &leftover, &records, &numrecords)) != 0) {
+			zpool_standard_error_fmt(hdl, err,
+			    dgettext(TEXT_DOMAIN,
+			    "cannot get history for '%s'"), zhp->zpool_name);
 			break;
+		}
 		*off -= leftover;
 		if (leftover == bytes_read) {
 			/*
@@ -4474,9 +4478,7 @@ zpool_get_history(zpool_handle_t *zhp, nvlist_t **nvhisp, uint64_t *off,
 			 */
 			buflen *= 2;
 			free(buf);
-			buf = malloc(buflen);
-			if (buf == NULL)
-				return (ENOMEM);
+			buf = zfs_alloc(hdl, buflen);
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: WHR <msl0000023508@gmail.com>

### Motivation and Context
`zpool history` didn't report an error message when getting history failed due to nvlist decoding failed inside libzfs.

### Description
This is a simple fix for this issue.

### How Has This Been Tested?
Tested with a pool containing currently undecodable history records (due to #13322).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
