### PR TITLE
Re-fix -Wwrite-strings on FreeBSD

### DIFF
--- a/lib/libspl/include/os/freebsd/sys/mnttab.h
+++ b/lib/libspl/include/os/freebsd/sys/mnttab.h
@@ -79,7 +79,7 @@ extern int _sol_getmntent(FILE *fp, struct mnttab *mp);
 extern int getextmntent(const char *path, struct extmnttab *entry,
     struct stat64 *statbuf);
 extern void statfs2mnttab(struct statfs *sfs, struct mnttab *mp);
-extern char *hasmntopt(struct mnttab *mnt, char *opt);
+extern char *hasmntopt(struct mnttab *mnt, const char *opt);
 extern int getmntent(FILE *fp, struct mnttab *mp);
 
 #endif

--- a/lib/libspl/os/freebsd/mnttab.c
+++ b/lib/libspl/os/freebsd/mnttab.c
@@ -67,7 +67,7 @@ mntopt(char **p)
 }
 
 char *
-hasmntopt(struct mnttab *mnt, char *opt)
+hasmntopt(struct mnttab *mnt, const char *opt)
 {
 	char tmpopts[MNT_LINE_MAX];
 	char *f, *opts = tmpopts;

--- a/lib/libzfs/os/freebsd/libzfs_zmount.c
+++ b/lib/libzfs/os/freebsd/libzfs_zmount.c
@@ -75,7 +75,7 @@ build_iovec(struct iovec **iov, int *iovlen, const char *name, void *val,
 
 static int
 do_mount_(const char *spec, const char *dir, int mflag,
-    char *dataptr, int datalen, char *optptr, int optlen)
+    char *dataptr, int datalen, const char *optptr, int optlen)
 {
 	struct iovec *iov;
 	char *optstr, *p, *tofree;

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -1669,7 +1669,7 @@ zfs_acl_ids_create(znode_t *dzp, int flag, vattr_t *vap, cred_t *cr,
 				acl_ids->z_fgid = 0;
 		}
 		if (acl_ids->z_fgid == 0) {
-			char		*domain;
+			const char	*domain;
 			uint32_t	rid;
 
 			acl_ids->z_fgid = dzp->z_gid;


### PR DESCRIPTION
### How Has This Been Tested?
~~Not at all~~ static analysis

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – Ci take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
