### PR TITLE
[2.1.5] automake: don't install /e/d/zfs or /e/z/zfs-functions +x

### DIFF
--- a/etc/default/Makefile.am
+++ b/etc/default/Makefile.am
@@ -1,9 +1,10 @@
 include $(top_srcdir)/config/Substfiles.am
 include $(top_srcdir)/config/Shellcheck.am
 
-initconf_SCRIPTS = zfs
+initconf_DATA = zfs
 
-SUBSTFILES += $(initconf_SCRIPTS)
+SUBSTFILES += $(initconf_DATA)
 
+SHELLCHECKSCRIPTS = $(initconf_DATA)
 SHELLCHECK_SHELL = sh
 SHELLCHECK_IGNORE = ,SC2034

--- a/etc/zfs/Makefile.am
+++ b/etc/zfs/Makefile.am
@@ -10,9 +10,10 @@ dist_pkgsysconf_DATA = \
 	vdev_id.conf.multipath.example \
 	vdev_id.conf.scsi.example
 
-pkgsysconf_SCRIPTS = \
+pkgsysconf_DATA = \
 	zfs-functions
 
-SUBSTFILES += $(pkgsysconf_SCRIPTS)
+SUBSTFILES += $(pkgsysconf_DATA)
 
+SHELLCHECKSCRIPTS = $(pkgsysconf_DATA)
 SHELLCHECK_SHELL = dash # local variables


### PR DESCRIPTION
### Motivation and Context
#13503

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
