### PR TITLE
zstd early abort, 2.1 backport edition

### DIFF
--- a/include/sys/zstd/zstd.h
+++ b/include/sys/zstd/zstd.h
@@ -78,6 +78,8 @@ typedef struct zfs_zstd_meta {
  * kstat helper macros
  */
 #define	ZSTDSTAT(stat)		(zstd_stats.stat.value.ui64)
+#define	ZSTDSTAT_ZERO(stat)	\
+	atomic_store_64(&zstd_stats.stat.value.ui64, 0)
 #define	ZSTDSTAT_ADD(stat, val) \
 	atomic_add_64(&zstd_stats.stat.value.ui64, (val))
 #define	ZSTDSTAT_SUB(stat, val) \
@@ -89,6 +91,8 @@ int zstd_init(void);
 void zstd_fini(void);
 
 size_t zfs_zstd_compress(void *s_start, void *d_start, size_t s_len,
+    size_t d_len, int level);
+size_t zfs_zstd_compress_wrap(void *s_start, void *d_start, size_t s_len,
     size_t d_len, int level);
 int zfs_zstd_get_level(void *s_start, size_t s_len, uint8_t *level);
 int zfs_zstd_decompress_level(void *s_start, void *d_start, size_t s_len,

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -809,11 +809,14 @@ kernel_init(int mode)
 	system_taskq_init();
 	icp_init();
 
+	lz4_init();
+
 	zstd_init();
 
 	spa_init((spa_mode_t)mode);
 
 	fletcher_4_init();
+	
 
 	tsd_create(&rrw_tsd_key, rrw_tsd_destroy);
 }
@@ -825,6 +828,8 @@ kernel_fini(void)
 	spa_fini();
 
 	zstd_fini();
+	
+	lz4_fini();
 
 	icp_fini();
 	system_taskq_fini();

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2090,6 +2090,16 @@ However, if there are fewer than
 metaslabs in the vdev, this functionality is disabled.
 This ensures that we don't set aside an unreasonable amount of space for the ZIL.
 .
+.It Sy zstd_earlyabort_pass Ns = Ns Sy 1 Pq int
+(Note: this is a module parameter to zzstd, not zfs.)
+Whether heuristic for detection of incompressible data with zstd levels >= 3
+using LZ4 and zstd-1 passes is enabled.
+.
+.It Sy zstd_abort_size Ns = Ns Sy 131072 Pq int
+(Note: this is a module parameter to zzstd, not zfs.)
+Minimal uncompressed size (inclusive) of a record before the early abort
+heuristic will be attempted.
+.
 .It Sy zio_deadman_log_all Ns = Ns Sy 0 Ns | Ns 1 Pq int
 If non-zero, the zio deadman will produce debugging messages
 .Pq see Sy zfs_dbgmsg_enable

--- a/module/zcommon/Makefile.in
+++ b/module/zcommon/Makefile.in
@@ -11,6 +11,7 @@ obj-$(CONFIG_ZFS) := $(MODULE).o
 ccflags-$(CONFIG_SPARC64) += -Wno-unused-value
 
 $(MODULE)-objs += cityhash.o
+$(MODULE)-objs += lz4.o
 $(MODULE)-objs += zfeature_common.o
 $(MODULE)-objs += zfs_comutil.o
 $(MODULE)-objs += zfs_deleg.o

--- a/module/zcommon/lz4.c
+++ b/module/zcommon/lz4.c
@@ -1027,3 +1027,8 @@ lz4_fini(void)
 		lz4_cache = NULL;
 	}
 }
+
+EXPORT_SYMBOL(lz4_compress_zfs);
+EXPORT_SYMBOL(lz4_init);
+EXPORT_SYMBOL(lz4_fini);
+EXPORT_SYMBOL(lz4_decompress_zfs);

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -1010,6 +1010,8 @@ zcommon_init(void)
 
 	fletcher_4_init();
 
+	lz4_init();
+
 	return (0);
 }
 
@@ -1017,6 +1019,7 @@ static void __exit
 zcommon_fini(void)
 {
 	fletcher_4_fini();
+	lz4_fini();
 	kfpu_fini();
 }
 

--- a/module/zfs/Makefile.in
+++ b/module/zfs/Makefile.in
@@ -55,7 +55,6 @@ $(MODULE)-objs += edonr_zfs.o
 $(MODULE)-objs += fm.o
 $(MODULE)-objs += gzip.o
 $(MODULE)-objs += hkdf.o
-$(MODULE)-objs += lz4.o
 $(MODULE)-objs += lzjb.o
 $(MODULE)-objs += metaslab.o
 $(MODULE)-objs += mmp.o

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -9312,26 +9312,37 @@ l2arc_apply_transforms(spa_t *spa, arc_buf_hdr_t *hdr, uint64_t asize,
 	}
 
 	if (compress != ZIO_COMPRESS_OFF && !HDR_COMPRESSION_ENABLED(hdr)) {
-		cabd = abd_alloc_for_io(asize, ismd);
-		tmp = abd_borrow_buf(cabd, asize);
+		/*
+		 * In some cases, we can wind up with size > asize, so
+		 * we need to opt for the larger allocation option here.
+		 *
+		 * (We also need abd_return_buf_copy in all cases because
+		 * it's an ASSERT() to modify the buffer before returning it
+		 * with arc_return_buf(), and all the compressors
+		 * write things before deciding to fail compression in nearly
+		 * every case.)
+		 */
+		cabd = abd_alloc_for_io(size, ismd);
+		tmp = abd_borrow_buf(cabd, size);
 
 		psize = zio_compress_data(compress, to_write, tmp, size,
 		    hdr->b_complevel);
 
-		if (psize >= size) {
-			abd_return_buf(cabd, tmp, asize);
+		if (psize >= asize) {
+			psize = HDR_GET_PSIZE(hdr);
+			abd_return_buf_copy(cabd, tmp, size);
 			HDR_SET_COMPRESS(hdr, ZIO_COMPRESS_OFF);
 			to_write = cabd;
-			abd_copy(to_write, hdr->b_l1hdr.b_pabd, size);
-			if (size != asize)
-				abd_zero_off(to_write, size, asize - size);
+			abd_copy(to_write, hdr->b_l1hdr.b_pabd, psize);
+			if (psize != asize)
+				abd_zero_off(to_write, psize, asize - psize);
 			goto encrypt;
 		}
 		ASSERT3U(psize, <=, HDR_GET_PSIZE(hdr));
 		if (psize < asize)
 			bzero((char *)tmp + psize, asize - psize);
 		psize = HDR_GET_PSIZE(hdr);
-		abd_return_buf_copy(cabd, tmp, asize);
+		abd_return_buf_copy(cabd, tmp, size);
 		to_write = cabd;
 	}
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -241,8 +241,6 @@ zio_init(void)
 	}
 
 	zio_inject_init();
-
-	lz4_init();
 }
 
 void
@@ -298,8 +296,6 @@ zio_fini(void)
 	kmem_cache_destroy(zio_cache);
 
 	zio_inject_fini();
-
-	lz4_fini();
 }
 
 /*

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -66,7 +66,7 @@ zio_compress_info_t zio_compress_table[ZIO_COMPRESS_FUNCTIONS] = {
 	{"gzip-9",	9,	gzip_compress,	gzip_decompress, NULL},
 	{"zle",		64,	zle_compress,	zle_decompress, NULL},
 	{"lz4",		0,	lz4_compress_zfs, lz4_decompress_zfs, NULL},
-	{"zstd",	ZIO_ZSTD_LEVEL_DEFAULT,	zfs_zstd_compress,
+	{"zstd",	ZIO_ZSTD_LEVEL_DEFAULT,	zfs_zstd_compress_wrap,
 	    zfs_zstd_decompress, zfs_zstd_decompress_level},
 };
 


### PR DESCRIPTION
### Motivation and Context
I'd like to use early abort before 3.0.

### Description
The actual `zfs_zstd.c` changes are pretty clean - I had to change back a few things that have been modified since (like the ZFS_ASAN_ENABLED macro). I bumped the version string on the module for the same reason I did the last time - I've seen DKMS decide "oh, this module version number is the same, I don't need to upgrade it".

Imported bf533a1b for the same reason I initially wrote it in master; moved lz4 into zcommon so it could be called from zzstd.ko, moved `lz4_init` and `fini` out of `zio_init` and into kernel.c and zfs_prop.c because we need to init lz4 before zstd, otherwise surprising outcomes (like libzpool consumers crashing) might ensue.

zloop crashed when I initially pushed the branch, but the crash seems unrelated to these changes (it's in the zio gang block code?)

(I also noticed I got the tunable settings wrong in the man page. Whoops...)

### How Has This Been Tested?
It built, it passed a run of ZTS on my testbed, it passed tests when I pushed the branch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
