### PR TITLE
Fix zio_flag_t print format

### DIFF
--- a/include/os/linux/zfs/sys/trace_common.h
+++ b/include/os/linux/zfs/sys/trace_common.h
@@ -92,7 +92,7 @@
 #define	ZIO_TP_PRINTK_FMT						\
 	"zio { type %u cmd %i prio %u size %llu orig_size %llu "	\
 	"offset %llu timestamp %llu delta %llu delay %llu "		\
-	"flags 0x%x stage 0x%x pipeline 0x%x orig_flags 0x%x "		\
+	"flags 0x%llx stage 0x%x pipeline 0x%x orig_flags 0x%llx "	\
 	"orig_stage 0x%x orig_pipeline 0x%x reexecute %u "		\
 	"txg %llu error %d ena %llu prop { checksum %u compress %u "	\
 	"type %u level %u copies %u dedup %u dedup_verify %u nopwrite %u } }"


### PR DESCRIPTION
Signed-off-by: Youzhong Yang <yyang@mathworks.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

buildbot/Kernel.org failed with errors like the following:

```
In file included from ./include/trace/define_trace.h:102:0,
                 from ./include/zfs/os/linux/zfs/sys/trace_arc.h:385,
                 from fs/zfs/os/linux/zfs/trace.c:43:
./include/zfs/os/linux/zfs/sys/trace_arc.h: In function ‘trace_raw_output_zfs_l2arc_rw_class’:
./include/zfs/os/linux/zfs/sys/trace_arc.h:138:12: error: format ‘%x’ expects argument of type ‘unsigned int’, but argument 15 has type ‘zio_flag_t {aka long long unsigned int}’ [-Werror=format=]
  TP_printk("vdev { id %llu guid %llu state %llu } "
            ^
./include/trace/trace_events.h:203:27: note: in definition of macro ‘DECLARE_EVENT_CLASS’
  trace_event_printf(iter, print);    \
                           ^~~~~
./include/zfs/os/linux/zfs/sys/trace_arc.h:138:2: note: in expansion of macro ‘TP_printk’
  TP_printk("vdev { id %llu guid %llu state %llu } "
  ^~~~~~~~~
In file included from ./include/zfs/os/linux/zfs/sys/trace_arc.h:38:0,
                 from fs/zfs/os/linux/zfs/trace.c:43:
./include/zfs/os/linux/zfs/sys/trace_common.h:95:12: note: format string is defined here
  "flags 0x%x stage 0x%x pipeline 0x%x orig_flags 0x%x "  \
           ~^
           %llx
```

It is likely caused by [commit 4938d01db7](https://github.com/openzfs/zfs/commit/4938d01db7e12751e0cc3161d23dd549a0cee8ab) which changed zio_flag from enum to uint64_t.

### Description
<!--- Describe your changes in detail -->

Use the suggested format %llx.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
No, buildbot will tell.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
