### PR TITLE
Update coverity model

### DIFF
--- a/contrib/coverity/model.c
+++ b/contrib/coverity/model.c
@@ -70,9 +70,24 @@ panic(const char *fmt, ...)
 void
 vpanic(const char *fmt, va_list adx)
 {
-	(void) fmt;
 	(void) adx;
 
+	__coverity_format_string_sink__(fmt);
+	__coverity_panic__();
+}
+
+void
+uu_panic(const char *format, ...)
+{
+	__coverity_format_string_sink__(format);
+	__coverity_panic__();
+}
+
+int
+libspl_assertf(const char *file, const char *func, int line,
+    const char *format, ...)
+{
+	__coverity_format_string_sink__(format);
 	__coverity_panic__();
 }
 


### PR DESCRIPTION
### Motivation and Context
When doing #13900, I noticed that our coverity model needed some minor improvements.

### Description
`uu_panic()` needs to be modelled and the definition of `vpanic()` from the original coverity model was missing
`__coverity_format_string_sink__()`.

### How Has This Been Tested?
It was given to coverity and coverity accepted it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
