### PR TITLE
Revert "Reduce false positives from Static Analyzers"

### DIFF
--- a/cmd/zed/zed_log.h
+++ b/cmd/zed/zed_log.h
@@ -39,7 +39,6 @@ void zed_log_syslog_close(void);
 
 void zed_log_msg(int priority, const char *fmt, ...);
 
-__attribute__((format(printf, 1, 2), __noreturn__))
 void zed_log_die(const char *fmt, ...);
 
 #endif	/* !ZED_LOG_H */

--- a/include/libuutil_impl.h
+++ b/include/libuutil_impl.h
@@ -42,8 +42,7 @@ extern "C" {
 void uu_set_error(uint_t);
 
 
-__attribute__((format(printf, 1, 2), __noreturn__))
-void uu_panic(const char *format, ...);
+void uu_panic(const char *format, ...) __attribute__((format(printf, 1, 2)));
 
 
 /*

--- a/include/os/freebsd/spl/sys/byteorder.h
+++ b/include/os/freebsd/spl/sys/byteorder.h
@@ -44,18 +44,6 @@
 
 #include <sys/endian.h>
 
-#ifdef __COVERITY__
-/*
- * Coverity's taint warnings from byteswapping are false positives for us.
- * Suppress them by hiding byteswapping from Coverity.
- */
-#define	BSWAP_8(x)	((x) & 0xff)
-#define	BSWAP_16(x)	((x) & 0xffff)
-#define	BSWAP_32(x)	((x) & 0xffffffff)
-#define	BSWAP_64(x)	(x)
-
-#else /* __COVERITY__ */
-
 /*
  * Macros to reverse byte order
  */
@@ -63,8 +51,6 @@
 #define	BSWAP_16(x)	((BSWAP_8(x) << 8) | BSWAP_8((x) >> 8))
 #define	BSWAP_32(x)	((BSWAP_16(x) << 16) | BSWAP_16((x) >> 16))
 #define	BSWAP_64(x)	((BSWAP_32(x) << 32) | BSWAP_32((x) >> 32))
-
-#endif /* __COVERITY__ */
 
 #define	BMASK_8(x)	((x) & 0xff)
 #define	BMASK_16(x)	((x) & 0xffff)

--- a/include/os/freebsd/spl/sys/cmn_err.h
+++ b/include/os/freebsd/spl/sys/cmn_err.h
@@ -71,7 +71,7 @@ extern void vuprintf(const char *, __va_list)
     __attribute__((format(printf, 1, 0)));
 
 extern void panic(const char *, ...)
-    __attribute__((format(printf, 1, 2), __noreturn__));
+    __attribute__((format(printf, 1, 2)));
 
 #endif /* !_ASM */
 

--- a/include/os/freebsd/spl/sys/debug.h
+++ b/include/os/freebsd/spl/sys/debug.h
@@ -54,16 +54,9 @@
 /*
  * Common DEBUG functionality.
  */
-extern void spl_panic(const char *file, const char *func, int line,
-    const char *fmt, ...) __attribute__((__noreturn__));
-extern void spl_dumpstack(void);
-
-static inline int
-spl_assert(const char *buf, const char *file, const char *func, int line)
-{
-	spl_panic(file, func, line, "%s", buf);
-	return (0);
-}
+int spl_panic(const char *file, const char *func, int line,
+    const char *fmt, ...);
+void spl_dumpstack(void);
 
 #ifndef expect
 #define	expect(expr, value) (__builtin_expect((expr), (value)))
@@ -76,8 +69,8 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 
 #define	VERIFY(cond)							\
 	(void) (unlikely(!(cond)) &&					\
-	    spl_assert("VERIFY(" #cond ") failed\n",			\
-	    __FILE__, __FUNCTION__, __LINE__))
+	    spl_panic(__FILE__, __FUNCTION__, __LINE__,			\
+	    "%s", "VERIFY(" #cond ") failed\n"))
 
 #define	VERIFY3B(LEFT, OP, RIGHT)	do {				\
 		const boolean_t _verify3_left = (boolean_t)(LEFT);	\
@@ -165,14 +158,13 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #define	ASSERT0		VERIFY0
 #define	ASSERT		VERIFY
 #define	IMPLY(A, B) \
-	((void)(likely((!(A)) || (B)) ||				\
-	    spl_assert("(" #A ") implies (" #B ")",			\
-	    __FILE__, __FUNCTION__, __LINE__)))
+	((void)(likely((!(A)) || (B)) || \
+	    spl_panic(__FILE__, __FUNCTION__, __LINE__, \
+	    "(" #A ") implies (" #B ")")))
 #define	EQUIV(A, B) \
-	((void)(likely(!!(A) == !!(B)) || 				\
-	    spl_assert("(" #A ") is equivalent to (" #B ")",		\
-	    __FILE__, __FUNCTION__, __LINE__)))
-
+	((void)(likely(!!(A) == !!(B)) || \
+	    spl_panic(__FILE__, __FUNCTION__, __LINE__, \
+	    "(" #A ") is equivalent to (" #B ")")))
 
 #endif /* NDEBUG */
 

--- a/include/os/freebsd/spl/sys/kmem.h
+++ b/include/os/freebsd/spl/sys/kmem.h
@@ -52,10 +52,8 @@ MALLOC_DECLARE(M_SOLARIS);
 
 typedef struct vmem vmem_t;
 
-extern char	*kmem_asprintf(const char *, ...)
-    __attribute__((format(printf, 1, 2)));
-extern char *kmem_vasprintf(const char *fmt, va_list ap)
-    __attribute__((format(printf, 1, 0)));
+extern char	*kmem_asprintf(const char *, ...);
+extern char *kmem_vasprintf(const char *fmt, va_list ap);
 
 typedef struct kmem_cache {
 	char		kc_name[32];
@@ -72,7 +70,6 @@ typedef struct kmem_cache {
 extern uint64_t spl_kmem_cache_inuse(kmem_cache_t *cache);
 extern uint64_t spl_kmem_cache_entry_size(kmem_cache_t *cache);
 
-__attribute__((alloc_size(1)))
 void *zfs_kmem_alloc(size_t size, int kmflags);
 void zfs_kmem_free(void *buf, size_t size);
 uint64_t kmem_size(void);

--- a/include/os/linux/spl/sys/byteorder.h
+++ b/include/os/linux/spl/sys/byteorder.h
@@ -36,25 +36,10 @@
 
 #include <sys/isa_defs.h>
 
-#ifdef __COVERITY__
-/*
- * Coverity's taint warnings from byteswapping are false positives for us.
- * Suppress them by hiding byteswapping from Coverity.
- */
-
-#define	BSWAP_8(x)	((x) & 0xff)
-#define	BSWAP_16(x)	((x) & 0xffff)
-#define	BSWAP_32(x)	((x) & 0xffffffff)
-#define	BSWAP_64(x)	(x)
-
-#else /* __COVERITY__ */
-
 #define	BSWAP_8(x)	((x) & 0xff)
 #define	BSWAP_16(x)	((BSWAP_8(x) << 8) | BSWAP_8((x) >> 8))
 #define	BSWAP_32(x)	((BSWAP_16(x) << 16) | BSWAP_16((x) >> 16))
 #define	BSWAP_64(x)	((BSWAP_32(x) << 32) | BSWAP_32((x) >> 32))
-
-#endif /* __COVERITY__ */
 
 #define	LE_16(x)	cpu_to_le16(x)
 #define	LE_32(x)	cpu_to_le32(x)

--- a/include/os/linux/spl/sys/cmn_err.h
+++ b/include/os/linux/spl/sys/cmn_err.h
@@ -41,7 +41,7 @@ extern void cmn_err(int, const char *, ...)
 extern void vcmn_err(int, const char *, va_list)
     __attribute__((format(printf, 2, 0)));
 extern void vpanic(const char *, va_list)
-    __attribute__((format(printf, 1, 0), __noreturn__));
+    __attribute__((format(printf, 1, 0)));
 
 #define	fm_panic	panic
 

--- a/include/os/linux/spl/sys/debug.h
+++ b/include/os/linux/spl/sys/debug.h
@@ -54,24 +54,17 @@
 #define	__maybe_unused __attribute__((unused))
 #endif
 
-extern void spl_panic(const char *file, const char *func, int line,
-    const char *fmt, ...) __attribute__((__noreturn__));
-extern void spl_dumpstack(void);
-
-static inline int
-spl_assert(const char *buf, const char *file, const char *func, int line)
-{
-	spl_panic(file, func, line, "%s", buf);
-	return (0);
-}
+int spl_panic(const char *file, const char *func, int line,
+    const char *fmt, ...);
+void spl_dumpstack(void);
 
 #define	PANIC(fmt, a...)						\
 	spl_panic(__FILE__, __FUNCTION__, __LINE__, fmt, ## a)
 
 #define	VERIFY(cond)							\
 	(void) (unlikely(!(cond)) &&					\
-	    spl_assert("VERIFY(" #cond ") failed\n",			\
-	    __FILE__, __FUNCTION__, __LINE__))
+	    spl_panic(__FILE__, __FUNCTION__, __LINE__,			\
+	    "%s", "VERIFY(" #cond ") failed\n"))
 
 #define	VERIFY3B(LEFT, OP, RIGHT)	do {				\
 		const boolean_t _verify3_left = (boolean_t)(LEFT);	\
@@ -159,13 +152,13 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #define	ASSERT0		VERIFY0
 #define	ASSERT		VERIFY
 #define	IMPLY(A, B) \
-	((void)(likely((!(A)) || (B)) ||				\
-	    spl_assert("(" #A ") implies (" #B ")",			\
-	    __FILE__, __FUNCTION__, __LINE__)))
+	((void)(likely((!(A)) || (B)) || \
+	    spl_panic(__FILE__, __FUNCTION__, __LINE__, \
+	    "(" #A ") implies (" #B ")")))
 #define	EQUIV(A, B) \
-	((void)(likely(!!(A) == !!(B)) || 				\
-	    spl_assert("(" #A ") is equivalent to (" #B ")",		\
-	    __FILE__, __FUNCTION__, __LINE__)))
+	((void)(likely(!!(A) == !!(B)) || \
+	    spl_panic(__FILE__, __FUNCTION__, __LINE__, \
+	    "(" #A ") is equivalent to (" #B ")")))
 
 #endif /* NDEBUG */
 

--- a/include/os/linux/spl/sys/kmem.h
+++ b/include/os/linux/spl/sys/kmem.h
@@ -31,10 +31,8 @@
 #include <linux/vmalloc.h>
 
 extern int kmem_debugging(void);
-extern char *kmem_vasprintf(const char *fmt, va_list ap)
-    __attribute__((format(printf, 1, 0)));
-extern char *kmem_asprintf(const char *fmt, ...)
-    __attribute__((format(printf, 1, 2)));
+extern char *kmem_vasprintf(const char *fmt, va_list ap);
+extern char *kmem_asprintf(const char *fmt, ...);
 extern char *kmem_strdup(const char *str);
 extern void kmem_strfree(char *str);
 
@@ -181,10 +179,8 @@ extern unsigned int spl_kmem_alloc_max;
 #define	kmem_free(ptr, sz)	spl_kmem_free((ptr), (sz))
 #define	kmem_cache_reap_active	spl_kmem_cache_reap_active
 
-extern void *spl_kmem_alloc(size_t sz, int fl, const char *func, int line)
-    __attribute__((alloc_size(1)));
-extern void *spl_kmem_zalloc(size_t sz, int fl, const char *func, int line)
-    __attribute__((alloc_size(1)));
+extern void *spl_kmem_alloc(size_t sz, int fl, const char *func, int line);
+extern void *spl_kmem_zalloc(size_t sz, int fl, const char *func, int line);
 extern void spl_kmem_free(const void *ptr, size_t sz);
 
 /*

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -151,14 +151,10 @@ extern "C" {
 
 extern void dprintf_setup(int *argc, char **argv);
 
-extern void cmn_err(int, const char *, ...)
-    __attribute__((format(printf, 2, 3)));
-extern void vcmn_err(int, const char *, va_list)
-    __attribute__((format(printf, 2, 0)));
-extern void panic(const char *, ...)
-    __attribute__((format(printf, 1, 2), noreturn));
-extern void vpanic(const char *, va_list)
-    __attribute__((format(printf, 1, 0), noreturn));
+extern void cmn_err(int, const char *, ...);
+extern void vcmn_err(int, const char *, va_list);
+extern __attribute__((noreturn)) void panic(const char *, ...);
+extern __attribute__((noreturn)) void vpanic(const char *, va_list);
 
 #define	fm_panic	panic
 

--- a/lib/libspl/assert.c
+++ b/lib/libspl/assert.c
@@ -45,11 +45,8 @@ libspl_assertf(const char *file, const char *func, int line,
 	fprintf(stderr, "\n");
 	fprintf(stderr, "ASSERT at %s:%d:%s()", file, line, func);
 	va_end(args);
-
-#if !__has_feature(attribute_analyzer_noreturn) && !defined(__COVERITY__)
 	if (libspl_assert_ok) {
 		return;
 	}
-#endif
 	abort();
 }

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -34,24 +34,12 @@
 #include <stdarg.h>
 #include <sys/types.h>
 
-/* Workaround for non-Clang compilers */
-#ifndef __has_feature
-#define	__has_feature(x) 0
-#endif
-
-/* We need to workaround libspl_set_assert_ok() that we have for zdb */
-#if __has_feature(attribute_analyzer_noreturn) || defined(__COVERITY__)
-#define	NORETURN	__attribute__((__noreturn__))
-#else
-#define	NORETURN
-#endif
-
 /* Set to non-zero to avoid abort()ing on an assertion failure */
 extern void libspl_set_assert_ok(boolean_t val);
 
 /* printf version of libspl_assert */
 extern void libspl_assertf(const char *file, const char *func, int line,
-    const char *format, ...) NORETURN __attribute__((format(printf, 4, 5)));
+    const char *format, ...);
 
 static inline int
 libspl_assert(const char *buf, const char *file, const char *func, int line)

--- a/lib/libspl/include/os/freebsd/sys/byteorder.h
+++ b/lib/libspl/include/os/freebsd/sys/byteorder.h
@@ -59,18 +59,6 @@ extern "C" {
  */
 #if !defined(_XPG4_2) || defined(__EXTENSIONS__)
 
-#ifdef __COVERITY__
-/*
- * Coverity's taint warnings from byteswapping are false positives for us.
- * Suppress them by hiding byteswapping from Coverity.
- */
-#define	BSWAP_8(x)	((x) & 0xff)
-#define	BSWAP_16(x)	((x) & 0xffff)
-#define	BSWAP_32(x)	((x) & 0xffffffff)
-#define	BSWAP_64(x)	(x)
-
-#else /* __COVERITY__ */
-
 /*
  * Macros to reverse byte order
  */
@@ -78,8 +66,6 @@ extern "C" {
 #define	BSWAP_16(x)	((BSWAP_8(x) << 8) | BSWAP_8((x) >> 8))
 #define	BSWAP_32(x)	((BSWAP_16(x) << 16) | BSWAP_16((x) >> 16))
 #define	BSWAP_64(x)	((BSWAP_32(x) << 32) | BSWAP_32((x) >> 32))
-
-#endif /* __COVERITY__ */
 
 #define	BMASK_8(x)	((x) & 0xff)
 #define	BMASK_16(x)	((x) & 0xffff)

--- a/lib/libspl/include/os/linux/sys/byteorder.h
+++ b/lib/libspl/include/os/linux/sys/byteorder.h
@@ -90,18 +90,6 @@ extern	in_port_t ntohs(in_port_t);
 
 #if !defined(_XPG4_2) || defined(__EXTENSIONS__)
 
-#ifdef __COVERITY__
-/*
- * Coverity's taint warnings from byteswapping are false positives for us.
- * Suppress them by hiding byteswapping from Coverity.
- */
-#define	BSWAP_8(x)	((x) & 0xff)
-#define	BSWAP_16(x)	((x) & 0xffff)
-#define	BSWAP_32(x)	((x) & 0xffffffff)
-#define	BSWAP_64(x)	(x)
-
-#else /* __COVERITY__ */
-
 /*
  * Macros to reverse byte order
  */
@@ -109,8 +97,6 @@ extern	in_port_t ntohs(in_port_t);
 #define	BSWAP_16(x)	((BSWAP_8(x) << 8) | BSWAP_8((x) >> 8))
 #define	BSWAP_32(x)	((BSWAP_16(x) << 16) | BSWAP_16((x) >> 16))
 #define	BSWAP_64(x)	((BSWAP_32(x) << 32) | BSWAP_32((x) >> 32))
-
-#endif /* __COVERITY__ */
 
 #define	BMASK_8(x)	((x) & 0xff)
 #define	BMASK_16(x)	((x) & 0xffff)

--- a/lib/libspl/include/umem.h
+++ b/lib/libspl/include/umem.h
@@ -83,7 +83,6 @@ const char *_umem_debug_init(void);
 const char *_umem_options_init(void);
 const char *_umem_logging_init(void);
 
-__attribute__((alloc_size(1)))
 static inline void *
 umem_alloc(size_t size, int flags)
 {
@@ -96,7 +95,6 @@ umem_alloc(size_t size, int flags)
 	return (ptr);
 }
 
-__attribute__((alloc_size(1)))
 static inline void *
 umem_alloc_aligned(size_t size, size_t align, int flags)
 {
@@ -118,7 +116,6 @@ umem_alloc_aligned(size_t size, size_t align, int flags)
 	return (ptr);
 }
 
-__attribute__((alloc_size(1)))
 static inline void *
 umem_zalloc(size_t size, int flags)
 {

--- a/module/os/freebsd/spl/spl_misc.c
+++ b/module/os/freebsd/spl/spl_misc.c
@@ -94,7 +94,7 @@ ddi_copyout(const void *from, void *to, size_t len, int flags)
 	return (copyout(from, to, len));
 }
 
-void
+int
 spl_panic(const char *file, const char *func, int line, const char *fmt, ...)
 {
 	va_list ap;

--- a/module/os/linux/spl/spl-err.c
+++ b/module/os/linux/spl/spl-err.c
@@ -45,7 +45,7 @@ spl_dumpstack(void)
 }
 EXPORT_SYMBOL(spl_dumpstack);
 
-void
+int
 spl_panic(const char *file, const char *func, int line, const char *fmt, ...)
 {
 	const char *newfile;
@@ -75,6 +75,7 @@ spl_panic(const char *file, const char *func, int line, const char *fmt, ...)
 		schedule();
 
 	/* Unreachable */
+	return (1);
 }
 EXPORT_SYMBOL(spl_panic);
 


### PR DESCRIPTION
### Description

This partially reverts commit 55d7afa4adbb4ca569e9c4477a7d121f4dc0bfbd which introduced a large number of `objtool` "falls through to next function" warnings when `CONFIG_STACK_VALIDATION=y` is set.  Only the latest version of the Coverity model has been retained.  For example:

```sh
module/os/linux/spl/spl-kstat.o: warning: objtool: kstat_seq_data_addr() falls through to next function kstat_seq_next()
module/os/linux/spl/spl-kstat.o: warning: objtool: kstat_seq_start() falls through to next function kstat_proc_entry_install()
module/os/linux/spl/spl-kstat.o: warning: objtool: __kstat_delete() falls through to next function __kstat_create()
module/os/linux/spl/spl-kstat.o: warning: objtool: __kstat_create() falls through to next function spl_kstat_init()
module/os/linux/spl/spl-kstat.o: warning: objtool: .text: unexpected end of section
```

### How Has This Been Tested?

Verified a clean compile on the stock Ubuntu 22.04 `5.15.0` kernel and the RHEL 8  `4.18.0-372.19.1` kernel with `CONFIG_STACK_VALIDATION=y` enabled.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
