### PR TITLE
zio_crypt functions should use random_get_bytes()

### DIFF
--- a/module/os/freebsd/zfs/zio_crypt.c
+++ b/module/os/freebsd/zfs/zio_crypt.c
@@ -441,7 +441,7 @@ zio_crypt_key_wrap(crypto_key_t *cwkey, zio_crypt_key_t *key, uint8_t *iv,
 	keydata_len = zio_crypt_table[crypt].ci_keylen;
 
 	/* generate iv for wrapping the master and hmac key */
-	ret = random_get_pseudo_bytes(iv, WRAPPING_IV_LEN);
+	ret = random_get_bytes(iv, WRAPPING_IV_LEN);
 	if (ret != 0)
 		goto error;
 
@@ -609,7 +609,7 @@ zio_crypt_generate_iv(uint8_t *ivbuf)
 	int ret;
 
 	/* randomly generate the IV */
-	ret = random_get_pseudo_bytes(ivbuf, ZIO_DATA_IV_LEN);
+	ret = random_get_bytes(ivbuf, ZIO_DATA_IV_LEN);
 	if (ret != 0)
 		goto error;
 

--- a/module/os/linux/zfs/zio_crypt.c
+++ b/module/os/linux/zfs/zio_crypt.c
@@ -483,7 +483,7 @@ zio_crypt_key_wrap(crypto_key_t *cwkey, zio_crypt_key_t *key, uint8_t *iv,
 	keydata_len = zio_crypt_table[crypt].ci_keylen;
 
 	/* generate iv for wrapping the master and hmac key */
-	ret = random_get_pseudo_bytes(iv, WRAPPING_IV_LEN);
+	ret = random_get_bytes(iv, WRAPPING_IV_LEN);
 	if (ret != 0)
 		goto error;
 
@@ -645,7 +645,7 @@ zio_crypt_generate_iv(uint8_t *ivbuf)
 	int ret;
 
 	/* randomly generate the IV */
-	ret = random_get_pseudo_bytes(ivbuf, ZIO_DATA_IV_LEN);
+	ret = random_get_bytes(ivbuf, ZIO_DATA_IV_LEN);
 	if (ret != 0)
 		goto error;
 


### PR DESCRIPTION
### Motivation and Context
We should not use random_get_pseudo_bytes() to generate random numbers for encryption because we only guarantee cryptographic quality randomness from random_get_bytes().

In practice, FreeBSD implements random_get_pseudo_bytes() using cryptographic grade randomness, so we only use a weak random number generator on Linux.

I implemented the Linux SPL random_get_pseudo_bytes() random number generator in 0b43696e6676391e5bee8ba49e76e599bac1d89d. I never intended for it to be used by encryption. Unfortunately, I did not participate in the review process for the encryption support, so I am only seeing this now.

I am not a cryptoanalyst, so I cannot say whether this caused a weakness. However, I can say that we should switch to using a cryptographic grade random number generator since that is best practice.

### Description
We switch from `random_get_pseudo_bytes()` to `random_get_bytes()` in zio_crypt functions.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
