### PR TITLE
Add support for ARCH=um for x86 sub-architectures

### DIFF
--- a/include/os/linux/zfs/sys/zfs_context_os.h
+++ b/include/os/linux/zfs/sys/zfs_context_os.h
@@ -32,4 +32,9 @@
 #define	HAVE_LARGE_STACKS	1
 #endif
 
+#if defined(CONFIG_UML)
+#undef setjmp
+#undef longjmp
+#endif
+
 #endif

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -138,6 +138,7 @@ ICP_OBJS_PPC_PPC64 := \
 
 zfs-objs             += $(addprefix icp/,$(ICP_OBJS))
 zfs-$(CONFIG_X86)    += $(addprefix icp/,$(ICP_OBJS_X86))
+zfs-$(CONFIG_UML_X86)+= $(addprefix icp/,$(ICP_OBJS_X86))
 zfs-$(CONFIG_X86_64) += $(addprefix icp/,$(ICP_OBJS_X86_64))
 zfs-$(CONFIG_ARM64)  += $(addprefix icp/,$(ICP_OBJS_ARM64))
 zfs-$(CONFIG_PPC)    += $(addprefix icp/,$(ICP_OBJS_PPC_PPC64))
@@ -232,6 +233,7 @@ ZCOMMON_OBJS_ARM64 := \
 
 zfs-objs            += $(addprefix zcommon/,$(ZCOMMON_OBJS))
 zfs-$(CONFIG_X86)   += $(addprefix zcommon/,$(ZCOMMON_OBJS_X86))
+zfs-$(CONFIG_UML_X86)+= $(addprefix zcommon/,$(ZCOMMON_OBJS_X86))
 zfs-$(CONFIG_ARM64) += $(addprefix zcommon/,$(ZCOMMON_OBJS_ARM64))
 
 
@@ -457,6 +459,7 @@ ZFS_OBJS_PPC_PPC64 := \
 
 zfs-objs            += $(addprefix zfs/,$(ZFS_OBJS)) $(addprefix os/linux/zfs/,$(ZFS_OBJS_OS))
 zfs-$(CONFIG_X86)   += $(addprefix zfs/,$(ZFS_OBJS_X86))
+zfs-$(CONFIG_UML_X86)+= $(addprefix zfs/,$(ZFS_OBJS_X86))
 zfs-$(CONFIG_ARM64) += $(addprefix zfs/,$(ZFS_OBJS_ARM64))
 zfs-$(CONFIG_PPC)   += $(addprefix zfs/,$(ZFS_OBJS_PPC_PPC64))
 zfs-$(CONFIG_PPC64) += $(addprefix zfs/,$(ZFS_OBJS_PPC_PPC64))


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This adds support for building the zfs kernel modules for the UML architecture. This should allow another avenue for testing/developing zfs, which I'm guessing involves full blown VMs right now. I'm hoping to use this to get the zfs tests running for GRUB without needing to have root or introducing system instability on the testing system.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
This patch adds support for building the zfs kernel modules for a UML, User-Mode Linux, kernel (`ARCH=um`). Only the x86 sub-architectures are supported, but I would guess that adding support for PPC, which UML supports (or so I'm told), should be similar to the Kbuild changes of this patch.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This has only been roughly tested. I have verified that the kernel modules load in a UML instance. Here is the output of the test I ran inside the UML instance:
```
root@(none):~/sources/zfs.git# zgrep UML /proc/config.gz 
# UML-specific options
CONFIG_UML=y
CONFIG_UML_X86=y
# end of UML-specific options
# UML Character Devices
CONFIG_UML_SOUND=m
# end of UML Character Devices
# UML Network Devices
CONFIG_UML_NET=y
CONFIG_UML_NET_ETHERTAP=y
CONFIG_UML_NET_TUNTAP=y
CONFIG_UML_NET_SLIP=y
CONFIG_UML_NET_DAEMON=y
# CONFIG_UML_NET_VECTOR is not set
# CONFIG_UML_NET_VDE is not set
CONFIG_UML_NET_MCAST=y
# CONFIG_UML_NET_PCAP is not set
CONFIG_UML_NET_SLIRP=y
# end of UML Network Devices
# CONFIG_VIRTIO_UML is not set
CONFIG_UML_RANDOM=y
root@(none):~/sources/zfs.git# insmod module/spl.ko
root@(none):~/sources/zfs.git# insmod module/zfs.ko
root@(none):~/sources/zfs.git# dmesg | tail
[    2.750000] NILFS version 2 loaded
[    2.780000] JFS: nTxBlock = 3980, nTxLock = 31842
[    2.900000] romfs: ROMFS MTD (C) 2007 Red Hat, Inc.
[    2.960000] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    3.010000] fuse: init (API version 7.34)
[   10.720000] random: crng init done
[   41.020000] spl: loading out-of-tree module taints kernel.
[   46.900000] zfs: module license 'CDDL' taints kernel.
[   46.900000] Disabling lock debugging due to kernel taint
[   47.370000] ZFS: Loaded module v2.1.99-1256_g87b46d63b (DEBUG mode), ZFS pool version 5000, ZFS filesystem version 5
root@(none):~/sources/zfs.git# truncate -s 256M /tmp/test.zfs
root@(none):~/sources/zfs.git# zpool create test /tmp/test.zfs
cannot mount '/test': failed to create mountpoint: Read-only file system
root@(none):~/sources/zfs.git# zfs list
NAME   USED  AVAIL     REFER  MOUNTPOINT
test  85.5K   120M       24K  /test
```
<!--- Include details of your testing environment, and the tests you ran to -->
This was tested on a Debian 11 system using a linux UML kernel at version 5.14.8 and sources. 
<!--- see how your change affects other areas of the code, etc. -->
This change should have no affects on other areas of the code.
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I've thought about making this a draft PR, however, its so minimal and is in working condition that I don't see the point.

I expect that this patch series can be backported to older zfs releases. I attempted to test the latest 3.10 series kernel 3.10.108, however it fails to compile a UML kernel. It looks like the issue may be that Debian 11's gcc at version 10.2.1 is too new.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
  - I didn't see anything in the code style link, but someone may take issue with the whitespacing in `module/Kbuild.in`. I didn't want to change the whitespacing of the lines around the change so that it was obvious what was being changed. Let me know exactly how the spacing should be, and I can change it, if need be.
- [ ] I have updated the documentation accordingly.
  - I don't think there's any documentation in this repo that needs to be updated. However, the [supported architectures](https://openzfs.github.io/openzfs-docs/Project%20and%20Community/FAQ.html#supported-architectures) list should be updated to note the `um` architecture is supported. Also it would be nice to have somewhere in the [build documentation](https://openzfs.github.io/openzfs-docs/Developer%20Resources/Building%20ZFS.html) how to build for kernels whose architecture is different than the build system. One thing that got me the first time around was that the environment variable `ARCH` must be set to `um` for both the `configure` **and** `make` commands. The commands I ended up using to build were the following: `export ARCH=um; ./configure --enable-debug --with-linux=$HOME/build-uml/linux-5.14.8; make`
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
