### PR TITLE
autoconf: Pretend `CONFIG_MODULES` is always on

### DIFF
--- a/config/kernel-config-defined.m4
+++ b/config/kernel-config-defined.m4
@@ -19,6 +19,7 @@ AC_DEFUN([ZFS_AC_KERNEL_CONFIG_DEFINED], [
 		])
 	])
 
+	ZFS_AC_KERNEL_SRC_CONFIG_MODULES
 	ZFS_AC_KERNEL_SRC_CONFIG_BLOCK
 	ZFS_AC_KERNEL_SRC_CONFIG_DEBUG_LOCK_ALLOC
 	ZFS_AC_KERNEL_SRC_CONFIG_TRIM_UNUSED_KSYMS
@@ -29,6 +30,7 @@ AC_DEFUN([ZFS_AC_KERNEL_CONFIG_DEFINED], [
 	ZFS_LINUX_TEST_COMPILE_ALL([config])
 	AC_MSG_RESULT([done])
 
+	ZFS_AC_KERNEL_CONFIG_MODULES
 	ZFS_AC_KERNEL_CONFIG_BLOCK
 	ZFS_AC_KERNEL_CONFIG_DEBUG_LOCK_ALLOC
 	ZFS_AC_KERNEL_CONFIG_TRIM_UNUSED_KSYMS
@@ -96,6 +98,61 @@ AC_DEFUN([ZFS_AC_KERNEL_CONFIG_DEBUG_LOCK_ALLOC], [
 	*** with the CDDL license and will prevent the module linking stage
 	*** from succeeding.  You must rebuild your kernel without this
 	*** option enabled.])
+	])
+])
+
+dnl #
+dnl # Check CONFIG_MODULES
+dnl #
+dnl # Verify the kernel has CONFIG_MODULES support enabled.
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_CONFIG_MODULES], [
+	ZFS_LINUX_TEST_SRC([config_modules], [
+		#if !defined(CONFIG_MODULES)
+		#error CONFIG_MODULES not defined
+		#endif
+	],[])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_CONFIG_MODULES], [
+	AC_MSG_CHECKING([whether CONFIG_MODULES is defined])
+	AS_IF([test "x$enable_linux_builtin" != xyes], [
+		ZFS_LINUX_TEST_RESULT([config_modules], [
+			AC_MSG_RESULT([yes])
+		],[
+			AC_MSG_RESULT([no])
+			AC_MSG_ERROR([
+		*** This kernel does not include the required loadable module
+		*** support!
+		***
+		*** To build OpenZFS as a loadable Linux kernel module
+		*** enable loadable module support by setting
+		*** `CONFIG_MODULES=y` in the kernel configuration and run
+		*** `make modules_prepare` in the Linux source tree.
+		***
+		*** If you don't intend to enable loadable kernel module
+		*** support, please compile OpenZFS as a Linux kernel built-in.
+		***
+		*** Prepare the Linux source tree by running `make prepare`,
+		*** use the OpenZFS `--enable-linux-builtin` configure option,
+		*** copy the OpenZFS sources into the Linux source tree using
+		*** `./copy-builtin <linux source directory>`,
+		*** set `CONFIG_ZFS=y` in the kernel configuration and compile
+		*** kernel as usual.
+			])
+		])
+	], [
+		ZFS_LINUX_TRY_COMPILE([], [], [
+			AC_MSG_RESULT([not needed])
+		],[
+			AC_MSG_RESULT([error])
+			AC_MSG_ERROR([
+		*** This kernel is unable to compile object files.
+		***
+		*** Please make sure you prepared the Linux source tree
+		*** by running `make prepare` there.
+			])
+		])
 	])
 ])
 

--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -8,8 +8,8 @@ AC_DEFUN([ZFS_AC_CONFIG_KERNEL], [
 		ZFS_AC_QAT
 
 		dnl # Sanity checks for module building and CONFIG_* defines
-		ZFS_AC_KERNEL_TEST_MODULE
 		ZFS_AC_KERNEL_CONFIG_DEFINED
+		ZFS_AC_MODULE_SYMVERS
 
 		dnl # Sequential ZFS_LINUX_TRY_COMPILE tests
 		ZFS_AC_KERNEL_FPU_HEADER
@@ -443,8 +443,6 @@ AC_DEFUN([ZFS_AC_KERNEL], [
 	AC_SUBST(LINUX)
 	AC_SUBST(LINUX_OBJ)
 	AC_SUBST(LINUX_VERSION)
-
-	ZFS_AC_MODULE_SYMVERS
 ])
 
 dnl #
@@ -536,27 +534,6 @@ AC_DEFUN([ZFS_AC_QAT], [
 	$QAT_SYMBOLS
 			])
 		])
-	])
-])
-
-dnl #
-dnl # Basic toolchain sanity check.
-dnl #
-AC_DEFUN([ZFS_AC_KERNEL_TEST_MODULE], [
-	AC_MSG_CHECKING([whether modules can be built])
-	ZFS_LINUX_TRY_COMPILE([], [], [
-		AC_MSG_RESULT([yes])
-	],[
-		AC_MSG_RESULT([no])
-		if test "x$enable_linux_builtin" != xyes; then
-			AC_MSG_ERROR([
-	*** Unable to build an empty module.
-			])
-		else
-			AC_MSG_ERROR([
-	*** Unable to build an empty module.
-	*** Please run 'make scripts' inside the kernel source tree.])
-		fi
 	])
 ])
 
@@ -662,8 +639,10 @@ AC_DEFUN([ZFS_LINUX_COMPILE], [
 		build kernel modules with LLVM/CLANG toolchain])
 	AC_TRY_COMMAND([
 	    KBUILD_MODPOST_NOFINAL="$5" KBUILD_MODPOST_WARN="$6"
-	    make modules -k -j$TEST_JOBS ${KERNEL_CC:+CC=$KERNEL_CC} ${KERNEL_LD:+LD=$KERNEL_LD} ${KERNEL_LLVM:+LLVM=$KERNEL_LLVM} -C $LINUX_OBJ $ARCH_UM
-	    M=$PWD/$1 >$1/build.log 2>&1])
+	    make modules -k -j$TEST_JOBS ${KERNEL_CC:+CC=$KERNEL_CC}
+	    ${KERNEL_LD:+LD=$KERNEL_LD} ${KERNEL_LLVM:+LLVM=$KERNEL_LLVM}
+	    CONFIG_MODULES=y CFLAGS_MODULE=-DCONFIG_MODULES
+	    -C $LINUX_OBJ $ARCH_UM M=$PWD/$1 >$1/build.log 2>&1])
 	AS_IF([AC_TRY_COMMAND([$2])], [$3], [$4])
 ])
 


### PR DESCRIPTION
### Motivation and Context
Close #10832 `configure fails with --enable-linux-builtin when CONFIG_MODULES=n`

### Description
- Unconditionally inject `CONFIG_MODULES` make variable                                                                            
  and `#define CONFIG_MODULES` to Kbuild in `ZFS_LINUX_COMPILE`                                                                    
  autoconf function to emulate loadable kernel modules support.                                                                    
  This allows OpenZFS to perform Linux checks despite                                                                              
  `CONFIG_MODULES=n` in the actual Linux config.                                                                                   
                                                                                                                                   
- Add `ZFS_AC_KERNEL_CONFIG_MODULES` check which encompasses                                                                       
  the logic from `ZFS_AC_KERNEL_TEST_MODULE` with additional                                                                       
  diagnostic messages to the user                                                                                                  

- Removed `ZFS_AC_KERNEL_TEST_MODULE` as it merely duplicates
  every check in `ZFS_AC_KERNEL_CONFIG_DEFINED`

- Moved `ZFS_AC_MODULE_SYMVERS` after `ZFS_AC_KERNEL_CONFIG_DEFINED`
  so the user has a chance to see the proper diagnostic from the
  steps before.

A workaround for Linux's

```
commit 3e3005df73b535cb849cf4ec8075d6aa3c460f68
Author: Masahiro Yamada <masahiroy@kernel.org>
Date:   Wed Mar 31 22:38:03 2021 +0900

kbuild: unify modules(_install) for in-tree and external modules

If you attempt to build or install modules ('make modules(_install)'
with CONFIG_MODULES disabled, you will get a clear error message, but
nothing for external module builds.

Factor out the modules and modules_install rules into the common part,
so you will get the same error message when you try to build external
modules with CONFIG_MODULES=n.

Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
```

### How Has This Been Tested?
$ make

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
