### PR TITLE
btree_test: smatch did detect few issues

### DIFF
--- a/tests/zfs-tests/cmd/btree_test.c
+++ b/tests/zfs-tests/cmd/btree_test.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/avl.h>
 #include <sys/btree.h>
 #include <sys/time.h>
@@ -164,7 +165,7 @@ find_without_index(zfs_btree_t *bt, char *why)
 	zfs_btree_add(bt, &i);
 	if ((p = (u_longlong_t *)zfs_btree_find(bt, &i, NULL)) == NULL ||
 	    *p != i) {
-		snprintf(why, BUFSIZE, "Unexpectedly found %llu\n",
+		(void) snprintf(why, BUFSIZE, "Unexpectedly found %llu\n",
 		    p == NULL ? 0 : *p);
 		return (1);
 	}
@@ -172,7 +173,7 @@ find_without_index(zfs_btree_t *bt, char *why)
 	i++;
 
 	if ((p = (u_longlong_t *)zfs_btree_find(bt, &i, NULL)) != NULL) {
-		snprintf(why, BUFSIZE, "Found bad value: %llu\n", *p);
+		(void) snprintf(why, BUFSIZE, "Found bad value: %llu\n", *p);
 		return (1);
 	}
 
@@ -189,10 +190,10 @@ insert_find_remove(zfs_btree_t *bt, char *why)
 	/* Insert 'i' into the tree, and attempt to find it again. */
 	zfs_btree_add(bt, &i);
 	if ((p = (u_longlong_t *)zfs_btree_find(bt, &i, &bt_idx)) == NULL) {
-		snprintf(why, BUFSIZE, "Didn't find value in tree\n");
+		(void) snprintf(why, BUFSIZE, "Didn't find value in tree\n");
 		return (1);
 	} else if (*p != i) {
-		snprintf(why, BUFSIZE, "Found (%llu) in tree\n", *p);
+		(void) snprintf(why, BUFSIZE, "Found (%llu) in tree\n", *p);
 		return (1);
 	}
 	ASSERT3S(zfs_btree_numnodes(bt), ==, 1);
@@ -201,7 +202,8 @@ insert_find_remove(zfs_btree_t *bt, char *why)
 	/* Remove 'i' from the tree, and verify it is not found. */
 	zfs_btree_remove(bt, &i);
 	if ((p = (u_longlong_t *)zfs_btree_find(bt, &i, &bt_idx)) != NULL) {
-		snprintf(why, BUFSIZE, "Found removed value (%llu)\n", *p);
+		(void) snprintf(why, BUFSIZE,
+		    "Found removed value (%llu)\n", *p);
 		return (1);
 	}
 	ASSERT3S(zfs_btree_numnodes(bt), ==, 0);
@@ -240,9 +242,12 @@ drain_tree(zfs_btree_t *bt, char *why)
 		zfs_btree_add_idx(bt, &randval, &bt_idx);
 
 		node = malloc(sizeof (int_node_t));
+		ASSERT3P(node, !=, NULL);
+
 		node->data = randval;
 		if ((ret = avl_find(&avl, node, &avl_idx)) != NULL) {
-			snprintf(why, BUFSIZE, "Found in avl: %llu\n", randval);
+			(void) snprintf(why, BUFSIZE,
+			    "Found in avl: %llu\n", randval);
 			return (1);
 		}
 		avl_insert(&avl, node, avl_idx);
@@ -422,7 +427,8 @@ do_negative_test(zfs_btree_t *bt, char *test_name)
 {
 	int rval = 0;
 	struct rlimit rlim = {0};
-	setrlimit(RLIMIT_CORE, &rlim);
+
+	(void) setrlimit(RLIMIT_CORE, &rlim);
 
 	if (strcmp(test_name, "insert_duplicate") == 0) {
 		rval = insert_duplicate(bt);


### PR DESCRIPTION
Add missing header.
Properly ignore return values.

Memory leak/unchecked malloc. We do allocate a bit too early (and fail to validate the result). From this, smatch is angry when we overwrite the value of 'node' later.

Signed-off-by: Toomas Soome <tsoome@me.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
