### PR TITLE
Reject streams that set ->drr_payloadlen to unreasonably large values

### DIFF
--- a/cmd/zstream/zstream_decompress.c
+++ b/cmd/zstream/zstream_decompress.c
@@ -179,7 +179,10 @@ zstream_do_decompress(int argc, char *argv[])
 			VERIFY0(begin++);
 			seen = B_TRUE;
 
-			int sz = drr->drr_payloadlen;
+			uint32_t sz = drr->drr_payloadlen;
+
+			VERIFY3U(sz, <=, 1U << 28);
+
 			if (sz != 0) {
 				if (sz > bufsz) {
 					buf = realloc(buf, sz);

--- a/cmd/zstream/zstream_recompress.c
+++ b/cmd/zstream/zstream_recompress.c
@@ -160,7 +160,10 @@ zstream_do_recompress(int argc, char *argv[])
 			VERIFY0(begin++);
 			seen = B_TRUE;
 
-			int sz = drr->drr_payloadlen;
+			uint32_t sz = drr->drr_payloadlen;
+
+			VERIFY3U(sz, <=, 1U << 28);
+
 			if (sz != 0) {
 				if (sz > bufsz) {
 					buf = realloc(buf, sz);

--- a/cmd/zstream/zstream_redup.c
+++ b/cmd/zstream/zstream_redup.c
@@ -254,7 +254,10 @@ zfs_redup_stream(int infd, int outfd, boolean_t verbose)
 			/* cppcheck-suppress syntaxError */
 			DMU_SET_FEATUREFLAGS(drrb->drr_versioninfo, fflags);
 
-			int sz = drr->drr_payloadlen;
+			uint32_t sz = drr->drr_payloadlen;
+
+			VERIFY3U(sz, <=, 1U << 28);
+
 			if (sz != 0) {
 				if (sz > bufsz) {
 					free(buf);

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -5197,6 +5197,14 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 			    destsnap);
 			*cp = '@';
 			break;
+		case E2BIG:
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "zfs receive required kernel memory allocation "
+			    "larger than the system can support. Please file "
+			    "an issue at the OpenZFS issue tracker:\n"
+			    "https://github.com/openzfs/zfs/issues/new"));
+			(void) zfs_error(hdl, EZFS_BADSTREAM, errbuf);
+			break;
 		case EBUSY:
 			if (hastoken) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,


### PR DESCRIPTION
### Motivation and Context
In the zstream code, Coverity reported:

"The argument could be controlled by an attacker, who could invoke the function with arbitrary values (for example, a very high or negative buffer size)."

It did not report this in the kernel. This is likely because the userspace code stored this in an int before passing it into the allocator, while the kernel code stored it in a uint32_t.

However, this did reveal a potentially real problem. On 32-bit systems and systems with only 4GB of physical memory or less in general, it is possible to pass a large enough value that the system will hang. Even worse, on Linux systems, the kernel memory allocator is not able to support allocations up to the maximum 4GB allocation size that this allows.

The limit Linux enforces varies based on the kernel memory allocator choice and the architecture's page size. The minimum maximum allocation size on Linux is 4MB, which seems reasonable as an upper limit on the size passed by `->drr_payloadlen` in userspace on 32-bit machines and on Linux systems in general. In the kernel, we enforce a 4MB limit on Linux systems, but use the more flexible (arc_all_memory() / 4) to enforce a limit on non-Linux systems.

Reported-by: Coverity (CID-1529836)
Reported-by: Coverity (CID-1529837)
Reported-by: Coverity (CID-1529838)

### Description
We change the type in the zstream code from `int` to `uint32_t` to match `->drr_payloadlen`. We also add a check on 32-bit machines to enforce a 4MB limit on this variable.

In the kernel, we enforce a 4MB upper bound on Linux systems in general. On non-Linux systems, we allow allocations up to `(arc_all_memory() / 4` in size. If the value of `->drr_payloadlen` seen by `zfs receive` exceeds these limits, we return `E2BIG`. `zfs_receive_one()` has been modified to direct users to file an issue when it sees `E2BIG`.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
