### PR TITLE
quota: disable quota check for ZVOL

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -15,7 +15,7 @@
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
 .\"
-.Dd June 1, 2021
+.Dd November 7, 2022
 .Dt ZFS 4
 .Os
 .
@@ -2379,6 +2379,10 @@ Defines zvol block devices behaviour when
 .It Sy 3
 .No equivalent to Sy none
 .El
+.
+.It Sy zvol_enforce_quotas Ns = Ns Sy 0 Ns | Ns 1 Pq uint
+Enable strict ZVOL quota enforcement.
+The strict quota enforcement may have a performance impact.
 .El
 .
 .Sh ZFS I/O SCHEDULER

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -54,6 +54,15 @@
 #include "zfs_prop.h"
 
 /*
+ * This controls if we verify the ZVOL quota or not.
+ * Currently, quotas are not implemented for ZVOLs.
+ * The quota size is the size of the ZVOL.
+ * The size of the volume already implies the ZVOL size quota.
+ * The quota mechanism can introduce a significant performance drop.
+ */
+static int zvol_enforce_quotas = B_TRUE;
+
+/*
  * Filesystem and Snapshot Limits
  * ------------------------------
  *
@@ -1311,7 +1320,9 @@ top_of_function:
 	 * If this transaction will result in a net free of space,
 	 * we want to let it through.
 	 */
-	if (ignorequota || netfree || dsl_dir_phys(dd)->dd_quota == 0)
+	if (ignorequota || netfree || dsl_dir_phys(dd)->dd_quota == 0 ||
+	    (dmu_objset_type(tx->tx_objset) == DMU_OST_ZVOL &&
+	    zvol_enforce_quotas == B_FALSE))
 		quota = UINT64_MAX;
 	else
 		quota = dsl_dir_phys(dd)->dd_quota;
@@ -1399,10 +1410,9 @@ top_of_function:
 		ignorequota = (dsl_dir_phys(dd)->dd_head_dataset_obj == 0);
 		first = B_FALSE;
 		goto top_of_function;
-
-	} else {
-		return (0);
 	}
+
+	return (0);
 }
 
 /*
@@ -2483,3 +2493,7 @@ dsl_dir_cancel_waiters(dsl_dir_t *dd)
 EXPORT_SYMBOL(dsl_dir_set_quota);
 EXPORT_SYMBOL(dsl_dir_set_reservation);
 #endif
+
+/* CSTYLED */
+ZFS_MODULE_PARAM(zfs, , zvol_enforce_quotas, INT, ZMOD_RW,
+	"Enable strict ZVOL quota enforcment");


### PR DESCRIPTION
### Motivation and Context

I have created to separate PRs as I think the solution for ZVOL and dataset are quite different one and should be considered separately.

This is continuation of the https://github.com/openzfs/zfs/pull/12868. We based our assumption that the issue is a smoothing mechanism. This graph shows the dirty buff change during write: 
![image](https://user-images.githubusercontent.com/673352/188319472-c535958b-1db1-4fec-bc4c-eefe87fcf704.png)

As pointed out by Matt on our previous call the dirty buffer doesn’t hit the maximum while it suddenly stops. So we look if the existing smoothing mechanism is actually used, and it turns out that it isn't. So we look into what is causing this stop. And we found out that the issue is the quota mechanism. The `dsl_dir_tempreserve_impl` is causing a hard stop if the used_on_disk + est_inflight >= quota . This callcalation don’t take in account if the new data override old ones or not. If the data are just override, we still issuing a full stop.

### Description
The quota for ZVOLs is set to the size of the volume. When the quota reaches the maximum, there isn't an excellent way to check if the new writers are overwriting the data or if they are inserting a new one. Because of that, when we reach the maximum quota, we wait till `txg` is flushed. This is causing a significant fluctuation in bandwidth.

In the case of ZVOL, the quota is enforced by the `volsize`, so we can omit it.

Sponsored-by: Zededa Inc.
Sponsored-by: Klara Inc.

### How Has This Been Tested?
We test this using `fio` tool. Without this test we can notice uneven bandwidth which finally drops to 0, until the TXG will be flushed. With this patch we see a nice stable bandwidth.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
