### PR TITLE
Cleanup: Address Clang's static analyzer's unused code complaints

### DIFF
--- a/cmd/raidz_test/raidz_test.c
+++ b/cmd/raidz_test/raidz_test.c
@@ -146,8 +146,6 @@ static void process_options(int argc, char **argv)
 	memcpy(o, &rto_opts_defaults, sizeof (*o));
 
 	while ((opt = getopt(argc, argv, "TDBSvha:er:o:d:s:t:")) != -1) {
-		value = 0;
-
 		switch (opt) {
 		case 'a':
 			value = strtoull(optarg, NULL, 0);

--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -423,7 +423,6 @@ efi_alloc_and_read(int fd, struct dk_gpt **vtoc)
 		void *tmp;
 		length = (int) sizeof (struct dk_gpt) +
 		    (int) sizeof (struct dk_part) * (vptr->efi_nparts - 1);
-		nparts = vptr->efi_nparts;
 		if ((tmp = realloc(vptr, length)) == NULL) {
 			/* cppcheck-suppress doubleFree */
 			free(vptr);
@@ -565,10 +564,9 @@ int
 efi_rescan(int fd)
 {
 	int retry = 10;
-	int error;
 
 	/* Notify the kernel a devices partition table has been updated */
-	while ((error = ioctl(fd, BLKRRPART)) != 0) {
+	while (ioctl(fd, BLKRRPART) != 0) {
 		if ((--retry == 0) || (errno != EBUSY)) {
 			(void) fprintf(stderr, "the kernel failed to rescan "
 			    "the partition table: %d\n", errno);

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -2006,7 +2006,7 @@ zfs_prop_inherit(zfs_handle_t *zhp, const char *propname, boolean_t received)
 	if ((ret = changelist_prefix(cl)) != 0)
 		goto error;
 
-	if ((ret = zfs_ioctl(zhp->zfs_hdl, ZFS_IOC_INHERIT_PROP, &zc)) != 0) {
+	if (zfs_ioctl(zhp->zfs_hdl, ZFS_IOC_INHERIT_PROP, &zc) != 0) {
 		changelist_free(cl);
 		return (zfs_standard_error(hdl, errno, errbuf));
 	} else {

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -377,7 +377,7 @@ write_free_diffs(FILE *fp, differ_info_t *di, dmu_diff_record_t *dr)
 			if (zc.zc_obj > dr->ddr_last) {
 				break;
 			}
-			err = describe_free(fp, di, zc.zc_obj, fobjname,
+			(void) describe_free(fp, di, zc.zc_obj, fobjname,
 			    MAXPATHLEN);
 		} else if (errno == ESRCH) {
 			break;

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2214,7 +2214,6 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 			    ((policy.zlp_rewind & ZPOOL_TRY_REWIND) != 0), nv);
 		}
 		nvlist_free(nv);
-		return (0);
 	}
 
 	return (ret);

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -2117,9 +2117,9 @@ send_prelim_records(zfs_handle_t *zhp, const char *from, int fd,
 			fnvlist_add_boolean(hdrnv, "raw");
 		}
 
-		if ((err = gather_nvlist(zhp->zfs_hdl, tofs,
+		if (gather_nvlist(zhp->zfs_hdl, tofs,
 		    from, tosnap, recursive, raw, doall, replicate, skipmissing,
-		    verbose, backup, holds, props, &fss, fsavlp)) != 0) {
+		    verbose, backup, holds, props, &fss, fsavlp) != 0) {
 			return (zfs_error(zhp->zfs_hdl, EZFS_BADBACKUP,
 			    errbuf));
 		}

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1249,7 +1249,7 @@ zcmd_read_dst_nvlist(libzfs_handle_t *hdl, zfs_cmd_t *zc, nvlist_t **nvlp)
 static void
 zprop_print_headers(zprop_get_cbdata_t *cbp, zfs_type_t type)
 {
-	zprop_list_t *pl = cbp->cb_proplist;
+	zprop_list_t *pl;
 	int i;
 	char *title;
 	size_t len;

--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -428,7 +428,6 @@ dm_get_underlying_path(const char *dm_name)
 	char *tmp = NULL;
 	char *path = NULL;
 	char *dev_str;
-	int size;
 	char *first_path = NULL;
 	char *enclosure_path;
 
@@ -450,7 +449,7 @@ dm_get_underlying_path(const char *dm_name)
 	else
 		dev_str = tmp;
 
-	if ((size = asprintf(&tmp, "/sys/block/%s/slaves/", dev_str)) == -1) {
+	if (asprintf(&tmp, "/sys/block/%s/slaves/", dev_str) == -1) {
 		tmp = NULL;
 		goto end;
 	}
@@ -479,8 +478,7 @@ dm_get_underlying_path(const char *dm_name)
 			if (!enclosure_path)
 				continue;
 
-			if ((size = asprintf(
-			    &path, "/dev/%s", ep->d_name)) == -1)
+			if (asprintf(&path, "/dev/%s", ep->d_name) == -1)
 				path = NULL;
 			free(enclosure_path);
 			break;
@@ -499,7 +497,7 @@ end:
 		 * enclosure devices.  Throw up out hands and return the first
 		 * underlying path.
 		 */
-		if ((size = asprintf(&path, "/dev/%s", first_path)) == -1)
+		if (asprintf(&path, "/dev/%s", first_path) == -1)
 			path = NULL;
 	}
 

--- a/module/icp/algs/blake3/blake3.c
+++ b/module/icp/algs/blake3/blake3.c
@@ -189,9 +189,7 @@ static void chunk_state_update(const blake3_ops_t *ops,
 		input_len -= BLAKE3_BLOCK_LEN;
 	}
 
-	size_t take = chunk_state_fill_buf(ctx, input, input_len);
-	input += take;
-	input_len -= take;
+	chunk_state_fill_buf(ctx, input, input_len);
 }
 
 static output_t chunk_state_output(const blake3_chunk_state_t *ctx)

--- a/module/icp/algs/modes/ccm.c
+++ b/module/icp/algs/modes/ccm.c
@@ -67,7 +67,6 @@ ccm_mode_encrypt_contiguous_blocks(ccm_ctx_t *ctx, char *data, size_t length,
 		return (CRYPTO_SUCCESS);
 	}
 
-	lastp = (uint8_t *)ctx->ccm_cb;
 	crypto_init_ptrs(out, &iov_or_mp, &offset);
 
 	mac_buf = (uint8_t *)ctx->ccm_mac_buf;

--- a/module/icp/algs/modes/ctr.c
+++ b/module/icp/algs/modes/ctr.c
@@ -60,7 +60,6 @@ ctr_mode_contiguous_blocks(ctr_ctx_t *ctx, char *data, size_t length,
 		return (CRYPTO_SUCCESS);
 	}
 
-	lastp = (uint8_t *)ctx->ctr_cb;
 	crypto_init_ptrs(out, &iov_or_mp, &offset);
 
 	do {

--- a/module/icp/algs/modes/gcm.c
+++ b/module/icp/algs/modes/gcm.c
@@ -118,7 +118,6 @@ gcm_mode_encrypt_contiguous_blocks(gcm_ctx_t *ctx, char *data, size_t length,
 		return (CRYPTO_SUCCESS);
 	}
 
-	lastp = (uint8_t *)ctx->gcm_cb;
 	crypto_init_ptrs(out, &iov_or_mp, &offset);
 
 	gops = gcm_impl_get_ops();

--- a/module/lua/ldo.c
+++ b/module/lua/ldo.c
@@ -452,7 +452,7 @@ int luaD_poscall (lua_State *L, StkId firstResult) {
   }
   res = ci->func;  /* res == final position of 1st result */
   wanted = ci->nresults;
-  L->ci = ci = ci->previous;  /* back to caller */
+  L->ci = ci->previous;  /* back to caller */
   /* move results to correct place */
   for (i = wanted; i != 0 && firstResult < L->top; i--)
     setobjs2s(L, res++, firstResult++);

--- a/module/os/freebsd/zfs/zfs_znode.c
+++ b/module/os/freebsd/zfs/zfs_znode.c
@@ -1949,7 +1949,6 @@ zfs_obj_to_path_impl(objset_t *osp, uint64_t obj, sa_handle_t *hdl,
 	} else if (error != ENOENT) {
 		return (error);
 	}
-	error = 0;
 
 	for (;;) {
 		uint64_t pobj;

--- a/module/os/freebsd/zfs/zio_crypt.c
+++ b/module/os/freebsd/zfs/zio_crypt.c
@@ -1735,7 +1735,6 @@ zio_do_crypt_data(boolean_t encrypt, zio_crypt_key_t *key,
 		goto error;
 	if (locked) {
 		rw_exit(&key->zk_salt_lock);
-		locked = B_FALSE;
 	}
 
 	if (authbuf != NULL)

--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -2136,7 +2136,6 @@ zfs_obj_to_path_impl(objset_t *osp, uint64_t obj, sa_handle_t *hdl,
 	} else if (error != ENOENT) {
 		return (error);
 	}
-	error = 0;
 
 	for (;;) {
 		uint64_t pobj = 0;

--- a/module/os/linux/zfs/zio_crypt.c
+++ b/module/os/linux/zfs/zio_crypt.c
@@ -1968,7 +1968,6 @@ zio_do_crypt_data(boolean_t encrypt, zio_crypt_key_t *key,
 
 	if (locked) {
 		rw_exit(&key->zk_salt_lock);
-		locked = B_FALSE;
 	}
 
 	if (authbuf != NULL)

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3939,7 +3939,7 @@ arc_evict_hdr(arc_buf_hdr_t *hdr, kmutex_t *hash_lock, uint64_t *real_evicted)
 			 * dropping from L1+L2 cached to L2-only,
 			 * realloc to remove the L1 header.
 			 */
-			hdr = arc_hdr_realloc(hdr, hdr_full_cache,
+			(void) arc_hdr_realloc(hdr, hdr_full_cache,
 			    hdr_l2only_cache);
 			*real_evicted += HDR_FULL_SIZE - HDR_L2ONLY_SIZE;
 		} else {

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1549,7 +1549,6 @@ dbuf_read_impl(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags,
 	uint32_t aflags = ARC_FLAG_NOWAIT;
 	int err, zio_flags;
 
-	err = zio_flags = 0;
 	DB_DNODE_ENTER(db);
 	dn = DB_DNODE(db);
 	ASSERT(!zfs_refcount_is_zero(&db->db_holds));

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -229,7 +229,6 @@ dsl_bookmark_create_check_impl(dsl_pool_t *dp,
 	switch (error) {
 	case ESRCH:
 		/* happy path: new bmark doesn't exist, proceed after switch */
-		error = 0;
 		break;
 	case 0:
 		error = SET_ERROR(EEXIST);

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -3421,7 +3421,8 @@ dsl_dataset_promote_check(void *arg, dmu_tx_t *tx)
 			conflicting_snaps = B_TRUE;
 		} else if (err == ESRCH) {
 			err = 0;
-		} else if (err != 0) {
+		}
+		if (err != 0) {
 			goto out;
 		}
 	}

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -331,7 +331,6 @@ dsl_pool_open(dsl_pool_t *dp)
 			/*
 			 * We might not have created the remap bpobj yet.
 			 */
-			err = 0;
 		} else {
 			goto out;
 		}

--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -548,11 +548,11 @@ mmp_thread(void *arg)
 	uint32_t mmp_fail_intervals = MMP_FAIL_INTVS_OK(
 	    zfs_multihost_fail_intervals);
 	hrtime_t mmp_fail_ns = mmp_fail_intervals * mmp_interval;
-	boolean_t last_spa_suspended = suspended;
-	boolean_t last_spa_multihost = multihost;
-	uint64_t last_mmp_interval = mmp_interval;
-	uint32_t last_mmp_fail_intervals = mmp_fail_intervals;
-	hrtime_t last_mmp_fail_ns = mmp_fail_ns;
+	boolean_t last_spa_suspended;
+	boolean_t last_spa_multihost;
+	uint64_t last_mmp_interval;
+	uint32_t last_mmp_fail_intervals;
+	hrtime_t last_mmp_fail_ns;
 	callb_cpr_t cpr;
 	int skip_wait = 0;
 

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6803,8 +6803,8 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 
 	pvd = oldvd->vdev_parent;
 
-	if ((error = spa_config_parse(spa, &newrootvd, nvroot, NULL, 0,
-	    VDEV_ALLOC_ATTACH)) != 0)
+	if (spa_config_parse(spa, &newrootvd, nvroot, NULL, 0,
+	    VDEV_ALLOC_ATTACH) != 0)
 		return (spa_vdev_exit(spa, NULL, txg, EINVAL));
 
 	if (newrootvd->vdev_children != 1)
@@ -7160,7 +7160,7 @@ spa_vdev_detach(spa_t *spa, uint64_t guid, uint64_t pguid, int replace_done)
 	 * it may be that the unwritability of the disk is the reason
 	 * it's being detached!
 	 */
-	error = vdev_label_init(vd, 0, VDEV_LABEL_REMOVE);
+	(void) vdev_label_init(vd, 0, VDEV_LABEL_REMOVE);
 
 	/*
 	 * Remove vd from its parent and compact the parent's children.

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -6078,7 +6078,6 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 			strval = NULL;
 			zprop_source_t src = ZPROP_SRC_DEFAULT;
 			propname = za.za_name;
-			prop = vdev_name_to_prop(propname);
 
 			switch (za.za_integer_length) {
 			case 8:

--- a/module/zfs/zcp_get.c
+++ b/module/zfs/zcp_get.c
@@ -467,7 +467,8 @@ get_zap_prop(lua_State *state, dsl_dataset_t *ds, zfs_prop_t zfs_prop)
 	} else {
 		error = dsl_prop_get_ds(ds, prop_name, sizeof (numval),
 		    1, &numval, setpoint);
-
+		if (error != 0)
+			goto out;
 #ifdef _KERNEL
 		/* Fill in temporary value for prop, if applicable */
 		(void) zfs_get_temporary_prop(ds, zfs_prop, &numval, setpoint);
@@ -489,6 +490,7 @@ get_zap_prop(lua_State *state, dsl_dataset_t *ds, zfs_prop_t zfs_prop)
 				(void) lua_pushnumber(state, numval);
 		}
 	}
+out:
 	kmem_free(strval, ZAP_MAXVALUELEN);
 	if (error == 0)
 		get_prop_src(state, setpoint, zfs_prop);

--- a/tests/zfs-tests/cmd/btree_test.c
+++ b/tests/zfs-tests/cmd/btree_test.c
@@ -220,7 +220,6 @@ insert_find_remove(zfs_btree_t *bt, char *why)
 static int
 drain_tree(zfs_btree_t *bt, char *why)
 {
-	uint64_t *p;
 	avl_tree_t avl;
 	int i = 0;
 	int_node_t *node;
@@ -232,11 +231,8 @@ drain_tree(zfs_btree_t *bt, char *why)
 
 	/* Fill both trees with the same data */
 	for (i = 0; i < 64 * 1024; i++) {
-		void *ret;
-
 		u_longlong_t randval = random();
-		if ((p = (uint64_t *)zfs_btree_find(bt, &randval, &bt_idx)) !=
-		    NULL) {
+		if (zfs_btree_find(bt, &randval, &bt_idx) != NULL) {
 			continue;
 		}
 		zfs_btree_add_idx(bt, &randval, &bt_idx);
@@ -245,7 +241,7 @@ drain_tree(zfs_btree_t *bt, char *why)
 		ASSERT3P(node, !=, NULL);
 
 		node->data = randval;
-		if ((ret = avl_find(&avl, node, &avl_idx)) != NULL) {
+		if (avl_find(&avl, node, &avl_idx) != NULL) {
 			(void) snprintf(why, BUFSIZE,
 			    "Found in avl: %llu\n", randval);
 			return (1);
@@ -365,9 +361,7 @@ stress_tree(zfs_btree_t *bt, char *why)
 
 	if (stress_only) {
 		zfs_btree_index_t *idx = NULL;
-		uint64_t *rv;
-
-		while ((rv = zfs_btree_destroy_nodes(bt, &idx)) != NULL)
+		while (zfs_btree_destroy_nodes(bt, &idx) != NULL)
 			;
 		zfs_btree_verify(bt);
 	}
@@ -382,15 +376,15 @@ stress_tree(zfs_btree_t *bt, char *why)
 static int
 insert_duplicate(zfs_btree_t *bt)
 {
-	uint64_t *p, i = 23456;
+	uint64_t i = 23456;
 	zfs_btree_index_t bt_idx = {0};
 
-	if ((p = (uint64_t *)zfs_btree_find(bt, &i, &bt_idx)) != NULL) {
+	if (zfs_btree_find(bt, &i, &bt_idx) != NULL) {
 		fprintf(stderr, "Found value in empty tree.\n");
 		return (0);
 	}
 	zfs_btree_add_idx(bt, &i, &bt_idx);
-	if ((p = (uint64_t *)zfs_btree_find(bt, &i, &bt_idx)) == NULL) {
+	if (zfs_btree_find(bt, &i, &bt_idx) == NULL) {
 		fprintf(stderr, "Did not find expected value.\n");
 		return (0);
 	}
@@ -408,10 +402,10 @@ insert_duplicate(zfs_btree_t *bt)
 static int
 remove_missing(zfs_btree_t *bt)
 {
-	uint64_t *p, i = 23456;
+	uint64_t i = 23456;
 	zfs_btree_index_t bt_idx = {0};
 
-	if ((p = (uint64_t *)zfs_btree_find(bt, &i, &bt_idx)) != NULL) {
+	if (zfs_btree_find(bt, &i, &bt_idx) != NULL) {
 		fprintf(stderr, "Found value in empty tree.\n");
 		return (0);
 	}
@@ -492,10 +486,6 @@ main(int argc, char *argv[])
 			break;
 		}
 	}
-	argc -= optind;
-	argv += optind;
-	optind = 1;
-
 
 	if (seed == 0) {
 		(void) gettimeofday(&tp, NULL);
@@ -529,7 +519,6 @@ main(int argc, char *argv[])
 	btree_test_t *test = &test_table[0];
 	while (test->name) {
 		int retval;
-		uint64_t *rv;
 		char why[BUFSIZE] = {0};
 		zfs_btree_index_t *idx = NULL;
 
@@ -547,7 +536,7 @@ main(int argc, char *argv[])
 		}
 
 		/* Remove all the elements and re-verify the tree */
-		while ((rv = zfs_btree_destroy_nodes(&bt, &idx)) != NULL)
+		while (zfs_btree_destroy_nodes(&bt, &idx) != NULL)
 			;
 		zfs_btree_verify(&bt);
 

--- a/tests/zfs-tests/cmd/ctime.c
+++ b/tests/zfs-tests/cmd/ctime.c
@@ -327,7 +327,6 @@ main(void)
 	if (access(tfile, F_OK) == 0) {
 		(void) unlink(tfile);
 	}
-	ret = 0;
 	if ((fd = open(tfile, O_WRONLY | O_CREAT | O_TRUNC, ALL_MODE)) == -1) {
 		(void) fprintf(stderr, "open(%s) failed: %d\n", tfile, errno);
 		return (1);

--- a/tests/zfs-tests/cmd/draid.c
+++ b/tests/zfs-tests/cmd/draid.c
@@ -1285,12 +1285,11 @@ draid_merge_impl(nvlist_t *allcfgs, const char *srcfilename, int *mergedp)
 
 				if (nv_worst_ratio < allcfg_worst_ratio) {
 					fnvlist_remove(allcfgs, key);
-					error = nvlist_add_nvlist(allcfgs,
-					    key, cfg);
+					fnvlist_add_nvlist(allcfgs, key, cfg);
 					merged++;
 				}
 			} else if (error == ENOENT) {
-				error = nvlist_add_nvlist(allcfgs, key, cfg);
+				fnvlist_add_nvlist(allcfgs, key, cfg);
 				merged++;
 			} else {
 				return (error);

--- a/tests/zfs-tests/cmd/mkbusy.c
+++ b/tests/zfs-tests/cmd/mkbusy.c
@@ -148,14 +148,10 @@ main(int argc, char *argv[])
 		}
 
 	if (!isdir) {
-		int	fd;
-
-		if ((fd = open(fpath, O_CREAT | O_RDWR, 0600)) < 0)
+		if (open(fpath, O_CREAT | O_RDWR, 0600) < 0)
 			fail("open");
 	} else {
-		DIR	*dp;
-
-		if ((dp = opendir(fpath)) == NULL)
+		if (opendir(fpath) == NULL)
 			fail("opendir");
 	}
 	free(fpath);

--- a/tests/zfs-tests/cmd/user_ns_exec.c
+++ b/tests/zfs-tests/cmd/user_ns_exec.c
@@ -97,7 +97,6 @@ set_idmap(pid_t pid, const char *file)
 
 	mapfd = open(path, O_WRONLY);
 	if (mapfd < 0) {
-		result = errno;
 		perror("open");
 		return (errno);
 	}


### PR DESCRIPTION
### Motivation and Context
These were categorized as the following:

 * Dead assignment		23

 * Dead increment		4

 * Dead initialization		6

 * Dead nested assignment	18

Most of these are harmless, but since actual issues can hide among them, we correct them.

After this commit is merged, regressions like dee8934e8fcd002eb826cf29aa453632d634b826 should become extremely obvious with Clang's static analyzer since a regression would appear in the results as the only instance of unused code. That assumes that Coverity does not catch the issue first.

My local branch with fixes from all of my outstanding non-draft pull requests shows 118 reports from Clang's static anlayzer after this patch. That is down by 51 from 169.

### Description
There were a few return values that were being ignored that appeared to merit some correction:

 * `destroy_callback()` in `cmd/zfs/zfs_main.c` ignored the error from `destroy_batched()`. We handle it by returning -1 if there is an error.

 * `zfs_do_upgrade()` in `cmd/zfs/zfs_main.c` ignored the error from `zfs_for_each()`. We handle it by doing a binary OR of the error value from the subsequent `zfs_for_each()` call to the existing value. This is how errors are mostly handled inside `zfs_for_each()`. The error value here is passed to exit from the zfs command, so doing a binary or on it is better than what we did previously.

 * `get_zap_prop()` in `module/zfs/zcp_get.c` ignored the error from `dsl_prop_get_ds()` when the property is not of type string. We return an error when it does. There is a small concern that the `zfs_get_temporary_prop()` call would handle things, but in the case that it does not, we would be pushing an uninitialized numval onto the lua stack. It is expected that `dsl_prop_get_ds()` will succeed anytime that `zfs_get_temporary_prop()` does, so that not giving it a chance to fix things is not a problem.

 * `draid_merge_impl()` in `tests/zfs-tests/cmd/draid.c` used `nvlist_add_nvlist()` twice in ways in which errors are expected to be impossible, so we switch to `fnvlist_add_nvlist()`.

A few notable ones did not merit use of the return value, so we suppressed it with `(void)`:

 * `write_free_diffs()` in `lib/libzfs/libzfs_diff.c` ignored the error value from `describe_free()`. A look through the commit history revealed that this was intentional.

 * `arc_evict_hdr()` in `module/zfs/arc.c` did not need to use the returned handle from `arc_hdr_realloc()` because it is already referenced in lists.

 * `spa_vdev_detach()` in `module/zfs/spa.c` has a comment explicitly saying not to use the error from `vdev_label_init()` because whatever causes the error could be the reason why a detach is being done.

### How Has This Been Tested?
A build test was done. More extensive testing will be done on the buildbot.

Unfortunately, I am not presently able to analyze the kernel modules with Clang's static analyzer, so I could have missed some cases of this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
