### PR TITLE
Relatime: set on by default

### DIFF
--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1545,7 +1545,7 @@ Access time is only updated if the previous
 access time was earlier than the current modify or change time or if the
 existing access time hasn't been updated within the past 24 hours.
 The default value is
-.Sy off .
+.Sy on .
 The values
 .Sy on
 and

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -465,7 +465,7 @@ zfs_prop_init(void)
 	/* inherit index (boolean) properties */
 	zprop_register_index(ZFS_PROP_ATIME, "atime", 1, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM, "on | off", "ATIME", boolean_table, sfeatures);
-	zprop_register_index(ZFS_PROP_RELATIME, "relatime", 0, PROP_INHERIT,
+	zprop_register_index(ZFS_PROP_RELATIME, "relatime", 1, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM, "on | off", "RELATIME", boolean_table,
 	    sfeatures);
 	zprop_register_index(ZFS_PROP_DEVICES, "devices", 1, PROP_INHERIT,

--- a/tests/zfs-tests/tests/functional/atime/atime_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/atime/atime_001_pos.ksh
@@ -62,11 +62,9 @@ do
 		mtpt=$(snapshot_mountpoint $dst)
 		log_mustnot check_atime_updated $mtpt/$TESTFILE
 	else
-		if is_linux; then
-			log_must zfs set relatime=off $dst
-		fi
-
 		log_must zfs set atime=on $dst
+		log_must zfs set relatime=off $dst
+
 		log_must check_atime_updated $mtpt/$TESTFILE
 		log_must check_atime_updated $mtpt/$TESTFILE
 	fi

--- a/tests/zfs-tests/tests/functional/atime/atime_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/atime/atime_003_pos.ksh
@@ -62,6 +62,7 @@ do
 	else
 		log_must zfs set atime=on $dst
 		log_must zfs set relatime=on $dst
+
 		log_must check_atime_updated $mtpt/$TESTFILE
 		log_mustnot check_atime_updated $mtpt/$TESTFILE
 	fi

--- a/tests/zfs-tests/tests/functional/atime/root_atime_on.ksh
+++ b/tests/zfs-tests/tests/functional/atime/root_atime_on.ksh
@@ -65,11 +65,10 @@ do
 		mtpt=$(snapshot_mountpoint $dst)
 		log_mustnot check_atime_updated $mtpt/$TESTFILE
 	else
-		if is_linux; then
-			log_must zfs set relatime=off $(dirname $dst)
-		fi
-
 		log_must zfs set atime=on $(dirname $dst)
+		# inherited relatime won't apply because of mount option, set explicitly
+		log_must zfs set relatime=off $dst
+
 		log_must check_atime_updated $mtpt/$TESTFILE
 		log_must check_atime_updated $mtpt/$TESTFILE
 	fi

--- a/tests/zfs-tests/tests/functional/atime/root_relatime_on.ksh
+++ b/tests/zfs-tests/tests/functional/atime/root_relatime_on.ksh
@@ -68,6 +68,7 @@ do
 	else
 		log_must zfs set atime=on $(dirname $dst)
 		log_must zfs set relatime=on $(dirname $dst)
+
 		log_must check_atime_updated $mtpt/$TESTFILE
 		log_mustnot check_atime_updated $mtpt/$TESTFILE
 	fi

--- a/tests/zfs-tests/tests/functional/cache/cache_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cache/cache_012_pos.ksh
@@ -33,7 +33,7 @@
 #		for 10 sec.
 #	4. Verify that l2arc_write_max is set back to the default.
 #	5. Set l2arc_write_max to a value less than the cache device size but
-#		larger than the default (64MB).
+#		larger than the default (256MB).
 #	6. Record the l2_size.
 #	7. Random read for 1 sec.
 #	8. Record the l2_size again.
@@ -87,6 +87,9 @@ log_must truncate -s $VDEV_SZ $VDEV
 
 log_must zpool create -f $TESTPOOL $VDEV cache $VCACHE
 
+# Actually, this test relies on atime writes to force the L2 ARC discards
+log_must zfs set relatime=off $TESTPOOL
+
 log_must fio $FIO_SCRIPTS/mkfiles.fio
 log_must fio $FIO_SCRIPTS/random_reads.fio
 
@@ -94,7 +97,7 @@ typeset write_max2=$(get_tunable L2ARC_WRITE_MAX)
 
 log_must test $write_max2 -eq $write_max
 
-log_must set_tunable32 L2ARC_WRITE_MAX $(( 64 * 1024 * 1024 ))
+log_must set_tunable32 L2ARC_WRITE_MAX $(( 256 * 1024 * 1024 ))
 export RUNTIME=1
 
 typeset do_once=true


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Linux sets relatime on mount by default 
for any file system https://github.com/torvalds/linux/commit/0a1c01c9477602ee8b44548a9405b2c1d587b5a2 ,
but relatime=off in ZFS disables it explicitly
(because best-practice is to mount datasets via ZFS itself).

Let's be on par with other file systems on Linux
(and it's our largest target OS too).

Looks like it won't hurt FreeBSD, but it would be great to validate me here.

Additional motivation - we already have some changed defaults for next release
(compression, volblocksize), so it would be great to have one more property be optimal by default too.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
On linux, manual pool creation, recheck atime of file after read.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
