### PR TITLE
zpool: guard vs_noalloc and vs_pspace with VDEV_STAT_VALID()

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2472,7 +2472,7 @@ print_status_config(zpool_handle_t *zhp, status_cbdata_t *cb, const char *name,
 
 	if (vs->vs_scan_removing != 0) {
 		(void) printf(gettext("  (removing)"));
-	} else if (vs->vs_noalloc != 0) {
+	} else if (VDEV_STAT_VALID(vs_noalloc, vsc) && vs->vs_noalloc != 0) {
 		(void) printf(gettext("  (non-allocating)"));
 	}
 
@@ -6162,7 +6162,7 @@ print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		 * 'toplevel' boolean value is passed to the print_one_column()
 		 * to indicate that the value is valid.
 		 */
-		if (vs->vs_pspace)
+		if (VDEV_STAT_VALID(vs_pspace, c) && vs->vs_pspace)
 			print_one_column(ZPOOL_PROP_SIZE, vs->vs_pspace, NULL,
 			    scripted, B_TRUE, format);
 		else


### PR DESCRIPTION
### Motivation and Context
I kept getting "(non-allocating)" spuriously in `./zpool status` and, uh, spot the problem with `./zpool list -v`:
```
NAME                                    SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
filling                                25.5T  6.85T  18.6T        -       64M     5%    26%  1.00x    ONLINE  -
  mirror-0                                97   500G  3.15T        -       64M    17%  13.4%      -    ONLINE
    ata-HGST_HUS726T4TALE6L4_V6K2L4RR     97      -      -        -       64M      -      -      -    ONLINE
    ata-HGST_HUS726T4TALE6L4_V6K2MHYR     97      -      -        -       64M      -      -      -    ONLINE
  raidz1-1                                97  6.36T  15.5T        -         -     3%  29.1%      -    ONLINE
    ata-HGST_HUS728T8TALE6L4_VDKT237K     97      -      -        -         -      -      -      -    ONLINE
    ata-HGST_HUS728T8TALE6L4_VDGY075D     97      -      -        -         -      -      -      -    ONLINE
    ata-HGST_HUS728T8TALE6L4_VDKVRRJK     97      -      -        -         -      -      -      -    ONLINE
cache                                      -      -      -        -         -      -      -      -         -
  nvme0n1p4                               97  12.8G  50.2G        -         -     0%  20.3%      -    ONLINE
tarta-boot                              240M  50.0M   190M        -         -    16%    20%  1.00x    ONLINE  -
  mirror-0                                97  50.0M   190M        -         -    16%  20.8%      -    ONLINE
    tarta-boot                            97      -      -        -         -      -      -      -    ONLINE
    tarta-boot-nvme                       97      -      -        -         -      -      -      -    ONLINE
tarta-zoot                             55.5G  6.96G  48.5G        -         -    14%    12%  1.00x    ONLINE  -
  mirror-0                                97  6.96G  48.5G        -         -    14%  12.5%      -    ONLINE
    tarta-zoot                            97      -      -        -         -      -      -      -    ONLINE
    tarta-zoot-nvme                       97      -      -        -         -      -      -      -    ONLINE
testpsko                               39.5G   744K  39.5G        -         -     0%     0%  1.00x    ONLINE  -
  testpsko1                               97   744K  39.5G        -         -     0%  0.00%      -    ONLINE
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
