### PR TITLE
Address theoretical uninitialized variable usage in zstream

### DIFF
--- a/cmd/zstream/zstream_recompress.c
+++ b/cmd/zstream/zstream_recompress.c
@@ -138,6 +138,8 @@ zstream_do_recompress(int argc, char *argv[])
 	fletcher_4_init();
 	zio_init();
 	zstd_init();
+	int begin = 0;
+	boolean_t seen = B_FALSE;
 	while (sfread(drr, sizeof (*drr), stdin) != 0) {
 		struct drr_write *drrw;
 		uint64_t payload_size = 0;
@@ -155,6 +157,8 @@ zstream_do_recompress(int argc, char *argv[])
 		case DRR_BEGIN:
 		{
 			ZIO_SET_CHECKSUM(&stream_cksum, 0, 0, 0, 0);
+			VERIFY0(begin++);
+			seen = B_TRUE;
 
 			int sz = drr->drr_payloadlen;
 			if (sz != 0) {
@@ -173,6 +177,13 @@ zstream_do_recompress(int argc, char *argv[])
 		{
 			struct drr_end *drre = &drr->drr_u.drr_end;
 			/*
+			 * We would prefer to just check --begin == 0, but
+			 * replication streams have an end of stream END
+			 * record, so we must avoid tripping it.
+			 */
+			VERIFY3B(seen, ==, B_TRUE);
+			begin--;
+			/*
 			 * Use the recalculated checksum, unless this is
 			 * the END record of a stream package, which has
 			 * no checksum.
@@ -185,6 +196,7 @@ zstream_do_recompress(int argc, char *argv[])
 		case DRR_OBJECT:
 		{
 			struct drr_object *drro = &drr->drr_u.drr_object;
+			VERIFY3S(begin, ==, 1);
 
 			if (drro->drr_bonuslen > 0) {
 				payload_size = DRR_OBJECT_PAYLOAD_SIZE(drro);
@@ -196,12 +208,14 @@ zstream_do_recompress(int argc, char *argv[])
 		case DRR_SPILL:
 		{
 			struct drr_spill *drrs = &drr->drr_u.drr_spill;
+			VERIFY3S(begin, ==, 1);
 			payload_size = DRR_SPILL_PAYLOAD_SIZE(drrs);
 			(void) sfread(buf, payload_size, stdin);
 			break;
 		}
 
 		case DRR_WRITE_BYREF:
+			VERIFY3S(begin, ==, 1);
 			fprintf(stderr,
 			    "Deduplicated streams are not supported\n");
 			exit(1);
@@ -209,6 +223,7 @@ zstream_do_recompress(int argc, char *argv[])
 
 		case DRR_WRITE:
 		{
+			VERIFY3S(begin, ==, 1);
 			drrw = &thedrr.drr_u.drr_write;
 			payload_size = DRR_WRITE_PAYLOAD_SIZE(drrw);
 			/*
@@ -295,6 +310,7 @@ zstream_do_recompress(int argc, char *argv[])
 		{
 			struct drr_write_embedded *drrwe =
 			    &drr->drr_u.drr_write_embedded;
+			VERIFY3S(begin, ==, 1);
 			payload_size =
 			    P2ROUNDUP((uint64_t)drrwe->drr_psize, 8);
 			(void) sfread(buf, payload_size, stdin);
@@ -304,6 +320,7 @@ zstream_do_recompress(int argc, char *argv[])
 		case DRR_FREEOBJECTS:
 		case DRR_FREE:
 		case DRR_OBJECT_RANGE:
+			VERIFY3S(begin, ==, 1);
 			break;
 
 		default:


### PR DESCRIPTION
### Motivation and Context
Coverity has long complained about the checksum being uninitialized if an END record is processed before its BEGIN record. This should not happen, but there was no code to check for it. I had left this unfixed since it was a low priority issue, but then 9f4ede63d23be4f43ba8dd0ca42c6a773a8eaa8d added another instance of this.

I am making an effort to "hold the line" to keep new coverity defect reports from going unaddressed, so I find myself forced to fix this much earlier than I had originally planned to address it.

### Description
The solution is to maintain a counter and a flag. Then use VERIFY statements to verify the following runtime constraints:

 * Every record either has a corresponding BEGIN record, is a BEGIN record or is the end of stream END record for replication streams.
 * BEGIN records cannot be nested. i.e. There must be an END record before another BEGIN record may be seen.

Failure to meet these constraints will cause the program to exit.

This is sufficient to ensure that the checksum is never accessed when uninitialized.

### How Has This Been Tested?
It has been revised following feedback from the ZTS on the buildbot and now is passing the ZTS on the buildbot. Some local tests were also done by sending a replication stream from my desktop's pool through `zstream decompress`, as well as reproducing the stream used by the ZTS that failed the initial version (because it did not allow for an end of replication stream END record).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
