### PR TITLE
Fix memory allocation for the checksum benchmark

### DIFF
--- a/module/zfs/zfs_chksum.c
+++ b/module/zfs/zfs_chksum.c
@@ -20,7 +20,7 @@
  */
 
 /*
- * Copyright (c) 2021 Tino Reichardt <milky-zfs@mcmilk.de>
+ * Copyright (c) 2021-2022 Tino Reichardt <milky-zfs@mcmilk.de>
  */
 
 #include <sys/types.h>
@@ -43,6 +43,7 @@ typedef struct {
 	uint64_t bs256k;
 	uint64_t bs1m;
 	uint64_t bs4m;
+	uint64_t bs16m;
 	zio_cksum_salt_t salt;
 	zio_checksum_t *(func);
 	zio_checksum_tmpl_init_t *(init);
@@ -85,7 +86,8 @@ chksum_stat_kstat_headers(char *buf, size_t size)
 	off += snprintf(buf + off, size - off, "%8s", "64k");
 	off += snprintf(buf + off, size - off, "%8s", "256k");
 	off += snprintf(buf + off, size - off, "%8s", "1m");
-	(void) snprintf(buf + off, size - off, "%8s\n", "4m");
+	off += snprintf(buf + off, size - off, "%8s", "4m");
+	(void) snprintf(buf + off, size - off, "%8s\n", "16m");
 
 	return (0);
 }
@@ -112,8 +114,10 @@ chksum_stat_kstat_data(char *buf, size_t size, void *data)
 	    (u_longlong_t)cs->bs256k);
 	off += snprintf(buf + off, size - off, "%8llu",
 	    (u_longlong_t)cs->bs1m);
-	(void) snprintf(buf + off, size - off, "%8llu\n",
+	off += snprintf(buf + off, size - off, "%8llu",
 	    (u_longlong_t)cs->bs4m);
+	(void) snprintf(buf + off, size - off, "%8llu\n",
+	    (u_longlong_t)cs->bs16m);
 
 	return (0);
 }
@@ -153,6 +157,8 @@ chksum_run(chksum_stat_t *cs, abd_t *abd, void *ctx, int round,
 		size = 1<<20; loops = 4; break;
 	case 7: /* 4m */
 		size = 1<<22; loops = 1; break;
+	case 8: /* 16m */
+		size = 1<<24; loops = 1; break;
 	}
 
 	kpreempt_disable();
@@ -177,26 +183,31 @@ chksum_benchit(chksum_stat_t *cs)
 	void *ctx = 0;
 	void *salt = &cs->salt.zcs_bytes;
 
-	/* allocate test memory via default abd interface */
-	abd = abd_alloc_linear(1<<22, B_FALSE);
 	memset(salt, 0, sizeof (cs->salt.zcs_bytes));
 	if (cs->init) {
 		ctx = cs->init(&cs->salt);
 	}
 
+	/* allocate test memory via abd linear interface */
+	abd = abd_alloc_linear(1<<20, B_FALSE);
 	chksum_run(cs, abd, ctx, 1, &cs->bs1k);
 	chksum_run(cs, abd, ctx, 2, &cs->bs4k);
 	chksum_run(cs, abd, ctx, 3, &cs->bs16k);
 	chksum_run(cs, abd, ctx, 4, &cs->bs64k);
 	chksum_run(cs, abd, ctx, 5, &cs->bs256k);
 	chksum_run(cs, abd, ctx, 6, &cs->bs1m);
+	abd_free(abd);
+
+	/* allocate test memory via abd non linear interface */
+	abd = abd_alloc(1<<24, B_FALSE);
 	chksum_run(cs, abd, ctx, 7, &cs->bs4m);
+	chksum_run(cs, abd, ctx, 8, &cs->bs16m);
+	abd_free(abd);
 
 	/* free up temp memory */
 	if (cs->free) {
 		cs->free(ctx);
 	}
-	abd_free(abd);
 }
 
 /*


### PR DESCRIPTION
Allocation via kmem_cache_alloc() is limited to less then 4m for
some architectures.

This commit limits the benchmarks with the linear abd cache to 1m
on all architectures and adds 4m + 16m benchmarks via non-linear
abd_alloc().

Signed-off-by: Tino Reichardt <milky-zfs@mcmilk.de>
Co-authored-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>
Fixes: #13669

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
