### PR TITLE
Support FS_CASEFOLD_FL (F) file attribute on Linux

### DIFF
--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -197,4 +197,9 @@ zpl_dir_emit_dots(struct file *file, zpl_dir_context_t *ctx)
 #define	zpl_setattr_prepare(ns, dentry, ia)	setattr_prepare(dentry, ia)
 #endif
 
+#ifdef FS_CASEFOLD_FL
+#define	ZFS_CASEFOLD_FL FS_CASEFOLD_FL
+#else
+#define	ZFS_CASEFOLD_FL 0x40000000
+#endif
 #endif	/* _SYS_ZPL_H */

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1937,6 +1937,20 @@ mixed behavior is limited to the SMB server product.
 For more information about the
 .Sy mixed
 value behavior, see the "ZFS Administration Guide".
+.Pp
+On Linux, the
+.Sy insensitive
+value for the
+.Sy casesensitivity
+property will set the +F file attribute on directories to inform software such
+as Wine that it can avoid slow emulation of case-insensitive directory lookups.
+The semantics of +F mainly differ from other Linux filesystems by not implying
+.Sy normalization=formD ,
+which ZFS offers as a user choice, and only making file names case-insensitive,
+rather than doing the more extensive casefold operation on file names. This is
+believed to be more compatible with software that needs case-insensitive
+directory lookups than the semantics of +F on other linux filesystems. For a
+full discussion of the differences, see OpenZFS Pull Request #13790.
 .It Xo
 .Sy normalization Ns = Ns Sy none Ns | Ns Sy formC Ns | Ns
 .Sy formD Ns | Ns Sy formKC Ns | Ns Sy formKD

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -35,7 +35,7 @@ tests = ['atime_003_pos', 'root_relatime_on']
 tags = ['functional', 'atime']
 
 [tests/functional/chattr:Linux]
-tests = ['chattr_001_pos', 'chattr_002_neg']
+tests = ['chattr_001_pos', 'chattr_002_neg', 'chattr_003_pos', 'chattr_004_neg']
 tags = ['functional', 'chattr']
 
 [tests/functional/cli_root/zfs:Linux]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -540,6 +540,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/channel_program/synctask_core/tst.terminate_by_signal.ksh \
 	functional/chattr/chattr_001_pos.ksh \
 	functional/chattr/chattr_002_neg.ksh \
+	functional/chattr/chattr_003_pos.ksh \
+	functional/chattr/chattr_004_neg.ksh \
 	functional/chattr/cleanup.ksh \
 	functional/chattr/setup.ksh \
 	functional/checksum/cleanup.ksh \

--- a/tests/zfs-tests/tests/functional/chattr/chattr_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/chattr/chattr_003_pos.ksh
@@ -1,0 +1,120 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2017 by Fan Yong. All rights reserved.
+# Copyright 2022 Zettabyte Software, LLC.  All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/userquota/userquota_common.kshlib
+
+#
+# DESCRIPTION:
+#	Verify FS_CASEFOLD_FL implementation is working as intended on case
+#	insensitive filesystems.
+#
+# STRATEGY:
+#	1. Create a filesystem with casesensitivity=insensitive.
+#	2. Create directory in filesystem and make a file in it.
+#	3. Use lsattr to verify '+F' is set on the directory.
+#	4. Use lsattr to verify '-F' is set on the file.
+#	5. Use chattr to verify setting '+F' on the directory is accepted.
+#	6. Use chattr to verify setting '+F' on the file is rejected.
+#	7. Use lsattr to verify F has not changed on either.
+#	8. Use chattr to verify setting '-F' on the directory is accepted.
+#	9. Use chattr to verify setting '-F' on the file is accepted.
+#	10. Use lsattr to verify F has not changed on either.
+#	11. Repeat steps 3 through 10 as a user that owns both.
+#
+
+TESTFS=$TESTPOOL/chattr_003_pos
+
+function cleanup
+{
+	datasetexists $TESTFS && destroy_dataset $TESTFS
+}
+
+log_assert "Check whether chattr -/+F works as expected on case insensitive " \
+	"filesystems."
+
+e2ver=$(lsattr -Vd 3>&1 1>/dev/null 2>&3-)
+e2ver=${e2ver% *}
+e2ver=${e2ver#* }
+major="${e2ver%%.*}"
+minor="${e2ver#*.*}"
+minor="${minor%%.*}"
+
+if test $major -lt 1 -o $major -eq 1 -a $minor -lt 45; then
+	log_unsupported "This test requires e2fsprogs version 1.45.0 or " \
+	"later. Saw version $e2ver, skipping."
+fi
+
+log_onexit cleanup
+
+log_must zfs create -o casesensitivity=insensitive $TESTFS
+
+log_must mkdir /$TESTFS/dir
+
+log_must mkfile 16M /$TESTFS/dir/file
+
+log_must eval "lsattr -d /$TESTFS/dir | grep '\-F[- ]* '"
+log_must eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_must chattr +F /$TESTFS/dir
+log_mustnot chattr +F /$TESTFS/dir/file
+
+log_must eval "lsattr -d /$TESTFS/dir | grep '\-F[- ]* '"
+log_must eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_must chattr -F /$TESTFS/dir
+log_must chattr -F /$TESTFS/dir/file
+
+log_must eval "lsattr -d /$TESTFS/dir | grep '\-F[- ]* '"
+log_must eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_must chmod -R 0777 /$TESTFS/dir
+log_must chown -R $QUSER1 /$TESTFS/dir
+
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir | grep '\-F[- ]* '"
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_must user_run $QUSER1 chattr +F /$TESTFS/dir
+log_mustnot user_run $QUSER1 chattr +F /$TESTFS/dir/file
+
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir | grep '\-F[- ]* '"
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_must user_run $QUSER1 chattr -F /$TESTFS/dir
+log_must user_run $QUSER1 chattr -F /$TESTFS/dir/file
+
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir | grep '\-F[- ]* '"
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+
+log_pass "chattr -/+F works as expected on case insensitive filesystems."

--- a/tests/zfs-tests/tests/functional/chattr/chattr_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/chattr/chattr_004_neg.ksh
@@ -1,0 +1,118 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2017 by Fan Yong. All rights reserved.
+# Copyright 2022 Zettabyte Software, LLC.  All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/userquota/userquota_common.kshlib
+
+#
+# DESCRIPTION:
+#	Verify FS_CASEFOLD_FL is unsupported on case sensitive filesystems.
+#
+# STRATEGY:
+#	1. Create a filesystem with casesensitivity=sensitive.
+#	2. Create directory in filesystem and make a file in it.
+#	3. Use lsattr to verify '-F' is set on the directory.
+#	4. Use lsattr to verify '-F' is set on the file.
+#	5. Use chattr to verify setting '+F' on the directory is rejected.
+#	6. Use chattr to verify setting '+F' on the file is rejected.
+#	7. Use lsattr to verify F has not changed on either.
+#	8. Use chattr to verify setting '-F' on the directory is accepted.
+#	9. Use chattr to verify setting '-F' on the file is accepted.
+#	10. Use lsattr to verify F has not changed on either.
+#	11. Repeat steps 3 through 10 as a user that owns both.
+#
+
+TESTFS=$TESTPOOL/chattr_004_neg
+
+function cleanup
+{
+	datasetexists $TESTFS && destroy_dataset $TESTFS
+}
+
+log_assert "Check whether chattr +F is unsupported as expected on case " \
+	"sensitive filesystems."
+
+e2ver=$(lsattr -Vd 3>&1 1>/dev/null 2>&3-)
+e2ver=${e2ver% *}
+e2ver=${e2ver#* }
+major="${e2ver%%.*}"
+minor="${e2ver#*.*}"
+minor="${minor%%.*}"
+
+if test $major -lt 1 -o $major -eq 1 -a $minor -lt 45; then
+	log_unsupported "This test requires e2fsprogs version 1.45.0 or " \
+	"later. Saw version $e2ver, skipping."
+fi
+
+log_onexit cleanup
+
+log_must zfs create -o casesensitivity=sensitive $TESTFS
+
+log_must mkdir /$TESTFS/dir
+
+log_must mkfile 16M /$TESTFS/dir/file
+
+log_must eval "lsattr -d /$TESTFS/dir | grep -v '\-F[- ]* '"
+log_must eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_mustnot chattr +F /$TESTFS/dir
+log_mustnot chattr +F /$TESTFS/dir/file
+
+log_must eval "lsattr -d /$TESTFS/dir | grep -v '\-F[- ]* '"
+log_must eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_must chattr -F /$TESTFS/dir
+log_must chattr -F /$TESTFS/dir/file
+
+log_must eval "lsattr -d /$TESTFS/dir | grep -v '\-F[- ]* '"
+log_must eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_must chmod -R 0777 /$TESTFS/dir
+log_must chown -R $QUSER1 /$TESTFS/dir
+
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir | grep -v '\-F[- ]* '"
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_mustnot user_run $QUSER1 chattr +F /$TESTFS/dir
+log_mustnot user_run $QUSER1 chattr +F /$TESTFS/dir/file
+
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir | grep -v '\-F[- ]* '"
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_must user_run $QUSER1 chattr -F /$TESTFS/dir
+log_must user_run $QUSER1 chattr -F /$TESTFS/dir/file
+
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir | grep -v '\-F[- ]* '"
+log_must user_run $QUSER1 eval "lsattr -d /$TESTFS/dir/file | grep -v '\-F[- ]* '"
+
+log_pass "chattr +F is unsupported on case sensitive filesystems."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
I got a steam deck recently and examined how it formatted the microsd card that I gave it. It is formatted as ext4 with an interesting feature called casefold, which was introduced in Linux 5.2. That feature allows empty directories to be marked as case insensitive on what is an otherwise case sensitive filesystem. Userland will then have case insensitive lookups after the directory is populated and software such as wine that typically does expensive emulation of case insensitive directory lookups can instead check the file attribute on directories to discover opportunities to offload the lookups to the filesystem, which improves performance.

https://github.com/wine-mirror/wine/blob/cb8937801d42417c2b98cba15366ccc154c1cc40/dlls/ntdll/unix/file.c#L1166
https://github.com/ValveSoftware/Proton/blob/4221d9ef07cc38209ff93dbbbca9473581a38255/proton#L390

Anyway, I felt inspired upon seeing ext4's casefold extension to take a look at whether we could support additional Linux file attributes in ZFS and it turns out that we can. `FS_CASEFOLD_FL`, `FS_INLINE_DATA_FL` and `FS_ENCRYPT_FL` all can be implemented as virtual file attributes. While `FS_CASEFOLD_FL` is not implemented as a virtual file attribute in other filesystems, implementing it that way is compatible with both how current and future userland software is expected to interact with it. The latter two are actually virtual file attributes on other filesystems, but they are more difficult to implement since implementing them appears to require passing metadata from the DMU to the ZPL. Thus, I have only implemented `FS_CASEFOLD_FL` in this patch.

### Description
This is a tiny change to the ZPL to implement the `FS_CASEFOLD_FL` file attribute. It only affects case insensitive filesystems. case sensitive filesystems and mixed filesystems are unaffected.

The semantics of this implementation on case
insensitive filesystems are as follows:

 * Directories always report `FS_CASEFOLD_FL` through the `FS_IOC_GETFLAGS`
   ioctl while non-directories never report it.

 * The `FS_IOC_SETFLAGS` ioctl accepts the `FS_CASEFOLD_FL` file attribute
   on directories, but rejects it on non-directories by returning an
   `ENOTDIR`.

 * The `FS_IOC_SETFLAGS` ioctl silently ignores attempts to unset the
   `FS_CASEFOLD_FL` file attribute. This theoretically maintains
   compatibility with userland tools that copy directories from case
   sensitive (ZFS) filesystems and do not read the file attribute
   bitmask before setting it. This is also consistent with the behavior
   of other Linux filesystems when given file attribute bitmasks missing
   file attributes that userland may not unset.

This is compatible both with how proton is programmed to set the
`FS_CASEFOLD_FL` file attribute and with how wine reads the
`FS_CASEFOLD_FL` file attribute.  It differs from the ext4 semantics in
the following ways:

 * ext4 does not create directories with this file attribute set on
   casefold ext4 filesystems. All directories on case insensitive ZFS
   filesystems have this file attribute implicitly set.

 * ext4 will return `ENOTEMPTY` when userland attempts to set this bit
   on non-empty directories on casefold ext4 filesystems. Since the file
   attribute is always set on directories on case insensitive ZFS
   filesystems, it does not make sense to return `ENOTEMPTY`.
   Furthermore, having this bit always implicitly set interacts with the
   design of the Linux interface for setting file attributes in such a
   way that we never encounter the case to be able to return `ENOTEMPTY`
   even if we wanted to return it.

 * ext4 allows the bit to be unset on empty directories. We silently
   accept the unset operation on case insensitive filesystems, but we do
   not "unset" the bit.

There is a theoretical edge case that occurs if userland attempts to
copy a directory from a case insensitive filesystem to a case sensitive
filesystem while preserving file attributes. In that situation, a naive
attempt to set the original bitmask would be rejected, which could cause
the loss of file attributes unless userland falls back to setting 1 bit
at a time to preserve as many bits as possible. Any directories with the
immutable bit set would need to have more intelligent treatment (such as
setting it after creating the files inside the directory), so expecting
userland to be smart is reasonable and we do not have to worry about
this edge case.

The semantics of this implementation are sufficiently compatible with
both current userland software and any foreseeable future userland
software that I feel comfortable implementing this file attribute in ZFS
on Linux.

Most of the above description is copied from the commit message. There is a little more written there, although nearly everything except a remark about F2FS also supporting this file attribute has been rewritten here in some form. There are also comments inline in the code mentioning things that I felt were non-obvious.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

I have only done a local build test of the Linux ZFS kernel modules from git master with this patch applied against Linux 5.16.14-gentoo-x86_64.

I have done no functional testing. Instead, I have written test cases and included them with the changes. The test cases are expected to enable the buildbot to validate that this change is working as expected. The test cases have the limitation that they only test for errors and do not check if the error codes are what are expected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
