### PR TITLE
[2.1.5] Document zfs inherit -S's interaction with noninheritable properties

### DIFF
--- a/man/man8/zfs-set.8
+++ b/man/man8/zfs-set.8
@@ -170,8 +170,9 @@ inherited.
 .It Fl r
 Recursively inherit the given property for all children.
 .It Fl S
-Revert the property to the received value if one exists; otherwise operate as
-if the
+Revert the property to the received value, if one exists;
+otherwise, for non-inheritable properties, to the default;
+otherwise, operate as if the
 .Fl S
 option was not specified.
 .El


### PR DESCRIPTION
### Description
Auto-merged cherry-pick of #13335, Upstream-commit: trailer added.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
