### PR TITLE
systemd: set restart=always for zfs-zed.service

### DIFF
--- a/etc/systemd/system/zfs-zed.service.in
+++ b/etc/systemd/system/zfs-zed.service.in
@@ -6,7 +6,7 @@ ConditionPathIsDirectory=/sys/module/zfs
 [Service]
 EnvironmentFile=-@initconfdir@/zfs
 ExecStart=@sbindir@/zed -F
-Restart=on-abort
+Restart=always
 
 [Install]
 Alias=zed.service


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://zfsonlinux.topicbox.com/groups/zfs-discuss/T74605c31a8a6fef0-Mfc0d752b5c53d6895b0f394d highlighted a problem for me. 
Looks like there may be cases when zed can stop correctly, but I'm not ready to dig into them now.

### Description
<!--- Describe your changes in detail -->
If I understand correctly, ZED daemon is a background daemon, which should be restarted on any problem.
So, it's best just to set `restart=always` in it's systemd service.

- I don't see any legitimate case not to restart it on any exit code (it can be stopped via `systemctl stop` though correctly with `restart=always`)
- If there is a problem with start, start loop will be gracefully processed by systemd with `StartLimitBurst` and etc.

@behlendorf if there was a hidden meaning for `on-abort` in https://github.com/openzfs/zfs/commit/11a7043324b3df606b7d7e8f214cbe2eba076446 - it would be great to know. If there wasn't any - I propose this PR.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Just successfully restarted zed service, so as if systemd restarted it by itself.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
