### PR TITLE
Retire Ubuntu 18.04 CI builder

### DIFF
--- a/.github/workflows/zfs-tests-functional.yml
+++ b/.github/workflows/zfs-tests-functional.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [18.04, 20.04, 22.04]
+        os: [20.04, 22.04]
     runs-on: ubuntu-${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -22,9 +22,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -qq upgrade
-        if [ "${{ matrix.os }}" = "18.04" ]; then
-          sed -i.bak 's/rng-tools-debian/rng-tools/' ${{ github.workspace }}/.github/workflows/build-dependencies.txt
-        fi
         sudo xargs --arg-file=${{ github.workspace }}/.github/workflows/build-dependencies.txt apt-get install -qq
         sudo apt-get clean
     - name: Autogen.sh


### PR DESCRIPTION
### Motivation and Context

The GitHub-hosted Ubuntu 18.04 has been deprecated and will be entirely unsupported as of April 2023.  Leading up to this there will be scheduled "brownouts" to encourage users to update their workflows.

Retiring these runners now also has the advantage of resolving the frequent CI failures on Ubuntu 18.04 due to hitting the maximum instance run time.  This is believed to be caused by these running using older, slower, hardware.

### Description

This commit retires our use of the GitHub-hosted Ubuntu 18.04 runners in advance of their removal.

### How Has This Been Tested?

Locally inspected, will be tested by the CI.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
