### PR TITLE
Prevent zevent list from consuming all of kernel memory

### DIFF
--- a/cmd/zed/zed_conf.h
+++ b/cmd/zed/zed_conf.h
@@ -33,6 +33,7 @@ struct zed_conf {
 	int		zevent_fd;		/* fd for access to zevents */
 
 	int16_t max_jobs;		/* max zedlets to run at one time */
+	int32_t max_zevent_buf_len;	/* max size of kernel event list */
 
 	boolean_t	do_force:1;		/* true if force enabled */
 	boolean_t	do_foreground:1;	/* true if run in foreground */

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -38,6 +38,8 @@
 
 #define	MAXBUF	4096
 
+static int max_zevent_buf_len = 1 << 20;
+
 /*
  * Open the libzfs interface.
  */
@@ -69,6 +71,9 @@ zed_event_init(struct zed_conf *zcp)
 			return (-1);
 		zed_log_die("Failed to initialize disk events");
 	}
+
+	if (zcp->max_zevent_buf_len != 0)
+		max_zevent_buf_len = zcp->max_zevent_buf_len;
 
 	return (0);
 }
@@ -105,7 +110,7 @@ _bump_event_queue_length(void)
 {
 	int zzlm = -1, wr;
 	char qlen_buf[12] = {0}; /* parameter is int => max "-2147483647\n" */
-	long int qlen;
+	long int qlen, orig_qlen;
 
 	zzlm = open("/sys/module/zfs/parameters/zfs_zevent_len_max", O_RDWR);
 	if (zzlm < 0)
@@ -116,7 +121,7 @@ _bump_event_queue_length(void)
 	qlen_buf[sizeof (qlen_buf) - 1] = '\0';
 
 	errno = 0;
-	qlen = strtol(qlen_buf, NULL, 10);
+	orig_qlen = qlen = strtol(qlen_buf, NULL, 10);
 	if (errno == ERANGE)
 		goto done;
 
@@ -125,8 +130,14 @@ _bump_event_queue_length(void)
 	else
 		qlen *= 2;
 
-	if (qlen > INT_MAX)
-		qlen = INT_MAX;
+	/*
+	 * Don't consume all of kernel memory with event logs if something
+	 * goes wrong.
+	 */
+	if (qlen > max_zevent_buf_len)
+		qlen = max_zevent_buf_len;
+	if (qlen == orig_qlen)
+		goto done;
 	wr = snprintf(qlen_buf, sizeof (qlen_buf), "%ld", qlen);
 
 	if (pwrite(zzlm, qlen_buf, wr, 0) < 0)

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -27,6 +27,7 @@
 .Op Fl P Ar path
 .Op Fl s Ar statefile
 .Op Fl j Ar jobs
+.Op Fl b Ar buflen
 .
 .Sh DESCRIPTION
 The
@@ -96,6 +97,17 @@ ZEDLETs to run concurrently,
 delaying execution of new ones until they finish.
 Defaults to
 .Sy 16 .
+.It Fl b Ar buflen
+Cap kernel event buffer growth to
+.Ar buflen
+entries.
+This buffer is grown when the daemon misses an event, but results in
+unreclaimable memory use in the kernel.
+A value of
+.Sy 0
+removes the cap.
+Defaults to
+.Sy 1048576 .
 .El
 .Sh ZEVENTS
 A zevent is comprised of a list of nvpairs (name/value pairs).

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -88,6 +88,8 @@ int zfs_max_recordsize = 16 * 1024 * 1024;
 #endif
 static int zfs_allow_redacted_dataset_mount = 0;
 
+int zfs_snapshot_history_enabled = 1;
+
 #define	SWITCH64(x, y) \
 	{ \
 		uint64_t __tmp = (x); \
@@ -1867,7 +1869,8 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 
 	dsl_dir_snap_cmtime_update(ds->ds_dir, tx);
 
-	spa_history_log_internal_ds(ds->ds_prev, "snapshot", tx, " ");
+	if (zfs_snapshot_history_enabled)
+		spa_history_log_internal_ds(ds->ds_prev, "snapshot", tx, " ");
 }
 
 void
@@ -4984,6 +4987,9 @@ ZFS_MODULE_PARAM(zfs, zfs_, max_recordsize, INT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs, zfs_, allow_redacted_dataset_mount, INT, ZMOD_RW,
 	"Allow mounting of redacted datasets");
+
+ZFS_MODULE_PARAM(zfs, zfs_, snapshot_history_enabled, INT, ZMOD_RW,
+	"Include snapshot events in pool history/events");
 
 EXPORT_SYMBOL(dsl_dataset_hold);
 EXPORT_SYMBOL(dsl_dataset_hold_flags);


### PR DESCRIPTION
### Motivation and Context
We had a customer who apparently was running into a memory leak. Over the course of a month or so, their system's memory use would slowly grow in the 64 and 96 byte kmalloc slabs, and eventually the oom killer would start running rampant. Analysis using [memleak.py](https://github.com/iovisor/bcc/blob/master/tools/memleak.py) showed that the "leaked" allocations were in fact merely zevent nvlists being allocated due to snapshot deletion. When we checked the `zfs_zevent_len_max`, we found that it was 64 million. This could easily consume large quantities of kernel memory, and would never be reclaimed.  While the default value for this variable is 512, the ZFS Event Daemon doubles it every time it detects a missed event. Normally this isn't a problem, but this customer had some unusual workload that caused them to absolutely spam snapshot creation and deletion, with over 30 events occurring per second. This overpowered the single-threaded ZED, causing it to grow the list size until all of kernel memory was consumed.

### Description
There are a couple changes included here. The first is to introduce a cap on the size the ZED will grow the zevent list to. One million entries is more than enough for most use cases, and if you are overflowing that value, the problem needs to be addressed another way. The value is also tunable, for those who want the limit to be higher or lower. The other change is to add a kernel module parameter that allows snapshot creation/deletion to be exempted from the history logging; for most workloads, having these things logged is valuable, but for some workloads it produces large quantities of log spam and isn't especially helpful.

Another thing that could and perhaps should be done but is outside of the scope of this PR are to improve the performance of the ZED. A single thread responsible for all of its tasks can easily be overwhelmed by the output of the rest of the system's combined logging efforts, and this can result in dropped events. Having separate threads fetching the events out of the kernel queue and processing zedlets would probably improve matters significantly. Another small improvement that could be made is that when the ZED limit increase fires, it usually fires twice. This is because the first time it fires, and the routine is executed to double the buffer size, by the time the buffer size is increased the entry that we had has our cursor could already have been dropped before the increased size could be of use. Adding a debounce to this would be reasonable, though not critical.

### How Has This Been Tested?
Manual testing under a heavy snapshot workload to verify that the ZED limiter works (when turned down to 8k). Manual testing using bpftrace to verify that the history disable tunable works. ZFS test suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
