### PR TITLE
FreeBSD: vn_flush_cached_data: observe vnode locking contract

### DIFF
--- a/include/os/freebsd/spl/sys/vnode.h
+++ b/include/os/freebsd/spl/sys/vnode.h
@@ -95,9 +95,11 @@ vn_flush_cached_data(vnode_t *vp, boolean_t sync)
 	if (vp->v_object->flags & OBJ_MIGHTBEDIRTY) {
 #endif
 		int flags = sync ? OBJPC_SYNC : 0;
+		vn_lock(vp, LK_SHARED | LK_RETRY);
 		zfs_vmobject_wlock(vp->v_object);
 		vm_object_page_clean(vp->v_object, 0, 0, flags);
 		zfs_vmobject_wunlock(vp->v_object);
+		VOP_UNLOCK(vp);
 	}
 }
 


### PR DESCRIPTION
vm_object_page_clean() expects that the associated vnode is locked as VOP_PUTPAGES() may get called on the vnode.

(cherry picked from commit 41133c97949af43daadee0503a9842a8dce8f0fd)