### PR TITLE
Cache dbuf_hash() calculation

### DIFF
--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -294,6 +294,8 @@ typedef struct dmu_buf_impl {
 	/* Tells us which dbuf cache this dbuf is in, if any */
 	dbuf_cached_state_t db_caching_status;
 
+	uint64_t db_hash;
+
 	/* Data which is unique to data (leaf) blocks: */
 
 	/* User callback information. */
@@ -364,7 +366,7 @@ void dbuf_rele_and_unlock(dmu_buf_impl_t *db, const void *tag,
     boolean_t evicting);
 
 dmu_buf_impl_t *dbuf_find(struct objset *os, uint64_t object, uint8_t level,
-    uint64_t blkid);
+    uint64_t blkid, uint64_t *hash_out);
 
 int dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags);
 void dmu_buf_will_not_fill(dmu_buf_t *db, dmu_tx_t *tx);

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -70,8 +70,8 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 	dmu_buf_impl_t *children[DN_MAX_NBLKPTR];
 	ASSERT3U(nblkptr, <=, DN_MAX_NBLKPTR);
 	for (i = 0; i < nblkptr; i++) {
-		children[i] =
-		    dbuf_find(dn->dn_objset, dn->dn_object, old_toplvl, i);
+		children[i] = dbuf_find(dn->dn_objset, dn->dn_object,
+		    old_toplvl, i, NULL);
 	}
 
 	/* transfer dnode's block pointers to new indirect block */


### PR DESCRIPTION
### Motivation and Context
We currently compute a 64-bit hash three times, which consumes 0.8% CPU time on ARC eviction heavy workloads. 

This was done by Klara Systems and sponsored by Wasabi Technology, Inc.

### Description
We cache the 64-bit hash.

### How Has This Been Tested?
It has been build tested and runtime tested, a couple months ago on an older version of the code.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
