### PR TITLE
Fix unchecked return values

### DIFF
--- a/cmd/zpool_influxdb/zpool_influxdb.c
+++ b/cmd/zpool_influxdb/zpool_influxdb.c
@@ -687,8 +687,10 @@ print_recursive_stats(stat_printer_f func, nvlist_t *nvroot,
 		    sizeof (vdev_name));
 
 		for (c = 0; c < children; c++) {
-			print_recursive_stats(func, child[c], pool_name,
+			err = print_recursive_stats(func, child[c], pool_name,
 			    vdev_name, descend);
+			if (err)
+				return (err);
 		}
 	}
 	return (0);

--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -1461,7 +1461,7 @@ zfs_ereport_snapshot_post(const char *subclass, spa_t *spa, const char *name)
 	nvlist_t *aux;
 
 	aux = fm_nvlist_create(NULL);
-	nvlist_add_string(aux, FM_EREPORT_PAYLOAD_ZFS_SNAPSHOT_NAME, name);
+	fnvlist_add_string(aux, FM_EREPORT_PAYLOAD_ZFS_SNAPSHOT_NAME, name);
 
 	zfs_post_common(spa, NULL, FM_RSRC_CLASS, subclass, aux);
 	fm_nvlist_destroy(aux, FM_NVA_FREE);


### PR DESCRIPTION
### Motivation and Context
2a493a4c7127258b14c39e8c71a9d6f01167c5cd was intended to fix all instances of coverity reported unchecked return values, but unfortunately, two were missed by mistake. This commit fixes the unchecked return values that had been missed.

### Description
We switch from `nvlist_add_string()` to `fnvlist_add_string()` as we did for the others in `zfs_fm.c` and make `print_recursive_stats()` propagate errors to the original caller instead of continuing.

### How Has This Been Tested?
The buildbot will test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
