### PR TITLE
expose free space histograms in /proc

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -944,6 +944,7 @@ typedef struct spa_stats {
 	spa_history_kstat_t	state;		/* pool state */
 	spa_history_kstat_t	guid;		/* pool guid */
 	spa_history_kstat_t	iostats;
+	spa_history_kstat_t	fragmentation[6];
 } spa_stats_t;
 
 typedef enum txg_state {

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -25,6 +25,7 @@
 #include <sys/vdev_impl.h>
 #include <sys/spa.h>
 #include <zfs_comutil.h>
+#include <sys/metaslab_impl.h>
 
 /*
  * Keeps stats on last N reads per spa_t, disabled by default.
@@ -301,6 +302,107 @@ spa_txg_history_init(spa_t *spa)
 	    spa_txg_history_show_header,
 	    spa_txg_history_clear,
 	    offsetof(spa_txg_history_t, sth_node));
+}
+
+typedef struct {
+    spa_t *spa;
+    int metaclass;
+} freespace_histogram_stat_t;
+
+static void *
+spa_frag_addr(kstat_t *ksp, loff_t n)
+{
+	if (n == 0) {
+		freespace_histogram_stat_t *stat = ksp->ks_private;
+		switch (stat->metaclass) {
+		case 0:
+			return (spa_normal_class(stat->spa));
+		case 1:
+			return (spa_log_class(stat->spa));
+		case 2:
+			return (spa_embedded_log_class(stat->spa));
+		case 3:
+			return (spa_special_class(stat->spa));
+		case 4:
+			return (spa_dedup_class(stat->spa));
+		case 5:
+			return (spa_special_embedded_log_class(stat->spa));
+		}
+	}
+	return (NULL);
+}
+
+static int
+spa_frag_data(char *buf, size_t size, void *data)
+{
+	metaslab_class_t *mc = data;
+	size_t offset = 0;
+	snprintf(buf+offset, size-offset, "bucket count\n");
+	offset = strlen(buf);
+
+	mutex_enter(&mc->mc_lock);
+	for (int i = 0; i < ZFS_RANGE_TREE_HISTOGRAM_SIZE; i++) {
+		if (mc->mc_histogram[i] > 0) {
+			snprintf(buf + offset, size - offset, "%d %llu\n", i,
+			    (u_longlong_t)mc->mc_histogram[i]);
+			offset = strlen(buf);
+		}
+	}
+	mutex_exit(&mc->mc_lock);
+
+	return (0);
+}
+
+static void
+spa_fragmentation_init(spa_t *spa)
+{
+	char *dirname;
+	const char *statnames[] = {
+	    "class_normal_free_histogram",
+	    "class_log_free_histogram",
+	    "class_elog_free_histogram",
+	    "class_special_free_histogram",
+	    "class_dedup_free_histogram",
+	    "class_special_elog_free_histogram"
+	};
+	for (int i = 0; i < 6; i++) {
+		spa_history_kstat_t *shk = &spa->spa_stats.fragmentation[i];
+		kstat_t *ksp;
+
+		dirname = kmem_asprintf("zfs/%s", spa_name(spa));
+		ksp = kstat_create(dirname, 0, statnames[i], "misc",
+		    KSTAT_TYPE_RAW, 0, KSTAT_FLAG_VIRTUAL);
+		kmem_strfree(dirname);
+
+		shk->kstat = ksp;
+		if (ksp) {
+			freespace_histogram_stat_t *stat = kmem_zalloc(
+			    sizeof (freespace_histogram_stat_t), KM_SLEEP);
+			stat->spa = spa;
+			stat->metaclass = i;
+			ksp->ks_private = stat;
+			ksp->ks_flags |= KSTAT_FLAG_NO_HEADERS;
+			kstat_set_raw_ops(ksp, NULL, spa_frag_data,
+			    spa_frag_addr);
+			kstat_install(ksp);
+		}
+	}
+}
+
+static void
+spa_fragmentation_destroy(spa_t *spa)
+{
+	for (int i = 0; i < 6; i++) {
+		spa_history_kstat_t *shk = &spa->spa_stats.fragmentation[i];
+		kstat_t *ksp = shk->kstat;
+		if (ksp) {
+			if (ksp->ks_private) {
+				kmem_free(ksp->ks_private,
+				    sizeof (freespace_histogram_stat_t));
+			}
+			kstat_delete(ksp);
+		}
+	}
 }
 
 static void
@@ -1047,11 +1149,13 @@ spa_stats_init(spa_t *spa)
 	spa_state_init(spa);
 	spa_guid_init(spa);
 	spa_iostats_init(spa);
+	spa_fragmentation_init(spa);
 }
 
 void
 spa_stats_destroy(spa_t *spa)
 {
+	spa_fragmentation_destroy(spa);
 	spa_iostats_destroy(spa);
 	spa_health_destroy(spa);
 	spa_tx_assign_destroy(spa);


### PR DESCRIPTION
### Motivation and Context
this allows graphing `zdb -MM` without any performance costs

### Description
adds a new kstat in /proc with free space fragmentation
example output:
```
[root@nixos:~]# cat /proc/spl/kstat/zfs/vm/fragmentation
normal{power="9",pool="vm"} 14
normal{power="10",pool="vm"} 75
normal{power="11",pool="vm"} 16
normal{power="12",pool="vm"} 37
```

### How Has This Been Tested?
booting a vm and comparing the output to `zdb -MM vm`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
