### PR TITLE
unicode buffer overflow fix

### DIFF
--- a/module/unicode/u8_textprep.c
+++ b/module/unicode/u8_textprep.c
@@ -1287,7 +1287,7 @@ TRY_THE_NEXT_MARK:
 
 		while (p < oslast) {
 			size = u8_number_of_bytes[*p];
-			if (size <= 1 || (p + size) > oslast)
+			if ((ssize_t)size <= 1 || (p + size) > oslast)
 				break;
 
 			saved_p = p;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
As of Linux 6.2, `-funsigned-char` is set by the build system to change how C compilers interpret the char type so that type promotion to an int will always result in a positive number. This caused me to become concerned that miscompilation could happen, which lead to an earlier version of this PR that had a patch to disable that, plus a fix for a buffer overflow issue that I found when doing an audit of the code to find potential issues that change could cause.

The patch disabling `-funsigned-char` turned out to be an overreaction, so it has since been dropped from the PR. The patch fixing the buffer overflow is all that remains. Interestingly, the buffer overflow was not one of the bugs that I had expected to find during my audit while the bugs that I had expected to find do not appear to be present in the code. The buffer overflow is present both with and without `-funsigned-char`.

### Description
I have fixed the buffer overflow that I found in `module/unicode/u8_textprep.c`.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
