### PR TITLE
kcfpool_alloc() should have its argument list marked void

### DIFF
--- a/module/icp/core/kcf_sched.c
+++ b/module/icp/core/kcf_sched.c
@@ -1274,7 +1274,7 @@ kcf_aop_done(kcf_areq_node_t *areq, int error)
  * Allocate the thread pool and initialize all the fields.
  */
 static void
-kcfpool_alloc()
+kcfpool_alloc(void)
 {
 	kcfpool = kmem_alloc(sizeof (kcf_pool_t), KM_SLEEP);
 


### PR DESCRIPTION
### Motivation and Context
This error occurred when bulding on Gentoo with debugging enabled:

```
/var/tmp/portage/sys-fs/zfs-kmod-2.1.6/work/zfs-2.1.6/module/icp/core/kcf_sched.c:1277:14: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes] kcfpool_alloc()
             ^
              void
1 error generated.
```

This function is not present in master.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
