### PR TITLE
[FreeBSD] vn_flush_cached_data: observe vnode locking contract

### DIFF
--- a/include/os/freebsd/spl/sys/vnode.h
+++ b/include/os/freebsd/spl/sys/vnode.h
@@ -96,9 +96,11 @@ vn_flush_cached_data(vnode_t *vp, boolean_t sync)
 	if (vp->v_object->flags & OBJ_MIGHTBEDIRTY) {
 #endif
 		int flags = sync ? OBJPC_SYNC : 0;
+		vn_lock(vp, LK_SHARED | LK_RETRY);
 		zfs_vmobject_wlock(vp->v_object);
 		vm_object_page_clean(vp->v_object, 0, 0, flags);
 		zfs_vmobject_wunlock(vp->v_object);
+		VOP_UNLOCK(vp);
 	}
 }
 #endif


### PR DESCRIPTION
vm_object_page_clean() expects that the associated vnode is locked as VOP_PUTPAGES() may get called on the vnode.
Without this fix I got a panic on a system with `DEBUG_VFS_LOCKS` enabled in kernel configuration.

The panic output:
```
KDB: stack backtrace:
db_trace_self_wrapper() at 0xffffffff80614ddb = db_trace_self_wrapper+0x2b/frame 0xfffffe021e5d66f0
kdb_backtrace() at 0xffffffff80941b17 = kdb_backtrace+0x37/frame 0xfffffe021e5d67a0
assert_vop_locked() at 0xffffffff809d1275 = assert_vop_locked+0x55/frame 0xfffffe021e5d67d0
VOP_PUTPAGES_APV() at 0xffffffff80cbb7a2 = VOP_PUTPAGES_APV+0x82/frame 0xfffffe021e5d67f0
vnode_pager_putpages() at 0xffffffff80bb6a66 = vnode_pager_putpages+0x96/frame 0xfffffe021e5d6860
vm_pageout_flush() at 0xffffffff80ba8e25 = vm_pageout_flush+0xf5/frame 0xfffffe021e5d68f0
vm_object_page_collect_flush() at 0xffffffff80b9b473 = vm_object_page_collect_flush+0x273/frame 0xfffffe021e5d6a60
vm_object_page_clean() at 0xffffffff80b9b0a4 = vm_object_page_clean+0x184/frame 0xfffffe021e5d6ac0
zfs_holey() at 0xffffffff804ffc9b = zfs_holey+0xcb/frame 0xfffffe021e5d6b20
zfs_freebsd_ioctl() at 0xffffffff80397c3f = zfs_freebsd_ioctl+0x4f/frame 0xfffffe021e5d6b50
VOP_IOCTL_APV() at 0xffffffff80cb7c46 = VOP_IOCTL_APV+0x96/frame 0xfffffe021e5d6b70
vn_ioctl() at 0xffffffff809e8a1f = vn_ioctl+0x12f/frame 0xfffffe021e5d6c80
vn_seek() at 0xffffffff809e8fe3 = vn_seek+0x1b3/frame 0xfffffe021e5d6da0
kern_lseek() at 0xffffffff809e2779 = kern_lseek+0x69/frame 0xfffffe021e5d6de0
sys_lseek() at 0xffffffff809e2704 = sys_lseek+0x14/frame 0xfffffe021e5d6df0
amd64_syscall() at 0xffffffff80c2b836 = amd64_syscall+0x186/frame 0xfffffe021e5d6f30
fast_syscall_common() at 0xffffffff80c0240b = fast_syscall_common+0xf8/frame 0xfffffe021e5d6f30
--- syscall (478, FreeBSD ELF64, sys_lseek), rip = 0x36f419e1b73a, rsp = 0x36f416fe9458, rbp = 0x36f416fe97d0 ---
vnode 0xfffff801cd140b70: type VREG
    usecount 3, writecount 2, refcount 2 seqc users 0
    hold count flags ()
    flags ()
    v_object 0xfffff802057fb738 ref 1 pages 8 cleanbuf 0 dirtybuf 0
    lock type zfs: UNLOCKED
VOP_PUTPAGES: 0xfffff801cd140b70 is not locked but should be
KDB: enter: lock violation
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
