### PR TITLE
Replace EXTRA_DIST with dist_noinst_DATA

### DIFF
--- a/.github/workflows/zfs-tests-functional.yml
+++ b/.github/workflows/zfs-tests-functional.yml
@@ -28,7 +28,7 @@ jobs:
         ./autogen.sh
     - name: Configure
       run: |
-        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan
+        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan --with-config=dist
     - name: Make
       run: |
         make -j$(nproc) --no-print-directory --silent pkg-utils pkg-kmod

--- a/.github/workflows/zfs-tests-sanity.yml
+++ b/.github/workflows/zfs-tests-sanity.yml
@@ -24,7 +24,7 @@ jobs:
         ./autogen.sh
     - name: Configure
       run: |
-        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan
+        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan --with-config=dist
     - name: Make
       run: |
         make -j$(nproc) --no-print-directory --silent pkg-utils pkg-kmod

--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -23,7 +23,7 @@ jobs:
         ./autogen.sh
     - name: Configure
       run: |
-        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan
+        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan --with-config=dist
     - name: Make
       run: |
         make -j$(nproc) --no-print-directory --silent pkg-utils pkg-kmod

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 CLEANFILES =
-EXTRA_DIST =
+dist_noinst_DATA =
 INSTALL_DATA_HOOKS =
 ALL_LOCAL =
 CLEAN_LOCAL =
@@ -37,26 +37,26 @@ extradir = $(prefix)/src/zfs-$(VERSION)
 extra_HEADERS = zfs.release.in zfs_config.h.in
 endif
 
-EXTRA_DIST += autogen.sh copy-builtin
-EXTRA_DIST += AUTHORS CODE_OF_CONDUCT.md COPYRIGHT LICENSE META NEWS NOTICE
-EXTRA_DIST += README.md RELEASES.md
-EXTRA_DIST += module/lua/README.zfs module/os/linux/spl/README.md
+dist_noinst_DATA += autogen.sh copy-builtin
+dist_noinst_DATA += AUTHORS CODE_OF_CONDUCT.md COPYRIGHT LICENSE META NEWS NOTICE
+dist_noinst_DATA += README.md RELEASES.md
+dist_noinst_DATA += module/lua/README.zfs module/os/linux/spl/README.md
 
 # Include all the extra licensing information for modules
-EXTRA_DIST += module/icp/algs/skein/THIRDPARTYLICENSE
-EXTRA_DIST += module/icp/algs/skein/THIRDPARTYLICENSE.descrip
-EXTRA_DIST += module/icp/asm-x86_64/aes/THIRDPARTYLICENSE.gladman
-EXTRA_DIST += module/icp/asm-x86_64/aes/THIRDPARTYLICENSE.gladman.descrip
-EXTRA_DIST += module/icp/asm-x86_64/aes/THIRDPARTYLICENSE.openssl
-EXTRA_DIST += module/icp/asm-x86_64/aes/THIRDPARTYLICENSE.openssl.descrip
-EXTRA_DIST += module/icp/asm-x86_64/modes/THIRDPARTYLICENSE.cryptogams
-EXTRA_DIST += module/icp/asm-x86_64/modes/THIRDPARTYLICENSE.cryptogams.descrip
-EXTRA_DIST += module/icp/asm-x86_64/modes/THIRDPARTYLICENSE.openssl
-EXTRA_DIST += module/icp/asm-x86_64/modes/THIRDPARTYLICENSE.openssl.descrip
-EXTRA_DIST += module/os/linux/spl/THIRDPARTYLICENSE.gplv2
-EXTRA_DIST += module/os/linux/spl/THIRDPARTYLICENSE.gplv2.descrip
-EXTRA_DIST += module/zfs/THIRDPARTYLICENSE.cityhash
-EXTRA_DIST += module/zfs/THIRDPARTYLICENSE.cityhash.descrip
+dist_noinst_DATA += module/icp/algs/skein/THIRDPARTYLICENSE
+dist_noinst_DATA += module/icp/algs/skein/THIRDPARTYLICENSE.descrip
+dist_noinst_DATA += module/icp/asm-x86_64/aes/THIRDPARTYLICENSE.gladman
+dist_noinst_DATA += module/icp/asm-x86_64/aes/THIRDPARTYLICENSE.gladman.descrip
+dist_noinst_DATA += module/icp/asm-x86_64/aes/THIRDPARTYLICENSE.openssl
+dist_noinst_DATA += module/icp/asm-x86_64/aes/THIRDPARTYLICENSE.openssl.descrip
+dist_noinst_DATA += module/icp/asm-x86_64/modes/THIRDPARTYLICENSE.cryptogams
+dist_noinst_DATA += module/icp/asm-x86_64/modes/THIRDPARTYLICENSE.cryptogams.descrip
+dist_noinst_DATA += module/icp/asm-x86_64/modes/THIRDPARTYLICENSE.openssl
+dist_noinst_DATA += module/icp/asm-x86_64/modes/THIRDPARTYLICENSE.openssl.descrip
+dist_noinst_DATA += module/os/linux/spl/THIRDPARTYLICENSE.gplv2
+dist_noinst_DATA += module/os/linux/spl/THIRDPARTYLICENSE.gplv2.descrip
+dist_noinst_DATA += module/zfs/THIRDPARTYLICENSE.cityhash
+dist_noinst_DATA += module/zfs/THIRDPARTYLICENSE.cityhash.descrip
 
 @CODE_COVERAGE_RULES@
 

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -10,7 +10,7 @@ mounthelper_PROGRAMS =
 sbin_SCRIPTS      += fsck.zfs
 SHELLCHECKSCRIPTS += fsck.zfs
 CLEANFILES        += fsck.zfs
-EXTRA_DIST        += %D%/fsck.zfs.in
+dist_noinst_DATA  += %D%/fsck.zfs.in
 $(call SUBST,fsck.zfs,%D%/)
 
 
@@ -100,9 +100,9 @@ endif
 
 
 if USING_PYTHON
-bin_SCRIPTS += arc_summary     arcstat        dbufstat
-CLEANFILES  += arc_summary     arcstat        dbufstat
-EXTRA_DIST  += %D%/arc_summary %D%/arcstat.in %D%/dbufstat.in
+bin_SCRIPTS      += arc_summary     arcstat        dbufstat
+CLEANFILES       += arc_summary     arcstat        dbufstat
+dist_noinst_DATA += %D%/arc_summary %D%/arcstat.in %D%/dbufstat.in
 
 $(call SUBST,arcstat,%D%/)
 $(call SUBST,dbufstat,%D%/)

--- a/cmd/zed/Makefile.am
+++ b/cmd/zed/Makefile.am
@@ -43,4 +43,4 @@ zed_LDADD = \
 zed_LDADD += -lrt $(LIBATOMIC_LIBS) $(LIBUDEV_LIBS) $(LIBUUID_LIBS)
 zed_LDFLAGS = -pthread
 
-EXTRA_DIST += $(addprefix %D%/,agents/README.md)
+dist_noinst_DATA += %D%/agents/README.md

--- a/cmd/zed/zed.d/Makefile.am
+++ b/cmd/zed/zed.d/Makefile.am
@@ -38,7 +38,7 @@ zedconfdefaults = \
 	vdev_attach-led.sh \
 	vdev_clear-led.sh
 
-EXTRA_DIST += $(addprefix %D%/,README)
+dist_noinst_DATA += %D%/README
 
 INSTALL_DATA_HOOKS += zed-install-data-hook
 zed-install-data-hook:

--- a/cmd/zpool/Makefile.am
+++ b/cmd/zpool/Makefile.am
@@ -38,7 +38,7 @@ zpool_LDADD += -lgeom
 endif
 zpool_LDADD += -lm $(LIBBLKID_LIBS) $(LIBUUID_LIBS)
 
-EXTRA_DIST += $(addprefix %D%/,zpool.d/README compatibility.d)
+dist_noinst_DATA += %D%/zpool.d/README
 
 SHELLCHECKSCRIPTS += $(dist_zpoolexec_SCRIPTS)
 zpoolexecdir = $(zfsexecdir)/zpool.d

--- a/config/Substfiles.am
+++ b/config/Substfiles.am
@@ -41,6 +41,6 @@ endef
 
 SUBSTFILES =
 CLEANFILES += $(SUBSTFILES)
-EXTRA_DIST += $(SUBSTFILES:=.in)
+dist_noinst_DATA += $(SUBSTFILES:=.in)
 
 $(call SUBST,%,)

--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -268,6 +268,7 @@ AC_DEFUN([ZFS_AC_CONFIG], [
 		user)	ZFS_AC_CONFIG_USER   ;;
 		all)    ZFS_AC_CONFIG_USER
 			ZFS_AC_CONFIG_KERNEL ;;
+		dist)                        ;;
 		srpm)                        ;;
 		*)
 		AC_MSG_RESULT([Error!])

--- a/contrib/bpftrace/Makefile.am
+++ b/contrib/bpftrace/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST += $(addprefix %D%/, \
-	taskqlatency.bt \
-	zfs-trace.sh)
+dist_noinst_DATA += %D%/taskqlatency.bt %D%/zfs-trace.sh
 
 SHELLCHECKSCRIPTS += %D%/zfs-trace.sh

--- a/contrib/dracut/Makefile.am
+++ b/contrib/dracut/Makefile.am
@@ -24,4 +24,4 @@ SHELLCHECKSCRIPTS += $(pkgdracut_02_SCRIPTS) $(pkgdracut_90_SCRIPTS)
 # Provided by /bin/sleep, and, again, every implementation of that supports this
 $(call SHELLCHECK_OPTS,$(pkgdracut_90_SCRIPTS)): CHECKBASHISMS_IGNORE = -e 'sleep only takes one integer' -e 'sleep 0.'
 
-EXTRA_DIST += $(addprefix %D%/,README.md)
+dist_noinst_DATA += %D%/README.md

--- a/contrib/initramfs/Makefile.am
+++ b/contrib/initramfs/Makefile.am
@@ -36,4 +36,4 @@ SHELLCHECKSCRIPTS   += $(i_t_check_scripts)
 $(call SHELLCHECK_OPTS,$(i_t_check_scripts)): SHELLCHECK_SHELL = sh
 
 
-EXTRA_DIST += $(addprefix %D%/,README.md)
+dist_noinst_DATA += %D%/README.md

--- a/contrib/pyzfs/Makefile.am
+++ b/contrib/pyzfs/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST += $(addprefix %D%/,libzfs_core README LICENSE docs)
+dist_noinst_DATA += %D%/libzfs_core %D%/README %D%/LICENSE %D%/docs
 SUBSTFILES += %D%/setup.py
 
 if PYZFS_ENABLED

--- a/contrib/zcp/Makefile.am
+++ b/contrib/zcp/Makefile.am
@@ -1,1 +1,1 @@
-EXTRA_DIST += $(addprefix %D%/,autosnap.lua)
+dist_noinst_DATA += %D%/autosnap.lua

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -2,7 +2,7 @@ sudoersddir = $(sysconfdir)/sudoers.d
 sudoersd_DATA = \
 	%D%/sudoers.d/zfs
 
-EXTRA_DIST += $(sudoersd_DATA)
+dist_noinst_DATA += $(sudoersd_DATA)
 
 
 sysconf_zfsdir = $(sysconfdir)/zfs
@@ -32,7 +32,7 @@ $(call SHELLCHECK_OPTS,$(initconf_SCRIPTS)): SHELLCHECK_SHELL = sh
 
 
 if INIT_SYSV
-EXTRA_DIST += $(addprefix %D%/,init.d/README.md)
+dist_noinst_DATA += %D%/init.d/README.md
 
 init_SCRIPTS = \
 	%D%/init.d/zfs-import \

--- a/lib/libnvpair/Makefile.am
+++ b/lib/libnvpair/Makefile.am
@@ -32,4 +32,4 @@ endif
 
 libnvpair_la_LDFLAGS += -version-info 3:0:0
 
-EXTRA_DIST += $(addprefix %D%/,libnvpair.abi libnvpair.suppr)
+dist_noinst_DATA += %D%/libnvpair.abi %D%/libnvpair.suppr

--- a/lib/libuutil/Makefile.am
+++ b/lib/libuutil/Makefile.am
@@ -26,4 +26,4 @@ endif
 
 libuutil_la_LDFLAGS += -version-info 3:0:0
 
-EXTRA_DIST += $(addprefix %D%/,libuutil.abi libuutil.suppr)
+dist_noinst_DATA += %D%/libuutil.abi %D%/libuutil.suppr

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -76,5 +76,5 @@ libzfs_la_LDFLAGS += -version-info 5:0:1
 
 pkgconfig_DATA += %D%/libzfs.pc
 
-EXTRA_DIST += $(addprefix %D%/,libzfs.abi libzfs.suppr)
-EXTRA_DIST += $(addprefix %D%/,THIRDPARTYLICENSE.openssl THIRDPARTYLICENSE.openssl.descrip)
+dist_noinst_DATA += %D%/libzfs.abi %D%/libzfs.suppr
+dist_noinst_DATA += %D%/THIRDPARTYLICENSE.openssl %D%/THIRDPARTYLICENSE.openssl.descrip

--- a/lib/libzfs_core/Makefile.am
+++ b/lib/libzfs_core/Makefile.am
@@ -43,4 +43,4 @@ libzfs_core_la_LDFLAGS += -version-info 3:0:0
 
 pkgconfig_DATA += %D%/libzfs_core.pc
 
-EXTRA_DIST += $(addprefix %D%/,libzfs_core.abi libzfs_core.suppr)
+dist_noinst_DATA += %D%/libzfs_core.abi %D%/libzfs_core.suppr

--- a/lib/libzfsbootenv/Makefile.am
+++ b/lib/libzfsbootenv/Makefile.am
@@ -26,4 +26,4 @@ libzfsbootenv_la_LDFLAGS += -version-info 1:0:0
 
 pkgconfig_DATA += %D%/libzfsbootenv.pc
 
-EXTRA_DIST += $(addprefix %D%/,libzfsbootenv.abi libzfsbootenv.suppr)
+dist_noinst_DATA += %D%/libzfsbootenv.abi %D%/libzfsbootenv.suppr

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST += \
+dist_noinst_man_MANS = \
 	%D%/man1/cstyle.1
 
 dist_man_MANS = \
@@ -105,8 +105,9 @@ nodist_man_MANS = \
 	%D%/man8/zed.8 \
 	%D%/man8/zfs-mount-generator.8
 
-SUBSTFILES += $(nodist_man_MANS)
+dist_noinst_DATA += $(dist_noinst_man_MANS) $(dist_man_MANS)
 
+SUBSTFILES += $(nodist_man_MANS)
 
 CHECKS += mancheck
 mancheck:

--- a/rpm/Makefile.am
+++ b/rpm/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST += \
+dist_noinst_DATA += \
 	%D%/generic/zfs-dkms.spec.in \
 	%D%/generic/zfs-kmod.spec.in \
 	%D%/generic/zfs.spec.in \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -6,7 +6,7 @@ dist_scripts_SCRIPTS = \
 	%D%/zimport.sh \
 	%D%/zloop.sh
 
-EXTRA_SCRIPTS = \
+dist_noinst_SCRIPTS = \
 	%D%/commitcheck.sh \
 	%D%/common.sh.in \
 	%D%/dkms.mkconf \
@@ -18,14 +18,13 @@ EXTRA_SCRIPTS = \
 	%D%/paxcheck.sh \
 	%D%/zfs-tests-color.sh
 
-EXTRA_DIST += \
+dist_noinst_DATA += \
 	%D%/cstyle.pl \
 	%D%/enum-extract.pl \
 	%D%/zfs2zol-patch.sed \
-	%D%/zol2zfs-patch.sed \
-	$(EXTRA_SCRIPTS)
+	%D%/zol2zfs-patch.sed
 
-SHELLCHECKSCRIPTS += $(dist_scripts_SCRIPTS) $(EXTRA_SCRIPTS)
+SHELLCHECKSCRIPTS += $(dist_scripts_SCRIPTS) $(dist_noinst_SCRIPTS)
 
 define SCRIPTS_EXTRA_ENVIRONMENT
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -25,6 +25,6 @@ dist_scripts_runfiles_DATA = \
 	%D%/runfiles/sunos.run
 
 
-EXTRA_DIST += $(addprefix %D%/,README.md)
+dist_noinst_DATA += %D%/README.md
 
 SHELLCHECKSCRIPTS += $(shell find $(srcdir)/%D% -name '*.sh')

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -41,7 +41,7 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/draid
 	libnvpair.la
 %C%_draid_LDADD += $(ZLIB_LIBS)
 
-EXTRA_DIST += $(addprefix %D%/,file/file_common.h)
+dist_noinst_DATA += %D%/file/file_common.h
 scripts_zfs_tests_bin_PROGRAMS += %D%/file_append %D%/file_check %D%/file_trunc %D%/file_write %D%/largest_file %D%/randwritecomp
 %C%_file_append_SOURCES   = %D%/file/file_append.c
 %C%_file_check_SOURCES    = %D%/file/file_check.c
@@ -116,7 +116,7 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/xattrtest
 scripts_zfs_tests_bin_PROGRAMS += %D%/zed_fd_spill-zedlet
 
 
-EXTRA_DIST += $(addprefix %D%/,linux_dos_attributes/dos_attributes.h)
+dist_noinst_DATA += %D%/linux_dos_attributes/dos_attributes.h
 scripts_zfs_tests_bin_PROGRAMS  += %D%/read_dos_attributes %D%/write_dos_attributes
 %C%_read_dos_attributes_SOURCES  = %D%/linux_dos_attributes/read_dos_attributes.c
 %C%_write_dos_attributes_SOURCES = %D%/linux_dos_attributes/write_dos_attributes.c

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1,5 +1,5 @@
 CLEANFILES =
-EXTRA_DIST =
+dist_noinst_DATA =
 include $(top_srcdir)/config/Substfiles.am
 
 


### PR DESCRIPTION
### Motivation and Context

Alternative for #13481
Closes: #13459

### Description

The EXTRA_DIST variable is ignored when used in the FALSE conditional
of a Makefile.am.  This results in the `make dist` target omitting
these files from the generated tarball unless CONFIG_USER is defined.
This issue can be avoided by switching to use the dist_noinst_DATA
variable which is handled as expected by autoconf.

This change also adds support for --with-config=dist as an alias
for --with-config=srpm and updates the GitHub workflows to use it.

### How Has This Been Tested?

Locally compiled on Ubuntu 20.04 with:

```
sh autogen.sh && ./configure --with-config=dist && V=1 make -j16 pkg-utils
```

Updated the CI to use `--with-config=dist` when building.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
