### PR TITLE
Linux PPC: Fix build failures on kernels built without CONFIG_SPE

### DIFF
--- a/include/os/linux/kernel/linux/simd_powerpc.h
+++ b/include/os/linux/kernel/linux/simd_powerpc.h
@@ -69,6 +69,7 @@
 #define	kfpu_allowed()			1
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+#ifdef CONFIG_SPE
 #define	kfpu_begin()				\
 	{					\
 		preempt_disable();		\
@@ -83,6 +84,20 @@
 		disable_kernel_altivec();	\
 		preempt_enable();		\
 	}
+#else /* CONFIG_SPE */
+#define	kfpu_begin()				\
+	{					\
+		preempt_disable();		\
+		enable_kernel_altivec();	\
+		enable_kernel_vsx();		\
+	}
+#define	kfpu_end()				\
+	{					\
+		disable_kernel_vsx();		\
+		disable_kernel_altivec();	\
+		preempt_enable();		\
+	}
+#endif
 #else
 /* seems that before 4.5 no-one bothered */
 #define	kfpu_begin()


### PR DESCRIPTION
### Motivation and Context
@rincebrain reported in #14233 that builds were broken on recent kernels without CONFIG_SPE.

### Description
We do a simple ifdef to avoid calling `enable_kernel_spe()`/`disable_kernel_spe()` on PowerPC.

### How Has This Been Tested?
@gyakovlev tested it for me.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
