### PR TITLE
CI: revert `--with-config=dist` to hotfix Ubuntu 20.04

### DIFF
--- a/.github/workflows/zfs-tests-functional.yml
+++ b/.github/workflows/zfs-tests-functional.yml
@@ -28,7 +28,7 @@ jobs:
         ./autogen.sh
     - name: Configure
       run: |
-        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan --with-config=dist
+        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan
     - name: Make
       run: |
         make -j$(nproc) --no-print-directory --silent pkg-utils pkg-kmod

--- a/.github/workflows/zfs-tests-sanity.yml
+++ b/.github/workflows/zfs-tests-sanity.yml
@@ -24,7 +24,7 @@ jobs:
         ./autogen.sh
     - name: Configure
       run: |
-        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan --with-config=dist
+        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan
     - name: Make
       run: |
         make -j$(nproc) --no-print-directory --silent pkg-utils pkg-kmod

--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -23,7 +23,7 @@ jobs:
         ./autogen.sh
     - name: Configure
       run: |
-        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan --with-config=dist
+        ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan
     - name: Make
       run: |
         make -j$(nproc) --no-print-directory --silent pkg-utils pkg-kmod


### PR DESCRIPTION
### Motivation and Context
Recently Github action runners started to fail on kmod build:
```
 2022-09-09T21:41:02.5168127Z checking for C compiler default output file name... a.out
 2022-09-09T21:41:02.5513924Z warning: line 101: Invalid version (double separator '-'): 5.15.0-1017-azure: Provides:         kernel-modules-for-kernel = 5.15.0-1017-azure
 2022-09-09T21:41:02.5514577Z warning: line 101: Invalid version (double separator '-'): 5.15.0-1017-azure: Provides:         kmod-zfs-uname-r = 5.15.0-1017-azure
 2022-09-09T21:41:02.5515337Z warning: line 101: Invalid version (double separator '-'): 5.15.0-1017-azure: Provides:         kernel-objects-for-kernel = 5.15.0-1017-azure
 2022-09-09T21:41:02.5515918Z warning: line 101: Invalid version (double separator '-'): 5.15.0-1017-azure: Provides:         kmod-zfs-devel-uname-r = 5.15.0-1017-azure
 2022-09-09T21:41:02.5516508Z warning: line 101: Invalid version (double separator '-'): 5.15.0-1019-azure: Provides:         kernel-modules-for-kernel = 5.15.0-1019-azure
 2022-09-09T21:41:02.5517075Z warning: line 101: Invalid version (double separator '-'): 5.15.0-1019-azure: Provides:         kmod-zfs-uname-r = 5.15.0-1019-azure
 2022-09-09T21:41:02.5517475Z error: line 101: %package       -n kmod-zfs-devel
 2022-09-09T21:41:02.5517794Z : package kmod-zfs-devel already exists
 2022-09-09T21:41:02.5518193Z checking for suffix of executables... Installing zfs-kmod-2.1.99-1.src.rpm
 2022-09-09T21:41:02.5522886Z make[1]: *** [Makefile:13915: rpm-common] Error 1
 2022-09-09T21:41:02.5523215Z make: *** [Makefile:13854: rpm-kmod] Error 2
 2022-09-09T21:41:02.5523473Z make: *** Waiting for unfinished jobs....
```
Looks like it's a problem with rpm spec file. 

I hadn't a time until my vacation to properly dig into root cause, but I've bisected it at least to https://github.com/openzfs/zfs/commit/d98a67a53a180bd88ec8d9aeea75d92e1c9968b5

### Description
Revert `--with-config=dist` from `./configure` section of github runners to stabilize CI for now.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
https://github.com/gmelikov/zfs/actions/runs/3056269854

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] CI fix
