### PR TITLE
ZTS: Add missing tests to Makefile.am

### DIFF
--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -627,4 +627,6 @@ tags = ['functional', 'zpool_influxdb']
 
 [tests/functional/pyzfs]
 tests = ['pyzfs_unittest']
+pre =
+post =
 tags = ['functional', 'pyzfs']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1711,6 +1711,11 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/rename_dirs/cleanup.ksh \
 	functional/rename_dirs/rename_dirs_001_pos.ksh \
 	functional/rename_dirs/setup.ksh \
+	functional/renameat2/cleanup.ksh \
+	functional/renameat2/setup.ksh \
+	functional/renameat2/renameat2_exchange.ksh \
+	functional/renameat2/renameat2_noreplace.ksh \
+	functional/renameat2/renameat2_whiteout.ksh \
 	functional/replacement/attach_import.ksh \
 	functional/replacement/attach_multiple.ksh \
 	functional/replacement/attach_rebuild.ksh \
@@ -1789,7 +1794,6 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/rsend/send-c_incremental.ksh \
 	functional/rsend/send-c_lz4_disabled.ksh \
 	functional/rsend/send-c_mixed_compression.ksh \
-	functional/rsend/send-cpL_varied_recsize.ksh \
 	functional/rsend/send-c_props.ksh \
 	functional/rsend/send-c_recv_dedup.ksh \
 	functional/rsend/send-c_recv_lz4_disabled.ksh \
@@ -1798,7 +1802,9 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/rsend/send-c_verify_contents.ksh \
 	functional/rsend/send-c_verify_ratio.ksh \
 	functional/rsend/send-c_volume.ksh \
+	functional/rsend/send-c_zstream_recompress.ksh \
 	functional/rsend/send-c_zstreamdump.ksh \
+	functional/rsend/send-cpL_varied_recsize.ksh \
 	functional/rsend/send_doall.ksh \
 	functional/rsend/send_encrypted_files.ksh \
 	functional/rsend/send_encrypted_hierarchy.ksh \

--- a/tests/zfs-tests/tests/functional/renameat2/Makefile.am
+++ b/tests/zfs-tests/tests/functional/renameat2/Makefile.am
@@ -1,7 +1,0 @@
-pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/renameat2
-dist_pkgdata_SCRIPTS = \
-	setup.ksh \
-	cleanup.ksh \
-	renameat2_noreplace.ksh \
-	renameat2_exchange.ksh \
-	renameat2_whiteout.ksh


### PR DESCRIPTION
### Motivation and Context

Resolve the following CI warnings:

```
Warning: TestGroup '/home/runner/work/zfs/zfs/tests/functional/renameat2' not added to this run. Auxiliary script '/home/runner/work/zfs/zfs/tests/functional/renameat2/setup' failed verification.
Warning: Test 'send-c_zstream_recompress' removed from TestGroup '/usr/share/zfs/zfs-tests/tests/functional/rsend' because it failed verification.
```

### Description

The send-c_zstream_recompress.ksh test case was being skipped because it was not added to the Makefile.am, and was thus left out of the package.

As for the renameat2 tests these were being skipped because when the patch was rebased it was not updated to use the new Makefile layout for the tests directory.  Correct this.

### How Has This Been Tested?

It has not, we'll need to check the CI results.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
