### PR TITLE
Fix double const qualifier declarations

### DIFF
--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -56,8 +56,8 @@ typedef const struct pool_config_ops {
 /*
  * An instance of pool_config_ops_t is expected in the caller's binary.
  */
-_LIBZUTIL_H const pool_config_ops_t libzfs_config_ops;
-_LIBZUTIL_H const pool_config_ops_t libzpool_config_ops;
+_LIBZUTIL_H pool_config_ops_t libzfs_config_ops;
+_LIBZUTIL_H pool_config_ops_t libzpool_config_ops;
 
 typedef struct importargs {
 	char **path;		/* a list of paths to search		*/
@@ -71,9 +71,9 @@ typedef struct importargs {
 } importargs_t;
 
 _LIBZUTIL_H nvlist_t *zpool_search_import(void *, importargs_t *,
-    const pool_config_ops_t *);
+    pool_config_ops_t *);
 _LIBZUTIL_H int zpool_find_config(void *, const char *, nvlist_t **,
-    importargs_t *, const pool_config_ops_t *);
+    importargs_t *, pool_config_ops_t *);
 
 _LIBZUTIL_H const char * const * zpool_default_search_paths(size_t *count);
 _LIBZUTIL_H int zpool_read_label(int, nvlist_t **, int *);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -907,7 +907,7 @@ typedef const struct dmu_object_byteswap_info {
 } dmu_object_byteswap_info_t;
 
 extern const dmu_object_type_info_t dmu_ot[DMU_OT_NUMTYPES];
-extern const dmu_object_byteswap_info_t dmu_ot_byteswap[DMU_BSWAP_NUMFUNCS];
+extern dmu_object_byteswap_info_t dmu_ot_byteswap[DMU_BSWAP_NUMFUNCS];
 
 /*
  * Get information on a DMU object.

--- a/include/sys/zio_checksum.h
+++ b/include/sys/zio_checksum.h
@@ -102,7 +102,7 @@ typedef struct zio_bad_cksum {
 	uint8_t			zbc_has_cksum;	/* expected/actual valid */
 } zio_bad_cksum_t;
 
-_SYS_ZIO_CHECKSUM_H const zio_checksum_info_t
+_SYS_ZIO_CHECKSUM_H zio_checksum_info_t
     zio_checksum_table[ZIO_CHECKSUM_FUNCTIONS];
 
 /*

--- a/include/sys/zio_compress.h
+++ b/include/sys/zio_compress.h
@@ -152,7 +152,7 @@ typedef const struct zio_compress_info {
 	zio_decompresslevel_func_t	*ci_decompress_level;
 } zio_compress_info_t;
 
-extern const zio_compress_info_t zio_compress_table[ZIO_COMPRESS_FUNCTIONS];
+extern zio_compress_info_t zio_compress_table[ZIO_COMPRESS_FUNCTIONS];
 
 /*
  * lz4 compression init & free

--- a/lib/libzpool/util.c
+++ b/lib/libzpool/util.c
@@ -350,7 +350,7 @@ pool_active(void *unused, const char *name, uint64_t guid,
 }
 #endif
 
-const pool_config_ops_t libzpool_config_ops = {
+pool_config_ops_t libzpool_config_ops = {
 	.pco_refresh_config = refresh_config,
 	.pco_pool_active = pool_active,
 };

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -1777,8 +1777,7 @@ zpool_find_import(libpc_handle_t *hdl, importargs_t *iarg)
 
 
 nvlist_t *
-zpool_search_import(void *hdl, importargs_t *import,
-    const pool_config_ops_t *pco)
+zpool_search_import(void *hdl, importargs_t *import, pool_config_ops_t *pco)
 {
 	libpc_handle_t handle = { 0 };
 	nvlist_t *pools = NULL;
@@ -1821,7 +1820,7 @@ pool_match(nvlist_t *cfg, char *tgt)
 
 int
 zpool_find_config(void *hdl, const char *target, nvlist_t **configp,
-    importargs_t *args, const pool_config_ops_t *pco)
+    importargs_t *args, pool_config_ops_t *pco)
 {
 	nvlist_t *pools;
 	nvlist_t *match = NULL;

--- a/lib/libzutil/zutil_import.h
+++ b/lib/libzutil/zutil_import.h
@@ -43,7 +43,7 @@ typedef struct libpc_handle {
 	boolean_t lpc_open_access_error;
 	boolean_t lpc_desc_active;
 	char lpc_desc[1024];
-	const pool_config_ops_t *lpc_ops;
+	pool_config_ops_t *lpc_ops;
 	void *lpc_lib_handle;
 } libpc_handle_t;
 

--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -208,7 +208,7 @@ zpl_snapdir_revalidate(struct dentry *dentry, unsigned int flags)
 	return (!!dentry->d_inode);
 }
 
-static const dentry_operations_t zpl_dops_snapdirs = {
+static dentry_operations_t zpl_dops_snapdirs = {
 /*
  * Auto mounting of snapshots is only supported for 2.6.37 and
  * newer kernels.  Prior to this kernel the ops->follow_link()

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -145,7 +145,7 @@ const dmu_object_type_info_t dmu_ot[DMU_OT_NUMTYPES] = {
 	{DMU_BSWAP_UINT64, TRUE,  FALSE, FALSE, "bpobj subobj"		}
 };
 
-const dmu_object_byteswap_info_t dmu_ot_byteswap[DMU_BSWAP_NUMFUNCS] = {
+dmu_object_byteswap_info_t dmu_ot_byteswap[DMU_BSWAP_NUMFUNCS] = {
 	{	byteswap_uint8_array,	"uint8"		},
 	{	byteswap_uint16_array,	"uint16"	},
 	{	byteswap_uint32_array,	"uint32"	},

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -141,7 +141,7 @@ static int sa_modify_attrs(sa_handle_t *hdl, sa_attr_type_t newattr,
     sa_data_op_t action, sa_data_locator_t *locator, void *datastart,
     uint16_t buflen, dmu_tx_t *tx);
 
-static const arc_byteswap_func_t sa_bswap_table[] = {
+static arc_byteswap_func_t sa_bswap_table[] = {
 	byteswap_uint64_array,
 	byteswap_uint32_array,
 	byteswap_uint16_array,

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -224,7 +224,7 @@ vdev_dbgmsg_print_tree(vdev_t *vd, int indent)
  * Virtual device management.
  */
 
-static const vdev_ops_t *const vdev_ops_table[] = {
+static vdev_ops_t *const vdev_ops_table[] = {
 	&vdev_root_ops,
 	&vdev_raidz_ops,
 	&vdev_draid_ops,
@@ -246,7 +246,7 @@ static const vdev_ops_t *const vdev_ops_table[] = {
 static vdev_ops_t *
 vdev_getops(const char *type)
 {
-	const vdev_ops_t *ops, *const *opspp;
+	vdev_ops_t *ops, *const *opspp;
 
 	for (opspp = vdev_ops_table; (ops = *opspp) != NULL; opspp++)
 		if (strcmp(ops->vdev_op_type, type) == 0)

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -160,7 +160,7 @@ abd_fletcher_4_byteswap(abd_t *abd, uint64_t size,
 	abd_fletcher_4_impl(abd, size, &acd);
 }
 
-const zio_checksum_info_t zio_checksum_table[ZIO_CHECKSUM_FUNCTIONS] = {
+zio_checksum_info_t zio_checksum_table[ZIO_CHECKSUM_FUNCTIONS] = {
 	{{NULL, NULL}, NULL, NULL, 0, "inherit"},
 	{{NULL, NULL}, NULL, NULL, 0, "on"},
 	{{abd_checksum_off,		abd_checksum_off},

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -49,7 +49,7 @@ unsigned long zio_decompress_fail_fraction = 0;
 /*
  * Compression vectors.
  */
-const zio_compress_info_t zio_compress_table[ZIO_COMPRESS_FUNCTIONS] = {
+zio_compress_info_t zio_compress_table[ZIO_COMPRESS_FUNCTIONS] = {
 	{"inherit",	0,	NULL,		NULL, NULL},
 	{"on",		0,	NULL,		NULL, NULL},
 	{"uncompressed", 0,	NULL,		NULL, NULL},


### PR DESCRIPTION
Some header files define structures like this one:

```
typedef const struct zio_checksum_info {
	/* ... */
	const char	*ci_name;
} zio_abd_checksum_func_t;

```
So we can use `zio_abd_checksum_func_t` for const declarations now. It's not needed that we use the `const` qualifier again like this: `const zio_abd_checksum_func_t *varname;`

This patch solves the double const qualifiers, which were found by smatch.

Signed-off-by: Tino Reichardt <milky-zfs@mcmilk.de>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
A build test was done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
