### PR TITLE
Fix theoretical infinite loop in vdev removal

### DIFF
--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -81,12 +81,12 @@
  */
 
 typedef struct vdev_copy_arg {
-	metaslab_t	*vca_msp;
-	uint64_t	vca_outstanding_bytes;
-	uint64_t	vca_read_error_bytes;
-	uint64_t	vca_write_error_bytes;
-	kcondvar_t	vca_cv;
-	kmutex_t	vca_lock;
+	metaslab_t		*vca_msp;
+	volatile uint64_t	vca_outstanding_bytes;
+	uint64_t		vca_read_error_bytes;
+	uint64_t		vca_write_error_bytes;
+	kcondvar_t		vca_cv;
+	kmutex_t		vca_lock;
 } vdev_copy_arg_t;
 
 /*


### PR DESCRIPTION


### Motivation and Context
Coverity complained that this is an infinite loop. 

### Description
<!--- Describe your changes in detail -->
Whether it is or is not an infinite loop depends on the compiler. If the compiler caches vca.vca_outstanding_bytes across loop iterations, then we have an infinite loop. At present, I assume that the compiler does not do this because the code would never have worked had it done that. However, I do not see any reason to think that the compiler will never do this.  To protect ourselves, we should mark the structure member volatile. This should signal the compiler that it should *NEVER* cache the value.
### How Has This Been Tested?
The buildbot is expected to do testing for us.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
