### PR TITLE
nopwrites on dmu_sync-ed blocks can result in a panic

### DIFF
--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite.shlib
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite.shlib
@@ -57,12 +57,12 @@ function verify_nopwrite
 	within_percent $origin_used $snap_refer $high || return 1
 
 	#
-	# The comparisons below should pass regardless of nopwrite. They're
-	# here for sanity.
+	# The comparisons below should be within 90% regardless of nopwrite.
+	# They're here for sanity.
 	#
 	typeset deadlist=$(zdb -Pddd $clone | awk '/Deadlist:/ {print $2}')
-	within_percent $deadlist $clone_written $high || return 1
-	within_percent $snap_refer $snap_written $high || return 1
+	within_percent $deadlist $clone_written 90 || return 1
+	within_percent $snap_refer $snap_written 90 || return 1
 
 	return 0
 }


### PR DESCRIPTION
After a device has been removed, any nopwrites for blocks on that indirect vdev should be ignored and a new block should be allocated. The original code attempted to handle this but used the wrong block pointer when checking for indirect vdevs and failed to check all DVAs.

This change corrects both of these issues and modifies the test case to ensure that it properly tests nopwrites with device removal.

Signed-off-by: George Wilson <gwilson@delphix.com>
