### PR TITLE
scripts/enum-extract.pl should not hard code perl path

### DIFF
--- a/scripts/enum-extract.pl
+++ b/scripts/enum-extract.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 my $usage = <<EOT;
 usage: config-enum enum [file ...]


### PR DESCRIPTION
### Motivation and Context
This is a portability issue. The issue had already been fixed for scripts/cstyle.pl by 2dbf1bf8296f66f24d5e404505c991bfbeec7808. scripts/enum-extract.pl was added to the repository the following year without this portability fix.

Michael Bishop informed me that this broke his attempt to build ZFS 2.1.6 on NixOS, since he was building manually outside of their package manager (that usually rewrites the shebangs to NixOS' unusual paths). NixOS puts all of the paths into $PATH, so scripts that portably rely on env to find the interpreter still work.

### Description
Corrected shebang. Also, dropped `-w` flag since the non-deprecated `use warnings` is already in use.

### How Has This Been Tested?
No testing is needed, but the buildbot will test it anyway.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
