### PR TITLE
Fix null pointer dereferences in PAM

### DIFF
--- a/contrib/pam_zfs_key/pam_zfs_key.c
+++ b/contrib/pam_zfs_key/pam_zfs_key.c
@@ -531,7 +531,6 @@ zfs_key_config_get_dataset(zfs_key_config_t *config)
 		if (zhp == NULL) {
 			pam_syslog(NULL, LOG_ERR, "dataset %s not found",
 			    config->homes_prefix);
-			zfs_close(zhp);
 			return (NULL);
 		}
 
@@ -541,6 +540,10 @@ zfs_key_config_get_dataset(zfs_key_config_t *config)
 		char *dsname = config->dsname;
 		config->dsname = NULL;
 		return (dsname);
+	}
+
+	if (config->homes_prefix == NULL) {
+		return (NULL);
 	}
 
 	size_t len = ZFS_MAX_DATASET_NAME_LEN;


### PR DESCRIPTION
### Motivation and Context
Coverity caught these.

### Description
We fix them.

### How Has This Been Tested?
I am letting the buildbot test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
