### PR TITLE
ZIL kstats update

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2908,7 +2908,7 @@ ztest_zil_remount(ztest_ds_t *zd, uint64_t id)
 	zil_close(zd->zd_zilog);
 
 	/* zfsvfs_setup() */
-	VERIFY3P(zil_open(os, ztest_get_data), ==, zd->zd_zilog);
+	VERIFY3P(zil_open(os, ztest_get_data, NULL), ==, zd->zd_zilog);
 	zil_replay(os, zd, ztest_replay_vector);
 
 	(void) pthread_rwlock_unlock(&zd->zd_zilog_lock);
@@ -4378,7 +4378,7 @@ ztest_dmu_objset_create_destroy(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Open the intent log for it.
 	 */
-	zilog = zil_open(os, ztest_get_data);
+	zilog = zil_open(os, ztest_get_data, NULL);
 
 	/*
 	 * Put some objects in there, do a little I/O to them,
@@ -7304,7 +7304,7 @@ ztest_dataset_open(int d)
 		    zilog->zl_parse_lr_count,
 		    zilog->zl_replaying_seq);
 
-	zilog = zil_open(os, ztest_get_data);
+	zilog = zil_open(os, ztest_get_data, NULL);
 
 	if (zilog->zl_replaying_seq != 0 &&
 	    zilog->zl_replaying_seq < committed_seq)

--- a/include/sys/dataset_kstats.h
+++ b/include/sys/dataset_kstats.h
@@ -30,6 +30,7 @@
 #include <sys/wmsum.h>
 #include <sys/dmu.h>
 #include <sys/kstat.h>
+#include <sys/zil.h>
 
 typedef struct dataset_sum_stats_t {
 	wmsum_t dss_writes;
@@ -56,14 +57,19 @@ typedef struct dataset_kstat_values {
 	 * entry is removed from the unlinked set
 	 */
 	kstat_named_t dkv_nunlinked;
+	/*
+	 * Per dataset zil kstats
+	 */
+	zil_kstat_values_t dkv_zil_stats;
 } dataset_kstat_values_t;
 
 typedef struct dataset_kstats {
 	dataset_sum_stats_t dk_sums;
+	zil_sums_t dk_zil_sums;
 	kstat_t *dk_kstats;
 } dataset_kstats_t;
 
-void dataset_kstats_create(dataset_kstats_t *, objset_t *);
+int dataset_kstats_create(dataset_kstats_t *, objset_t *);
 void dataset_kstats_destroy(dataset_kstats_t *);
 
 void dataset_kstats_update_write_kstats(dataset_kstats_t *, int64_t);

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -33,6 +33,7 @@
 #include <sys/zio.h>
 #include <sys/dmu.h>
 #include <sys/zio_crypt.h>
+#include <sys/wmsum.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -472,12 +473,34 @@ typedef struct zil_stats {
 	 */
 	kstat_named_t zil_itx_metaslab_slog_count;
 	kstat_named_t zil_itx_metaslab_slog_bytes;
-} zil_stats_t;
+} zil_kstat_values_t;
 
-#define	ZIL_STAT_INCR(stat, val) \
-    atomic_add_64(&zil_stats.stat.value.ui64, (val));
-#define	ZIL_STAT_BUMP(stat) \
-    ZIL_STAT_INCR(stat, 1);
+typedef struct zil_sums {
+	wmsum_t zil_commit_count;
+	wmsum_t zil_commit_writer_count;
+	wmsum_t zil_itx_count;
+	wmsum_t zil_itx_indirect_count;
+	wmsum_t zil_itx_indirect_bytes;
+	wmsum_t zil_itx_copied_count;
+	wmsum_t zil_itx_copied_bytes;
+	wmsum_t zil_itx_needcopy_count;
+	wmsum_t zil_itx_needcopy_bytes;
+	wmsum_t zil_itx_metaslab_normal_count;
+	wmsum_t zil_itx_metaslab_normal_bytes;
+	wmsum_t zil_itx_metaslab_slog_count;
+	wmsum_t zil_itx_metaslab_slog_bytes;
+} zil_sums_t;
+
+#define	ZIL_STAT_INCR(zil, stat, val) \
+	do { \
+		int64_t tmpval = (val); \
+		wmsum_add(&(zil_sums_global.stat), tmpval); \
+		if ((zil)->zl_sums) \
+			wmsum_add(&((zil)->zl_sums->stat), tmpval); \
+	} while (0)
+
+#define	ZIL_STAT_BUMP(zil, stat) \
+    ZIL_STAT_INCR(zil, stat, 1);
 
 typedef int zil_parse_blk_func_t(zilog_t *zilog, const blkptr_t *bp, void *arg,
     uint64_t txg);
@@ -497,7 +520,8 @@ extern void	zil_fini(void);
 extern zilog_t	*zil_alloc(objset_t *os, zil_header_t *zh_phys);
 extern void	zil_free(zilog_t *zilog);
 
-extern zilog_t	*zil_open(objset_t *os, zil_get_data_t *get_data);
+extern zilog_t	*zil_open(objset_t *os, zil_get_data_t *get_data,
+    zil_sums_t *zil_sums);
 extern void	zil_close(zilog_t *zilog);
 
 extern void	zil_replay(objset_t *os, void *arg,
@@ -536,6 +560,11 @@ extern void	zil_set_logbias(zilog_t *zilog, uint64_t slogval);
 
 extern uint64_t	zil_max_copied_data(zilog_t *zilog);
 extern uint64_t	zil_max_log_data(zilog_t *zilog);
+
+extern void zil_sums_init(zil_sums_t *zs);
+extern void zil_sums_fini(zil_sums_t *zs);
+extern void zil_kstat_values_update(zil_kstat_values_t *zs,
+    zil_sums_t *zil_sums);
 
 extern int zil_replay_disable;
 

--- a/include/sys/zil_impl.h
+++ b/include/sys/zil_impl.h
@@ -222,6 +222,9 @@ struct zilog {
 	 * (see zil_max_copied_data()).
 	 */
 	uint64_t	zl_max_block_size;
+
+	/* Pointer for per dataset zil sums */
+	zil_sums_t *zl_sums;
 };
 
 typedef struct zil_bp_node {

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -1027,8 +1027,6 @@ zfsvfs_setup(zfsvfs_t *zfsvfs, boolean_t mounting)
 	if (error)
 		return (error);
 
-	zfsvfs->z_log = zil_open(zfsvfs->z_os, zfs_get_data);
-
 	/*
 	 * If we are not mounting (ie: online recv), then we don't
 	 * have to worry about replaying the log as we blocked all
@@ -1038,7 +1036,11 @@ zfsvfs_setup(zfsvfs_t *zfsvfs, boolean_t mounting)
 		boolean_t readonly;
 
 		ASSERT3P(zfsvfs->z_kstat.dk_kstats, ==, NULL);
-		dataset_kstats_create(&zfsvfs->z_kstat, zfsvfs->z_os);
+		error = dataset_kstats_create(&zfsvfs->z_kstat, zfsvfs->z_os);
+		if (error)
+			return (error);
+		zfsvfs->z_log = zil_open(zfsvfs->z_os, zfs_get_data,
+		    &zfsvfs->z_kstat.dk_zil_sums);
 
 		/*
 		 * During replay we remove the read only flag to
@@ -1109,6 +1111,10 @@ zfsvfs_setup(zfsvfs_t *zfsvfs, boolean_t mounting)
 		/* restore readonly bit */
 		if (readonly != 0)
 			zfsvfs->z_vfs->vfs_flag |= VFS_RDONLY;
+	} else {
+		ASSERT3P(zfsvfs->z_kstat.dk_kstats, !=, NULL);
+		zfsvfs->z_log = zil_open(zfsvfs->z_os, zfs_get_data,
+		    &zfsvfs->z_kstat.dk_zil_sums);
 	}
 
 	/*

--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -1189,7 +1189,7 @@ zvol_ensure_zilog(zvol_state_t *zv)
 		}
 		if (zv->zv_zilog == NULL) {
 			zv->zv_zilog = zil_open(zv->zv_objset,
-			    zvol_get_data);
+			    zvol_get_data, &zv->zv_kstat.dk_zil_sums);
 			zv->zv_flags |= ZVOL_WRITTEN_TO;
 			/* replay / destroy done in zvol_os_create_minor() */
 			VERIFY0(zv->zv_zilog->zl_header->zh_flags &
@@ -1422,8 +1422,12 @@ zvol_os_create_minor(const char *name)
 	zv->zv_volsize = volsize;
 	zv->zv_objset = os;
 
+	ASSERT3P(zv->zv_kstat.dk_kstats, ==, NULL);
+	error = dataset_kstats_create(&zv->zv_kstat, zv->zv_objset);
+	if (error)
+		goto out_dmu_objset_disown;
 	ASSERT3P(zv->zv_zilog, ==, NULL);
-	zv->zv_zilog = zil_open(os, zvol_get_data);
+	zv->zv_zilog = zil_open(os, zvol_get_data, &zv->zv_kstat.dk_zil_sums);
 	if (spa_writeable(dmu_objset_spa(os))) {
 		if (zil_replay_disable)
 			zil_destroy(zv->zv_zilog, B_FALSE);
@@ -1432,8 +1436,6 @@ zvol_os_create_minor(const char *name)
 	}
 	zil_close(zv->zv_zilog);
 	zv->zv_zilog = NULL;
-	ASSERT3P(zv->zv_kstat.dk_kstats, ==, NULL);
-	dataset_kstats_create(&zv->zv_kstat, zv->zv_objset);
 
 	/* TODO: prefetch for geom tasting */
 

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -558,7 +558,7 @@ zvol_request_impl(zvol_state_t *zv, struct bio *bio, struct request *rq,
 			rw_enter(&zv->zv_suspend_lock, RW_WRITER);
 			if (zv->zv_zilog == NULL) {
 				zv->zv_zilog = zil_open(zv->zv_objset,
-				    zvol_get_data);
+				    zvol_get_data, &zv->zv_kstat.dk_zil_sums);
 				zv->zv_flags |= ZVOL_WRITTEN_TO;
 				/* replay / destroy done in zvol_create_minor */
 				VERIFY0((zv->zv_zilog->zl_header->zh_flags &
@@ -1408,8 +1408,12 @@ zvol_os_create_minor(const char *name)
 	blk_queue_flag_set(QUEUE_FLAG_SCSI_PASSTHROUGH, zv->zv_zso->zvo_queue);
 #endif
 
+	ASSERT3P(zv->zv_kstat.dk_kstats, ==, NULL);
+	error = dataset_kstats_create(&zv->zv_kstat, zv->zv_objset);
+	if (error)
+		goto out_dmu_objset_disown;
 	ASSERT3P(zv->zv_zilog, ==, NULL);
-	zv->zv_zilog = zil_open(os, zvol_get_data);
+	zv->zv_zilog = zil_open(os, zvol_get_data, &zv->zv_kstat.dk_zil_sums);
 	if (spa_writeable(dmu_objset_spa(os))) {
 		if (zil_replay_disable)
 			zil_destroy(zv->zv_zilog, B_FALSE);
@@ -1418,8 +1422,6 @@ zvol_os_create_minor(const char *name)
 	}
 	zil_close(zv->zv_zilog);
 	zv->zv_zilog = NULL;
-	ASSERT3P(zv->zv_kstat.dk_kstats, ==, NULL);
-	dataset_kstats_create(&zv->zv_kstat, zv->zv_objset);
 
 	/*
 	 * When udev detects the addition of the device it will immediately

--- a/module/zfs/dataset_kstats.c
+++ b/module/zfs/dataset_kstats.c
@@ -37,18 +37,33 @@ static dataset_kstat_values_t empty_dataset_kstats = {
 	{ "nread",	KSTAT_DATA_UINT64 },
 	{ "nunlinks",	KSTAT_DATA_UINT64 },
 	{ "nunlinked",	KSTAT_DATA_UINT64 },
+	{
+	{ "zil_commit_count",			KSTAT_DATA_UINT64 },
+	{ "zil_commit_writer_count",		KSTAT_DATA_UINT64 },
+	{ "zil_itx_count",			KSTAT_DATA_UINT64 },
+	{ "zil_itx_indirect_count",		KSTAT_DATA_UINT64 },
+	{ "zil_itx_indirect_bytes",		KSTAT_DATA_UINT64 },
+	{ "zil_itx_copied_count",		KSTAT_DATA_UINT64 },
+	{ "zil_itx_copied_bytes",		KSTAT_DATA_UINT64 },
+	{ "zil_itx_needcopy_count",		KSTAT_DATA_UINT64 },
+	{ "zil_itx_needcopy_bytes",		KSTAT_DATA_UINT64 },
+	{ "zil_itx_metaslab_normal_count",	KSTAT_DATA_UINT64 },
+	{ "zil_itx_metaslab_normal_bytes",	KSTAT_DATA_UINT64 },
+	{ "zil_itx_metaslab_slog_count",	KSTAT_DATA_UINT64 },
+	{ "zil_itx_metaslab_slog_bytes",	KSTAT_DATA_UINT64 }
+	}
 };
 
 static int
 dataset_kstats_update(kstat_t *ksp, int rw)
 {
 	dataset_kstats_t *dk = ksp->ks_private;
-	ASSERT3P(dk->dk_kstats->ks_data, ==, ksp->ks_data);
+	dataset_kstat_values_t *dkv = ksp->ks_data;
+	ASSERT3P(dk->dk_kstats->ks_data, ==, dkv);
 
 	if (rw == KSTAT_WRITE)
 		return (EACCES);
 
-	dataset_kstat_values_t *dkv = dk->dk_kstats->ks_data;
 	dkv->dkv_writes.value.ui64 =
 	    wmsum_value(&dk->dk_sums.dss_writes);
 	dkv->dkv_nwritten.value.ui64 =
@@ -62,10 +77,12 @@ dataset_kstats_update(kstat_t *ksp, int rw)
 	dkv->dkv_nunlinked.value.ui64 =
 	    wmsum_value(&dk->dk_sums.dss_nunlinked);
 
+	zil_kstat_values_update(&dkv->dkv_zil_stats, &dk->dk_zil_sums);
+
 	return (0);
 }
 
-void
+int
 dataset_kstats_create(dataset_kstats_t *dk, objset_t *objset)
 {
 	/*
@@ -75,7 +92,7 @@ dataset_kstats_create(dataset_kstats_t *dk, objset_t *objset)
 	 * a filesystem with many snapshots, we skip them for now.
 	 */
 	if (dmu_objset_is_snapshot(objset))
-		return;
+		return (0);
 
 	/*
 	 * At the time of this writing, KSTAT_STRLEN is 255 in Linux,
@@ -94,13 +111,13 @@ dataset_kstats_create(dataset_kstats_t *dk, objset_t *objset)
 		zfs_dbgmsg("failed to create dataset kstat for objset %lld: "
 		    " snprintf() for kstat module name returned %d",
 		    (unsigned long long)dmu_objset_id(objset), n);
-		return;
+		return (SET_ERROR(EINVAL));
 	} else if (n >= KSTAT_STRLEN) {
 		zfs_dbgmsg("failed to create dataset kstat for objset %lld: "
 		    "kstat module name length (%d) exceeds limit (%d)",
 		    (unsigned long long)dmu_objset_id(objset),
 		    n, KSTAT_STRLEN);
-		return;
+		return (SET_ERROR(ENAMETOOLONG));
 	}
 
 	char kstat_name[KSTAT_STRLEN];
@@ -110,7 +127,7 @@ dataset_kstats_create(dataset_kstats_t *dk, objset_t *objset)
 		zfs_dbgmsg("failed to create dataset kstat for objset %lld: "
 		    " snprintf() for kstat name returned %d",
 		    (unsigned long long)dmu_objset_id(objset), n);
-		return;
+		return (SET_ERROR(EINVAL));
 	}
 	ASSERT3U(n, <, KSTAT_STRLEN);
 
@@ -119,7 +136,7 @@ dataset_kstats_create(dataset_kstats_t *dk, objset_t *objset)
 	    sizeof (empty_dataset_kstats) / sizeof (kstat_named_t),
 	    KSTAT_FLAG_VIRTUAL);
 	if (kstat == NULL)
-		return;
+		return (SET_ERROR(ENOMEM));
 
 	dataset_kstat_values_t *dk_kstats =
 	    kmem_alloc(sizeof (empty_dataset_kstats), KM_SLEEP);
@@ -137,15 +154,17 @@ dataset_kstats_create(dataset_kstats_t *dk, objset_t *objset)
 	kstat->ks_private = dk;
 	kstat->ks_data_size += ZFS_MAX_DATASET_NAME_LEN;
 
-	kstat_install(kstat);
-	dk->dk_kstats = kstat;
-
 	wmsum_init(&dk->dk_sums.dss_writes, 0);
 	wmsum_init(&dk->dk_sums.dss_nwritten, 0);
 	wmsum_init(&dk->dk_sums.dss_reads, 0);
 	wmsum_init(&dk->dk_sums.dss_nread, 0);
 	wmsum_init(&dk->dk_sums.dss_nunlinks, 0);
 	wmsum_init(&dk->dk_sums.dss_nunlinked, 0);
+	zil_sums_init(&dk->dk_zil_sums);
+
+	dk->dk_kstats = kstat;
+	kstat_install(kstat);
+	return (0);
 }
 
 void
@@ -155,12 +174,11 @@ dataset_kstats_destroy(dataset_kstats_t *dk)
 		return;
 
 	dataset_kstat_values_t *dkv = dk->dk_kstats->ks_data;
+	kstat_delete(dk->dk_kstats);
+	dk->dk_kstats = NULL;
 	kmem_free(KSTAT_NAMED_STR_PTR(&dkv->dkv_ds_name),
 	    KSTAT_NAMED_STR_BUFLEN(&dkv->dkv_ds_name));
 	kmem_free(dkv, sizeof (empty_dataset_kstats));
-
-	kstat_delete(dk->dk_kstats);
-	dk->dk_kstats = NULL;
 
 	wmsum_fini(&dk->dk_sums.dss_writes);
 	wmsum_fini(&dk->dk_sums.dss_nwritten);
@@ -168,6 +186,7 @@ dataset_kstats_destroy(dataset_kstats_t *dk)
 	wmsum_fini(&dk->dk_sums.dss_nread);
 	wmsum_fini(&dk->dk_sums.dss_nunlinks);
 	wmsum_fini(&dk->dk_sums.dss_nunlinked);
+	zil_sums_fini(&dk->dk_zil_sums);
 }
 
 void


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
- Add support to report per dataset zil stats
- Update zil kstats to use wmsum counter instead of atomic counters
- Add support for wmsum_zero() to reset wmsum counters
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
- Zil kstats are reported in an inclusive way, i.e., same counters are shared to capture all the activities happening in zil. Added support to report zil stats for every datset individually.
- Wmsum uses per cpu counters and provide less overhead as compared to atomic operations. Updated zil kstats to replace wmsum counters to avoid atomic operations.
- Added wmsum_zero() function to reset wmsum counter that can be used by kstat to zero out the counters.

<!--- Describe your changes in detail -->

### How Has This Been Tested?
Tested by monitoring zil kstats for multiple dataset
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
