### PR TITLE
Linux compat  changes [2.1]

### DIFF
--- a/META
+++ b/META
@@ -6,5 +6,5 @@ Release:       1
 Release-Tags:  relext
 License:       CDDL
 Author:        OpenZFS
-Linux-Maximum: 5.18
+Linux-Maximum: 5.19
 Linux-Minimum: 3.10

--- a/config/kernel-blkdev.m4
+++ b/config/kernel-blkdev.m4
@@ -295,6 +295,32 @@ AC_DEFUN([ZFS_AC_KERNEL_BLKDEV_BDEV_WHOLE], [
 ])
 
 dnl #
+dnl # 5.20 API change,
+dnl # Removed bdevname(), snprintf(.., %pg) should be used.
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV_BDEVNAME], [
+	ZFS_LINUX_TEST_SRC([bdevname], [
+		#include <linux/fs.h>
+		#include <linux/blkdev.h>
+	], [
+		struct block_device *bdev __attribute__ ((unused)) = NULL;
+		char path[BDEVNAME_SIZE];
+
+		(void) bdevname(bdev, path);
+	])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_BLKDEV_BDEVNAME], [
+	AC_MSG_CHECKING([whether bdevname() exists])
+	ZFS_LINUX_TEST_RESULT([bdevname], [
+		AC_DEFINE(HAVE_BDEVNAME, 1, [bdevname() is available])
+		AC_MSG_RESULT(yes)
+	], [
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
 dnl # 5.19 API: blkdev_issue_secure_erase()
 dnl # 3.10 API: blkdev_issue_discard(..., BLKDEV_DISCARD_SECURE)
 dnl #
@@ -377,6 +403,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV], [
 	ZFS_AC_KERNEL_SRC_BLKDEV_CHECK_DISK_CHANGE
 	ZFS_AC_KERNEL_SRC_BLKDEV_BDEV_CHECK_MEDIA_CHANGE
 	ZFS_AC_KERNEL_SRC_BLKDEV_BDEV_WHOLE
+	ZFS_AC_KERNEL_SRC_BLKDEV_BDEVNAME
 	ZFS_AC_KERNEL_SRC_BLKDEV_ISSUE_SECURE_ERASE
 ])
 
@@ -391,6 +418,7 @@ AC_DEFUN([ZFS_AC_KERNEL_BLKDEV], [
 	ZFS_AC_KERNEL_BLKDEV_CHECK_DISK_CHANGE
 	ZFS_AC_KERNEL_BLKDEV_BDEV_CHECK_MEDIA_CHANGE
 	ZFS_AC_KERNEL_BLKDEV_BDEV_WHOLE
+	ZFS_AC_KERNEL_BLKDEV_BDEVNAME
 	ZFS_AC_KERNEL_BLKDEV_GET_ERESTARTSYS
 	ZFS_AC_KERNEL_BLKDEV_ISSUE_SECURE_ERASE
 ])

--- a/config/kernel-make-request-fn.m4
+++ b/config/kernel-make-request-fn.m4
@@ -49,6 +49,13 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_MAKE_REQUEST_FN], [
 		struct gendisk *disk  __attribute__ ((unused));
 		disk = blk_alloc_disk(NUMA_NO_NODE);
 	])
+
+	ZFS_LINUX_TEST_SRC([blk_cleanup_disk], [
+		#include <linux/blkdev.h>
+	],[
+		struct gendisk *disk  __attribute__ ((unused));
+		blk_cleanup_disk(disk);
+	])
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_MAKE_REQUEST_FN], [
@@ -73,6 +80,19 @@ AC_DEFUN([ZFS_AC_KERNEL_MAKE_REQUEST_FN], [
 		ZFS_LINUX_TEST_RESULT([blk_alloc_disk], [
 			AC_MSG_RESULT(yes)
 			AC_DEFINE([HAVE_BLK_ALLOC_DISK], 1, [blk_alloc_disk() exists])
+
+			dnl #
+			dnl # 5.20 API change,
+			dnl # Removed blk_cleanup_disk(), put_disk() should be used.
+			dnl #
+			AC_MSG_CHECKING([whether blk_cleanup_disk() exists])
+			ZFS_LINUX_TEST_RESULT([blk_cleanup_disk], [
+				AC_MSG_RESULT(yes)
+				AC_DEFINE([HAVE_BLK_CLEANUP_DISK], 1,
+				    [blk_cleanup_disk() exists])
+			], [
+				AC_MSG_RESULT(no)
+			])
 		], [
 			AC_MSG_RESULT(no)
 		])

--- a/config/kernel-shrink.m4
+++ b/config/kernel-shrink.m4
@@ -54,6 +54,21 @@ AC_DEFUN([ZFS_AC_KERNEL_SHRINK_CONTROL_HAS_NID], [
 	])
 ])
 
+AC_DEFUN([ZFS_AC_KERNEL_SRC_REGISTER_SHRINKER_VARARG], [
+	ZFS_LINUX_TEST_SRC([register_shrinker_vararg], [
+		#include <linux/mm.h>
+		unsigned long shrinker_cb(struct shrinker *shrink,
+		    struct shrink_control *sc) { return 0; }
+	],[
+		struct shrinker cache_shrinker = {
+			.count_objects = shrinker_cb,
+			.scan_objects = shrinker_cb,
+			.seeks = DEFAULT_SEEKS,
+		};
+		register_shrinker(&cache_shrinker, "vararg-reg-shrink-test");
+	])
+])
+
 AC_DEFUN([ZFS_AC_KERNEL_SRC_SHRINKER_CALLBACK], [
 	ZFS_LINUX_TEST_SRC([shrinker_cb_shrink_control], [
 		#include <linux/mm.h>
@@ -83,29 +98,50 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_SHRINKER_CALLBACK], [
 
 AC_DEFUN([ZFS_AC_KERNEL_SHRINKER_CALLBACK],[
 	dnl #
-	dnl # 3.0 - 3.11 API change
-	dnl # cs->shrink(struct shrinker *, struct shrink_control *sc)
+	dnl # 6.0 API change
+	dnl # register_shrinker() becomes a var-arg function that takes
+	dnl # a printf-style format string as args > 0
 	dnl #
-	AC_MSG_CHECKING([whether new 2-argument shrinker exists])
-	ZFS_LINUX_TEST_RESULT([shrinker_cb_shrink_control], [
+	AC_MSG_CHECKING([whether new var-arg register_shrinker() exists])
+	ZFS_LINUX_TEST_RESULT([register_shrinker_vararg], [
 		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_SINGLE_SHRINKER_CALLBACK, 1,
-		    [new shrinker callback wants 2 args])
+		AC_DEFINE(HAVE_REGISTER_SHRINKER_VARARG, 1,
+		    [register_shrinker is vararg])
+
+		dnl # We assume that the split shrinker callback exists if the
+		dnl # vararg register_shrinker() exists, because the latter is
+		dnl # a much more recent addition, and the macro test for the
+		dnl # var-arg version only works if the callback is split
+		AC_DEFINE(HAVE_SPLIT_SHRINKER_CALLBACK, 1,
+			[cs->count_objects exists])
 	],[
 		AC_MSG_RESULT(no)
-
 		dnl #
-		dnl # 3.12 API change,
-		dnl # cs->shrink() is logically split in to
-		dnl # cs->count_objects() and cs->scan_objects()
+		dnl # 3.0 - 3.11 API change
+		dnl # cs->shrink(struct shrinker *, struct shrink_control *sc)
 		dnl #
-		AC_MSG_CHECKING([whether cs->count_objects callback exists])
-		ZFS_LINUX_TEST_RESULT([shrinker_cb_shrink_control_split], [
+		AC_MSG_CHECKING([whether new 2-argument shrinker exists])
+		ZFS_LINUX_TEST_RESULT([shrinker_cb_shrink_control], [
 			AC_MSG_RESULT(yes)
-			AC_DEFINE(HAVE_SPLIT_SHRINKER_CALLBACK, 1,
-			    [cs->count_objects exists])
+			AC_DEFINE(HAVE_SINGLE_SHRINKER_CALLBACK, 1,
+				[new shrinker callback wants 2 args])
 		],[
-			ZFS_LINUX_TEST_ERROR([shrinker])
+			AC_MSG_RESULT(no)
+
+			dnl #
+			dnl # 3.12 API change,
+			dnl # cs->shrink() is logically split in to
+			dnl # cs->count_objects() and cs->scan_objects()
+			dnl #
+			AC_MSG_CHECKING([if cs->count_objects callback exists])
+			ZFS_LINUX_TEST_RESULT(
+				[shrinker_cb_shrink_control_split],[
+					AC_MSG_RESULT(yes)
+					AC_DEFINE(HAVE_SPLIT_SHRINKER_CALLBACK, 1,
+						[cs->count_objects exists])
+			],[
+					ZFS_LINUX_TEST_ERROR([shrinker])
+			])
 		])
 	])
 ])
@@ -141,6 +177,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_SHRINKER], [
 	ZFS_AC_KERNEL_SRC_SHRINK_CONTROL_HAS_NID
 	ZFS_AC_KERNEL_SRC_SHRINKER_CALLBACK
 	ZFS_AC_KERNEL_SRC_SHRINK_CONTROL_STRUCT
+	ZFS_AC_KERNEL_SRC_REGISTER_SHRINKER_VARARG
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_SHRINKER], [

--- a/include/os/linux/spl/sys/shrinker.h
+++ b/include/os/linux/spl/sys/shrinker.h
@@ -64,7 +64,11 @@
  * }
  */
 
+#ifdef HAVE_REGISTER_SHRINKER_VARARG
+#define	spl_register_shrinker(x)	register_shrinker(x, "zfs-arc-shrinker")
+#else
 #define	spl_register_shrinker(x)	register_shrinker(x)
+#endif
 #define	spl_unregister_shrinker(x)	unregister_shrinker(x)
 
 /*

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -105,6 +105,16 @@ bdev_whole(struct block_device *bdev)
 }
 #endif
 
+#if defined(HAVE_BDEVNAME)
+#define	vdev_bdevname(bdev, name)	bdevname(bdev, name)
+#else
+static inline void
+vdev_bdevname(struct block_device *bdev, char *name)
+{
+	snprintf(name, BDEVNAME_SIZE, "%pg", bdev);
+}
+#endif
+
 /*
  * Returns the maximum expansion capacity of the block device (in bytes).
  *
@@ -204,7 +214,7 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 
 		if (bdev) {
 			if (v->vdev_expanding && bdev != bdev_whole(bdev)) {
-				bdevname(bdev_whole(bdev), disk_name + 5);
+				vdev_bdevname(bdev_whole(bdev), disk_name + 5);
 				/*
 				 * If userland has BLKPG_RESIZE_PARTITION,
 				 * then it should have updated the partition

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -954,7 +954,11 @@ zvol_free(zvol_state_t *zv)
 	del_gendisk(zv->zv_zso->zvo_disk);
 #if defined(HAVE_SUBMIT_BIO_IN_BLOCK_DEVICE_OPERATIONS) && \
 	defined(HAVE_BLK_ALLOC_DISK)
+#if defined(HAVE_BLK_CLEANUP_DISK)
 	blk_cleanup_disk(zv->zv_zso->zvo_disk);
+#else
+	put_disk(zv->zv_zso->zvo_disk);
+#endif
 #else
 	blk_cleanup_queue(zv->zv_zso->zvo_queue);
 	put_disk(zv->zv_zso->zvo_disk);


### PR DESCRIPTION
### Motivation and Context

Clearly document the maximum supported Linux kernel version (5.19).

Also start pulling in changes which will be need when 5.20 is finalized.

### Description

c10ff9a72 Linux 5.20 compat: blk_cleanup_disk()
063dd2c73 Linux 5.20 compat: bdevname()
110aee540 Linux 5.19 compat: META

### How Has This Been Tested?

Cherry picked from master, compile tested by CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
