### PR TITLE
Undefine NDEBUG when both NDEBUG and DEBUG are set

### DIFF
--- a/include/os/linux/spl/sys/debug.h
+++ b/include/os/linux/spl/sys/debug.h
@@ -120,6 +120,11 @@ void spl_dumpstack(void);
 		    (long long) (_verify3_right));			\
 	} while (0)
 
+/* Workaround possible coverity bug */
+#if defined(DEBUG) && defined(NDEBUG)
+#undef NDEBUG
+#endif
+
 /*
  * Debugging disabled (--disable-debug)
  */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Coverity insists that the NDEBUG macros are being used despite being given debug builds. This is causing it to report false positives in places where assertions would ordinarily prevent false positives. I suspect this is a bug in coverity's interpretation of `-UNDEBUG`.

It occurred to me that we could defensively undefine NDEBUG when both NDEBUG and DEBUG are set. This should prevent someone from accidentally using this configuration and should also workaround the coverity bug.

### Description
We unset NDEBUG when both DEBUG and NDEBUG are set.

### How Has This Been Tested?
The buildbot can test this for us.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
