### PR TITLE
ZTS: Fix io_uring support check

### DIFF
--- a/tests/zfs-tests/tests/functional/io/io_uring.ksh
+++ b/tests/zfs-tests/tests/functional/io/io_uring.ksh
@@ -40,7 +40,7 @@
 verify_runnable "global"
 
 
-if [[ $(linux_version) -lt $(linux_version "5.1") ]]; then
+if ! $(grep -q "CONFIG_IO_URING=y" /boot/config-$(uname -r)); then
 	log_unsupported "Requires io_uring support"
 fi
 


### PR DESCRIPTION
### Motivation and Context

Issue #13648

### Description

Not all Linux distribution kernels enable io_uring support by
default.  Update the run time check to verify not only that the
kernel is new enough but that it was built with CONFIG_IO_URING=y.
The `fio --ioengine=io_uring --parse-only` check was intended for
this same purpose but would always incorrectly succeed.

### How Has This Been Tested?

Verified correct behavior on Fedora 35 kernel where CONFIG_IO_URING
is enabled by default, and on AlmaLinux 9 where it is not. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
