### PR TITLE
Remove ambiguity on demand vs prefetch stats reported by arc_summary

### DIFF
--- a/cmd/arc_summary
+++ b/cmd/arc_summary
@@ -678,9 +678,9 @@ def section_archits(kstats_dict):
     print()
     print('Cache hits by data type:')
     dt_todo = (('Demand data:', arc_stats['demand_data_hits']),
-               ('Demand prefetch data:', arc_stats['prefetch_data_hits']),
+               ('Prefetch data:', arc_stats['prefetch_data_hits']),
                ('Demand metadata:', arc_stats['demand_metadata_hits']),
-               ('Demand prefetch metadata:',
+               ('Prefetch metadata:',
                 arc_stats['prefetch_metadata_hits']))
 
     for title, value in dt_todo:
@@ -689,10 +689,10 @@ def section_archits(kstats_dict):
     print()
     print('Cache misses by data type:')
     dm_todo = (('Demand data:', arc_stats['demand_data_misses']),
-               ('Demand prefetch data:',
+               ('Prefetch data:',
                 arc_stats['prefetch_data_misses']),
                ('Demand metadata:', arc_stats['demand_metadata_misses']),
-               ('Demand prefetch metadata:',
+               ('Prefetch metadata:',
                 arc_stats['prefetch_metadata_misses']))
 
     for title, value in dm_todo:


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
`arc_summary` currently list prefetch stats as "demand prefetch". For example:
```
Cache hits by data type:
        Demand data:                                   26.3 %      13.6M
        Demand prefetch data:                           0.6 %     323.5k
        Demand metadata:                               73.1 %      37.9M
        Demand prefetch metadata:                     < 0.1 %      15.0k

Cache misses by data type:
        Demand data:                                   65.9 %       1.1M
        Demand prefetch data:                          31.2 %     534.2k
        Demand metadata:                                1.2 %      20.8k
        Demand prefetch metadata:                       1.7 %      28.6k
```
However, a hit/miss can be due to demand **or** prefetch, not both at the same time. 
This commit clearly marks prefetched data/metadata as such, by removing "Demand" from the line.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
The commit is extremely simple, and only affects the `arc_summary` file in how it prints four rows.
<!--- Describe your changes in detail -->

### How Has This Been Tested?
On a local machine with the commit applied, `arc_summary` correctly show the following:
```
Cache hits by data type:
        Demand data:                                   26.3 %      13.6M
        Prefetch data:                                  0.6 %     323.5k
        Demand metadata:                               73.1 %      37.9M
        Prefetch metadata:                            < 0.1 %      15.0k

Cache misses by data type:
        Demand data:                                   65.9 %       1.1M
        Prefetch data:                                 31.2 %     534.2k
        Demand metadata:                                1.2 %      20.8k
        Prefetch metadata:                              1.7 %      28.6k
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
