### PR TITLE
zstream: allow decompress to fix metadata for uncompressed records

### DIFF
--- a/cmd/zstream/zstream_decompress.c
+++ b/cmd/zstream/zstream_decompress.c
@@ -279,8 +279,10 @@ zstream_do_decompress(int argc, char *argv[])
 						    "compression type to off "
 						    "for ino %llu offset "
 						    "%llu\n",
-						    (u_longlong_t)drrw->drr_object,
-						    (u_longlong_t)drrw->drr_offset);
+						    (u_longlong_t)
+						    drrw->drr_object,
+						    (u_longlong_t)
+						    drrw->drr_offset);
 				} else if (0 != xfunc(lzbuf, buf,
 				    payload_size, payload_size, 0)) {
 					/*

--- a/cmd/zstream/zstream_decompress.c
+++ b/cmd/zstream/zstream_decompress.c
@@ -115,7 +115,9 @@ zstream_do_decompress(int argc, char *argv[])
 		if (errno || *end != '\0')
 			errx(1, "invalid value for offset");
 		if (argv[i]) {
-			if (0 == strcmp("lz4", argv[i]))
+			if (0 == strcmp("off", argv[i]))
+				type = ZIO_COMPRESS_OFF;
+			else if (0 == strcmp("lz4", argv[i]))
 				type = ZIO_COMPRESS_LZ4;
 			else if (0 == strcmp("lzjb", argv[i]))
 				type = ZIO_COMPRESS_LZJB;
@@ -127,8 +129,8 @@ zstream_do_decompress(int argc, char *argv[])
 				type = ZIO_COMPRESS_ZSTD;
 			else {
 				fprintf(stderr, "Invalid compression type %s.\n"
-				    "Supported types are lz4, lzjb, gzip, zle, "
-				    "and zstd\n",
+				    "Supported types are off, lz4, lzjb, gzip, "
+				    "zle, and zstd\n",
 				    argv[i]);
 				exit(2);
 			}
@@ -240,6 +242,9 @@ zstream_do_decompress(int argc, char *argv[])
 			if (p != NULL) {
 				zio_decompress_func_t *xfunc = NULL;
 				switch ((enum zio_compress)(intptr_t)p->data) {
+				case ZIO_COMPRESS_OFF:
+					xfunc = NULL;
+					break;
 				case ZIO_COMPRESS_LZJB:
 					xfunc = lzjb_decompress;
 					break;
@@ -258,7 +263,6 @@ zstream_do_decompress(int argc, char *argv[])
 				default:
 					assert(B_FALSE);
 				}
-				assert(xfunc != NULL);
 
 
 				/*
@@ -266,12 +270,25 @@ zstream_do_decompress(int argc, char *argv[])
 				 */
 				char *lzbuf = safe_calloc(payload_size);
 				(void) sfread(lzbuf, payload_size, stdin);
-				if (0 != xfunc(lzbuf, buf,
+				if (xfunc == NULL) {
+					memcpy(buf, lzbuf, payload_size);
+					drrw->drr_compressiontype =
+					    ZIO_COMPRESS_OFF;
+					if (verbose)
+						fprintf(stderr, "Resetting "
+						    "compression type to off "
+						    "for ino %llu offset "
+						    "%llu\n",
+						    (u_longlong_t)drrw->drr_object,
+						    (u_longlong_t)drrw->drr_offset);
+				} else if (0 != xfunc(lzbuf, buf,
 				    payload_size, payload_size, 0)) {
 					/*
 					 * The block must not be compressed,
-					 * possibly because it gets written
-					 * multiple times in this stream.
+					 * at least not with this compression
+					 * type, possibly because it gets
+					 * written multiple times in this
+					 * stream.
 					 */
 					warnx("decompression failed for "
 					    "ino %llu offset %llu",
@@ -279,11 +296,16 @@ zstream_do_decompress(int argc, char *argv[])
 					    (u_longlong_t)drrw->drr_offset);
 					memcpy(buf, lzbuf, payload_size);
 				} else if (verbose) {
+					drrw->drr_compressiontype =
+					    ZIO_COMPRESS_OFF;
 					fprintf(stderr, "successfully "
 					    "decompressed ino %llu "
 					    "offset %llu\n",
 					    (u_longlong_t)drrw->drr_object,
 					    (u_longlong_t)drrw->drr_offset);
+				} else {
+					drrw->drr_compressiontype =
+					    ZIO_COMPRESS_OFF;
 				}
 				free(lzbuf);
 			} else {

--- a/man/man8/zstream.8
+++ b/man/man8/zstream.8
@@ -20,7 +20,7 @@
 .\"
 .\" Copyright (c) 2020 by Delphix. All rights reserved.
 .\"
-.Dd March 25, 2022
+.Dd October 4, 2022
 .Dt ZSTREAM 8
 .Os
 .
@@ -96,6 +96,7 @@ Specify the object number and byte offset of each record that you wish to
 decompress.
 Optionally specify the compression type.
 Valid compression types include
+.Sy off ,
 .Sy gzip ,
 .Sy lz4 ,
 .Sy lzjb ,
@@ -108,6 +109,11 @@ Every record for that object beginning at that offset will be decompressed, if
 possible.
 It may not be possible, because the record may be corrupted in some but not
 all of the stream's snapshots.
+Specifying a compression type of
+.Sy off
+will change the stream's metadata accordingly, without attempting decompression.
+This can be useful if the record is already uncompressed but the metadata
+insists otherwise.
 The repaired stream will be written to standard output.
 .Bl -tag -width "-v"
 .It Fl v


### PR DESCRIPTION
If a record is uncompressed on-disk but the block pointer insists otherwise, reading it will return EIO.  This commit adds an "off" type to the "zstream decompress" command.  Using it will set the compression field in a zfs stream to "off" without changing the record's data.

Signed-off-by:	Alan Somers <asomers@FreeBSD.org>
Sponsored by:	Axcient

### Motivation and Context
Similarly to the problem in #12762 , I found a dataset containing a record which was clearly uncompressed, as shown by zdb, but the block pointer's comp field was set to ZIO_COMPRESS_LZ4.  That resulted in attempts to read the record returning EIO.  I don't know how it got into that state.  This commit allows zstream to fix the problem with a command like:
```
zfs send -c <DS> | zstream decompress 10,0,off | zfs recv <DST_DS>
```

### Description
"zstream decompress" can already fix the opposite problem: compressed records whose block pointer indicates that they are uncompressed.  This change simply adds a new "off" option to that command.

### How Has This Been Tested?
Tested with a corrupted production dataset.  I don't know how to create such a corrupted dataset in the first place.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
