### PR TITLE
cstyle: Allow URLs in C++ comments

### DIFF
--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -498,9 +498,6 @@ line: while (<$filehandle>) {
 	if (/\S\*\/[^)]|\S\*\/$/ && !/$lint_re/) {
 		err("missing blank before close comment");
 	}
-	if (/\/\/\S/) {		# C++ comments
-		err("missing blank after start comment");
-	}
 	# check for unterminated single line comments, but allow them when
 	# they are used to comment out the argument list of a function
 	# declaration.
@@ -534,7 +531,15 @@ line: while (<$filehandle>) {
 	# multiple comments on the same line.
 	#
 	s/\/\*.*?\*\///g;
-	s/\/\/.*$//;		# C++ comments
+	s/\/\/(?:\s.*)?$//;	# Valid C++ comments
+
+	# After stripping correctly spaced comments, check for (and strip) comments
+	# without a blank.  By checking this after clearing out C++ comments that
+	# correctly have a blank, we guarantee URIs in a C++ comment will not cause
+	# an error.
+	if (s!//.*$!!) {		# C++ comments
+		err("missing blank after start comment");
+	}
 
 	# delete any trailing whitespace; we have already checked for that.
 	s/\s*$//;


### PR DESCRIPTION
### Motivation and Context
Received message `Error: missing blank after start comment` on the following line of C code:
```
// http://www.illumos.org/license/CDDL.
```

As far as I can tell, this comment is valid by the rules, but the checker mistakenly flagged it because two SOLIDUS characters in sequence, followed immediately by a non-whitespace character (specifically, LATIN SMALL LETTER W), appears somewhere on the line.

### Description
This PR moves the error check so it occurs after the C++ comment's content is cleared out.  To make sure invalid comments are still recognized, only valid C++ comments are cleared out in the first check.  Invalid C++ comments are cleared out at the same time they are detected.

Note: The check for invalid C++ comments matches on all C++ comments, valid or invalid.

### How Has This Been Tested?
Ran the checkstyle GitHub action on a branch with the line mentioned above, observed a failure.
Applied this patch and re-ran the checkstyle action, observed success.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
