### PR TITLE
Add missing AC_MSG_RESULT(no) to configure

### DIFF
--- a/config/kernel-mkdir.m4
+++ b/config/kernel-mkdir.m4
@@ -53,6 +53,8 @@ AC_DEFUN([ZFS_AC_KERNEL_MKDIR], [
 		AC_DEFINE(HAVE_IOPS_MKDIR_USERNS, 1,
 		    [iops->mkdir() takes struct user_namespace*])
 	],[
+		AC_MSG_RESULT(no)
+
 		AC_MSG_CHECKING([whether iops->mkdir() takes umode_t])
 		ZFS_LINUX_TEST_RESULT([inode_operations_mkdir], [
 			AC_MSG_RESULT(yes)


### PR DESCRIPTION
### Motivation and Context

Resolve a formatting issue with the `./configure` output.

### Description

When the `HAVE_IOPS_MKDIR_USERNS` check fails output the result as required.

### How Has This Been Tested?

Before:

```sh
checking whether struct shrink_control exists... yes
checking whether iops->mkdir() takes struct user_namespace*... checking whether iops->mkdir() takes umode_t... yes
checking whether iops->lookup() passes flags... yes
```

After:

```sh
checking whether struct shrink_control exists... yes
checking whether iops->mkdir() takes struct user_namespace*... no
checking whether iops->mkdir() takes umode_t... yes
checking whether iops->lookup() passes flags... yes
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
