### PR TITLE
FreeBSD: Fix out of bounds read in zfs_ioctl_ozfs_to_legacy()

### DIFF
--- a/module/os/freebsd/zfs/zfs_ioctl_compat.c
+++ b/module/os/freebsd/zfs/zfs_ioctl_compat.c
@@ -319,7 +319,7 @@ zfs_ioctl_legacy_to_ozfs(int request)
 int
 zfs_ioctl_ozfs_to_legacy(int request)
 {
-	if (request > ZFS_IOC_LAST)
+	if (request >= ZFS_IOC_LAST)
 		return (-1);
 
 	if (request > ZFS_IOC_PLATFORM) {


### PR DESCRIPTION
### Motivation and Context
There is an off by 1 error in the check. Fortunately, this function does not appear to be used in kernel space, despite being compiled as part of the kernel module. However, it is used in userspace. Callers of lzc_ioctl_fd() likely will crash if they attempt to use the unimplemented request number.

This was reported by FreeBSD's coverity scan.

Reported-by: Coverity (CID 1432059)

### Description
Making the check greater than or equal to is sufficient to fix this.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
