### PR TITLE
ZTS: zts-report silently ignores perf test resutls

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -325,7 +325,7 @@ def process_results(pathname):
         print('Error opening file:', e)
         sys.exit(1)
 
-    prefix = '/zfs-tests/tests/functional/'
+    prefix = '/zfs-tests/tests/(?:functional|perf/regression)/'
     pattern = \
         r'^Test(?:\s+\(\S+\))?:' + \
         rf'\s*\S*{prefix}(\S+)' + \


### PR DESCRIPTION
### Motivation and Context
The regex used to extract test result information from a test run only matches the functional tests. Update the regex so it matches both.

### How Has This Been Tested?
Locally tested passing and failing runs of functional and performance tests.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
