### PR TITLE
Codeql fixes

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2858,9 +2858,11 @@ dump_bookmarks(objset_t *os, int verbosity)
 	    zap_cursor_advance(&zc)) {
 		char osname[ZFS_MAX_DATASET_NAME_LEN];
 		char buf[ZFS_MAX_DATASET_NAME_LEN];
+		int len;
 		dmu_objset_name(os, osname);
-		VERIFY3S(0, <=, snprintf(buf, sizeof (buf), "%s#%s", osname,
-		    attr.za_name));
+		len = snprintf(buf, sizeof (buf), "%s#%s", osname,
+		    attr.za_name);
+		VERIFY3S(len, <, ZFS_MAX_DATASET_NAME_LEN);
 		(void) dump_bookmark(dp, buf, verbosity >= 5, verbosity >= 6);
 	}
 	zap_cursor_fini(&zc);

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -139,8 +139,12 @@ _bump_event_queue_length(void)
 	if (qlen == orig_qlen)
 		goto done;
 	wr = snprintf(qlen_buf, sizeof (qlen_buf), "%ld", qlen);
+	if (wr >= sizeof (qlen_buf)) {
+		wr = sizeof (qlen_buf) - 1;
+		zed_log_msg(LOG_WARNING, "Truncation in %s()", __func__);
+	}
 
-	if (pwrite(zzlm, qlen_buf, wr, 0) < 0)
+	if (pwrite(zzlm, qlen_buf, wr + 1, 0) < 0)
 		goto done;
 
 	zed_log_msg(LOG_WARNING, "Bumping queue length to %ld", qlen);

--- a/include/os/freebsd/spl/sys/kmem.h
+++ b/include/os/freebsd/spl/sys/kmem.h
@@ -57,6 +57,9 @@ extern char	*kmem_asprintf(const char *, ...)
 extern char *kmem_vasprintf(const char *fmt, va_list ap)
     __attribute__((format(printf, 1, 0)));
 
+extern int kmem_scnprintf(char *restrict str, size_t size,
+    const char *restrict fmt, ...);
+
 typedef struct kmem_cache {
 	char		kc_name[32];
 #if !defined(KMEM_DEBUG)

--- a/include/os/linux/spl/sys/kmem.h
+++ b/include/os/linux/spl/sys/kmem.h
@@ -38,6 +38,8 @@ extern char *kmem_asprintf(const char *fmt, ...)
 extern char *kmem_strdup(const char *str);
 extern void kmem_strfree(char *str);
 
+#define	kmem_scnprintf	scnprintf
+
 /*
  * Memory allocation interfaces
  */

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -600,7 +600,7 @@ typedef struct blkptr {
 
 /*
  * This macro allows code sharing between zfs, libzpool, and mdb.
- * 'func' is either snprintf() or mdb_snprintf().
+ * 'func' is either kmem_scnprintf() or mdb_snprintf().
  * 'ws' (whitespace) can be ' ' for single-line format, '\n' for multi-line.
  */
 

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -695,6 +695,9 @@ extern char *kmem_asprintf(const char *fmt, ...);
 #define	kmem_strfree(str) kmem_free((str), strlen(str) + 1)
 #define	kmem_strdup(s)  strdup(s)
 
+extern int kmem_scnprintf(char *restrict str, size_t size,
+    const char *restrict fmt, ...);
+
 /*
  * Hostname information
  */

--- a/lib/libspl/os/linux/zone.c
+++ b/lib/libspl/os/linux/zone.c
@@ -41,7 +41,7 @@ getzoneid(void)
 
 	int c = snprintf(path, sizeof (path), "/proc/self/ns/user");
 	/* This API doesn't have any error checking... */
-	if (c < 0)
+	if (c < 0 || c >= sizeof (path))
 		return (0);
 
 	ssize_t r = readlink(path, buf, sizeof (buf) - 1);

--- a/lib/libzfs/os/freebsd/libzfs_compat.c
+++ b/lib/libzfs/os/freebsd/libzfs_compat.c
@@ -202,7 +202,7 @@ libzfs_error_init(int error)
 	size_t msglen = sizeof (errbuf);
 
 	if (modfind("zfs") < 0) {
-		size_t len = snprintf(msg, msglen, dgettext(TEXT_DOMAIN,
+		size_t len = kmem_scnprintf(msg, msglen, dgettext(TEXT_DOMAIN,
 		    "Failed to load %s module: "), ZFS_KMOD);
 		msg += len;
 		msglen -= len;

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -956,6 +956,35 @@ kmem_asprintf(const char *fmt, ...)
 	return (buf);
 }
 
+/*
+ * kmem_scnprintf() will return the number of characters that it would have
+ * printed whenever it is limited by value of the size variable, rather than
+ * the number of characters that it did print. This can cause misbehavior on
+ * subsequent uses of the return value, so we define a safe version that will
+ * return the number of characters actually printed, minus the NULL format
+ * character.  Subsequent use of this by the safe string functions is safe
+ * whether it is snprintf(), strlcat() or strlcpy().
+ */
+int
+kmem_scnprintf(char *restrict str, size_t size, const char *restrict fmt, ...)
+{
+	int n;
+	va_list ap;
+
+	/* Make the 0 case a no-op so that we do not return -1 */
+	if (size == 0)
+		return (0);
+
+	va_start(ap, fmt);
+	n = vsnprintf(str, size, fmt, ap);
+	va_end(ap);
+
+	if (n >= size)
+		n = size - 1;
+
+	return (n);
+}
+
 zfs_file_t *
 zfs_onexit_fd_hold(int fd, minor_t *minorp)
 {

--- a/module/os/linux/zfs/zfs_sysfs.c
+++ b/module/os/linux/zfs/zfs_sysfs.c
@@ -279,11 +279,11 @@ zprop_sysfs_show(const char *attr_name, const zprop_desc_t *property,
 
 		for (int i = 0; i < ARRAY_SIZE(type_map); i++) {
 			if (type_map[i].ztm_type & property->pd_types)  {
-				len += snprintf(buf + len, buflen - len, "%s ",
-				    type_map[i].ztm_name);
+				len += kmem_scnprintf(buf + len, buflen - len,
+				    "%s ", type_map[i].ztm_name);
 			}
 		}
-		len += snprintf(buf + len, buflen - len, "\n");
+		len += kmem_scnprintf(buf + len, buflen - len, "\n");
 		return (len);
 	}
 

--- a/module/zfs/dataset_kstats.c
+++ b/module/zfs/dataset_kstats.c
@@ -128,8 +128,13 @@ dataset_kstats_create(dataset_kstats_t *dk, objset_t *objset)
 		    " snprintf() for kstat name returned %d",
 		    (unsigned long long)dmu_objset_id(objset), n);
 		return (SET_ERROR(EINVAL));
+	} else if (n >= KSTAT_STRLEN) {
+		zfs_dbgmsg("failed to create dataset kstat for objset %lld: "
+		    "kstat name length (%d) exceeds limit (%d)",
+		    (unsigned long long)dmu_objset_id(objset),
+		    n, KSTAT_STRLEN);
+		return (SET_ERROR(ENAMETOOLONG));
 	}
-	ASSERT3U(n, <, KSTAT_STRLEN);
 
 	kstat_t *kstat = kstat_create(kstat_module_name, 0, kstat_name,
 	    "dataset", KSTAT_TYPE_NAMED,

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1536,7 +1536,7 @@ snprintf_blkptr(char *buf, size_t buflen, const blkptr_t *bp)
 		compress = zio_compress_table[BP_GET_COMPRESS(bp)].ci_name;
 	}
 
-	SNPRINTF_BLKPTR(snprintf, ' ', buf, buflen, bp, type, checksum,
+	SNPRINTF_BLKPTR(kmem_scnprintf, ' ', buf, buflen, bp, type, checksum,
 	    compress);
 }
 

--- a/module/zfs/vdev_raidz_math.c
+++ b/module/zfs/vdev_raidz_math.c
@@ -285,17 +285,17 @@ raidz_math_kstat_headers(char *buf, size_t size)
 {
 	ASSERT3U(size, >=, RAIDZ_KSTAT_LINE_LEN);
 
-	ssize_t off = snprintf(buf, size, "%-17s", "implementation");
+	ssize_t off = kmem_scnprintf(buf, size, "%-17s", "implementation");
 
 	for (int i = 0; i < ARRAY_SIZE(raidz_gen_name); i++)
-		off += snprintf(buf + off, size - off, "%-16s",
+		off += kmem_scnprintf(buf + off, size - off, "%-16s",
 		    raidz_gen_name[i]);
 
 	for (int i = 0; i < ARRAY_SIZE(raidz_rec_name); i++)
-		off += snprintf(buf + off, size - off, "%-16s",
+		off += kmem_scnprintf(buf + off, size - off, "%-16s",
 		    raidz_rec_name[i]);
 
-	(void) snprintf(buf + off, size - off, "\n");
+	(void) kmem_scnprintf(buf + off, size - off, "\n");
 
 	return (0);
 }
@@ -311,34 +311,35 @@ raidz_math_kstat_data(char *buf, size_t size, void *data)
 	ASSERT3U(size, >=, RAIDZ_KSTAT_LINE_LEN);
 
 	if (cstat == fstat) {
-		off += snprintf(buf + off, size - off, "%-17s", "fastest");
+		off += kmem_scnprintf(buf + off, size - off, "%-17s",
+		    "fastest");
 
 		for (i = 0; i < ARRAY_SIZE(raidz_gen_name); i++) {
 			int id = fstat->gen[i];
-			off += snprintf(buf + off, size - off, "%-16s",
+			off += kmem_scnprintf(buf + off, size - off, "%-16s",
 			    raidz_supp_impl[id]->name);
 		}
 		for (i = 0; i < ARRAY_SIZE(raidz_rec_name); i++) {
 			int id = fstat->rec[i];
-			off += snprintf(buf + off, size - off, "%-16s",
+			off += kmem_scnprintf(buf + off, size - off, "%-16s",
 			    raidz_supp_impl[id]->name);
 		}
 	} else {
 		ptrdiff_t id = cstat - raidz_impl_kstats;
 
-		off += snprintf(buf + off, size - off, "%-17s",
+		off += kmem_scnprintf(buf + off, size - off, "%-17s",
 		    raidz_supp_impl[id]->name);
 
 		for (i = 0; i < ARRAY_SIZE(raidz_gen_name); i++)
-			off += snprintf(buf + off, size - off, "%-16llu",
+			off += kmem_scnprintf(buf + off, size - off, "%-16llu",
 			    (u_longlong_t)cstat->gen[i]);
 
 		for (i = 0; i < ARRAY_SIZE(raidz_rec_name); i++)
-			off += snprintf(buf + off, size - off, "%-16llu",
+			off += kmem_scnprintf(buf + off, size - off, "%-16llu",
 			    (u_longlong_t)cstat->rec[i]);
 	}
 
-	(void) snprintf(buf + off, size - off, "\n");
+	(void) kmem_scnprintf(buf + off, size - off, "\n");
 
 	return (0);
 }

--- a/module/zfs/zcp.c
+++ b/module/zfs/zcp.c
@@ -277,9 +277,9 @@ zcp_table_to_nvlist(lua_State *state, int index, int depth)
 			}
 			break;
 		case LUA_TNUMBER:
-			VERIFY3U(sizeof (buf), >,
-			    snprintf(buf, sizeof (buf), "%lld",
-			    (longlong_t)lua_tonumber(state, -2)));
+			(void) snprintf(buf, sizeof (buf), "%lld",
+			    (longlong_t)lua_tonumber(state, -2));
+
 			key = buf;
 			if (saw_str_could_collide) {
 				key_could_collide = B_TRUE;

--- a/module/zfs/zfs_chksum.c
+++ b/module/zfs/zfs_chksum.c
@@ -81,15 +81,15 @@ chksum_kstat_headers(char *buf, size_t size)
 {
 	ssize_t off = 0;
 
-	off += snprintf(buf + off, size, "%-23s", "implementation");
-	off += snprintf(buf + off, size - off, "%8s", "1k");
-	off += snprintf(buf + off, size - off, "%8s", "4k");
-	off += snprintf(buf + off, size - off, "%8s", "16k");
-	off += snprintf(buf + off, size - off, "%8s", "64k");
-	off += snprintf(buf + off, size - off, "%8s", "256k");
-	off += snprintf(buf + off, size - off, "%8s", "1m");
-	off += snprintf(buf + off, size - off, "%8s", "4m");
-	(void) snprintf(buf + off, size - off, "%8s\n", "16m");
+	off += kmem_scnprintf(buf + off, size, "%-23s", "implementation");
+	off += kmem_scnprintf(buf + off, size - off, "%8s", "1k");
+	off += kmem_scnprintf(buf + off, size - off, "%8s", "4k");
+	off += kmem_scnprintf(buf + off, size - off, "%8s", "16k");
+	off += kmem_scnprintf(buf + off, size - off, "%8s", "64k");
+	off += kmem_scnprintf(buf + off, size - off, "%8s", "256k");
+	off += kmem_scnprintf(buf + off, size - off, "%8s", "1m");
+	off += kmem_scnprintf(buf + off, size - off, "%8s", "4m");
+	(void) kmem_scnprintf(buf + off, size - off, "%8s\n", "16m");
 
 	return (0);
 }
@@ -102,23 +102,23 @@ chksum_kstat_data(char *buf, size_t size, void *data)
 	char b[24];
 
 	cs = (chksum_stat_t *)data;
-	snprintf(b, 23, "%s-%s", cs->name, cs->impl);
-	off += snprintf(buf + off, size - off, "%-23s", b);
-	off += snprintf(buf + off, size - off, "%8llu",
+	kmem_scnprintf(b, 23, "%s-%s", cs->name, cs->impl);
+	off += kmem_scnprintf(buf + off, size - off, "%-23s", b);
+	off += kmem_scnprintf(buf + off, size - off, "%8llu",
 	    (u_longlong_t)cs->bs1k);
-	off += snprintf(buf + off, size - off, "%8llu",
+	off += kmem_scnprintf(buf + off, size - off, "%8llu",
 	    (u_longlong_t)cs->bs4k);
-	off += snprintf(buf + off, size - off, "%8llu",
+	off += kmem_scnprintf(buf + off, size - off, "%8llu",
 	    (u_longlong_t)cs->bs16k);
-	off += snprintf(buf + off, size - off, "%8llu",
+	off += kmem_scnprintf(buf + off, size - off, "%8llu",
 	    (u_longlong_t)cs->bs64k);
-	off += snprintf(buf + off, size - off, "%8llu",
+	off += kmem_scnprintf(buf + off, size - off, "%8llu",
 	    (u_longlong_t)cs->bs256k);
-	off += snprintf(buf + off, size - off, "%8llu",
+	off += kmem_scnprintf(buf + off, size - off, "%8llu",
 	    (u_longlong_t)cs->bs1m);
-	off += snprintf(buf + off, size - off, "%8llu",
+	off += kmem_scnprintf(buf + off, size - off, "%8llu",
 	    (u_longlong_t)cs->bs4m);
-	(void) snprintf(buf + off, size - off, "%8llu\n",
+	(void) kmem_scnprintf(buf + off, size - off, "%8llu\n",
 	    (u_longlong_t)cs->bs16m);
 
 	return (0);

--- a/tests/zfs-tests/cmd/mmapwrite.c
+++ b/tests/zfs-tests/cmd/mmapwrite.c
@@ -88,29 +88,21 @@ map_writer(void *filename)
 	int ret = 0;
 	char *buf = NULL;
 	int page_size = getpagesize();
-	int op_errno = 0;
 	char *file_path = filename;
 
 	while (1) {
-		ret = access(file_path, F_OK);
-		if (ret) {
-			op_errno = errno;
-			if (op_errno == ENOENT) {
+		fd = open(file_path, O_RDWR);
+		if (fd == -1) {
+			if (errno == ENOENT) {
 				fd = open(file_path, O_RDWR | O_CREAT, 0777);
 				if (fd == -1) {
 					err(1, "open file failed");
 				}
-
 				ret = ftruncate(fd, page_size);
 				if (ret == -1) {
 					err(1, "truncate file failed");
 				}
 			} else {
-				err(1, "access file failed!");
-			}
-		} else {
-			fd = open(file_path, O_RDWR, 0777);
-			if (fd == -1) {
 				err(1, "open file failed");
 			}
 		}

--- a/tests/zfs-tests/tests/functional/tmpfile/tmpfile_002_pos.c
+++ b/tests/zfs-tests/tests/functional/tmpfile/tmpfile_002_pos.c
@@ -46,7 +46,6 @@ main(void)
 	int i, fd;
 	char spath[1024], dpath[1024];
 	const char *penv[] = {"TESTDIR", "TESTFILE0"};
-	struct stat sbuf;
 
 	(void) fprintf(stdout, "Verify O_TMPFILE file can be linked.\n");
 
@@ -73,12 +72,10 @@ main(void)
 	run("export");
 	run("import");
 
-	if (stat(dpath, &sbuf) < 0) {
-		perror("stat");
-		unlink(dpath);
+	if (unlink(dpath) == -1) {
+		perror("unlink");
 		exit(5);
 	}
-	unlink(dpath);
 
 	return (0);
 }

--- a/tests/zfs-tests/tests/functional/tmpfile/tmpfile_stat_mode.c
+++ b/tests/zfs-tests/tests/functional/tmpfile/tmpfile_stat_mode.c
@@ -48,7 +48,7 @@
 static void
 test_stat_mode(mode_t mask)
 {
-	struct stat st, fst;
+	struct stat fst;
 	int i, fd;
 	char spath[1024], dpath[1024];
 	const char *penv[] = {"TESTDIR", "TESTFILE0"};
@@ -68,7 +68,7 @@ test_stat_mode(mode_t mask)
 		err(2, "open(%s)", penv[0]);
 
 	if (fstat(fd, &fst) == -1)
-		err(3, "open");
+		err(3, "fstat(%s)", penv[0]);
 
 	snprintf(spath, sizeof (spath), "/proc/self/fd/%d", fd);
 	snprintf(dpath, sizeof (dpath), "%s/%s", penv[0], penv[1]);
@@ -78,19 +78,22 @@ test_stat_mode(mode_t mask)
 		err(4, "linkat");
 	close(fd);
 
-	if (stat(dpath, &st) == -1)
-		err(5, "stat");
-	unlink(dpath);
-
-	/* Verify fstat(2) result */
+	/* Verify fstat(2) result at old path */
 	mode = fst.st_mode & 0777;
 	if (mode != masked)
-		errx(6, "fstat(2) %o != %o\n", mode, masked);
+		errx(5, "fstat(2) %o != %o\n", mode, masked);
 
-	/* Verify stat(2) result */
-	mode = st.st_mode & 0777;
+	fd = open(dpath, O_RDWR);
+	if (fd == -1)
+		err(6, "open(%s)", dpath);
+
+	if (fstat(fd, &fst) == -1)
+		err(7, "fstat(%s)", dpath);
+
+	/* Verify fstat(2) result at new path */
+	mode = fst.st_mode & 0777;
 	if (mode != masked)
-		errx(7, "stat(2) %o != %o\n", mode, masked);
+		errx(8, "fstat(2) %o != %o\n", mode, masked);
 }
 
 int


### PR DESCRIPTION
### Motivation and Context
CodeQL caught some issues in our codebase.

### Description
These patches are intended to fix a number of them. Details are in each commit message. A solution for the integer overflow issues reported are not included since that is covered by #14094.

### How Has This Been Tested?
A local build test has been done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
