### PR TITLE
Miscellaneous ZTS fixes

### DIFF
--- a/tests/zfs-tests/cmd/draid.c
+++ b/tests/zfs-tests/cmd/draid.c
@@ -93,8 +93,8 @@ read_map(const char *filename, nvlist_t **allcfgs)
 		rc = gzread(fp, buf + bytes, block_size);
 		if ((rc < 0) || (rc == 0 && !gzeof(fp))) {
 			free(buf);
-			(void) gzclose(fp);
 			(void) gzerror(fp, &error);
+			(void) gzclose(fp);
 			return (error);
 		} else {
 			bytes += rc;
@@ -505,6 +505,8 @@ eval_resilver(draid_map_t *map, uint64_t groupwidth, uint64_t nspares,
 
 	int *ios = calloc(map->dm_children, sizeof (uint64_t));
 
+	ASSERT3P(ios, !=, NULL);
+
 	/* Resilver all rows */
 	for (int i = 0; i < map->dm_nperms; i++) {
 		uint8_t *row = &map->dm_perms[i * map->dm_children];
@@ -767,7 +769,7 @@ static int
 draid_generate(int argc, char *argv[])
 {
 	char filename[MAXPATHLEN] = {0};
-	uint64_t map_seed;
+	uint64_t map_seed[2];
 	int c, fd, error, verbose = 0, passes = 1, continuous = 0;
 	int min_children = VDEV_DRAID_MIN_CHILDREN;
 	int max_children = VDEV_DRAID_MAX_CHILDREN;
@@ -844,7 +846,7 @@ restart:
 		ssize_t bytes_read = 0;
 
 		while (bytes_read < bytes) {
-			ssize_t rc = read(fd, ((char *)&map_seed) + bytes_read,
+			ssize_t rc = read(fd, ((char *)map_seed) + bytes_read,
 			    bytes - bytes_read);
 			if (rc < 0) {
 				printf("Unable to read /dev/urandom: %s\n:",
@@ -872,7 +874,7 @@ restart:
 		double worst_ratio = 1000.0;
 		double avg_ratio = 1000.0;
 
-		error = eval_maps(children, passes, &map_seed, &map,
+		error = eval_maps(children, passes, map_seed, &map,
 		    &worst_ratio, &avg_ratio);
 		if (error) {
 			printf("Error eval_maps(): %s\n", strerror(error));

--- a/tests/zfs-tests/cmd/file/file_trunc.c
+++ b/tests/zfs-tests/cmd/file/file_trunc.c
@@ -53,7 +53,7 @@ static long	fsize = FSIZE;
 static size_t	bsize = BSIZE;
 static int	count = 0;
 static int	rflag = 0;
-static int	seed = 0;
+static uint_t	seed = 0;
 static int	vflag = 0;
 static int	errflag = 0;
 static off_t	offset = 0;
@@ -105,7 +105,7 @@ parse_options(int argc, char *argv[])
 	extern int optind, optopt;
 
 	count = fsize / bsize;
-	seed = time(NULL);
+	seed = (uint_t)time(NULL);
 	while ((c = getopt(argc, argv, "b:c:f:o:rs:v")) != -1) {
 		switch (c) {
 			case 'b':

--- a/tests/zfs-tests/cmd/file/randwritecomp.c
+++ b/tests/zfs-tests/cmd/file/randwritecomp.c
@@ -152,6 +152,11 @@ main(int argc, char *argv[])
 		n = strtoull(argv[0], NULL, 0);
 
 	fd = open(filename, O_RDWR|O_CREAT, 0666);
+	if (fd == -1) {
+		(void) fprintf(stderr, "open(%s) failed: %s\n", filename,
+		    strerror(errno));
+		exit(EXIT_FAILURE);
+	}
 	err = fstat(fd, &ss);
 	if (err != 0) {
 		(void) fprintf(stderr,

--- a/tests/zfs-tests/cmd/get_diff.c
+++ b/tests/zfs-tests/cmd/get_diff.c
@@ -96,7 +96,7 @@ main(int argc, char *argv[])
 		off += bytes;
 	}
 
-	if (diff_len != 0 && diff_len != 0) {
+	if (diff_len != 0) {
 		(void) fprintf(stdout, "%lld,%lld\n", (long long)diff_off,
 		    (long long)diff_len);
 	}

--- a/tests/zfs-tests/cmd/libzfs_input_check.c
+++ b/tests/zfs-tests/cmd/libzfs_input_check.c
@@ -528,7 +528,11 @@ test_recv_new(const char *dataset, int fd)
 	ssize_t count;
 
 	int cleanup_fd = open(ZFS_DEV, O_RDWR);
-
+	if (cleanup_fd == -1) {
+		(void) fprintf(stderr, "open(%s) failed: %s\n", ZFS_DEV,
+		    strerror(errno));
+		exit(EXIT_FAILURE);
+	}
 	(void) snprintf(snapshot, sizeof (snapshot), "%s@replicant", dataset);
 
 	count = pread(fd, &drr, sizeof (drr), 0);

--- a/tests/zfs-tests/cmd/mmapwrite.c
+++ b/tests/zfs-tests/cmd/mmapwrite.c
@@ -66,7 +66,7 @@ normal_writer(void *filename)
 		err(1, "failed to open %s", file_path);
 	}
 
-	char buf;
+	char buf = 'z';
 	while (1) {
 		write_num = write(fd, &buf, 1);
 		if (write_num == 0) {

--- a/tests/zfs-tests/cmd/readmmap.c
+++ b/tests/zfs-tests/cmd/readmmap.c
@@ -55,7 +55,7 @@ main(int argc, char **argv)
 	char *buf = NULL;
 	char *map = NULL;
 	int fd = -1, bytes, retval = 0;
-	unsigned seed;
+	uint_t seed;
 
 	if (argc < 2 || optind == argc) {
 		(void) fprintf(stderr,
@@ -92,7 +92,7 @@ main(int argc, char **argv)
 		retval = 1;
 		goto end;
 	}
-	seed = time(NULL);
+	seed = (uint_t)time(NULL);
 	srandom(seed);
 
 	idx = random() % size;


### PR DESCRIPTION
### Motivation and Context
Coverity had various complaints about minor issues. They are all fairly straightforward to understand without reading additional files, with the exception of the draid.c issue. vdev_draid_rand() takes a 128-bit starting seed, but we were passing a pointer to a 64-bit value, which understandably made Coverity complain. This is perhaps the only significant issue fixed in this patch, since it causes stack corruption.

These are not all of the issues in the ZTS that Coverity caught, but a number of them are already fixed in other PRs. There is also a class of TOUTOC complaints that involve very minor things in the ZTS (e.g. access() before unlink()). I have yet to decide whether they are false positives (since this is not security sensitive code) or something to cleanup.

### How Has This Been Tested?
A build test has been done. The buildbot can verify that things are still working.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
