### PR TITLE
Switch from gnu99 to gnu11

### DIFF
--- a/config/CppCheck.am
+++ b/config/CppCheck.am
@@ -4,7 +4,7 @@
 
 PHONY += cppcheck
 
-CPPCHECKFLAGS  = --std=c99 --quiet --max-configs=1 --error-exitcode=2
+CPPCHECKFLAGS  = --std=c11 --quiet --max-configs=1 --error-exitcode=2
 CPPCHECKFLAGS += --inline-suppr -U_KERNEL
 
 cppcheck:

--- a/config/Rules.am
+++ b/config/Rules.am
@@ -23,7 +23,7 @@ endif
 
 AM_LIBTOOLFLAGS = --silent
 
-AM_CFLAGS  = -std=gnu99 -Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wno-sign-compare -Wno-missing-field-initializers
+AM_CFLAGS  = -std=gnu11 -Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wno-sign-compare -Wno-missing-field-initializers
 AM_CFLAGS += -fno-strict-aliasing
 AM_CFLAGS += $(NO_OMIT_FRAME_POINTER)
 AM_CFLAGS += $(IMPLICIT_FALLTHROUGH)

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -16,7 +16,7 @@ ifneq ($(KERNELRELEASE),)
 
 obj-$(CONFIG_ZFS) := $(ZFS_MODULES)
 
-ZFS_MODULE_CFLAGS += -std=gnu99 -Wno-declaration-after-statement
+ZFS_MODULE_CFLAGS += -std=gnu11 -Wno-declaration-after-statement
 ZFS_MODULE_CFLAGS += -Wmissing-prototypes
 ZFS_MODULE_CFLAGS += @KERNEL_DEBUG_CFLAGS@  @NO_FORMAT_ZERO_LENGTH@
 

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -120,7 +120,7 @@ modules_uninstall-FreeBSD:
 modules_uninstall: modules_uninstall-@ac_system@
 
 cppcheck-Linux:
-	@CPPCHECK@ -j@CPU_COUNT@ --std=c99 --quiet --force --error-exitcode=2 \
+	@CPPCHECK@ -j@CPU_COUNT@ --std=c11 --quiet --force --error-exitcode=2 \
 		--inline-suppr \
 		--suppress=unmatchedSuppression \
 		--suppress=noValidConfiguration \


### PR DESCRIPTION
### Motivation and Context
To keep up with the times
https://www.phoronix.com/scan.php?page=news_item&px=Linux-Kernel-C89-To-C11

### Description
`--std=gnu99` -> `--std=gnu11`

### How Has This Been Tested?
$ make

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
