### PR TITLE
linux: libshare: smb: don't swallow net(1) errors

### DIFF
--- a/lib/libshare/os/linux/smb.c
+++ b/lib/libshare/os/linux/smb.c
@@ -248,7 +248,7 @@ smb_enable_share_one(const char *sharename, const char *sharepath)
 		NULL,
 	};
 
-	if (libzfs_run_process(argv[0], argv, 0) < 0)
+	if (libzfs_run_process(argv[0], argv, 0) != 0)
 		return (SA_SYSTEM_ERR);
 
 	/* Reload the share file */
@@ -297,7 +297,7 @@ smb_disable_share_one(const char *sharename)
 		NULL,
 	};
 
-	if (libzfs_run_process(argv[0], argv, 0) < 0)
+	if (libzfs_run_process(argv[0], argv, 0) != 0)
 		return (SA_SYSTEM_ERR);
 	else
 		return (SA_OK);


### PR DESCRIPTION
### Motivation and Context
#13191; @heeplr

### How Has This Been Tested?
```
# ./zfs set sharesmb=on tarta-zoot/home/nabijaczleweli
cannot share 'tarta-zoot/home/nabijaczleweli: system error': SMB share creation failed
cannot share 'tarta-zoot/home/nabijaczleweli/tftp: system error': SMB share creation failed
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply(?)
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
