### PR TITLE
RFC: Generic Fletcher4 vector implementation

### DIFF
--- a/include/zfs_fletcher.h
+++ b/include/zfs_fletcher.h
@@ -75,6 +75,23 @@ typedef struct zfs_fletcher_superscalar {
 	uint64_t v[4];
 } zfs_fletcher_superscalar_t;
 
+typedef uint32_t u32x4 __attribute__((vector_size(16)));
+typedef uint64_t u64x2 __attribute__((vector_size(16)));
+
+typedef uint8_t u8x32 __attribute__((vector_size(32)));
+typedef uint64_t u64x4 __attribute__((vector_size(32)));
+
+typedef uint64_t u64x8 __attribute__((vector_size(64)));
+
+typedef union {
+	u8x32   u8h[2];
+	u64x8   u64;
+	u64x4   u64h[2];
+	u64x2   u64q[4];
+} v512;
+
+typedef v512 zfs_fletcher_generic_t;
+
 typedef struct zfs_fletcher_sse {
 	uint64_t v[2] __attribute__((aligned(16)));
 } zfs_fletcher_sse_t;
@@ -95,6 +112,7 @@ typedef struct zfs_fletcher_aarch64_neon {
 typedef union fletcher_4_ctx {
 	zio_cksum_t scalar;
 	zfs_fletcher_superscalar_t superscalar[4];
+	zfs_fletcher_generic_t generic[4];
 
 #if defined(HAVE_SSE2) || (defined(HAVE_SSE2) && defined(HAVE_SSSE3))
 	zfs_fletcher_sse_t sse[4];
@@ -131,6 +149,7 @@ typedef struct fletcher_4_func {
 
 _ZFS_FLETCHER_H const fletcher_4_ops_t fletcher_4_superscalar_ops;
 _ZFS_FLETCHER_H const fletcher_4_ops_t fletcher_4_superscalar4_ops;
+_ZFS_FLETCHER_H const fletcher_4_ops_t fletcher_4_generic_ops;
 
 #if defined(HAVE_SSE2)
 _ZFS_FLETCHER_H const fletcher_4_ops_t fletcher_4_sse2_ops;

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -43,6 +43,7 @@ nodist_libzfs_la_SOURCES = \
 	module/zcommon/zfs_fletcher.c \
 	module/zcommon/zfs_fletcher_aarch64_neon.c \
 	module/zcommon/zfs_fletcher_avx512.c \
+	module/zcommon/zfs_fletcher_generic.c \
 	module/zcommon/zfs_fletcher_intel.c \
 	module/zcommon/zfs_fletcher_sse.c \
 	module/zcommon/zfs_fletcher_superscalar.c \

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -582,6 +582,7 @@
     <elf-symbol name='fletcher_4_avx2_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_4_avx512bw_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_4_avx512f_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_generic_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_4_sse2_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_4_ssse3_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_4_superscalar4_ops' size='64' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -5344,6 +5345,9 @@
       <parameter type-id='c24fc2ee'/>
       <return type-id='48b5725f'/>
     </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='module/zcommon/zfs_fletcher_generic.c' language='LANG_C99'>
+    <var-decl name='fletcher_4_generic_ops' type-id='9eeabdc8' mangled-name='fletcher_4_generic_ops' visibility='default' elf-symbol-id='fletcher_4_generic_ops'/>
   </abi-instr>
   <abi-instr address-size='64' path='module/zcommon/zfs_fletcher_intel.c' language='LANG_C99'>
     <var-decl name='fletcher_4_avx2_ops' type-id='9eeabdc8' mangled-name='fletcher_4_avx2_ops' visibility='default' elf-symbol-id='fletcher_4_avx2_ops'/>

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -55,6 +55,7 @@ nodist_libzpool_la_SOURCES = \
 	module/zcommon/zfs_fletcher.c \
 	module/zcommon/zfs_fletcher_aarch64_neon.c \
 	module/zcommon/zfs_fletcher_avx512.c \
+	module/zcommon/zfs_fletcher_generic.c \
 	module/zcommon/zfs_fletcher_intel.c \
 	module/zcommon/zfs_fletcher_sse.c \
 	module/zcommon/zfs_fletcher_superscalar.c \

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -43,9 +43,14 @@ asflags-y := $(ZFS_MODULE_CFLAGS) $(ZFS_MODULE_CPPFLAGS)
 ccflags-y := $(ZFS_MODULE_CFLAGS) $(ZFS_MODULE_CPPFLAGS)
 
 ifeq ($(CONFIG_ARM64),y)
+CFLAGS_REMOVE_zcommon/zfs_fletcher_generic.o += -mgeneral-regs-only
 CFLAGS_REMOVE_zcommon/zfs_fletcher_aarch64_neon.o += -mgeneral-regs-only
 CFLAGS_REMOVE_zfs/vdev_raidz_math_aarch64_neon.o += -mgeneral-regs-only
 CFLAGS_REMOVE_zfs/vdev_raidz_math_aarch64_neonx2.o += -mgeneral-regs-only
+endif
+
+ifeq ($(CONFIG_PPC64),y)
+CFLAGS_REMOVE_zcommon/zfs_fletcher_generic.o += -msoft-float
 endif
 
 # Suppress unused-value warnings in sparc64 architecture headers
@@ -218,6 +223,7 @@ ZCOMMON_OBJS := \
 	zfs_comutil.o \
 	zfs_deleg.o \
 	zfs_fletcher.o \
+	zfs_fletcher_generic.o \
 	zfs_fletcher_superscalar.o \
 	zfs_fletcher_superscalar4.o \
 	zfs_namecheck.o \

--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -203,6 +203,7 @@ SRCS+=	zfeature_common.c \
 	zfs_deleg.c \
 	zfs_fletcher.c \
 	zfs_fletcher_avx512.c \
+	zfs_fletcher_generic.c \
 	zfs_fletcher_intel.c \
 	zfs_fletcher_sse.c \
 	zfs_fletcher_superscalar.c \
@@ -391,6 +392,7 @@ CFLAGS.zfs_log.c= -Wno-cast-qual
 CFLAGS.zfs_vnops_os.c= -Wno-pointer-arith
 CFLAGS.u8_textprep.c= -Wno-cast-qual
 CFLAGS.zfs_fletcher.c= -Wno-cast-qual -Wno-pointer-arith
+CFLAGS.zfs_fletcher_generic.c= -Wno-cast-qual -Wno-pointer-arith
 CFLAGS.zfs_fletcher_intel.c= -Wno-cast-qual -Wno-pointer-arith
 CFLAGS.zfs_fletcher_sse.c= -Wno-cast-qual -Wno-pointer-arith
 CFLAGS.zfs_fletcher_avx512.c= -Wno-cast-qual -Wno-pointer-arith

--- a/module/zcommon/zfs_fletcher.c
+++ b/module/zcommon/zfs_fletcher.c
@@ -172,6 +172,9 @@ static const fletcher_4_ops_t *fletcher_4_impls[] = {
 	&fletcher_4_scalar_ops,
 	&fletcher_4_superscalar_ops,
 	&fletcher_4_superscalar4_ops,
+#ifndef _MSC_VER
+	&fletcher_4_generic_ops,
+#endif
 #if defined(HAVE_SSE2)
 	&fletcher_4_sse2_ops,
 #endif

--- a/module/zcommon/zfs_fletcher_generic.c
+++ b/module/zcommon/zfs_fletcher_generic.c
@@ -1,0 +1,413 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (C) 2016 Gvozden Nešković. All rights reserved.
+ * Copyright (C) 2022 Zettabyte Software, LLC. All rights reserved.
+ */
+
+/*
+ * Implement fast Fletcher4 with generic vectorization.
+ *
+ * Use generic GNU C vectors to generate optimized SIMD code through the
+ * compiler. This has the advantage of allowing SIMD on various architectures
+ * to be supported with ease.
+ */
+
+#include <sys/spa_checksum.h>
+#include <sys/string.h>
+#include <sys/simd.h>
+#include <zfs_fletcher.h>
+
+#ifndef	__has_builtin
+#define	__has_builtin(x) 0
+#endif
+
+/*
+ * GCC 4.9.0 is the minimum that supports the inline vpmovzxdq that we use.
+ * Give builds that use older compilers superscalar8 instead.
+ *
+ * Clang reports itself as an old version of gcc, so we must explicitly exclude
+ * it or else it will produce superscalar8 too.
+ */
+#if defined(HAVE_AVX2) && defined(__GNUC__) && defined(__GNUC_MINOR__) && \
+	!defined(__clang_major__)
+#if (__GNUC__ == 4 && __GNUC_MINOR__ < 9) || __GNUC__ < 4
+#undef HAVE_AVX2
+#endif
+#endif
+
+ZFS_NO_SANITIZE_UNDEFINED
+static void
+fletcher_4_generic_init(fletcher_4_ctx_t *ctx)
+{
+#if defined(HAVE_AVX2) || defined(__powerpc64__) || defined(__aarch64__)
+	kfpu_begin();
+#endif
+	memset(ctx->generic, 0, 4 * sizeof (zfs_fletcher_generic_t));
+}
+
+#pragma GCC push_options
+
+#if defined(HAVE_AVX2)
+
+#ifdef __clang_major__
+#pragma clang attribute push(__attribute__((target("avx2"))), \
+    apply_to = function)
+#else
+#pragma GCC target("avx2")
+#endif
+
+#elif defined(__aarch64__)
+#ifdef __clang_major__
+#pragma clang attribute \
+    push(__attribute__((target("+fp+simd"))), \
+    apply_to = function)
+#else
+#pragma GCC target("+fp+simd")
+#endif
+
+
+#elif defined(__powerpc64__)
+#ifdef __clang_major__
+#pragma clang attribute \
+    push(__attribute__((target("vsx,power8-vector"))), \
+    apply_to = function)
+#else
+#pragma GCC target("vsx,power8-vector")
+#endif
+
+#endif
+
+ZFS_NO_SANITIZE_UNDEFINED
+static void
+fletcher_4_generic_native(fletcher_4_ctx_t *ctx, const void *buf,
+    uint64_t size)
+{
+	const u32x4 *ip = buf;
+	const u32x4 *ipend = (u32x4 *)((uint8_t *)ip + size);
+
+	v512 a = ctx->generic[0];
+	v512 b = ctx->generic[1];
+	v512 c = ctx->generic[2];
+	v512 d = ctx->generic[3];
+
+	do {
+#if defined(HAVE_AVX2) && !defined(__clang_major__)
+		/*
+		 * GCC 12.2 is not smart enough to generate vpmovzxdq, so we
+		 * must do it manually.
+		 *
+		 * We also implement 256-bit vector operations in generic GNU C
+		 * code to workaround the following GCC vector lowering bug:
+		 *
+		 * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107916
+		 */
+		v512 t;
+		asm("vpmovzxdq %1, %0" : "=x" (t.u64h[0]) : "m" (*ip));
+		a.u64h[0] += t.u64h[0];
+		b.u64h[0] += a.u64h[0];
+		c.u64h[0] += b.u64h[0];
+		d.u64h[0] += c.u64h[0];
+		asm("vpmovzxdq %1, %0" : "=x" (t.u64h[1]) : "m" (*(ip+1)));
+		a.u64h[1] += t.u64h[1];
+		b.u64h[1] += a.u64h[1];
+		c.u64h[1] += b.u64h[1];
+		d.u64h[1] += c.u64h[1];
+#elif (defined(__powerpc64__) || defined(__aarch64__)) && \
+	!defined(__clang_major__)
+		/*
+		 * GCC has a vector lowering bug that makes using vector
+		 * operations larger than the hardware SIMD width extremely
+		 * inefficient, so we manually do generic 128-bit operations.
+		 * This code could be reused for relatively efficient assembly
+		 * output from GCC on other architectures that do 128-bit SIMD
+		 * operations.
+		 */
+		v512 t;
+		t.u64[0] = (*ip)[0];
+		t.u64[1] = (*ip)[1];
+		t.u64[2] = (*ip)[2];
+		t.u64[3] = (*ip)[3];
+		t.u64[4] = (*(ip+1))[0];
+		t.u64[5] = (*(ip+1))[1];
+		t.u64[6] = (*(ip+1))[2];
+		t.u64[7] = (*(ip+1))[3];
+
+		a.u64q[0] += t.u64q[0];
+		a.u64q[1] += t.u64q[1];
+		a.u64q[2] += t.u64q[2];
+		a.u64q[3] += t.u64q[3];
+		b.u64q[0] += a.u64q[0];
+		b.u64q[1] += a.u64q[1];
+		b.u64q[2] += a.u64q[2];
+		b.u64q[3] += a.u64q[3];
+		c.u64q[0] += b.u64q[0];
+		c.u64q[1] += b.u64q[1];
+		c.u64q[2] += b.u64q[2];
+		c.u64q[3] += b.u64q[3];
+		d.u64q[0] += c.u64q[0];
+		d.u64q[1] += c.u64q[1];
+		d.u64q[2] += c.u64q[2];
+		d.u64q[3] += c.u64q[3];
+#else
+/* GCC versions before 9.1.0 do not support __builtin_convertvector() */
+#if __has_builtin(__builtin_convertvector)
+		a.u64h[0] += __builtin_convertvector(*ip, u64x4);
+		a.u64h[1] += __builtin_convertvector(*(ip+1), u64x4);
+#else
+		v512 t;
+		t.u64[0] = (*ip)[0];
+		t.u64[1] = (*ip)[1];
+		t.u64[2] = (*ip)[2];
+		t.u64[3] = (*ip)[3];
+		t.u64[4] = (*(ip+1))[0];
+		t.u64[5] = (*(ip+1))[1];
+		t.u64[6] = (*(ip+1))[2];
+		t.u64[7] = (*(ip+1))[3];
+		a.u64 += t.u64;
+#endif
+		b.u64 += a.u64;
+		c.u64 += b.u64;
+		d.u64 += c.u64;
+#endif
+	} while ((ip += 2) < ipend);
+
+	ctx->generic[0] = a;
+	ctx->generic[1] = b;
+	ctx->generic[2] = c;
+	ctx->generic[3] = d;
+}
+
+ZFS_NO_SANITIZE_UNDEFINED
+static void
+fletcher_4_generic_byteswap(fletcher_4_ctx_t *ctx, const void *buf,
+    uint64_t size)
+{
+	const u32x4 *ip = buf;
+	const u32x4 *ipend = (u32x4 *)((uint8_t *)ip + size);
+
+
+	v512 a = ctx->generic[0];
+	v512 b = ctx->generic[1];
+	v512 c = ctx->generic[2];
+	v512 d = ctx->generic[3];
+
+	do {
+#if defined(HAVE_AVX2) && !defined(__clang_major__)
+		/*
+		 * GCC does not optimize the generic version well, so we need
+		 * to give it a version that it does optimize well. That means
+		 * an inline instruction on x86_64 and the shuffle instead of
+		 * __builtin_byteswap64().
+		 *
+		 * We also implement 256-bit vector operations in generic GNU C
+		 * code to workaround the following GCC vector lowering bug:
+		 *
+		 * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107916
+		 */
+		v512 t;
+
+		u8x32 mask = {7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10,
+		    9, 8, 23, 22, 21, 20, 19, 18, 17, 16, 31, 30, 29, 28, 27,
+		    26, 25, 24};
+		asm("vpmovzxdq %1, %0" : "=x" (t.u64h[0]) : "m" (*ip));
+		t.u8h[0] = __builtin_shuffle(t.u8h[0], mask);
+		a.u64h[0] += t.u64h[0];
+		b.u64h[0] += a.u64h[0];
+		c.u64h[0] += b.u64h[0];
+		d.u64h[0] += c.u64h[0];
+		asm("vpmovzxdq %1, %0" : "=x" (t.u64h[1]) : "m" (*(ip+1)));
+		t.u8h[1] = __builtin_shuffle(t.u8h[1], mask);
+		a.u64h[1] += t.u64h[1];
+		b.u64h[1] += a.u64h[1];
+		c.u64h[1] += b.u64h[1];
+		d.u64h[1] += c.u64h[1];
+#elif (defined(__powerpc64__) || defined(__aarch64__)) && \
+	!defined(__clang_major__)
+		/*
+		 * GCC has a vector lowering bug that makes using vector
+		 * operations larger than the hardware SIMD width extremely
+		 * inefficient, so we manually do generic 128-bit operations.
+		 * This code could be reused for relatively efficient assembly
+		 * output from GCC on other architectures that do 128-bit SIMD
+		 * operations.
+		 *
+		 * Note that this version should not be compiled by Clang. It
+		 * generates inefficient scalar byteswaps rather than doing
+		 * vector byteswaps for this.
+		 */
+		v512 t;
+		t.u64[0] = __builtin_bswap32((*ip)[0]);
+		t.u64[1] = __builtin_bswap32((*ip)[1]);
+		t.u64[2] = __builtin_bswap32((*ip)[2]);
+		t.u64[3] = __builtin_bswap32((*ip)[3]);
+		t.u64[4] = __builtin_bswap32((*(ip+1))[0]);
+		t.u64[5] = __builtin_bswap32((*(ip+1))[1]);
+		t.u64[6] = __builtin_bswap32((*(ip+1))[2]);
+		t.u64[7] = __builtin_bswap32((*(ip+1))[3]);
+
+		a.u64q[0] += t.u64q[0];
+		a.u64q[1] += t.u64q[1];
+		a.u64q[2] += t.u64q[2];
+		a.u64q[3] += t.u64q[3];
+		b.u64q[0] += a.u64q[0];
+		b.u64q[1] += a.u64q[1];
+		b.u64q[2] += a.u64q[2];
+		b.u64q[3] += a.u64q[3];
+		c.u64q[0] += b.u64q[0];
+		c.u64q[1] += b.u64q[1];
+		c.u64q[2] += b.u64q[2];
+		c.u64q[3] += b.u64q[3];
+		d.u64q[0] += c.u64q[0];
+		d.u64q[1] += c.u64q[1];
+		d.u64q[2] += c.u64q[2];
+		d.u64q[3] += c.u64q[3];
+#else
+/* GCC versions before 9.1.0 do not support __builtin_convertvector() */
+#if __has_builtin(__builtin_convertvector)
+		v512 t;
+		t.u64h[0] = __builtin_convertvector(*ip, u64x4);
+		t.u64h[1] = __builtin_convertvector(*(ip+1), u64x4);
+#else
+		v512 t;
+		t.u64[0] = (*ip)[0];
+		t.u64[1] = (*ip)[1];
+		t.u64[2] = (*ip)[2];
+		t.u64[3] = (*ip)[3];
+		t.u64[4] = (*(ip+1))[0];
+		t.u64[5] = (*(ip+1))[1];
+		t.u64[6] = (*(ip+1))[2];
+		t.u64[7] = (*(ip+1))[3];
+#endif
+
+		/*
+		 * Clang had no problem with earlier versions of this code, but
+		 * it has trouble optimizing the latest version that used
+		 * `__builtin_byteswap64()`, so we use
+		 * `__builtin_shufflevector()`.
+		 *
+		 * GCC versions prior to 12 have no hope of generating good
+		 * code with `__builtin_byteswap64()`.
+		 */
+#ifdef __clang_major__
+		t.u8h[0] = __builtin_shufflevector(t.u8h[0], t.u8h[0], 7, 6, 5,
+		    4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8, 23, 22, 21,
+		    20, 19, 18, 17, 16, 31, 30, 29, 28, 27, 26, 25, 24);
+		t.u8h[1] = __builtin_shufflevector(t.u8h[1], t.u8h[1], 7, 6, 5,
+		    4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8, 23, 22, 21,
+		    20, 19, 18, 17, 16, 31, 30, 29, 28, 27, 26, 25, 24);
+#else
+		u8x32 mask = {7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10,
+		    9, 8, 23, 22, 21, 20, 19, 18, 17, 16, 31, 30, 29, 28, 27,
+		    26, 25, 24};
+		t.u8h[0] = __builtin_shuffle(t.u8h[0], mask);
+		t.u8h[1] = __builtin_shuffle(t.u8h[1], mask);
+#endif
+		a.u64 += t.u64;
+		b.u64 += a.u64;
+		c.u64 += b.u64;
+		d.u64 += c.u64;
+#endif
+	} while ((ip += 2) < ipend);
+
+	ctx->generic[0] = a;
+	ctx->generic[1] = b;
+	ctx->generic[2] = c;
+	ctx->generic[3] = d;
+}
+
+#ifdef __clang_major__
+#if defined(HAVE_AVX2) || defined(__powerpc64__) || defined(__aarch64__)
+#pragma clang attribute pop
+#endif
+#else
+#pragma GCC pop_options
+#endif
+
+ZFS_NO_SANITIZE_UNDEFINED
+static void
+fletcher_4_generic_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
+{
+	static const uint8_t
+	CcA[] = {   0,   0,   1,   3,   6,  10,  15,  21 },
+	CcB[] = {  28,  36,  44,  52,  60,  68,  76,  84 },
+	DcA[] = {   0,   0,   0,   1,   4,  10,  20,  35 };
+	static const uint16_t
+	DcB[] = {  56,  84, 120, 164, 216, 276, 344, 420 },
+	DcC[] = { 448, 512, 576, 640, 704, 768, 832, 896 };
+
+	uint64_t A, B, C, D;
+	uint64_t i;
+
+	A = ctx->generic[0].u64[0];
+	B = 8 * ctx->generic[1].u64[0];
+	C = 64 * ctx->generic[2].u64[0] - CcB[0] * ctx->generic[1].u64[0];
+	D = 512 * ctx->generic[3].u64[0] - DcC[0] * ctx->generic[2].u64[0] +
+	    DcB[0] * ctx->generic[1].u64[0];
+
+	for (i = 1; i < 8; i++) {
+		A += ctx->generic[0].u64[i];
+		B += 8 * ctx->generic[1].u64[i] - i * ctx->generic[0].u64[i];
+		C += 64 * ctx->generic[2].u64[i] - CcB[i] *
+		    ctx->generic[1].u64[i] + CcA[i] * ctx->generic[0].u64[i];
+		D += 512 * ctx->generic[3].u64[i] - DcC[i] *
+		    ctx->generic[2].u64[i] + DcB[i] * ctx->generic[1].u64[i] -
+		    DcA[i] * ctx->generic[0].u64[i];
+	}
+
+	ZIO_SET_CHECKSUM(zcp, A, B, C, D);
+#if defined(HAVE_AVX2) || defined(__powerpc64__) || defined(__aarch64__)
+	kfpu_end();
+#endif
+}
+
+static boolean_t fletcher_4_generic_valid(void)
+{
+#if defined(HAVE_AVX2)
+	return (kfpu_allowed() && zfs_avx_available() && zfs_avx2_available());
+#elif defined(__powerpc64__)
+	return (kfpu_allowed() && zfs_vsx_available() &&
+	    zfs_isa207_available());
+#elif defined(__aarch64__)
+	return (kfpu_allowed());
+#else
+	return (B_TRUE);
+#endif
+}
+
+const fletcher_4_ops_t fletcher_4_generic_ops = {
+	.init_native = fletcher_4_generic_init,
+	.fini_native = fletcher_4_generic_fini,
+	.compute_native = fletcher_4_generic_native,
+	.init_byteswap = fletcher_4_generic_init,
+	.fini_byteswap = fletcher_4_generic_fini,
+	.compute_byteswap = fletcher_4_generic_byteswap,
+	.valid = fletcher_4_generic_valid,
+#if defined(HAVE_AVX2)
+	.name = "generic-avx2"
+#elif defined(__powerpc64__)
+	.name = "generic-vsx"
+#elif defined(__aarch64__)
+	.name = "generic-aarch64_neon"
+#else
+	.name = "superscalar8"
+#endif
+};


### PR DESCRIPTION
### Motivation and Context
I was nerd-sniped by the review process for #14219, which lead me to attempt to improve our fletcher4 code. My initial attempt was a beautiful algorithm, but it was not performant, so I decided to reimplement Intel's algorithm in generic GNU C vector code. This allows multiple architectures to have vectorized fletcher4 code, although in practice only PPC64 is expected to see a benefit from this since it does not already have vectorized fletcher4 code. Beyond improving performance on PPC64, this serves as a proof of concept for the idea, since the AVX2 code generated for x86/x86_64 systems is functionally identical to the handwritten AVX2 code we have now. Performance is effectively identical for the native case:

```
# cat /proc/spl/kstat/zfs/fletcher_4_bench
0 0 0x01 -1 0 1356713338 54571347430
implementation   native         byteswap       
scalar           9807681425     8305936247     
superscalar      12644986237    12713922615    
superscalar4     13007328108    12526754559    
sse2             24056322356    12412353845    
ssse3            23744546669    20716336171    
avx2             40177711703    38436973064    
generic-avx2     42662563525    9563983290     
fastest          generic-avx2   avx2
```

For the byteswap case, the problem is that GCC 11.3.0 does not generate optimal assembly. However, GCC 12.2.1_p20221008 does and is expected to have identical performance. From the numbers, it appears that the generic-avx2 code is faster on the native case here, but in reality, that is from normal run by run variation. In some runs, the existing avx2 implementation is faster. In others, the generic-avx2 implementation is faster. The two are effectively equal. This was confirmed by disassembly. The disassembly for critical loop for native in generic-avx2 from GCC 12.2.1_p20221008 is:

```
 198:   c4 e2 7d 35 26          vpmovzxdq (%rsi),%ymm4
 19d:   c5 ed d4 d4             vpaddq %ymm4,%ymm2,%ymm2
 1a1:   48 83 c6 10             add    $0x10,%rsi
 1a5:   c5 f5 d4 ca             vpaddq %ymm2,%ymm1,%ymm1
 1a9:   c5 fd d4 c1             vpaddq %ymm1,%ymm0,%ymm0
 1ad:   c5 e5 d4 d8             vpaddq %ymm0,%ymm3,%ymm3
 1b1:   48 39 d6                cmp    %rdx,%rsi
 1b4:   72 e2                   jb     198 <fletcher_4_generic_native_impl+0x28>
```

For the handwritten intel assembly, we have:

```
 328:   c4 e2 7d 35 23          vpmovzxdq (%rbx),%ymm4
 32d:   c5 fd d4 c4             vpaddq %ymm4,%ymm0,%ymm0
 331:   c5 f5 d4 c8             vpaddq %ymm0,%ymm1,%ymm1
 335:   c5 ed d4 d1             vpaddq %ymm1,%ymm2,%ymm2
 339:   c5 e5 d4 da             vpaddq %ymm2,%ymm3,%ymm3
 33d:   48 83 c3 10             add    $0x10,%rbx
 341:   48 39 eb                cmp    %rbp,%rbx
 344:   72 e2                   jb     328 <fletcher_4_avx2_native+0x38>
```

Similarly, this is what generic-avx2 generates for the byteswap code with the GCC12.2.1_p20221008:

```
 260:   c4 e2 7d 35 06          vpmovzxdq (%rsi),%ymm0
 265:   c4 e2 7d 00 c5          vpshufb %ymm5,%ymm0,%ymm0
 26a:   48 83 c6 10             add    $0x10,%rsi
 26e:   c5 e5 d4 d8             vpaddq %ymm0,%ymm3,%ymm3
 272:   c5 ed d4 d3             vpaddq %ymm3,%ymm2,%ymm2
 276:   c5 f5 d4 ca             vpaddq %ymm2,%ymm1,%ymm1
 27a:   c5 dd d4 e1             vpaddq %ymm1,%ymm4,%ymm4
 27e:   48 39 d6                cmp    %rdx,%rsi
 281:   72 dd                   jb     260 <fletcher_4_generic_byteswap_impl+0x30>
```

And this is what the handwritten version generates:

```
 2a0:   c4 e2 7d 35 23          vpmovzxdq (%rbx),%ymm4
 2a5:   c4 e2 5d 00 e5          vpshufb %ymm5,%ymm4,%ymm4
 2aa:   c5 fd d4 c4             vpaddq %ymm4,%ymm0,%ymm0
 2ae:   c5 f5 d4 c8             vpaddq %ymm0,%ymm1,%ymm1
 2b2:   c5 ed d4 d1             vpaddq %ymm1,%ymm2,%ymm2
 2b6:   c5 e5 d4 da             vpaddq %ymm2,%ymm3,%ymm3
 2ba:   48 83 c3 10             add    $0x10,%rbx
 2be:   48 39 eb                cmp    %rbp,%rbx
 2c1:   72 dd                   jb     2a0 <fletcher_4_avx2_byteswap+0x40>
```

Clang will output the same assembly for avx2-generic and presumably, also the existing avx2 code, but the latter was not checked.

For completeness, here is the gorgeous VSX assembly produced by Clang for the native case on ppc64:

```
.LBB0_2:                                # =>This Inner Loop Header: Depth=1
        lxvw4x 1, 0, 4
        addi 4, 4, 16
        xxmrglw 40, 0, 1
        xxmrghw 41, 0, 1
        vaddudm 3, 3, 8
        vaddudm 2, 2, 9
        vaddudm 1, 3, 1
        vaddudm 0, 2, 0
        vaddudm 5, 1, 5
        vaddudm 4, 0, 4
        vaddudm 7, 5, 7
        vaddudm 6, 4, 6
        bdnz .LBB0_2
```

Also, here is the Clang produced assembly for the native case on ppc64le:

```
.LBB0_2:                                # =>This Inner Loop Header: Depth=1
        lxvd2x 1, 0, 4
        addi 4, 4, 16
        xxswapd 1, 1
        xxmrghw 40, 0, 1
        xxmrglw 41, 0, 1
        vaddudm 7, 7, 8
        vaddudm 6, 6, 9
        vaddudm 1, 7, 1
        vaddudm 5, 6, 5
        vaddudm 0, 1, 0
        vaddudm 4, 5, 4
        vaddudm 3, 0, 3
        vaddudm 2, 4, 2
        bdnz .LBB0_2
```

VSX is only capable of doing two 64-bit additions in parallel. I do not understand PPC64 assembly very well, but the ppc64 assembly looks optimal to me while the ppc64le assembly is near optimal. The xxswapd instruction seems unnecessary to me, but I assume that future versions of LLVM will fix that. I will refrain from posting the GCC assembly, since it is fairly bad.

ARM support was initially attempted, but the way that GCC and Clang allow ISA extensions to be turned on/off made it difficult to do, so it was abandoned. In specific, on the architectures where this currently generates SIMD instructions in the kernel, we opt out of ISA extensions via compiler flags and can opt into them on individual functions via pragmas. On ARM, there is an opt-out via `-mgeneral-regs-only`, but there is no way given to opt-in via pragmas. One idea was to disable that via `CFLAGS_REMOVE` and then set it on all of the non-accelerated functions, but it did not work out well in practice on GCC and at that point, I decided it was not worth it to try to continue.

Rewriting this code in FORTRAN was briefly considered as a way to make ARM support easier. Unfortunately, with the exception of a non-standard extension in the Sun Studio FORTRAN compiler, FORTRAN does not support unsigned integer arithmetic, so the idea was dropped.

Prior to abandoning the attempt at ARM support, I did discover that Clang will compile the code into optimal looking NEON assembly, so perhaps this could be revisited in the future. Alternatively, the assembly generated by Clang could be helpful in review of #14219.

In summary, the only real benefactor of this is expected to be FreeBSD's PPC64 port and anyone who builds the ZFS kernel modules for Linux on PPC64 with Clang. I am not sure if that makes it worthwhile to merge this as is. I am putting this into a pull request to see what others think for the sake of my own curiosity.

### Description
The individual patch commit messages have greater detail. However, in summary, this adds a generic vector implementation in GNU dialect of C's vector extension to the C language. Both GCC and Clang will compiled it into SIMD instructions on x86, x86_64 and ppc64 on both Linux and FreeBSD. On other architectures, the GCC and Clang compilers will generate scalar instructions that are expected to be equivalent to superscalar4. This is not compatible with the MSVC compiler, so we premptively disable it on Windows to make things easier for the Windows port.

### How Has This Been Tested?
It has been tested in a x86_64 VM running Gentoo Linux. The assembly output of `fletcher_4_generic_native_impl()` on various architectures was examined at gcc.godbolt.org.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
