### PR TITLE
Fix potential NULL pointer dereferences 

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -3066,7 +3066,7 @@ open_objset(const char *path, const void *tag, objset_t **osp)
 	}
 	sa_os = *osp;
 
-	return (0);
+	return (err);
 }
 
 static void

--- a/lib/libzpool/util.c
+++ b/lib/libzpool/util.c
@@ -229,13 +229,14 @@ set_global_var(char const *arg)
 		fprintf(stderr, "Failed to open libzpool.so to set global "
 		    "variable\n");
 		ret = EIO;
-		goto out_dlclose;
+		goto out_free;
 	}
 
 	ret = 0;
 
 out_dlclose:
 	dlclose(zpoolhdl);
+out_free:
 	free(varname);
 out_ret:
 	return (ret);

--- a/module/icp/io/sha2_mod.c
+++ b/module/icp/io/sha2_mod.c
@@ -737,12 +737,15 @@ sha2_mac_init(crypto_ctx_t *ctx, crypto_mechanism_t *mechanism,
 	 */
 	if (mechanism->cm_type % 3 == 2) {
 		if (mechanism->cm_param == NULL ||
-		    mechanism->cm_param_len != sizeof (ulong_t))
+		    mechanism->cm_param_len != sizeof (ulong_t)) {
 			ret = CRYPTO_MECHANISM_PARAM_INVALID;
-		PROV_SHA2_GET_DIGEST_LEN(mechanism,
-		    PROV_SHA2_HMAC_CTX(ctx)->hc_digest_len);
-		if (PROV_SHA2_HMAC_CTX(ctx)->hc_digest_len > sha_digest_len)
-			ret = CRYPTO_MECHANISM_PARAM_INVALID;
+		} else {
+			PROV_SHA2_GET_DIGEST_LEN(mechanism,
+			    PROV_SHA2_HMAC_CTX(ctx)->hc_digest_len);
+			if (PROV_SHA2_HMAC_CTX(ctx)->hc_digest_len >
+			    sha_digest_len)
+				ret = CRYPTO_MECHANISM_PARAM_INVALID;
+		}
 	}
 
 	if (ret != CRYPTO_SUCCESS) {

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -955,6 +955,7 @@ fm_fmri_hc_create(nvlist_t *fmri, int version, const nvlist_t *auth,
 			}
 			atomic_inc_64(
 			    &erpt_kstat_data.fmri_set_failed.value.ui64);
+			va_end(ap);
 			return;
 		}
 	}

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -5267,7 +5267,7 @@ spa_open_common(const char *pool, spa_t **spapp, const void *tag,
 	 * If we've recovered the pool, pass back any information we
 	 * gathered while doing the load.
 	 */
-	if (state == SPA_LOAD_RECOVER) {
+	if (state == SPA_LOAD_RECOVER && config != NULL) {
 		fnvlist_add_nvlist(*config, ZPOOL_CONFIG_LOAD_INFO,
 		    spa->spa_load_info);
 	}

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -990,8 +990,10 @@ zap_lookup_impl(zap_t *zap, const char *name,
 			} else {
 				*(uint64_t *)buf =
 				    MZE_PHYS(zap, mze)->mze_value;
-				(void) strlcpy(realname,
-				    MZE_PHYS(zap, mze)->mze_name, rn_len);
+				if (realname != NULL)
+					(void) strlcpy(realname,
+					    MZE_PHYS(zap, mze)->mze_name,
+					    rn_len);
 				if (ncp) {
 					*ncp = mzap_normalization_conflict(zap,
 					    zn, mze);


### PR DESCRIPTION
### Motivation and Context
Coverity and Clang's static analyzer complained about various NULL pointer dereferences that appear to be real issues. Additionally, clang-tidy complained about a failure to call `va_end()` that I am including with this patch set.

### Description
The individual commit messages document the issues. The documentation of what was fixed and why was clearer when leaving them unsquashed, so I opened this PR as is.

### How Has This Been Tested?
A local build test has been done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
