### PR TITLE
automake: don't install /e/d/zfs or /e/z/zfs-functions +x

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -14,21 +14,21 @@ dist_sysconf_zfs_DATA = \
 	%D%/zfs/vdev_id.conf.sas_switch.example \
 	%D%/zfs/vdev_id.conf.scsi.example
 
-sysconf_zfs_SCRIPTS = \
+sysconf_zfs_DATA = \
 	%D%/zfs/zfs-functions
 
-SUBSTFILES          += $(sysconf_zfs_SCRIPTS)
-SHELLCHECKSCRIPTS   += $(sysconf_zfs_SCRIPTS)
-$(call SHELLCHECK_OPTS,$(sysconf_zfs_SCRIPTS)): SHELLCHECK_SHELL = sh
+SUBSTFILES          += $(sysconf_zfs_DATA)
+SHELLCHECKSCRIPTS   += $(sysconf_zfs_DATA)
+$(call SHELLCHECK_OPTS,$(sysconf_zfs_DATA)): SHELLCHECK_SHELL = sh
 
 
 if BUILD_LINUX
-initconf_SCRIPTS = \
+initconf_DATA = \
 	%D%/default/zfs
 
-SUBSTFILES          += $(initconf_SCRIPTS)
-SHELLCHECKSCRIPTS   += $(initconf_SCRIPTS)
-$(call SHELLCHECK_OPTS,$(initconf_SCRIPTS)): SHELLCHECK_SHELL = sh
+SUBSTFILES          += $(initconf_DATA)
+SHELLCHECKSCRIPTS   += $(initconf_DATA)
+$(call SHELLCHECK_OPTS,$(initconf_DATA)): SHELLCHECK_SHELL = sh
 
 
 if INIT_SYSV


### PR DESCRIPTION
### Motivation and Context
#13496

### Description
_SCRIPTS means it's made +x when installing; _DATA is made -x

### How Has This Been Tested?
`make install`, 
```
-rw-r--r-- 1 nabijaczleweli users 4.4K May 25 01:03 /tmp/dest/etc/default/zfs
-rw-r--r-- 1 nabijaczleweli users 9.3K May 25 01:03 /tmp/dest/usr/local/etc/zfs/zfs-functions
```

A few cursory `git grep`s point toward these being the only affected files (well, in this direction, anyway; the other direction is more obvious so we're probably fine there).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
