### PR TITLE
make zfs-share service resilient to stale exports

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7093,6 +7093,9 @@ share_mount(int op, int argc, char **argv)
 		share_mount_state.sm_total = cb.cb_used;
 		pthread_mutex_init(&share_mount_state.sm_lock, NULL);
 
+		/* For a 'zfs share -a' operation start with a clean slate. */
+		zfs_truncate_shares(NULL);
+
 		/*
 		 * libshare isn't mt-safe, so only do the operation in parallel
 		 * if we're mounting. Additionally, the key-loading option must

--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=ZFS file system shares
 Documentation=man:zfs(8)
-After=nfs-server.service nfs-kernel-server.service
+Before=nfs-server.service nfs-kernel-server.service
 After=smb.service
 Before=rpc-statd-notify.service
 Wants=zfs-mount.service

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2020 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2022 by Delphix. All rights reserved.
  * Copyright Joyent, Inc.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
  * Copyright (c) 2016, Intel Corporation.
@@ -895,6 +895,7 @@ _LIBZFS_H int zfs_unshare(zfs_handle_t *zhp, const char *mountpoint,
 _LIBZFS_H int zfs_unshareall(zfs_handle_t *zhp,
     const enum sa_protocol *proto);
 _LIBZFS_H void zfs_commit_shares(const enum sa_protocol *proto);
+_LIBZFS_H void zfs_truncate_shares(const enum sa_protocol *proto);
 
 _LIBZFS_H int zfs_nicestrtonum(libzfs_handle_t *, const char *, uint64_t *);
 

--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Gunnar Beutner
- * Copyright (c) 2018, 2020 by Delphix. All rights reserved.
+ * Copyright (c) 2018, 2022 by Delphix. All rights reserved.
  */
 
 #include <stdio.h>
@@ -94,6 +94,16 @@ sa_commit_shares(enum sa_protocol protocol)
 	VALIDATE_PROTOCOL(protocol, );
 
 	fstypes[protocol]->commit_shares();
+}
+
+void
+sa_truncate_shares(enum sa_protocol protocol)
+{
+	/* CSTYLED */
+	VALIDATE_PROTOCOL(protocol, );
+
+	if (fstypes[protocol]->truncate_shares != NULL)
+		fstypes[protocol]->truncate_shares();
 }
 
 int

--- a/lib/libshare/libshare_impl.h
+++ b/lib/libshare/libshare_impl.h
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Gunnar Beutner
- * Copyright (c) 2019, 2020 by Delphix. All rights reserved.
+ * Copyright (c) 2019, 2022 by Delphix. All rights reserved.
  */
 #ifndef _LIBSPL_LIBSHARE_IMPL_H
 #define	_LIBSPL_LIBSHARE_IMPL_H
@@ -39,6 +39,7 @@ typedef struct {
 	boolean_t (*const is_shared)(sa_share_impl_t share);
 	int (*const validate_shareopts)(const char *shareopts);
 	int (*const commit_shares)(void);
+	void (*const truncate_shares)(void);
 } sa_fstype_t;
 
 extern const sa_fstype_t libshare_nfs_type, libshare_smb_type;

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <libshare.h>
+#include <unistd.h>
 #include "nfs.h"
 
 
@@ -279,6 +280,17 @@ fullerr:
 	nfs_abort_tmpfile(&tmpf);
 	nfs_exports_unlock(lockfile, &nfs_lock_fd);
 	return (error);
+}
+
+void
+nfs_reset_shares(const char *lockfile, const char *exports)
+{
+	int nfs_lock_fd = -1;
+
+	if (nfs_exports_lock(lockfile, &nfs_lock_fd) == 0) {
+		(void) ! truncate(exports, 0);
+		nfs_exports_unlock(lockfile, &nfs_lock_fd);
+	}
 }
 
 static boolean_t

--- a/lib/libshare/nfs.h
+++ b/lib/libshare/nfs.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Gunnar Beutner
+ * Copyright (c) 2022 by Delphix. All rights reserved.
  */
 
 #include "libshare_impl.h"
@@ -33,3 +34,4 @@ boolean_t nfs_is_shared_impl(const char *exports, sa_share_impl_t impl_share);
 int nfs_toggle_share(const char *lockfile, const char *exports,
     const char *expdir, sa_share_impl_t impl_share,
     int(*cbk)(sa_share_impl_t impl_share, FILE *tmpfile));
+void nfs_reset_shares(const char *lockfile, const char *exports);

--- a/lib/libshare/os/freebsd/nfs.c
+++ b/lib/libshare/os/freebsd/nfs.c
@@ -23,7 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * Copyright (c) 2020 by Delphix. All rights reserved.
+ * Copyright (c) 2020, 2022 by Delphix. All rights reserved.
  */
 
 #include <sys/cdefs.h>
@@ -195,6 +195,12 @@ start:
 	return (SA_OK);
 }
 
+static void
+nfs_truncate_shares(void)
+{
+	nfs_reset_shares(ZFS_EXPORTS_LOCK, ZFS_EXPORTS_FILE);
+}
+
 const sa_fstype_t libshare_nfs_type = {
 	.enable_share = nfs_enable_share,
 	.disable_share = nfs_disable_share,
@@ -202,4 +208,5 @@ const sa_fstype_t libshare_nfs_type = {
 
 	.validate_shareopts = nfs_validate_shareopts,
 	.commit_shares = nfs_commit_shares,
+	.truncate_shares = nfs_truncate_shares,
 };

--- a/lib/libshare/os/linux/nfs.c
+++ b/lib/libshare/os/linux/nfs.c
@@ -23,7 +23,7 @@
  * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Gunnar Beutner
  * Copyright (c) 2012 Cyril Plisko. All rights reserved.
- * Copyright (c) 2019, 2020 by Delphix. All rights reserved.
+ * Copyright (c) 2019, 2022 by Delphix. All rights reserved.
  */
 
 #include <dirent.h>
@@ -495,6 +495,12 @@ nfs_commit_shares(void)
 	return (libzfs_run_process(argv[0], argv, 0));
 }
 
+static void
+nfs_truncate_shares(void)
+{
+	nfs_reset_shares(ZFS_EXPORTS_LOCK, ZFS_EXPORTS_FILE);
+}
+
 const sa_fstype_t libshare_nfs_type = {
 	.enable_share = nfs_enable_share,
 	.disable_share = nfs_disable_share,
@@ -502,6 +508,7 @@ const sa_fstype_t libshare_nfs_type = {
 
 	.validate_shareopts = nfs_validate_shareopts,
 	.commit_shares = nfs_commit_shares,
+	.truncate_shares = nfs_truncate_shares,
 };
 
 static boolean_t

--- a/lib/libspl/include/libshare.h
+++ b/lib/libspl/include/libshare.h
@@ -22,7 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright (c) 2019, 2020 by Delphix. All rights reserved.
+ * Copyright (c) 2019, 2022 by Delphix. All rights reserved.
  */
 #ifndef _LIBSPL_LIBSHARE_H
 #define	_LIBSPL_LIBSHARE_H extern __attribute__((visibility("default")))
@@ -88,6 +88,7 @@ _LIBSPL_LIBSHARE_H int sa_enable_share(const char *, const char *, const char *,
 _LIBSPL_LIBSHARE_H int sa_disable_share(const char *, enum sa_protocol);
 _LIBSPL_LIBSHARE_H boolean_t sa_is_shared(const char *, enum sa_protocol);
 _LIBSPL_LIBSHARE_H void sa_commit_shares(enum sa_protocol);
+_LIBSPL_LIBSHARE_H void sa_truncate_shares(enum sa_protocol);
 
 /* protocol specific interfaces */
 _LIBSPL_LIBSHARE_H int sa_validate_shareopts(const char *, enum sa_protocol);

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -245,6 +245,7 @@
     <elf-symbol name='sa_enable_share' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='sa_errorstr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='sa_is_shared' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='sa_truncate_shares' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='sa_validate_shareopts' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='snapshot_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='spl_pagesize' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -428,6 +429,7 @@
     <elf-symbol name='zfs_strcmp_pathname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_strip_partition' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_strip_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_truncate_shares' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_type_to_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_unmount' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_unmountall' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -758,6 +760,10 @@
       <parameter type-id='9155d4b5' name='protocol'/>
       <return type-id='48b5725f'/>
     </function-decl>
+    <function-decl name='sa_truncate_shares' mangled-name='sa_truncate_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_truncate_shares'>
+      <parameter type-id='9155d4b5' name='protocol'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
     <function-decl name='sa_validate_shareopts' mangled-name='sa_validate_shareopts' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='sa_validate_shareopts'>
       <parameter type-id='80f4b756' name='options'/>
       <parameter type-id='9155d4b5' name='protocol'/>
@@ -787,7 +793,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='sa_share_impl_t' type-id='946a2c6b' id='a48b47d0'/>
-    <class-decl name='sa_fstype_t' size-in-bits='320' is-struct='yes' naming-typedef-id='639af739' visibility='default' id='944afa86'>
+    <class-decl name='sa_fstype_t' size-in-bits='384' is-struct='yes' naming-typedef-id='639af739' visibility='default' id='944afa86'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='enable_share' type-id='2f78a9c1' visibility='default'/>
       </data-member>
@@ -803,6 +809,9 @@
       <data-member access='public' layout-offset-in-bits='256'>
         <var-decl name='commit_shares' type-id='797ee7da' visibility='default'/>
       </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='truncate_shares' type-id='5d51038b' visibility='default'/>
+      </data-member>
     </class-decl>
     <typedef-decl name='sa_fstype_t' type-id='944afa86' id='639af739'/>
     <qualified-type-def type-id='639af739' const='yes' id='d19dbca9'/>
@@ -816,6 +825,8 @@
     <qualified-type-def type-id='fa1f29ce' const='yes' id='2f78a9c1'/>
     <pointer-type-def type-id='86373eb1' size-in-bits='64' id='f337456d'/>
     <qualified-type-def type-id='f337456d' const='yes' id='81020bc2'/>
+    <pointer-type-def type-id='ee076206' size-in-bits='64' id='953b12f8'/>
+    <qualified-type-def type-id='953b12f8' const='yes' id='5d51038b'/>
     <var-decl name='libshare_nfs_type' type-id='d19dbca9' visibility='default'/>
     <function-type size-in-bits='64' id='276427e1'>
       <return type-id='95e97e5e'/>
@@ -831,6 +842,9 @@
     <function-type size-in-bits='64' id='86373eb1'>
       <parameter type-id='a48b47d0'/>
       <return type-id='c19b74c3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='ee076206'>
+      <return type-id='48b5725f'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libshare/os/linux/smb.c' language='LANG_C99'>
@@ -2302,6 +2316,7 @@
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZPROP_CONT' value='-2'/>
       <enumerator name='ZPROP_INVAL' value='-1'/>
+      <enumerator name='ZPROP_USERPROP' value='-1'/>
       <enumerator name='ZFS_PROP_TYPE' value='0'/>
       <enumerator name='ZFS_PROP_CREATION' value='1'/>
       <enumerator name='ZFS_PROP_USED' value='2'/>
@@ -3034,6 +3049,10 @@
       <parameter type-id='4567bbc9' name='proto'/>
       <return type-id='48b5725f'/>
     </function-decl>
+    <function-decl name='zfs_truncate_shares' mangled-name='zfs_truncate_shares' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_truncate_shares'>
+      <parameter type-id='4567bbc9' name='proto'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
     <function-decl name='zfs_unshare' mangled-name='zfs_unshare' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_unshare'>
       <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='80f4b756' name='mountpoint'/>
@@ -3150,6 +3169,7 @@
     <enum-decl name='vdev_prop_t' naming-typedef-id='5aa5c90c' id='1573bec8'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='VDEV_PROP_INVAL' value='-1'/>
+      <enumerator name='VDEV_PROP_USERPROP' value='-1'/>
       <enumerator name='VDEV_PROP_NAME' value='0'/>
       <enumerator name='VDEV_PROP_CAPACITY' value='1'/>
       <enumerator name='VDEV_PROP_STATE' value='2'/>
@@ -3750,7 +3770,7 @@
     </class-decl>
     <typedef-decl name='sendflags_t' type-id='f6aa15be' id='945467e6'/>
     <typedef-decl name='snapfilter_cb_t' type-id='d2a5e211' id='3d3ffb69'/>
-    <class-decl name='recvflags' size-in-bits='416' is-struct='yes' visibility='default' id='34a384dc'>
+    <class-decl name='recvflags' size-in-bits='448' is-struct='yes' visibility='default' id='34a384dc'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='verbose' type-id='c19b74c3' visibility='default'/>
       </data-member>
@@ -3789,6 +3809,9 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
         <var-decl name='forceunmount' type-id='c19b74c3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='heal' type-id='c19b74c3' visibility='default'/>
       </data-member>
     </class-decl>
     <typedef-decl name='recvflags_t' type-id='34a384dc' id='9e59d1d4'/>
@@ -3903,16 +3926,17 @@
       <enumerator name='ZPOOL_ERRATA_ZOL_8308_ENCRYPTION' value='4'/>
     </enum-decl>
     <typedef-decl name='zpool_errata_t' type-id='d9abbf54' id='688c495b'/>
+    <pointer-type-def type-id='80f4b756' size-in-bits='64' id='7d3cd834'/>
     <pointer-type-def type-id='688c495b' size-in-bits='64' id='cec6f2e4'/>
     <function-decl name='zpool_get_status' mangled-name='zpool_get_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_status'>
       <parameter type-id='4c81de99' name='zhp'/>
-      <parameter type-id='9b23c9ad' name='msgid'/>
+      <parameter type-id='7d3cd834' name='msgid'/>
       <parameter type-id='cec6f2e4' name='errata'/>
       <return type-id='d3dd6294'/>
     </function-decl>
     <function-decl name='zpool_import_status' mangled-name='zpool_import_status' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_status'>
       <parameter type-id='5ce45b60' name='config'/>
-      <parameter type-id='9b23c9ad' name='msgid'/>
+      <parameter type-id='7d3cd834' name='msgid'/>
       <parameter type-id='cec6f2e4' name='errata'/>
       <return type-id='d3dd6294'/>
     </function-decl>
@@ -4032,8 +4056,8 @@
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='libzfs_envvar_is_set' mangled-name='libzfs_envvar_is_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_envvar_is_set'>
-      <parameter type-id='26a90f95' name='envvar'/>
-      <return type-id='95e97e5e'/>
+      <parameter type-id='80f4b756' name='envvar'/>
+      <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='libzfs_init' mangled-name='libzfs_init' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_init'>
       <return type-id='b0382bb3'/>
@@ -4102,15 +4126,15 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='color_start' mangled-name='color_start' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_start'>
-      <parameter type-id='26a90f95' name='color'/>
+      <parameter type-id='80f4b756' name='color'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='color_end' mangled-name='color_end' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='color_end'>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='printf_color' mangled-name='printf_color' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
-      <parameter type-id='26a90f95' name='color'/>
-      <parameter type-id='26a90f95' name='format'/>
+      <parameter type-id='80f4b756' name='color'/>
+      <parameter type-id='80f4b756' name='format'/>
       <parameter is-variadic='yes'/>
       <return type-id='95e97e5e'/>
     </function-decl>
@@ -4123,7 +4147,7 @@
   <abi-instr address-size='64' path='lib/libzfs/os/linux/libzfs_mount_os.c' language='LANG_C99'>
     <pointer-type-def type-id='7359adad' size-in-bits='64' id='1d2c2b85'/>
     <function-decl name='zfs_parse_mount_options' mangled-name='zfs_parse_mount_options' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parse_mount_options'>
-      <parameter type-id='26a90f95' name='mntopts'/>
+      <parameter type-id='80f4b756' name='mntopts'/>
       <parameter type-id='1d2c2b85' name='mntflags'/>
       <parameter type-id='1d2c2b85' name='zfsflags'/>
       <parameter type-id='95e97e5e' name='sloppy'/>
@@ -4771,8 +4795,8 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='module/zcommon/zfeature_common.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='83f29ca2' size-in-bits='16576' id='9d5e9e2e'>
-      <subrange length='37' type-id='7359adad' id='ae666bde'/>
+    <array-type-def dimensions='1' type-id='83f29ca2' size-in-bits='16576' id='d95b2b0b'>
+      <subrange length='37' type-id='7359adad' id='aa6426fb'/>
     </array-type-def>
     <enum-decl name='spa_feature' id='33ecb627'>
       <underlying-type type-id='9cac1fee'/>
@@ -4872,7 +4896,7 @@
     <qualified-type-def type-id='3eee3342' const='yes' id='0c1d5bbb'/>
     <pointer-type-def type-id='0c1d5bbb' size-in-bits='64' id='a3372543'/>
     <pointer-type-def type-id='d6618c78' size-in-bits='64' id='a8425263'/>
-    <var-decl name='spa_feature_table' type-id='9d5e9e2e' mangled-name='spa_feature_table' visibility='default' elf-symbol-id='spa_feature_table'/>
+    <var-decl name='spa_feature_table' type-id='d95b2b0b' mangled-name='spa_feature_table' visibility='default' elf-symbol-id='spa_feature_table'/>
     <var-decl name='zfeature_checks_disable' type-id='c19b74c3' mangled-name='zfeature_checks_disable' visibility='default' elf-symbol-id='zfeature_checks_disable'/>
     <function-decl name='zfeature_is_valid_guid' mangled-name='zfeature_is_valid_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_valid_guid'>
       <parameter type-id='80f4b756' name='name'/>
@@ -4935,7 +4959,7 @@
     </function-decl>
     <function-decl name='zfs_special_devs' mangled-name='zfs_special_devs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_special_devs'>
       <parameter type-id='5ce45b60' name='nv'/>
-      <parameter type-id='26a90f95' name='type'/>
+      <parameter type-id='80f4b756' name='type'/>
       <return type-id='c19b74c3'/>
     </function-decl>
     <function-decl name='zpool_get_load_policy' mangled-name='zpool_get_load_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_load_policy'>
@@ -5013,7 +5037,7 @@
     <typedef-decl name='zfs_deleg_note_t' type-id='729d4547' id='4613c173'/>
     <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' id='5aa05c1f'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='z_perm' type-id='26a90f95' visibility='default'/>
+        <var-decl name='z_perm' type-id='80f4b756' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='z_note' type-id='4613c173' visibility='default'/>
@@ -5455,7 +5479,6 @@
       </data-member>
     </class-decl>
     <typedef-decl name='zprop_desc_t' type-id='bbff5e4b' id='ffa52b96'/>
-    <pointer-type-def type-id='80f4b756' size-in-bits='64' id='7d3cd834'/>
     <qualified-type-def type-id='64636ce3' const='yes' id='072f7953'/>
     <pointer-type-def type-id='072f7953' size-in-bits='64' id='c8bc397b'/>
     <pointer-type-def type-id='ffa52b96' size-in-bits='64' id='76c8174b'/>

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2021 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2022 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  * Copyright 2017 RackTop Systems.
  * Copyright (c) 2018 Datto Inc.
@@ -786,6 +786,16 @@ zfs_commit_shares(const enum sa_protocol *proto)
 
 	for (const enum sa_protocol *p = proto; *p != SA_NO_PROTOCOL; ++p)
 		sa_commit_shares(*p);
+}
+
+void
+zfs_truncate_shares(const enum sa_protocol *proto)
+{
+	if (proto == NULL)
+		proto = share_all_proto;
+
+	for (const enum sa_protocol *p = proto; *p != SA_NO_PROTOCOL; ++p)
+		sa_truncate_shares(*p);
 }
 
 /*


### PR DESCRIPTION
### Motivation and Context
We have encountered a few cases where stale entries in `/etc/exports.d/zfs.exports` will cause the `nfs-server` service to fail when starting up. Below is a simple reproducible case that demonstrates this failure.

**Confirm nfs server is active and create a pool with some nfs exports**
```
$ sudo systemctl is-active nfs-server
active
$ sudo zpool create perm xvdz
$ sudo zfs create -o sharenfs=rw perm/export-1
$ sudo zfs create -o sharenfs=rw perm/export-2
$ sudo zfs create -o sharenfs=rw perm/export-3
```
**Create a temporary pool with an export**
```
$ sudo zpool create temp xvdy ; sudo zfs create -o sharenfs=rw temp/export
```
**Confirm our zfs exports**
```
$ cat /etc/exports.d/zfs.exports
# !!! DO NOT EDIT THIS FILE MANUALLY !!!

/perm/export-1 *(sec=sys,rw,no_subtree_check,mountpoint)
/perm/export-2 *(sec=sys,rw,no_subtree_check,mountpoint)
/perm/export-3 *(sec=sys,rw,no_subtree_check,mountpoint)
/temp/export *(sec=sys,rw,no_subtree_check,mountpoint)

```
**Destroy our temporary pool, confirming it is gone**
```
$ sudo umount /temp/export ; sudo zpool destroy temp
$ zpool list temp
cannot open 'temp': no such pool
```
**However,  since we used `umount(8)`,  a stale export persists!**
```
$ cat /etc/exports.d/zfs.exports
# !!! DO NOT EDIT THIS FILE MANUALLY !!!

/perm/export-1 *(sec=sys,rw,no_subtree_check,mountpoint)
/perm/export-2 *(sec=sys,rw,no_subtree_check,mountpoint)
/perm/export-3 *(sec=sys,rw,no_subtree_check,mountpoint)
/temp/export *(sec=sys,rw,no_subtree_check,mountpoint)
```
**Confirm that this stale import prevents the nfs server from successfully starting up**
```
$ sudo systemctl restart nfs-server ; echo $? ;  sudo systemctl status nfs-server
Job for nfs-server.service canceled.
1
● nfs-server.service - NFS server and services
     Loaded: loaded (/lib/systemd/system/nfs-server.service; enabled; vendor preset: enabled)
    Drop-In: /run/systemd/generator/nfs-server.service.d
             └─order-with-mounts.conf
     Active: failed (Result: exit-code) since Mon 2022-08-15 17:17:55 UTC; 48ms ago
    Process: 2832 ExecStartPre=/usr/sbin/exportfs -r (code=exited, status=1/FAILURE)
    Process: 2833 ExecStopPost=/usr/sbin/exportfs -au (code=exited, status=0/SUCCESS)
    Process: 2835 ExecStopPost=/usr/sbin/exportfs -f (code=exited, status=0/SUCCESS)

Aug 15 17:17:55 ip-10-110-204-53 systemd[1]: Starting NFS server and services...
Aug 15 17:17:55 ip-10-110-204-53 exportfs[2832]: exportfs: Failed to stat /temp/export: No such file or directory
Aug 15 17:17:55 ip-10-110-204-53 systemd[1]: nfs-server.service: Control process exited, code=exited, status=1/FAILURE
Aug 15 17:17:55 ip-10-110-204-53 systemd[1]: nfs-server.service: Failed with result 'exit-code'.
Aug 15 17:17:55 ip-10-110-204-53 systemd[1]: Stopped NFS server and services.
```

### Description
1. Ideally, since the `nfs-server` startup consumes `/etc/exports.d/zfs.exports`, the `zfs-share` service (which rebuilds the list of zfs exports) should run _before_ the nfs-server service. 
2. ~To make the `zfs-share` service resilient to stale exports, this change truncates the zfs config file right before the `zfs share -a`  which is appending all known exports.~ To make the `zfs-share` service resilient to stale exports, this change truncates the zfs config file as part of the `zfs share -a` operation.

### How Has This Been Tested?
1. Re-ran the reproducible case above to demonstrate that the `zfs-share` service will remove any stale entries.
2. In-house testing at scale where stale entries were causing the nfs server to fail startup was reproducing and it no longer occurs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
