### PR TITLE
Workaround broken VDEV_UPATH

### DIFF
--- a/cmd/zpool/zpool.d/iostat
+++ b/cmd/zpool/zpool.d/iostat
@@ -15,6 +15,15 @@ if [ "$1" = "-h" ] ; then
 	exit
 fi
 
+# Sometimes, UPATH ends up /dev/(null).
+# That should be corrected, but for now...
+# shellcheck disable=SC2154
+if [ ! -b "$VDEV_UPATH" ]; then
+	somepath="${VDEV_PATH}"
+else
+	somepath="${VDEV_UPATH}"
+fi
+
 if [ "$script" = "iostat-1s" ] ; then
 	# Do a single one-second sample
 	interval=1
@@ -27,8 +36,7 @@ elif [ "$script" = "iostat-10s" ] ; then
 	brief="yes"
 fi
 
-# shellcheck disable=SC2154
-if [ -f "$VDEV_UPATH" ] ; then
+if [ -f "$somepath" ] ; then
 	# We're a file-based vdev, iostat doesn't work on us.  Do nothing.
 	exit
 fi
@@ -37,13 +45,13 @@ if [ "$(uname)" = "FreeBSD" ]; then
 	out=$(iostat -dKx \
 		${interval:+"-w $interval"} \
 		${interval:+"-c 1"} \
-		"$VDEV_UPATH" | tail -n 2)
+		"$somepath" | tail -n 2)
 else
 	out=$(iostat -kx \
 		${brief:+"-y"} \
 		${interval:+"$interval"} \
 		${interval:+"1"} \
-		"$VDEV_UPATH" | grep -v '^$' | tail -n 2)
+		"$somepath" | grep -v '^$' | tail -n 2)
 fi
 
 

--- a/cmd/zpool/zpool.d/lsblk
+++ b/cmd/zpool/zpool.d/lsblk
@@ -61,21 +61,29 @@ else
 	list=$(echo "$script" | tr '[:upper:]' '[:lower:]')
 fi
 
+# Sometimes, UPATH ends up /dev/(null).
+# That should be corrected, but for now...
+# shellcheck disable=SC2154
+if [ ! -b "$VDEV_UPATH" ]; then
+	somepath="${VDEV_PATH}"
+else
+	somepath="${VDEV_UPATH}"
+fi
+
 # Older versions of lsblk don't support all these values (like SERIAL).
 for i in $list ; do
 
 	# Special case: Looking up the size of a file-based vdev can't
 	# be done with lsblk.
-	# shellcheck disable=SC2154
-	if [ "$i" = "size" ] && [ -f "$VDEV_UPATH" ] ; then
-		size=$(du -h --apparent-size "$VDEV_UPATH" | cut -f 1)
+	if [ "$i" = "size" ] && [ -f "$somepath" ] ; then
+		size=$(du -h --apparent-size "$somepath" | cut -f 1)
 		echo "size=$size"
 		continue
 	fi
 
 
 	val=""
-	if val=$(eval "lsblk -dl -n -o $i $VDEV_UPATH 2>/dev/null") ; then
+	if val=$(eval "lsblk -dl -n -o $i $somepath 2>/dev/null") ; then
 		# Remove leading/trailing whitespace from value
 		val=$(echo "$val" | sed -e 's/^[[:space:]]*//' \
 		     -e 's/[[:space:]]*$//')

--- a/cmd/zpool/zpool.d/smart
+++ b/cmd/zpool/zpool.d/smart
@@ -69,8 +69,16 @@ if [ "$1" = "-h" ] ; then
         exit
 fi
 
+# Sometimes, UPATH ends up /dev/(null).
+# That should be corrected, but for now...
 # shellcheck disable=SC2154
-if [ -b "$VDEV_UPATH" ] && PATH="/usr/sbin:$PATH" command -v smartctl > /dev/null || [ -n "$samples" ] ; then
+if [ ! -b "$VDEV_UPATH" ]; then
+	somepath="${VDEV_PATH}"
+else
+	somepath="${VDEV_UPATH}"
+fi
+
+if [ -b "$somepath" ] && PATH="/usr/sbin:$PATH" command -v smartctl > /dev/null || [ -n "$samples" ] ; then
 	if [ -n "$samples" ] ; then
 		# cat a smartctl output text file instead of running smartctl
 		# on a vdev (only used for developer testing).
@@ -78,7 +86,7 @@ if [ -b "$VDEV_UPATH" ] && PATH="/usr/sbin:$PATH" command -v smartctl > /dev/nul
 		echo "file=$file"
 		raw_out=$(cat "$samples/$file")
 	else
-		raw_out=$(sudo smartctl -a "$VDEV_UPATH")
+		raw_out=$(sudo smartctl -a "$somepath")
 	fi
 
 	# What kind of drive are we?  Look for the right line in smartctl:


### PR DESCRIPTION
### Motivation and Context
For quite some time, I've just ignored the zpool scripts that I didn't write myself, because they've been completely broken for me:
```
$ sudo ZPOOL_SCRIPTS_AS_ROOT=1 zpool iostat -v ohnopool 1 -c upath
              capacity     operations     bandwidth
pool        alloc   free   read  write   read  write        upath
----------  -----  -----  -----  -----  -----  -----  -----------
ohnopool     636M  2.13G      0      0     18  1.39K
  raidz1     636M  2.13G      0      0     18  1.39K
    /ohno1      -      -      0      0      5    474  /dev/(null)
    /ohno2      -      -      0      0      6    474  /dev/(null)
    /ohno3      -      -      0      0      6    474  /dev/(null)
----------  -----  -----  -----  -----  -----  -----  -----------
$ sudo ZPOOL_SCRIPTS_AS_ROOT=1 zpool iostat -c upath phantasm 1
                                          capacity     operations     bandwidth
pool                                    alloc   free   read  write   read  write        upath
--------------------------------------  -----  -----  -----  -----  -----  -----  -----------
phantasm                                1.03T  8.07T      1      0  6.18K  1.76K
  mirror                                1.03T  8.07T      1      0  6.18K  1.76K
    ata-WDC_WD100EMAZ-00WJTA0_JEHVB59Z      -      -      0      0  2.06K    601  /dev/(null)
    ata-WDC_WD100EMAZ-00WJTA0_2YK8Y1WD      -      -      0      0  2.08K    601  /dev/(null)
    ata-WDC_WD100EMAZ-00WJTA0_JEK8PB5Z      -      -      0      0  2.03K    601  /dev/(null)
--------------------------------------  -----  -----  -----  -----  -----  -----  -----------
```

This is a quick set of workarounds that restore most functionality to them for now, while I plan to go figure out what broke UPATH later.

### Description
I kept meaning to look into why it was broken, but I use the scripts so infrequently that I never remembered long enough. Then #13404 reminded me.

(I have no idea if this passes checkstyle, since checkstyle never passes on my machine.)

### How Has This Been Tested?
I've been using it for a couple days infrequently on my Debian bullseye system where it was misbehaving before.

I've not got a FreeBSD VM booted at the moment, so I don't know how broken they are there. I'll probably try it at some point, but I mostly just wanted to get it opened to point people to who encounter the problem.

Before:
```
$ sudo ZPOOL_SCRIPTS_AS_ROOT=1 zpool iostat -v phantasm -c smart
                                          capacity     operations     bandwidth
pool                                    alloc   free   read  write   read  write  temp  health  ata_err  realloc  rep_ucor  cmd_to  pend_sec  off_ucor
--------------------------------------  -----  -----  -----  -----  -----  -----  ----  ------  -------  -------  --------  ------  --------  --------
phantasm                                1.03T  8.07T      1      0  6.18K  1.76K
  mirror                                1.03T  8.07T      1      0  6.18K  1.76K
    ata-WDC_WD100EMAZ-00WJTA0_JEHVB59Z      -      -      0      0  2.06K    601     -       -        -        -         -       -         -         -
    ata-WDC_WD100EMAZ-00WJTA0_2YK8Y1WD      -      -      0      0  2.08K    601     -       -        -        -         -       -         -         -
    ata-WDC_WD100EMAZ-00WJTA0_JEK8PB5Z      -      -      0      0  2.03K    601     -       -        -        -         -       -         -         -
--------------------------------------  -----  -----  -----  -----  -----  -----  ----  ------  -------  -------  --------  ------  --------  --------
```
After:
```
$ sudo ZPOOL_SCRIPTS_AS_ROOT=1 zpool iostat -v phantasm -c smart
                                          capacity     operations     bandwidth
pool                                    alloc   free   read  write   read  write  health  realloc  temp  pend_sec  off_ucor  ata_err  rep_ucor  cmd_to
--------------------------------------  -----  -----  -----  -----  -----  -----  ------  -------  ----  --------  --------  -------  --------  ------
phantasm                                1.03T  8.07T      1      0  6.18K  1.76K
  mirror                                1.03T  8.07T      1      0  6.18K  1.76K
    ata-WDC_WD100EMAZ-00WJTA0_JEHVB59Z      -      -      0      0  2.07K    601  PASSED        0    40         0         0        -         -       -
    ata-WDC_WD100EMAZ-00WJTA0_2YK8Y1WD      -      -      0      0  2.08K    601  PASSED        0    41         0         0        -         -       -
    ata-WDC_WD100EMAZ-00WJTA0_JEK8PB5Z      -      -      0      0  2.03K    601  PASSED        0    41         0         0     4891         -       -
--------------------------------------  -----  -----  -----  -----  -----  -----  ------  -------  ----  --------  --------  -------  --------  ------
```

(Lest you wonder, it's not reporting a 0 for ATA Error Count because smartctl isn't listing it on drives with n=0.

As I commented in the bug mentioned above, lsblk seems totally lost as to how to figure out vendor and model - SATL seems to confuse it.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
