### PR TITLE
Cleanup: Make memory barrier definitions consistent across kernels

### DIFF
--- a/include/os/freebsd/linux/compiler.h
+++ b/include/os/freebsd/linux/compiler.h
@@ -83,7 +83,6 @@
 #define	__printf(a, b)			__printflike(a, b)
 
 #define	barrier()			__asm__ __volatile__("": : :"memory")
-#define	smp_rmb()		rmb()
 #define	___PASTE(a, b) a##b
 #define	__PASTE(a, b) ___PASTE(a, b)
 

--- a/include/os/freebsd/spl/sys/atomic.h
+++ b/include/os/freebsd/spl/sys/atomic.h
@@ -57,7 +57,8 @@ extern uint64_t atomic_cas_64(volatile uint64_t *target, uint64_t cmp,
     uint64_t newval);
 #endif
 
-#define	membar_producer	atomic_thread_fence_rel
+#define	membar_consumer()		atomic_thread_fence_acq()
+#define	membar_producer()		atomic_thread_fence_rel()
 
 static __inline uint32_t
 atomic_add_32_nv(volatile uint32_t *target, int32_t delta)

--- a/include/os/linux/spl/sys/vmsystm.h
+++ b/include/os/linux/spl/sys/vmsystm.h
@@ -44,7 +44,9 @@
 #define	zfs_totalhigh_pages	totalhigh_pages
 #endif
 
+#define	membar_consumer()		smp_rmb()
 #define	membar_producer()		smp_wmb()
+
 #define	physmem				zfs_totalram_pages
 
 #define	xcopyin(from, to, size)		copy_from_user(to, from, size)

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7482,7 +7482,7 @@ zfsdev_get_state(minor_t minor, enum zfsdev_state_type which)
 
 	for (zs = zfsdev_state_list; zs != NULL; zs = zs->zs_next) {
 		if (zs->zs_minor == minor) {
-			smp_rmb();
+			membar_consumer();
 			switch (which) {
 			case ZST_ONEXIT:
 				return (zs->zs_onexit);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
When reading `module/zfs/zfs_ioctl.c`, I noticed a Linux kernel specific `smp_rmb()` in platform independent code that should have used `membar_consumer()`. This merits cleanup.

When cleaning it up, I noticed that FreeBSD had not defined `membar_consumer()`, but had defined `smp_rmb()` in `include/os/freebsd/linux/compiler.h` when `membar_producer()` had been in `include/os/freebsd/sys/atomic.h`. The definition for `membar_producer()` had been optimized to a compiler memory barrier on amd64/x86 by exploiting the total store order (TSO) memory model, but the `smp_rmb()` definition lacked that optimization.

### Description
I replaced `smp_rmb()` with `membar_consumer()`. I also deleted the  `smp_rmb()` definition from `include/os/freebsd/linux/compiler.h` and put the correct definitions for `membar_consumer()` into `include/os/freebsd/sys/atomic.h` and `include/os/linux/spl/sys/vmsystm.h`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
It has not been tested. This kind of change should only require a build test. I intend to rely on the buildbot to verify that I have not broken kernel builds on either FreeBSD or Linux. I am not setup to compile FreeBSD here, so the buildbot's verification is a time saver for me.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
