### PR TITLE
linux: Fix compiler warnings about zero-length arrays in inline bitops

### DIFF
--- a/config/kernel-blk-queue.m4
+++ b/config/kernel-blk-queue.m4
@@ -93,8 +93,10 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLK_QUEUE_DISCARD], [
 	ZFS_LINUX_TEST_SRC([blk_queue_discard], [
 		#include <linux/blkdev.h>
 	],[
-		struct request_queue *q __attribute__ ((unused)) = NULL;
+		struct request_queue r;
+		struct request_queue *q = &r;
 		int value __attribute__ ((unused));
+		memset(q, 0, sizeof(r));
 		value = blk_queue_discard(q);
 	])
 ])
@@ -119,16 +121,20 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLK_QUEUE_SECURE_ERASE], [
 	ZFS_LINUX_TEST_SRC([blk_queue_secure_erase], [
 		#include <linux/blkdev.h>
 	],[
-		struct request_queue *q __attribute__ ((unused)) = NULL;
+		struct request_queue r;
+		struct request_queue *q = &r;
 		int value __attribute__ ((unused));
+		memset(q, 0, sizeof(r));
 		value = blk_queue_secure_erase(q);
 	])
 
 	ZFS_LINUX_TEST_SRC([blk_queue_secdiscard], [
 		#include <linux/blkdev.h>
 	],[
-		struct request_queue *q __attribute__ ((unused)) = NULL;
+		struct request_queue r;
+		struct request_queue *q = &r;
 		int value __attribute__ ((unused));
+		memset(q, 0, sizeof(r));
 		value = blk_queue_secdiscard(q);
 	])
 ])


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The compiler appears to be expanding the unused NULL pointer into a zero-length array via the inline bitops code. When `-Werror=array-bounds` is used, this causes a build failure.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #13463 

### Description
<!--- Describe your changes in detail -->
Recommended solution is allocate temporary structures, fill with zeros (to avoid uninitialized data use warnings), and pass the pointer to those to the inline calls.

### How Has This Been Tested?
So far, just build-testing

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
