### PR TITLE
config: support 5.19 blk_queue_discard() -> bdev_max_discard_sectors()

### DIFF
--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -316,7 +316,11 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 	v->vdev_nowritecache = B_FALSE;
 
 	/* Set when device reports it supports TRIM. */
+#ifdef HAVE_BDEV_MAX_DISCARD_SECTORS
+	v->vdev_has_trim = !!bdev_max_discard_sectors(vd->vd_bdev);
+#else
 	v->vdev_has_trim = !!blk_queue_discard(q);
+#endif
 
 	/* Set when device reports it supports secure TRIM. */
 	v->vdev_has_securetrim = !!blk_queue_discard_secure(q);


### PR DESCRIPTION
### Motivation and Context
http://build.zfsonlinux.org/builders/Kernel.org%20Built-in%20x86_64%20%28BUILD%29/builds/45314/steps/shell_1/logs/make

### Description
Upstream-commit: 70200574cc22 ("block: remove QUEUE_FLAG_DISCARD")
Upstream-commit: cf0fbf894bb5 ("block: add a bdev_max_discard_sectors helper")
Signed-off-by: Ahelenia Ziemiańska <nabijaczleweli@nabijaczleweli.xyz>

### How Has This Been Tested?
Not at all.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
