### PR TITLE
FreeBSD: Fix a pair of bugs in zfs_fhtovp()

### DIFF
--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -1845,7 +1845,8 @@ zfs_fhtovp(vfs_t *vfsp, fid_t *fidp, int flags, vnode_t **vpp)
 		return (SET_ERROR(EINVAL));
 	}
 
-	if (fidp->fid_len == LONG_FID_LEN && (fid_gen > 1 || setgen != 0)) {
+	if (fidp->fid_len == LONG_FID_LEN && setgen != 0) {
+		ZFS_EXIT(zfsvfs);
 		dprintf("snapdir fid: fid_gen (%llu) and setgen (%llu)\n",
 		    (u_longlong_t)fid_gen, (u_longlong_t)setgen);
 		return (SET_ERROR(EINVAL));


### PR DESCRIPTION
- Add a zfs_exit() call in an error path, otherwise a lock is leaked.
- Remove the fid_gen > 1 check.  That appears to be Linux-specific: zfsctl_snapdir_fid() sets fid_gen to 0 or 1 depending on whether the snapshot directory is mounted.  On FreeBSD it fails, making snapshot dirs inaccessible via NFS.

(cherry picked from commit ed566bf1cd0bdbf85e8c63c1c119e3d2ef5db1f6)
