### PR TITLE
Fix oversights from 4170ae4ea600fea6ac9daa8b145960c9de3915fc

### DIFF
--- a/lib/libshare/os/linux/smb.c
+++ b/lib/libshare/os/linux/smb.c
@@ -103,7 +103,7 @@ smb_retrieve_shares(void)
 			goto out;
 		}
 
-		if (stat(file_path, &eStat) == -1) {
+		if (fstat(fd, &eStat) == -1) {
 			close(fd);
 			rc = SA_SYSTEM_ERR;
 			goto out;

--- a/tests/zfs-tests/tests/functional/tmpfile/tmpfile_stat_mode.c
+++ b/tests/zfs-tests/tests/functional/tmpfile/tmpfile_stat_mode.c
@@ -37,12 +37,12 @@
 
 /*
  * DESCRIPTION:
- *	Verify stat(2) for O_TMPFILE file considers umask.
+ *	Verify fstat(2) for O_TMPFILE file considers umask.
  *
  * STRATEGY:
  *	1. open(2) with O_TMPFILE.
  *	2. linkat(2).
- *	3. fstat(2)/stat(2) and verify .st_mode value.
+ *	3. fstat(2) and verify .st_mode value.
  */
 
 static void
@@ -94,6 +94,7 @@ test_stat_mode(mode_t mask)
 	mode = fst.st_mode & 0777;
 	if (mode != masked)
 		errx(8, "fstat(2) %o != %o\n", mode, masked);
+	close(fd);
 }
 
 int


### PR DESCRIPTION
### Motivation and Context
4170ae4ea600fea6ac9daa8b145960c9de3915fc was intended to tackle TOCTOU race conditions reported by CodeQL, but as an oversight, a file descriptor was not closed and some comments were not updated. Interestingly, CodeQL did not complain about the file descriptor leak, so there is room for improvement in how we configure it to try to detect this issue so that we get early warning about this.

In addition, an optimization opportunity was missed by mistake in lib/libshare/os/linux/smb.c, which prevented us from truly closing the TOCTOU race. This was also caught by Coverity.

Reported-by: Coverity (CID 1524424)
Reported-by: Coverity (CID 1526804)

### Description
The issues have been fixed.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
