### PR TITLE
FreeBSD cleanup

### DIFF
--- a/lib/libzfs_core/os/freebsd/libzfs_core_ioctl.c
+++ b/lib/libzfs_core/os/freebsd/libzfs_core_ioctl.c
@@ -38,7 +38,7 @@ get_zfs_ioctl_version(void)
 	int ver = ZFS_IOCVER_NONE;
 
 	ver_size = sizeof (ver);
-	sysctlbyname("vfs.zfs.version.ioctl", &ver, &ver_size, NULL, 0);
+	(void) sysctlbyname("vfs.zfs.version.ioctl", &ver, &ver_size, NULL, 0);
 
 	return (ver);
 }


### PR DESCRIPTION
### Motivation and Context
FreeBSD's coverity scans complained about a few things that are not real issues, but are cleanup opportunities.

### Description
We do cleanup.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
