### PR TITLE
allow zfs holds -r command on datasets

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6407,6 +6407,7 @@ zfs_do_release(int argc, char **argv)
 
 typedef struct holds_cbdata {
 	boolean_t	cb_recursive;
+	boolean_t	cb_all;
 	const char	*cb_snapname;
 	nvlist_t	**cb_nvlp;
 	size_t		cb_max_namelen;
@@ -6486,7 +6487,7 @@ holds_callback(zfs_handle_t *zhp, void *data)
 			return (0);
 
 		snapname = delim + 1;
-		if (strcmp(cbp->cb_snapname, snapname))
+		if (!cbp->cb_all && strcmp(cbp->cb_snapname, snapname) != 0)
 			return (0);
 	}
 
@@ -6564,17 +6565,24 @@ zfs_do_holds(int argc, char **argv)
 
 		delim = strchr(snapshot, '@');
 		if (delim == NULL) {
-			(void) fprintf(stderr,
-			    gettext("'%s' is not a snapshot\n"), snapshot);
-			errors = B_TRUE;
-			continue;
+			if (!recursive) {
+				(void) fprintf(stderr,
+				    gettext("'%s' is not a snapshot\n"),
+				    snapshot);
+				errors = B_TRUE;
+				continue;
+			} else {
+				cb.cb_all = B_TRUE;
+				cb.cb_snapname = NULL;
+			}
+		} else {
+			snapname = delim + 1;
+			if (recursive)
+				snapshot[delim - snapshot] = '\0';
+			cb.cb_all = B_FALSE;
+			cb.cb_snapname = snapname;
 		}
-		snapname = delim + 1;
-		if (recursive)
-			snapshot[delim - snapshot] = '\0';
-
 		cb.cb_recursive = recursive;
-		cb.cb_snapname = snapname;
 		cb.cb_nvlp = &nvl;
 
 		/*

--- a/man/man8/zfs-hold.8
+++ b/man/man8/zfs-hold.8
@@ -89,6 +89,21 @@ Do not print headers, use tab-delimited output.
 .El
 .It Xo
 .Nm zfs
+.Cm holds
+.Fl r
+.Op Fl H
+.Ar dataset Ns …
+.Xc
+Lists all existing user references for all snapshots of the given datasets and
+their descendants.
+.Bl -tag -width "-r"
+.It Fl r
+Recursive operation, mandatory for dataset arguments.
+.It Fl H
+Do not print headers, use tab-delimited output.
+.El
+.It Xo
+.Nm zfs
 .Cm release
 .Op Fl r
 .Ar tag Ar snapshot Ns …


### PR DESCRIPTION
### Motivation and Context
Sometimes it is useful to list all user holds of all snapshots under certain dataset.
For example, when those holds do not allow to destroy the dataset.

### Description
The change allows to specify a dataset as an argument for `zfs holds -r`.
In that case, all descendants and snapshots are traversed.

### How Has This Been Tested?
Simply executed `zfs holds -r` on various targets.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
