### PR TITLE
ZTS: zvol_stress: fix race condition with zinject usage

### DIFF
--- a/tests/zfs-tests/tests/functional/zvol/zvol_stress/zvol_stress.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_stress/zvol_stress.ksh
@@ -151,6 +151,7 @@ for DISK in $DISKS ; do
 	log_must zinject -d $DISK -f 10 -e io -T write $TESTPOOL
 done
 log_must dd if=/dev/zero of=$ZVOL_DEVDIR/$TESTPOOL/testvol1 bs=512 count=50
+sync_pool $TESTPOOL
 log_must zinject -c all
 
 # We should see write errors


### PR DESCRIPTION
In automated ZTS runs, I'd occassionally hit

    log_fail "Expected to see some write errors"

because there weren't any write errors.

The reason is that we're not syncing the zpool before `zinject -c`.
If the writes by `dd` aren't synced out at the time `zinject -c` runs,
they will not hit an error and we'll hit the log_fail above.

Signed-off-by: Christian Schwarz <christian.schwarz@nutanix.com>

