### PR TITLE
Linux: cleanup_fd cleanup

### DIFF
--- a/lib/libzfs/os/linux/libzfs_util_os.c
+++ b/lib/libzfs/os/linux/libzfs_util_os.c
@@ -274,5 +274,7 @@ zfs_userns(zfs_handle_t *zhp, const char *nspath, int attach)
 	if ((ret = zfs_ioctl(hdl, cmd, &zc)) != 0)
 		zfs_standard_error(hdl, errno, errbuf);
 
+	(void) close(zc.zc_cleanup_fd);
+
 	return (ret);
 }

--- a/module/os/linux/spl/spl-zone.c
+++ b/module/os/linux/spl/spl-zone.c
@@ -164,7 +164,7 @@ zone_dataset_name_check(const char *dataset, size_t *dsnamelen)
 }
 
 int
-zone_dataset_attach(cred_t *cred, const char *dataset, int cleanup_fd)
+zone_dataset_attach(cred_t *cred, const char *dataset, int userns_fd)
 {
 #if defined(CONFIG_USER_NS) && defined(HAVE_USER_NS_COMMON_INUM)
 	struct user_namespace *userns;
@@ -177,7 +177,7 @@ zone_dataset_attach(cred_t *cred, const char *dataset, int cleanup_fd)
 		return (error);
 	if ((error = zone_dataset_name_check(dataset, &dsnamelen)) != 0)
 		return (error);
-	if ((error = user_ns_get(cleanup_fd, &userns)) != 0)
+	if ((error = user_ns_get(userns_fd, &userns)) != 0)
 		return (error);
 
 	mutex_enter(&zone_datasets_lock);
@@ -217,7 +217,7 @@ zone_dataset_attach(cred_t *cred, const char *dataset, int cleanup_fd)
 EXPORT_SYMBOL(zone_dataset_attach);
 
 int
-zone_dataset_detach(cred_t *cred, const char *dataset, int cleanup_fd)
+zone_dataset_detach(cred_t *cred, const char *dataset, int userns_fd)
 {
 #if defined(CONFIG_USER_NS) && defined(HAVE_USER_NS_COMMON_INUM)
 	struct user_namespace *userns;
@@ -230,7 +230,7 @@ zone_dataset_detach(cred_t *cred, const char *dataset, int cleanup_fd)
 		return (error);
 	if ((error = zone_dataset_name_check(dataset, &dsnamelen)) != 0)
 		return (error);
-	if ((error = user_ns_get(cleanup_fd, &userns)) != 0)
+	if ((error = user_ns_get(userns_fd, &userns)) != 0)
 		return (error);
 
 	mutex_enter(&zone_datasets_lock);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
zfs_userns opens a file descriptor for the kernel to look up a namespace, but does not close it.
This is an issue if some external consumer of libzfs wants to use zfs_userns from a long-lived process.

### Description
<!--- Describe your changes in detail -->
Close the fd when we're done with it.

While here, this fd has nothing to do with cleanup,
that's just the name of the field in zfs_cmd_t that was used to pass it to the kernel.

Call it what it is, an fd for a user namespace.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
