### PR TITLE
FreeBSD: only define B_FALSE/B_TRUE if NEED_SOLARIS_BOOLEAN is not set

### DIFF
--- a/include/os/freebsd/spl/sys/types.h
+++ b/include/os/freebsd/spl/sys/types.h
@@ -78,9 +78,6 @@ typedef id_t		ctid_t;
 typedef	mode_t		o_mode_t;
 typedef	uint64_t	pgcnt_t;
 
-#define	B_FALSE	0
-#define	B_TRUE	1
-
 typedef	short		index_t;
 typedef	off_t		offset_t;
 #ifndef _PTRDIFF_T_DECLARED
@@ -90,13 +87,17 @@ typedef	__ptrdiff_t		ptrdiff_t;	/* pointer difference */
 typedef	int64_t		rlim64_t;
 typedef	int		major_t;
 
-#else
 #ifdef NEED_SOLARIS_BOOLEAN
 #if defined(__XOPEN_OR_POSIX)
 typedef enum { _B_FALSE, _B_TRUE }	boolean_t;
 #else
 typedef enum { B_FALSE, B_TRUE }	boolean_t;
 #endif /* defined(__XOPEN_OR_POSIX) */
+#else
+
+#define	B_FALSE	0
+#define	B_TRUE	1
+
 #endif
 
 typedef	u_longlong_t	u_offset_t;


### PR DESCRIPTION
If NEED_SOLARIS_BOOLEAN is defined we define an enum boolean_t, which
defines B_TRUE/B_FALSE as well. If we have both the define and the enum
things don't build (because that translates to
'enum { 0, 1 }     boolean_t').

While here also remove an incorrect '#else'. With it in place we only
parse a section if the include guard is triggered. So we'd only use that
code if this file is included twice. This is clearly unintended, and
also means we don't get the 'boolean_t' definition. Fix this.

Signed-off-by: Kristof Provost <kprovost@netgate.com>
Sponsored-By: Rubicon Communications, LLC ("Netgate")

### Motivation and Context
This fixes build issues on FreeBSD, for users of libbe (boot environments, on top of libzfs).

### Description
See also https://reviews.freebsd.org/D35610

### How Has This Been Tested?
Build tested (`make universe`, so all supported FreeBSD architectures). No runtime behaviour change is intended or expected.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
