### PR TITLE
hw_serial removal, ddi_strto*() fixes

### DIFF
--- a/include/os/freebsd/spl/sys/misc.h
+++ b/include/os/freebsd/spl/sys/misc.h
@@ -52,8 +52,6 @@ struct opensolaris_utsname {
 	char	*machine;
 };
 
-extern char hw_serial[11];
-
 #define	task_io_account_read(n)
 #define	task_io_account_write(n)
 

--- a/include/os/freebsd/spl/sys/sunddi.h
+++ b/include/os/freebsd/spl/sys/sunddi.h
@@ -48,7 +48,6 @@ typedef int ddi_devid_t;
 #define	ddi_prop_free(x)				(void)0
 #define	ddi_root_node()					(void)0
 
-extern int ddi_strtoul(const char *, char **, int, unsigned long *);
 extern int ddi_strtol(const char *, char **, int, long *);
 extern int ddi_strtoull(const char *, char **, int, unsigned long long *);
 extern int ddi_strtoll(const char *, char **, int, long long *);

--- a/include/os/linux/spl/sys/sunddi.h
+++ b/include/os/linux/spl/sys/sunddi.h
@@ -46,7 +46,6 @@ typedef int ddi_devid_t;
 #define	ddi_prop_free(x)				(void)0
 #define	ddi_root_node()					(void)0
 
-extern int ddi_strtoul(const char *, char **, int, unsigned long *);
 extern int ddi_strtol(const char *, char **, int, long *);
 extern int ddi_strtoull(const char *, char **, int, unsigned long long *);
 extern int ddi_strtoll(const char *, char **, int, long long *);

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -692,10 +692,6 @@ extern char *kmem_asprintf(const char *fmt, ...);
 /*
  * Hostname information
  */
-extern char hw_serial[];	/* for userland-emulated hostid access */
-extern int ddi_strtoul(const char *str, char **nptr, int base,
-    unsigned long *result);
-
 extern int ddi_strtoull(const char *str, char **nptr, int base,
     u_longlong_t *result);
 

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -53,7 +53,7 @@
  */
 
 uint64_t physmem;
-char hw_serial[HW_HOSTID_LEN];
+uint32_t hostid;
 struct utsname hw_utsname;
 
 /* If set, all blocks read will be copied to the specified directory. */
@@ -299,7 +299,7 @@ zone_get_hostid(void *zonep)
 	 * We're emulating the system's hostid in userland.
 	 */
 	(void) zonep;
-	return (strtoul(hw_serial, NULL, 10));
+	return (hostid);
 }
 
 int
@@ -767,18 +767,6 @@ random_get_pseudo_bytes(uint8_t *ptr, size_t len)
 }
 
 int
-ddi_strtoul(const char *hw_serial, char **nptr, int base, unsigned long *result)
-{
-	(void) nptr;
-	char *end;
-
-	*result = strtoul(hw_serial, &end, base);
-	if (*result == 0)
-		return (errno);
-	return (0);
-}
-
-int
 ddi_strtoull(const char *str, char **nptr, int base, u_longlong_t *result)
 {
 	(void) nptr;
@@ -823,8 +811,7 @@ kernel_init(int mode)
 	dprintf("physmem = %llu pages (%.2f GB)\n", (u_longlong_t)physmem,
 	    (double)physmem * sysconf(_SC_PAGE_SIZE) / (1ULL << 30));
 
-	(void) snprintf(hw_serial, sizeof (hw_serial), "%ld",
-	    (mode & SPA_MODE_WRITE) ? get_system_hostid() : 0);
+	hostid = (mode & SPA_MODE_WRITE) ? get_system_hostid() : 0;
 
 	random_init();
 

--- a/module/os/freebsd/spl/spl_misc.c
+++ b/module/os/freebsd/spl/spl_misc.c
@@ -43,15 +43,11 @@ static struct opensolaris_utsname hw_utsname = {
 	.machine = MACHINE
 };
 
-#ifndef KERNEL_STATIC
-char hw_serial[11] = "0";
-
 utsname_t *
 utsname(void)
 {
 	return (&hw_utsname);
 }
-#endif
 
 static void
 opensolaris_utsname_init(void *arg)

--- a/module/os/freebsd/spl/spl_sunddi.c
+++ b/module/os/freebsd/spl/spl_sunddi.c
@@ -46,19 +46,6 @@ ddi_strtol(const char *str, char **nptr, int base, long *result)
 }
 
 int
-ddi_strtoul(const char *str, char **nptr, int base, unsigned long *result)
-{
-
-	if (str == hw_serial) {
-		*result = prison0.pr_hostid;
-		return (0);
-	}
-
-	*result = strtoul(str, nptr, base);
-	return (0);
-}
-
-int
 ddi_strtoull(const char *str, char **nptr, int base, unsigned long long *result)
 {
 

--- a/module/os/linux/spl/spl-generic.c
+++ b/module/os/linux/spl/spl-generic.c
@@ -436,7 +436,7 @@ __VA_ARGS__ int ddi_strtou##type(const char *str, char **endptr,	\
 {									\
 	valtype last_value, value = 0;					\
 	char *ptr = (char *)str;					\
-	int flag = 1, digit;						\
+	int digit;							\
 									\
 	if (strlen(ptr) == 0)						\
 		return (EINVAL);					\
@@ -474,15 +474,13 @@ __VA_ARGS__ int ddi_strtou##type(const char *str, char **endptr,	\
 		if (last_value > value) /* Overflow */			\
 			return (ERANGE);				\
 									\
-		flag = 1;						\
 		ptr++;							\
 	}								\
 									\
-	if (flag)							\
-		*result = value;					\
+	*result = value;						\
 									\
 	if (endptr)							\
-		*endptr = (char *)(flag ? ptr : str);			\
+		*endptr = ptr;						\
 									\
 	return (0);							\
 }									\

--- a/module/os/linux/spl/spl-generic.c
+++ b/module/os/linux/spl/spl-generic.c
@@ -425,13 +425,13 @@ EXPORT_SYMBOL(__aeabi_ldivmod);
  * functions against their Solaris counterparts.  It is possible that I
  * may have misinterpreted the man page or the man page is incorrect.
  */
-int ddi_strtoul(const char *, char **, int, unsigned long *);
+static int ddi_strtoul(const char *, char **, int, unsigned long *);
 int ddi_strtol(const char *, char **, int, long *);
 int ddi_strtoull(const char *, char **, int, unsigned long long *);
 int ddi_strtoll(const char *, char **, int, long long *);
 
-#define	define_ddi_strtoux(type, valtype)				\
-int ddi_strtou##type(const char *str, char **endptr,			\
+#define	define_ddi_strtoux(type, valtype, ...)				\
+__VA_ARGS__ int ddi_strtou##type(const char *str, char **endptr,	\
     int base, valtype *result)						\
 {									\
 	valtype last_value, value = 0;					\
@@ -508,12 +508,12 @@ int ddi_strto##type(const char *str, char **endptr,			\
 	return (rc);							\
 }
 
-define_ddi_strtoux(l, unsigned long)
+#define	blank
+define_ddi_strtoux(l, unsigned long, static)
 define_ddi_strtox(l, long)
-define_ddi_strtoux(ll, unsigned long long)
+define_ddi_strtoux(ll, unsigned long long, blank)
 define_ddi_strtox(ll, long long)
 
-EXPORT_SYMBOL(ddi_strtoul);
 EXPORT_SYMBOL(ddi_strtol);
 EXPORT_SYMBOL(ddi_strtoll);
 EXPORT_SYMBOL(ddi_strtoull);

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -1068,8 +1068,8 @@ sa_setup(objset_t *os, uint64_t sa_obj, const sa_attr_reg_t *reg_attrs,
 				    za.za_num_integers);
 				break;
 			}
-			VERIFY(ddi_strtoull(za.za_name, NULL, 10,
-			    (unsigned long long *)&lot_num) == 0);
+			VERIFY0(ddi_strtoull(za.za_name, NULL, 10,
+			    (unsigned long long *)&lot_num));
 
 			(void) sa_add_layout_entry(os, lot_attrs,
 			    za.za_num_integers, lot_num,


### PR DESCRIPTION
### Motivation and Context
https://docs.oracle.com/cd/E86824_01/html/E54779/ddi-strtoul-9f.html, hw_serial is unused

### Description
See commit messages. Of course, we might not actually want to process initial whitespace, but.

Draft because on top of unification

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
