### PR TITLE
zts: Fix zpool_expand_001_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh
@@ -54,6 +54,14 @@
 
 verify_runnable "global"
 
+# We override $org_size and $exp_size from zpool_expand.cfg to make sure we get
+# an expected free space value every time.  Otherwise, if we left it
+# configurable, the free space ratio to pool size ratio would diverge too much
+# much at low $org_size values.
+#
+org_size=$((1024 * 1024 * 1024))
+exp_size=$(($org_size * 2))
+
 function cleanup
 {
 	poolexists $TESTPOOL1 && destroy_pool $TESTPOOL1
@@ -66,6 +74,30 @@ function cleanup
 
 	block_device_wait
 	unload_scsi_debug
+}
+
+# Wait for the size of a pool to autoexpand to $1 and the total free space to
+# expand to $2 (both values allowing a 10% tolerance).
+#
+# Wait for up to 10 seconds for this to happen (typically takes 1-2 seconds)
+#
+function wait_for_autoexpand
+{
+	typeset exp_new_size=$1
+	typeset exp_new_free=$2
+
+	for i in $(seq 1 10) ; do
+		typeset new_size=$(get_pool_prop size $TESTPOOL1)
+		typeset new_free=$(get_prop avail $TESTPOOL1)
+		# Values need to be within 90% of each other (10% tolerance)
+		if within_percent $new_size $exp_new_size 90 > /dev/null && \
+		    within_percent $new_free $exp_new_free 90 > /dev/null ; then
+			return
+		fi
+		sleep 1
+	done
+	log_fail "$TESTPOOL never expanded to $exp_new_size with $exp_new_free" \
+	    " free space (got $new_size with $new_free free space)"
 }
 
 log_onexit cleanup
@@ -105,62 +137,37 @@ for type in " " mirror raidz draid:1s; do
 	log_note "Expanding loopback, scsi_debug, and file vdevs"
 	log_must truncate -s $exp_size $FILE_LO
 	log_must losetup -c $DEV1
-	sleep 3
 
 	echo "2" > /sys/bus/pseudo/drivers/scsi_debug/virtual_gb
 	echo "1" > /sys/class/block/$DEV2/device/rescan
 	block_device_wait
-	sleep 3
 
 	log_must truncate -s $exp_size $FILE_RAW
 	log_must zpool online -e $TESTPOOL1 $FILE_RAW
 
-	typeset expand_size=$(get_pool_prop size $TESTPOOL1)
-	typeset zfs_expand_size=$(get_prop avail $TESTPOOL1)
 
-	log_note "$TESTPOOL1 $type has previous size: $prev_size and " \
-	    "expanded size: $expand_size"
-	# compare available pool size from zfs
-	if [[ $zfs_expand_size -gt $zfs_prev_size ]]; then
-		# check for zpool history for the pool size expansion
-		if [[ $type == " " ]]; then
-			typeset expansion_size=$(($exp_size-$org_size))
-			typeset	size_addition=$(zpool history -il $TESTPOOL1 |\
-			    grep "pool '$TESTPOOL1' size:" | \
-			    grep "vdev online" | \
-			    grep -c "(+${expansion_size}")
-
-			if [[ $size_addition -ne 3 ]]; then
-				log_fail "pool $TESTPOOL1 has not expanded, " \
-				    "$size_addition/3 vdevs expanded"
-			fi
-		elif [[ $type == "mirror" ]]; then
-			typeset expansion_size=$(($exp_size-$org_size))
-			zpool history -il $TESTPOOL1 | \
-			    grep "pool '$TESTPOOL1' size:" | \
-			    grep "vdev online" | \
-			    grep -q "(+${expansion_size})" ||
-				log_fail "pool $TESTPOOL1 has not expanded"
-		elif [[ $type == "draid:1s" ]]; then
-			typeset expansion_size=$((2*($exp_size-$org_size)))
-			zpool history -il $TESTPOOL1 | \
-			    grep "pool '$TESTPOOL1' size:" | \
-			    grep "vdev online" | \
-			    grep -q "(+${expansion_size})" ||
-					log_fail "pool $TESTPOOL has not expanded"
-		else
-			typeset expansion_size=$((3*($exp_size-$org_size)))
-			zpool history -il $TESTPOOL1 | \
-			    grep "pool '$TESTPOOL1' size:" | \
-			    grep "vdev online" | \
-			    grep -q "(+${expansion_size})" ||
-					log_fail "pool $TESTPOOL has not expanded"
-		fi
-	else
-		log_fail "pool $TESTPOOL1 is not autoexpanded after vdev " \
-		    "expansion.  Previous size: $zfs_prev_size and expanded " \
-		    "size: $zfs_expand_size"
+	# The expected free space values below were observed at the time of
+	# this commit.  However, we know ZFS overhead will change over time,
+	# and thus we do not do an exact comparison to these values in
+	# wait_for_autoexpand.  Rather, we make sure the free space
+	# is within some small percentage threshold of these values.
+	typeset exp_new_size=$(($prev_size * 2))
+	if [[ "$type" == " " ]] ; then
+		exp_new_free=6045892608
+	elif [[ "$type" == "mirror" ]] ; then
+		exp_new_free=1945997312
+	elif [[ "$type" == "raidz" ]] ; then
+		exp_new_free=3977637338
+	elif [[ "$type" == "draid:1s" ]] then
+		exp_new_free=1946000384
 	fi
+
+	wait_for_autoexpand $exp_new_size $exp_new_free
+
+	expand_size=$(get_pool_prop size $TESTPOOL1)
+
+	log_note "$TESTPOOL1 '$type' grew from $prev_size -> $expand_size with" \
+	    "free space from $zfs_prev_size -> $(get_prop avail $TESTPOOL1)"
 
 	cleanup
 done


### PR DESCRIPTION
### Motivation and Context
Make `zpool_expand_001_pos` test reliable.

### Description
`zpool_expand_001_pos` was often failing due to not seeing autoexpand commands in the `zpool history`.  During testing, I found this to be unreliable (sometimes the "online" wouldn't appear in `zpool history`) and unnecessary, as we could simply check that the pool increased in size.

This commit revamps the test to check for the expanded pool size and corresponding new free space.

### How Has This Been Tested?
Updated the test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
