### PR TITLE
Cleanup: Use OpenSolaris functions to call scheduler

### DIFF
--- a/include/os/freebsd/spl/sys/disp.h
+++ b/include/os/freebsd/spl/sys/disp.h
@@ -31,6 +31,8 @@
 
 #include <sys/proc.h>
 
+#define	KPREEMPT_SYNC		(-1)
+
 #define	kpreempt(x)	kern_yield(PRI_USER)
 
 #endif	/* _OPENSOLARIS_SYS_DISP_H_ */

--- a/include/os/freebsd/spl/sys/timer.h
+++ b/include/os/freebsd/spl/sys/timer.h
@@ -33,6 +33,4 @@
 #define	usleep_range(wakeup, wakeupepsilon)				   \
 	pause_sbt("usleep_range", ustosbt(wakeup), \
 	ustosbt(wakeupepsilon - wakeup), 0)
-
-#define	schedule() pause("schedule", 1)
 #endif

--- a/include/os/freebsd/zfs/sys/zfs_context_os.h
+++ b/include/os/freebsd/zfs/sys/zfs_context_os.h
@@ -45,8 +45,6 @@
 #define	HAVE_LARGE_STACKS	1
 #endif
 
-#define	cond_resched()		kern_yield(PRI_USER)
-
 #define	taskq_create_sysdc(a, b, d, e, p, dc, f) \
 	    ((void) sizeof (dc), taskq_create(a, b, maxclsyspri, d, e, f))
 

--- a/include/os/linux/spl/sys/disp.h
+++ b/include/os/linux/spl/sys/disp.h
@@ -26,7 +26,9 @@
 
 #include <linux/preempt.h>
 
-#define	kpreempt(unused)	schedule()
+#define	KPREEMPT_SYNC		(-1)
+
+#define	kpreempt(unused)	cond_resched()
 #define	kpreempt_disable()	preempt_disable()
 #define	kpreempt_enable()	preempt_enable()
 

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -219,7 +219,6 @@ typedef pthread_t	kthread_t;
 #define	TS_JOINABLE	0x00000004
 
 #define	curthread	((void *)(uintptr_t)pthread_self())
-#define	kpreempt(x)	yield()
 #define	getcomm()	"unknown"
 
 #define	thread_create_named(name, stk, stksize, func, arg, len, \
@@ -248,9 +247,11 @@ extern kthread_t *zk_thread_create(void (*func)(void *), void *arg,
 #define	issig(why)	(FALSE)
 #define	ISSIG(thr, why)	(FALSE)
 
+#define	KPREEMPT_SYNC		(-1)
+
+#define	kpreempt(x)		sched_yield()
 #define	kpreempt_disable()	((void)0)
 #define	kpreempt_enable()	((void)0)
-#define	cond_resched()		sched_yield()
 
 /*
  * Mutexes

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4165,7 +4165,7 @@ arc_evict_state_impl(multilist_t *ml, int idx, arc_buf_hdr_t *marker,
 	 * this CPU are able to make progress, make a voluntary preemption
 	 * call here.
 	 */
-	cond_resched();
+	kpreempt(KPREEMPT_SYNC);
 
 	return (bytes_evicted);
 }
@@ -10335,7 +10335,7 @@ l2arc_rebuild(l2arc_dev_t *dev)
 		    !dev->l2ad_first)
 			goto out;
 
-		cond_resched();
+		kpreempt(KPREEMPT_SYNC);
 		for (;;) {
 			mutex_enter(&l2arc_rebuild_thr_lock);
 			if (dev->l2ad_rebuild_cancel) {

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1142,7 +1142,7 @@ dnode_free_interior_slots(dnode_t *dn)
 
 	while (!dnode_slots_tryenter(children, idx, slots)) {
 		DNODE_STAT_BUMP(dnode_free_interior_lock_retry);
-		cond_resched();
+		kpreempt(KPREEMPT_SYNC);
 	}
 
 	dnode_set_slots(children, idx, slots, DN_SLOT_FREE);
@@ -1423,7 +1423,7 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 			dnode_slots_rele(dnc, idx, slots);
 			while (!dnode_slots_tryenter(dnc, idx, slots)) {
 				DNODE_STAT_BUMP(dnode_hold_alloc_lock_retry);
-				cond_resched();
+				kpreempt(KPREEMPT_SYNC);
 			}
 
 			/*
@@ -1478,7 +1478,7 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 		dnode_slots_rele(dnc, idx, slots);
 		while (!dnode_slots_tryenter(dnc, idx, slots)) {
 			DNODE_STAT_BUMP(dnode_hold_free_lock_retry);
-			cond_resched();
+			kpreempt(KPREEMPT_SYNC);
 		}
 
 		if (!dnode_check_slots_free(dnc, idx, slots)) {

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -1354,7 +1354,7 @@ fm_fini(void)
 	zevent_flags |= ZEVENT_SHUTDOWN;
 	while (zevent_waiters > 0) {
 		mutex_exit(&zevent_lock);
-		schedule();
+		kpreempt(KPREEMPT_SYNC);
 		mutex_enter(&zevent_lock);
 	}
 	mutex_exit(&zevent_lock);

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -1176,7 +1176,7 @@ spa_ld_log_sm_data(spa_t *spa)
 		}
 
 		/* Load TXG log spacemap into ms_unflushed_allocs/frees. */
-		cond_resched();
+		kpreempt(KPREEMPT_SYNC);
 		ASSERT0(sls->sls_nblocks);
 		sls->sls_nblocks = space_map_nblocks(sls->sls_sm);
 		spa->spa_unflushed_stats.sus_nblocks += sls->sls_nblocks;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
In our codebase, `cond_resched()` and `schedule()` are Linux kernel
functions that have replaced the OpenSolaris `kpreempt()` and `swtch()`
functions in the codebase to such an extent that `kpreempt()` in
zfs_context.h was broken and `swtch()` was unimplemented. Nobody noticed
because we did not actually use either of them. The header had defined
`kpreempt()` as `yield()`, which works on OpenSolaris and Illumos where
`sched_yield()` is a wrapper for `yield()`, but that does not work on any
other platform.

The FreeBSD platform specific code implemented shims for these, but the
shim for `schedule()` forced us to wait, which is different than merely
rescheduling to another thread as the original Linux code does, while
the shim for `cond_resched()` had the same definition as its kernel
`kpreempt()` shim.

The use of Linux functions in what should be OpenSolaris code and the
incorrect implementation of one of those functions in FreeBSD's SPL is
needlessly confusing and merits cleanup. This should have the benefit
of making it slightly easier to port the code to new platforms by making
how things should be mapped less confusing.

### Description
This patch reintroduces the `swtch()` and `kpreempt()` functions in platform
independent code with the following definitions:

	- In the Linux kernel:
		swtch()			-> schedule()
		kpreempt(unused)	-> cond_resched()

	- In the FreeBSD kernel:
		swtch()			-> kern_yield(PRI_UNCHANGED)
		kpreempt(unused)	-> kern_yield(PRI_USER)

	- In userspace:
		swtch()			-> sched_yield()
		kpreempt(unused)	-> sched_yield()

Both in the Linux kernel and in userspace, nothing changes from this
cleanup. In the FreeBSD kernel, the function `fm_fini()` will call
`kern_swtch(PRI_UNCHANGED)` instead of `pause("schedule", 1)`, which
makes its behavior analogous to the Linux behavior. The `fm_fini()`
function appears to have originally been written against Linux, so
mimicking the Linux behavior should be correct.

Note that Linux's SPL continues to use `cond_resched()` and `schedule()`.
However, those functions have been removed from both the FreeBSD code
and userspace code.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
No testing has been done. On Linux, the compiled binary is expected to be the same, so only compile testing by the buildbot is considered necessary. On FreeBSD, only a single call into the scheduler changes to a definition that is more appropriate. Compile testing should also be sufficient there.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
