### PR TITLE
Manually unbreak if 0, EXTRA_DIST = (and dist_xxx_MANS =) being ignored

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2016,SC2094
 [ "${0%/*}" = "$0" ] || cd "${0%/*}" || exit
 
 # %reldir%/%canon_reldir% (%D%/%C%) only appeared in automake 1.14, but RHEL/CentOS 7 has 1.13.4
@@ -47,6 +48,7 @@ automake --version | awk '{print $NF; exit}' | (
 
 	roots="$(sed '/Makefile$/!d;/module/d;s:^\s*:./:;s:/Makefile::;/^\.$/d' configure.ac)"
 
+	OIFS="$IFS"
 	IFS="
 "
 	for root in $roots; do
@@ -57,6 +59,67 @@ automake --version | awk '{print $NF; exit}' | (
 	set -f
 	# shellcheck disable=SC2086,SC2046
 	process_root . $(printf '!\n-path\n%s/*\n' $roots)
+	IFS="$OIFS"
 }
 
 autoreconf -fiv && rm -rf autom4te.cache
+
+# https://github.com/openzfs/zfs/issues/13459
+# https://bugs.debian.org/1011024
+# When including, EXTRA_DIST in false conditionals is skipped; we need to preprocess Makefile.in to unbreak this.
+# The same happens to dist_man_MANS (DISTFILES -> DIST_COMMON -> am__DIST_COMMON -> dist_man_MANS).
+#
+# Shortcuts taken:
+#   * only the root Makefile.in is processed because it's the only one that does if, include; it takes too long to process this as-is (~0.3s)
+#   * only one level of :suff=suff allowed
+{
+	deverbol() {
+		type rollback > /dev/null 2>&1 && rollback
+		rm -f "$verbols"
+	}
+
+	trap deverbol EXIT
+	verbols="$(mktemp)"
+
+	parse_verbols() {
+		v="${v#\$\(}"
+		v="${v%\)}"
+		[ -z "$suff_bundle" ] && {
+			suff_bundle="${v#*:}"
+			[ "$suff_bundle" = "$v" ] && suff_bundle= || suff_bundle=":$suff_bundle"
+		}
+		v="${v%:*}"
+	}
+
+	printf "%s\n" dist_man_MANS EXTRA_DIST > "$verbols"
+	while read -r v suff_bundle; do
+		parse_verbols
+		# Early exit buys back 0.43s here
+		awk -v v="$v" '($0 ~ ("^(@[A-Z_@]*@)?" v " =")),!/\\$/ {copying=1; print}  copying && !/\\$/ {exit}' Makefile.in |
+			grep -o '$([^ )]*)' |
+			sed 's/$/ '"$suff_bundle"'/'
+	done < "$verbols" >> "$verbols"
+	sort "$verbols" | uniq |
+	while read -r v suff_bundle; do
+		parse_verbols
+		# And another 0.34s here
+		awk -v v="$v" '
+				BEGIN {
+					printf "faux_" v "_faux := "
+				}
+				($0 ~ ("^@[A-Z_@]*@" v " =")),!/\\$/ {
+					l = $0
+					sub(/^@[A-Z_@]*@/, "", l)
+					sub("^" v " =", "", l)
+					sub(/\\$/, "", l)
+					printf "%s", l
+					copying = 1
+				}
+				copying && !/\\$/ {
+					exit
+				}
+			' Makefile.in
+		echo
+		echo "EXTRA_DIST += \$(faux_${v}_faux${suff_bundle})"
+	done >> Makefile.in
+}


### PR DESCRIPTION
### Motivation and Context
Workaround-for: https://bugs.debian.org/1011024
Closes: #13459

### Description
In a partial configuration (e.g. --with-config=srpm, which is !CONFIG_USER !CONFIG_KERNEL), `make dist` doesn't distribute `if FALSY, include`s' `EXTRA_DIST` (and `dist_MANS`); when `SUBDIR`sing, this is worked around via the `DIST_SUBDIRS =` mechanism, which always includes all subdirs. Here, we have to work around this by always including

### How Has This Been Tested?
#13459

Since this operates on `Makefile.in`, downstreams that don't reconfigure do not need to do anything. Hell, no downstream cares about this, and can call `autoreconf` manually (if it has a new enough autoconf), since no downstream generates a distribution tarball.

This is only relevant for `make dist`ing from the checkout, and ensures that everything that's supposed to land in the distribution tarball does, even with a partial configuration (of which `--with-config=srpm` is an extreme case).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
