### PR TITLE
autoconf: Fail when __copy_from_user_inatomic is a non-GPL symbol

### DIFF
--- a/config/kernel-copy-from-user-inatomic.m4
+++ b/config/kernel-copy-from-user-inatomic.m4
@@ -18,9 +18,13 @@ AC_DEFUN([ZFS_AC_KERNEL___COPY_FROM_USER_INATOMIC], [
 	AC_MSG_CHECKING([whether __copy_from_user_inatomic is available])
 	ZFS_LINUX_TEST_RESULT([__copy_from_user_inatomic_license], [
 		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE___COPY_FROM_USER_INATOMIC, 1,
-		    [__copy_from_user_inatomic is available])
 	], [
 		AC_MSG_RESULT(no)
+		AC_MSG_ERROR([
+	*** The `__copy_from_user_inatomic()` Linux kernel function license
+	*** (GPL only) is incompatible with the OpenZFS license
+	*** ($ZFS_META_LICENSE). OpenZFS cannot be compiled due to
+	*** legal and compliance reasons.
+		])
 	])
 ])

--- a/module/os/linux/zfs/zfs_uio.c
+++ b/module/os/linux/zfs/zfs_uio.c
@@ -75,7 +75,6 @@ zfs_uiomove_iov(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio)
 			} else {
 				unsigned long b_left = 0;
 				if (uio->uio_fault_disable) {
-#if defined(HAVE___COPY_FROM_USER_INATOMIC)
 					if (!zfs_access_ok(VERIFY_READ,
 					    (iov->iov_base + skip), cnt)) {
 						return (EFAULT);
@@ -85,9 +84,6 @@ zfs_uiomove_iov(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio)
 					    __copy_from_user_inatomic(p,
 					    (iov->iov_base + skip), cnt);
 					pagefault_enable();
-#else
-					return (EFAULT);
-#endif
 				} else {
 					b_left =
 					    copy_from_user(p,


### PR DESCRIPTION
### Motivation and Context
https://github.com/openzfs/zfs/pull/13367#issuecomment-1112694226

### Description
A followup to 849c14e04844a2f0e1f7e42886c2cef083563f35
Fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1009242

### How Has This Been Tested?
`$ make`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
