### PR TITLE
Aligned free for aligned alloc

### DIFF
--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -935,7 +935,6 @@ zpool_read_label_slow(int fd, nvlist_t **config, int *num_labels)
 	vdev_phys_t *label;
 	nvlist_t *expected_config = NULL;
 	uint64_t expected_guid = 0, size;
-	int error;
 
 	*config = NULL;
 
@@ -943,8 +942,9 @@ zpool_read_label_slow(int fd, nvlist_t **config, int *num_labels)
 		return (0);
 	size = P2ALIGN_TYPED(statbuf.st_size, sizeof (vdev_label_t), uint64_t);
 
-	error = posix_memalign((void **)&label, PAGESIZE, sizeof (*label));
-	if (error)
+	label = (vdev_phys_t *)umem_alloc_aligned(sizeof (*label), PAGESIZE,
+	    UMEM_DEFAULT);
+	if (label == NULL)
 		return (-1);
 
 	for (l = 0; l < VDEV_LABELS; l++) {
@@ -993,7 +993,7 @@ zpool_read_label_slow(int fd, nvlist_t **config, int *num_labels)
 	if (num_labels != NULL)
 		*num_labels = count;
 
-	free(label);
+	umem_free_aligned(label, sizeof (*label));
 	*config = expected_config;
 
 	return (0);
@@ -1024,9 +1024,9 @@ zpool_read_label(int fd, nvlist_t **config, int *num_labels)
 		return (0);
 	size = P2ALIGN_TYPED(statbuf.st_size, sizeof (vdev_label_t), uint64_t);
 
-	error = posix_memalign((void **)&labels, PAGESIZE,
-	    VDEV_LABELS * sizeof (*labels));
-	if (error)
+	labels = (vdev_phys_t *)umem_alloc_aligned(
+	    VDEV_LABELS * sizeof (*labels), PAGESIZE, UMEM_DEFAULT);
+	if (labels == NULL)
 		return (-1);
 
 	memset(aiocbs, 0, sizeof (aiocbs));
@@ -1079,7 +1079,7 @@ zpool_read_label(int fd, nvlist_t **config, int *num_labels)
 			error = zpool_read_label_slow(fd, config, num_labels);
 			saved_errno = errno;
 		}
-		free(labels);
+		umem_free_aligned(labels, VDEV_LABELS * sizeof (*labels));
 		errno = saved_errno;
 		return (error);
 	}
@@ -1128,7 +1128,7 @@ zpool_read_label(int fd, nvlist_t **config, int *num_labels)
 	if (num_labels != NULL)
 		*num_labels = count;
 
-	free(labels);
+	umem_free_aligned(labels, VDEV_LABELS * sizeof (*labels));
 	*config = expected_config;
 
 	return (0);

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -598,7 +598,7 @@ abd_free_chunks(abd_t *abd)
 
 	abd_for_each_sg(abd, sg, n, i) {
 		struct page *p = nth_page(sg_page(sg), 0);
-		umem_free(p, PAGESIZE);
+		umem_free_aligned(p, PAGESIZE);
 	}
 	abd_free_sg_table(abd);
 }
@@ -704,7 +704,7 @@ abd_free_zero_scatter(void)
 	__free_page(abd_zero_page);
 #endif /* HAVE_ZERO_PAGE_GPL_ONLY */
 #else
-	umem_free(abd_zero_page, PAGESIZE);
+	umem_free_aligned(abd_zero_page, PAGESIZE);
 #endif /* _KERNEL */
 }
 


### PR DESCRIPTION
Windows port frees memory that was alloc'd aligned in a different way than alloc'd memory.
So changing frees to be specific and just ignoring it on non windows systems with a define.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
