### PR TITLE
ZTS: fallocate tests fail with hard coded values

### DIFF
--- a/tests/zfs-tests/tests/functional/fallocate/fallocate_zero-range.ksh
+++ b/tests/zfs-tests/tests/functional/fallocate/fallocate_zero-range.ksh
@@ -23,6 +23,7 @@
 #
 # Copyright (c) 2020 by Lawrence Livermore National Security, LLC.
 # Copyright (c) 2021 by The FreeBSD Foundation.
+# Copyright (c) 2022 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -34,6 +35,10 @@
 # STRATEGY:
 # 1. Create a dense file
 # 2. Zero various ranges in the file and verify the result.
+#
+# Note: We can't compare exact block numbers as reported by du, because
+# different backing stores may allocate different numbers of blocks for
+# the same amount of data.
 #
 
 verify_runnable "global"
@@ -50,28 +55,24 @@ function cleanup
 	[[ -e $TESTDIR ]] && log_must rm -f $FILE
 }
 
-# Helpfully, this function expects kilobytes, and check_apparent_size expects bytes.
-function check_reported_size
+function get_reported_size
 {
-	typeset expected_size=$1
-
-	if ! [ -e "${FILE}" ]; then
+	if ! [ -e "$FILE" ]; then
 		log_fail "$FILE does not exist"
 	fi
-		
-	reported_size=$(du "${FILE}" | awk '{print $1}')
-	if [ "$reported_size" != "$expected_size" ]; then
-		log_fail "Incorrect reported size: $reported_size != $expected_size"
-	fi
+
+	sync_pool $TESTPOOL >/dev/null 2>&1
+	du "$FILE" | awk '{print $1}'
 }
 
 function check_apparent_size
 {
 	typeset expected_size=$1
 
-	apparent_size=$(stat_size "${FILE}")
+	apparent_size=$(stat_size "$FILE")
 	if [ "$apparent_size" != "$expected_size" ]; then
-		log_fail "Incorrect apparent size: $apparent_size != $expected_size"
+		log_fail \
+		    "Incorrect apparent size: $apparent_size != $expected_size"
 	fi
 }
 
@@ -82,38 +83,46 @@ log_onexit cleanup
 # Create a dense file and check it is the correct size.
 log_must file_write -o create -f $FILE -b $BLKSZ -c 8
 sync_pool $TESTPOOL
-log_must check_reported_size 1027
+full_size=$(get_reported_size)
 
-# Zero a range covering the first full block.
+# Zero a range covering the first full block. The reported size should decrease.
 log_must zero_range 0 $BLKSZ $FILE
-sync_pool $TESTPOOL
-log_must check_reported_size 899
+one_range=$(get_reported_size)
+[[ $full_size -gt $one_range ]] || log_fail \
+    "One range failure: $full_size -> $one_range"
 
-# Partially zero a range in the second block.
+# Partially zero a range in the second block. The reported size should
+# remain constant.
 log_must zero_range $BLKSZ $((BLKSZ / 2)) $FILE
-sync_pool $TESTPOOL
-log_must check_reported_size 899
+partial_range=$(get_reported_size)
+[[ $one_range -eq $partial_range ]] || log_fail \
+    "Partial range failure: $one_range -> $partial_range"
 
-# Zero range which overlaps the third and fourth block.
+# Zero range which overlaps the third and fourth block. The reported size
+# should remain constant.
 log_must zero_range $(((BLKSZ * 2) + (BLKSZ / 2))) $((BLKSZ)) $FILE
-sync_pool $TESTPOOL
-log_must check_reported_size 899
+overlap_range=$(get_reported_size)
+[[ $one_range -eq $overlap_range ]] || log_fail \
+    "Overlap range failure: $one_range -> $overlap_range"
 
 # Zero range from the fifth block past the end of file, with --keep-size.
-# The apparent file size must not change, since we did specify --keep-size.
+# The reported size should decrease, and the apparent file size must not
+# change, since we did specify --keep-size.
 apparent_size=$(stat_size $FILE)
 log_must fallocate --keep-size --zero-range --offset $((BLKSZ * 4)) --length $((BLKSZ * 10)) "$FILE"
-sync_pool $TESTPOOL
-log_must check_reported_size 387
+eof_range=$(get_reported_size)
+[[ $overlap_range -gt $eof_range ]] || log_fail \
+    "EOF range failure: $overlap_range -> $eof_range"
 log_must check_apparent_size $apparent_size
 
 # Zero range from the fifth block past the end of file.  The apparent
 # file size should change since --keep-size is not implied, unlike
-# with PUNCH_HOLE.
+# with PUNCH_HOLE. The reported size should remain constant.
 apparent_size=$(stat_size $FILE)
 log_must zero_range $((BLKSZ * 4)) $((BLKSZ * 10)) $FILE
-sync_pool $TESTPOOL
-log_must check_reported_size 387
+eof_range2=$(get_reported_size)
+[[ $eof_range -eq $eof_range2 ]] || log_fail \
+    "Second EOF range failure: $eof_range -> $eof_range2"
 log_must check_apparent_size $((BLKSZ * 14))
 
 log_pass "Ensure ranges can be zeroed in files"


### PR DESCRIPTION
### Motivation and Context
Some of the fallocate tests fail if run on backing stores with different sector sizes.

### Description
Currently, these two tests pass on disks with 512 byte sectors. In environments where the backing store is different, the number of blocks allocated to write the same file may differ. This change modifes the reported size check to detect an expected change in the reported number of blocks without specifying a particular number.

A breakdown of the block count at different stages of the test in different environments:
```
                                        AWS     Azure   Object Store
Create file                             1027    1033    1026
Punch hole block 1                      899     905     898
Punch partial hole in block 2           899     905     898
Punch hole that overlaps blocks 3+4     899     905     898
Punch hole from fifth past eof          387     393     386
```
### How Has This Been Tested?
Ran the fallocate tests locally in AWS, Azure and on object storage.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
