### PR TITLE
Draft: Start zfs-load-key.service before basic.target

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -55,6 +55,7 @@ systemdunit_DATA = \
 	%D%/systemd/system/zfs-import-cache.service \
 	%D%/systemd/system/zfs-import-scan.service \
 	%D%/systemd/system/zfs-import.target \
+	%D%/systemd/system/zfs-load-key.service \
 	%D%/systemd/system/zfs-mount.service \
 	%D%/systemd/system/zfs-scrub-monthly@.timer \
 	%D%/systemd/system/zfs-scrub-weekly@.timer \

--- a/etc/systemd/system/zfs-load-key.service.in
+++ b/etc/systemd/system/zfs-load-key.service.in
@@ -1,0 +1,20 @@
+# Based on systemd-sysv-generator output of /etc/init.d/zfs-load-key
+[Unit]
+SourcePath=/etc/init.d/zfs-load-key
+Description=Load ZFS keys for filesystems and volumes
+Documentation=man:zfs-load-key(8)
+Before=zfs-mount.service
+After=zfs-import.service
+DefaultDependencies=no
+
+[Service]
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=yes
+SuccessExitStatus=5 6
+ExecStart=/etc/init.d/zfs-load-key start
+ExecStop=/etc/init.d/zfs-load-key stop


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `zfs-load-key` is generated from `https://github.com/openzfs/zfs/blob/master/etc/init.d/zfs-load-key.in` via `systemd-sysv-generator`
- by default systemd adds `default.target` to all services, if `DefaultDependencies=no` wasn't explicitly set
- `default.target` usually means `all local FSes are already mounted` -> waits for `zfs-mount`, **boom, blast**
- I don't see that `systemd-sysv-generator` supports for `DefaultDependencies=no` https://github.com/systemd/systemd/blob/main/src/sysv-generator/sysv-generator.c
- Maybe worse https://www.freedesktop.org/software/systemd/man/systemd-sysv-generator.html `systemd does not support SysV scripts as part of early boot, so all wrapper units are ordered after basic.target.`

Thankfully, real service file overrides sysv generator.

Closes https://github.com/openzfs/zfs/issues/14010


### Description
<!--- Describe your changes in detail -->
Create honest systemd service based on generated one, use DefaultDependencies=no.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Manual file creation on laptop with reproducer. I'll test deb package tomorrow and remove draft status after that, until then - review and thoughts are welcome!
@ogelpre @nabijaczleweli review please.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
