### PR TITLE
man: fix ellipses, -X in zfs-send.8 part 2

### DIFF
--- a/man/man8/zfs-send.8
+++ b/man/man8/zfs-send.8
@@ -39,8 +39,8 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm send
-.Op Fl DLPRbcehnpsvw
-.Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
+.Op Fl DLPbcehnpsvw
+.Op Fl R Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
 .Op Oo Fl I Ns | Ns Fl i Oc Ar snapshot
 .Ar snapshot
 .Nm zfs
@@ -73,8 +73,8 @@
 .It Xo
 .Nm zfs
 .Cm send
-.Op Fl DLPRbcehnpvw
-.Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
+.Op Fl DLPbcehnpsvw
+.Op Fl R Op Fl X Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
 .Op Oo Fl I Ns | Ns Fl i Oc Ar snapshot
 .Ar snapshot
 .Xc
@@ -143,22 +143,15 @@ flag is used to send encrypted datasets, then
 .Fl w
 must also be specified.
 .It Fl X , -exclude Ar dataset Ns Oo , Ns Ar dataset Oc Ns …
-When the
-.Fl R
-flag is given,
+With
+.Fl R ,
 .Fl X
-can be used to specify a list of datasets to be excluded from the
-data stream.
-The
-.Fl X
-option can be used multiple times, or the list of datasets can be
-specified as a comma-separated list, or both.
-.Ar dataset
-must not be the pool's root dataset, and all descendant datasets of
-.Ar dataset
-will be excluded from the send stream.
-Requires
-.Fl R .
+specifies a set of datasets (and, hence, their descendants),
+to be excluded from the send stream.
+The root dataset may not be excluded.
+.Fl X Ar a Fl X Ar b
+is equivalent to
+.Fl X Ar a , Ns Ar b .
 .It Fl e , -embed
 Generate a more compact stream by using
 .Sy WRITE_EMBEDDED

--- a/tests/zfs-tests/tests/functional/cli_user/misc/zfs_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/zfs_001_neg.ksh
@@ -55,6 +55,6 @@ TEMPFILE="$TEST_BASE_DIR/zfs_001_neg.$$.txt"
 zfs > $TEMPFILE 2>&1
 log_must grep "usage: zfs command args" "$TEMPFILE"
 
-log_must awk '{if (length($0) > 80) exit 1}' $TEMPFILE
+log_must awk 'length($0) > 80 {print; ++err} END {exit err}' $TEMPFILE
 
 log_pass "zfs shows a usage message when run as a user"


### PR DESCRIPTION
### Motivation and Context
Also clean up/optimise the horrendously verbose -X handling in zfs_main()

### Description
Picked from #13255

### How Has This Been Tested?
Works as near as I can tell.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
