### PR TITLE
Linux: Fix big endian and partial read bugs in get_system_hostid()

### DIFF
--- a/lib/libspl/os/linux/gethostid.c
+++ b/lib/libspl/os/linux/gethostid.c
@@ -59,6 +59,7 @@ unsigned long
 get_system_hostid(void)
 {
 	unsigned long hostid = get_spl_hostid();
+	uint32_t system_hostid;
 
 	/*
 	 * We do not use gethostid(3) because it can return a bogus ID,
@@ -69,8 +70,11 @@ get_system_hostid(void)
 	if (hostid == 0) {
 		int fd = open("/etc/hostid", O_RDONLY | O_CLOEXEC);
 		if (fd >= 0) {
-			if (read(fd, &hostid, 4) < 0)
+			if (read(fd, &system_hostid, sizeof (system_hostid))
+			    != sizeof (system_hostid))
 				hostid = 0;
+			else
+				hostid = system_hostid;
 			(void) close(fd);
 		}
 	}


### PR DESCRIPTION
### Motivation and Context
Coverity made two complaints about this function. The first is that we ignore the number of bytes read. The second is that we have a sizeof mismatch.

On 64-bit systems, long is a 64-bit type. Paradoxically, the standard says that hostid is 32-bit, yet is also a long type. On 64-bit big endian systems, reading into the long would cause us to return 0 as our hostid after the mask. This is wrong.

Also, if a partial read were to happen (it should not), we would return a partial hostid, which is also wrong.

### Description
We introduce a uint32_t system_hostid stack variable and ensure that the read is done into it and check the read's return value. Then we set the value based on whether the read was successful. This should fix both of coverity's complaints.

### How Has This Been Tested?
A local build test was done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
