### PR TITLE
Offload SHA256 to FreeBSD's OCF.

### DIFF
--- a/include/os/freebsd/zfs/sys/crypto_os.h
+++ b/include/os/freebsd/zfs/sys/crypto_os.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Jeremy Faulkner <gldisater@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef	_ZFS_CRYPTO_OS_H
+#define	_ZFS_CRYPTO_OS_H
+
+#include <sys/freebsd_crypto.h>
+
+#define	zfs_offload_hash(checksum, abd, size, zcp)	\
+	freebsd_offload_hash_to_ocf(checksum, abd, size, zcp)
+
+#endif /* _ZFS_CRYPTO_OS_H */

--- a/include/os/freebsd/zfs/sys/freebsd_crypto.h
+++ b/include/os/freebsd/zfs/sys/freebsd_crypto.h
@@ -37,6 +37,7 @@
 #include <opencrypto/cryptodev.h>
 #include <crypto/sha2/sha256.h>
 #include <crypto/sha2/sha512.h>
+#include <sys/zio_checksum.h>
 
 #define	SUN_CKM_AES_CCM	"CKM_AES_CCM"
 #define	SUN_CKM_AES_GCM	"CKM_AES_GCM"
@@ -87,6 +88,14 @@ void crypto_mac_final(struct hmac_ctx *ctx, void *out_data,
 int freebsd_crypt_newsession(freebsd_crypt_session_t *sessp,
     const struct zio_crypt_info *, crypto_key_t *);
 void freebsd_crypt_freesession(freebsd_crypt_session_t *sessp);
+
+int freebsd_hash_newsession(freebsd_crypt_session_t *sessionp,
+    size_t checksum);
+int freebsd_hash(freebsd_crypt_session_t *input_sessionp,
+    size_t checksum, uint8_t *buf, uint64_t size, uint8_t *obuf,
+    uint64_t osize);
+int freebsd_offload_hash_to_ocf(uint64_t checksum, abd_t *abd,
+    uint64_t size, zio_cksum_t *zcp);
 
 int freebsd_crypt_uio(boolean_t, freebsd_crypt_session_t *,
 	const struct zio_crypt_info *, zfs_uio_t *, crypto_key_t *, uint8_t *,

--- a/include/os/linux/zfs/sys/crypto_os.h
+++ b/include/os/linux/zfs/sys/crypto_os.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Jeremy Faulkner <gldisater@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef	_ZFS_CRYPTO_OS_H
+#define	_ZFS_CRYPTO_OS_H
+
+#define	zfs_offload_hash(checksum, abd, size, zcp)	EOPNOTSUPP
+
+#endif /* _ZFS_CRYPTO_OS_H */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve the performance of SHA256 checksum usage by ZFS.

### Description
<!--- Describe your changes in detail -->
Check if OCF has hardware acceleration available. If so, use it instead of the software implementation that's built into OpenZFS. Allan Jude did a review of this patch and wanted the crypto_os.h files and cleaned up style issues.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
On Intel without SHA256 acceleration and on Ryzen and Apple M1, created a zpool and dataset using SHA256, dd 100GB of /dev/random into the dataset and scrub the pool. Apply the patch, recompile the FreeBSD kernel and reboot. Scrub the pool.

On Apple M1 the pre-patch scrub is 1000MB/s and 80% cpu usage, after the patch and loading ossl.ko to provide the SHA256 acceleration results in 1.7GB/s and 30% cpu usage.

On my Ryzen 1700 I don't have fast enough SSDs to saturate my cpu, about 25-30% cpu usage before at 500MB/s. After is 5-8% 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
