### PR TITLE
Fix problem with zdb -d

### DIFF
--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -23,7 +23,7 @@
 .Nd display ZFS storage pool debugging and consistency information
 .Sh SYNOPSIS
 .Nm
-.Op Fl AbcdDFGhikLMPsvXYy
+.Op Fl AbcdDFGhikLMNPsvXYy
 .Op Fl e Oo Fl V Oc Oo Fl p Ar path Oc Ns …
 .Op Fl I Ar inflight I/Os
 .Oo Fl o Ar var Ns = Ns Ar value Oc Ns …
@@ -137,6 +137,14 @@ also display the configuration that would be used were the pool to be imported.
 Display information about datasets.
 Specified once, displays basic dataset information: ID, create transaction,
 size, and object count.
+See
+.Fl N
+for determining if
+.Op Ar poolname Ns Op / Ns Ar dataset | objset ID
+is to use the specified
+.Op Ar dataset | objset ID
+as a string (dataset name) or a number (objset ID) when
+datasets have numeric names.
 .Pp
 If specified multiple times provides greater and greater verbosity.
 .Pp
@@ -272,6 +280,14 @@ Also display information about the maximum contiguous free space and the
 percentage of free space in each space map.
 .It Fl MMM
 Display every spacemap record.
+.It Fl N
+Same as
+.Fl d
+but force zdb to interpret the
+.Op Ar dataset | objset ID
+in
+.Op Ar poolname Ns Op / Ns Ar dataset | objset ID
+as a numeric objset ID.
 .It Fl O Ar dataset path
 Look up the specified
 .Ar path

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_neg.ksh
@@ -58,7 +58,7 @@ set -A args "create" "add" "destroy" "import fakepool" \
     "setvprop" "blah blah" "-%" "--?" "-*" "-=" \
     "-a" "-f" "-g" "-j" "-n" "-o" "-p" "-p /tmp" \
     "-t" "-w" "-z" "-E" "-H" "-I" "-J" "-K" \
-    "-N" "-Q" "-R" "-T" "-W"
+    "-Q" "-R" "-T" "-W"
 
 log_assert "Execute zdb using invalid parameters."
 

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_objset_id.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_objset_id.ksh
@@ -30,10 +30,16 @@
 # 6. Confirm names
 # 7. Run zdb -dddddd pool/objsetID objectID (hex) 
 # 8. Confirm names
-# 9. Obtain objsetID from /proc/spl/kstat/zfs/testpool/obset-0x<ID>
+# 9. Repeat with zdb -NNNNNN pool/objsetID objectID
+# 10. Obtain objsetID from /proc/spl/kstat/zfs/testpool/obset-0x<ID>
 #    (linux only)
-# 10. Run zdb -dddddd pool/objsetID (hex)
-# 11. Match name from zdb against proc entry
+# 11. Run zdb -dddddd pool/objsetID (hex)
+# 12. Match name from zdb against proc entry
+# 13. Create dataset with hex numeric name
+# 14. Create dataset with decimal numeric name
+# 15. zdb -d for numeric datasets succeeds
+# 16. zdb -N for numeric datasets fails
+# 17. zdb -dN for numeric datasets fails
 #
 
 function cleanup
@@ -78,6 +84,17 @@ do
 	(( $? != 0 )) && log_fail \
 	    "zdb -dddddd $TESTPOOL/$id $obj failed $reason"
 	obj=$(printf "0x%X" $obj)
+
+ 	log_note "zdb -NNNNNN $TESTPOOL/$id $obj"
+        output=$(zdb -NNNNNN $TESTPOOL/$id $obj)
+        reason="($TESTPOOL/$TESTFS not in zdb output)"
+        echo $output |grep "$TESTPOOL/$TESTFS" > /dev/null
+        (( $? != 0 )) && log_fail \
+            "zdb -NNNNNN $TESTPOOL/$id $obj failed $reason"
+        reason="(file1 not in zdb output)"
+        echo $output |grep "file1" > /dev/null
+        (( $? != 0 )) && log_fail \
+            "zdb -NNNNNN $TESTPOOL/$id $obj failed $reason"
 done
 
 if is_linux; then
@@ -93,5 +110,24 @@ if is_linux; then
 	(( $? != 0 )) && log_fail \
 	    "zdb -dddddd $TESTPOOL/$objset_hex failed $reason"
 fi
+
+log_must zfs create $TESTPOOL/0x400
+log_must zfs create $TESTPOOL/100
+output=$(zdb -d $TESTPOOL/0x400)
+reason="($TESTPOOL/0x400 not in zdb output)"
+echo $output |grep "$TESTPOOL/0x400" > /dev/null
+(( $? != 0 )) && log_fail \
+    "zdb -d $TESTPOOL/0x400 failed $reason"
+output=$(zdb -d $TESTPOOL/100)
+reason="($TESTPOOL/100 not in zdb output)"
+echo $output |grep "$TESTPOOL/100" > /dev/null
+(( $? != 0 )) && log_fail \
+    "zdb -d $TESTPOOL/100 failed $reason"
+
+# force numeric interpretation, should fail
+log_mustnot zdb -N $TESTPOOL/0x400
+log_mustnot zdb -N $TESTPOOL/100
+log_mustnot zdb -Nd $TESTPOOL/0x400
+log_mustnot zdb -Nd $TESTPOOL/100
 
 log_pass "zdb -d <pool>/<objset ID> generates the correct names."


### PR DESCRIPTION
zdb -d <pool>/<objset ID> does not work when
other command line arguments are included i.e.
zdb -U <cachefile> -d <pool>/<objset ID>
This change fixes the command line parsing
to handle this situation.  Also fix issue
where zdb -r <dataset> <file> does not handle
the root <dataset> of the pool. Introduce -N
option to force <objset ID> to be interpreted
as a numeric objsetID.

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed-by: Rich Ercolani <rincebrain@gmail.com>
Reviewed-by: Tony Nguyen <tony.nguyen@delphix.com>
Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>
Closes #12845
Closes #12944

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Fix is present on master branch.  Need to have on zfs-2.1.6 as well.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
Ran zdb portion of zfstest

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
