### PR TITLE
Use native-deb* targets for zloop workflow

### DIFF
--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       TEST_DIR: /var/tmp/zloop
     steps:
@@ -27,15 +27,18 @@ jobs:
         ./configure --enable-debug --enable-debuginfo --enable-asan --enable-ubsan
     - name: Make
       run: |
-        make -j$(nproc) --no-print-directory --silent pkg-utils pkg-kmod
+        make --no-print-directory --silent native-deb-utils native-deb-kmod
+        mv ../*.deb .
+        rm ./openzfs-zfs-dkms*.deb ./openzfs-zfs-dracut*.deb
     - name: Install
       run: |
-        sudo dpkg -i *.deb
         # Update order of directories to search for modules, otherwise
         #   Ubuntu will load kernel-shipped ones.
         sudo sed -i.bak 's/updates/extra updates/' /etc/depmod.d/ubuntu.conf
-        sudo depmod
-        sudo modprobe zfs
+        sudo dpkg -i *.deb
+        # Native Debian packages enable and start the services
+        # Stop zfs-zed daemon, as it may interfere with some ZTS test cases
+        sudo systemctl stop zfs-zed
     - name: Tests
       run: |
         sudo mkdir -p $TEST_DIR


### PR DESCRIPTION
### Motivation and Context

The `zloop` workflow is [failing in the CI](https://github.com/openzfs/zfs/actions/runs/3742099232/jobs/6354241242) due to an issue detecting the python version when using the rpm/alien packaging.  The native Debian packaging doesn't encounter this issue, and arguably the `zloop` workflow should be using it anyway, so we update the workflow accordingly.  This does not resolve the underlying python detection issue but should sort out the `zloop` worker.

```
 checking for python3.10... /usr/bin/python3
Traceback (most recent call last):
  File "<stdin>", line 10, in <module>
  File "<string>", line 1, in <module>
AttributeError: module 'packaging.version' has no attribute 'LegacyVersion'
configure: error: "Python >= '3.6.0' development library is not installed"
checking for a version of Python >= '2.1.0'... no

error: Bad exit status from /tmp/zfs-build-runner-RBKDjMjj/TMP/rpm-tmp.DvuEmm (%build)
    Bad exit status from /tmp/zfs-build-runner-RBKDjMjj/TMP/rpm-tmp.DvuEmm (%build)
make[1]: *** [Makefile:13966: rpm-common] Error 1
make: *** [Makefile:13925: rpm-utils-initramfs] Error 2
make: *** Waiting for unfinished jobs....
```

### Description

The zloop workflow always requests an Ubuntu worker.  Since we now have native Debian style packaging use these targets for the zloop workflow.  This follows up on the work done in #14265.

### How Has This Been Tested?

Pending verification by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
