### PR TITLE
Silence clang 13.0.0 false positive warnings

### DIFF
--- a/module/zstd/lib/compress/fse_compress.c
+++ b/module/zstd/lib/compress/fse_compress.c
@@ -304,7 +304,7 @@ size_t FSE_writeNCount (void* buffer, size_t bufferSize,
 
 FSE_CTable* FSE_createCTable (unsigned maxSymbolValue, unsigned tableLog)
 {
-    size_t size;
+    size_t size __attribute__ ((unused));
     if (tableLog > FSE_TABLELOG_ABSOLUTE_MAX) tableLog = FSE_TABLELOG_ABSOLUTE_MAX;
     size = FSE_CTABLE_SIZE_U32 (tableLog, maxSymbolValue) * sizeof(U32);
     return (FSE_CTable*)malloc(size);

--- a/module/zstd/lib/compress/zstd_compress_superblock.c
+++ b/module/zstd/lib/compress/zstd_compress_superblock.c
@@ -409,7 +409,7 @@ static size_t ZSTD_seqDecompressedSize(seqStore_t const* seqStore, const seqDef*
     const seqDef* const send = sequences + nbSeq;
     const seqDef* sp = sstart;
     size_t matchLengthSum = 0;
-    size_t litLengthSum = 0;
+    size_t litLengthSum __attribute__ ((unused)) = 0;
     while (send-sp > 0) {
         ZSTD_sequenceLength const seqLen = ZSTD_getSequenceLength(seqStore, sp);
         litLengthSum += seqLen.litLength;


### PR DESCRIPTION
### Motivation and Context

The FreeBSD main builder has updated to using clang 13.0.0 by
default.  This results in a CI failing reliably due to unused variables
in the zstd code reported by the new clang version.

http://build.zfsonlinux.org/builders/FreeBSD%20main%20amd64%20%28TEST%29/builds/3765/steps/shell_1/logs/make

While I'd really prefer not to modify the zstd code, annotating the
code is a tiny change which resolves the warning and CI failures.

### Description

Clang 13.0.0 added support for `Wunused-but-set-parameter` and
`-Wunused-but-set-variable` which correctly detects two unused
variables in zstd resulting in a build failure.  This commit
annotates these instances accordingly.
    
https://releases.llvm.org/13.0.1/tools/clang/docs/ReleaseNotes.html#id6
    
In FSE_createCTable(), malloc() is intentionally defined as NULL when
compiled in the kernel so the variable is unused.
    
    zstd/lib/compress/fse_compress.c:307:12: error: variable 'size'
    set but not used [-Werror,-Wunused-but-set-variable]
    
Additionally, in ZSTD_seqDecompressedSize() the assert is compiled
out similarly resulting in an unused variable.
    
    zstd/lib/compress/zstd_compress_superblock.c:412:12: error: variable
    'litLengthSum' set but not used [-Werror,-Wunused-but-set-variable]

### How Has This Been Tested?

Pending CI results.  Locally compiled, but not with clang.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
