### PR TITLE
dracut: skip zfsexpandknoweldge when zfs_devs is present in dracut - Backport

### DIFF
--- a/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
+++ b/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
@@ -57,6 +57,12 @@ array_contains () {
 }
 
 check() {
+    # https://github.com/dracutdevs/dracut/pull/1711 provides a zfs_devs
+    # function to detect the physical devices backing zfs pools. If this
+    # function exists in the version of dracut this module is being called
+    # from, then it does not need to run.
+    type zfs_devs >/dev/null 2>&1 && return 1
+
     local mp
     local dev
     local blockdevs


### PR DESCRIPTION
### Motivation and Context

Backport for 2.1.8 staging branch

### Description

PR 1711 (https://github.com/dracutdevs/dracut/pull/1711) adds a zfs_devs function to dracut to detect the physical devices backing zfs pools. If this function exists in the version of dracut this module is being called from, then it does not need to run.

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed-by: Ahelenia Ziemiańska <nabijaczleweli@nabijaczleweli.xyz>
Signed-off-by: Savyasachee Jha <hi@savyasacheejha.com>
Closes #13121

### How Has This Been Tested?

Clean backport from master, otherwise untested.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
