### PR TITLE
bump checksum error count before generating ereport

### DIFF
--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -1479,12 +1479,12 @@ vdev_indirect_all_checksum_errors(zio_t *zio)
 
 			vdev_t *vd = ic->ic_vdev;
 
-			(void) zfs_ereport_post_checksum(zio->io_spa, vd,
-			    NULL, zio, is->is_target_offset, is->is_size,
-			    NULL, NULL, NULL);
 			mutex_enter(&vd->vdev_stat_lock);
 			vd->vdev_stat.vs_checksum_errors++;
 			mutex_exit(&vd->vdev_stat_lock);
+			(void) zfs_ereport_post_checksum(zio->io_spa, vd,
+			    NULL, zio, is->is_target_offset, is->is_size,
+			    NULL, NULL, NULL);
 		}
 	}
 }

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -1769,12 +1769,12 @@ vdev_raidz_checksum_error(zio_t *zio, raidz_col_t *rc, abd_t *bad_data)
 		zbc.zbc_has_cksum = 0;
 		zbc.zbc_injected = rm->rm_ecksuminjected;
 
-		(void) zfs_ereport_post_checksum(zio->io_spa, vd,
-		    &zio->io_bookmark, zio, rc->rc_offset, rc->rc_size,
-		    rc->rc_abd, bad_data, &zbc);
 		mutex_enter(&vd->vdev_stat_lock);
 		vd->vdev_stat.vs_checksum_errors++;
 		mutex_exit(&vd->vdev_stat_lock);
+		(void) zfs_ereport_post_checksum(zio->io_spa, vd,
+		    &zio->io_bookmark, zio, rc->rc_offset, rc->rc_size,
+		    rc->rc_abd, bad_data, &zbc);
 	}
 }
 
@@ -2380,12 +2380,12 @@ vdev_raidz_io_done_unrecoverable(zio_t *zio)
 			zbc.zbc_has_cksum = 0;
 			zbc.zbc_injected = rm->rm_ecksuminjected;
 
-			(void) zfs_ereport_start_checksum(zio->io_spa,
-			    cvd, &zio->io_bookmark, zio, rc->rc_offset,
-			    rc->rc_size, &zbc);
 			mutex_enter(&cvd->vdev_stat_lock);
 			cvd->vdev_stat.vs_checksum_errors++;
 			mutex_exit(&cvd->vdev_stat_lock);
+			(void) zfs_ereport_start_checksum(zio->io_spa,
+			    cvd, &zio->io_bookmark, zio, rc->rc_offset,
+			    rc->rc_size, &zbc);
 		}
 	}
 }

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -4311,12 +4311,12 @@ zio_checksum_verify(zio_t *zio)
 		zio->io_error = error;
 		if (error == ECKSUM &&
 		    !(zio->io_flags & ZIO_FLAG_SPECULATIVE)) {
-			(void) zfs_ereport_start_checksum(zio->io_spa,
-			    zio->io_vd, &zio->io_bookmark, zio,
-			    zio->io_offset, zio->io_size, &info);
 			mutex_enter(&zio->io_vd->vdev_stat_lock);
 			zio->io_vd->vdev_stat.vs_checksum_errors++;
 			mutex_exit(&zio->io_vd->vdev_stat_lock);
+			(void) zfs_ereport_start_checksum(zio->io_spa,
+			    zio->io_vd, &zio->io_bookmark, zio,
+			    zio->io_offset, zio->io_size, &info);
 		}
 	}
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -86,7 +86,8 @@ tests = ['devices_001_pos', 'devices_002_neg', 'devices_003_pos']
 tags = ['functional', 'devices']
 
 [tests/functional/events:Linux]
-tests = ['events_001_pos', 'events_002_pos', 'zed_rc_filter', 'zed_fd_spill']
+tests = ['events_001_pos', 'events_002_pos', 'zed_rc_filter', 'zed_fd_spill',
+    'zed_cksum_reported']
 tags = ['functional', 'events']
 
 [tests/functional/fadvise:Linux]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1367,6 +1367,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/events/events_001_pos.ksh \
 	functional/events/events_002_pos.ksh \
 	functional/events/setup.ksh \
+	functional/events/zed_cksum_reported.ksh \
 	functional/events/zed_fd_spill.ksh \
 	functional/events/zed_rc_filter.ksh \
 	functional/exec/cleanup.ksh \

--- a/tests/zfs-tests/tests/functional/events/zed_cksum_reported.ksh
+++ b/tests/zfs-tests/tests/functional/events/zed_cksum_reported.ksh
@@ -1,0 +1,124 @@
+#!/bin/ksh -p
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2022, Klara Inc.
+#
+# This software was developed by Rob Wing <rob.wing@klarasystems.com>
+# under sponsorship from Seagate Technology LLC and Klara Inc.
+
+# DESCRIPTION:
+#	Verify that checksum errors are accurately reported to ZED
+#
+# STRATEGY:
+#	1. Create a mirrored/raidz pool
+#	2. Inject checksum error
+#	3. Verify checksum error count reported to ZED is not zero
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/events/events_common.kshlib
+
+verify_runnable "both"
+
+MOUNTDIR="$TEST_BASE_DIR/checksum_mount"
+FILEPATH="$MOUNTDIR/checksum_file"
+VDEV="$TEST_BASE_DIR/vdevfile.$$"
+VDEV1="$TEST_BASE_DIR/vdevfile1.$$"
+POOL="checksum_pool"
+FILESIZE="10M"
+
+function cleanup
+{
+	log_must zed_stop
+
+	log_must zinject -c all
+	if poolexists $POOL ; then
+		destroy_pool $POOL
+	fi
+	log_must rm -fd $VDEV $MOUNTDIR
+}
+log_onexit cleanup
+
+log_assert "Test reported checksum errors to ZED"
+
+function setup_pool
+{
+	type="$1"
+
+	log_must zpool create -f -m $MOUNTDIR $POOL $type $VDEV $VDEV1
+	log_must zpool events -c
+	log_must truncate -s 0 $ZED_DEBUG_LOG
+	log_must zfs set compression=off $POOL
+	log_must zfs set primarycache=none $POOL
+}
+
+function do_clean
+{
+	log_must zinject -c all
+	log_must zpool destroy $POOL
+}
+
+function do_checksum_error
+{
+	log_must mkfile $FILESIZE $FILEPATH
+	log_must zinject -a -t data -e checksum -T read -f 100 $FILEPATH
+
+	dd if=$FILEPATH of=/dev/null bs=1 count=1 2>/dev/null
+
+	log_must file_wait_event $ZED_DEBUG_LOG "ereport.fs.zfs.checksum" 10
+
+	# checksum error as reported from the vdev.
+	zpool_cksum=`zpool get -H -o value checksum_errors $POOL $VDEV`
+
+	# first checksum error reported to ZED.
+	zed_cksum=$(awk '/ZEVENT_CLASS=ereport.fs.zfs.checksum/, \
+	    /ZEVENT_VDEV_CKSUM_ERRORS=/ { \
+	    if ($1 ~ "ZEVENT_VDEV_CKSUM_ERRORS") \
+	    { print $0; exit } }' $ZED_DEBUG_LOG)
+
+	log_must [ $zpool_cksum -gt 0 ]
+
+	log_mustnot [ "$zed_cksum" = "ZEVENT_VDEV_CKSUM_ERRORS=0" ]
+
+	log_must [ "$zed_cksum" = "ZEVENT_VDEV_CKSUM_ERRORS=1" ]
+}
+
+# Set checksum_n=1
+# fire 1 event, should degrade.
+function checksum_error
+{
+	type=$1
+
+	setup_pool $type
+	do_checksum_error
+	do_clean
+}
+
+log_must truncate -s $MINVDEVSIZE $VDEV
+log_must truncate -s $MINVDEVSIZE $VDEV1
+log_must mkdir -p $MOUNTDIR
+
+log_must zed_start
+checksum_error mirror
+checksum_error raidz
+
+log_pass "Test reported checksum errors to ZED"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I noticed this while reviewing zed debug log output when a checksum error report is received but the number of checksum errors was zero. 

### Description
<!--- Describe your changes in detail -->

Increment the checksum error counter before sending an ereport.

The included tests check the call paths zio_checksum_verify() and vdev_raidz_io_done_unrecoverable(). 

The other call paths that bump the checksum error counter are vdev_raidz_checksum_error() and vdev_indirect_all_checksum_errors() - so I changed these to increment the counter before generating an ereport as well.

### How Has This Been Tested?

- generate a checksum error
- verify the vdev has a checksum error via zpool get
- verify that ZED debug log reports checksum error

One thing to note is that, it's possible that checksum errors reported by the vdev will not match the number of errors reported by ZED since duplicate checksum ereports aren't generated. When a checksum error occurs, the checksum error counter is incremented and an ereport is generated...the IO may then be reissued which causes the checksum error counter to get bumped again..however, a duplicate ereport will not be generated. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
