### PR TITLE
Unbreak zstd build on sparc64

### DIFF
--- a/include/sys/zstd/zstd.h
+++ b/include/sys/zstd/zstd.h
@@ -79,7 +79,7 @@ typedef struct zfs_zstd_meta {
  */
 #define	ZSTDSTAT(stat)		(zstd_stats.stat.value.ui64)
 #define	ZSTDSTAT_ZERO(stat)	\
-	(atomic_store_64(&zstd_stats.stat.value.ui64, 0))
+	atomic_store_64(&zstd_stats.stat.value.ui64, 0)
 #define	ZSTDSTAT_ADD(stat, val) \
 	atomic_add_64(&zstd_stats.stat.value.ui64, (val))
 #define	ZSTDSTAT_SUB(stat, val) \


### PR DESCRIPTION
### Motivation and Context
`git pull origin master` on my sparc testbed, and lo and behold, I broke the build.

```
In file included from ./arch/sparc/include/generated/asm/rwonce.h:1,
                 from /usr/src/linux-headers-5.10.0-8-common/include/linux/compiler.h:246,
                 from /usr/src/linux-headers-5.10.0-8-common/include/asm-generic/getorder.h:7,
                 from /usr/src/linux-headers-5.10.0-8-common/arch/sparc/include/asm/page_64.h:161,
                 from /usr/src/linux-headers-5.10.0-8-common/arch/sparc/include/asm/page.h:8,
                 from /home/rich/zfs_howsthiswork/include/os/linux/spl/sys/param.h:27,
                 from /home/rich/zfs_howsthiswork/module/zstd/zfs_zstd.c:42:
/home/rich/zfs_howsthiswork/module/zstd/zfs_zstd.c: In function ‘kstat_zstd_update’:
/usr/src/linux-headers-5.10.0-8-common/include/asm-generic/rwonce.h:59:1: error: expected expression before ‘do’
   59 | do {         \
      | ^~
/usr/src/linux-headers-5.10.0-8-common/arch/sparc/include/asm/atomic_64.h:21:28: note: in expansion of macro ‘WRITE_ONCE’
   21 | #define atomic64_set(v, i) WRITE_ONCE(((v)->counter), (i))
      |                            ^~~~~~~~~~
/home/rich/zfs_howsthiswork/include/os/linux/spl/sys/atomic.h:64:31: note: in expansion of macro ‘atomic64_set’
   64 | #define atomic_store_64(v, x) atomic64_set((atomic64_t *)(v), x)
      |                               ^~~~~~~~~~~~
/home/rich/zfs_howsthiswork/include/sys/zstd/zstd.h:82:3: note: in expansion of macro ‘atomic_store_64’
   82 |  (atomic_store_64(&zstd_stats.stat.value.ui64, 0))
      |   ^~~~~~~~~~~~~~~
/home/rich/zfs_howsthiswork/module/zstd/zfs_zstd.c:115:3: note: in expansion of macro ‘ZSTDSTAT_ZERO’
  115 |   ZSTDSTAT_ZERO(zstd_stat_alloc_fail);
      |   ^~~~~~~~~~~~~
/usr/src/linux-headers-5.10.0-8-common/include/asm-generic/rwonce.h:59:1: error: expected expression before ‘do’
   59 | do {         \
      | ^~
/usr/src/linux-headers-5.10.0-8-common/arch/sparc/include/asm/atomic_64.h:21:28: note: in expansion of macro ‘WRITE_ONCE’
   21 | #define atomic64_set(v, i) WRITE_ONCE(((v)->counter), (i))
      |                            ^~~~~~~~~~
/home/rich/zfs_howsthiswork/include/os/linux/spl/sys/atomic.h:64:31: note: in expansion of macro ‘atomic64_set’
   64 | #define atomic_store_64(v, x) atomic64_set((atomic64_t *)(v), x)
      |                               ^~~~~~~~~~~~
/home/rich/zfs_howsthiswork/include/sys/zstd/zstd.h:82:3: note: in expansion of macro ‘atomic_store_64’
   82 |  (atomic_store_64(&zstd_stats.stat.value.ui64, 0))
      |   ^~~~~~~~~~~~~~~
/home/rich/zfs_howsthiswork/module/zstd/zfs_zstd.c:116:3: note: in expansion of macro ‘ZSTDSTAT_ZERO’
  116 |   ZSTDSTAT_ZERO(zstd_stat_alloc_fallback);
      |   ^~~~~~~~~~~~~
/usr/src/linux-headers-5.10.0-8-common/include/asm-generic/rwonce.h:59:1: error: expected expression before ‘do’
   59 | do {         \
      | ^~
```
and so on.

### Description
Drop the ever so harmful parentheses.

### How Has This Been Tested?
It built on the sparc testbed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
