### PR TITLE
contrib: dracut: zfs-snapshot-bootfs: exit status fix

### DIFF
--- a/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in
@@ -8,5 +8,5 @@ ConditionKernelCommandLine=bootfs.snapshot
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPNAME="$(getarg bootfs.snapshot)"; exec @sbindir@/zfs snapshot "$root@${SNAPNAME:-%v}"'
+ExecStart=-/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPNAME="$(getarg bootfs.snapshot)"; exec @sbindir@/zfs snapshot "$root@${SNAPNAME:-%v}"'
 RemainAfterExit=yes


### PR DESCRIPTION
### Motivation and Context

When the zfs-snapshot-bootfs service attempts to create a snapshot that already exists, the exit status of the command is non-zero and the service reports failed to the systemd service manager. This is a common occurrence if `bootfs.snapshot` is left set on the kernel command line and it should not be considered a failure. This service was originally set to ignore this error by prefixing the command with `-` on the `ExecStart` line, but the leading `-` appears to have been dropped in #13359.

### Description

Adds the `-` prefix to the command on the `ExecStart` line in the `zfs-snapshot-bootfs` service so non-zero exit statuses will not be considered failures.

### How Has This Been Tested?

I've tested this on 6 servers and 2 workstations. It worked correctly for several years prior to its removal in #13359.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
