### PR TITLE
Various Coverity patches

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -468,7 +468,7 @@ static void
 verify_livelist_allocs(metaslab_verify_t *mv, uint64_t txg,
     uint64_t offset, uint64_t size)
 {
-	sublivelist_verify_block_t svb;
+	sublivelist_verify_block_t svb = {{{0}}};
 	DVA_SET_VDEV(&svb.svb_dva, mv->mv_vdid);
 	DVA_SET_OFFSET(&svb.svb_dva, offset);
 	DVA_SET_ASIZE(&svb.svb_dva, size);

--- a/contrib/coverity/model.c
+++ b/contrib/coverity/model.c
@@ -24,6 +24,8 @@
 
 #include <stdarg.h>
 
+#define	KM_NOSLEEP		0x0001  /* cannot block for memory; may fail */
+
 #define	UMEM_DEFAULT		0x0000  /* normal -- may fail */
 #define	UMEM_NOFAIL		0x0100  /* Never fails */
 
@@ -173,7 +175,7 @@ spl_kmem_alloc(size_t sz, int fl, const char *func, int line)
 	if (condition1)
 		__coverity_sleep__();
 
-	if ((fl == 0) || condition0) {
+	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) || condition0) {
 		void *buf = __coverity_alloc__(sz);
 		__coverity_mark_as_uninitialized_buffer__(buf);
 		__coverity_mark_as_afm_allocated__(buf, "spl_kmem_free");
@@ -194,7 +196,7 @@ spl_kmem_zalloc(size_t sz, int fl, const char *func, int line)
 	if (condition1)
 		__coverity_sleep__();
 
-	if ((fl == 0) || condition0) {
+	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) || condition0) {
 		void *buf = __coverity_alloc__(sz);
 		__coverity_writeall0__(buf);
 		__coverity_mark_as_afm_allocated__(buf, "spl_kmem_free");
@@ -276,7 +278,7 @@ spl_vmem_alloc(size_t sz, int fl, const char *func, int line)
 	if (condition1)
 		__coverity_sleep__();
 
-	if ((fl == 0) || condition0) {
+	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) || condition0) {
 		void *buf = __coverity_alloc__(sz);
 		__coverity_mark_as_uninitialized_buffer__(buf);
 		__coverity_mark_as_afm_allocated__(buf, "spl_vmem_free");
@@ -295,7 +297,7 @@ spl_vmem_zalloc(size_t sz, int fl, const char *func, int line)
 	if (condition1)
 		__coverity_sleep__();
 
-	if ((fl == 0) || condition0) {
+	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) || condition0) {
 		void *buf = __coverity_alloc__(sz);
 		__coverity_writeall0__(buf);
 		__coverity_mark_as_afm_allocated__(buf, "spl_vmem_free");

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -3323,10 +3323,10 @@ dbuf_prefetch_indirect_done(zio_t *zio, const zbookmark_phys_t *zb,
 	blkptr_t *bp = ((blkptr_t *)abuf->b_data) +
 	    P2PHASE(nextblkid, 1ULL << dpa->dpa_epbs);
 
-	ASSERT(!BP_IS_REDACTED(bp) ||
+	ASSERT(!BP_IS_REDACTED(bp) || (dpa->dpa_dnode &&
 	    dsl_dataset_feature_is_active(
 	    dpa->dpa_dnode->dn_objset->os_dsl_dataset,
-	    SPA_FEATURE_REDACTED_DATASETS));
+	    SPA_FEATURE_REDACTED_DATASETS)));
 	if (BP_IS_HOLE(bp) || BP_IS_REDACTED(bp)) {
 		arc_buf_destroy(abuf, private);
 		dbuf_prefetch_fini(dpa, B_TRUE);

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -1586,8 +1586,6 @@ send_merge_thread(void *arg)
 		}
 		range_free(front_ranges[i]);
 	}
-	if (range == NULL)
-		range = kmem_zalloc(sizeof (*range), KM_SLEEP);
 	range->eos_marker = B_TRUE;
 	bqueue_enqueue_flush(&smt_arg->q, range, 1);
 	spl_fstrans_unmark(cookie);


### PR DESCRIPTION
### Motivation and Context
Reducing the number of open Coverity reports eliminates opportunities for serious bugs to hide among the reports.

### Description
See the individual patches for descriptions.

### How Has This Been Tested?
Build tests have been done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
