### PR TITLE
Set multiple make jobs on CodeQL github workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@ jobs:
         language: [ 'cpp', 'python' ]
 
     steps:
+    - name: Set make jobs
+      run: |
+        echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+
     - name: Checkout repository
       uses: actions/checkout@v3
 


### PR DESCRIPTION
### Motivation and Context
Github reports that their runners have two cores:

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

We are not taking advantage of that when building ZFS in the CodeQL workflow, which makes it take somewhat longer than necessary to get results.

We can save about 10 to 15 minutes by passing the result of `-j$(nproc)` to make.

### Description
github supports 2 processors right now, although we use nproc instead of hard coding -j2, so if that ever increases, we will take advantage of it right away.

### How Has This Been Tested?
I tested it against CodeQL in my private repository at ryao/zfs. The build time dropped from `27m 13s` in one control run to `12m 5s` and `16m 49s` in different experiment runs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
