### PR TITLE
[2.1.5] Remove REMAKE_INITRD

### DIFF
--- a/scripts/dkms.mkconf
+++ b/scripts/dkms.mkconf
@@ -68,7 +68,6 @@ POST_BUILD="scripts/dkms.postbuild
   -t \${dkms_tree}
 "
 AUTOINSTALL="yes"
-REMAKE_INITRD="no"
 MAKE[0]="make"
 STRIP[0]="\$(
   [[ -r \${PACKAGE_CONFIG} ]] \\


### PR DESCRIPTION
### Motivation and Context
I just got those warnings on sid.

### Description
Clean cherry-pick of b5c16861e9fa91871540a101e92013e05182fc2f, Upstream-commit: trailer added

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
