### PR TITLE
linux: libzutil: zfs_strip_path: only strip known prefixes

### DIFF
--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -97,8 +97,8 @@ _LIBZUTIL_H int zfs_append_partition(char *path, size_t max_len);
 _LIBZUTIL_H int zfs_resolve_shortname(const char *name, char *path,
     size_t pathlen);
 
-_LIBZUTIL_H char *zfs_strip_partition(char *);
-_LIBZUTIL_H char *zfs_strip_path(char *);
+_LIBZUTIL_H char *zfs_strip_partition(const char *);
+_LIBZUTIL_H const char *zfs_strip_path(const char *);
 
 _LIBZUTIL_H int zfs_strcmp_pathname(const char *, const char *, int);
 

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -5597,12 +5597,12 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_strip_partition' mangled-name='zfs_strip_partition' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_partition'>
-      <parameter type-id='26a90f95' name='path'/>
+      <parameter type-id='80f4b756' name='path'/>
       <return type-id='26a90f95'/>
     </function-decl>
     <function-decl name='zfs_strip_path' mangled-name='zfs_strip_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_strip_path'>
-      <parameter type-id='26a90f95' name='path'/>
-      <return type-id='26a90f95'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='zfs_get_enclosure_sysfs_path' mangled-name='zfs_get_enclosure_sysfs_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_get_enclosure_sysfs_path'>
       <parameter type-id='80f4b756' name='dev_name'/>

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4123,7 +4123,8 @@ char *
 zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
     int name_flags)
 {
-	char *path, *type;
+	char *type, *tpath;
+	const char *path;
 	uint64_t value;
 	char buf[PATH_BUF_LEN];
 	char tmpbuf[PATH_BUF_LEN * 2];
@@ -4148,7 +4149,9 @@ zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
 		(void) nvlist_lookup_uint64(nv, ZPOOL_CONFIG_GUID, &value);
 		(void) snprintf(buf, sizeof (buf), "%llu", (u_longlong_t)value);
 		path = buf;
-	} else if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &path) == 0) {
+	} else if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &tpath) == 0) {
+		path = tpath;
+
 		if (name_flags & VDEV_NAME_FOLLOW_LINKS) {
 			char *rp = realpath(path, NULL);
 			if (rp) {

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4123,10 +4123,10 @@ char *
 zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
     int name_flags)
 {
-	char *path, *type, *env;
+	char *path, *type;
 	uint64_t value;
 	char buf[PATH_BUF_LEN];
-	char tmpbuf[PATH_BUF_LEN];
+	char tmpbuf[PATH_BUF_LEN * 2];
 
 	/*
 	 * vdev_name will be "root"/"root-0" for the root vdev, but it is the
@@ -4136,19 +4136,11 @@ zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
 	if (zhp != NULL && strcmp(type, "root") == 0)
 		return (zfs_strdup(hdl, zpool_get_name(zhp)));
 
-	env = getenv("ZPOOL_VDEV_NAME_PATH");
-	if (env && (strtoul(env, NULL, 0) > 0 ||
-	    !strncasecmp(env, "YES", 3) || !strncasecmp(env, "ON", 2)))
+	if (libzfs_envvar_is_set("ZPOOL_VDEV_NAME_PATH"))
 		name_flags |= VDEV_NAME_PATH;
-
-	env = getenv("ZPOOL_VDEV_NAME_GUID");
-	if (env && (strtoul(env, NULL, 0) > 0 ||
-	    !strncasecmp(env, "YES", 3) || !strncasecmp(env, "ON", 2)))
+	if (libzfs_envvar_is_set("ZPOOL_VDEV_NAME_GUID"))
 		name_flags |= VDEV_NAME_GUID;
-
-	env = getenv("ZPOOL_VDEV_NAME_FOLLOW_LINKS");
-	if (env && (strtoul(env, NULL, 0) > 0 ||
-	    !strncasecmp(env, "YES", 3) || !strncasecmp(env, "ON", 2)))
+	if (libzfs_envvar_is_set("ZPOOL_VDEV_NAME_FOLLOW_LINKS"))
 		name_flags |= VDEV_NAME_FOLLOW_LINKS;
 
 	if (nvlist_lookup_uint64(nv, ZPOOL_CONFIG_NOT_PRESENT, &value) == 0 ||

--- a/lib/libzutil/os/freebsd/zutil_device_path_os.c
+++ b/lib/libzutil/os/freebsd/zutil_device_path_os.c
@@ -40,7 +40,7 @@
  * Note: The caller must free the returned string.
  */
 char *
-zfs_strip_partition(char *dev)
+zfs_strip_partition(const char *dev)
 {
 	return (strdup(dev));
 }
@@ -56,8 +56,8 @@ zfs_append_partition(char *path, size_t max_len)
  * On FreeBSD we only want to remove "/dev/" from the beginning of
  * paths if present.
  */
-char *
-zfs_strip_path(char *path)
+const char *
+zfs_strip_path(const char *path)
 {
 	if (strncmp(path, _PATH_DEV, sizeof (_PATH_DEV) - 1) == 0)
 		return (path + sizeof (_PATH_DEV) - 1);

--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -151,7 +151,15 @@ zfs_strip_partition_path(const char *path)
 const char *
 zfs_strip_path(const char *path)
 {
-	return (strrchr(path, '/') + 1);
+	size_t spath_count;
+	const char *const *spaths = zpool_default_search_paths(&spath_count);
+
+	for (size_t i = 0; i < spath_count; ++i)
+		if (strncmp(path, spaths[i], strlen(spaths[i])) == 0 &&
+		    path[strlen(spaths[i])] == '/')
+			return (path + strlen(spaths[i]) + 1);
+
+	return (path);
 }
 
 /*

--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -81,7 +81,7 @@ zfs_append_partition(char *path, size_t max_len)
  * caller must free the returned string
  */
 char *
-zfs_strip_partition(char *path)
+zfs_strip_partition(const char *path)
 {
 	char *tmp = strdup(path);
 	char *part = NULL, *d = NULL;
@@ -117,7 +117,7 @@ zfs_strip_partition(char *path)
  * Returned string must be freed.
  */
 static char *
-zfs_strip_partition_path(char *path)
+zfs_strip_partition_path(const char *path)
 {
 	char *newpath = strdup(path);
 	char *sd_offset;
@@ -148,8 +148,8 @@ zfs_strip_partition_path(char *path)
 /*
  * Strip the unwanted portion of a device path.
  */
-char *
-zfs_strip_path(char *path)
+const char *
+zfs_strip_path(const char *path)
 {
 	return (strrchr(path, '/') + 1);
 }


### PR DESCRIPTION
### Motivation and Context
CC: @cleverca22 for #9771

### Description
See commit messages.

Draft because on top of unification and #13412, otherwise g2g.

### How Has This Been Tested?
```
# zpool create -o cachefile= testpsko media/testpsko
# zpool create -o cachefile= testpsko2 $PWD/testpsko2
$ ./zpool list -v
NAME                                              SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
filling                                          25.5T  6.85T  18.6T        -       64M     5%    26%  1.00x    ONLINE  -
  mirror-0                                       3.64T   500G  3.15T        -       64M    17%  13.4%      -    ONLINE
    ata-HGST_HUS726T4TALE6L4_V6K2L4RR                -      -      -        -       64M      -      -      -    ONLINE
    ata-HGST_HUS726T4TALE6L4_V6K2MHYR                -      -      -        -       64M      -      -      -    ONLINE
  raidz1-1                                       21.8T  6.36T  15.5T        -         -     3%  29.1%      -    ONLINE
    ata-HGST_HUS728T8TALE6L4_VDKT237K                -      -      -        -         -      -      -      -    ONLINE
    ata-HGST_HUS728T8TALE6L4_VDGY075D                -      -      -        -         -      -      -      -    ONLINE
    ata-HGST_HUS728T8TALE6L4_VDKVRRJK                -      -      -        -         -      -      -      -    ONLINE
cache                                                -      -      -        -         -      -      -      -         -
  nvme0n1p4                                      63.0G  12.8G  50.2G        -         -     0%  20.3%      -    ONLINE
tarta-boot                                        240M  50.0M   190M        -         -    16%    20%  1.00x    ONLINE  -
  mirror-0                                        240M  50.0M   190M        -         -    16%  20.8%      -    ONLINE
    tarta-boot                                       -      -      -        -         -      -      -      -    ONLINE
    tarta-boot-nvme                                  -      -      -        -         -      -      -      -    ONLINE
tarta-zoot                                       55.5G  6.96G  48.5G        -         -    14%    12%  1.00x    ONLINE  -
  mirror-0                                       55.5G  6.96G  48.5G        -         -    14%  12.5%      -    ONLINE
    tarta-zoot                                       -      -      -        -         -      -      -      -    ONLINE
    tarta-zoot-nvme                                  -      -      -        -         -      -      -      -    ONLINE
testpsko                                         39.5G   744K  39.5G        -         -     0%     0%  1.00x    ONLINE  -
  media/testpsko1                                39.5G   744K  39.5G        -         -     0%  0.00%      -    ONLINE
testpsko2                                        39.5G   130K  39.5G        -         -     0%     0%  1.00x    ONLINE  -
  /home/nabijaczleweli/store/code/zfs/testpsko2  39.5G   130K  39.5G        -         -     0%  0.00%      -    ONLINE

$ ./zpool status
  pool: filling
 state: ONLINE
status: Some supported and requested features are not enabled on the pool.
	The pool can still be used, but some features are unavailable.
action: Enable all features using 'zpool upgrade'. Once this is done,
	the pool may no longer be accessible by software that does not support
	the features. See zpool-features(7) for details.
  scan: scrub repaired 0B in 04:13:50 with 0 errors on Sun May  1 11:05:50 2022
config:

	NAME                                   STATE     READ WRITE CKSUM
	filling                                ONLINE       0     0     0
	  mirror-0                             ONLINE       0     0     0
	    ata-HGST_HUS726T4TALE6L4_V6K2L4RR  ONLINE       0     0     0
	    ata-HGST_HUS726T4TALE6L4_V6K2MHYR  ONLINE       0     0     0
	  raidz1-1                             ONLINE       0     0     0
	    ata-HGST_HUS728T8TALE6L4_VDKT237K  ONLINE       0     0     0
	    ata-HGST_HUS728T8TALE6L4_VDGY075D  ONLINE       0     0     0
	    ata-HGST_HUS728T8TALE6L4_VDKVRRJK  ONLINE       0     0     0
	cache
	  nvme0n1p4                            ONLINE       0     0     0

errors: No known data errors

  pool: tarta-boot
 state: ONLINE
status: This pool has a compatibility list specified, but it could not be
	read/parsed at this time. The pool can still be used, but this
	should be investigated.
action: Check the value of the 'compatibility' property against the
	appropriate file in /usr/local/etc/zfs/compatibility.d or /usr/local/share/zfs/compatibility.d.
  scan: scrub repaired 0B in 00:00:00 with 0 errors on Sun May  1 06:52:02 2022
config:

	NAME                 STATE     READ WRITE CKSUM
	tarta-boot           ONLINE       0     0     0
	  mirror-0           ONLINE       0     0     0
	    tarta-boot       ONLINE       0     0     0
	    tarta-boot-nvme  ONLINE       0     0     0

errors: No known data errors

  pool: tarta-zoot
 state: ONLINE
status: Some supported and requested features are not enabled on the pool.
	The pool can still be used, but some features are unavailable.
action: Enable all features using 'zpool upgrade'. Once this is done,
	the pool may no longer be accessible by software that does not support
	the features. See zpool-features(7) for details.
  scan: scrub repaired 0B in 00:01:05 with 0 errors on Sun May  1 06:53:07 2022
config:

	NAME                 STATE     READ WRITE CKSUM
	tarta-zoot           ONLINE       0     0     0
	  mirror-0           ONLINE       0     0     0
	    tarta-zoot       ONLINE       0     0     0
	    tarta-zoot-nvme  ONLINE       0     0     0

errors: No known data errors

  pool: testpsko
 state: ONLINE
config:

	NAME               STATE     READ WRITE CKSUM
	testpsko           ONLINE       0     0     0
	  media/testpsko1  ONLINE       0     0     0

errors: No known data errors

  pool: testpsko2
 state: ONLINE
config:

	NAME                                             STATE     READ WRITE CKSUM
	testpsko2                                        ONLINE       0     0     0
	  /home/nabijaczleweli/store/code/zfs/testpsko2  ONLINE       0     0     0

errors: No known data errors
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).