### PR TITLE
Convert enum zio_flag to uint64_t

### DIFF
--- a/include/os/linux/zfs/sys/trace_common.h
+++ b/include/os/linux/zfs/sys/trace_common.h
@@ -39,10 +39,10 @@
 		__field(hrtime_t,		zio_timestamp)		\
 		__field(hrtime_t,		zio_delta)		\
 		__field(uint64_t,		zio_delay)		\
-		__field(enum zio_flag,		zio_flags)		\
+		__field(zio_flag_t,		zio_flags)		\
 		__field(enum zio_stage,		zio_stage)		\
 		__field(enum zio_stage,		zio_pipeline)		\
-		__field(enum zio_flag,		zio_orig_flags)		\
+		__field(zio_flag_t,		zio_orig_flags)		\
 		__field(enum zio_stage,		zio_orig_stage)		\
 		__field(enum zio_stage,		zio_orig_pipeline)	\
 		__field(uint8_t,		zio_reexecute)		\

--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -190,7 +190,7 @@ typedef struct dbuf_dirty_record {
 			uint64_t dr_blkid;
 			abd_t *dr_abd;
 			zio_prop_t dr_props;
-			enum zio_flag dr_flags;
+			zio_flag_t dr_flags;
 		} dll;
 	} dt;
 } dbuf_dirty_record_t;
@@ -380,7 +380,7 @@ void dmu_buf_write_embedded(dmu_buf_t *dbuf, void *data,
     int uncompressed_size, int compressed_size, int byteorder, dmu_tx_t *tx);
 
 int dmu_lightweight_write_by_dnode(dnode_t *dn, uint64_t offset, abd_t *abd,
-    const struct zio_prop *zp, enum zio_flag flags, dmu_tx_t *tx);
+    const struct zio_prop *zp, zio_flag_t flags, dmu_tx_t *tx);
 
 void dmu_buf_redact(dmu_buf_t *dbuf, dmu_tx_t *tx);
 void dbuf_destroy(dmu_buf_impl_t *db);

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -163,32 +163,37 @@ typedef enum zio_suspend_reason {
 	ZIO_SUSPEND_MMP,
 } zio_suspend_reason_t;
 
-enum zio_flag {
+/*
+ * This was originally an enum type. However, those are 32-bit and there is no
+ * way to make a 64-bit enum type. Since we ran out of bits for flags, we were
+ * forced to upgrade it to a uint64_t.
+ */
+typedef uint64_t zio_flag_t;
 	/*
 	 * Flags inherited by gang, ddt, and vdev children,
 	 * and that must be equal for two zios to aggregate
 	 */
-	ZIO_FLAG_DONT_AGGREGATE	= 1U << 0,
-	ZIO_FLAG_IO_REPAIR	= 1U << 1,
-	ZIO_FLAG_SELF_HEAL	= 1U << 2,
-	ZIO_FLAG_RESILVER	= 1U << 3,
-	ZIO_FLAG_SCRUB		= 1U << 4,
-	ZIO_FLAG_SCAN_THREAD	= 1U << 5,
-	ZIO_FLAG_PHYSICAL	= 1U << 6,
+#define	ZIO_FLAG_DONT_AGGREGATE	(1ULL << 0)
+#define	ZIO_FLAG_IO_REPAIR	(1ULL << 1)
+#define	ZIO_FLAG_SELF_HEAL	(1ULL << 2)
+#define	ZIO_FLAG_RESILVER	(1ULL << 3)
+#define	ZIO_FLAG_SCRUB		(1ULL << 4)
+#define	ZIO_FLAG_SCAN_THREAD	(1ULL << 5)
+#define	ZIO_FLAG_PHYSICAL	(1ULL << 6)
 
 #define	ZIO_FLAG_AGG_INHERIT	(ZIO_FLAG_CANFAIL - 1)
 
 	/*
 	 * Flags inherited by ddt, gang, and vdev children.
 	 */
-	ZIO_FLAG_CANFAIL	= 1U << 7,	/* must be first for INHERIT */
-	ZIO_FLAG_SPECULATIVE	= 1U << 8,
-	ZIO_FLAG_CONFIG_WRITER	= 1U << 9,
-	ZIO_FLAG_DONT_RETRY	= 1U << 10,
-	ZIO_FLAG_DONT_CACHE	= 1U << 11,
-	ZIO_FLAG_NODATA		= 1U << 12,
-	ZIO_FLAG_INDUCE_DAMAGE	= 1U << 13,
-	ZIO_FLAG_IO_ALLOCATING  = 1U << 14,
+#define	ZIO_FLAG_CANFAIL	(1ULL << 7)	/* must be first for INHERIT */
+#define	ZIO_FLAG_SPECULATIVE	(1ULL << 8)
+#define	ZIO_FLAG_CONFIG_WRITER	(1ULL << 9)
+#define	ZIO_FLAG_DONT_RETRY	(1ULL << 10)
+#define	ZIO_FLAG_DONT_CACHE	(1ULL << 11)
+#define	ZIO_FLAG_NODATA		(1ULL << 12)
+#define	ZIO_FLAG_INDUCE_DAMAGE	(1ULL << 13)
+#define	ZIO_FLAG_IO_ALLOCATING	(1ULL << 14)
 
 #define	ZIO_FLAG_DDT_INHERIT	(ZIO_FLAG_IO_RETRY - 1)
 #define	ZIO_FLAG_GANG_INHERIT	(ZIO_FLAG_IO_RETRY - 1)
@@ -196,30 +201,29 @@ enum zio_flag {
 	/*
 	 * Flags inherited by vdev children.
 	 */
-	ZIO_FLAG_IO_RETRY	= 1U << 15,	/* must be first for INHERIT */
-	ZIO_FLAG_PROBE		= 1U << 16,
-	ZIO_FLAG_TRYHARD	= 1U << 17,
-	ZIO_FLAG_OPTIONAL	= 1U << 18,
+#define	ZIO_FLAG_IO_RETRY	(1ULL << 15)	/* must be first for INHERIT */
+#define	ZIO_FLAG_PROBE		(1ULL << 16)
+#define	ZIO_FLAG_TRYHARD	(1ULL << 17)
+#define	ZIO_FLAG_OPTIONAL	(1ULL << 18)
 
 #define	ZIO_FLAG_VDEV_INHERIT	(ZIO_FLAG_DONT_QUEUE - 1)
 
 	/*
 	 * Flags not inherited by any children.
 	 */
-	ZIO_FLAG_DONT_QUEUE	= 1U << 19,	/* must be first for INHERIT */
-	ZIO_FLAG_DONT_PROPAGATE	= 1U << 20,
-	ZIO_FLAG_IO_BYPASS	= 1U << 21,
-	ZIO_FLAG_IO_REWRITE	= 1U << 22,
-	ZIO_FLAG_RAW_COMPRESS	= 1U << 23,
-	ZIO_FLAG_RAW_ENCRYPT	= 1U << 24,
-	ZIO_FLAG_GANG_CHILD	= 1U << 25,
-	ZIO_FLAG_DDT_CHILD	= 1U << 26,
-	ZIO_FLAG_GODFATHER	= 1U << 27,
-	ZIO_FLAG_NOPWRITE	= 1U << 28,
-	ZIO_FLAG_REEXECUTED	= 1U << 29,
-	ZIO_FLAG_DELEGATED	= 1U << 30,
-	ZIO_FLAG_FASTWRITE	= 1U << 31,
-};
+#define	ZIO_FLAG_DONT_QUEUE	(1ULL << 19)	/* must be first for INHERIT */
+#define	ZIO_FLAG_DONT_PROPAGATE	(1ULL << 20)
+#define	ZIO_FLAG_IO_BYPASS	(1ULL << 21)
+#define	ZIO_FLAG_IO_REWRITE	(1ULL << 22)
+#define	ZIO_FLAG_RAW_COMPRESS	(1ULL << 23)
+#define	ZIO_FLAG_RAW_ENCRYPT	(1ULL << 24)
+#define	ZIO_FLAG_GANG_CHILD	(1ULL << 25)
+#define	ZIO_FLAG_DDT_CHILD	(1ULL << 26)
+#define	ZIO_FLAG_GODFATHER	(1ULL << 27)
+#define	ZIO_FLAG_NOPWRITE	(1ULL << 28)
+#define	ZIO_FLAG_REEXECUTED	(1ULL << 29)
+#define	ZIO_FLAG_DELEGATED	(1ULL << 30)
+#define	ZIO_FLAG_FASTWRITE	(1ULL << 31)
 
 #define	ZIO_FLAG_MUSTSUCCEED		0
 #define	ZIO_FLAG_RAW	(ZIO_FLAG_RAW_COMPRESS | ZIO_FLAG_RAW_ENCRYPT)
@@ -489,10 +493,10 @@ struct zio {
 	zio_alloc_list_t 	io_alloc_list;
 
 	/* Internal pipeline state */
-	enum zio_flag	io_flags;
+	zio_flag_t	io_flags;
 	enum zio_stage	io_stage;
 	enum zio_stage	io_pipeline;
-	enum zio_flag	io_orig_flags;
+	zio_flag_t	io_orig_flags;
 	enum zio_stage	io_orig_stage;
 	enum zio_stage	io_orig_pipeline;
 	enum zio_stage	io_pipeline_trace;
@@ -529,27 +533,27 @@ enum blk_verify_flag {
 extern int zio_bookmark_compare(const void *, const void *);
 
 extern zio_t *zio_null(zio_t *pio, spa_t *spa, vdev_t *vd,
-    zio_done_func_t *done, void *priv, enum zio_flag flags);
+    zio_done_func_t *done, void *priv, zio_flag_t flags);
 
 extern zio_t *zio_root(spa_t *spa,
-    zio_done_func_t *done, void *priv, enum zio_flag flags);
+    zio_done_func_t *done, void *priv, zio_flag_t flags);
 
 extern void zio_destroy(zio_t *zio);
 
 extern zio_t *zio_read(zio_t *pio, spa_t *spa, const blkptr_t *bp,
     struct abd *data, uint64_t lsize, zio_done_func_t *done, void *priv,
-    zio_priority_t priority, enum zio_flag flags, const zbookmark_phys_t *zb);
+    zio_priority_t priority, zio_flag_t flags, const zbookmark_phys_t *zb);
 
 extern zio_t *zio_write(zio_t *pio, spa_t *spa, uint64_t txg, blkptr_t *bp,
     struct abd *data, uint64_t size, uint64_t psize, const zio_prop_t *zp,
     zio_done_func_t *ready, zio_done_func_t *children_ready,
     zio_done_func_t *physdone, zio_done_func_t *done,
-    void *priv, zio_priority_t priority, enum zio_flag flags,
+    void *priv, zio_priority_t priority, zio_flag_t flags,
     const zbookmark_phys_t *zb);
 
 extern zio_t *zio_rewrite(zio_t *pio, spa_t *spa, uint64_t txg, blkptr_t *bp,
     struct abd *data, uint64_t size, zio_done_func_t *done, void *priv,
-    zio_priority_t priority, enum zio_flag flags, zbookmark_phys_t *zb);
+    zio_priority_t priority, zio_flag_t flags, zbookmark_phys_t *zb);
 
 extern void zio_write_override(zio_t *zio, blkptr_t *bp, int copies,
     boolean_t nopwrite);
@@ -558,27 +562,27 @@ extern void zio_free(spa_t *spa, uint64_t txg, const blkptr_t *bp);
 
 extern zio_t *zio_claim(zio_t *pio, spa_t *spa, uint64_t txg,
     const blkptr_t *bp,
-    zio_done_func_t *done, void *priv, enum zio_flag flags);
+    zio_done_func_t *done, void *priv, zio_flag_t flags);
 
 extern zio_t *zio_ioctl(zio_t *pio, spa_t *spa, vdev_t *vd, int cmd,
-    zio_done_func_t *done, void *priv, enum zio_flag flags);
+    zio_done_func_t *done, void *priv, zio_flag_t flags);
 
 extern zio_t *zio_trim(zio_t *pio, vdev_t *vd, uint64_t offset, uint64_t size,
     zio_done_func_t *done, void *priv, zio_priority_t priority,
-    enum zio_flag flags, enum trim_flag trim_flags);
+    zio_flag_t flags, enum trim_flag trim_flags);
 
 extern zio_t *zio_read_phys(zio_t *pio, vdev_t *vd, uint64_t offset,
     uint64_t size, struct abd *data, int checksum,
     zio_done_func_t *done, void *priv, zio_priority_t priority,
-    enum zio_flag flags, boolean_t labels);
+    zio_flag_t flags, boolean_t labels);
 
 extern zio_t *zio_write_phys(zio_t *pio, vdev_t *vd, uint64_t offset,
     uint64_t size, struct abd *data, int checksum,
     zio_done_func_t *done, void *priv, zio_priority_t priority,
-    enum zio_flag flags, boolean_t labels);
+    zio_flag_t flags, boolean_t labels);
 
 extern zio_t *zio_free_sync(zio_t *pio, spa_t *spa, uint64_t txg,
-    const blkptr_t *bp, enum zio_flag flags);
+    const blkptr_t *bp, zio_flag_t flags);
 
 extern int zio_alloc_zil(spa_t *spa, objset_t *os, uint64_t txg,
     blkptr_t *new_bp, uint64_t size, boolean_t *slog);
@@ -611,12 +615,12 @@ extern void zio_resubmit_stage_async(void *);
 
 extern zio_t *zio_vdev_child_io(zio_t *zio, blkptr_t *bp, vdev_t *vd,
     uint64_t offset, struct abd *data, uint64_t size, int type,
-    zio_priority_t priority, enum zio_flag flags,
+    zio_priority_t priority, zio_flag_t flags,
     zio_done_func_t *done, void *priv);
 
 extern zio_t *zio_vdev_delegated_io(vdev_t *vd, uint64_t offset,
     struct abd *data, uint64_t size, zio_type_t type, zio_priority_t priority,
-    enum zio_flag flags, zio_done_func_t *done, void *priv);
+    zio_flag_t flags, zio_done_func_t *done, void *priv);
 
 extern void zio_vdev_io_bypass(zio_t *zio);
 extern void zio_vdev_io_reissue(zio_t *zio);

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -173,7 +173,7 @@ vdev_disk_error(zio_t *zio)
 	 * which is safe from any context.
 	 */
 	printk(KERN_WARNING "zio pool=%s vdev=%s error=%d type=%d "
-	    "offset=%llu size=%llu flags=%x\n", spa_name(zio->io_spa),
+	    "offset=%llu size=%llu flags=%llu\n", spa_name(zio->io_spa),
 	    zio->io_vd->vdev_path, zio->io_error, zio->io_type,
 	    (u_longlong_t)zio->io_offset, (u_longlong_t)zio->io_size,
 	    zio->io_flags);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1436,7 +1436,7 @@ dmu_return_arcbuf(arc_buf_t *buf)
  */
 int
 dmu_lightweight_write_by_dnode(dnode_t *dn, uint64_t offset, abd_t *abd,
-    const zio_prop_t *zp, enum zio_flag flags, dmu_tx_t *tx)
+    const zio_prop_t *zp, zio_flag_t flags, dmu_tx_t *tx)
 {
 	dbuf_dirty_record_t *dr =
 	    dbuf_dirty_lightweight(dn, dbuf_whichblock(dn, 0, offset), tx);

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -482,7 +482,7 @@ dmu_objset_open_impl(spa_t *spa, dsl_dataset_t *ds, blkptr_t *bp,
 		arc_flags_t aflags = ARC_FLAG_WAIT;
 		zbookmark_phys_t zb;
 		int size;
-		enum zio_flag zio_flags = ZIO_FLAG_CANFAIL;
+		zio_flag_t zio_flags = ZIO_FLAG_CANFAIL;
 		SET_BOOKMARK(&zb, ds ? ds->ds_object : DMU_META_OBJSET,
 		    ZB_ROOT_OBJECT, ZB_ROOT_LEVEL, ZB_ROOT_BLKID);
 

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -1344,7 +1344,7 @@ do_corrective_recv(struct receive_writer_arg *rwa, struct drr_write *drrw,
 	dnode_t *dn;
 	abd_t *abd = rrd->abd;
 	zio_cksum_t bp_cksum = bp->blk_cksum;
-	enum zio_flag flags = ZIO_FLAG_SPECULATIVE |
+	zio_flag_t flags = ZIO_FLAG_SPECULATIVE |
 	    ZIO_FLAG_DONT_CACHE | ZIO_FLAG_DONT_RETRY | ZIO_FLAG_CANFAIL;
 
 	if (rwa->raw)
@@ -2186,7 +2186,7 @@ flush_write_batch_impl(struct receive_writer_arg *rwa)
 			zio_prop_t zp;
 			dmu_write_policy(rwa->os, dn, 0, 0, &zp);
 
-			enum zio_flag zio_flags = 0;
+			zio_flag_t zio_flags = 0;
 
 			if (rwa->raw) {
 				zp.zp_encrypt = B_TRUE;

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -934,7 +934,7 @@ do_dump(dmu_send_cookie_t *dscp, struct send_range *range)
 		ASSERT3U(range->start_blkid + 1, ==, range->end_blkid);
 		if (BP_GET_TYPE(bp) == DMU_OT_SA) {
 			arc_flags_t aflags = ARC_FLAG_WAIT;
-			enum zio_flag zioflags = ZIO_FLAG_CANFAIL;
+			zio_flag_t zioflags = ZIO_FLAG_CANFAIL;
 
 			if (dscp->dsc_featureflags & DMU_BACKUP_FEATURE_RAW) {
 				ASSERT(BP_IS_PROTECTED(bp));
@@ -1653,7 +1653,7 @@ issue_data_read(struct send_reader_thread_arg *srta, struct send_range *range)
 	    !split_large_blocks && !BP_SHOULD_BYTESWAP(bp) &&
 	    !BP_IS_EMBEDDED(bp) && !DMU_OT_IS_METADATA(BP_GET_TYPE(bp));
 
-	enum zio_flag zioflags = ZIO_FLAG_CANFAIL;
+	zio_flag_t zioflags = ZIO_FLAG_CANFAIL;
 
 	if (srta->featureflags & DMU_BACKUP_FEATURE_RAW) {
 		zioflags |= ZIO_FLAG_RAW;

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -671,7 +671,7 @@ traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
 
 	/* See comment on ZIL traversal in dsl_scan_visitds. */
 	if (ds != NULL && !ds->ds_is_snapshot && !BP_IS_HOLE(rootbp)) {
-		enum zio_flag zio_flags = ZIO_FLAG_CANFAIL;
+		zio_flag_t zio_flags = ZIO_FLAG_CANFAIL;
 		uint32_t flags = ARC_FLAG_WAIT;
 		objset_phys_t *osp;
 		arc_buf_t *buf;

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -605,7 +605,7 @@ vdev_queue_aggregate(vdev_queue_t *vq, zio_t *zio)
 	int maxblocksize;
 	boolean_t stretch = B_FALSE;
 	avl_tree_t *t = vdev_queue_type_tree(vq, zio->io_type);
-	enum zio_flag flags = zio->io_flags & ZIO_FLAG_AGG_INHERIT;
+	zio_flag_t flags = zio->io_flags & ZIO_FLAG_AGG_INHERIT;
 	uint64_t next_offset;
 	abd_t *abd;
 

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -237,7 +237,7 @@ static int
 zil_read_log_block(zilog_t *zilog, boolean_t decrypt, const blkptr_t *bp,
     blkptr_t *nbp, void *dst, char **end)
 {
-	enum zio_flag zio_flags = ZIO_FLAG_CANFAIL;
+	zio_flag_t zio_flags = ZIO_FLAG_CANFAIL;
 	arc_flags_t aflags = ARC_FLAG_WAIT;
 	arc_buf_t *abuf = NULL;
 	zbookmark_phys_t zb;
@@ -315,7 +315,7 @@ zil_read_log_block(zilog_t *zilog, boolean_t decrypt, const blkptr_t *bp,
 static int
 zil_read_log_data(zilog_t *zilog, const lr_write_t *lr, void *wbuf)
 {
-	enum zio_flag zio_flags = ZIO_FLAG_CANFAIL;
+	zio_flag_t zio_flags = ZIO_FLAG_CANFAIL;
 	const blkptr_t *bp = &lr->lr_blkptr;
 	arc_flags_t aflags = ARC_FLAG_WAIT;
 	arc_buf_t *abuf = NULL;


### PR DESCRIPTION
### Motivation and Context
We ran out of space in enum zio_flag for additional flags.

### Description
Rather than introduce enum zio_flag2 and then modify a bunch of functions to take a second flags variable, we expand the type to 64 bits via `typedef uint64_t zio_flag_t`.

Note that I signed off using my Klara Systems email because the copyright ownership belongs to Klara Systems. This is unlike my previous commits, the most recent of which were done with my university email.

### How Has This Been Tested?
Build test and runtime tests have been done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
