### PR TITLE
contrib: dracut: introduce the bootfs.snapkeep=n kernel parameter

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -90,6 +90,7 @@ install() {
 
 		for _service in \
 			"zfs-snapshot-bootfs.service" \
+			"zfs-snapkeep-bootfs.service" \
 			"zfs-rollback-bootfs.service"; do
 			inst_simple "${moddir}/${_service}" "${systemdsystemunitdir}/${_service}"
 			systemctl -q --root "${initdir}" add-wants initrd.target "${_service}"

--- a/contrib/dracut/90zfs/zfs-snapkeep-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-snapkeep-bootfs.service.in
@@ -8,5 +8,5 @@ ConditionKernelCommandLine=bootfs.snapkeep
 
 [Service]
 Type=oneshot
-ExecStart=-/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPKEEP="$(getarg bootfs.snapkeep)"; [ "$SNAPKEEP" -ge 0 ] || exit 1; for SNAPNAME in $(/sbin/zfs list -H -o name -t snapshot "$root" | head -n -$SNAPKEEP); do /sbin/zfs destroy -Rf "$SNAPNAME"; done'
+ExecStart=-/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPKEEP="$(getarg bootfs.snapkeep)"; [ "$SNAPKEEP" -ge 0 ] || exit 1; printf -v IFS "\n"; for SNAPNAME in $(/sbin/zfs list -H -o name -t snapshot "$root" | head -n -$SNAPKEEP); do echo "$SNAPNAME" | grep -q "@" || continue; /sbin/zfs destroy -Rf "$SNAPNAME"; done'
 RemainAfterExit=yes

--- a/contrib/dracut/90zfs/zfs-snapkeep-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-snapkeep-bootfs.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Purge old snapshots of the bootfs
+Requisite=zfs-import.target
+After=zfs-import.target dracut-pre-mount.service zfs-snapshot-bootfs.service
+Before=dracut-mount.service
+DefaultDependencies=no
+ConditionKernelCommandLine=bootfs.snapkeep
+
+[Service]
+Type=oneshot
+ExecStart=-/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPKEEP="$(getarg bootfs.snapkeep)"; [ "$SNAPKEEP" -ge 0 ] || exit 1; for SNAPNAME in $(/sbin/zfs list -H -o name -t snapshot "$root" | head -n -$SNAPKEEP); do /sbin/zfs destroy -Rf "$SNAPNAME"; done'
+RemainAfterExit=yes

--- a/contrib/dracut/90zfs/zfs-snapkeep-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-snapkeep-bootfs.service.in
@@ -8,5 +8,5 @@ ConditionKernelCommandLine=bootfs.snapkeep
 
 [Service]
 Type=oneshot
-ExecStart=-/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPKEEP="$(getarg bootfs.snapkeep)"; [ "$SNAPKEEP" -ge 0 ] || exit 1; printf -v IFS "\n"; for SNAPNAME in $(/sbin/zfs list -H -o name -t snapshot "$root" | head -n -$SNAPKEEP); do echo "$SNAPNAME" | grep -q "@" || continue; /sbin/zfs destroy -Rf "$SNAPNAME"; done'
+ExecStart=-/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPKEEP="$(getarg bootfs.snapkeep)"; [ "$SNAPKEEP" -ge 0 ] || exit 1; for SNAPNAME in $(/sbin/zfs list -H -o name -t snapshot "$root" | head -n -$SNAPKEEP | cut -d "@" -f 2); do /sbin/zfs destroy -Rf "$root@$SNAPNAME"; done'
 RemainAfterExit=yes

--- a/contrib/dracut/90zfs/zfs-snapkeep-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-snapkeep-bootfs.service.in
@@ -8,5 +8,5 @@ ConditionKernelCommandLine=bootfs.snapkeep
 
 [Service]
 Type=oneshot
-ExecStart=-/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPKEEP="$(getarg bootfs.snapkeep)"; [ "$SNAPKEEP" -ge 0 ] || exit 1; for SNAPNAME in $(/sbin/zfs list -H -o name -t snapshot "$root" | head -n -$SNAPKEEP | cut -d "@" -f 2); do /sbin/zfs destroy -Rf "$root@$SNAPNAME"; done'
+ExecStart=-/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPKEEP="$(getarg bootfs.snapkeep)"; [ "$SNAPKEEP" -ge 0 ] || exit 1; printf -v IFS "\n"; for SNAPNAME in $(/sbin/zfs list -H -o name -t snapshot "$root" | head -n -$SNAPKEEP | cut -d "@" -f 2); do /sbin/zfs destroy -Rf "$root@$SNAPNAME"; done'
 RemainAfterExit=yes

--- a/contrib/dracut/90zfs/zfs-snapkeep-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-snapkeep-bootfs.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Purge old snapshots of the bootfs
 Requisite=zfs-import.target
-After=zfs-import.target dracut-pre-mount.service zfs-snapshot-bootfs.service
+After=zfs-import.target dracut-pre-mount.service zfs-snapshot-bootfs.service zfs-rollback-bootfs.service
 Before=dracut-mount.service
 DefaultDependencies=no
 ConditionKernelCommandLine=bootfs.snapkeep

--- a/contrib/dracut/README.md
+++ b/contrib/dracut/README.md
@@ -42,6 +42,7 @@ For complete documentation, see `dracut.zfs(7)`.
    which `-Rf` destroys *all* snapshots of `$root_dataset`
    except the last `n` where `n` is a positive integer.
    `bootfs.snapkeep=n` is ordered after `bootfs.snapshot`.
+   `bootfs.snapkeep=n` is ordered after `bootfs.rollback`.
    Failure to destroy the snapshot(s) is noted, but booting continues.
 
 5. `bootfs.rollback`, `bootfs.rollback=snapshot-name`: enables `zfs-rollback-bootfs.service`,

--- a/contrib/dracut/README.md
+++ b/contrib/dracut/README.md
@@ -40,9 +40,8 @@ For complete documentation, see `dracut.zfs(7)`.
 
 4. `bootfs.snapkeep=n`: enables `zfs-snapkeep-bootfs.service`,
    which `-Rf` destroys *all* snapshots of `$root_dataset`
-   except the last `n` where `n` is a positive integer.
-   `bootfs.snapkeep=n` is ordered after `bootfs.snapshot`.
-   `bootfs.snapkeep=n` is ordered after `bootfs.rollback`.
+   except the last `n` where `n` is a nonnegative integer.
+   `bootfs.snapkeep=n` is ordered after `bootfs.snapshot` and `bootfs.rollback`.
    Failure to destroy the snapshot(s) is noted, but booting continues.
 
 5. `bootfs.rollback`, `bootfs.rollback=snapshot-name`: enables `zfs-rollback-bootfs.service`,

--- a/contrib/dracut/README.md
+++ b/contrib/dracut/README.md
@@ -38,13 +38,19 @@ For complete documentation, see `dracut.zfs(7)`.
    after pool import but before the rootfs is mounted.
    Failure to create the snapshot is noted, but booting continues.
 
-4. `bootfs.rollback`, `bootfs.rollback=snapshot-name`: enables `zfs-rollback-bootfs.service`,
+4. `bootfs.snapkeep=n`: enables `zfs-snapkeep-bootfs.service`,
+   which `-Rf` destroys *all* snapshots of `$root_dataset`
+   except the last `n` where `n` is a positive integer.
+   `bootfs.snapkeep=n` is ordered after `bootfs.snapshot`.
+   Failure to destroy the snapshot(s) is noted, but booting continues.
+
+5. `bootfs.rollback`, `bootfs.rollback=snapshot-name`: enables `zfs-rollback-bootfs.service`,
    which `-Rf` rolls back to `$root_dataset@$(uname -r)` (or, in the second form, `$root_dataset@snapshot-name`)
    after pool import but before the rootfs is mounted.
    Failure to roll back will fall down to the rescue shell.
    This has obvious potential for data loss: make sure your persistent data is not below the rootfs and you don't care about any intermediate snapshots.
 
-5. If both `bootfs.snapshot` and `bootfs.rollback` are set, `bootfs.rollback` is ordered *after* `bootfs.snapshot`.
+6. If both `bootfs.snapshot` and `bootfs.rollback` are set, `bootfs.rollback` is ordered *after* `bootfs.snapshot`.
 
-6. `zfs_force`, `zfs.force`, `zfsforce`: add `-f` to all `zpool import` invocations.
+7. `zfs_force`, `zfs.force`, `zfsforce`: add `-f` to all `zpool import` invocations.
    May be useful. Use with caution.


### PR DESCRIPTION
### Motivation and Context

The bootfs.snapshot kernel parameter provides users with an automated way to create periodic snapshots of their root dataset. But no system is currently available for removing these automated snapshots. Without such a system, the user will eventually run out of disk space unless they manage the snapshots by other means. The bootfs.snapkeep=n kernel parameter is meant to work in conjunction with the bootfs.snapshot kernel parameter as a means of keeping the number of snapshots from growing without bound.

### Description

This patch adds a `zfs-snapkeep-bootfs.service` to Dracut. The service only runs if a `bootfs.snapkeep=n` kernel parameter is present and `n` is a nonnegative integer. The service will run `zfs destroy -Rf $root_dataset@$snapname` for all except the last `n` snapshots of `$root_dataset`.

### How Has This Been Tested?

I have only done light testing of this service on my PC.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
