### PR TITLE
`zpool_history_unpack` didn't return correct errno on nvlist decoding failure

### DIFF
--- a/lib/libzutil/zutil_pool.c
+++ b/lib/libzutil/zutil_pool.c
@@ -120,8 +120,9 @@ zpool_history_unpack(char *buf, uint64_t bytes_read, uint64_t *leftover,
 			break;
 
 		/* unpack record */
-		if (nvlist_unpack(buf + sizeof (reclen), reclen, &nv, 0) != 0)
-			return (ENOMEM);
+		int err = nvlist_unpack(buf + sizeof (reclen), reclen, &nv, 0);
+		if (err != 0)
+			return (err);
 		bytes_read -= sizeof (reclen) + reclen;
 		buf += sizeof (reclen) + reclen;
 


### PR DESCRIPTION
Signed-off-by: WHR <msl0000023508@gmail.com>

### Motivation and Context
The `zpool_history_unpack` function (used by `zpool_get_history`) in libzfs has a small issue that didn't return the correct errno for nvlist decoding failure.

### Description
The following code in `zpool_history_unpack` assumes that failures from `nvlist_unpack` can only be `ENOMEM`:
```c
		/* unpack record */
		if (nvlist_unpack(buf + sizeof (reclen), reclen, &nv, 0) != 0)
			return (ENOMEM);
```
This is incorrect because nvlist decoding can fail from several different errors, such as #13322.

### How Has This Been Tested?
With this fix and fix from #13320 applied, the #13322 failure would be shown as:
```
# zpool history test-pool
History for 'test-pool':
cannot get history for pool 'test-pool': Operation not supported
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
