### PR TITLE
isa_defs.h cleanups (RISC-V and GC)

### DIFF
--- a/include/os/linux/spl/sys/isa_defs.h
+++ b/include/os/linux/spl/sys/isa_defs.h
@@ -206,8 +206,12 @@
  * RISC-V arch specific defines
  * only RV64G (including atomic) LP64 is supported yet
  */
-#elif defined(__riscv) && defined(_LP64) && _LP64 && \
+#elif defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64 && \
 	defined(__riscv_atomic) && __riscv_atomic
+
+#if !defined(_LP64)
+#define	_LP64 1
+#endif
 
 #ifndef	__riscv__
 #define	__riscv__

--- a/include/os/linux/spl/sys/isa_defs.h
+++ b/include/os/linux/spl/sys/isa_defs.h
@@ -47,9 +47,6 @@
 #endif
 #endif
 
-#define	_ALIGNMENT_REQUIRED	1
-
-
 /* i386 arch specific defines */
 #elif defined(__i386) || defined(__i386__)
 
@@ -64,8 +61,6 @@
 #if !defined(_ILP32)
 #define	_ILP32
 #endif
-
-#define	_ALIGNMENT_REQUIRED	0
 
 /* powerpc (ppc64) arch specific defines */
 #elif defined(__powerpc) || defined(__powerpc__) || defined(__powerpc64__)
@@ -88,12 +83,6 @@
 #endif
 #endif
 
-/*
- * Illumos doesn't define _ALIGNMENT_REQUIRED for PPC, so default to 1
- * out of paranoia.
- */
-#define	_ALIGNMENT_REQUIRED	1
-
 /* arm arch specific defines */
 #elif defined(__arm) || defined(__arm__)
 
@@ -114,12 +103,6 @@
 #else
 #define	_ZFS_BIG_ENDIAN
 #endif
-
-/*
- * Illumos doesn't define _ALIGNMENT_REQUIRED for ARM, so default to 1
- * out of paranoia.
- */
-#define	_ALIGNMENT_REQUIRED	1
 
 /* aarch64 arch specific defines */
 #elif defined(__aarch64__)
@@ -157,7 +140,6 @@
 
 #define	_ZFS_BIG_ENDIAN
 #define	_SUNOS_VTOC_16
-#define	_ALIGNMENT_REQUIRED	1
 
 /* s390 arch specific defines */
 #elif defined(__s390__)
@@ -172,12 +154,6 @@
 #endif
 
 #define	_ZFS_BIG_ENDIAN
-
-/*
- * Illumos doesn't define _ALIGNMENT_REQUIRED for s390, so default to 1
- * out of paranoia.
- */
-#define	_ALIGNMENT_REQUIRED	1
 
 /* MIPS arch specific defines */
 #elif defined(__mips__)
@@ -195,12 +171,6 @@
 #endif
 
 #define	_SUNOS_VTOC_16
-
-/*
- * Illumos doesn't define _ALIGNMENT_REQUIRED for MIPS, so default to 1
- * out of paranoia.
- */
-#define	_ALIGNMENT_REQUIRED	1
 
 /*
  * RISC-V arch specific defines
@@ -224,8 +194,6 @@
 #define	_ZFS_LITTLE_ENDIAN
 
 #define	_SUNOS_VTOC_16
-
-#define	_ALIGNMENT_REQUIRED	1
 
 #else
 /*

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -227,8 +227,12 @@ extern "C" {
  * RISC-V arch specific defines
  * only RV64G (including atomic) LP64 is supported yet
  */
-#elif defined(__riscv) && defined(_LP64) && _LP64 && \
+#elif defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64 && \
 	defined(__riscv_atomic) && __riscv_atomic
+
+#if !defined(_LP64)
+#define	_LP64 1
+#endif
 
 #ifndef	__riscv__
 #define	__riscv__


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
I needed to improve the RISC-V entry in the common isa_defs.h for CheriBSD. This PR contains that and some follow on changes.

### Description
Based on feedback from @ryao I've added the RISC-V changes to the linux SPL. I've also included a follow on cleanup to the Linux isa_defs.h following FreeBSD changes in #14127.

### How Has This Been Tested?
zfs-test sanity tests on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Requires-builders: build