### PR TITLE
Make send -v play nice with readonly sends

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -1534,8 +1534,15 @@ estimate_size(zfs_handle_t *zhp, const char *from, int fd, sendflags_t *flags,
 	    lzc_flags_from_sendflags(flags), resumeobj, resumeoff, bytes,
 	    redactbook, fd, &size);
 
-	if (flags->progress && send_progress_thread_exit(zhp->zfs_hdl, ptid))
+	if (err == EINVAL) {
+		(void) fprintf(fout,
+		    "couldn't estimate size, continuing...\n");
+		return (0);
+	}
+
+	if (flags->progress && send_progress_thread_exit(zhp->zfs_hdl, ptid)) {
 		return (-1);
+	}
 
 	if (err != 0) {
 		zfs_error_aux(zhp->zfs_hdl, "%s", strerror(err));


### PR DESCRIPTION
Currently, send -v will fail to estimate size if you hand it a ro dataset to send, and fail out.

Printing a little note that it can't guess and then continuing seems preferable to me.

### Motivation and Context
@cleverca22 pointed out it was broken.

### Description
Just add a special case for handling getting EINVAL back that doesn't fail the send - if it's truly an invalid argument, we should fail elsewhere as well, without this breaking something unexpectedly.

### How Has This Been Tested?
It failed before, now it just prints a note and sends.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
