### PR TITLE
scripts: zfs.sh: unload zfs with rmmod

### DIFF
--- a/scripts/zfs.sh
+++ b/scripts/zfs.sh
@@ -18,7 +18,7 @@ STACK_TRACER="no"
 
 ZED_PIDFILE=${ZED_PIDFILE:-/var/run/zed.pid}
 LDMOD=${LDMOD:-/sbin/modprobe}
-DELMOD=${DELMOD:-/sbin/modprobe -r}
+DELMOD=${DELMOD:-/sbin/rmmod}
 
 KMOD_ZLIB_DEFLATE=${KMOD_ZLIB_DEFLATE:-zlib_deflate}
 KMOD_ZLIB_INFLATE=${KMOD_ZLIB_INFLATE:-zlib_inflate}
@@ -162,9 +162,11 @@ unload_modules_freebsd() {
 }
 
 unload_modules_linux() {
-	NAME="${KMOD_ZFS##*/}"
-	NAME="${NAME%.ko}"
-	$DELMOD "$NAME" || return
+	for KMOD in $KMOD_ZFS $KMOD_SPL; do
+		NAME="${KMOD##*/}"
+		NAME="${NAME%.ko}"
+		$DELMOD "$NAME" || return
+	done
 
 	if [ "$VERBOSE" = "yes" ]; then
 		echo "Successfully unloaded ZFS module stack"


### PR DESCRIPTION
### Motivation and Context

The `zfs.sh` script can no longer be used to remove the kmods
when they are not installed on the system. 

```
$ sudo ./scripts/zfs.sh -u
modprobe: FATAL: Module zfs not found.

$ sudo modprobe -r zfs
modprobe: FATAL: Module zfs not found.
```

cc: @nabijaczleweli 

### Description

Use `rmmod` instead of `modprobe -r` in the zfs.sh script to unload
the kmods.  While `modprobe -r` is nicer, it can only be used when
the kmods are installed on the system, if they're not the following
error will always be returned.

    sudo modprobe -r zfs
    modprobe: FATAL: Module zfs not found.

This reverts the switch to modprobe from commit 469b8481.

### How Has This Been Tested?

Locally by building the source then loading and then unloading the
in-tree kmods.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
