### PR TITLE
removal of LegacyVersion broke ax_python_dev.m4

### DIFF
--- a/config/ax_python_devel.m4
+++ b/config/ax_python_devel.m4
@@ -97,23 +97,13 @@ AC_DEFUN([AX_PYTHON_DEVEL],[
 	# Check for a version of Python >= 2.1.0
 	#
 	AC_MSG_CHECKING([for a version of Python >= '2.1.0'])
-	ac_supports_python_ver=`cat<<EOD | $PYTHON -
-from __future__ import print_function;
-import sys;
-try:
-	from packaging import version;
-except ImportError:
-	from distlib import version;
-ver = sys.version.split ()[[0]];
-(tst_cmp, tst_ver) = ">= '2.1.0'".split ();
-tst_ver = tst_ver.strip ("'");
-eval ("print (version.LegacyVersion (ver)"+ tst_cmp +"version.LegacyVersion (tst_ver))")
-EOD`
+	ac_supports_python_ver=`$PYTHON -c "import sys; \
+		ver = sys.version.split ()[[0]]; \
+		print (ver >= '2.1.0')"`
 	if test "$ac_supports_python_ver" != "True"; then
 		if test -z "$PYTHON_NOVERSIONCHECK"; then
 			AC_MSG_RESULT([no])
-			m4_ifvaln([$2],[$2],[
-				AC_MSG_FAILURE([
+			AC_MSG_FAILURE([
 This version of the AC@&t@_PYTHON_DEVEL macro
 doesn't work properly with versions of Python before
 2.1.0. You may need to re-run configure, setting the
@@ -122,7 +112,6 @@ PYTHON_EXTRA_LIBS and PYTHON_EXTRA_LDFLAGS by hand.
 Moreover, to disable this check, set PYTHON_NOVERSIONCHECK
 to something else than an empty string.
 ])
-			])
 		else
 			AC_MSG_RESULT([skip at user request])
 		fi
@@ -131,37 +120,47 @@ to something else than an empty string.
 	fi
 
 	#
-	# if the macro parameter ``version'' is set, honour it
+	# If the macro parameter ``version'' is set, honour it.
+	# A Python shim class, VPy, is used to implement correct version comparisons via
+	# string expressions, since e.g. a naive textual ">= 2.7.3" won't work for
+	# Python 2.7.10 (the ".1" being evaluated as less than ".3").
 	#
 	if test -n "$1"; then
 		AC_MSG_CHECKING([for a version of Python $1])
-		# Why the strip ()?  Because if we don't, version.parse
-		# will, for example, report 3.10.0 >= '3.11.0'
-		ac_supports_python_ver=`cat<<EOD | $PYTHON -
-
-from __future__ import print_function;
-import sys;
-try:
-	from packaging import version;
-except ImportError:
-	from distlib import version;
-ver = sys.version.split ()[[0]];
-(tst_cmp, tst_ver) = "$1".split ();
-tst_ver = tst_ver.strip ("'");
-eval ("print (version.LegacyVersion (ver)"+ tst_cmp +"version.LegacyVersion (tst_ver))")
-EOD`
+                cat << EOF > ax_python_devel_vpy.py
+class VPy:
+    def vtup(self, s):
+        return tuple(map(int, s.strip().replace("rc", ".").split(".")))
+    def __init__(self):
+        import sys
+        self.vpy = tuple(sys.version_info)
+    def __eq__(self, s):
+        return self.vpy == self.vtup(s)
+    def __ne__(self, s):
+        return self.vpy != self.vtup(s)
+    def __lt__(self, s):
+        return self.vpy < self.vtup(s)
+    def __gt__(self, s):
+        return self.vpy > self.vtup(s)
+    def __le__(self, s):
+        return self.vpy <= self.vtup(s)
+    def __ge__(self, s):
+        return self.vpy >= self.vtup(s)
+EOF
+		ac_supports_python_ver=`$PYTHON -c "import ax_python_devel_vpy; \
+                        ver = ax_python_devel_vpy.VPy(); \
+			print (ver $1)"`
+                rm -rf ax_python_devel_vpy*.py* __pycache__/ax_python_devel_vpy*.py*
 		if test "$ac_supports_python_ver" = "True"; then
-		   AC_MSG_RESULT([yes])
+			AC_MSG_RESULT([yes])
 		else
 			AC_MSG_RESULT([no])
-			m4_ifvaln([$2],[$2],[
-				AC_MSG_ERROR([this package requires Python $1.
+			AC_MSG_ERROR([this package requires Python $1.
 If you have it installed, but it isn't the default Python
 interpreter in your system path, please pass the PYTHON_VERSION
 variable to configure. See ``configure --help'' for reference.
 ])
-				PYTHON_VERSION=""
-			])
+			PYTHON_VERSION=""
 		fi
 	fi
 


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The [22.0 release](https://packaging.pypa.io/en/stable/changelog.html#id1) of the python `packaging` package removed the `LegacyVersion` trait, causing ZFS to no longer compile: https://github.com/pypa/packaging/pull/407

### Description
<!--- Describe your changes in detail -->
This commit replaces the sections of `ax_python_dev.m4` that rely on `LegacyVersion` with updated implementations from the [upstream](https://www.gnu.org/software/autoconf-archive/ax_python_devel.html) `autoconf-archive`.

I saw that we had made some changes to this file, so I didn't replace it entirely.  But I also didn't totally understand our changes, so I'm hoping someone can confirm that this is the right approach.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Since github [updated](https://github.com/actions/runner-images/commit/6b249254da3f78ee8828c2c5d018127eaaaebf47) their Ubuntu 20.04 environment yesterday, build fails in this environment.  With this PR, it succeeds.

OpenZFS uses github's ubuntu 22.04 actions runner, and is therefore currently unaffected.  However, I suspect it's only a matter of time before github's 22.04 environment is updated to use the 22.0 release of the python `packaging` package, at which point it will fail to compile.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
