### PR TITLE
Fix typos in zfs-bookmark examples

### DIFF
--- a/man/man8/zfs-bookmark.8
+++ b/man/man8/zfs-bookmark.8
@@ -30,7 +30,7 @@
 .\" Copyright 2019 Joyent, Inc.
 .\" Copyright (c) 2019, 2020 by Christian Schwarz. All Rights Reserved.
 .\"
-.Dd March 16, 2022
+.Dd May 12, 2022
 .Dt ZFS-BOOKMARK 8
 .Os
 .
@@ -65,8 +65,8 @@ feature.
 .\" These are, respectively, examples 23 from zfs.8
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Creating a bookmark
-The following example create a bookmark to a snapshot.
-This bookmark can then be used instead of snapshot in send streams.
+The following example creates a bookmark to a snapshot.
+This bookmark can then be used instead of a snapshot in send streams.
 .Dl # Nm zfs Cm bookmark Ar rpool Ns @ Ns Ar snapshot rpool Ns # Ns Ar bookmark
 .
 .Sh SEE ALSO

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -36,7 +36,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd March 16, 2022
+.Dd May 12, 2022
 .Dt ZFS 8
 .Os
 .
@@ -703,8 +703,8 @@ M       F       /tank/test/modified
 .Ed
 .
 .Ss Example 23 : No Creating a bookmark
-The following example create a bookmark to a snapshot.
-This bookmark can then be used instead of snapshot in send streams.
+The following example creates a bookmark to a snapshot.
+This bookmark can then be used instead of a snapshot in send streams.
 .Dl # Nm zfs Cm bookmark Ar rpool Ns @ Ns Ar snapshot rpool Ns # Ns Ar bookmark
 .
 .Ss Example 24 : No Setting Sy sharesmb No Property Options on a ZFS File System


### PR DESCRIPTION
Signed-off-by: Mateusz Piotrowski <0mp@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
This is just a couple of typos I noticed when reading the docs.

### Description
Fix typos in the examples of the zfs bookmark command.

### How Has This Been Tested?
N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
