### PR TITLE
Fix column width in 'zpool iostat -v' and 'zpool list -v'

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -5466,8 +5466,8 @@ get_namewidth_iostat(zpool_handle_t *zhp, void *data)
 	 * get_namewidth() returns the maximum width of any name in that column
 	 * for any pool/vdev/device line that will be output.
 	 */
-	width = get_namewidth(zhp, cb->cb_namewidth, cb->cb_vdevs.cb_name_flags,
-	    cb->cb_verbose);
+	width = get_namewidth(zhp, cb->cb_namewidth,
+	    cb->cb_vdevs.cb_name_flags | VDEV_NAME_TYPE_ID, cb->cb_verbose);
 
 	/*
 	 * The width we are calculating is the width of the header and also the
@@ -6298,8 +6298,8 @@ get_namewidth_list(zpool_handle_t *zhp, void *data)
 	list_cbdata_t *cb = data;
 	int width;
 
-	width = get_namewidth(zhp, cb->cb_namewidth, cb->cb_name_flags,
-	    cb->cb_verbose);
+	width = get_namewidth(zhp, cb->cb_namewidth,
+	    cb->cb_name_flags | VDEV_NAME_TYPE_ID, cb->cb_verbose);
 
 	if (width < 9)
 		width = 9;


### PR DESCRIPTION
This commit fixes a minor spacing issue caused when enumerating vdev names, which originated from #13031

Signed-off-by: Samuel Wycliffe <samuelwycliffe@gmail.com>


### Motivation and Context
The tabular spacing was off by a few characters after enumerating vdev names, in both `zpool iostat -v` and `zpool list -v` .
This PR fixes it in the same way as it is in `zpool status` as seen [here](https://github.com/openzfs/zfs/blob/2d5622f5be15e9e977a4c8fe5d24baaf487b0432/cmd/zpool/zpool_main.c#L8546) 

### Description
Before:
![image](https://user-images.githubusercontent.com/50765275/187217038-013da5cd-ab67-4f2c-b1c7-2614fe004145.png)

After:
![image](https://user-images.githubusercontent.com/50765275/187217131-fe80faec-edf4-4fa5-b43e-cd913084478f.png)


### How Has This Been Tested?
As this is a very minor visual change, I've done the changes and compiled it in-tree (using `make cmd`).
Manually ran the commands before and after, as shown above.
 
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
