### PR TITLE
Stop UB complaints and autovectorization of scalar fletcher4 implementation

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -33,6 +33,23 @@ extern "C" {
 #endif
 
 /*
+ * Sometimes, it's an extremely bad idea to allow the compiler to vectorize
+ * scalar code, either because we want the code to work even if SIMD is
+ * broken, because the compiler is known to produce much worse results,
+ * or because it's very unsafe to do.
+ *
+ * Of course, in kernel mode, all platforms have explicit CFLAGS for
+ * "no, don't auto-vectorize random segments, not ever"...
+ */
+#if defined(__GNUC__)
+#define	novector	__attribute__((optimize("no-tree-vectorize")))
+#elif defined(__clang__)
+#define	novector	__attribute__((optimize("no-vectorize")))
+#else
+#define	novector
+#endif
+
+/*
  * This code compiles in three different contexts. When __KERNEL__ is defined,
  * the code uses "unix-like" kernel interfaces. When _STANDALONE is defined, the
  * code is running in a reduced capacity environment of the boot loader which is

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -33,23 +33,6 @@ extern "C" {
 #endif
 
 /*
- * Sometimes, it's an extremely bad idea to allow the compiler to vectorize
- * scalar code, either because we want the code to work even if SIMD is
- * broken, because the compiler is known to produce much worse results,
- * or because it's very unsafe to do.
- *
- * Of course, in kernel mode, all platforms have explicit CFLAGS for
- * "no, don't auto-vectorize random segments, not ever"...
- */
-#if defined(__GNUC__)
-#define	novector	__attribute__((optimize("no-tree-vectorize")))
-#elif defined(__clang__)
-#define	novector	__attribute__((optimize("no-vectorize")))
-#else
-#define	novector
-#endif
-
-/*
  * This code compiles in three different contexts. When __KERNEL__ is defined,
  * the code uses "unix-like" kernel interfaces. When _STANDALONE is defined, the
  * code is running in a reduced capacity environment of the boot loader which is

--- a/include/zfs_fletcher.h
+++ b/include/zfs_fletcher.h
@@ -76,19 +76,19 @@ typedef struct zfs_fletcher_superscalar {
 } zfs_fletcher_superscalar_t;
 
 typedef struct zfs_fletcher_sse {
-	uint64_t v[2] __attribute__((aligned(16)));
+	uint64_t v[2];
 } zfs_fletcher_sse_t;
 
 typedef struct zfs_fletcher_avx {
-	uint64_t v[4] __attribute__((aligned(32)));
+	uint64_t v[4];
 } zfs_fletcher_avx_t;
 
 typedef struct zfs_fletcher_avx512 {
-	uint64_t v[8] __attribute__((aligned(64)));
+	uint64_t v[8];
 } zfs_fletcher_avx512_t;
 
 typedef struct zfs_fletcher_aarch64_neon {
-	uint64_t v[2] __attribute__((aligned(16)));
+	uint64_t v[2];
 } zfs_fletcher_aarch64_neon_t;
 
 
@@ -159,21 +159,5 @@ _ZFS_FLETCHER_H const fletcher_4_ops_t fletcher_4_aarch64_neon_ops;
 #ifdef	__cplusplus
 }
 #endif
-
-#if	defined(ZFS_UBSAN_ENABLED)
-#if	defined(__has_attribute)
-#if	__has_attribute(no_sanitize_undefined)
-#define	ZFS_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize_undefined))
-#elif	__has_attribute(no_sanitize)
-#define	ZFS_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))
-#else
-#error	"Compiler has to support attribute "
-	"`no_sanitize_undefined` or `no_sanitize(\"undefined\")`"
-	"when compiling with UBSan enabled"
-#endif	/* __has_attribute(no_sanitize_undefined) */
-#endif	/* defined(__has_attribute) */
-#else
-#define	ZFS_NO_SANITIZE_UNDEFINED
-#endif	/* defined(ZFS_UBSAN_ENABLED) */
 
 #endif	/* _ZFS_FLETCHER_H */

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -2,6 +2,22 @@ libzfs_la_CFLAGS  = $(AM_CFLAGS) $(LIBRARY_CFLAGS)
 libzfs_la_CFLAGS += $(LIBCRYPTO_CFLAGS) $(ZLIB_CFLAGS)
 libzfs_la_CFLAGS += -fvisibility=hidden
 
+# Less dire than if you override this in the kernel, but autovectorizing
+# random portions seems like a great way to encounter crashes in places
+# that look, on the surface, like there's no SIMD involved...
+#
+# We would keep -mgeneral-regs-only, but on e.g. x64, things like atof
+# can't be defined without implying using FPU regs, so it's a compile
+# time error.
+NOVECTOR := -fno-tree-vectorize
+$(addprefix module/zcommon/libzfs_la-,zfs_fletcher.$(OBJEXT) zfs_fletcher.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzfs_la-,zfs_fletcher_aarch64_neon.$(OBJEXT) zfs_fletcher_aarch64_neon.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzfs_la-,zfs_fletcher_avx512.$(OBJEXT) zfs_fletcher_avx512.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzfs_la-,zfs_fletcher_intel.$(OBJEXT) zfs_fletcher_intel.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzfs_la-,zfs_fletcher_sse.$(OBJEXT) zfs_fletcher_sse.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzfs_la-,zfs_fletcher_superscalar.$(OBJEXT) zfs_fletcher_superscalar.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzfs_la-,zfs_fletcher_superscalar4.$(OBJEXT) zfs_fletcher_superscalar4.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+
 lib_LTLIBRARIES += libzfs.la
 CPPCHECKTARGETS += libzfs.la
 

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -5,6 +5,22 @@ libzpool_la_CPPFLAGS  = $(AM_CPPFLAGS) $(FORCEDEBUG_CPPFLAGS)
 libzpool_la_CPPFLAGS += -I$(srcdir)/include/os/@ac_system_l@/zfs
 libzpool_la_CPPFLAGS += -DLIB_ZPOOL_BUILD
 
+# Less dire than if you override this in the kernel, but autovectorizing
+# random portions seems like a great way to encounter crashes in places
+# that look, on the surface, like there's no SIMD involved...
+#
+# We would keep -mgeneral-regs-only, but on e.g. x64, things like atof
+# can't be defined without implying using FPU regs, so it's a compile
+# time error.
+NOVECTOR := -fno-tree-vectorize
+$(addprefix module/zcommon/libzpool_la-,zfs_fletcher.$(OBJEXT) zfs_fletcher.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzpool_la-,zfs_fletcher_aarch64_neon.$(OBJEXT) zfs_fletcher_aarch64_neon.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzpool_la-,zfs_fletcher_avx512.$(OBJEXT) zfs_fletcher_avx512.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzpool_la-,zfs_fletcher_intel.$(OBJEXT) zfs_fletcher_intel.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzpool_la-,zfs_fletcher_sse.$(OBJEXT) zfs_fletcher_sse.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzpool_la-,zfs_fletcher_superscalar.$(OBJEXT) zfs_fletcher_superscalar.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+$(addprefix module/zcommon/libzpool_la-,zfs_fletcher_superscalar4.$(OBJEXT) zfs_fletcher_superscalar4.l$(OBJEXT)) : CFLAGS += $(NOVECTOR)
+
 lib_LTLIBRARIES += libzpool.la
 CPPCHECKTARGETS += libzpool.la
 

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -472,3 +472,12 @@ OBJECT_FILES_NON_STANDARD_vdev_raidz_math_avx512f.o := y
 ifeq ($(CONFIG_ALTIVEC),y)
 $(obj)/zfs/vdev_raidz_math_powerpc_altivec.o : c_flags += -maltivec
 endif
+
+# Woe betide ye who override this, for yours is the kingdom of mysterious segfaults
+# absolutely everywhere.
+#
+# Free warning to anyone considering it - -march=native or the like later in the line
+# will undo -mgeneral-regs-only, and gcc's -O2 starting in 12 does autovectorizing.
+#
+# Good luck.
+ZFS_MODULE_CFLAGS += -mgeneral-regs-only -fno-tree-vectorize

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -39,6 +39,15 @@ ifneq ($(KBUILD_EXTMOD),)
 @CONFIG_QAT_TRUE@KBUILD_EXTRA_SYMBOLS += @QAT_SYMBOLS@
 endif
 
+# Woe betide ye who override this, for yours is the kingdom of mysterious segfaults
+# absolutely everywhere.
+#
+# Free warning to anyone considering it - -march=native or the like later in the line
+# will undo -mgeneral-regs-only, and gcc's -O2 starting in 12 does autovectorizing.
+#
+# Good luck.
+ZFS_MODULE_CFLAGS += -mgeneral-regs-only -fno-tree-vectorize
+
 asflags-y := $(ZFS_MODULE_CFLAGS) $(ZFS_MODULE_CPPFLAGS)
 ccflags-y := $(ZFS_MODULE_CFLAGS) $(ZFS_MODULE_CPPFLAGS)
 
@@ -472,12 +481,3 @@ OBJECT_FILES_NON_STANDARD_vdev_raidz_math_avx512f.o := y
 ifeq ($(CONFIG_ALTIVEC),y)
 $(obj)/zfs/vdev_raidz_math_powerpc_altivec.o : c_flags += -maltivec
 endif
-
-# Woe betide ye who override this, for yours is the kingdom of mysterious segfaults
-# absolutely everywhere.
-#
-# Free warning to anyone considering it - -march=native or the like later in the line
-# will undo -mgeneral-regs-only, and gcc's -O2 starting in 12 does autovectorizing.
-#
-# Good luck.
-ZFS_MODULE_CFLAGS += -mgeneral-regs-only -fno-tree-vectorize

--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -423,25 +423,34 @@ CFLAGS.zil.c= -Wno-cast-qual
 CFLAGS.zio.c= -Wno-cast-qual
 CFLAGS.zrlock.c= -Wno-cast-qual
 CFLAGS.zfs_zstd.c= -Wno-cast-qual -Wno-pointer-arith
-CFLAGS.entropy_common.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.error_private.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.fse_decompress.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.pool.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.xxhash.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_common.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.fse_compress.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.hist.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.huf_compress.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_compress.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_compress_literals.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_compress_sequences.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_compress_superblock.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_double_fast.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_fast.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_lazy.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_ldm.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_opt.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.huf_decompress.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_ddict.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_decompress.c= -fno-tree-vectorize -U__BMI__
-CFLAGS.zstd_decompress_block.c= -fno-tree-vectorize -U__BMI__
+CFLAGS.entropy_common.c=-U__BMI__
+CFLAGS.error_private.c= -U__BMI__
+CFLAGS.fse_decompress.c= -U__BMI__
+CFLAGS.pool.c= -U__BMI__
+CFLAGS.xxhash.c= -U__BMI__
+CFLAGS.zstd_common.c= -U__BMI__
+CFLAGS.fse_compress.c= -U__BMI__
+CFLAGS.hist.c= -U__BMI__
+CFLAGS.huf_compress.c= -U__BMI__
+CFLAGS.zstd_compress.c= -U__BMI__
+CFLAGS.zstd_compress_literals.c= -U__BMI__
+CFLAGS.zstd_compress_sequences.c= -U__BMI__
+CFLAGS.zstd_compress_superblock.c= -U__BMI__
+CFLAGS.zstd_double_fast.c= -U__BMI__
+CFLAGS.zstd_fast.c= -U__BMI__
+CFLAGS.zstd_lazy.c= -U__BMI__
+CFLAGS.zstd_ldm.c= -U__BMI__
+CFLAGS.zstd_opt.c= -U__BMI__
+CFLAGS.huf_decompress.c= -U__BMI__
+CFLAGS.zstd_ddict.c= -U__BMI__
+CFLAGS.zstd_decompress.c= -U__BMI__
+CFLAGS.zstd_decompress_block.c= -U__BMI__
+
+# Woe betide ye who override this, for yours is the kingdom of mysterious segfaults
+# absolutely everywhere.
+#
+# Free warning to anyone considering it - -march=native or the like later in the line
+# will undo -mgeneral-regs-only, and gcc's -O2 starting in 12 does autovectorizing.
+#
+# Good luck.
+CFLAGS += -mgeneral-regs-only -fno-tree-vectorize

--- a/module/zcommon/zfs_fletcher.c
+++ b/module/zcommon/zfs_fletcher.c
@@ -300,21 +300,18 @@ fletcher_2_byteswap(const void *buf, uint64_t size,
 	(void) fletcher_2_incremental_byteswap((void *) buf, size, zcp);
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_scalar_init(fletcher_4_ctx_t *ctx)
 {
 	ZIO_SET_CHECKSUM(&ctx->scalar, 0, 0, 0, 0);
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_scalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	memcpy(zcp, &ctx->scalar, sizeof (zio_cksum_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_scalar_native(fletcher_4_ctx_t *ctx, const void *buf,
     uint64_t size)
@@ -338,7 +335,6 @@ fletcher_4_scalar_native(fletcher_4_ctx_t *ctx, const void *buf,
 	ZIO_SET_CHECKSUM(&ctx->scalar, a, b, c, d);
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_scalar_byteswap(fletcher_4_ctx_t *ctx, const void *buf,
     uint64_t size)

--- a/module/zcommon/zfs_fletcher.c
+++ b/module/zcommon/zfs_fletcher.c
@@ -142,13 +142,6 @@
 #include <sys/zfs_context.h>
 #include <zfs_fletcher.h>
 
-/*
- * The fletcher implementation functions are all annotated to forbid
- * auto-vectorization, because we would like things that work even if
- * SIMD is on the fritz, and auto-vectorizing random code can lead to
- * strange side effects...
- */
-
 #define	FLETCHER_MIN_SIMD_SIZE	64
 
 static void fletcher_4_scalar_init(fletcher_4_ctx_t *ctx);
@@ -233,13 +226,13 @@ static struct fletcher_4_kstat {
 /* Indicate that benchmark has been completed */
 static boolean_t fletcher_4_initialized = B_FALSE;
 
-novector void
+void
 fletcher_init(zio_cksum_t *zcp)
 {
 	ZIO_SET_CHECKSUM(zcp, 0, 0, 0, 0);
 }
 
-novector int
+int
 fletcher_2_incremental_native(void *buf, size_t size, void *data)
 {
 	zio_cksum_t *zcp = data;
@@ -264,7 +257,7 @@ fletcher_2_incremental_native(void *buf, size_t size, void *data)
 	return (0);
 }
 
-novector void
+void
 fletcher_2_native(const void *buf, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
@@ -273,7 +266,7 @@ fletcher_2_native(const void *buf, uint64_t size,
 	(void) fletcher_2_incremental_native((void *) buf, size, zcp);
 }
 
-novector int
+int
 fletcher_2_incremental_byteswap(void *buf, size_t size, void *data)
 {
 	zio_cksum_t *zcp = data;
@@ -298,7 +291,7 @@ fletcher_2_incremental_byteswap(void *buf, size_t size, void *data)
 	return (0);
 }
 
-novector void
+void
 fletcher_2_byteswap(const void *buf, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
@@ -307,19 +300,19 @@ fletcher_2_byteswap(const void *buf, uint64_t size,
 	(void) fletcher_2_incremental_byteswap((void *) buf, size, zcp);
 }
 
-novector static void
+static void
 fletcher_4_scalar_init(fletcher_4_ctx_t *ctx)
 {
 	ZIO_SET_CHECKSUM(&ctx->scalar, 0, 0, 0, 0);
 }
 
-novector static void
+static void
 fletcher_4_scalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	memcpy(zcp, &ctx->scalar, sizeof (zio_cksum_t));
 }
 
-novector static void
+static void
 fletcher_4_scalar_native(fletcher_4_ctx_t *ctx, const void *buf,
     uint64_t size)
 {
@@ -342,7 +335,7 @@ fletcher_4_scalar_native(fletcher_4_ctx_t *ctx, const void *buf,
 	ZIO_SET_CHECKSUM(&ctx->scalar, a, b, c, d);
 }
 
-novector static void
+static void
 fletcher_4_scalar_byteswap(fletcher_4_ctx_t *ctx, const void *buf,
     uint64_t size)
 {
@@ -466,7 +459,7 @@ fletcher_4_native_impl(const void *buf, uint64_t size, zio_cksum_t *zcp)
 	ops->fini_native(&ctx, zcp);
 }
 
-novector void
+void
 fletcher_4_native(const void *buf, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
@@ -490,14 +483,14 @@ fletcher_4_native(const void *buf, uint64_t size,
 	}
 }
 
-novector void
+void
 fletcher_4_native_varsize(const void *buf, uint64_t size, zio_cksum_t *zcp)
 {
 	ZIO_SET_CHECKSUM(zcp, 0, 0, 0, 0);
 	fletcher_4_scalar_native((fletcher_4_ctx_t *)zcp, buf, size);
 }
 
-novector static inline void
+static inline void
 fletcher_4_byteswap_impl(const void *buf, uint64_t size, zio_cksum_t *zcp)
 {
 	fletcher_4_ctx_t ctx;
@@ -508,7 +501,7 @@ fletcher_4_byteswap_impl(const void *buf, uint64_t size, zio_cksum_t *zcp)
 	ops->fini_byteswap(&ctx, zcp);
 }
 
-novector void
+void
 fletcher_4_byteswap(const void *buf, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
@@ -536,7 +529,7 @@ fletcher_4_byteswap(const void *buf, uint64_t size,
 
 #define	ZFS_FLETCHER_4_INC_MAX_SIZE	(8ULL << 20)
 
-novector static inline void
+static inline void
 fletcher_4_incremental_combine(zio_cksum_t *zcp, const uint64_t size,
     const zio_cksum_t *nzcp)
 {
@@ -579,7 +572,7 @@ fletcher_4_incremental_impl(boolean_t native, const void *buf, uint64_t size,
 	}
 }
 
-novector int
+int
 fletcher_4_incremental_native(void *buf, size_t size, void *data)
 {
 	zio_cksum_t *zcp = data;
@@ -591,7 +584,7 @@ fletcher_4_incremental_native(void *buf, size_t size, void *data)
 	return (0);
 }
 
-novector int
+int
 fletcher_4_incremental_byteswap(void *buf, size_t size, void *data)
 {
 	zio_cksum_t *zcp = data;

--- a/module/zcommon/zfs_fletcher_aarch64_neon.c
+++ b/module/zcommon/zfs_fletcher_aarch64_neon.c
@@ -48,14 +48,12 @@
 #include <sys/string.h>
 #include <zfs_fletcher.h>
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_aarch64_neon_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->aarch64_neon, 0, 4 * sizeof (zfs_fletcher_aarch64_neon_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_aarch64_neon_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {

--- a/module/zcommon/zfs_fletcher_aarch64_neon.c
+++ b/module/zcommon/zfs_fletcher_aarch64_neon.c
@@ -49,13 +49,13 @@
 #include <zfs_fletcher.h>
 #include <sys/zfs_context.h>
 
-novector static void
+static void
 fletcher_4_aarch64_neon_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->aarch64_neon, 0, 4 * sizeof (zfs_fletcher_aarch64_neon_t));
 }
 
-novector static void
+static void
 fletcher_4_aarch64_neon_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	uint64_t A, B, C, D;

--- a/module/zcommon/zfs_fletcher_aarch64_neon.c
+++ b/module/zcommon/zfs_fletcher_aarch64_neon.c
@@ -47,14 +47,15 @@
 #include <sys/spa_checksum.h>
 #include <sys/string.h>
 #include <zfs_fletcher.h>
+#include <sys/zfs_context.h>
 
-static void
+novector static void
 fletcher_4_aarch64_neon_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->aarch64_neon, 0, 4 * sizeof (zfs_fletcher_aarch64_neon_t));
 }
 
-static void
+novector static void
 fletcher_4_aarch64_neon_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	uint64_t A, B, C, D;

--- a/module/zcommon/zfs_fletcher_avx512.c
+++ b/module/zcommon/zfs_fletcher_avx512.c
@@ -30,20 +30,19 @@
 #include <sys/string.h>
 #include <sys/simd.h>
 #include <zfs_fletcher.h>
+#include <sys/zfs_context.h>
 
 #ifdef __linux__
 #define	__asm __asm__ __volatile__
 #endif
 
-ZFS_NO_SANITIZE_UNDEFINED
-static void
+novector static void
 fletcher_4_avx512f_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->avx512, 0, 4 * sizeof (zfs_fletcher_avx512_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
-static void
+novector static void
 fletcher_4_avx512f_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	static const uint64_t

--- a/module/zcommon/zfs_fletcher_avx512.c
+++ b/module/zcommon/zfs_fletcher_avx512.c
@@ -36,13 +36,13 @@
 #define	__asm __asm__ __volatile__
 #endif
 
-novector static void
+static void
 fletcher_4_avx512f_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->avx512, 0, 4 * sizeof (zfs_fletcher_avx512_t));
 }
 
-novector static void
+static void
 fletcher_4_avx512f_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	static const uint64_t

--- a/module/zcommon/zfs_fletcher_intel.c
+++ b/module/zcommon/zfs_fletcher_intel.c
@@ -47,14 +47,12 @@
 #include <sys/simd.h>
 #include <zfs_fletcher.h>
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_avx2_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->avx, 0, 4 * sizeof (zfs_fletcher_avx_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_avx2_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {

--- a/module/zcommon/zfs_fletcher_intel.c
+++ b/module/zcommon/zfs_fletcher_intel.c
@@ -48,13 +48,13 @@
 #include <zfs_fletcher.h>
 #include <sys/zfs_context.h>
 
-novector static void
+static void
 fletcher_4_avx2_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->avx, 0, 4 * sizeof (zfs_fletcher_avx_t));
 }
 
-novector static void
+static void
 fletcher_4_avx2_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	uint64_t A, B, C, D;

--- a/module/zcommon/zfs_fletcher_intel.c
+++ b/module/zcommon/zfs_fletcher_intel.c
@@ -46,14 +46,15 @@
 #include <sys/string.h>
 #include <sys/simd.h>
 #include <zfs_fletcher.h>
+#include <sys/zfs_context.h>
 
-static void
+novector static void
 fletcher_4_avx2_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->avx, 0, 4 * sizeof (zfs_fletcher_avx_t));
 }
 
-static void
+novector static void
 fletcher_4_avx2_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	uint64_t A, B, C, D;

--- a/module/zcommon/zfs_fletcher_sse.c
+++ b/module/zcommon/zfs_fletcher_sse.c
@@ -49,14 +49,12 @@
 #include <sys/byteorder.h>
 #include <zfs_fletcher.h>
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_sse2_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->sse, 0, 4 * sizeof (zfs_fletcher_sse_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_sse2_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {

--- a/module/zcommon/zfs_fletcher_sse.c
+++ b/module/zcommon/zfs_fletcher_sse.c
@@ -50,13 +50,13 @@
 #include <zfs_fletcher.h>
 #include <sys/zfs_context.h>
 
-novector static void
+static void
 fletcher_4_sse2_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->sse, 0, 4 * sizeof (zfs_fletcher_sse_t));
 }
 
-novector static void
+static void
 fletcher_4_sse2_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	uint64_t A, B, C, D;

--- a/module/zcommon/zfs_fletcher_sse.c
+++ b/module/zcommon/zfs_fletcher_sse.c
@@ -48,14 +48,15 @@
 #include <sys/string.h>
 #include <sys/byteorder.h>
 #include <zfs_fletcher.h>
+#include <sys/zfs_context.h>
 
-static void
+novector static void
 fletcher_4_sse2_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->sse, 0, 4 * sizeof (zfs_fletcher_sse_t));
 }
 
-static void
+novector static void
 fletcher_4_sse2_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	uint64_t A, B, C, D;

--- a/module/zcommon/zfs_fletcher_superscalar.c
+++ b/module/zcommon/zfs_fletcher_superscalar.c
@@ -47,14 +47,12 @@
 #include <sys/string.h>
 #include <zfs_fletcher.h>
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->superscalar, 0, 4 * sizeof (zfs_fletcher_superscalar_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
@@ -70,7 +68,6 @@ fletcher_4_superscalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 	ZIO_SET_CHECKSUM(zcp, A, B, C, D);
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar_native(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
@@ -110,7 +107,6 @@ fletcher_4_superscalar_native(fletcher_4_ctx_t *ctx,
 	ctx->superscalar[3].v[1] = d2;
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar_byteswap(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)

--- a/module/zcommon/zfs_fletcher_superscalar.c
+++ b/module/zcommon/zfs_fletcher_superscalar.c
@@ -54,13 +54,13 @@
  * and auto-vectorizing random code can lead to strange side effects...
  */
 
-novector static void
+static void
 fletcher_4_superscalar_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->superscalar, 0, 4 * sizeof (zfs_fletcher_superscalar_t));
 }
 
-novector static void
+static void
 fletcher_4_superscalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	uint64_t A, B, C, D;
@@ -75,7 +75,7 @@ fletcher_4_superscalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 	ZIO_SET_CHECKSUM(zcp, A, B, C, D);
 }
 
-novector static void
+static void
 fletcher_4_superscalar_native(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
 {
@@ -114,7 +114,7 @@ fletcher_4_superscalar_native(fletcher_4_ctx_t *ctx,
 	ctx->superscalar[3].v[1] = d2;
 }
 
-novector static void
+static void
 fletcher_4_superscalar_byteswap(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
 {

--- a/module/zcommon/zfs_fletcher_superscalar.c
+++ b/module/zcommon/zfs_fletcher_superscalar.c
@@ -46,14 +46,21 @@
 #include <sys/spa_checksum.h>
 #include <sys/string.h>
 #include <zfs_fletcher.h>
+#include <sys/zfs_context.h>
 
-static void
+/*
+ * These functions are all annotated to forbid auto-vectorization, because
+ * we would like some implementations that work even if SIMD is on the fritz,
+ * and auto-vectorizing random code can lead to strange side effects...
+ */
+
+novector static void
 fletcher_4_superscalar_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->superscalar, 0, 4 * sizeof (zfs_fletcher_superscalar_t));
 }
 
-static void
+novector static void
 fletcher_4_superscalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	uint64_t A, B, C, D;
@@ -68,7 +75,7 @@ fletcher_4_superscalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 	ZIO_SET_CHECKSUM(zcp, A, B, C, D);
 }
 
-static void
+novector static void
 fletcher_4_superscalar_native(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
 {
@@ -107,7 +114,7 @@ fletcher_4_superscalar_native(fletcher_4_ctx_t *ctx,
 	ctx->superscalar[3].v[1] = d2;
 }
 
-static void
+novector static void
 fletcher_4_superscalar_byteswap(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
 {

--- a/module/zcommon/zfs_fletcher_superscalar4.c
+++ b/module/zcommon/zfs_fletcher_superscalar4.c
@@ -47,14 +47,12 @@
 #include <sys/string.h>
 #include <zfs_fletcher.h>
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar4_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->superscalar, 0, 4 * sizeof (zfs_fletcher_superscalar_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar4_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
@@ -84,7 +82,6 @@ fletcher_4_superscalar4_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 	ZIO_SET_CHECKSUM(zcp, A, B, C, D);
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar4_native(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
@@ -150,7 +147,6 @@ fletcher_4_superscalar4_native(fletcher_4_ctx_t *ctx,
 	ctx->superscalar[3].v[3] = d4;
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar4_byteswap(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)

--- a/module/zcommon/zfs_fletcher_superscalar4.c
+++ b/module/zcommon/zfs_fletcher_superscalar4.c
@@ -54,13 +54,13 @@
  * and auto-vectorizing random code can lead to strange side effects...
  */
 
-novector static void
+static void
 fletcher_4_superscalar4_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->superscalar, 0, 4 * sizeof (zfs_fletcher_superscalar_t));
 }
 
-novector static void
+static void
 fletcher_4_superscalar4_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	uint64_t A, B, C, D;
@@ -89,7 +89,7 @@ fletcher_4_superscalar4_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 	ZIO_SET_CHECKSUM(zcp, A, B, C, D);
 }
 
-novector static void
+static void
 fletcher_4_superscalar4_native(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
 {
@@ -154,7 +154,7 @@ fletcher_4_superscalar4_native(fletcher_4_ctx_t *ctx,
 	ctx->superscalar[3].v[3] = d4;
 }
 
-novector static void
+static void
 fletcher_4_superscalar4_byteswap(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
 {

--- a/module/zcommon/zfs_fletcher_superscalar4.c
+++ b/module/zcommon/zfs_fletcher_superscalar4.c
@@ -46,14 +46,21 @@
 #include <sys/spa_checksum.h>
 #include <sys/string.h>
 #include <zfs_fletcher.h>
+#include <sys/zfs_context.h>
 
-static void
+/*
+ * These functions are all annotated to forbid auto-vectorization, because
+ * we would like some implementations that work even if SIMD is on the fritz,
+ * and auto-vectorizing random code can lead to strange side effects...
+ */
+
+novector static void
 fletcher_4_superscalar4_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->superscalar, 0, 4 * sizeof (zfs_fletcher_superscalar_t));
 }
 
-static void
+novector static void
 fletcher_4_superscalar4_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	uint64_t A, B, C, D;
@@ -82,7 +89,7 @@ fletcher_4_superscalar4_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 	ZIO_SET_CHECKSUM(zcp, A, B, C, D);
 }
 
-static void
+novector static void
 fletcher_4_superscalar4_native(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
 {
@@ -147,7 +154,7 @@ fletcher_4_superscalar4_native(fletcher_4_ctx_t *ctx,
 	ctx->superscalar[3].v[3] = d4;
 }
 
-static void
+novector static void
 fletcher_4_superscalar4_byteswap(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
 {


### PR DESCRIPTION
(I'll rebase with a better description before merge assuming nobody has a reason this is a terrible idea, but since we're doing the opposite cast as input in a number of places, it seems no worse than status quo ante...)

### Motivation and Context
Getting rid of "shhh nobody look it's fine we promise" excludes in the code is always good, plus with gcc defaulting to auto-vectorization at O2 now, the results can be...explosive (#13605 #13620).

### Description
When we cast the input to `fletcher_4_scalar_native` or friends to `fletcher_4_ctx_t`, we're promising that the thing is up to 64B (!) aligned, as far as the compiler's concerned, but because we're not actually guaranteeing that, auto-vectorizing the code results in trying to do an aligned write to the item, and that is sometimes going to crash (in userland; since the kernel has big flashing NO DON'T around auto-vectorizing, it's probably just going to upset sanitizers).

But it turns out, everywhere we explicitly call the scalar implementation, we're just casting a `zio_cksum_t *` to `fletcher_4_ctx_t *`, so if that's ever incorrect behavior, we're going to horrifically crash a dozen ways to Sunday anyway.

I just dropped the forced __alignment__ annotations, because it turns out all the implementations are written entirely in unaligned access instructions anyway, so if we really think that giving unaligned instructions aligned accesses is more performant in some spots, we can just do that there, rather than claiming it's aligned everywhere and then lying a few times.

### How Has This Been Tested?
Before this change, using `-ftree-vectorize -march=znver2` would result in a `zfs` binary that crashed around half the time on trying to send on my 8700k or my 5900X, and removing the UBSan exceptions would result in erroring out hard immediately on send with or without the `-ftree-vectorize`.

After this change, with or without the `-ftree-vectorize`, UBSan as far as I can see has no complaints about these functions, and I haven't made it crash again.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
