### PR TITLE
Micro-optimize fletcher4 calculations

### DIFF
--- a/module/zcommon/zfs_fletcher_superscalar.c
+++ b/module/zcommon/zfs_fletcher_superscalar.c
@@ -89,7 +89,7 @@ fletcher_4_superscalar_native(fletcher_4_ctx_t *ctx,
 	c2 = ctx->superscalar[2].v[1];
 	d2 = ctx->superscalar[3].v[1];
 
-	for (; ip < ipend; ip += 2) {
+	do {
 		a += ip[0];
 		a2 += ip[1];
 		b += a;
@@ -98,7 +98,7 @@ fletcher_4_superscalar_native(fletcher_4_ctx_t *ctx,
 		c2 += b2;
 		d += c;
 		d2 += c2;
-	}
+	} while ((ip += 2) < ipend);
 
 	ctx->superscalar[0].v[0] = a;
 	ctx->superscalar[1].v[0] = b;
@@ -129,7 +129,7 @@ fletcher_4_superscalar_byteswap(fletcher_4_ctx_t *ctx,
 	c2 = ctx->superscalar[2].v[1];
 	d2 = ctx->superscalar[3].v[1];
 
-	for (; ip < ipend; ip += 2) {
+	do {
 		a += BSWAP_32(ip[0]);
 		a2 += BSWAP_32(ip[1]);
 		b += a;
@@ -138,7 +138,7 @@ fletcher_4_superscalar_byteswap(fletcher_4_ctx_t *ctx,
 		c2 += b2;
 		d += c;
 		d2 += c2;
-	}
+	} while ((ip += 2) < ipend);
 
 	ctx->superscalar[0].v[0] = a;
 	ctx->superscalar[1].v[0] = b;

--- a/module/zcommon/zfs_fletcher_superscalar4.c
+++ b/module/zcommon/zfs_fletcher_superscalar4.c
@@ -113,7 +113,7 @@ fletcher_4_superscalar4_native(fletcher_4_ctx_t *ctx,
 	c4 = ctx->superscalar[2].v[3];
 	d4 = ctx->superscalar[3].v[3];
 
-	for (; ip < ipend; ip += 4) {
+	do {
 		a += ip[0];
 		a2 += ip[1];
 		a3 += ip[2];
@@ -130,7 +130,7 @@ fletcher_4_superscalar4_native(fletcher_4_ctx_t *ctx,
 		d2 += c2;
 		d3 += c3;
 		d4 += c4;
-	}
+	} while ((ip += 4) < ipend);
 
 	ctx->superscalar[0].v[0] = a;
 	ctx->superscalar[1].v[0] = b;
@@ -179,7 +179,7 @@ fletcher_4_superscalar4_byteswap(fletcher_4_ctx_t *ctx,
 	c4 = ctx->superscalar[2].v[3];
 	d4 = ctx->superscalar[3].v[3];
 
-	for (; ip < ipend; ip += 4) {
+	do {
 		a += BSWAP_32(ip[0]);
 		a2 += BSWAP_32(ip[1]);
 		a3 += BSWAP_32(ip[2]);
@@ -196,7 +196,7 @@ fletcher_4_superscalar4_byteswap(fletcher_4_ctx_t *ctx,
 		d2 += c2;
 		d3 += c3;
 		d4 += c4;
-	}
+	} while ((ip += 4) < ipend);
 
 	ctx->superscalar[0].v[0] = a;
 	ctx->superscalar[1].v[0] = b;


### PR DESCRIPTION
### Motivation and Context
When processing abds, we execute 1 `kfpu_begin()`/`kfpu_end()` pair on every page in the abd. This is wasteful and slows down checksum performance versus what the fletcher4 benchmark claims it to be.

Also, we always check the buffer length against 0 before calling the non-scalar checksum functions. This means that we do not need to execute the loop condition for the first loop iteration. 

### Description
We move the `kfpu_begin()`/`kfpu_end()` calls to the init and fini functions so that it is only called once per abd.

We also micro-optimize the checksum calculations by switching to do-while loops to skip the first loop condition check. Note that we do not apply that micro-optimization to the scalar implementation because there is no check in
`fletcher_4_incremental_native()`/`fletcher_4_incremental_byteswap()` against 0 sized buffers being passed.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
