### PR TITLE
Don't double-zero buffers in fault management nvlists

### DIFF
--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -487,7 +487,7 @@ static void *
 i_fm_alloc(nv_alloc_t *nva, size_t size)
 {
 	(void) nva;
-	return (kmem_zalloc(size, KM_SLEEP));
+	return (kmem_alloc(size, KM_SLEEP));
 }
 
 static void


### PR DESCRIPTION
### Motivation and Context
This an extremely small and unimportant problem that I noticed while hunting down a larger and more important problem that will get a PR later (ZED doubling the zevent limit over and over again until all of system memory is consumed). The nvpair code has support for custom allocators, and the fm code uses this to wrap `kmem_alloc` and `free`. I'm not sure why; I guess they really want to use `kmem_alloc` instead of `vmem_alloc`, the default. The nvpair code zeroes the memory after it gets returned from the allocator, custom or not (see `nv_mem_zalloc` and `nv_priv_alloc` in `nvpair.c`).

### Description
Unfortunately, the fm custom allocator is actually `kmem_zalloc`, so we end up double zeroing the buffer.

### How Has This Been Tested?
Just the test suite, the problem is obvious from code inspection.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
