### PR TITLE
add weekly and monthly systemd timers for trimming

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -59,6 +59,9 @@ systemdunit_DATA = \
 	%D%/systemd/system/zfs-scrub-monthly@.timer \
 	%D%/systemd/system/zfs-scrub-weekly@.timer \
 	%D%/systemd/system/zfs-scrub@.service \
+	%D%/systemd/system/zfs-trim-monthly@.timer \
+	%D%/systemd/system/zfs-trim-weekly@.timer \
+	%D%/systemd/system/zfs-trim@.service \
 	%D%/systemd/system/zfs-share.service \
 	%D%/systemd/system/zfs-volume-wait.service \
 	%D%/systemd/system/zfs-volumes.target \

--- a/etc/systemd/system/zfs-trim-monthly@.timer.in
+++ b/etc/systemd/system/zfs-trim-monthly@.timer.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Monthly zpool trim timer for %i
+Documentation=man:zpool-trim(8)
+
+[Timer]
+OnCalendar=monthly
+Persistent=true
+RandomizedDelaySec=1h
+Unit=zfs-trim@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/etc/systemd/system/zfs-trim-weekly@.timer.in
+++ b/etc/systemd/system/zfs-trim-weekly@.timer.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Weekly zpool trim timer for %i
+Documentation=man:zpool-trim(8)
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+RandomizedDelaySec=1h
+Unit=zfs-trim@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/etc/systemd/system/zfs-trim@.service.in
+++ b/etc/systemd/system/zfs-trim@.service.in
@@ -1,0 +1,15 @@
+[Unit]
+Description=zpool trim on %i
+Documentation=man:zpool-trim(8)
+Requires=zfs.target
+After=zfs.target
+ConditionACPower=true
+ConditionPathIsDirectory=/sys/module/zfs
+
+[Service]
+EnvironmentFile=-@initconfdir@/zfs
+ExecStart=/bin/sh -c '\
+if @sbindir@/zpool status %i | grep -q "(trimming)"; then\
+exec @sbindir@/zpool wait -t trim %i;\
+else exec @sbindir@/zpool trim -w %i; fi'
+ExecStop=-/bin/sh -c '@sbindir@/zpool trim -s %i 2>/dev/null || true'

--- a/man/man8/zpool-trim.8
+++ b/man/man8/zpool-trim.8
@@ -84,8 +84,29 @@ with no flags on the relevant target devices.
 .It Fl w , -wait
 Wait until the devices are done being trimmed before returning.
 .El
+.Sh PERIODIC TRIM
+On machines using systemd, trim timers can be enabled on a per-pool basis.
+.Nm weekly
+and
+.Nm monthly
+timer units are provided.
+.Bl -tag -width Ds
+.It Xo
+.Xc
+.Nm systemctl
+.Cm enable
+.Cm zfs-trim-\fIweekly\fB@\fIrpool\fB.timer
+.Cm --now
+.It Xo
+.Xc
+.Nm systemctl
+.Cm enable
+.Cm zfs-trim-\fImonthly\fB@\fIotherpool\fB.timer
+.Cm --now
+.El
 .
 .Sh SEE ALSO
+.Xr systemd.timer 5 ,
 .Xr zpoolprops 7 ,
 .Xr zpool-initialize 8 ,
 .Xr zpool-wait 8


### PR DESCRIPTION
### Motivation and Context
Provide systemd timers to make it easy for users to enable scheduled trimming of selected pools.
This PR is completely analogous to PR #12193, which provides the same functionality for scrubbing.

### Description
Provides the following systemd units, consisting of two timers and a common service that is started by these timers.

    zfs-trim-monthly@.timer
    zfs-trim-weekly@.timer
    zfs-trim@.service

The timers can be enabled as follows:

    systemctl enable zfs-trim-weekly@rpool.timer --now
    systemctl enable zfs-trim-monthly@otherpool.timer --now

Compared to PR #12193, the `zfs-trim@.service` service was adjusted slightly. It uses `zpool trim -s` instead of `zpool scrub -p`. It also checks for the string `(trimming)` instead of `scrub in progress`. Everything else is completely analogous.

Documentation is provided as part of the `zpool-trim` manpage.

### How Has This Been Tested?

Tested on Debian 5.10.113-1, using deb-based DKMS package.

    # systemctl enable zfs-trim-weekly@espeon.timer --now
    Created symlink /etc/systemd/system/timers.target.wants/zfs-trim-weekly@espeon.timer → /lib/systemd/system/zfs-trim-weekly@.timer.

    # systemctl status zfs-trim-weekly@espeon.timer 
    ● zfs-trim-weekly@espeon.timer - Weekly zpool trim timer for espeon
         Loaded: loaded (/lib/systemd/system/zfs-trim-weekly@.timer; enabled; vendor preset: enabled)
         Active: active (waiting) since Fri 2022-06-10 00:32:00 CEST; 29s ago
        Trigger: Mon 2022-06-13 00:09:23 CEST; 2 days left
       Triggers: ● zfs-trim@espeon.service
           Docs: man:zpool-trim(8)

    # systemctl status zfs-trim@espeon.service 
    ● zfs-trim@espeon.service - zpool trim on espeon
         Loaded: loaded (/lib/systemd/system/zfs-trim@.service; static)
         Active: inactive (dead)
    TriggeredBy: ● zfs-trim-weekly@espeon.timer
           Docs: man:zpool-trim(8)

    # systemctl start zfs-trim@espeon.service
    # systemctl status zfs-trim@espeon.service 
    ● zfs-trim@espeon.service - zpool trim on espeon
         Loaded: loaded (/lib/systemd/system/zfs-trim@.service; static)
         Active: active (running) since Fri 2022-06-10 00:35:41 CEST; 2s ago
    TriggeredBy: ● zfs-trim-weekly@espeon.timer
           Docs: man:zpool-trim(8)
       Main PID: 39901 (zpool)
          Tasks: 1 (limit: 309109)
         Memory: 768.0K
            CPU: 17ms
         CGroup: /system.slice/system-zfs\x2dtrim.slice/zfs-trim@espeon.service
                 └─39901 /sbin/zpool trim -w espeon

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).