### PR TITLE
FreeBSD compile fix

### DIFF
--- a/module/os/freebsd/zfs/zfs_ioctl_compat.c
+++ b/module/os/freebsd/zfs/zfs_ioctl_compat.c
@@ -125,7 +125,7 @@ enum zfs_ioc_legacy {
 	ZFS_IOC_LEGACY_LAST
 };
 
-unsigned static long zfs_ioctl_legacy_to_ozfs_[] = {
+static unsigned long zfs_ioctl_legacy_to_ozfs_[] = {
 	ZFS_IOC_POOL_CREATE,			/* 0x00 */
 	ZFS_IOC_POOL_DESTROY,			/* 0x01 */
 	ZFS_IOC_POOL_IMPORT,			/* 0x02 */
@@ -208,7 +208,7 @@ unsigned static long zfs_ioctl_legacy_to_ozfs_[] = {
 	ZFS_IOC_POOL_INITIALIZE,		/* 0x4d:0x4f */
 };
 
-unsigned static long zfs_ioctl_ozfs_to_legacy_common_[] = {
+static unsigned long zfs_ioctl_ozfs_to_legacy_common_[] = {
 	ZFS_IOC_POOL_CREATE,			/* 0x00 */
 	ZFS_IOC_POOL_DESTROY,			/* 0x01 */
 	ZFS_IOC_POOL_IMPORT,			/* 0x02 */
@@ -297,7 +297,7 @@ unsigned static long zfs_ioctl_ozfs_to_legacy_common_[] = {
 	ZFS_IOC_LEGACY_NONE, /* ZFS_IOC_WAIT_FS */
 };
 
-unsigned static long zfs_ioctl_ozfs_to_legacy_platform_[] = {
+static unsigned long zfs_ioctl_ozfs_to_legacy_platform_[] = {
 	ZFS_IOC_LEGACY_NONE, /* ZFS_IOC_EVENTS_NEXT */
 	ZFS_IOC_LEGACY_NONE, /* ZFS_IOC_EVENTS_CLEAR */
 	ZFS_IOC_LEGACY_NONE, /* ZFS_IOC_EVENTS_SEEK */


### PR DESCRIPTION
The file module/os/freebsd/zfs/zfs_ioctl_compat.c fails compiling
because of this error: 'static' is not at beginning of declaration

This commit fixes the three places within that file.

Signed-off-by: Tino Reichardt <milky-zfs@mcmilk.de>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I got this error while compiling on FreeBSD 13.1.
I have also installed `gcc-11` on that system - so the `configure` uses `gcc` instead of `clang`.

Normally the code will compile fine on FreeBSD... because `gcc` isn't installed per default.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
