### PR TITLE
Linux 6.0 compat fix for register_shrinker() now accepting var-arg name via printf-like interface

### DIFF
--- a/config/kernel-shrink.m4
+++ b/config/kernel-shrink.m4
@@ -54,6 +54,21 @@ AC_DEFUN([ZFS_AC_KERNEL_SHRINK_CONTROL_HAS_NID], [
 	])
 ])
 
+AC_DEFUN([ZFS_AC_KERNEL_SRC_REGISTER_SHRINKER_VARARG], [
+	ZFS_LINUX_TEST_SRC([register_shrinker_vararg], [
+		#include <linux/mm.h>
+		unsigned long shrinker_cb(struct shrinker *shrink,
+		    struct shrink_control *sc) { return 0; }
+	],[
+		struct shrinker cache_shrinker = {
+			.count_objects = shrinker_cb,
+			.scan_objects = shrinker_cb,
+			.seeks = DEFAULT_SEEKS,
+		};
+		register_shrinker(&cache_shrinker, "vararg-reg-shrink-test");
+	])
+])
+
 AC_DEFUN([ZFS_AC_KERNEL_SRC_SHRINKER_CALLBACK], [
 	ZFS_LINUX_TEST_SRC([shrinker_cb_shrink_control], [
 		#include <linux/mm.h>
@@ -83,29 +98,50 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_SHRINKER_CALLBACK], [
 
 AC_DEFUN([ZFS_AC_KERNEL_SHRINKER_CALLBACK],[
 	dnl #
-	dnl # 3.0 - 3.11 API change
-	dnl # cs->shrink(struct shrinker *, struct shrink_control *sc)
+	dnl # 6.0 API change
+	dnl # register_shrinker() becomes a var-arg function that takes
+	dnl # a printf-style format string as args > 0
 	dnl #
-	AC_MSG_CHECKING([whether new 2-argument shrinker exists])
-	ZFS_LINUX_TEST_RESULT([shrinker_cb_shrink_control], [
+	AC_MSG_CHECKING([whether new var-arg register_shrinker() exists])
+	ZFS_LINUX_TEST_RESULT([register_shrinker_vararg], [
 		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_SINGLE_SHRINKER_CALLBACK, 1,
-		    [new shrinker callback wants 2 args])
+		AC_DEFINE(HAVE_REGISTER_SHRINKER_VARARG, 1,
+		    [register_shrinker is vararg])
+
+		dnl # We assume that the split shrinker callback exists if the
+		dnl # vararg register_shrinker() exists, because the latter is
+		dnl # a much more recent addition, and the macro test for the
+		dnl # var-arg version only works if the callback is split
+		AC_DEFINE(HAVE_SPLIT_SHRINKER_CALLBACK, 1,
+			[cs->count_objects exists])
 	],[
 		AC_MSG_RESULT(no)
-
 		dnl #
-		dnl # 3.12 API change,
-		dnl # cs->shrink() is logically split in to
-		dnl # cs->count_objects() and cs->scan_objects()
+		dnl # 3.0 - 3.11 API change
+		dnl # cs->shrink(struct shrinker *, struct shrink_control *sc)
 		dnl #
-		AC_MSG_CHECKING([whether cs->count_objects callback exists])
-		ZFS_LINUX_TEST_RESULT([shrinker_cb_shrink_control_split], [
+		AC_MSG_CHECKING([whether new 2-argument shrinker exists])
+		ZFS_LINUX_TEST_RESULT([shrinker_cb_shrink_control], [
 			AC_MSG_RESULT(yes)
-			AC_DEFINE(HAVE_SPLIT_SHRINKER_CALLBACK, 1,
-			    [cs->count_objects exists])
+			AC_DEFINE(HAVE_SINGLE_SHRINKER_CALLBACK, 1,
+				[new shrinker callback wants 2 args])
 		],[
-			ZFS_LINUX_TEST_ERROR([shrinker])
+			AC_MSG_RESULT(no)
+
+			dnl #
+			dnl # 3.12 API change,
+			dnl # cs->shrink() is logically split in to
+			dnl # cs->count_objects() and cs->scan_objects()
+			dnl #
+			AC_MSG_CHECKING([if cs->count_objects callback exists])
+			ZFS_LINUX_TEST_RESULT(
+				[shrinker_cb_shrink_control_split],[
+					AC_MSG_RESULT(yes)
+					AC_DEFINE(HAVE_SPLIT_SHRINKER_CALLBACK, 1,
+						[cs->count_objects exists])
+			],[
+					ZFS_LINUX_TEST_ERROR([shrinker])
+			])
 		])
 	])
 ])
@@ -141,6 +177,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_SHRINKER], [
 	ZFS_AC_KERNEL_SRC_SHRINK_CONTROL_HAS_NID
 	ZFS_AC_KERNEL_SRC_SHRINKER_CALLBACK
 	ZFS_AC_KERNEL_SRC_SHRINK_CONTROL_STRUCT
+	ZFS_AC_KERNEL_SRC_REGISTER_SHRINKER_VARARG
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_SHRINKER], [

--- a/include/os/linux/spl/sys/shrinker.h
+++ b/include/os/linux/spl/sys/shrinker.h
@@ -64,7 +64,11 @@
  * }
  */
 
+#ifdef HAVE_REGISTER_SHRINKER_VARARG
+#define	spl_register_shrinker(x)	register_shrinker(x, "zfs-arc-shrinker")
+#else
 #define	spl_register_shrinker(x)	register_shrinker(x)
+#endif
 #define	spl_unregister_shrinker(x)	unregister_shrinker(x)
 
 /*


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The 6.0 kernel added a printf-style var-arg for args > 0 to the register_shrinker function, in order to add names to shrinkers, in commit e33c267ab70de4249d22d7eab1cc7d68a889bac2. This enables the shrinkers to have friendly names exposed in /sys/kernel/debug/shrinker/.

### Description
Added a new test inside of `config/kernel-shrink.m4` that looks for the var-arg version of `register_shrinker()` first, and if found, it also assumes the split-callback shrinker structure API, as well (which is a pre-requisite for the register_shrinker test). Since `spl_register_shrinker` is only called in one place (the `arc.c` code), I embedded the `"zfs-arc-shrinker"` name in the macro located in `include/os/linux/spl/sys/shrinker.h`, in order to minimize changes to lines of code. Should we ever want to implement more than one shrinker using this code, we'll have to move the naming out of the macro and into the module code.

### How Has This Been Tested?
So far have build tested, will be run-testing this week

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
