### PR TITLE
Dracut module: fix parsing of root= kernel command-line argument

### DIFF
--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -88,7 +88,7 @@ decode_root_args() {
         return
     fi
 
-    root=$(getarg root=)
+    [ -n  "$root" ] || root=$(getarg root=)
     rootfstype=$(getarg rootfstype=)
 
     # shellcheck disable=SC2249


### PR DESCRIPTION
Some Dracut modules may read the `root=` kernel command-line argument and rewrite it; in particular, `rootfs-block` installs a command-line hook that to canonicalize arguments that specify block devices. If the `zfs` module is added to an initramfs (which it is, by default, as long as the core ZFS utilities are available) on a system that does not use a ZFS root filesystem, the `zfs` module will overwrite the `root` shell variable with the contents of the kernel command-line in the process of determining if it should control mounting the root. This breaks the initramfs.

### Motivation and Context

If the `zfs` dracut module will be automatically included in initramfs images, it should avoid corrupting `root` arguments when those arguments refer to non-ZFS filesystems.

This bug was identified in https://github.com/void-linux/void-packages/issues/37667 and should be fixed by this patch.

### Description

Simply check if the `root` shell variable is non-empty, which means it has already been parsed (and possibly rewritten); prefer a previously parsed version if possible. Otherwise, parse the kernel command-line directly to populate the `root` shell variable. Subsequent decisions about rewriting `root` based on the existence of ZFS indicators remain unchanged.

### How Has This Been Tested?

I have no systems without ZFS roots, so this was "tested" by reasoning in a thought experiment.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
