### PR TITLE
Linux 6.1 regression: Fix failure to compile due to mutex_init() macro in Linux 6.1-rc1

### DIFF
--- a/module/os/linux/spl/spl-procfs-list.c
+++ b/module/os/linux/spl/spl-procfs-list.c
@@ -23,9 +23,9 @@
  */
 
 #include <sys/list.h>
-#include <sys/mutex.h>
 #include <sys/procfs_list.h>
 #include <linux/proc_fs.h>
+#include <sys/mutex.h>
 
 /*
  * A procfs_list is a wrapper around a linked list which implements the seq_file

--- a/module/os/linux/spl/spl-zone.c
+++ b/module/os/linux/spl/spl-zone.c
@@ -25,7 +25,6 @@
  */
 
 #include <sys/types.h>
-#include <sys/mutex.h>
 #include <sys/sysmacros.h>
 #include <sys/kmem.h>
 #include <linux/file.h>
@@ -36,6 +35,8 @@
 #include <linux/statfs.h>
 #include <linux/proc_ns.h>
 #endif
+
+#include <sys/mutex.h>
 
 static kmutex_t zone_datasets_lock;
 static struct list_head zone_datasets;


### PR DESCRIPTION
### Motivation and Context
Module fails to build for me on Linux 6.1-rc1 due to the mutex_init(...) macro definitions.

### Description
The error is thrown when trying to compile two files:
* `module/os/linux/spl/spl-procfs-list.c`
* `module/os/linux/spl/spl-zone.c`

In both files, I found that it properly compiles if I move the `#include <sys/mutex.h>` to a lower position in the list of header includes.

### How Has This Been Tested?
Testing on my Arch Linux desktop running Linux 6.1-rc1 right now

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
