### PR TITLE
contrib: dracut: README.md

### DIFF
--- a/contrib/dracut/README.md
+++ b/contrib/dracut/README.md
@@ -38,7 +38,7 @@ For complete documentation, see `dracut.zfs(7)`.
    after pool import but before the rootfs is mounted.
    Failure to create the snapshot is noted, but booting continues.
 
-4. `bootfs.rollback`, `bootfs.rollback=snapshot-name`: enables `zfs-snapshot-bootfs.service`,
+4. `bootfs.rollback`, `bootfs.rollback=snapshot-name`: enables `zfs-rollback-bootfs.service`,
    which `-Rf` rolls back to `$root_dataset@$(uname -r)` (or, in the second form, `$root_dataset@snapshot-name`)
    after pool import but before the rootfs is mounted.
    Failure to roll back will fall down to the rescue shell.


### PR DESCRIPTION
### Motivation and Context

Fix a small typo in the documentation for dracut.

### Description

Change `zfs-snapshot-bootfs.service` to `zfs-rollback-bootfs.service` in **cmdline point 4** of README.md.

### How Has This Been Tested?

N/A

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
