### PR TITLE
Document zfs inherit -S's interaction with noninheritable properties

### DIFF
--- a/etc/init.d/zfs-mount.in
+++ b/etc/init.d/zfs-mount.in
@@ -63,7 +63,7 @@ do_depend()
 # Mount all datasets/filesystems
 do_mount()
 {
-	local verbose overlay i mntpt
+	local verbose overlay
 
 	check_boolean "$VERBOSE_MOUNT" && verbose=v
 	check_boolean "$DO_OVERLAY_MOUNTS" && overlay=O
@@ -77,8 +77,6 @@ do_mount()
 # Unmount all filesystems
 do_unmount()
 {
-	local i var mntpt
-
 	# This shouldn't really be necessary, as long as one can get
 	# zfs-import to run sufficiently late in the shutdown/reboot process
 	# - after unmounting local filesystems. This is just here in case/if

--- a/man/man8/zfs-set.8
+++ b/man/man8/zfs-set.8
@@ -170,8 +170,9 @@ inherited.
 .It Fl r
 Recursively inherit the given property for all children.
 .It Fl S
-Revert the property to the received value if one exists; otherwise operate as
-if the
+Revert the property to the received value, if one exists;
+otherwise, for non-inheritable properties, to the default;
+otherwise, operate as if the
 .Fl S
 option was not specified.
 .El


### PR DESCRIPTION
### Motivation and Context
#11894

### Description
The only real difference with -S is 
```c
	zprop_source_t source = (received
	    ? ZPROP_SRC_NONE		/* revert to received value, if any */
	    : ZPROP_SRC_INHERITED);	/* explicitly inherit */
```
and
```c
	if (!received) {
		/*
		 * Only check this in the non-received case. We want to allow
		 * 'inherit -S' to revert non-inheritable properties like quota
		 * and reservation to the received or default values even though
		 * they are not considered inheritable.
		 */
		if (prop != ZPROP_INVAL && !zfs_prop_inheritable(prop))
			return (SET_ERROR(EINVAL));
	}
```

Transplant the consequences of that comment into the manual.

Also checkstyle for #12780 

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – Ci take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
