### PR TITLE
ZED: Enforce format specifier correctness

### DIFF
--- a/cmd/zed/agents/fmd_api.c
+++ b/cmd/zed/agents/fmd_api.c
@@ -125,14 +125,14 @@ fmd_hdl_unregister(fmd_hdl_t *hdl)
 	const fmd_hdl_ops_t *ops = mp->mod_info->fmdi_ops;
 
 	/* dump generic module stats */
-	fmd_hdl_debug(hdl, "%s: %llu", msp->ms_accepted.fmds_name,
+	fmd_hdl_debug(hdl, "%s: %"PRIu64, msp->ms_accepted.fmds_name,
 	    msp->ms_accepted.fmds_value.ui64);
 	if (ops->fmdo_close != NULL) {
-		fmd_hdl_debug(hdl, "%s: %llu", msp->ms_caseopen.fmds_name,
+		fmd_hdl_debug(hdl, "%s: %"PRIu64, msp->ms_caseopen.fmds_name,
 		    msp->ms_caseopen.fmds_value.ui64);
-		fmd_hdl_debug(hdl, "%s: %llu", msp->ms_casesolved.fmds_name,
+		fmd_hdl_debug(hdl, "%s: %"PRIu64, msp->ms_casesolved.fmds_name,
 		    msp->ms_casesolved.fmds_value.ui64);
-		fmd_hdl_debug(hdl, "%s: %llu", msp->ms_caseclosed.fmds_name,
+		fmd_hdl_debug(hdl, "%s: %"PRIu64, msp->ms_caseclosed.fmds_name,
 		    msp->ms_caseclosed.fmds_value.ui64);
 	}
 
@@ -141,7 +141,7 @@ fmd_hdl_unregister(fmd_hdl_t *hdl)
 		int i;
 
 		for (i = 0; i < mp->mod_ustat_cnt; i++) {
-			fmd_hdl_debug(hdl, "%s: %llu",
+			fmd_hdl_debug(hdl, "%s: %"PRIu64,
 			    mp->mod_ustat[i].fmds_name,
 			    mp->mod_ustat[i].fmds_value.ui64);
 		}
@@ -378,11 +378,11 @@ zed_log_fault(nvlist_t *nvl, const char *uuid, const char *code)
 			zed_log_msg(LOG_INFO, "\t%s: %s", FM_FMRI_SCHEME,
 			    strval);
 		if (nvlist_lookup_uint64(rsrc, FM_FMRI_ZFS_POOL, &guid) == 0)
-			zed_log_msg(LOG_INFO, "\t%s: %llu", FM_FMRI_ZFS_POOL,
+			zed_log_msg(LOG_INFO, "\t%s: %"PRIu64, FM_FMRI_ZFS_POOL,
 			    guid);
 		if (nvlist_lookup_uint64(rsrc, FM_FMRI_ZFS_VDEV, &guid) == 0)
-			zed_log_msg(LOG_INFO, "\t%s: %llu \n", FM_FMRI_ZFS_VDEV,
-			    guid);
+			zed_log_msg(LOG_INFO, "\t%s: %"PRIu64" \n",
+			    FM_FMRI_ZFS_VDEV, guid);
 	}
 }
 

--- a/cmd/zed/agents/fmd_api.h
+++ b/cmd/zed/agents/fmd_api.h
@@ -147,8 +147,10 @@ extern void fmd_hdl_free(fmd_hdl_t *, void *, size_t);
 extern char *fmd_hdl_strdup(fmd_hdl_t *, const char *, int);
 extern void fmd_hdl_strfree(fmd_hdl_t *, char *);
 
-extern void fmd_hdl_vdebug(fmd_hdl_t *, const char *, va_list);
-extern void fmd_hdl_debug(fmd_hdl_t *, const char *, ...);
+extern void fmd_hdl_vdebug(fmd_hdl_t *, const char *, va_list)
+    __attribute__((format(printf, 2, 0)));
+extern void fmd_hdl_debug(fmd_hdl_t *, const char *, ...)
+    __attribute__((format(printf, 2, 3)));
 
 extern int32_t fmd_prop_get_int32(fmd_hdl_t *, const char *);
 extern int64_t fmd_prop_get_int64(fmd_hdl_t *, const char *);

--- a/cmd/zed/agents/zfs_diagnosis.c
+++ b/cmd/zed/agents/zfs_diagnosis.c
@@ -562,10 +562,11 @@ zfs_fm_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl, const char *class)
 	 * once the pool is used.
 	 */
 	if (pool_found && timeval_earlier(&er_when, &pool_load)) {
-		fmd_hdl_debug(hdl, "ignoring pool %llx, "
-		    "ereport time %lld.%lld, pool load time = %lld.%lld",
-		    pool_guid, er_when.ertv_sec, er_when.ertv_nsec,
-		    pool_load.ertv_sec, pool_load.ertv_nsec);
+		fmd_hdl_debug(hdl, "ignoring pool %"PRIx64", "
+		    "ereport time %"PRId64".%"PRId64", pool load time = %"
+		    PRId64".%"PRId64, pool_guid, er_when.ertv_sec,
+		    er_when.ertv_nsec, pool_load.ertv_sec,
+		    pool_load.ertv_nsec);
 		zfs_stats.old_drops.fmds_value.ui64++;
 		return;
 	}
@@ -588,9 +589,9 @@ zfs_fm_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl, const char *class)
 			pool_found = B_TRUE;
 
 			if (timeval_earlier(&er_when, &pool_load)) {
-				fmd_hdl_debug(hdl, "ignoring pool %llx, "
-				    "ereport time %lld.%lld, "
-				    "pool load time = %lld.%lld",
+				fmd_hdl_debug(hdl, "ignoring pool %"PRIx64", "
+				    "ereport time %"PRId64".%"PRId64", "
+				    "pool load time = %"PRId64".%"PRId64,
 				    pool_guid, er_when.ertv_sec,
 				    er_when.ertv_nsec, pool_load.ertv_sec,
 				    pool_load.ertv_nsec);
@@ -610,7 +611,7 @@ zfs_fm_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl, const char *class)
 		 */
 		if (isresource) {
 			zfs_stats.resource_drops.fmds_value.ui64++;
-			fmd_hdl_debug(hdl, "discarding '%s for vdev %llu",
+			fmd_hdl_debug(hdl, "discarding '%s for vdev %"PRIu64,
 			    class, vdev_guid);
 			return;
 		}
@@ -633,8 +634,8 @@ zfs_fm_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl, const char *class)
 		 */
 		cs = fmd_case_open(hdl, NULL);
 
-		fmd_hdl_debug(hdl, "opening case for vdev %llu due to '%s'",
-		    vdev_guid, class);
+		fmd_hdl_debug(hdl, "opening case for vdev %"PRIu64
+		    " due to '%s'", vdev_guid, class);
 
 		/*
 		 * Initialize the case buffer.  To commonize code, we actually

--- a/cmd/zed/agents/zfs_mod.c
+++ b/cmd/zed/agents/zfs_mod.c
@@ -364,7 +364,7 @@ zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 	    (vs->vs_state != VDEV_STATE_FAULTED) &&
 	    (vs->vs_state != VDEV_STATE_CANT_OPEN)) {
 		zed_log_msg(LOG_INFO, "  not autoreplacing since disk isn't in "
-		    "a bad state (currently %llu)", vs->vs_state);
+		    "a bad state (currently %"PRIu64")", vs->vs_state);
 		return;
 	}
 
@@ -573,7 +573,8 @@ zfs_iter_vdev(zpool_handle_t *zhp, nvlist_t *nvl, void *data)
 		    &guid) != 0 || guid != dp->dd_vdev_guid) {
 			return;
 		}
-		zed_log_msg(LOG_INFO, "  zfs_iter_vdev: matched on %llu", guid);
+		zed_log_msg(LOG_INFO, "  zfs_iter_vdev: matched on %"PRIu64,
+		    guid);
 		dp->dd_found = B_TRUE;
 
 	} else if (dp->dd_compare != NULL) {
@@ -884,8 +885,8 @@ zfs_deliver_check(nvlist_t *nvl)
 	    data.dd_vdev_guid == 0)
 		return (0);
 
-	zed_log_msg(LOG_INFO, "zfs_deliver_check: pool '%llu', vdev %llu",
-	    data.dd_pool_guid, data.dd_vdev_guid);
+	zed_log_msg(LOG_INFO, "zfs_deliver_check: pool '%"PRIu64"', vdev %"
+	    PRIu64, data.dd_pool_guid, data.dd_vdev_guid);
 
 	data.dd_func = zfs_process_add;
 
@@ -1092,10 +1093,11 @@ zfsdle_vdev_online(zpool_handle_t *zhp, void *data)
 					    0, &newstate);
 
 					zed_log_msg(LOG_INFO,
-					    "%s: autoexpanding '%s' from %llu"
-					    " to %llu bytes in pool '%s': %d",
-					    __func__, fullpath, conf_size,
-					    MAX(udev_size, udev_parent_size),
+					    "%s: autoexpanding '%s' from %"
+					    PRIu64" to %"PRIu64" bytes in pool"
+					    "'%s': %d", __func__, fullpath,
+					    conf_size, MAX(udev_size,
+					    udev_parent_size),
 					    zpool_get_name(zhp), error);
 				}
 			}

--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -107,7 +107,7 @@ find_vdev(libzfs_handle_t *zhdl, nvlist_t *nv, uint64_t search_guid)
 	if (nvlist_lookup_uint64(nv, ZPOOL_CONFIG_GUID, &guid) == 0 &&
 	    guid == search_guid) {
 		fmd_hdl_debug(fmd_module_hdl("zfs-retire"),
-		    "matched vdev %llu", guid);
+		    "matched vdev %"PRIu64, guid);
 		return (nv);
 	}
 
@@ -297,7 +297,7 @@ zfs_vdev_repair(fmd_hdl_t *hdl, nvlist_t *nvl)
 	zrp->zrr_vdev = vdev_guid;
 	zdp->zrd_repaired = zrp;
 
-	fmd_hdl_debug(hdl, "marking repaired vdev %llu on pool %llu",
+	fmd_hdl_debug(hdl, "marking repaired vdev %"PRIu64" on pool %"PRIu64,
 	    vdev_guid, pool_guid);
 }
 
@@ -483,8 +483,8 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 		 */
 		if (is_repair) {
 			repair_done = 1;
-			fmd_hdl_debug(hdl, "zpool_clear of pool '%s' vdev %llu",
-			    zpool_get_name(zhp), vdev_guid);
+			fmd_hdl_debug(hdl, "zpool_clear of pool '%s' vdev %"
+			    PRIu64, zpool_get_name(zhp), vdev_guid);
 			(void) zpool_vdev_clear(zhp, vdev_guid);
 			zpool_close(zhp);
 			continue;
@@ -499,9 +499,9 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 			(void) zpool_vdev_degrade(zhp, vdev_guid, aux);
 
 		if (fault_device || degrade_device)
-			fmd_hdl_debug(hdl, "zpool_vdev_%s: vdev %llu on '%s'",
-			    fault_device ? "fault" : "degrade", vdev_guid,
-			    zpool_get_name(zhp));
+			fmd_hdl_debug(hdl, "zpool_vdev_%s: vdev %"PRIu64
+			    " on '%s'", fault_device ? "fault" : "degrade",
+			    vdev_guid, zpool_get_name(zhp));
 
 		/*
 		 * Attempt to substitute a hot spare.

--- a/cmd/zed/zed_disk_event.c
+++ b/cmd/zed/zed_disk_event.c
@@ -77,13 +77,16 @@ zed_udev_event(const char *class, const char *subclass, nvlist_t *nvl)
 	if (nvlist_lookup_string(nvl, DEV_PHYS_PATH, &strval) == 0)
 		zed_log_msg(LOG_INFO, "\t%s: %s", DEV_PHYS_PATH, strval);
 	if (nvlist_lookup_uint64(nvl, DEV_SIZE, &numval) == 0)
-		zed_log_msg(LOG_INFO, "\t%s: %llu", DEV_SIZE, numval);
+		zed_log_msg(LOG_INFO, "\t%s: %" PRIu64, DEV_SIZE, numval);
 	if (nvlist_lookup_uint64(nvl, DEV_PARENT_SIZE, &numval) == 0)
-		zed_log_msg(LOG_INFO, "\t%s: %llu", DEV_PARENT_SIZE, numval);
+		zed_log_msg(LOG_INFO, "\t%s: %" PRIu64, DEV_PARENT_SIZE,
+		    numval);
 	if (nvlist_lookup_uint64(nvl, ZFS_EV_POOL_GUID, &numval) == 0)
-		zed_log_msg(LOG_INFO, "\t%s: %llu", ZFS_EV_POOL_GUID, numval);
+		zed_log_msg(LOG_INFO, "\t%s: %" PRIu64, ZFS_EV_POOL_GUID,
+		    numval);
 	if (nvlist_lookup_uint64(nvl, ZFS_EV_VDEV_GUID, &numval) == 0)
-		zed_log_msg(LOG_INFO, "\t%s: %llu", ZFS_EV_VDEV_GUID, numval);
+		zed_log_msg(LOG_INFO, "\t%s: %" PRIu64, ZFS_EV_VDEV_GUID,
+		    numval);
 
 	(void) zfs_agent_post_event(class, subclass, nvl);
 }

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -195,11 +195,12 @@ zed_event_seek(struct zed_conf *zcp, uint64_t saved_eid, int64_t saved_etime[])
 		} else if (nvlist_lookup_int64_array(nvl, "time",
 		    &etime, &nelem) != 0) {
 			zed_log_msg(LOG_WARNING,
-			    "Failed to lookup zevent time (eid=%llu)", eid);
+			    "Failed to lookup zevent time (eid=%"PRIu64")",
+			    eid);
 		} else if (nelem != 2) {
 			zed_log_msg(LOG_WARNING,
-			    "Failed to lookup zevent time (eid=%llu, nelem=%u)",
-			    eid, nelem);
+			    "Failed to lookup zevent time (eid=%"
+			    PRIu64", nelem=%u)", eid, nelem);
 		} else if ((eid != saved_eid) ||
 		    (etime[0] != saved_etime[0]) ||
 		    (etime[1] != saved_etime[1])) {
@@ -216,7 +217,7 @@ zed_event_seek(struct zed_conf *zcp, uint64_t saved_eid, int64_t saved_etime[])
 		else
 			eid = 0;
 	}
-	zed_log_msg(LOG_NOTICE, "Processing events since eid=%llu", eid);
+	zed_log_msg(LOG_NOTICE, "Processing events since eid=%"PRIu64, eid);
 	return (found ? 0 : -1);
 }
 
@@ -279,12 +280,13 @@ _zed_event_add_var(uint64_t eid, zed_strings_t *zsp,
 	if (!name) {
 		errno = EINVAL;
 		zed_log_msg(LOG_WARNING,
-		    "Failed to add variable for eid=%llu: Name is empty", eid);
+		    "Failed to add variable for eid=%"PRIu64
+		    ": Name is empty", eid);
 		return (-1);
 	} else if (!isalpha(name[0])) {
 		errno = EINVAL;
 		zed_log_msg(LOG_WARNING,
-		    "Failed to add variable for eid=%llu: "
+		    "Failed to add variable for eid=%"PRIu64": "
 		    "Name \"%s\" is invalid", eid, name);
 		return (-1);
 	}
@@ -303,7 +305,8 @@ _zed_event_add_var(uint64_t eid, zed_strings_t *zsp,
 	if (dstp == lastp) {
 		errno = ENAMETOOLONG;
 		zed_log_msg(LOG_WARNING,
-		    "Failed to add variable for eid=%llu: Name too long", eid);
+		    "Failed to add variable for eid=%"PRIu64": Name too long",
+		    eid);
 		return (-1);
 	}
 	*dstp = '\0';
@@ -315,8 +318,8 @@ _zed_event_add_var(uint64_t eid, zed_strings_t *zsp,
 	n = strlcpy(dstp, keybuf, buflen);
 	if (n >= sizeof (valbuf)) {
 		errno = EMSGSIZE;
-		zed_log_msg(LOG_WARNING, "Failed to add %s for eid=%llu: %s",
-		    keybuf, eid, "Exceeded buffer size");
+		zed_log_msg(LOG_WARNING, "Failed to add %s for eid=%"PRIu64
+		    ": %s", keybuf, eid, "Exceeded buffer size");
 		return (-1);
 	}
 	dstp += n;
@@ -327,8 +330,8 @@ _zed_event_add_var(uint64_t eid, zed_strings_t *zsp,
 
 	if (buflen <= 0) {
 		errno = EMSGSIZE;
-		zed_log_msg(LOG_WARNING, "Failed to add %s for eid=%llu: %s",
-		    keybuf, eid, "Exceeded buffer size");
+		zed_log_msg(LOG_WARNING, "Failed to add %s for eid=%"PRIu64
+		    ": %s", keybuf, eid, "Exceeded buffer size");
 		return (-1);
 	}
 
@@ -338,12 +341,12 @@ _zed_event_add_var(uint64_t eid, zed_strings_t *zsp,
 
 	if ((n < 0) || (n >= buflen)) {
 		errno = EMSGSIZE;
-		zed_log_msg(LOG_WARNING, "Failed to add %s for eid=%llu: %s",
-		    keybuf, eid, "Exceeded buffer size");
+		zed_log_msg(LOG_WARNING, "Failed to add %s for eid=%"PRIu64
+		    ": %s", keybuf, eid, "Exceeded buffer size");
 		return (-1);
 	} else if (zed_strings_add(zsp, keybuf, valbuf) < 0) {
-		zed_log_msg(LOG_WARNING, "Failed to add %s for eid=%llu: %s",
-		    keybuf, eid, strerror(errno));
+		zed_log_msg(LOG_WARNING, "Failed to add %s for eid=%"PRIu64
+		    ": %s", keybuf, eid, strerror(errno));
 		return (-1);
 	}
 	return (0);
@@ -354,7 +357,7 @@ _zed_event_add_array_err(uint64_t eid, const char *name)
 {
 	errno = EMSGSIZE;
 	zed_log_msg(LOG_WARNING,
-	    "Failed to convert nvpair \"%s\" for eid=%llu: "
+	    "Failed to convert nvpair \"%s\" for eid=%"PRIu64": "
 	    "Exceeded buffer size", name, eid);
 	return (-1);
 }
@@ -586,7 +589,7 @@ _zed_event_add_uint64_array(uint64_t eid, zed_strings_t *zsp,
 	assert((nvp != NULL) && (nvpair_type(nvp) == DATA_TYPE_UINT64_ARRAY));
 
 	name = nvpair_name(nvp);
-	fmt = _zed_event_value_is_hex(name) ? "0x%.16llX " : "%llu ";
+	fmt = _zed_event_value_is_hex(name) ? "0x%.16llX " : "%"PRIu64" ";
 	(void) nvpair_value_uint64_array(nvp, &u64p, &nelem);
 	for (i = 0, p = buf; (i < nelem) && (buflen > 0); i++) {
 		n = snprintf(p, buflen, fmt, (u_longlong_t)u64p[i]);
@@ -700,8 +703,8 @@ _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
 	case DATA_TYPE_UINT64:
 		(void) nvpair_value_uint64(nvp, &i64);
 		_zed_event_add_var(eid, zsp, prefix, name,
-		    (_zed_event_value_is_hex(name) ? "0x%.16llX" : "%llu"),
-		    (u_longlong_t)i64);
+		    (_zed_event_value_is_hex(name) ? "0x%.16"PRIX64 :
+		    "%"PRIu64), i64);
 		/*
 		 * shadow readable strings for vdev state pairs
 		 */
@@ -731,7 +734,7 @@ _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
 	case DATA_TYPE_HRTIME:
 		(void) nvpair_value_hrtime(nvp, (hrtime_t *)&i64);
 		_zed_event_add_var(eid, zsp, prefix, name,
-		    "%llu", (u_longlong_t)i64);
+		    "%"PRIu64, i64);
 		break;
 	case DATA_TYPE_STRING:
 		(void) nvpair_value_string(nvp, &str);
@@ -774,7 +777,7 @@ _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
 	default:
 		errno = EINVAL;
 		zed_log_msg(LOG_WARNING,
-		    "Failed to convert nvpair \"%s\" for eid=%llu: "
+		    "Failed to convert nvpair \"%s\" for eid=%"PRIu64": "
 		    "Unrecognized type=%u", name, eid, (unsigned int) type);
 		break;
 	}
@@ -907,11 +910,13 @@ _zed_event_add_time_strings(uint64_t eid, zed_strings_t *zsp, int64_t etime[])
 	    "%" PRId64, etime[1]);
 
 	if (!localtime_r((const time_t *) &etime[0], &stp)) {
-		zed_log_msg(LOG_WARNING, "Failed to add %s%s for eid=%llu: %s",
-		    ZEVENT_VAR_PREFIX, "TIME_STRING", eid, "localtime error");
+		zed_log_msg(LOG_WARNING, "Failed to add %s%s for eid=%"PRIu64
+		    ": %s", ZEVENT_VAR_PREFIX, "TIME_STRING", eid,
+		    "localtime error");
 	} else if (!strftime(buf, sizeof (buf), "%Y-%m-%d %H:%M:%S%z", &stp)) {
-		zed_log_msg(LOG_WARNING, "Failed to add %s%s for eid=%llu: %s",
-		    ZEVENT_VAR_PREFIX, "TIME_STRING", eid, "strftime error");
+		zed_log_msg(LOG_WARNING, "Failed to add %s%s for eid=%"PRIu64
+		    ": %s", ZEVENT_VAR_PREFIX, "TIME_STRING", eid,
+		    "strftime error");
 	} else {
 		_zed_event_add_var(eid, zsp, ZEVENT_VAR_PREFIX, "TIME_STRING",
 		    "%s", buf);
@@ -956,14 +961,14 @@ zed_event_service(struct zed_conf *zcp)
 	} else if (nvlist_lookup_int64_array(
 	    nvl, "time", &etime, &nelem) != 0) {
 		zed_log_msg(LOG_WARNING,
-		    "Failed to lookup zevent time (eid=%llu)", eid);
+		    "Failed to lookup zevent time (eid=%"PRIu64")", eid);
 	} else if (nelem != 2) {
 		zed_log_msg(LOG_WARNING,
-		    "Failed to lookup zevent time (eid=%llu, nelem=%u)",
+		    "Failed to lookup zevent time (eid=%"PRIu64", nelem=%u)",
 		    eid, nelem);
 	} else if (nvlist_lookup_string(nvl, "class", &class) != 0) {
 		zed_log_msg(LOG_WARNING,
-		    "Failed to lookup zevent class (eid=%llu)", eid);
+		    "Failed to lookup zevent class (eid=%"PRIu64")", eid);
 	} else {
 		/* let internal modules see this event first */
 		zfs_agent_post_event(class, NULL, nvl);

--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -140,7 +140,7 @@ _zed_exec_fork_child(uint64_t eid, const char *dir, const char *prog,
 	n = snprintf(path, sizeof (path), "%s/%s", dir, prog);
 	if ((n < 0) || (n >= sizeof (path))) {
 		zed_log_msg(LOG_WARNING,
-		    "Failed to fork \"%s\" for eid=%llu: %s",
+		    "Failed to fork \"%s\" for eid=%"PRIu64": %s",
 		    prog, eid, strerror(ENAMETOOLONG));
 		return;
 	}
@@ -149,7 +149,7 @@ _zed_exec_fork_child(uint64_t eid, const char *dir, const char *prog,
 	if (pid < 0) {
 		(void) pthread_mutex_unlock(&_launched_processes_lock);
 		zed_log_msg(LOG_WARNING,
-		    "Failed to fork \"%s\" for eid=%llu: %s",
+		    "Failed to fork \"%s\" for eid=%"PRIu64": %s",
 		    prog, eid, strerror(errno));
 		return;
 	} else if (pid == 0) {
@@ -181,7 +181,7 @@ _zed_exec_fork_child(uint64_t eid, const char *dir, const char *prog,
 	(void) pthread_mutex_unlock(&_launched_processes_lock);
 
 	__atomic_sub_fetch(&_launched_processes_limit, 1, __ATOMIC_SEQ_CST);
-	zed_log_msg(LOG_INFO, "Invoking \"%s\" eid=%llu pid=%d",
+	zed_log_msg(LOG_INFO, "Invoking \"%s\" eid=%"PRIu64" pid=%d",
 	    prog, eid, pid);
 }
 
@@ -244,7 +244,7 @@ _reap_children(void *arg)
 
 			if (WIFEXITED(status)) {
 				zed_log_msg(LOG_INFO,
-				    "Finished \"%s\" eid=%llu pid=%d "
+				    "Finished \"%s\" eid=%"PRIu64" pid=%d "
 				    "time=%llu.%06us exit=%d",
 				    node.name, node.eid, pid,
 				    (unsigned long long) usage.ru_utime.tv_sec,
@@ -252,7 +252,7 @@ _reap_children(void *arg)
 				    WEXITSTATUS(status));
 			} else if (WIFSIGNALED(status)) {
 				zed_log_msg(LOG_INFO,
-				    "Finished \"%s\" eid=%llu pid=%d "
+				    "Finished \"%s\" eid=%"PRIu64" pid=%d "
 				    "time=%llu.%06us sig=%d/%s",
 				    node.name, node.eid, pid,
 				    (unsigned long long) usage.ru_utime.tv_sec,
@@ -261,7 +261,7 @@ _reap_children(void *arg)
 				    strsignal(WTERMSIG(status)));
 			} else {
 				zed_log_msg(LOG_INFO,
-				    "Finished \"%s\" eid=%llu pid=%d "
+				    "Finished \"%s\" eid=%"PRIu64" pid=%d "
 				    "time=%llu.%06us status=0x%X",
 				    node.name, node.eid, pid,
 				    (unsigned long long) usage.ru_utime.tv_sec,

--- a/cmd/zed/zed_log.h
+++ b/cmd/zed/zed_log.h
@@ -37,6 +37,7 @@ void zed_log_syslog_open(int facility);
 
 void zed_log_syslog_close(void);
 
+__attribute__((format(printf, 2, 3)))
 void zed_log_msg(int priority, const char *fmt, ...);
 
 void zed_log_die(const char *fmt, ...);


### PR DESCRIPTION
### Motivation and Context
While experimenting with ways to reduce false positives in static analyzers, I discovered that we could get the compiler to enforce correctness for format specifiers by annotating function prototypes.

This patch only applies to ZED, since we are not annotating things that affect the kernel, such as zfs_panic_recover(). Unfortunately, we do not have inttypes.h inside the kernel, so we need to hard code format specifiers if we annotate things that affect the kernel. However, GCC has this interesting behavior on amd64 where if you use %llu with uint64_t, it will complain that uint64_t is unsigned long int and suggests %lu, but if you actually use %lu, it will complain that uint64_t is unsigned long long int.

We could go through the trouble of defining PRIu64 and changing it to %llu or %lu depending on the architecture, like is done in inttypes.h, but upon inspection, it appears that the Linux kernel treats %llu and %lu the same, no matter whether the system is 64-bit or 32-bit, so getting it right is a moot point. The FreeBSD behavior was not checked.

### Description
We annotate fmd_hdl_vdebug(), fmd_hdl_debug() and zed_log_msg() so that the compiler will enforce format specifier correctness. We then fix all of the things that were broken using macros from inttypes.h.

### How Has This Been Tested?
A build test was done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).