### PR TITLE
Fix build on FreeBSD/powerpc64*

### DIFF
--- a/module/icp/algs/blake3/blake3_x86-64.c
+++ b/module/icp/algs/blake3/blake3_x86-64.c
@@ -74,7 +74,7 @@ static boolean_t blake3_is_sse2_supported(void)
 {
 #if defined(__x86_64)
 	return (kfpu_allowed() && zfs_sse2_available());
-#elif defined(__PPC64__)
+#elif defined(__PPC64__) && defined(__linux__)
 	return (kfpu_allowed() && zfs_vsx_available());
 #else
 	return (kfpu_allowed());
@@ -140,7 +140,7 @@ static boolean_t blake3_is_sse41_supported(void)
 {
 #if defined(__x86_64)
 	return (kfpu_allowed() && zfs_sse4_1_available());
-#elif defined(__PPC64__)
+#elif defined(__PPC64__) && defined(__linux__)
 	return (kfpu_allowed() && zfs_vsx_available());
 #else
 	return (kfpu_allowed());


### PR DESCRIPTION
There's no VSX handler on FreeBSD for now.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Build issue:
```
cc  -O2 -pipe  -std=gnu99 -Wno-format-zero-length -nobuiltininc -idirafter /usr/lib/clang/13.0.0/include -fstack-protector-strong -Wall -Wredundant-decls -Wnested-externs -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wcast-qual -Wundef -Wno-pointer-sign -D__printf__=__freebsd_kprintf__ -Wmissing-include-dirs -fdiagnostics-show-option -Wno-unknown-pragmas -Wno-error=tautological-compare -Wno-error=empty-body -Wno-error=parentheses-equality -Wno-error=unused-function -Wno-error=pointer-sign -Wno-error=shift-negative-value -Wno-address-of-packed-member -Wno-error=unused-but-set-variable -Wno-format-zero-length   -Qunused-arguments    -include /wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/include/os/freebsd/spl/sys/ccompile.h -D__KERNEL__ -DFREEBSD_NAMECACHE -DBUILDING_ZFS -D__BSD_VISIBLE=1 -DHAVE_UIO_ZEROCOPY -DWITHOUT_NETDUMP -D__KERNEL -D_SYS_CONDVAR_H_ -D_SYS_VMEM_H_ -DKDTRACE_HOOKS -DSMP -DCOMPAT_FREEBSD11 -DNDEBUG -DBITS_PER_LONG=64 -fno-strict-aliasing -Werror -D_KERNEL -DKLD_MODULE -nostdinc  -I/wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/include -I/wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/include -I/wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/include/os/freebsd -I/wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/include/os/freebsd/spl -I/wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/include/os/freebsd/zfs -I/wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/module/zstd/include -I/wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/module/icp/include -include /wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/module/opt_global.h -I. -I/usr/src/sys -I/usr/src/sys/contrib/ck/include -fno-common -g -fPIC -mlongcall -fno-omit-frame-pointer -fdebug-prefix-map=./machine=/usr/src/sys/powerpc/include     -MD  -MF.depend.blake3_x86-64.o -MTblake3_x86-64.o -mno-altivec -msoft-float -mabi=elfv2 -ffreestanding -fwrapv -fstack-protector -Wall -Wredundant-decls -Wnested-externs -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wcast-qual -Wundef -Wno-pointer-sign -D__printf__=__freebsd_kprintf__ -Wmissing-include-dirs -fdiagnostics-show-option -Wno-unknown-pragmas -Wno-error=tautological-compare -Wno-error=empty-body -Wno-error=parentheses-equality -Wno-error=unused-function -Wno-error=pointer-sign -Wno-error=shift-negative-value -Wno-address-of-packed-member -Wno-error=unused-but-set-variable -Wno-format-zero-length   -Qunused-arguments  -std=iso9899:1999 -c /wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/module/icp/algs/blake3/blake3_x86-64.c -o blake3_x86-64.o
/wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/module/icp/algs/blake3/blake3_x86-64.c:78:28: error: implicit declaration of function 'zfs_vsx_available' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        return (kfpu_allowed() && zfs_vsx_available());
                                  ^
/wrkdirs/usr/ports/sysutils/openzfs-kmod/work/zfs-2d5622f5b/module/icp/algs/blake3/blake3_x86-64.c:144:28: error: implicit declaration of function 'zfs_vsx_available' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        return (kfpu_allowed() && zfs_vsx_available());
```

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Build-time and run-time.
<!--- Include details of your testing environment, and the tests you ran to -->
FreeBSD 14.0-CURRENT on powerpc64, usage of the system.
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
