### PR TITLE
zed: Use ID_MODEL instead of ID_BUS for autoreplace

### DIFF
--- a/cmd/zed/zed_disk_event.c
+++ b/cmd/zed/zed_disk_event.c
@@ -169,7 +169,7 @@ zed_udev_monitor(void *arg)
 	while (1) {
 		struct udev_device *dev;
 		const char *action, *type, *part, *sectors;
-		const char *bus, *uuid;
+		const char *model, *uuid;
 		const char *class, *subclass;
 		nvlist_t *nvl;
 		boolean_t is_zfs = B_FALSE;
@@ -249,9 +249,9 @@ zed_udev_monitor(void *arg)
 		 * for matching with vdevs. Preflight here for expected
 		 * udev information.
 		 */
-		bus = udev_device_get_property_value(dev, "ID_BUS");
+		model = udev_device_get_property_value(dev, "ID_MODEL");
 		uuid = udev_device_get_property_value(dev, "DM_UUID");
-		if (!is_zfs && (bus == NULL && uuid == NULL)) {
+		if (!is_zfs && (model == NULL && uuid == NULL)) {
 			zed_log_msg(LOG_INFO, "zed_udev_monitor: %s no devid "
 			    "source", udev_device_get_devnode(dev));
 			udev_device_unref(dev);


### PR DESCRIPTION

### Motivation and Context
Fixes #13512

### Description
We tried replacing an NVMe drive using autoreplace, only to see zed reject it with:
```
zed[27955]: zed_udev_monitor: /dev/nvme5n1 no devid source
```
This happened because ZED saw that ID_BUS was not set by udev for the NVMe drive, and thus didn't think it was "real drive".
A better option is to look for ID_MODEL instead.  In testing, I saw ID_MODEL get set for a SATA drive (RHEL 7), SAS drive
(RHEL 8) and NVMe drive (RHEL 8), but not for a virtual drive on a VM.

### How Has This Been Tested?
Tested autoreplace using an NVMe drive that had an ID_MODEL udev entry but not ID_BUS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
