### PR TITLE
Fix recent regressions reported by Coverity

### DIFF
--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -121,7 +121,7 @@ zpl_vap_init(vattr_t *vap, struct inode *dir, umode_t mode, cred_t *cr,
 	vap->va_uid = zfs_vfsuid_to_uid((struct user_namespace *)mnt_ns,
 	    zfs_i_user_ns(dir), crgetuid(cr));
 
-	if (dir && dir->i_mode & S_ISGID) {
+	if (dir->i_mode & S_ISGID) {
 		vap->va_gid = KGID_TO_SGID(dir->i_gid);
 		if (S_ISDIR(mode))
 			vap->va_mode |= S_ISGID;

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1321,7 +1321,7 @@ top_of_function:
 	 * we want to let it through.
 	 */
 	if (ignorequota || netfree || dsl_dir_phys(dd)->dd_quota == 0 ||
-	    (dmu_objset_type(tx->tx_objset) == DMU_OST_ZVOL &&
+	    (tx->tx_objset && dmu_objset_type(tx->tx_objset) == DMU_OST_ZVOL &&
 	    zvol_enforce_quotas == B_FALSE))
 		quota = UINT64_MAX;
 	else


### PR DESCRIPTION
### Motivation and Context
A coverity scan last night reported 3 new defects.

### Description
"Unsafely" dereferencing a pointer that had an unnecessary NULL check in `zpl_vap_init()` introduced by f224eddf922a33ca4b86d83148e9e6fa155fc290 caused two defect reports. Well, it would have been unsafe if the pointer had not been guaranteed to always be non-NULL. Fixing this is cleanup.

A failure by 945b407486a0072ec7dd117a0bde2f72d52eb445 to properly NULL check tx->tx_objset before dereference, as was already being done in the function before another dereference, caused another defect report. This is believed to be an actual NULL pointer dereference, although it is odd that the ZTS did not catch it.

Additional details are in the individual commits.

### How Has This Been Tested?
Build tests have been done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
