### PR TITLE
scripts: zfs.sh: explicitly ignore unloaded modules, explicitly unload all modules via rmmod

### DIFF
--- a/scripts/zfs.sh
+++ b/scripts/zfs.sh
@@ -18,7 +18,7 @@ STACK_TRACER="no"
 
 ZED_PIDFILE=${ZED_PIDFILE:-/var/run/zed.pid}
 LDMOD=${LDMOD:-/sbin/modprobe}
-DELMOD=${DELMOD:-/sbin/modprobe -r}
+DELMOD=${DELMOD:-/sbin/rmmod}
 
 KMOD_ZLIB_DEFLATE=${KMOD_ZLIB_DEFLATE:-zlib_deflate}
 KMOD_ZLIB_INFLATE=${KMOD_ZLIB_INFLATE:-zlib_inflate}
@@ -162,9 +162,12 @@ unload_modules_freebsd() {
 }
 
 unload_modules_linux() {
-	NAME="${KMOD_ZFS##*/}"
-	NAME="${NAME%.ko}"
-	! [ -d "/sys/module/$NAME" ] || $DELMOD "$NAME" || return
+	legacy_kmods="icp zzstd zlua zcommon zunicode znvpair zavl"
+	for KMOD in "$KMOD_ZFS" $legacy_kmods "$KMOD_SPL"; do
+		NAME="${KMOD##*/}"
+		NAME="${NAME%.ko}"
+		! [ -d "/sys/module/$NAME" ] || $DELMOD "$NAME" || return
+	done
 
 	if [ "$VERBOSE" = "yes" ]; then
 		echo "Successfully unloaded ZFS module stack"

--- a/scripts/zfs.sh
+++ b/scripts/zfs.sh
@@ -164,7 +164,7 @@ unload_modules_freebsd() {
 unload_modules_linux() {
 	NAME="${KMOD_ZFS##*/}"
 	NAME="${NAME%.ko}"
-	$DELMOD "$NAME" || return
+	! [ -d "/sys/module/$NAME" ] || $DELMOD "$NAME" || return
 
 	if [ "$VERBOSE" = "yes" ]; then
 		echo "Successfully unloaded ZFS module stack"


### PR DESCRIPTION
### Description
See individual messages; supersedes #13353

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
