### PR TITLE
Change zpool email notifications to display the actual pool name instead of the pool GUID

### DIFF
--- a/cmd/zed/zed.d/statechange-notify.sh
+++ b/cmd/zed/zed.d/statechange-notify.sh
@@ -38,7 +38,7 @@ if [ "${ZEVENT_VDEV_STATE_STR}" != "FAULTED" ] \
 fi
 
 umask 077
-note_subject="ZFS device fault for pool ${ZEVENT_POOL_GUID} on $(hostname)"
+note_subject="ZFS device fault for pool ${ZEVENT_POOL} on $(hostname)"
 note_pathname="$(mktemp)"
 {
     if [ "${ZEVENT_VDEV_STATE_STR}" = "FAULTED" ] ; then
@@ -66,7 +66,7 @@ note_pathname="$(mktemp)"
     [ -n "${ZEVENT_VDEV_GUID}" ] && echo "  vguid: ${ZEVENT_VDEV_GUID}"
     [ -n "${ZEVENT_VDEV_DEVID}" ] && echo "  devid: ${ZEVENT_VDEV_DEVID}"
 
-    echo "   pool: ${ZEVENT_POOL_GUID}"
+    echo "   pool: ${ZEVENT_POOL} (${ZEVENT_POOL_GUID})"
 
 } > "${note_pathname}"
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
The current mail for a device / pool state change is printing out the pool GUID instead of the pool name in the email being sent. As a system administrator, I'd like to get a direct idea what is going on, and because I have multiple pools in my system, I don't know which pool just had the said event. (who memorizes pool GUIDs?)
Email notifications for finishing a pool resilver already do this.

### Description
Changing zed's `statechange-notify.sh` `ZEVENT_POOL_GUID` variable to `ZEVENT_POOL`.
If people like to have the pool GUID aswell, it could be added aswell alongside the pool name. Or make it even configurable, like zed's syslog output (`ZED_SYSLOG_DISPLAY_GUIDS`).

### How Has This Been Tested?
I applied the patch on one of my machines known to have not 100% reliable disks (with data I have backup-ed elsewhere) and let it run:
```
The number of I/O errors associated with a ZFS device exceeded
acceptable levels. ZFS has marked the device as faulted.

 impact: Fault tolerance of the pool may be compromised.
    eid: 3624
  class: statechange
  state: FAULTED
   host: <redacted>
   time: 2022-12-08 22:27:18+0100
  vpath: /dev/disk/by-partuuid/e32fbbe6-38e7-c94e-a655-6e3c480fb25a
  vguid: 0xF7D486597705238B
   pool: hdd2
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
