### PR TITLE
dracut: fix typo in mount-zfs.sh.in

### DIFF
--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -82,7 +82,7 @@ ZFS_DATASET="${ZFS_DATASET:-${root}}"
 ZFS_POOL="${ZFS_DATASET%%/*}"
 
 
-if ! zpool get -Ho name "${ZFS_POOL}" > /dev/null 2>&1; then
+if ! zpool get -Ho value name "${ZFS_POOL}" > /dev/null 2>&1; then
     info "ZFS: Importing pool ${ZFS_POOL}..."
     # shellcheck disable=SC2086
     if ! zpool import -N ${ZPOOL_IMPORT_OPTS} "${ZFS_POOL}"; then


### PR DESCRIPTION
### Motivation and Context

Issue #13600.  @nabijaczleweli would you mind reviewing this tiny fix for a typo.  This appears to have been accidentally introduced by eaf1e060453ad6a335b708c5e724092741d6d1d3.

### Description

Format the `zpool get` command correctly.  The `-o` option must
be followed by "all" or the requested field name.

### How Has This Been Tested?

Only by manually running the command.  I have not tested the updated script with dracut.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
