### PR TITLE
Corrected oversight in ZERO_RANGE behavior

### DIFF
--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -781,11 +781,13 @@ zpl_fallocate_common(struct inode *ip, int mode, loff_t offset, loff_t len)
 	if (mode & (test_mode)) {
 		flock64_t bf;
 
-		if (offset > olen)
-			goto out_unmark;
+		if (mode & FALLOC_FL_KEEP_SIZE) {
+			if (offset > olen)
+				goto out_unmark;
 
-		if (offset + len > olen)
-			len = olen - offset;
+			if (offset + len > olen)
+				len = olen - offset;
+		}
 		bf.l_type = F_WRLCK;
 		bf.l_whence = SEEK_SET;
 		bf.l_start = offset;

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -90,7 +90,7 @@ tests = ['events_001_pos', 'events_002_pos', 'zed_rc_filter', 'zed_fd_spill']
 tags = ['functional', 'events']
 
 [tests/functional/fallocate:Linux]
-tests = ['fallocate_prealloc']
+tests = ['fallocate_prealloc', 'fallocate_zero-range']
 tags = ['functional', 'fallocate']
 
 [tests/functional/fault:Linux]

--- a/tests/zfs-tests/cmd/file/file_write.c
+++ b/tests/zfs-tests/cmd/file/file_write.c
@@ -251,7 +251,7 @@ usage(char *prog)
 	    "\t[-s offset] [-c write_count] [-d data]\n\n"
 	    "Where [data] equal to zero causes chars "
 	    "0->%d to be repeated throughout, or [data]\n"
-	    "equal to 'R' for psudorandom data.\n",
+	    "equal to 'R' for pseudorandom data.\n",
 	    prog, DATA_RANGE);
 
 	exit(1);

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3604,6 +3604,22 @@ function punch_hole # offset length file
 	esac
 }
 
+function zero_range # offset length file
+{
+	typeset offset=$1
+	typeset length=$2
+	typeset file=$3
+
+	case "$UNAME" in
+	Linux)
+		fallocate --zero-range --offset $offset --length $length "$file"
+		;;
+	*)
+		false
+		;;
+	esac
+}
+
 #
 # Wait for the specified arcstat to reach non-zero quiescence.
 # If echo is 1 echo the value after reaching quiescence, otherwise

--- a/tests/zfs-tests/tests/functional/fallocate/Makefile.am
+++ b/tests/zfs-tests/tests/functional/fallocate/Makefile.am
@@ -3,4 +3,5 @@ dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
 	fallocate_prealloc.ksh \
-	fallocate_punch-hole.ksh
+	fallocate_punch-hole.ksh \
+	fallocate_zero-range.ksh

--- a/tests/zfs-tests/tests/functional/fallocate/setup.ksh
+++ b/tests/zfs-tests/tests/functional/fallocate/setup.ksh
@@ -26,4 +26,7 @@
 . $STF_SUITE/include/libtest.shlib
 
 DISK=${DISKS%% *}
-default_setup $DISK
+default_setup_noexit $DISK
+log_must zfs set compression=off $TESTPOOL
+log_pass
+


### PR DESCRIPTION
### Motivation and Context
It turns out, no, in fact, ZERO_RANGE and PUNCH_HOLE do
have differing semantics in some ways - in particular,
one requires KEEP_SIZE, and the other does not.

Also added a zero-range test to catch this, corrected a flaw
that made the punch-hole test succeed vacuously, and a typo
in file_write.

Fixes #13329

### Description
Added KEEP_SIZE handling conditional in the logic for `(ZERO_RANGE|PUNCH_HOLE)`, added a test for that, fixed both tests when I discovered the original was wrong (the hardcoded filename was incorrect, so `check_disk_size` was always comparing "" to the size value, but for whatever reason `ksh` swallows the error when it's only in the conditional and somehow the integer-based conditional check doesn't fire? I still don't understand why, just that it was the case, and switching over to string comparison yielded more predictable outcomes...)

(I did also rename `check_disk_size` after spending a little while going down a rabbit hole of thinking it was trying to check the size of the underlying vdev file...)

### How Has This Been Tested?
Well, it passes ZTS (though I notice the 18.04 runner seems confused and like it couldn't find the results file to process? Strange...), the bug reproduces (and my `zero-range` test) fails before this patch and not after.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
