### PR TITLE
zvol_wait logic may terminate prematurely

### DIFF
--- a/cmd/zvol_wait
+++ b/cmd/zvol_wait
@@ -109,6 +109,13 @@ while [ "$outer_loop" -lt 20 ]; do
 			exit 0
 		fi
 	fi
+
+	#
+	# zvol_count made some progress - let's stay in this loop.
+	#
+	if [ "$old_zvols_count" -gt "$zvols_count" ]; then
+		outer_loop=$((outer_loop - 1))
+	fi
 done
 
 echo "Timed out waiting on zvol links"


### PR DESCRIPTION
Setups that have a lot of zvols may see zvol_wait terminate prematurely even though the script is still making progress.  For example, we have a customer that called zvol_wait for ~7100 zvols and by the last iteration of that script it was still waiting on ~2900. Similarly another one called zvol_wait for 2200 and by the time the script terminated there were only 50 left.

This patch adjusts the logic to stay within the outer loop of the script if we are making any progress whatsoever.

Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>

## Testing

With @don-brady 's help I managed to reproduce the issue by invoking a 20-second sleep in the udev-rule that creates those links. Here is the rule with the sleep statemet:
```
$ sudo cat /lib/udev/rules.d/60-zvol.rules
# Persistent links for zvol
#
# persistent disk links: /dev/zvol/dataset_name
#
# NOTE: We used to also create an additional tree of zvol symlinks located at
#       /dev/dataset_name (i.e. without the 'zvol' path component) for
#       compatibility reasons. These are no longer created anymore, and should
#       not be relied upon.
#

KERNEL=="zd*", SUBSYSTEM=="block", ACTION=="add|change", PROGRAM+="/usr/bin/sleep 20", PROGRAM+="/lib/udev/zvol_id $devnode", SYMLINK+="zvol/%c"
```

And here is the reproduced error as seen by `journalctl`:
```
-- Reboot --
Oct 08 17:28:47 ip-10-110-252-123 systemd[1]: Starting Wait for ZFS Volume (zvol) links in /dev...
Oct 08 17:29:07 ip-10-110-252-123 zvol_wait[14121]: Testing 10002 zvol links
Oct 08 17:29:41 ip-10-110-252-123 zvol_wait[14121]: Still waiting on 9841 zvol links ...
Oct 08 17:30:14 ip-10-110-252-123 zvol_wait[14121]: Still waiting on 9809 zvol links ...
...cropped...
Oct 08 17:40:15 ip-10-110-252-123 zvol_wait[14121]: Still waiting on 8861 zvol links ...
Oct 08 17:40:15 ip-10-110-252-123 zvol_wait[14121]: Timed out waiting on zvol links
Oct 08 17:40:15 ip-10-110-252-123 systemd[1]: zfs-volume-wait.service: Main process exited, code=exited, status=1/F>
Oct 08 17:40:15 ip-10-110-252-123 systemd[1]: zfs-volume-wait.service: Failed with result 'exit-code'.
Oct 08 17:40:15 ip-10-110-252-123 systemd[1]: Failed to start Wait for ZFS Volume (zvol) links in /dev.
```

With this patch I verified that the service stays around and eventually finishes successfully.