### PR TITLE
Fix unchecked return values and unused return values

### DIFF
--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -326,7 +326,8 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 
 	fmd_hdl_debug(hdl, "zfs_retire_recv: '%s'", class);
 
-	nvlist_lookup_uint64(nvl, FM_EREPORT_PAYLOAD_ZFS_VDEV_STATE, &state);
+	(void) nvlist_lookup_uint64(nvl, FM_EREPORT_PAYLOAD_ZFS_VDEV_STATE,
+	    &state);
 
 	/*
 	 * If this is a resource notifying us of device removal then simply

--- a/cmd/zpool_influxdb/zpool_influxdb.c
+++ b/cmd/zpool_influxdb/zpool_influxdb.c
@@ -265,7 +265,7 @@ get_vdev_name(nvlist_t *nvroot, const char *parent_name)
 	uint64_t vdev_id = 0;
 
 	char *vdev_type = (char *)"unknown";
-	nvlist_lookup_string(nvroot, ZPOOL_CONFIG_TYPE, &vdev_type);
+	(void) nvlist_lookup_string(nvroot, ZPOOL_CONFIG_TYPE, &vdev_type);
 
 	if (nvlist_lookup_uint64(
 	    nvroot, ZPOOL_CONFIG_ID, &vdev_id) != 0)
@@ -302,9 +302,9 @@ get_vdev_desc(nvlist_t *nvroot, const char *parent_name)
 	char *vdev_type = (char *)"unknown";
 	uint64_t vdev_id = UINT64_MAX;
 	char *vdev_path = NULL;
-	nvlist_lookup_string(nvroot, ZPOOL_CONFIG_TYPE, &vdev_type);
-	nvlist_lookup_uint64(nvroot, ZPOOL_CONFIG_ID, &vdev_id);
-	nvlist_lookup_string(nvroot, ZPOOL_CONFIG_PATH, &vdev_path);
+	(void) nvlist_lookup_string(nvroot, ZPOOL_CONFIG_TYPE, &vdev_type);
+	(void) nvlist_lookup_uint64(nvroot, ZPOOL_CONFIG_ID, &vdev_id);
+	(void) nvlist_lookup_string(nvroot, ZPOOL_CONFIG_PATH, &vdev_path);
 
 	if (parent_name == NULL) {
 		s = escape_string(vdev_type);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2214,7 +2214,7 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 		dmu_write(os, lr->lr_foid, offset, length, data, tx);
 	} else {
 		memcpy(abuf->b_data, data, length);
-		dmu_assign_arcbuf_by_dbuf(db, offset, abuf, tx);
+		VERIFY0(dmu_assign_arcbuf_by_dbuf(db, offset, abuf, tx));
 	}
 
 	(void) ztest_log_write(zd, tx, lr);

--- a/lib/libzfsbootenv/lzbe_device.c
+++ b/lib/libzfsbootenv/lzbe_device.c
@@ -74,6 +74,7 @@ lzbe_set_boot_device(const char *pool, lzbe_flags_t flag, const char *device)
 	/* version is mandatory */
 	fnvlist_add_uint64(nv, BOOTENV_VERSION, VB_NVLIST);
 
+	rv = 0;
 	/*
 	 * If device name is empty, remove boot device configuration.
 	 */
@@ -95,8 +96,8 @@ lzbe_set_boot_device(const char *pool, lzbe_flags_t flag, const char *device)
 				rv = ENOMEM;
 		}
 	}
-
-	rv = zpool_set_bootenv(zphdl, nv);
+	if (rv == 0)
+		rv = zpool_set_bootenv(zphdl, nv);
 	if (rv != 0)
 		fprintf(stderr, "%s\n", libzfs_error_description(hdl));
 

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -1874,6 +1874,8 @@ receive_object(struct receive_writer_arg *rwa, struct drr_object *drro,
 	if (err == 0) {
 		err = receive_handle_existing_object(rwa, drro, &doi, data,
 		    &object_to_hold, &new_blksz);
+		if (err != 0)
+			return (err);
 	} else if (err == EEXIST) {
 		/*
 		 * The object requested is currently an interior slot of a

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -270,7 +270,7 @@ dsl_dir_hold_obj(dsl_pool_t *dp, uint64_t ddobj,
 
 		if (dsl_dir_is_zapified(dd)) {
 			inode_timespec_t t = {0};
-			zap_lookup(dp->dp_meta_objset, ddobj,
+			(void) zap_lookup(dp->dp_meta_objset, ddobj,
 			    DD_FIELD_SNAPSHOTS_CHANGED,
 			    sizeof (uint64_t),
 			    sizeof (inode_timespec_t) / sizeof (uint64_t),

--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -1389,17 +1389,17 @@ zfs_post_state_change(spa_t *spa, vdev_t *vd, uint64_t laststate)
 	aux = fm_nvlist_create(NULL);
 	if (vd && aux) {
 		if (vd->vdev_physpath) {
-			(void) nvlist_add_string(aux,
+			fnvlist_add_string(aux,
 			    FM_EREPORT_PAYLOAD_ZFS_VDEV_PHYSPATH,
 			    vd->vdev_physpath);
 		}
 		if (vd->vdev_enc_sysfs_path) {
-			(void) nvlist_add_string(aux,
+			fnvlist_add_string(aux,
 			    FM_EREPORT_PAYLOAD_ZFS_VDEV_ENC_SYSFS_PATH,
 			    vd->vdev_enc_sysfs_path);
 		}
 
-		(void) nvlist_add_uint64(aux,
+		fnvlist_add_uint64(aux,
 		    FM_EREPORT_PAYLOAD_ZFS_VDEV_LASTSTATE, laststate);
 	}
 
@@ -1496,12 +1496,12 @@ zfs_ereport_zvol_post(const char *subclass, const char *name,
 		return;
 
 	aux = fm_nvlist_create(NULL);
-	nvlist_add_string(aux, FM_EREPORT_PAYLOAD_ZFS_DEVICE_NAME, dev_name);
-	nvlist_add_string(aux, FM_EREPORT_PAYLOAD_ZFS_RAW_DEVICE_NAME,
+	fnvlist_add_string(aux, FM_EREPORT_PAYLOAD_ZFS_DEVICE_NAME, dev_name);
+	fnvlist_add_string(aux, FM_EREPORT_PAYLOAD_ZFS_RAW_DEVICE_NAME,
 	    raw_name);
 	r = strchr(name, '/');
 	if (r && r[1])
-		nvlist_add_string(aux, FM_EREPORT_PAYLOAD_ZFS_VOLUME, &r[1]);
+		fnvlist_add_string(aux, FM_EREPORT_PAYLOAD_ZFS_VOLUME, &r[1]);
 
 	zfs_post_common(spa, NULL, FM_RSRC_CLASS, subclass, aux);
 	fm_nvlist_destroy(aux, FM_NVA_FREE);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -429,7 +429,7 @@ zvol_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 	if (error != 0) {
 		dmu_tx_abort(tx);
 	} else {
-		zil_replaying(zv->zv_zilog, tx);
+		(void) zil_replaying(zv->zv_zilog, tx);
 		dmu_tx_commit(tx);
 		error = dmu_free_long_range(zv->zv_objset, ZVOL_OBJ, offset,
 		    length);
@@ -475,7 +475,7 @@ zvol_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 		dmu_tx_abort(tx);
 	} else {
 		dmu_write(os, ZVOL_OBJ, offset, length, data, tx);
-		zil_replaying(zv->zv_zilog, tx);
+		(void) zil_replaying(zv->zv_zilog, tx);
 		dmu_tx_commit(tx);
 	}
 

--- a/tests/zfs-tests/cmd/draid.c
+++ b/tests/zfs-tests/cmd/draid.c
@@ -139,7 +139,7 @@ read_map_key(const char *filename, const char *key, nvlist_t **cfg)
 	if (error != 0)
 		return (error);
 
-	nvlist_lookup_nvlist(allcfgs, key, &foundcfg);
+	(void) nvlist_lookup_nvlist(allcfgs, key, &foundcfg);
 	if (foundcfg != NULL) {
 		nvlist_dup(foundcfg, cfg, KM_SLEEP);
 		error = 0;
@@ -375,7 +375,7 @@ dump_map_nv(const char *key, nvlist_t *cfg, int verbose)
 	map.dm_checksum = fnvlist_lookup_uint64(cfg, MAP_CHECKSUM);
 	map.dm_children = fnvlist_lookup_uint64(cfg, MAP_CHILDREN);
 	map.dm_nperms = fnvlist_lookup_uint64(cfg, MAP_NPERMS);
-	nvlist_lookup_uint8_array(cfg, MAP_PERMS, &map.dm_perms, &c);
+	map.dm_perms = fnvlist_lookup_uint8_array(cfg, MAP_PERMS, &c);
 
 	dump_map(&map, key, (double)worst_ratio / 1000.0,
 	    avg_ratio / 1000.0, verbose);

--- a/tests/zfs-tests/cmd/file/file_fadvise.c
+++ b/tests/zfs-tests/cmd/file/file_fadvise.c
@@ -89,7 +89,11 @@ main(int argc, char *argv[])
 		return (1);
 	}
 
-	posix_fadvise(fd, 0, 0, advise);
+	if (posix_fadvise(fd, 0, 0, advise) != 0) {
+		perror("posix_fadvise");
+		close(fd);
+		return (1);
+	}
 
 	close(fd);
 

--- a/tests/zfs-tests/cmd/mmap_sync.c
+++ b/tests/zfs-tests/cmd/mmap_sync.c
@@ -32,7 +32,7 @@
 static void
 cleanup(char *file)
 {
-	remove(file);
+	(void) remove(file);
 }
 
 int
@@ -125,7 +125,8 @@ main(int argc, char *argv[])
 		elapsed += ((t2.tv_usec - t1.tv_usec) / 1000.0);
 		if (elapsed > max_msync_time_ms) {
 			fprintf(stderr, "slow msync: %f ms\n", elapsed);
-			munmap(ptr, LEN);
+			if (munmap(ptr, LEN) != 0)
+				perror("munmap");
 			cleanup(file);
 			return (1);
 		}

--- a/tests/zfs-tests/cmd/mmapwrite.c
+++ b/tests/zfs-tests/cmd/mmapwrite.c
@@ -73,7 +73,11 @@ normal_writer(void *filename)
 			err(1, "write failed!");
 			break;
 		}
-		lseek(fd, page_size, SEEK_CUR);
+		if (lseek(fd, page_size, SEEK_CUR) == -1) {
+			err(1, "lseek failed on %s: %s", file_path,
+			    strerror(errno));
+			break;
+		}
 	}
 }
 


### PR DESCRIPTION
### Motivation and Context
Coverity complained about unchecked return values and unused values that turned out to be unused return values.

### Description
Different approaches were used to handle the different cases.

* cmd/zdb/zdb.c: VERIFY0 was used since the existing code had no error handling.
* cmd/zed/agents/zfs_retire.c: We dismiss the return value with `(void)` because the values are expected to be potentially unset.
* cmd/zpool_influxdb/zpool_influxdb.c: We dismiss the return value with `(void)` because the values are expected to be potentially unset.
* cmd/ztest.c: VERIFY0 was used since we want failures if something goes wrong in ztest.
* module/zfs/dsl_dir.c: We dismiss the return value with `(void)` because there is no guarantee that the zap entry will always be there. For example, old pools imported readonly would not have it and we do not want to fail here because of that.
* module/zfs/zfs_fm.c: `fnvlist_add_*()` was used since the allocations sleep and thus can never fail.
* module/zfs/zvol.c: We dismiss the return value with `(void)` because we do not need it. This matches what is already done in the analogous `zfs_replay_write2()`.

As for unused return values, they were all in places where there was error handling, so logic was added to handle the return values.

### How Has This Been Tested?
A build test was done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
