### PR TITLE
rsend_009_pos.ksh is destructive on zfs-on-root system

### DIFF
--- a/tests/zfs-tests/tests/functional/rsend/rsend_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_009_pos.ksh
@@ -45,13 +45,16 @@
 
 verify_runnable "global"
 
+BPOOL=bpool_test
+SPOOL=spool_test
+
 function cleanup
 {
-	if datasetexists bpool ; then
-		log_must_busy zpool destroy -f bpool
+	if datasetexists $BPOOL ; then
+		log_must_busy zpool destroy -f $BPOOL
 	fi
-	if datasetexists spool ; then
-		log_must_busy zpool destroy -f spool
+	if datasetexists $SPOOL ; then
+		log_must_busy zpool destroy -f $SPOOL
 	fi
 }
 
@@ -60,33 +63,33 @@ log_onexit cleanup
 
 log_must mkfile $MINVDEVSIZE $TESTDIR/bfile
 log_must mkfile $SPA_MINDEVSIZE  $TESTDIR/sfile
-log_must zpool create -O compression=off bpool $TESTDIR/bfile
-log_must zpool create -O compression=off spool $TESTDIR/sfile
+log_must zpool create -O compression=off $BPOOL $TESTDIR/bfile
+log_must zpool create -O compression=off $SPOOL $TESTDIR/sfile
 
 #
 # Test out of space on sub-filesystem
 #
-log_must zfs create bpool/fs
-log_must mkfile 30M /bpool/fs/file
+log_must zfs create $BPOOL/fs
+log_must mkfile 30M /$BPOOL/fs/file
 
-log_must zfs snapshot bpool/fs@snap
-log_must eval "zfs send -R bpool/fs@snap > $BACKDIR/fs-R"
-log_mustnot eval "zfs receive -d -F spool < $BACKDIR/fs-R"
+log_must zfs snapshot $BPOOL/fs@snap
+log_must eval "zfs send -R $BPOOL/fs@snap > $BACKDIR/fs-R"
+log_mustnot eval "zfs receive -d -F $SPOOL < $BACKDIR/fs-R"
 
-log_must datasetnonexists spool/fs
-log_must ismounted spool
+log_must datasetnonexists $SPOOL/fs
+log_must ismounted $SPOOL
 
 #
 # Test out of space on top filesystem
 #
-log_must mv /bpool/fs/file /bpool
-log_must_busy zfs destroy -rf bpool/fs
+log_must mv /$BPOOL/fs/file /$BPOOL
+log_must_busy zfs destroy -rf $BPOOL/fs
 
-log_must zfs snapshot bpool@snap
-log_must eval "zfs send -R bpool@snap > $BACKDIR/bpool-R"
-log_mustnot eval "zfs receive -d -F spool < $BACKDIR/bpool-R"
+log_must zfs snapshot $BPOOL@snap
+log_must eval "zfs send -R $BPOOL@snap > $BACKDIR/bpool-R"
+log_mustnot eval "zfs receive -d -F $SPOOL < $BACKDIR/bpool-R"
 
-log_must datasetnonexists spool/fs
-log_must ismounted spool
+log_must datasetnonexists $SPOOL/fs
+log_must ismounted $SPOOL
 
 log_pass "zfs receive can handle out of space correctly."


### PR DESCRIPTION
Signed-off-by: Youzhong Yang <yyang@mathworks.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I ran zfs test suite on Ubuntu zfs-on-root VM, occasionally the VM failed to boot and I had to reimage it. The rsend_009_pos.ksh test seems to be the culprit, as it uses the zpool name 'bpool'.

### Description
<!--- Describe your changes in detail -->

Use variable to specify the pool name with suffix "_test".

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Ran rsend_009_pos test only.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
