### PR TITLE
Add FreeBSD posix_fadvise support.

### DIFF
--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -6092,6 +6092,80 @@ zfs_freebsd_aclcheck(struct vop_aclcheck_args *ap)
 	return (EOPNOTSUPP);
 }
 
+#ifndef _SYS_SYSPROTO_H_
+struct vop_advise_args {
+	struct vnode *a_vp;
+	off_t a_start;
+	off_t a_end;
+	int a_advice;
+};
+#endif
+
+static int
+zfs_freebsd_advise(struct vop_advise_args *ap)
+{
+	vnode_t *vp = ap->a_vp;
+	off_t start = ap->a_start;
+	off_t end = ap->a_end;
+	int advice = ap->a_advice;
+	off_t len;
+	znode_t *zp;
+	zfsvfs_t *zfsvfs;
+	objset_t *os;
+	int error = 0;
+
+	if (end < start)
+		return (EINVAL);
+
+	VOP_LOCK(vp, LK_SHARED);
+	if (VN_IS_DOOMED(vp)) {
+		error = EBADF;
+		goto out_unlock;
+	}
+
+	zp = VTOZ(vp);
+	zfsvfs = zp->z_zfsvfs;
+	os = zp->z_zfsvfs->z_os;
+
+	if ((error = zfs_enter_verify_zp(zfsvfs, zp, FTAG)) != 0)
+		goto out_unlock;
+
+	/* kern_posix_fadvise points to the last byte, we want one past */
+	if (end != OFF_MAX)
+		end += 1;
+	len = end - start;
+
+	switch (advice) {
+	case POSIX_FADV_WILLNEED:
+		/*
+		 * Pass on the caller's size directly, but note that
+		 * dmu_prefetch_max will effectively cap it.  If there really
+		 * is a larger sequential access pattern, perhaps dmu_zfetch
+		 * will detect it.
+		 */
+		dmu_prefetch(os, zp->z_id, 0, start, len,
+		    ZIO_PRIORITY_ASYNC_READ);
+		break;
+	case POSIX_FADV_NORMAL:
+	case POSIX_FADV_RANDOM:
+	case POSIX_FADV_SEQUENTIAL:
+	case POSIX_FADV_DONTNEED:
+	case POSIX_FADV_NOREUSE:
+		/* ignored for now */
+		break;
+	default:
+		error = EINVAL;
+		break;
+	}
+
+	zfs_exit(zfsvfs, FTAG);
+
+out_unlock:
+	VOP_UNLOCK(vp);
+
+	return (error);
+}
+
 static int
 zfs_vptocnp(struct vop_vptocnp_args *ap)
 {
@@ -6246,6 +6320,7 @@ struct vop_vector zfs_vnodeops = {
 	.vop_link =		zfs_freebsd_link,
 	.vop_symlink =		zfs_freebsd_symlink,
 	.vop_readlink =		zfs_freebsd_readlink,
+	.vop_advise =		zfs_freebsd_advise,
 	.vop_read =		zfs_freebsd_read,
 	.vop_write =		zfs_freebsd_write,
 	.vop_remove =		zfs_freebsd_remove,

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -746,7 +746,11 @@ dmu_prefetch(objset_t *os, uint64_t object, int64_t level, uint64_t offset,
 	}
 
 	if (nblks != 0) {
+		uint64_t maxnblks;
 		blkid = dbuf_whichblock(dn, level, offset);
+		maxnblks = dn->dn_maxblkid + 1 - blkid;
+		if (nblks > maxnblks)
+			nblks = maxnblks;
 		for (int i = 0; i < nblks; i++)
 			dbuf_prefetch(dn, level, blkid + i, pri, 0);
 	}

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -620,6 +620,10 @@ tags = ['functional', 'delegate']
 tests = ['exec_001_pos', 'exec_002_neg']
 tags = ['functional', 'exec']
 
+[tests/functional/fadvise]
+tests = ['fadvise_willneed']
+tags = ['functional', 'fadvise']
+
 [tests/functional/fallocate]
 tests = ['fallocate_punch-hole']
 tags = ['functional', 'fallocate']

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -90,10 +90,6 @@ tests = ['events_001_pos', 'events_002_pos', 'zed_rc_filter', 'zed_fd_spill',
     'zed_cksum_reported', 'zed_cksum_config', 'zed_io_config']
 tags = ['functional', 'events']
 
-[tests/functional/fadvise:Linux]
-tests = ['fadvise_willneed']
-tags = ['functional', 'fadvise']
-
 [tests/functional/fallocate:Linux]
 tests = ['fallocate_prealloc', 'fallocate_zero-range']
 tags = ['functional', 'fallocate']

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -91,7 +91,7 @@ tests = ['events_001_pos', 'events_002_pos', 'zed_rc_filter', 'zed_fd_spill',
 tags = ['functional', 'events']
 
 [tests/functional/fadvise:Linux]
-tests = ['fadvise_sequential']
+tests = ['fadvise_willneed']
 tags = ['functional', 'fadvise']
 
 [tests/functional/fallocate:Linux]

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -129,7 +129,7 @@ scripts_zfs_tests_bin_PROGRAMS  += %D%/read_dos_attributes %D%/write_dos_attribu
 
 scripts_zfs_tests_bin_PROGRAMS += %D%/randfree_file
 %C%_randfree_file_SOURCES       = %D%/file/randfree_file.c
+endif
 
 scripts_zfs_tests_bin_PROGRAMS += %D%/file_fadvise
 %C%_file_fadvise_SOURCES  = %D%/file/file_fadvise.c
-endif

--- a/tests/zfs-tests/cmd/file/file_fadvise.c
+++ b/tests/zfs-tests/cmd/file/file_fadvise.c
@@ -43,21 +43,41 @@ static void
 usage(void)
 {
 	(void) fprintf(stderr,
-	    "usage: %s -f filename -a advise \n", execname);
+	    "usage: %s -f filename -a advice \n", execname);
 }
+
+typedef struct advice_name {
+	const char *name;
+	int value;
+} advice_name;
+
+static const struct advice_name table[] = {
+#define	ADV(name) {#name, name}
+	ADV(POSIX_FADV_NORMAL),
+	ADV(POSIX_FADV_RANDOM),
+	ADV(POSIX_FADV_SEQUENTIAL),
+	ADV(POSIX_FADV_WILLNEED),
+	ADV(POSIX_FADV_DONTNEED),
+	ADV(POSIX_FADV_NOREUSE),
+	{NULL}
+};
 
 int
 main(int argc, char *argv[])
 {
 	char *filename = NULL;
-	int advise = 0;
+	int advice = POSIX_FADV_NORMAL;
 	int fd, ch;
 	int	err = 0;
 
 	while ((ch = getopt(argc, argv, "a:f:")) != EOF) {
 		switch (ch) {
 		case 'a':
-			advise = atoll(optarg);
+			advice = -1;
+			for (const advice_name *p = table; p->name; ++p) {
+				if (strcmp(p->name, optarg) == 0)
+					advice = p->value;
+			}
 			break;
 		case 'f':
 			filename = optarg;
@@ -74,8 +94,8 @@ main(int argc, char *argv[])
 		err++;
 	}
 
-	if (advise < POSIX_FADV_NORMAL || advise > POSIX_FADV_NOREUSE) {
-		(void) printf("advise is invalid\n");
+	if (advice == -1) {
+		(void) printf("advice is invalid\n");
 		err++;
 	}
 
@@ -89,7 +109,7 @@ main(int argc, char *argv[])
 		return (1);
 	}
 
-	if (posix_fadvise(fd, 0, 0, advise) != 0) {
+	if (posix_fadvise(fd, 0, 0, advice) != 0) {
 		perror("posix_fadvise");
 		close(fd);
 		return (1);

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3620,7 +3620,7 @@ function get_arcstat # stat
 		kstat arcstats.$stat
 		;;
 	Linux)
-		kstat arcstats | awk "/$stat/"' { print $3 }'
+		kstat arcstats | awk "/^$stat	/"' { print $3 }'
 		;;
 	*)
 		false

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1377,7 +1377,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/exec/exec_002_neg.ksh \
 	functional/exec/setup.ksh \
 	functional/fadvise/cleanup.ksh \
-	functional/fadvise/fadvise_sequential.ksh \
+	functional/fadvise/fadvise_willneed.ksh \
 	functional/fadvise/setup.ksh \
 	functional/fallocate/cleanup.ksh \
 	functional/fallocate/fallocate_prealloc.ksh \

--- a/tests/zfs-tests/tests/functional/fadvise/fadvise_willneed.ksh
+++ b/tests/zfs-tests/tests/functional/fadvise/fadvise_willneed.ksh
@@ -41,7 +41,7 @@
 #
 
 # NOTE: if HAVE_FILE_FADVISE is not defined former data_size
-# should less or eaqul to latter one
+# should less or equal to latter one
 
 verify_runnable "global"
 
@@ -54,10 +54,6 @@ function cleanup
 	[[ -e $TESTDIR ]] && log_must rm -Rf $TESTDIR/*
 }
 
-getstat() {
-	awk -v c="$1" '$1 == c {print $3; exit}' /proc/spl/kstat/zfs/arcstats
-}
-
 log_assert "Ensure fadvise prefetch data"
 
 log_onexit cleanup
@@ -67,12 +63,12 @@ log_must zfs set primarycache=metadata $TESTPOOL
 log_must file_write -o create -f $FILE -b $BLKSZ -c 1000
 sync_pool $TESTPOOL
 
-data_size1=$(getstat data_size)
+data_size1=$(get_arcstat data_size)
 
-log_must file_fadvise -f $FILE -a 2
+log_must file_fadvise -f $FILE -a POSIX_FADV_WILLNEED
 sleep 10
 
-data_size2=$(getstat data_size)
+data_size2=$(get_arcstat data_size)
 log_note "original data_size is $data_size1, final data_size is $data_size2"
 
 log_must [ $data_size1 -le $data_size2 ]


### PR DESCRIPTION
As commit 320f0c6 did for Linux, connect POSIX_FADV_WILLNEED and POSIX_FADV_SEQUENTIAL up to dmu_prefetch() on FreeBSD.

[Draft only, work in progress]

Signed-off-by: Thomas Munro <tmunro@freebsd.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context

See #13694 (née #9807) for motivation and context.  The present PR is for feature parity on FreeBSD.

### Description

Connects posix_fadvise() to dmu_prefetch().

Quite similar to Linux, but:

 * ESPIPE case is already handled by kern_posix_fadvise() function before we get here.
 * (offset, length) has already been converted to (start, end), and if length was 0 then end is OFF_MAX.  Is it OK to call dmu_prefetch() with a very large size, or should we also try to clamp it to zp->z_size?  It will be clamped by max prefetch size internally anyway.
 * This is only a draft because I haven't yet figured out what, if anything, needs to be done about mapped files (I don't understand why for Linux something was done before dmu_prefetch() and not after it completes, and whether that is done for correctness or performance).

### How Has This Been Tested?

I have tested on top of the main branch of FreeBSD, which most recently merged OpenZFS master a few days ago (openzfs/zfs commit c629f0bf6).  I've tested with simple programs, and PostgreSQL which generates a WILLNEED advice in various circumstances.

I wonder if we should implement POSIX_FADV_DONTNEED to evict ranges from ARC to facilitate testing, but that'd be another PR.



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
