### PR TITLE
remove install of zfs-load-module.service for dracut.

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -83,8 +83,7 @@ install() {
 
 		for _service in \
 			"zfs-import-scan.service" \
-			"zfs-import-cache.service" \
-			"zfs-load-module.service"; do
+			"zfs-import-cache.service"; do
 			inst_simple "${systemdsystemunitdir}/${_service}"
 			systemctl -q --root "${initdir}" add-wants zfs-import.target "${_service}"
 		done


### PR DESCRIPTION
### Motivation and Context
Removes the attempted installation of a file that is not provided by openzfs

### Description
The service only seems to exist on debian systems and if they would like
to include it, they can carry a patch to do so.

### How Has This Been Tested?
yes, dracut was run to test.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
