### PR TITLE
libuutil: deobfuscate internal pointers

### DIFF
--- a/include/libuutil_impl.h
+++ b/include/libuutil_impl.h
@@ -47,21 +47,6 @@ void uu_panic(const char *format, ...);
 
 
 /*
- * For debugging purposes, libuutil keeps around linked lists of all uu_lists
- * and uu_avls, along with pointers to their parents.  These can cause false
- * negatives when looking for memory leaks, so we encode the pointers by
- * storing them with swapped endianness;  this is not perfect, but it's about
- * the best we can do without wasting a lot of space.
- */
-#ifdef _LP64
-#define	UU_PTR_ENCODE(ptr)		BSWAP_64((uintptr_t)(void *)(ptr))
-#else
-#define	UU_PTR_ENCODE(ptr)		BSWAP_32((uintptr_t)(void *)(ptr))
-#endif
-
-#define	UU_PTR_DECODE(ptr)		((void *)UU_PTR_ENCODE(ptr))
-
-/*
  * uu_list structures
  */
 typedef struct uu_list_node_impl {
@@ -80,11 +65,11 @@ struct uu_list_walk {
 };
 
 struct uu_list {
-	uintptr_t	ul_next_enc;
-	uintptr_t	ul_prev_enc;
+	uu_list_t	*ul_next;
+	uu_list_t	*ul_prev;
 
 	uu_list_pool_t	*ul_pool;
-	uintptr_t	ul_parent_enc;	/* encoded parent pointer */
+	void		*ul_parent;
 	size_t		ul_offset;
 	size_t		ul_numnodes;
 	uint8_t		ul_debug;
@@ -94,8 +79,6 @@ struct uu_list {
 	uu_list_node_impl_t ul_null_node;
 	uu_list_walk_t	ul_null_walk;	/* for robust walkers */
 };
-
-#define	UU_LIST_PTR(ptr)		((uu_list_t *)UU_PTR_DECODE(ptr))
 
 #define	UU_LIST_POOL_MAXNAME	64
 
@@ -129,19 +112,17 @@ struct uu_avl_walk {
 };
 
 struct uu_avl {
-	uintptr_t	ua_next_enc;
-	uintptr_t	ua_prev_enc;
+	uu_avl_t	*ua_next;
+	uu_avl_t	*ua_prev;
 
 	uu_avl_pool_t	*ua_pool;
-	uintptr_t	ua_parent_enc;
+	void		*ua_parent;
 	uint8_t		ua_debug;
 	uint8_t		ua_index;	/* mark for uu_avl_index_ts */
 
 	struct avl_tree	ua_tree;
 	uu_avl_walk_t	ua_null_walk;
 };
-
-#define	UU_AVL_PTR(x)		((uu_avl_t *)UU_PTR_DECODE(x))
 
 #define	UU_AVL_POOL_MAXNAME	64
 

--- a/lib/libuutil/uu_avl.c
+++ b/lib/libuutil/uu_avl.c
@@ -97,8 +97,8 @@ uu_avl_pool_create(const char *name, size_t objsize, size_t nodeoffset,
 
 	(void) pthread_mutex_init(&pp->uap_lock, NULL);
 
-	pp->uap_null_avl.ua_next_enc = UU_PTR_ENCODE(&pp->uap_null_avl);
-	pp->uap_null_avl.ua_prev_enc = UU_PTR_ENCODE(&pp->uap_null_avl);
+	pp->uap_null_avl.ua_next = &pp->uap_null_avl;
+	pp->uap_null_avl.ua_prev = &pp->uap_null_avl;
 
 	(void) pthread_mutex_lock(&uu_apool_list_lock);
 	pp->uap_next = next = &uu_null_apool;
@@ -114,10 +114,8 @@ void
 uu_avl_pool_destroy(uu_avl_pool_t *pp)
 {
 	if (pp->uap_debug) {
-		if (pp->uap_null_avl.ua_next_enc !=
-		    UU_PTR_ENCODE(&pp->uap_null_avl) ||
-		    pp->uap_null_avl.ua_prev_enc !=
-		    UU_PTR_ENCODE(&pp->uap_null_avl)) {
+		if (pp->uap_null_avl.ua_next != &pp->uap_null_avl ||
+		    pp->uap_null_avl.ua_prev != &pp->uap_null_avl) {
 			uu_panic("uu_avl_pool_destroy: Pool \"%.*s\" (%p) has "
 			    "outstanding avls, or is corrupt.\n",
 			    (int)sizeof (pp->uap_name), pp->uap_name,
@@ -224,7 +222,7 @@ uu_avl_create(uu_avl_pool_t *pp, void *parent, uint32_t flags)
 	}
 
 	ap->ua_pool = pp;
-	ap->ua_parent_enc = UU_PTR_ENCODE(parent);
+	ap->ua_parent = parent;
 	ap->ua_debug = pp->uap_debug || (flags & UU_AVL_DEBUG);
 	ap->ua_index = (pp->uap_last_index = INDEX_NEXT(pp->uap_last_index));
 
@@ -236,11 +234,11 @@ uu_avl_create(uu_avl_pool_t *pp, void *parent, uint32_t flags)
 
 	(void) pthread_mutex_lock(&pp->uap_lock);
 	next = &pp->uap_null_avl;
-	prev = UU_PTR_DECODE(next->ua_prev_enc);
-	ap->ua_next_enc = UU_PTR_ENCODE(next);
-	ap->ua_prev_enc = UU_PTR_ENCODE(prev);
-	next->ua_prev_enc = UU_PTR_ENCODE(ap);
-	prev->ua_next_enc = UU_PTR_ENCODE(ap);
+	prev = next->ua_prev;
+	ap->ua_next = next;
+	ap->ua_prev = prev;
+	next->ua_prev = ap;
+	prev->ua_next = ap;
 	(void) pthread_mutex_unlock(&pp->uap_lock);
 
 	return (ap);
@@ -263,11 +261,11 @@ uu_avl_destroy(uu_avl_t *ap)
 		}
 	}
 	(void) pthread_mutex_lock(&pp->uap_lock);
-	UU_AVL_PTR(ap->ua_next_enc)->ua_prev_enc = ap->ua_prev_enc;
-	UU_AVL_PTR(ap->ua_prev_enc)->ua_next_enc = ap->ua_next_enc;
+	ap->ua_next->ua_prev = ap->ua_prev;
+	ap->ua_prev->ua_next = ap->ua_next;
 	(void) pthread_mutex_unlock(&pp->uap_lock);
-	ap->ua_prev_enc = UU_PTR_ENCODE(NULL);
-	ap->ua_next_enc = UU_PTR_ENCODE(NULL);
+	ap->ua_prev = NULL;
+	ap->ua_next = NULL;
 
 	ap->ua_pool = NULL;
 	avl_destroy(&ap->ua_tree);


### PR DESCRIPTION
### Motivation and Context
libuutil's uu_avl and uu_list data structures use a pointer obfuscation which is incompatible with CHERI pointers (byte swapping the address takes the pointer too far out of range) so I needed to disable it on CheriBSD. Simply removing the obfuscation is cleaner and modern leak sanitizers should be able to handle this case.

### Description
uu_avl and uu_list stored internal next/prev pointers and parent pointers (unused) obfuscated (byte swapped) to hide them from a long forgotten leak checker (No one at the 2022 OpenZFS developers meeting could recall the history.)  This would break on CHERI systems and adds no obvious value.  Rename the members, use proper types rather than uintptr_t, and elimate the related macros.

I've checked the library ABI box below as the .abi files need to be updated, but the change is and API change on internal struct members and the structs don't change size.

### How Has This Been Tested?
sanity tests on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Requires-builders: test