### PR TITLE
Fix problem with zdb_objset_id test

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_objset_id.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_objset_id.ksh
@@ -54,6 +54,8 @@ write_count=8
 blksize=131072
 verify_runnable "global"
 verify_disk_count "$DISKS" 2
+hex_ds=$TESTPOOL/0x400000
+num_ds=$TESTPOOL/100000
 
 default_mirror_setup_noexit $DISKS
 file_write -o create -w -f $init_data -b $blksize -c $write_count
@@ -111,23 +113,22 @@ if is_linux; then
 	    "zdb -dddddd $TESTPOOL/$objset_hex failed $reason"
 fi
 
-log_must zfs create $TESTPOOL/0x400
-log_must zfs create $TESTPOOL/100
-output=$(zdb -d $TESTPOOL/0x400)
+log_must zfs create $hex_ds
+log_must zfs create $num_ds
+output=$(zdb -d $hex_ds)
 reason="($TESTPOOL/0x400 not in zdb output)"
-echo $output |grep "$TESTPOOL/0x400" > /dev/null
+echo $output |grep "$hex_ds" > /dev/null
 (( $? != 0 )) && log_fail \
+     "zdb -d $hex_ds failed $reason"
+output=$(zdb -d $num_ds)
+reason="($num_ds not in zdb output)"
+echo $output |grep "$num_ds" > /dev/null
     "zdb -d $TESTPOOL/0x400 failed $reason"
-output=$(zdb -d $TESTPOOL/100)
-reason="($TESTPOOL/100 not in zdb output)"
-echo $output |grep "$TESTPOOL/100" > /dev/null
-(( $? != 0 )) && log_fail \
-    "zdb -d $TESTPOOL/100 failed $reason"
 
 # force numeric interpretation, should fail
-log_mustnot zdb -N $TESTPOOL/0x400
-log_mustnot zdb -N $TESTPOOL/100
-log_mustnot zdb -Nd $TESTPOOL/0x400
-log_mustnot zdb -Nd $TESTPOOL/100
+log_mustnot zdb -N $hex_ds
+log_mustnot zdb -N $num_ds
+log_mustnot zdb -Nd $hex_ds
+log_mustnot zdb -Nd $num_ds
 
 log_pass "zdb -d <pool>/<objset ID> generates the correct names."


### PR DESCRIPTION
Use large numbers for datasets with numeric names to avoid name and id collisions.

Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
This fix is present in the master branch and should also be in zfs-2.1.6

### Description
Brought over this fix from master to zfs-2.1.6-staging.

### How Has This Been Tested?
Ran zdb portion of zfstests successfully.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
