### PR TITLE
dmu feature flag bits 28 & 29

### DIFF
--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -124,6 +124,13 @@ typedef enum drr_headertype {
  * default use of "zfs send" won't encounter the bug mentioned above.
  */
 #define	DMU_BACKUP_FEATURE_SWITCH_TO_LARGE_BLOCKS (1 << 27)
+/* flag #28 is reserved for a Nutanix feature */
+/*
+ * flag #29 is the last unused bit. It is reserved to indicate a to-be-designed
+ * extension to the stream format which will accomodate more feature flags.
+ * If you need to add another feature flag, please reach out to the OpenZFS
+ * community, e.g., on GitHub or Slack.
+ */
 
 /*
  * Mask of all supported backup features

--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -124,7 +124,6 @@ typedef enum drr_headertype {
  * default use of "zfs send" won't encounter the bug mentioned above.
  */
 #define	DMU_BACKUP_FEATURE_SWITCH_TO_LARGE_BLOCKS (1 << 27)
-#define	DMU_BACKUP_FEATURE_BLAKE3		(1 << 28)
 
 /*
  * Mask of all supported backup features
@@ -135,7 +134,7 @@ typedef enum drr_headertype {
     DMU_BACKUP_FEATURE_COMPRESSED | DMU_BACKUP_FEATURE_LARGE_DNODE | \
     DMU_BACKUP_FEATURE_RAW | DMU_BACKUP_FEATURE_HOLDS | \
     DMU_BACKUP_FEATURE_REDACTED | DMU_BACKUP_FEATURE_SWITCH_TO_LARGE_BLOCKS | \
-    DMU_BACKUP_FEATURE_ZSTD | DMU_BACKUP_FEATURE_BLAKE3)
+    DMU_BACKUP_FEATURE_ZSTD)
 
 /* Are all features in the given flag word currently supported? */
 #define	DMU_STREAM_SUPPORTED(x)	(!((x) & ~DMU_BACKUP_FEATURE_MASK))


### PR DESCRIPTION
This PR contains two commits, both related to #13795 

```
commit e1202a9f983310e0ede78aecff58b4a149772992
Author: Christian Schwarz <christian.schwarz@nutanix.com>
Date:   Wed Aug 24 15:08:48 2022 +0000

    DMU_BACKUP_FEATURE: remove unused BLAKE3 feature

    Commit 985c33b132 added DMU_BACKUP_FEATURE_BLAKE3 but it is not used by
    the code.

    Signed-off-by: Christian Schwarz <christian.schwarz@nutanix.com>
```

The above is not necessarily the right conclusion, since `DMU_BACKUP_FEATURE_BLAKE3` should probably have been set by the blake3 code, and it just slipped through review. This should be fixed promptly.

However, considering the fact that the bit hasn't been used anywhere yet, and Nutanix uses bit 28 for an internal feature, I took the opportunity in the subsequent commit to reserve bit 28 for Nutanix:

```
commit 5384f82290ee89272101ded93a78dbd45a3a39f6
Author: Christian Schwarz <christian.schwarz@nutanix.com>
Date:   Wed Aug 24 17:04:19 2022 +0000

    DMU_BACKUP_FEATURE: indicate that bit 28 and 29 are reserved

    Bit 28 is used by an internal Nutanix feature which might be upstreamed in the future.

    Bit 29 is the last unused bit. It is reserved to indicate a to-be-designed
    extension to the stream format which will accomodate more feature flags.

    Signed-off-by: Christian Schwarz <christian.schwarz@nutanix.com>
```

The fix for #13795 will definitely involve a DMU stream featureflag to indicate blake3 usage.
But my point is that, since the flag hasn't been used yet, a bit other than 28 could be used.

Now, the problem with that we only have bit 29 left. What do we do about that?
Suggestion by @ahrens  on Slack:

> We’d probably use the last bit to indicate a change in the stream format, to add another word or a more flexible way of specifying the features.  Or start eating into the Solaris bits (3-15)

