### PR TITLE
quota: extend quota for dataset

### DIFF
--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1270,6 +1270,7 @@ dsl_dir_tempreserve_impl(dsl_dir_t *dd, uint64_t asize, boolean_t netfree,
 	uint64_t quota;
 	struct tempreserve *tr;
 	int retval;
+	uint64_t ext_quota;
 	uint64_t ref_rsrv;
 
 top_of_function:
@@ -1345,7 +1346,16 @@ top_of_function:
 	 * on-disk is over quota and there are no pending changes
 	 * or deferred frees (which may free up space for us).
 	 */
-	if (used_on_disk + est_inflight >= quota) {
+	ext_quota = quota >> 5;
+	if (quota == UINT64_MAX)
+		ext_quota = 0;
+
+	if (used_on_disk >= quota) {
+		/* Quota exceeded */
+		mutex_exit(&dd->dd_lock);
+		DMU_TX_STAT_BUMP(dmu_tx_quota);
+		return (retval);
+	} else if (used_on_disk + est_inflight >= quota + ext_quota) {
 		if (est_inflight > 0 || used_on_disk < quota) {
 			retval = SET_ERROR(ERESTART);
 		} else {


### PR DESCRIPTION
### Motivation and Context

I have created to separate PRs as I think the solution for ZVOL and dataset are quite different one and should be considered separately.

This is continuation of the https://github.com/openzfs/zfs/pull/12868. We based our assumption that the issue is a smoothing mechanism. This graph shows the dirty buff change during write:
![image](https://user-images.githubusercontent.com/673352/188321633-2ff48f8e-a8c4-43db-ad8a-40741ad44274.png)

As pointed out by Matt on our previous call the dirty buffer doesn’t hit the maximum while it suddenly stops. So we look if the existing smoothing mechanism is actually used, and it turns out that it isn't. So we look into what is causing this stop. And we found out that the issue is the quota mechanism. The dsl_dir_tempreserve_impl is causing a hard stop if the used_on_disk + est_inflight >= quota . This callcalation don’t take in account if the new data override old ones or not. If the data are just override, we still issuing a full stop.

### Description
This patch relax the quota limitation for dataset by around 3%. What this means is that user can write more data then the quota is set to. However thanks to that we can get more stable bandwidth, in case when we are overwriting data in-place, and not consuming any additional space.

If the used space is already over the quota we stop writing data immediately. However because the estimation of in flight data is often inaccurate (most of the time is to large), we allow to write data a little bit more then the quota itself.

### How Has This Been Tested?

Before this patch:
```
# dd if=/dev/zero of=zerofile bs=1M conv=notrunc status=progress count=10k
113246208 bytes (113 MB, 108 MiB) copied, 12 s, 9.4 MB/s^C
115+0 records in
115+0 records out
120586240 bytes (121 MB, 115 MiB) copied, 12.8306 s, 9.4 MB/s
```

After the patch:
```
# dd if=/dev/zero of=zerofile bs=1M conv=notrunc status=progress count=10k
1915748352 bytes (1.9 GB, 1.8 GiB) copied, 8 s, 238 MB/s^C
1904+0 records in
1904+0 records out
1996488704 bytes (2.0 GB, 1.9 GiB) copied, 8.42297 s, 237 MB/s
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
