### PR TITLE
Dracut fixes + manual for 2.1.5

### DIFF
--- a/contrib/dracut/90zfs/export-zfs.sh.in
+++ b/contrib/dracut/90zfs/export-zfs.sh.in
@@ -1,14 +1,12 @@
 #!/bin/sh
 
-. /lib/dracut-zfs-lib.sh
-
 _do_zpool_export() {
 	ret=0
 	errs=""
 	final="${1}"
 
 	info "ZFS: Exporting ZFS storage pools..."
-	errs=$(export_all -F 2>&1)
+	errs=$(zpool export -aF 2>&1)
 	ret=$?
 	[ -z "${errs}" ] || echo "${errs}" | vwarn
 	if [ "x${ret}" != "x0" ]; then

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -44,7 +44,7 @@ if [ "${root}" = "zfs:AUTO" ] ; then
 		zpool import -N -a ${ZPOOL_IMPORT_OPTS}
 		if ! ZFS_DATASET="$(find_bootfs)" ; then
 			warn "ZFS: No bootfs attribute found in importable pools."
-			export_all -F
+			zpool export -aF
 
 			rootok=0
 			return 1

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -20,6 +20,42 @@ fi
 info "ZFS: No sysroot.mount exists or zfs-generator did not extend it."
 info "ZFS: Mounting root with the traditional mount-zfs.sh instead."
 
+# ask_for_password tries prompt cmd
+#
+# Wraps around plymouth ask-for-password and adds fallback to tty password ask
+# if plymouth is not present.
+ask_for_password() {
+    tries="$1"
+    prompt="$2"
+    cmd="$3"
+
+    {
+        flock -s 9
+
+        # Prompt for password with plymouth, if installed and running.
+        if plymouth --ping 2>/dev/null; then
+            plymouth ask-for-password \
+                --prompt "$prompt" --number-of-tries="$tries" | \
+                eval "$cmd"
+            ret=$?
+        else
+            i=1
+            while [ "$i" -le "$tries" ]; do
+                printf "%s [%i/%i]:" "$prompt" "$i" "$tries" >&2
+                eval "$cmd" && ret=0 && break
+                ret=$?
+                i=$((i+1))
+                printf '\n' >&2
+            done
+            unset i
+        fi
+    } 9>/.console_lock
+
+    [ "$ret" -ne 0 ] && echo "Wrong password" >&2
+    return "$ret"
+}
+
+
 # Delay until all required block devices are present.
 modprobe zfs 2>/dev/null
 udevadm settle
@@ -45,31 +81,39 @@ fi
 ZFS_DATASET="${ZFS_DATASET:-${root}}"
 ZFS_POOL="${ZFS_DATASET%%/*}"
 
-if import_pool "${ZFS_POOL}" ; then
-	# Load keys if we can or if we need to
-	if [ "$(zpool list -H -o feature@encryption "${ZFS_POOL}")" = 'active' ]; then
-		# if the root dataset has encryption enabled
-		ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${ZFS_DATASET}")"
-		if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
-			KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
-			# if the key needs to be loaded
-			if [ "$KEYSTATUS" = "unavailable" ]; then
-				# decrypt them
-				ask_for_password \
-					5 \
-					"Encrypted ZFS password for ${ENCRYPTIONROOT}: " \
-					"zfs load-key '${ENCRYPTIONROOT}'"
-			fi
+
+if ! zpool get -Ho name "${ZFS_POOL}" > /dev/null 2>&1; then
+    info "ZFS: Importing pool ${ZFS_POOL}..."
+    # shellcheck disable=SC2086
+    if ! zpool import -N ${ZPOOL_IMPORT_OPTS} "${ZFS_POOL}"; then
+        warn "ZFS: Unable to import pool ${ZFS_POOL}"
+        rootok=0
+        return 1
+    fi
+fi
+
+# Load keys if we can or if we need to
+if [ "$(zpool get -Ho value feature@encryption "${ZFS_POOL}")" = 'active' ]; then
+	# if the root dataset has encryption enabled
+	ENCRYPTIONROOT="$(zfs get -Ho value encryptionroot "${ZFS_DATASET}")"
+	if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
+		KEYSTATUS="$(zfs get -Ho value keystatus "${ENCRYPTIONROOT}")"
+		# if the key needs to be loaded
+		if [ "$KEYSTATUS" = "unavailable" ]; then
+			# decrypt them
+			ask_for_password \
+				5 \
+				"Encrypted ZFS password for ${ENCRYPTIONROOT}: " \
+				"zfs load-key '${ENCRYPTIONROOT}'"
 		fi
-	fi
-	# Let us tell the initrd to run on shutdown.
-	# We have a shutdown hook to run
-	# because we imported the pool.
-	info "ZFS: Mounting dataset ${ZFS_DATASET}..."
-	if mount_dataset "${ZFS_DATASET}" ; then
-		ROOTFS_MOUNTED=yes
-		return 0
 	fi
 fi
 
-rootok=0
+# Let us tell the initrd to run on shutdown.
+# We have a shutdown hook to run
+# because we imported the pool.
+info "ZFS: Mounting dataset ${ZFS_DATASET}..."
+if ! mount_dataset "${ZFS_DATASET}"; then
+  rootok=0
+  return 1
+fi

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -3,40 +3,29 @@
 
 . /lib/dracut-zfs-lib.sh
 
-ZFS_DATASET=""
-ZFS_POOL=""
-
-case "${root}" in
-	zfs:*) ;;
-	*) return ;;
-esac
+decode_root_args || return 0
 
 GENERATOR_FILE=/run/systemd/generator/sysroot.mount
 GENERATOR_EXTENSION=/run/systemd/generator/sysroot.mount.d/zfs-enhancement.conf
 
-if [ -e "$GENERATOR_FILE" ] && [ -e "$GENERATOR_EXTENSION" ] ; then
-	# If the ZFS sysroot.mount flag exists, the initial RAM disk configured
-	# it to mount ZFS on root.  In that case, we bail early.  This flag
-	# file gets created by the zfs-generator program upon successful run.
-	info "ZFS: There is a sysroot.mount and zfs-generator has extended it."
-	info "ZFS: Delegating root mount to sysroot.mount."
-	# Let us tell the initrd to run on shutdown.
-	# We have a shutdown hook to run
-	# because we imported the pool.
+if [ -e "$GENERATOR_FILE" ] && [ -e "$GENERATOR_EXTENSION" ]; then
+	# We're under systemd and dracut-zfs-generator ran to completion.
+	info "ZFS: Delegating root mount to sysroot.mount at al."
+
 	# We now prevent Dracut from running this thing again.
-	for zfsmounthook in "$hookdir"/mount/*zfs* ; do
-		if [ -f "$zfsmounthook" ] ; then
-			rm -f "$zfsmounthook"
-		fi
-	done
+	rm -f "$hookdir"/mount/*zfs*
 	return
 fi
+
 info "ZFS: No sysroot.mount exists or zfs-generator did not extend it."
 info "ZFS: Mounting root with the traditional mount-zfs.sh instead."
 
 # Delay until all required block devices are present.
 modprobe zfs 2>/dev/null
 udevadm settle
+
+ZFS_DATASET=
+ZFS_POOL=
 
 if [ "${root}" = "zfs:AUTO" ] ; then
 	if ! ZFS_DATASET="$(find_bootfs)" ; then
@@ -53,7 +42,7 @@ if [ "${root}" = "zfs:AUTO" ] ; then
 	info "ZFS: Using ${ZFS_DATASET} as root."
 fi
 
-ZFS_DATASET="${ZFS_DATASET:-${root#zfs:}}"
+ZFS_DATASET="${ZFS_DATASET:-${root}}"
 ZFS_POOL="${ZFS_DATASET%%/*}"
 
 if import_pool "${ZFS_POOL}" ; then

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -28,10 +28,10 @@ ZFS_DATASET=
 ZFS_POOL=
 
 if [ "${root}" = "zfs:AUTO" ] ; then
-	if ! ZFS_DATASET="$(find_bootfs)" ; then
+	if ! ZFS_DATASET="$(zpool get -Ho value bootfs | grep -m1 -vFx -)"; then
 		# shellcheck disable=SC2086
 		zpool import -N -a ${ZPOOL_IMPORT_OPTS}
-		if ! ZFS_DATASET="$(find_bootfs)" ; then
+		if ! ZFS_DATASET="$(zpool get -Ho value bootfs | grep -m1 -vFx -)"; then
 			warn "ZFS: No bootfs attribute found in importable pools."
 			zpool export -aF
 

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -93,6 +93,7 @@ if ! zpool get -Ho name "${ZFS_POOL}" > /dev/null 2>&1; then
 fi
 
 # Load keys if we can or if we need to
+# TODO: for_relevant_root_children like in zfs-load-key.sh.in
 if [ "$(zpool get -Ho value feature@encryption "${ZFS_POOL}")" = 'active' ]; then
 	# if the root dataset has encryption enabled
 	ENCRYPTIONROOT="$(zfs get -Ho value encryptionroot "${ZFS_DATASET}")"

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -56,9 +56,9 @@ if import_pool "${ZFS_POOL}" ; then
 			if [ "$KEYSTATUS" = "unavailable" ]; then
 				# decrypt them
 				ask_for_password \
-					--tries 5 \
-					--prompt "Encrypted ZFS password for ${ENCRYPTIONROOT}: " \
-					--cmd "zfs load-key '${ENCRYPTIONROOT}'"
+					5 \
+					"Encrypted ZFS password for ${ENCRYPTIONROOT}: " \
+					"zfs load-key '${ENCRYPTIONROOT}'"
 			fi
 		fi
 	fi

--- a/contrib/dracut/90zfs/parse-zfs.sh.in
+++ b/contrib/dracut/90zfs/parse-zfs.sh.in
@@ -29,18 +29,15 @@ case "${root}" in
 		info "ZFS: Enabling autodetection of bootfs after udev settles."
 		;;
 
-	ZFS=*|zfs:*|FILESYSTEM=*)
+	ZFS=*|zfs:*)
 		# root is explicit ZFS root.  Parse it now.  We can handle
 		# a root=... param in any of the following formats:
 		# root=ZFS=rpool/ROOT
 		# root=zfs:rpool/ROOT
-		# root=zfs:FILESYSTEM=rpool/ROOT
-		# root=FILESYSTEM=rpool/ROOT
 		# root=ZFS=pool+with+space/ROOT+WITH+SPACE (translates to root=ZFS=pool with space/ROOT WITH SPACE)
 
 		# Strip down to just the pool/fs
 		root="${root#zfs:}"
-		root="${root#FILESYSTEM=}"
 		root="zfs:${root#ZFS=}"
 		# switch + with spaces because kernel cmdline does not allow us to quote parameters
 		root=$(echo "$root" | tr '+' ' ')

--- a/contrib/dracut/90zfs/parse-zfs.sh.in
+++ b/contrib/dracut/90zfs/parse-zfs.sh.in
@@ -56,8 +56,5 @@ esac
 if [ ${wait_for_zfs} -eq 1 ]; then
 	ln -s /dev/null /dev/root 2>/dev/null
 	initqueuedir="${hookdir}/initqueue/finished"
-	test -d "${initqueuedir}" || {
-		initqueuedir="${hookdir}/initqueue-finished"
-	}
 	echo '[ -e /dev/zfs ]' > "${initqueuedir}/zfs.sh"
 fi

--- a/contrib/dracut/90zfs/parse-zfs.sh.in
+++ b/contrib/dracut/90zfs/parse-zfs.sh.in
@@ -1,7 +1,8 @@
 #!/bin/sh
 # shellcheck disable=SC2034,SC2154
 
-. /lib/dracut-lib.sh
+# shellcheck source=zfs-lib.sh.in
+. /lib/dracut-zfs-lib.sh
 
 # Let the command line override our host id.
 spl_hostid=$(getarg spl_hostid=)
@@ -15,43 +16,20 @@ else
 	warn "ZFS: Pools may not import correctly."
 fi
 
-wait_for_zfs=0
-case "${root}" in
-	""|zfs|zfs:)
-		# We'll take root unset, root=zfs, or root=zfs:
-		# No root set, so we want to read the bootfs attribute.  We
-		# can't do that until udev settles so we'll set dummy values
-		# and hope for the best later on.
-		root="zfs:AUTO"
-		rootok=1
-		wait_for_zfs=1
+if decode_root_args; then
+	if [ "$root" = "zfs:AUTO" ]; then
+		info "ZFS: Boot dataset autodetected from bootfs=."
+	else
+		info "ZFS: Boot dataset is ${root}."
+	fi
 
-		info "ZFS: Enabling autodetection of bootfs after udev settles."
-		;;
-
-	ZFS=*|zfs:*)
-		# root is explicit ZFS root.  Parse it now.  We can handle
-		# a root=... param in any of the following formats:
-		# root=ZFS=rpool/ROOT
-		# root=zfs:rpool/ROOT
-		# root=ZFS=pool+with+space/ROOT+WITH+SPACE (translates to root=ZFS=pool with space/ROOT WITH SPACE)
-
-		# Strip down to just the pool/fs
-		root="${root#zfs:}"
-		root="zfs:${root#ZFS=}"
-		# switch + with spaces because kernel cmdline does not allow us to quote parameters
-		root=$(echo "$root" | tr '+' ' ')
-		rootok=1
-		wait_for_zfs=1
-
-		info "ZFS: Set ${root} as bootfs."
-		;;
-esac
-
-# Make sure Dracut is happy that we have a root and will wait for ZFS
-# modules to settle before mounting.
-if [ ${wait_for_zfs} -eq 1 ]; then
-	ln -s /dev/null /dev/root 2>/dev/null
-	initqueuedir="${hookdir}/initqueue/finished"
-	echo '[ -e /dev/zfs ]' > "${initqueuedir}/zfs.sh"
+	rootok=1
+	# Make sure Dracut is happy that we have a root and will wait for ZFS
+	# modules to settle before mounting.
+	if [ -n "${wait_for_zfs}" ]; then
+		ln -s null /dev/root
+		echo '[ -e /dev/zfs ]' > "${hookdir}/initqueue/finished/zfs.sh"
+	fi
+else
+	info "ZFS: no ZFS-on-root."
 fi

--- a/contrib/dracut/90zfs/zfs-env-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-env-bootfs.service.in
@@ -8,7 +8,7 @@ Before=zfs-import.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "exec systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | grep -m1 -v '^-$')"
+ExecStart=/bin/sh -c "exec systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | grep -m1 -vFx -)"
 
 [Install]
 WantedBy=zfs-import.target

--- a/contrib/dracut/90zfs/zfs-generator.sh.in
+++ b/contrib/dracut/90zfs/zfs-generator.sh.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC2016,SC1004
+# shellcheck disable=SC2016,SC1004,SC2154
 
 grep -wq debug /proc/cmdline && debug=1
 [ -n "$debug" ] && echo "zfs-generator: starting" >> /dev/kmsg
@@ -10,36 +10,16 @@ GENERATOR_DIR="$1"
     exit 1
 }
 
-[ -f /lib/dracut-lib.sh ] && dracutlib=/lib/dracut-lib.sh
-[ -f /usr/lib/dracut/modules.d/99base/dracut-lib.sh ] && dracutlib=/usr/lib/dracut/modules.d/99base/dracut-lib.sh
-command -v getarg >/dev/null 2>&1 || {
-    [ -n "$debug" ] && echo "zfs-generator: loading Dracut library from $dracutlib" >> /dev/kmsg
-    . "$dracutlib"
-}
-
+# shellcheck source=zfs-lib.sh.in
 . /lib/dracut-zfs-lib.sh
+decode_root_args || exit 0
 
-[ -z "$root" ]       && root=$(getarg root=)
-[ -z "$rootfstype" ] && rootfstype=$(getarg rootfstype=)
-[ -z "$rootflags" ]  && rootflags=$(getarg rootflags=)
-
-# If root is not ZFS= or zfs: or rootfstype is not zfs
-# then we are not supposed to handle it.
-[ "${root##zfs:}" = "${root}" ] &&
-	[ "${root##ZFS=}" = "${root}" ] &&
-	[ "$rootfstype" != "zfs" ] &&
-	exit 0
-
+[ -z "${rootflags}" ] && rootflags=$(getarg rootflags=)
 case ",${rootflags}," in
 	*,zfsutil,*) ;;
 	,,)	rootflags=zfsutil ;;
 	*)	rootflags="zfsutil,${rootflags}" ;;
 esac
-
-if [ "${root}" != "zfs:AUTO" ]; then
-  root="${root##zfs:}"
-  root="${root##ZFS=}"
-fi
 
 [ -n "$debug" ] && echo "zfs-generator: writing extension for sysroot.mount to $GENERATOR_DIR/sysroot.mount.d/zfs-enhancement.conf" >> /dev/kmsg
 
@@ -89,7 +69,7 @@ else
   _zfs_generator_cb() {
       dset="${1}"
       mpnt="${2}"
-      unit="sysroot$(echo "$mpnt" | tr '/' '-').mount"
+      unit="$(systemd-escape --suffix=mount -p "/sysroot${mpnt}")"
 
       {
           echo "[Unit]"

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -2,20 +2,6 @@
 # shellcheck disable=SC2034
 
 command -v getarg >/dev/null || . /lib/dracut-lib.sh || . /usr/lib/dracut/modules.d/99base/dracut-lib.sh
-command -v getargbool >/dev/null || {
-    # Compatibility with older Dracut versions.
-    # With apologies to the Dracut developers.
-    getargbool() {
-        _default="$1"; shift
-        ! _b=$(getarg "$@") && [ -z "$_b" ] && _b="$_default"
-        if [ -n "$_b" ]; then
-            [ "$_b" = "0" ] && return 1
-            [ "$_b" = "no" ] && return 1
-            [ "$_b" = "off" ] && return 1
-        fi
-        return 0
-    }
-}
 
 TAB="	"
 

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -27,31 +27,6 @@ if getargbool 0 zfs_force -y zfs.force -y zfsforce ; then
     ZPOOL_IMPORT_OPTS="${ZPOOL_IMPORT_OPTS} -f"
 fi
 
-# find_bootfs
-#   returns the first dataset with the bootfs attribute.
-find_bootfs() {
-    IFS="${NEWLINE}"
-    for dataset in $(zpool list -H -o bootfs); do
-        case "${dataset}" in
-            "" | "-")
-                continue
-                ;;
-            "no pools available")
-                IFS="${OLDIFS}"
-                return 1
-                ;;
-            *)
-                IFS="${OLDIFS}"
-                echo "${dataset}"
-                return 0
-                ;;
-        esac
-    done
-
-    IFS="${OLDIFS}"
-    return 1
-}
-
 # import_pool POOL
 #   imports the given zfs pool if it isn't imported already.
 import_pool() {

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -121,43 +121,14 @@ for_relevant_root_children() {
         )
 }
 
-# ask_for_password
+# ask_for_password tries prompt cmd
 #
 # Wraps around plymouth ask-for-password and adds fallback to tty password ask
 # if plymouth is not present.
-#
-# --cmd command
-#   Command to execute. Required.
-# --prompt prompt
-#   Password prompt. Note that function already adds ':' at the end.
-#   Recommended.
-# --tries n
-#   How many times repeat command on its failure.  Default is 3.
-# --ply-[cmd|prompt|tries]
-#   Command/prompt/tries specific for plymouth password ask only.
-# --tty-[cmd|prompt|tries]
-#   Command/prompt/tries specific for tty password ask only.
-# --tty-echo-off
-#   Turn off input echo before tty command is executed and turn on after.
-#   It's useful when password is read from stdin.
 ask_for_password() {
-    ply_tries=3
-    tty_tries=3
-    while [ "$#" -gt 0 ]; do
-        case "$1" in
-            --cmd) ply_cmd="$2"; tty_cmd="$2"; shift;;
-            --ply-cmd) ply_cmd="$2"; shift;;
-            --tty-cmd) tty_cmd="$2"; shift;;
-            --prompt) ply_prompt="$2"; tty_prompt="$2"; shift;;
-            --ply-prompt) ply_prompt="$2"; shift;;
-            --tty-prompt) tty_prompt="$2"; shift;;
-            --tries) ply_tries="$2"; tty_tries="$2"; shift;;
-            --ply-tries) ply_tries="$2"; shift;;
-            --tty-tries) tty_tries="$2"; shift;;
-            --tty-echo-off) tty_echo_off=yes;;
-        esac
-        shift
-    done
+    tries="$1"
+    prompt="$2"
+    cmd="$3"
 
     {
         flock -s 9
@@ -165,26 +136,19 @@ ask_for_password() {
         # Prompt for password with plymouth, if installed and running.
         if plymouth --ping 2>/dev/null; then
             plymouth ask-for-password \
-                --prompt "$ply_prompt" --number-of-tries="$ply_tries" | \
-                eval "$ply_cmd"
+                --prompt "$prompt" --number-of-tries="$tries" | \
+                eval "$cmd"
             ret=$?
         else
-            if [ "$tty_echo_off" = yes ]; then
-                stty_orig="$(stty -g)"
-                stty -echo
-            fi
-
             i=1
-            while [ "$i" -le "$tty_tries" ]; do
-                [ -n "$tty_prompt" ] && \
-                    printf "%s [%i/%i]:" "$tty_prompt" "$i" "$tty_tries" >&2
-                eval "$tty_cmd" && ret=0 && break
+            while [ "$i" -le "$tries" ]; do
+                printf "%s [%i/%i]:" "$prompt" "$i" "$tries" >&2
+                eval "$cmd" && ret=0 && break
                 ret=$?
                 i=$((i+1))
-                [ -n "$tty_prompt" ] && printf '\n' >&2
+                printf '\n' >&2
             done
             unset i
-            [ "$tty_echo_off" = yes ] && stty "$stty_orig"
         fi
     } 9>/.console_lock
 

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2034
 
 command -v getarg >/dev/null || . /lib/dracut-lib.sh || . /usr/lib/dracut/modules.d/99base/dracut-lib.sh
 command -v getargbool >/dev/null || {
@@ -16,33 +17,13 @@ command -v getargbool >/dev/null || {
     }
 }
 
-OLDIFS="${IFS}"
-NEWLINE="
-"
 TAB="	"
 
-ZPOOL_IMPORT_OPTS=""
-if getargbool 0 zfs_force -y zfs.force -y zfsforce ; then
+ZPOOL_IMPORT_OPTS=
+if getargbool 0 zfs_force -y zfs.force -y zfsforce; then
     warn "ZFS: Will force-import pools if necessary."
-    ZPOOL_IMPORT_OPTS="${ZPOOL_IMPORT_OPTS} -f"
+    ZPOOL_IMPORT_OPTS=-f
 fi
-
-# import_pool POOL
-#   imports the given zfs pool if it isn't imported already.
-import_pool() {
-    pool="${1}"
-
-    if ! zpool list -H "${pool}" > /dev/null 2>&1; then
-        info "ZFS: Importing pool ${pool}..."
-        # shellcheck disable=SC2086
-        if ! zpool import -N ${ZPOOL_IMPORT_OPTS} "${pool}" ; then
-            warn "ZFS: Unable to import pool ${pool}"
-            return 1
-        fi
-    fi
-
-    return 0
-}
 
 _mount_dataset_cb() {
     mount -o zfsutil -t zfs "${1}" "${NEWROOT}${2}"
@@ -94,41 +75,6 @@ for_relevant_root_children() {
             done
             exit ${_ret}
         )
-}
-
-# ask_for_password tries prompt cmd
-#
-# Wraps around plymouth ask-for-password and adds fallback to tty password ask
-# if plymouth is not present.
-ask_for_password() {
-    tries="$1"
-    prompt="$2"
-    cmd="$3"
-
-    {
-        flock -s 9
-
-        # Prompt for password with plymouth, if installed and running.
-        if plymouth --ping 2>/dev/null; then
-            plymouth ask-for-password \
-                --prompt "$prompt" --number-of-tries="$tries" | \
-                eval "$cmd"
-            ret=$?
-        else
-            i=1
-            while [ "$i" -le "$tries" ]; do
-                printf "%s [%i/%i]:" "$prompt" "$i" "$tries" >&2
-                eval "$cmd" && ret=0 && break
-                ret=$?
-                i=$((i+1))
-                printf '\n' >&2
-            done
-            unset i
-        fi
-    } 9>/.console_lock
-
-    [ $ret -ne 0 ] && echo "Wrong password" >&2
-    return $ret
 }
 
 # Parse root=, rootfstype=, return them decoded and normalised to zfs:AUTO for auto, plain dset for explicit

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -121,22 +121,6 @@ for_relevant_root_children() {
         )
 }
 
-# export_all OPTS
-#   exports all imported zfs pools.
-export_all() {
-    ret=0
-
-    IFS="${NEWLINE}"
-    for pool in $(zpool list -H -o name) ; do
-        if zpool list -H "${pool}" > /dev/null 2>&1; then
-            zpool export "${pool}" "$@" || ret=$?
-        fi
-    done
-    IFS="${OLDIFS}"
-
-    return ${ret}
-}
-
 # ask_for_password
 #
 # Wraps around plymouth ask-for-password and adds fallback to tty password ask

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-command -v getarg >/dev/null || . /lib/dracut-lib.sh
+command -v getarg >/dev/null || . /lib/dracut-lib.sh || . /usr/lib/dracut/modules.d/99base/dracut-lib.sh
 command -v getargbool >/dev/null || {
     # Compatibility with older Dracut versions.
     # With apologies to the Dracut developers.
@@ -159,7 +159,9 @@ ask_for_password() {
         shift
     done
 
-    { flock -s 9;
+    {
+        flock -s 9
+
         # Prompt for password with plymouth, if installed and running.
         if plymouth --ping 2>/dev/null; then
             plymouth ask-for-password \
@@ -188,4 +190,59 @@ ask_for_password() {
 
     [ $ret -ne 0 ] && echo "Wrong password" >&2
     return $ret
+}
+
+# Parse root=, rootfstype=, return them decoded and normalised to zfs:AUTO for auto, plain dset for explicit
+#
+# True if ZFS-on-root, false if we shouldn't
+#
+# Supported values:
+#   root=
+#   root=zfs
+#   root=zfs:
+#   root=zfs:AUTO
+#
+#   root=ZFS=data/set
+#   root=zfs:data/set
+#   root=zfs:ZFS=data/set (as a side-effect; allowed but undocumented)
+#
+#   rootfstype=zfs AND root=data/set <=> root=data/set
+#   rootfstype=zfs AND root=         <=> root=zfs:AUTO
+#
+# '+'es in explicit dataset decoded to ' 's.
+decode_root_args() {
+    if [ -n "$rootfstype" ]; then
+        [ "$rootfstype" = zfs ]
+        return
+    fi
+
+    root=$(getarg root=)
+    rootfstype=$(getarg rootfstype=)
+
+    # shellcheck disable=SC2249
+    case "$root" in
+        ""|zfs|zfs:|zfs:AUTO)
+            root=zfs:AUTO
+            rootfstype=zfs
+            return 0
+            ;;
+
+        ZFS=*|zfs:*)
+            root="${root#zfs:}"
+            root="${root#ZFS=}"
+            root=$(echo "$root" | tr '+' ' ')
+            rootfstype=zfs
+            return 0
+            ;;
+    esac
+
+    if [ "$rootfstype" = "zfs" ]; then
+        case "$root" in
+            "") root=zfs:AUTO ;;
+            *)  root=$(echo "$root" | tr '+' ' ') ;;
+        esac
+        return 0
+    fi
+
+    return 1
 }

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -20,42 +20,38 @@ if [ "$BOOTFS" = "zfs:AUTO" ]; then
     BOOTFS="$(zpool get -Ho value bootfs | grep -m1 -vFx -)"
 fi
 
-# if pool encryption is active and the zfs command understands '-o encryption'
-if [ "$(zpool list -H -o feature@encryption "${BOOTFS%%/*}")" = 'active' ]; then
-    # if the root dataset has encryption enabled
-    ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${BOOTFS}")"
-    if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
-        KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
-        # continue only if the key needs to be loaded
-        [ "$KEYSTATUS" = "unavailable" ] || exit 0
+[ "$(zpool get -Ho value feature@encryption "${BOOTFS%%/*}")" = 'active' ] || return 0
 
-        KEYLOCATION="$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")"
-        case "${KEYLOCATION%%://*}" in
-            prompt)
-                for _ in 1 2 3; do
-                    systemd-ask-password --no-tty "Encrypted ZFS password for ${BOOTFS}" | zfs load-key "${ENCRYPTIONROOT}" && break
-                done
-                ;;
-            http*)
-                systemctl start network-online.target
-                zfs load-key "${ENCRYPTIONROOT}"
-                ;;
-            file)
-                KEYFILE="${KEYLOCATION#file://}"
-                [ -r "${KEYFILE}" ] || udevadm settle
-                [ -r "${KEYFILE}" ] || {
-                    info "Waiting for key ${KEYFILE} for ${ENCRYPTIONROOT}..."
-                    for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-                        sleep 0.5s
-                        [ -r "${KEYFILE}" ] && break
-                    done
-                }
-                [ -r "${KEYFILE}" ] || warn "Key ${KEYFILE} for ${ENCRYPTIONROOT} hasn't appeared. Trying anyway."
-                zfs load-key "${ENCRYPTIONROOT}"
-                ;;
-            *)
-                zfs load-key "${ENCRYPTIONROOT}"
-                ;;
-        esac
-    fi
-fi
+ENCRYPTIONROOT="$(zfs get -Ho value encryptionroot "${BOOTFS}")"
+[ "${ENCRYPTIONROOT}" = "-" ] && return 0
+
+[ "$(zfs get -Ho value keystatus "${ENCRYPTIONROOT}")" = "unavailable" ] || return 0
+
+KEYLOCATION="$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")"
+case "${KEYLOCATION%%://*}" in
+    prompt)
+        for _ in 1 2 3; do
+            systemd-ask-password --no-tty "Encrypted ZFS password for ${BOOTFS}" | zfs load-key "${ENCRYPTIONROOT}" && break
+        done
+        ;;
+    http*)
+        systemctl start network-online.target
+        zfs load-key "${ENCRYPTIONROOT}"
+        ;;
+    file)
+        KEYFILE="${KEYLOCATION#file://}"
+        [ -r "${KEYFILE}" ] || udevadm settle
+        [ -r "${KEYFILE}" ] || {
+            info "ZFS: Waiting for key ${KEYFILE} for ${ENCRYPTIONROOT}..."
+            for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+                sleep 0.5s
+                [ -r "${KEYFILE}" ] && break
+            done
+        }
+        [ -r "${KEYFILE}" ] || warn "ZFS: Key ${KEYFILE} for ${ENCRYPTIONROOT} hasn't appeared. Trying anyway."
+        zfs load-key "${ENCRYPTIONROOT}"
+        ;;
+    *)
+        zfs load-key "${ENCRYPTIONROOT}"
+        ;;
+esac

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -4,32 +4,20 @@
 # only run this on systemd systems, we handle the decrypt in mount-zfs.sh in the mount hook otherwise
 [ -e /bin/systemctl ] || [ -e /usr/bin/systemctl ] || return 0
 
-# This script only gets executed on systemd systems, see mount-zfs.sh for non-systemd systems
+# shellcheck source=zfs-lib.sh.in
+. /lib/dracut-zfs-lib.sh
 
-# import the libs now that we know the pool imported
-[ -f /lib/dracut-lib.sh ] && dracutlib=/lib/dracut-lib.sh
-[ -f /usr/lib/dracut/modules.d/99base/dracut-lib.sh ] && dracutlib=/usr/lib/dracut/modules.d/99base/dracut-lib.sh
-# shellcheck source=./lib-zfs.sh.in
-. "$dracutlib"
-
-# load the kernel command line vars
-[ -z "$root" ] && root="$(getarg root=)"
-# If root is not ZFS= or zfs: or rootfstype is not zfs then we are not supposed to handle it.
-[ "${root##zfs:}" = "${root}" ] && [ "${root##ZFS=}" = "${root}" ] && [ "$rootfstype" != "zfs" ] && exit 0
+decode_root_args || return 0
 
 # There is a race between the zpool import and the pre-mount hooks, so we wait for a pool to be imported
-while [ "$(zpool list -H)" = "" ]; do
-    systemctl is-failed --quiet zfs-import-cache.service zfs-import-scan.service && exit 1
+while ! systemctl is-active --quiet zfs-import.target; do
+    systemctl is-failed --quiet zfs-import-cache.service zfs-import-scan.service && return 1
     sleep 0.1s
 done
 
-# run this after import as zfs-import-cache/scan service is confirmed good
-# we do not overwrite the ${root} variable, but create a new one, BOOTFS, to hold the dataset
-if [ "${root}" = "zfs:AUTO" ] ; then
-    BOOTFS="$(zpool list -H -o bootfs | awk '$1 != "-" {print; exit}')"
-else
-    BOOTFS="${root##zfs:}"
-    BOOTFS="${BOOTFS##ZFS=}"
+BOOTFS="$root"
+if [ "$BOOTFS" = "zfs:AUTO" ]; then
+    BOOTFS="$(zpool get -Ho value bootfs | grep -m1 -vFx -)"
 fi
 
 # if pool encryption is active and the zfs command understands '-o encryption'

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -22,36 +22,43 @@ fi
 
 [ "$(zpool get -Ho value feature@encryption "${BOOTFS%%/*}")" = 'active' ] || return 0
 
-ENCRYPTIONROOT="$(zfs get -Ho value encryptionroot "${BOOTFS}")"
-[ "${ENCRYPTIONROOT}" = "-" ] && return 0
+_load_key_cb() {
+    dataset="$1"
 
-[ "$(zfs get -Ho value keystatus "${ENCRYPTIONROOT}")" = "unavailable" ] || return 0
+    ENCRYPTIONROOT="$(zfs get -Ho value encryptionroot "${dataset}")"
+    [ "${ENCRYPTIONROOT}" = "-" ] && return 0
 
-KEYLOCATION="$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")"
-case "${KEYLOCATION%%://*}" in
-    prompt)
-        for _ in 1 2 3; do
-            systemd-ask-password --no-tty "Encrypted ZFS password for ${BOOTFS}" | zfs load-key "${ENCRYPTIONROOT}" && break
-        done
-        ;;
-    http*)
-        systemctl start network-online.target
-        zfs load-key "${ENCRYPTIONROOT}"
-        ;;
-    file)
-        KEYFILE="${KEYLOCATION#file://}"
-        [ -r "${KEYFILE}" ] || udevadm settle
-        [ -r "${KEYFILE}" ] || {
-            info "ZFS: Waiting for key ${KEYFILE} for ${ENCRYPTIONROOT}..."
-            for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-                sleep 0.5s
-                [ -r "${KEYFILE}" ] && break
+    [ "$(zfs get -Ho value keystatus "${ENCRYPTIONROOT}")" = "unavailable" ] || return 0
+
+    KEYLOCATION="$(zfs get -Ho value keylocation "${ENCRYPTIONROOT}")"
+    case "${KEYLOCATION%%://*}" in
+        prompt)
+            for _ in 1 2 3; do
+                systemd-ask-password --no-tty "Encrypted ZFS password for ${dataset}" | zfs load-key "${ENCRYPTIONROOT}" && break
             done
-        }
-        [ -r "${KEYFILE}" ] || warn "ZFS: Key ${KEYFILE} for ${ENCRYPTIONROOT} hasn't appeared. Trying anyway."
-        zfs load-key "${ENCRYPTIONROOT}"
-        ;;
-    *)
-        zfs load-key "${ENCRYPTIONROOT}"
-        ;;
-esac
+            ;;
+        http*)
+            systemctl start network-online.target
+            zfs load-key "${ENCRYPTIONROOT}"
+            ;;
+        file)
+            KEYFILE="${KEYLOCATION#file://}"
+            [ -r "${KEYFILE}" ] || udevadm settle
+            [ -r "${KEYFILE}" ] || {
+                info "ZFS: Waiting for key ${KEYFILE} for ${ENCRYPTIONROOT}..."
+                for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+                    sleep 0.5s
+                    [ -r "${KEYFILE}" ] && break
+                done
+            }
+            [ -r "${KEYFILE}" ] || warn "ZFS: Key ${KEYFILE} for ${ENCRYPTIONROOT} hasn't appeared. Trying anyway."
+            zfs load-key "${ENCRYPTIONROOT}"
+            ;;
+        *)
+            zfs load-key "${ENCRYPTIONROOT}"
+            ;;
+    esac
+}
+
+_load_key_cb "$BOOTFS"
+for_relevant_root_children "$BOOTFS" _load_key_cb

--- a/contrib/dracut/90zfs/zfs-needshutdown.sh.in
+++ b/contrib/dracut/90zfs/zfs-needshutdown.sh.in
@@ -2,7 +2,7 @@
 
 command -v getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-if zpool list 2>&1 | grep -q 'no pools available' ; then
+if [ -z "$(zpool get -Ho value name)" ]; then
     info "ZFS: No active pools, no need to export anything."
 else
     info "ZFS: There is an active pool, will export it."

--- a/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
@@ -1,14 +1,12 @@
 [Unit]
 Description=Rollback bootfs just before it is mounted
 Requisite=zfs-import.target
-After=zfs-import.target zfs-snapshot-bootfs.service
+After=zfs-import.target dracut-pre-mount.service zfs-snapshot-bootfs.service
 Before=dracut-mount.service
 DefaultDependencies=no
 ConditionKernelCommandLine=bootfs.rollback
 
 [Service]
-# ${BOOTFS} should have been set by zfs-env-bootfs.service
 Type=oneshot
-ExecStartPre=/bin/sh -c 'test -n "${BOOTFS}"'
-ExecStart=/bin/sh -c '. /lib/dracut-lib.sh; SNAPNAME="$(getarg bootfs.rollback)"; exec @sbindir@/zfs rollback -Rf "${BOOTFS}@${SNAPNAME:-%v}"'
+ExecStart=/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS" SNAPNAME="$(getarg bootfs.rollback)"; exec @sbindir@/zfs rollback -Rf "$root@${SNAPNAME:-%v}"'
 RemainAfterExit=yes

--- a/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in
@@ -1,14 +1,12 @@
 [Unit]
 Description=Snapshot bootfs just before it is mounted
 Requisite=zfs-import.target
-After=zfs-import.target
+After=zfs-import.target dracut-pre-mount.service
 Before=dracut-mount.service
 DefaultDependencies=no
 ConditionKernelCommandLine=bootfs.snapshot
 
 [Service]
-# ${BOOTFS} should have been set by zfs-env-bootfs.service
 Type=oneshot
-ExecStartPre=/bin/sh -c 'test -n "${BOOTFS}"'
-ExecStart=-/bin/sh -c '. /lib/dracut-lib.sh; SNAPNAME="$(getarg bootfs.snapshot)"; exec @sbindir@/zfs snapshot "${BOOTFS}@${SNAPNAME:-%v}"'
+ExecStart=/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS" SNAPNAME="$(getarg bootfs.snapshot)"; exec @sbindir@/zfs snapshot "$root@${SNAPNAME:-%v}"'
 RemainAfterExit=yes

--- a/contrib/dracut/README.dracut.markdown
+++ b/contrib/dracut/README.dracut.markdown
@@ -15,6 +15,8 @@ Encrypted datasets have keys loaded automatically or prompted for.
 
 If the root dataset contains children with `mountpoint=`s of `/etc`, `/bin`, `/lib*`, or `/usr`, they're mounted too.
 
+For complete documentation, see `dracut.zfs(7)`.
+
 ## cmdline
 1. `root=`                    | Root dataset is…                                         |
    ---------------------------|----------------------------------------------------------|

--- a/contrib/dracut/README.dracut.markdown
+++ b/contrib/dracut/README.dracut.markdown
@@ -1,225 +1,48 @@
-How to setup a zfs root filesystem using dracut
------------------------------------------------
+## Basic setup
+1. Install `zfs-dracut`
+2. Set `mountpoint=/` for your root dataset (for compatibility, `legacy` also works, but is not recommended for new installations):
+    ```sh
+    zfs set mountpoint=/ pool/dataset
+    ```
+3. Either (a) set `bootfs=` on the pool to the dataset:
+    ```sh
+    zpool set bootfs=pool/dataset pool
+    ```
+4. Or (b) append `root=zfs:pool/dataset` to your kernel cmdline.
+5. Re-generate your initrd and update it in your boot bundle
 
-1) Install the zfs-dracut package.  This package adds a zfs dracut module
-to the /usr/share/dracut/modules.d/ directory which allows dracut to
-create an initramfs which is zfs aware.
+Encrypted datasets have keys loaded automatically or prompted for.
 
-2) Set the bootfs property for the bootable dataset in the pool.  Then set
-the dataset mountpoint property to '/'.
+If the root dataset contains children with `mountpoint=`s of `/etc`, `/bin`, `/lib*`, or `/usr`, they're mounted too.
 
-    $ zpool set bootfs=pool/dataset pool
-    $ zfs set mountpoint=/ pool/dataset
+## cmdline
+1. `root=`                    | Root dataset is…                                         |
+   ---------------------------|----------------------------------------------------------|
+   *(empty)*                  | the first `bootfs=` after `zpool import -aN`             |
+   `zfs:AUTO`, `zfs:`, `zfs`  | *(as above, but overriding other autoselection methods)* |
+   `ZFS=pool/dataset`         | `pool/dataset`                                           |
+   `zfs:pool/dataset`         | *(as above)*                                             |
 
-Alternately, legacy mountpoints can be used by setting the 'root=' option
-on the kernel line of your grub.conf/menu.lst configuration file.  Then
-set the dataset mountpoint property to 'legacy'.
+   All `+`es are replaced with spaces (i.e. to boot from `root pool/data set`, pass `root=zfs:root+pool/data+set`).
 
-    $ grub.conf/menu.lst: kernel ... root=ZFS=pool/dataset
-    $ zfs set mountpoint=legacy pool/dataset
+   The dataset can be at any depth, including being the pool's root dataset (i.e. `root=zfs:pool`).
 
-3) To set zfs module options put them in /etc/modprobe.d/zfs.conf file.
-The complete list of zfs module options is available by running the
-_modinfo zfs_ command.  Commonly set options include: zfs_arc_min,
-zfs_arc_max, zfs_prefetch_disable, and zfs_vdev_max_pending.
+   `rootfstype=zfs` is equivalent to `root=zfs:AUTO`, `rootfstype=zfs root=pool/dataset` is equivalent to `root=zfs:pool/dataset`.
 
-4) Finally, create your new initramfs by running dracut.
+2. `spl_hostid`: passed to `zgenhostid -f`, useful to override the `/etc/hostid` file baked into the initrd.
 
-    $ dracut --force /path/to/initramfs kernel_version
+3. `bootfs.snapshot`, `bootfs.snapshot=snapshot-name`: enables `zfs-snapshot-bootfs.service`,
+   which creates a snapshot `$root_dataset@$(uname -r)` (or, in the second form, `$root_dataset@snapshot-name`)
+   after pool import but before the rootfs is mounted.
+   Failure to create the snapshot is noted, but booting continues.
 
-Kernel Command Line
--------------------
+4. `bootfs.rollback`, `bootfs.rollback=snapshot-name`: enables `zfs-snapshot-bootfs.service`,
+   which `-Rf` rolls back to `$root_dataset@$(uname -r)` (or, in the second form, `$root_dataset@snapshot-name`)
+   after pool import but before the rootfs is mounted.
+   Failure to roll back will fall down to the rescue shell.
+   This has obvious potential for data loss: make sure your persistent data is not below the rootfs and you don't care about any intermediate snapshots.
 
-The initramfs' behavior is influenced by the following kernel command line
-parameters passed in from the boot loader:
+5. If both `bootfs.snapshot` and `bootfs.rollback` are set, `bootfs.rollback` is ordered *after* `bootfs.snapshot`.
 
-* `root=...`: If not set, importable pools are searched for a bootfs
-attribute.  If an explicitly set root is desired, you may use
-`root=ZFS:pool/dataset`
-
-* `zfs_force=0`: If set to 1, the initramfs will run `zpool import -f` when
-attempting to import pools if the required pool isn't automatically imported
-by the zfs module.  This can save you a trip to a bootcd if hostid has
-changed, but is dangerous and can lead to zpool corruption, particularly in
-cases where storage is on a shared fabric such as iSCSI where multiple hosts
-can access storage devices concurrently.  _Please understand the implications
-of force-importing a pool before enabling this option!_
-
-* `spl_hostid`: By default, the hostid used by the SPL module is read from
-/etc/hostid inside the initramfs.  This file is placed there from the host
-system when the initramfs is built which effectively ties the ramdisk to the
-host which builds it.  If a different hostid is desired, one may be set in
-this attribute and will override any file present in the ramdisk.  The
-format should be hex exactly as found in the `/etc/hostid` file, IE
-`spl_hostid=0x00bab10c`.
-
-Note that changing the hostid between boots will most likely lead to an
-un-importable pool since the last importing hostid won't match.  In order
-to recover from this, you may use the `zfs_force` option or boot from a
-different filesystem and `zpool import -f` then `zpool export` the pool
-before rebooting with the new hostid.
-
-* `bootfs.snapshot`: If listed, enables the zfs-snapshot-bootfs service on a Dracut system. The zfs-snapshot-bootfs service simply runs `zfs snapshot $BOOTFS@%v` after the pool has been imported but before the bootfs is mounted. `$BOOTFS` is substituted with the value of the bootfs setting on the pool. `%v` is substituted with the version string of the kernel currently being booted (e.g. 5.6.6-200.fc31.x86\_64). Failure to create the snapshot (e.g. because one with the same name already exists) will be logged, but will not otherwise interrupt the boot process.
-
-    It is safe to leave the bootfs.snapshot flag set persistently on your kernel command line so that a new snapshot of your bootfs will be created on every kernel update. If you leave bootfs.snapshot set persistently on your kernel command line, you may find the below script helpful for automatically removing old snapshots of the bootfs along with their associated kernel.
-
-        #!/usr/bin/sh
-
-        if [[ "$1" == "remove" ]] && grep -q "\bbootfs.snapshot\b" /proc/cmdline; then
-           zfs destroy $(findmnt -n -o source /)@$2 &> /dev/null
-        fi
-
-        exit 0
-
-    To use the above script place it in a plain text file named /etc/kernel/install.d/99-zfs-cleanup.install and mark it executable with the following command:
-
-        $ chmod +x /etc/kernel/install.d/99-zfs-cleanup.install
-
-    On Red Hat based systems, you can change the value of `installonly_limit` in /etc/dnf/dnf.conf to adjust the number of kernels and their associated snapshots that are kept.
-
-* `bootfs.snapshot=<snapname>`: Is identical to the bootfs.snapshot parameter explained above except that the value substituted for \<snapname\> will be used when creating the snapshot instead of the version string of the kernel currently being booted. 
-
-* `bootfs.rollback`: If listed, enables the zfs-rollback-bootfs service on a Dracut system. The zfs-rollback-bootfs service simply runs `zfs rollback -Rf $BOOTFS@%v` after the pool has been imported but before the bootfs is mounted. If the rollback operation fails, the boot process will be interrupted with a Dracut rescue shell. __Use this parameter with caution. Intermediate snapshots of the bootfs will be destroyed!__ TIP: Keep your user data (e.g. /home) on separate file systems (it can be in the same pool though).
-
-* `bootfs.rollback=<snapname>`: Is identical to the bootfs.rollback parameter explained above except that the value substituted for \<snapname\> will be used when rolling back the bootfs instead of the version string of the kernel currently being booted. If you use this form, choose a snapshot that is new enough to contain the needed kernel modules under /lib/modules or use a kernel that has all the needed modules built-in.
-
-How it Works
-============
-
-The Dracut module consists of the following files (less Makefile's):
-
-* `module-setup.sh`: Script run by the initramfs builder to create the
-ramdisk.  Contains instructions on which files are required by the modules
-and z* programs.  Also triggers inclusion of `/etc/hostid` and the zpool
-cache.  This file is not included in the initramfs.
-
-* `90-zfs.rules`: udev rules which trigger loading of the ZFS modules at boot.
-
-* `zfs-lib.sh`: Utility functions used by the other files.
-
-* `parse-zfs.sh`: Run early in the initramfs boot process to parse kernel
-command line and determine if ZFS is the active root filesystem.
-
-* `mount-zfs.sh`: Run later in initramfs boot process after udev has settled
-to mount the root dataset.
-
-* `export-zfs.sh`: Run on shutdown after dracut has restored the initramfs
-and pivoted to it, allowing for a clean unmount and export of the ZFS root.
-
-`zfs-lib.sh`
-------------
-
-This file provides a few handy functions for working with ZFS. Those
-functions are used by the `mount-zfs.sh` and `export-zfs.sh` files.
-However, they could be used by any other file as well, as long as the file
-sources `/lib/dracut-zfs-lib.sh`.
-
-`module-setup.sh`
------------------
-
-This file is run by the Dracut script within the live system, not at boot
-time.  It's not included in the final initramfs.  Functions in this script
-describe which files are needed by ZFS at boot time.
-
-Currently all the various z* and spl modules are included, a dependency is
-asserted on udev-rules, and the various zfs, zpool, etc. helpers are included.
-Dracut provides library functions which automatically gather the shared libs
-necessary to run each of these binaries, so statically built binaries are
-not required.
-
-The zpool and zvol udev rules files are copied from where they are
-installed by the ZFS build.  __PACKAGERS TAKE NOTE__: If you move
-`/etc/udev/rules/60-z*.rules`, you'll need to update this file to match.
-
-Currently this file also includes `/etc/hostid` and `/etc/zfs/zpool.cache`
-which means the generated ramdisk is specific to the host system which built
-it.  If a generic initramfs is required, it may be preferable to omit these
-files and specify the `spl_hostid` from the boot loader instead.
-
-`parse-zfs.sh`
---------------
-
-Run during the cmdline phase of the initramfs boot process, this script
-performs some basic sanity checks on kernel command line parameters to
-determine if booting from ZFS is likely to be what is desired.  Dracut
-requires this script to adjust the `root` variable if required and to set
-`rootok=1` if a mountable root filesystem is available.  Unfortunately this
-script must run before udev is settled and kernel modules are known to be
-loaded, so accessing the zpool and zfs commands is unsafe.
-
-If the root=ZFS... parameter is set on the command line, then it's at least
-certain that ZFS is what is desired, though this script is unable to
-determine if ZFS is in fact available.  This script will alter the `root`
-parameter to replace several historical forms of specifying the pool and
-dataset name with the canonical form of `zfs:pool/dataset`.
-
-If no root= parameter is set, the best this script can do is guess that
-ZFS is desired.  At present, no other known filesystems will work with no
-root= parameter, though this might possibly interfere with using the
-compiled-in default root in the kernel image.  It's considered unlikely
-that would ever be the case when an initramfs is in use, so this script
-sets `root=zfs:AUTO` and hopes for the best.
-
-Once the root=... (or lack thereof) parameter is parsed, a dummy symlink
-is created from `/dev/root` -> `/dev/null` to satisfy parts of the Dracut
-process which check for presence of a single root device node.
-
-Finally, an initqueue/finished hook is registered which causes the initqueue
-phase of Dracut to wait for `/dev/zfs` to become available before attempting
-to mount anything.
-
-`mount-zfs.sh`
---------------
-
-This script is run after udev has settled and all tasks in the initqueue
-have succeeded.  This ensures that `/dev/zfs` is available and that the
-various ZFS modules are successfully loaded.  As it is now safe to call
-zpool and friends, we can proceed to find the bootfs attribute if necessary.
-
-If the root parameter was explicitly set on the command line, no parsing is
-necessary.  The list of imported pools is checked to see if the desired pool
-is already imported.  If it's not, and attempt is made to import the pool
-explicitly, though no force is attempted.  Finally the specified dataset
-is mounted on `$NEWROOT`, first using the `-o zfsutil` option to handle
-non-legacy mounts, then if that fails, without zfsutil to handle legacy
-mount points.
-
-If no root parameter was specified, this script attempts to find a pool with
-its bootfs attribute set.  First, already-imported pools are scanned and if
-an appropriate pool is found, no additional pools are imported.  If no pool
-with bootfs is found, any additional pools in the system are imported with
-`zpool import -N -a`, and the scan for bootfs is tried again.  If no bootfs
-is found with all pools imported, all pools are re-exported, and boot fails.
-Assuming a bootfs is found, an attempt is made to mount it to `$NEWROOT`,
-first with, then without the zfsutil option as above.
-
-Ordinarily pools are imported _without_ the force option which may cause
-boot to fail if the hostid has changed or a pool has been physically moved
-between servers.  The `zfs_force` kernel parameter is provided which when
-set to `1` causes `zpool import` to be run with the `-f` flag.  Forcing pool
-import can lead to serious data corruption and loss of pools, so this option
-should be used with extreme caution.  Note that even with this flag set, if
-the required zpool was auto-imported by the kernel module, no additional
-`zpool import` commands are run, so nothing is forced.
-
-`export-zfs.sh`
----------------
-
-Normally the zpool containing the root dataset cannot be exported on
-shutdown as it is still in use by the init process. To work around this,
-Dracut is able to restore the initramfs on shutdown and pivot to it.
-All remaining process are then running from a ramdisk, allowing for a
-clean unmount and export of the ZFS root. The theory of operation is
-described in detail in the [Dracut manual](https://www.kernel.org/pub/linux/utils/boot/dracut/dracut.html#_dracut_on_shutdown).
-
-This script will try to export all remaining zpools after Dracut has
-pivoted to the initramfs. If an initial regular export is not successful,
-Dracut will call this script once more with the `final` option,
-in which case a forceful export is attempted.
-
-Other Dracut modules include similar shutdown scripts and Dracut
-invokes these scripts round-robin until they succeed. In particular,
-the `90dm` module installs a script which tries to close and remove
-all device mapper targets. Thus, if there are ZVOLs containing
-dm-crypt volumes or if the zpool itself is backed by a dm-crypt
-volume, the shutdown scripts will try to untangle this.
+6. `zfs_force`, `zfs.force`, `zfsforce`: add `-f` to all `zpool import` invocations.
+   May be useful. Use with caution.

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -15,6 +15,7 @@ dist_man_MANS = \
 	man4/spl.4 \
 	man4/zfs.4 \
 	\
+	man7/dracut.zfs.7 \
 	man7/zpool-features.7 \
 	man7/zfsconcepts.7 \
 	man7/zfsprops.7 \

--- a/man/man7/dracut.zfs.7
+++ b/man/man7/dracut.zfs.7
@@ -1,0 +1,278 @@
+.\" SPDX-License-Identifier: 0BSD
+.\"
+.Dd April 4, 2022
+.Dt DRACUT.ZFS 7
+.Os
+.
+.Sh NAME
+.Nm dracut.zfs
+.Nd overview of ZFS dracut hooks
+.
+.Sh SYNOPSIS
+.Bd -literal -compact
+                      parse-zfs.sh \(-> dracut-cmdline.service
+                          |                     \(da
+                          |                     …
+                          |                     \(da
+                          \e\(em\(em\(em\(em\(em\(em\(em\(em\(-> dracut-initqueue.service
+                                                |                      zfs-import-opts.sh
+   zfs-load-module.service                      \(da                          |       |
+     |                  |                sysinit.target                    \(da       |
+     \(da                  |                       |        zfs-import-scan.service   \(da
+zfs-import-scan.service \(da                       \(da           | zfs-import-cache.service
+     |   zfs-import-cache.service         basic.target      |     |
+     \e__________________|                       |           \(da     \(da
+                        \(da                       |     zfs-load-key.sh
+     zfs-env-bootfs.service                     |         |
+                        \(da                       \(da         \(da
+                 zfs-import.target \(-> dracut-pre-mount.service
+                        |          \(ua            |
+                        | dracut-zfs-generator  |
+                        |  ____________________/|
+                        |/                      \(da
+                        |                   sysroot.mount \(<-\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em dracut-zfs-generator
+                        |                       |                                        \(da   |
+                        |                       \(da            sysroot-{usr,etc,lib,&c.}.mount |
+                        |             initrd-root-fs.target \(<-\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em or                 \(da
+                        |                       |              zfs-nonroot-necessities.service
+                        |                       \(da                                 |
+                        \(da             dracut-mount.service                        |
+       zfs-snapshot-bootfs.service              |                                 |
+                        |                       \(da                                 |
+                        \(da                       …                                 |
+       zfs-rollback-bootfs.service              |                                 |
+                        |                       \(da                                 |
+                        |               sysroot-usr.mount \(<-\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em/
+                        |                       |
+                        |                       \(da
+                        |                initrd-fs.target
+                        \e______________________ |
+                                               \e|
+                                                \(da
+        export-zfs.sh                      initrd.target
+              |                                 |
+              \(da                                 \(da
+   dracut-shutdown.service                      …
+                                                |
+                                                \(da
+                 zfs-needshutdown.sh \(-> initrd-cleanup.service
+.Ed
+.Pp
+Compare
+.Xr dracut.bootup 7
+for the full flowchart.
+.
+.Sh DESCRIPTION
+Under dracut, booting with
+.No ZFS-on- Ns Pa /
+is facilitated by a number of hooks in the
+.Nm 90zfs
+module.
+.Pp
+Booting into a ZFS dataset requires
+.Sy mountpoint Ns = Ns Pa /
+to be set on the dataset containing the root filesystem (henceforth "the boot dataset") and at the very least either the
+.Sy bootfs
+property to be set to that dataset, or the
+.Sy root=
+kernel cmdline (or dracut drop-in) argument to specify it.
+.Pp
+All children of the boot dataset with
+.Sy canmount Ns = Ns Sy on
+with
+.Sy mountpoint Ns s
+matching
+.Pa /etc , /bin , /lib , /lib?? , /libx32 , No and Pa /usr
+globs are deemed essential and will be mounted as well.
+.Pp
+.Xr zfs-mount-generator 8
+is recommended for proper functioning of the system afterward (correct mount properties, remounting, &c.).
+.
+.Sh CMDLINE
+.Ss Standard
+.Bl -tag -compact -width ".Sy root=zfs:AUTO , root=zfs: , root=zfs , Op Sy root="
+.It Sy root=zfs:\& Ns Ar dataset , Sy root=ZFS= Ns Ar dataset
+Use
+.Ar dataset
+as the boot dataset.
+All pluses
+.Pq Sq +
+are replaced with spaces
+.Pq Sq \  .
+.
+.It Sy root=zfs:AUTO , root=zfs:\& , root=zfs , Op Sy root=
+After import, search for the first pool with the
+.Sy bootfs
+property set, use its value as-if specified as the
+.Ar dataset
+above.
+.
+.It Sy rootfstype=zfs root= Ns Ar dataset
+Equivalent to
+.Sy root=zfs:\& Ns Ar dataset .
+.
+.It Sy rootfstype=zfs Op Sy root=
+Equivalent to
+.Sy root=zfs:AUTO .
+.
+.It Sy rootflags= Ns Ar flags
+Mount the boot dataset with
+.Fl o Ar flags ;
+cf.\&
+.Sx Temporary Mount Point Properties
+in
+.Xr zfsprops 7 .
+These properties will not last, since all filesystems will be re-mounted from the real root.
+.
+.It Sy debug
+If specified,
+.Nm dracut-zfs-generator
+logs to the journal.
+.El
+.Pp
+Be careful about setting neither
+.Sy rootfstype=zfs
+nor
+.Sy root=zfs:\& Ns Ar dataset
+\(em other automatic boot selection methods, like
+.Nm systemd-gpt-auto-generator
+and
+.Nm systemd-fstab-generator
+might take precedent.
+.
+.Ss ZFS-specific
+.Bl -tag -compact -width ".Sy bootfs.snapshot Ns Op Sy = Ns Ar snapshot-name"
+.It Sy bootfs.snapshot Ns Op Sy = Ns Ar snapshot-name
+Execute
+.Nm zfs Cm snapshot Ar boot-dataset Ns Sy @ Ns Ar snapshot-name
+before pivoting to the real root.
+.Ar snapshot-name
+defaults to the current kernel release.
+.
+.It Sy bootfs.rollback Ns Op Sy = Ns Ar snapshot-name
+Execute
+.Nm zfs Cm snapshot Fl Rf Ar boot-dataset Ns Sy @ Ns Ar snapshot-name
+before pivoting to the real root.
+.Ar snapshot-name
+defaults to the current kernel release.
+.
+.It Sy spl_hostid= Ns Ar host-id
+Use
+.Xr zgenhostid 8
+to set the host ID to
+.Ar host-id ;
+otherwise,
+.Pa /etc/hostid
+inherited from the real root is used.
+.
+.It Sy zfs_force , zfs.force , zfsforce
+Appends
+.Fl f
+to all
+.Nm zpool Cm import
+invocations; primarily useful in conjunction with
+.Sy spl_hostid= ,
+or if no host ID was inherited.
+.El
+.
+.Sh FILES
+.Bl -tag -width 0
+.It Pa parse-zfs.sh Pq Sy cmdline
+Processes
+.Sy spl_hostid= .
+If
+.Sy root=
+matches a known pattern, above, provides
+.Pa /dev/root
+and delays the initqueue until
+.Xr zfs 4
+is loaded,
+.
+.It Pa zfs-import-opts.sh Pq Nm systemd No environment generator
+Turns
+.Sy zfs_force , zfs.force , No or Sy zfsforce
+into
+.Ev ZPOOL_IMPORT_OPTS Ns = Ns Fl f
+for
+.Pa zfs-import-scan.service
+or
+.Pa zfs-import-cache.service .
+.
+.It Pa zfs-load-key.sh Pq Sy pre-mount
+Loads encryption keys for the boot dataset and its essential descendants.
+.Bl -tag -compact -offset 4n -width ".Sy keylocation Ns = Ns Sy https:// Ns Ar URL , Sy keylocation Ns = Ns Sy http:// Ns Ar URL"
+.It Sy keylocation Ns = Ns Sy prompt
+Is prompted for via
+.Nm systemd-ask-password
+thrice.
+.
+.It Sy keylocation Ns = Ns Sy https:// Ns Ar URL , Sy keylocation Ns = Ns Sy http:// Ns Ar URL
+.Pa network-online.target
+is started before loading.
+.
+.It Sy keylocation Ns = Ns Sy file:// Ns Ar path
+If
+.Ar path
+doesn't exist,
+.Nm udevadm No is Cm settle Ns d .
+If it still doesn't, it's waited for for up to
+.Sy 10 Ns s .
+.El
+.
+.It Pa zfs-env-bootfs.service Pq Nm systemd No service
+After pool import, sets
+.Ev BOOTFS Ns =
+in the systemd environment to the first non-null
+.Sy bootfs
+value in iteration order.
+.
+.It Pa dracut-zfs-generator Pq Nm systemd No generator
+Generates
+.Pa sysroot.mount Pq using Sy rootflags= , No if any .
+If an explicit boot dataset was specified, also generates essential mountpoints
+.Pq Pa sysroot-etc.mount , sysroot-bin.mount , No &c.\& ,
+otherwise generates
+.Pa zfs-nonroot-necessities.service
+which mounts them explicitly after
+.Pa /sysroot
+using
+.Ev BOOTFS Ns = .
+.
+.It Pa zfs-snapshot-bootfs.service , zfs-rollback-bootfs.service Pq Nm systemd No services
+Consume
+.Sy bootfs.snapshot
+and
+.Sy bootfs.rollback
+as described in
+.Sx CMDLINE  .
+Use
+.Ev BOOTFS Ns =
+if no explicit boot dataset was specified.
+.
+.It Pa zfs-needshutdown.sh Pq Sy cleanup
+If any pools were imported, signals that shutdown hooks are required.
+.
+.It Pa export-zfs.sh Pq Sy shutdown
+Forcibly exports all pools.
+.
+.It Pa /etc/hostid , /etc/zfs/zpool.cache , /etc/zfs/vdev_id.conf Pq regular files
+Included verbatim, hostonly.
+.
+.It Pa mount-zfs.sh Pq Sy mount
+Does nothing on
+.Nm systemd
+systems
+.Pq if Pa dracut-zfs-generator No succeeded .
+Otherwise, loads encryption key for the boot dataset from the console or via plymouth.
+It may not work at all!
+.El
+.
+.Sh SEE ALSO
+.Xr dracut.bootup 7 ,
+.Xr zfsprops 7 ,
+.Xr zpoolprops 7 ,
+.Xr dracut-shutdown.service 8 ,
+.Xr systemd-fstab-generator 8 ,
+.Xr systemd-gpt-auto-generator 8 ,
+.Xr zfs-mount-generator 8 ,
+.Xr zgenhostid 8


### PR DESCRIPTION
### Motivation and Context
Maybe it won't be atrocious on all accounts on stable now.

### Description
#13291, 6a41310c7099ca4532f2d8134bba37261f72410e (from #13093), and #13121. Mostly trivial merges, see Upstream-change: trailers where relevant.

### How Has This Been Tested?
Same suite as I did for #13291. Shock of shocks, it actually works now, incl. the new "features".

The diff of trunk against 2.1.5 is now (barring .gitignores and Makefile.ams):
```diff
diff --git a/trunk/90zfs/export-zfs.sh.in b/bpo/90zfs/export-zfs.sh.in
index cfe0594..9e05ee0 100755
--- a/trunk/90zfs/export-zfs.sh.in
+++ b/bpo/90zfs/export-zfs.sh.in
@@ -1,22 +1,28 @@
 #!/bin/sh
 
 _do_zpool_export() {
+	ret=0
+	errs=""
+	final="${1}"
+
 	info "ZFS: Exporting ZFS storage pools..."
 	errs=$(zpool export -aF 2>&1)
 	ret=$?
-	echo "${errs}" | vwarn
-	if [ "${ret}" -ne 0 ]; then
+	[ -z "${errs}" ] || echo "${errs}" | vwarn
+	if [ "x${ret}" != "x0" ]; then
 		info "ZFS: There was a problem exporting pools."
 	fi
 
-	if [ -n "$1" ]; then
+	if [ "x${final}" != "x" ]; then
 		info "ZFS: pool list"
 		zpool list 2>&1 | vinfo
 	fi
 
-	return "$ret"
+	return ${ret}
 }
 
 if command -v zpool >/dev/null; then
 	_do_zpool_export "${1}"
+else
+	:
 fi
diff --git a/trunk/90zfs/import-opts-generator.sh.in b/bpo/90zfs/import-opts-generator.sh.in
index 1900676..8bc8c9b 100755
--- a/trunk/90zfs/import-opts-generator.sh.in
+++ b/bpo/90zfs/import-opts-generator.sh.in
@@ -2,5 +2,4 @@
 
 . /lib/dracut-zfs-lib.sh
 
-# shellcheck disable=SC2154
 echo ZPOOL_IMPORT_OPTS="$ZPOOL_IMPORT_OPTS"
diff --git a/trunk/90zfs/zfs-lib.sh.in b/bpo/90zfs/zfs-lib.sh.in
index e44673c..a91b56b 100755
--- a/trunk/90zfs/zfs-lib.sh.in
+++ b/bpo/90zfs/zfs-lib.sh.in
@@ -12,7 +12,6 @@ if getargbool 0 zfs_force -y zfs.force -y zfsforce; then
 fi
 
 _mount_dataset_cb() {
-    # shellcheck disable=SC2154
     mount -o zfsutil -t zfs "${1}" "${NEWROOT}${2}"
 }
 
@@ -34,7 +33,7 @@ mount_dataset() {
         fi
     fi
 
-    return "${ret}"
+    return ${ret}
 }
 
 # for_relevant_root_children DATASET EXEC
@@ -60,7 +59,7 @@ for_relevant_root_children() {
                         ;;
                 esac
             done
-            exit "${_ret}"
+            exit ${_ret}
         )
 }
 
diff --git a/trunk/README.md b/bpo/README.dracut.markdown
similarity index 100%
rename from trunk/README.md
rename to bpo/README.dracut.markdown
```

Which is fine; the only major difference is 90/module-setup: 
```diff

diff --git a/trunk/90zfs/module-setup.sh.in b/bpo/90zfs/module-setup.sh.in
index f214586..fbf32b6 100755
--- a/trunk/90zfs/module-setup.sh.in
+++ b/bpo/90zfs/module-setup.sh.in
@@ -6,96 +6,138 @@ check() {
 	[ "${1}" = "-d" ] && return 0
 
 	# Verify the zfs tool chain
-	for tool in "zgenhostid" "zpool" "zfs" "mount.zfs"; do
-		command -v "${tool}" >/dev/null || return 1
+	for tool in "@sbindir@/zgenhostid" "@sbindir@/zpool" "@sbindir@/zfs" "@mounthelperdir@/mount.zfs" ; do
+		test -x "$tool" || return 1
 	done
+
+	return 0
 }
 
 depends() {
 	echo udev-rules
+	return 0
 }
 
 installkernel() {
-	instmods -c zfs
+	instmods zfs
+	instmods zcommon
+	instmods znvpair
+	instmods zavl
+	instmods zunicode
+	instmods zlua
+	instmods icp
+	instmods spl
+	instmods zlib_deflate
+	instmods zlib_inflate
 }
 
 install() {
-	inst_rules 90-zfs.rules 69-vdev.rules 60-zvol.rules
-
-	inst_multiple \
-		zgenhostid \
-		zfs \
-		zpool \
-		mount.zfs \
-		hostid \
-		grep \
-		awk \
-		tr \
-		cut \
-		head ||
-		{ dfatal "Failed to install essential binaries"; exit 1; }
-
-	# Adapted from https://github.com/zbm-dev/zfsbootmenu
-	if ! ldd "$(command -v zpool)" | grep -qF 'libgcc_s.so'; then
-		# On systems with gcc-config (Gentoo, Funtoo, etc.), use it to find libgcc_s
-		if command -v gcc-config >/dev/null; then
-			inst_simple "/usr/lib/gcc/$(s=$(gcc-config -c); echo "${s%-*}/${s##*-}")/libgcc_s.so.1" ||
-				{ dfatal "Unable to install libgcc_s.so"; exit 1; }
-			# Otherwise, use dracut's library installation function to find the right one
-		elif ! inst_libdir_file "libgcc_s.so*"; then
-			# If all else fails, just try looking for some gcc arch directory
-			inst_simple /usr/lib/gcc/*/*/libgcc_s.so* ||
-				{ dfatal "Unable to install libgcc_s.so"; exit 1; }
-		fi
+	inst_rules @udevruledir@/90-zfs.rules
+	inst_rules @udevruledir@/69-vdev.rules
+	inst_rules @udevruledir@/60-zvol.rules
+	dracut_install hostid
+	dracut_install grep
+	dracut_install @sbindir@/zgenhostid
+	dracut_install @sbindir@/zfs
+	dracut_install @sbindir@/zpool
+	# Workaround for https://github.com/openzfs/zfs/issues/4749 by
+	# ensuring libgcc_s.so(.1) is included
+	if ldd @sbindir@/zpool | grep -qF 'libgcc_s.so'; then
+		# Dracut will have already tracked and included it
+		:;
+	elif command -v gcc-config >/dev/null 2>&1; then
+		# On systems with gcc-config (Gentoo, Funtoo, etc.):
+		# Use the current profile to resolve the appropriate path
+		s="$(gcc-config -c)"
+		dracut_install "/usr/lib/gcc/${s%-*}/${s##*-}/libgcc_s.so"*
+	elif [ "$(echo /usr/lib/libgcc_s.so*)" != "/usr/lib/libgcc_s.so*" ]; then
+		# Try a simple path first
+		dracut_install /usr/lib/libgcc_s.so*
+	elif [ "$(echo /lib*/libgcc_s.so*)" != "/lib*/libgcc_s.so*" ]; then
+		# SUSE
+		dracut_install /lib*/libgcc_s.so*
+	else
+		# Fallback: Guess the path and include all matches
+		dracut_install /usr/lib*/gcc/**/libgcc_s.so*
 	fi
-
+	# shellcheck disable=SC2050
+	if [ @LIBFETCH_DYNAMIC@ -gt 0 ]; then
+		for d in $libdirs; do
+			[ -e "$d/@LIBFETCH_SONAME@" ] && dracut_install "$d/@LIBFETCH_SONAME@"
+		done
+	fi
+	dracut_install @mounthelperdir@/mount.zfs
+	dracut_install @udevdir@/vdev_id
+	dracut_install awk
+	dracut_install cut
+	dracut_install tr
+	dracut_install head
+	dracut_install @udevdir@/zvol_id
 	inst_hook cmdline 95 "${moddir}/parse-zfs.sh"
-	if [ -n "${systemdutildir}" ]; then
-		inst_script "${moddir}/zfs-generator.sh" "${systemdutildir}/system-generators/dracut-zfs-generator"
+	if [ -n "$systemdutildir" ] ; then
+		inst_script "${moddir}/zfs-generator.sh" "$systemdutildir"/system-generators/dracut-zfs-generator
 	fi
 	inst_hook pre-mount 90 "${moddir}/zfs-load-key.sh"
 	inst_hook mount 98 "${moddir}/mount-zfs.sh"
 	inst_hook cleanup 99 "${moddir}/zfs-needshutdown.sh"
 	inst_hook shutdown 20 "${moddir}/export-zfs.sh"
 
-	inst_script "${moddir}/zfs-lib.sh" "/lib/dracut-zfs-lib.sh"
+	inst_simple "${moddir}/zfs-lib.sh" "/lib/dracut-zfs-lib.sh"
+	if [ -e @sysconfdir@/zfs/zpool.cache ]; then
+		inst @sysconfdir@/zfs/zpool.cache
+		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @sysconfdir@/zfs/zpool.cache
+	fi
 
-	# -H ensures they are marked host-only
-	# -o ensures there is no error upon absence of these files
-	inst_multiple -o -H \
-		"@sysconfdir@/zfs/zpool.cache" \
-		"@sysconfdir@/zfs/vdev_id.conf"
+	if [ -e @sysconfdir@/zfs/vdev_id.conf ]; then
+		inst @sysconfdir@/zfs/vdev_id.conf
+		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @sysconfdir@/zfs/vdev_id.conf
+	fi
 
 	# Synchronize initramfs and system hostid
-	if ! inst_simple -H @sysconfdir@/hostid; then
-		if HOSTID="$(hostid 2>/dev/null)" && [ "${HOSTID}" != "00000000" ]; then
-			zgenhostid -o "${initdir}@sysconfdir@/hostid" "${HOSTID}"
-			mark_hostonly @sysconfdir@/hostid
-		fi
+	if [ -f @sysconfdir@/hostid ]; then
+		inst @sysconfdir@/hostid
+		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @sysconfdir@/hostid
+	elif HOSTID="$(hostid 2>/dev/null)" && [ "${HOSTID}" != "00000000" ]; then
+		zgenhostid -o "${initdir}@sysconfdir@/hostid" "${HOSTID}"
+		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @sysconfdir@/hostid
 	fi
 
 	if dracut_module_included "systemd"; then
-		inst_simple "${systemdsystemunitdir}/zfs-import.target"
-		systemctl -q --root "${initdir}" add-wants initrd.target zfs-import.target
+		mkdir -p "${initdir}/$systemdsystemunitdir/zfs-import.target.wants"
+		for _service in "zfs-import-scan.service" "zfs-import-cache.service" ; do
+			dracut_install "@systemdunitdir@/$_service"
+			if ! [ -L "${initdir}/$systemdsystemunitdir/zfs-import.target.wants/$_service" ]; then
+				ln -sf ../$_service "${initdir}/$systemdsystemunitdir/zfs-import.target.wants/$_service"
+				type mark_hostonly >/dev/null 2>&1 && mark_hostonly "@systemdunitdir@/$_service"
+			fi
+		done
 
-		inst_simple "${moddir}/zfs-env-bootfs.service" "${systemdsystemunitdir}/zfs-env-bootfs.service"
-		systemctl -q --root "${initdir}" add-wants zfs-import.target zfs-env-bootfs.service
+		inst "${moddir}"/zfs-env-bootfs.service "${systemdsystemunitdir}"/zfs-env-bootfs.service
+		ln -s ../zfs-env-bootfs.service "${initdir}/${systemdsystemunitdir}/zfs-import.target.wants"/zfs-env-bootfs.service
+		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/zfs-env-bootfs.service
 
-		for _service in \
-			"zfs-import-scan.service" \
-			"zfs-import-cache.service" \
-			"zfs-load-module.service"; do
-			inst_simple "${systemdsystemunitdir}/${_service}"
-			systemctl -q --root "${initdir}" add-wants zfs-import.target "${_service}"
-		done
+		dracut_install systemd-ask-password
+		dracut_install systemd-tty-ask-password-agent
+
+		mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
+		dracut_install @systemdunitdir@/zfs-import.target
+		if ! [ -L "${initdir}/$systemdsystemunitdir/initrd.target.wants"/zfs-import.target ]; then
+			ln -s ../zfs-import.target "${initdir}/$systemdsystemunitdir/initrd.target.wants"/zfs-import.target
+			type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/zfs-import.target
+		fi
 
-		for _service in \
-			"zfs-snapshot-bootfs.service" \
-			"zfs-rollback-bootfs.service"; do
-			inst_simple "${moddir}/${_service}" "${systemdsystemunitdir}/${_service}"
-			systemctl -q --root "${initdir}" add-wants initrd.target "${_service}"
+		for _service in zfs-snapshot-bootfs.service zfs-rollback-bootfs.service ; do
+			inst "${moddir}/$_service" "${systemdsystemunitdir}/$_service"
+			if ! [ -L "${initdir}/$systemdsystemunitdir/initrd.target.wants/$_service" ]; then
+				ln -s "../$_service" "${initdir}/$systemdsystemunitdir/initrd.target.wants/$_service"
+			fi
 		done
 
-		inst_simple "${moddir}/import-opts-generator.sh" "${systemdutildir}/system-environment-generators/zfs-import-opts.sh"
+		# There isn't a pkg-config variable for this,
+		# and dracut doesn't automatically resolve anything this'd be next to
+		local systemdsystemenvironmentgeneratordir
+		systemdsystemenvironmentgeneratordir="$(pkg-config --variable=prefix systemd || echo "/usr")/lib/systemd/system-environment-generators"
+		mkdir -p "${initdir}/${systemdsystemenvironmentgeneratordir}"
+		inst "${moddir}"/import-opts-generator.sh "${systemdsystemenvironmentgeneratordir}"/zfs-import-opts.sh
 	fi
 }
```

But all the files match, so there's no Real difference there (and both work with both module-setups).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
