### PR TITLE
Update arc_summary and arcstat outputs

### DIFF
--- a/cmd/arc_summary
+++ b/cmd/arc_summary
@@ -558,8 +558,12 @@ def section_arc(kstats_dict):
     arc_target_size = arc_stats['c']
     arc_max = arc_stats['c_max']
     arc_min = arc_stats['c_min']
+    anon_size = arc_stats['anon_size']
     mfu_size = arc_stats['mfu_size']
     mru_size = arc_stats['mru_size']
+    mfug_size = arc_stats['mfu_ghost_size']
+    mrug_size = arc_stats['mru_ghost_size']
+    unc_size = arc_stats['uncached_size']
     meta_limit = arc_stats['arc_meta_limit']
     meta_size = arc_stats['arc_meta_used']
     dnode_limit = arc_stats['arc_dnode_limit']
@@ -574,11 +578,17 @@ def section_arc(kstats_dict):
            f_perc(arc_min, arc_max), f_bytes(arc_min))
     prt_i2('Max size (high water):',
            target_size_ratio, f_bytes(arc_max))
-    caches_size = int(mfu_size)+int(mru_size)
+    caches_size = int(anon_size)+int(mfu_size)+int(mru_size)+int(unc_size)
+    prt_i2('Anonymouns data size:',
+           f_perc(anon_size, caches_size), f_bytes(anon_size))
     prt_i2('Most Frequently Used (MFU) cache size:',
            f_perc(mfu_size, caches_size), f_bytes(mfu_size))
     prt_i2('Most Recently Used (MRU) cache size:',
            f_perc(mru_size, caches_size), f_bytes(mru_size))
+    prt_i1('Most Frequently Used (MFU) ghost size:', f_bytes(mfug_size))
+    prt_i1('Most Recently Used (MRU) ghost size:', f_bytes(mrug_size))
+    prt_i2('Uncached data size:',
+           f_perc(unc_size, caches_size), f_bytes(unc_size))
     prt_i2('Metadata cache size (hard limit):',
            f_perc(meta_limit, arc_max), f_bytes(meta_limit))
     prt_i2('Metadata cache size (current):',
@@ -626,78 +636,119 @@ def section_archits(kstats_dict):
     """
 
     arc_stats = isolate_section('arcstats', kstats_dict)
-    all_accesses = int(arc_stats['hits'])+int(arc_stats['misses'])
-    actual_hits = int(arc_stats['mfu_hits'])+int(arc_stats['mru_hits'])
+    all_accesses = int(arc_stats['hits'])+int(arc_stats['iohits'])+\
+        int(arc_stats['misses'])
 
-    prt_1('ARC total accesses (hits + misses):', f_hits(all_accesses))
-    ta_todo = (('Cache hit ratio:', arc_stats['hits']),
-               ('Cache miss ratio:', arc_stats['misses']),
-               ('Actual hit ratio (MFU + MRU hits):', actual_hits))
-
+    prt_1('ARC total accesses:', f_hits(all_accesses))
+    ta_todo = (('Total hits:', arc_stats['hits']),
+               ('Total I/O hits:', arc_stats['iohits']),
+               ('Total misses:', arc_stats['misses']))
     for title, value in ta_todo:
         prt_i2(title, f_perc(value, all_accesses), f_hits(value))
+    print()
 
     dd_total = int(arc_stats['demand_data_hits']) +\
+        int(arc_stats['demand_data_iohits']) +\
         int(arc_stats['demand_data_misses'])
-    prt_i2('Data demand efficiency:',
-           f_perc(arc_stats['demand_data_hits'], dd_total),
-           f_hits(dd_total))
-
-    dp_total = int(arc_stats['prefetch_data_hits']) +\
-        int(arc_stats['prefetch_data_misses'])
-    prt_i2('Data prefetch efficiency:',
-           f_perc(arc_stats['prefetch_data_hits'], dp_total),
-           f_hits(dp_total))
-
-    known_hits = int(arc_stats['mfu_hits']) +\
-        int(arc_stats['mru_hits']) +\
-        int(arc_stats['mfu_ghost_hits']) +\
-        int(arc_stats['mru_ghost_hits'])
-
-    anon_hits = int(arc_stats['hits'])-known_hits
-
+    prt_2('ARC demand data accesses:', f_perc(dd_total, all_accesses),
+         f_hits(dd_total))
+    dd_todo = (('Demand data hits:', arc_stats['demand_data_hits']),
+               ('Demand data I/O hits:', arc_stats['demand_data_iohits']),
+               ('Demand data misses:', arc_stats['demand_data_misses']))
+    for title, value in dd_todo:
+        prt_i2(title, f_perc(value, dd_total), f_hits(value))
     print()
-    print('Cache hits by cache type:')
+
+    dm_total = int(arc_stats['demand_metadata_hits']) +\
+        int(arc_stats['demand_metadata_iohits']) +\
+        int(arc_stats['demand_metadata_misses'])
+    prt_2('ARC demand metadata accesses:', f_perc(dm_total, all_accesses),
+          f_hits(dm_total))
+    dm_todo = (('Demand metadata hits:', arc_stats['demand_metadata_hits']),
+               ('Demand metadata I/O hits:',
+                arc_stats['demand_metadata_iohits']),
+               ('Demand metadata misses:', arc_stats['demand_metadata_misses']))
+    for title, value in dm_todo:
+        prt_i2(title, f_perc(value, dm_total), f_hits(value))
+    print()
+
+    pd_total = int(arc_stats['prefetch_data_hits']) +\
+        int(arc_stats['prefetch_data_iohits']) +\
+        int(arc_stats['prefetch_data_misses'])
+    prt_2('ARC prefetch metadata accesses:', f_perc(pd_total, all_accesses),
+          f_hits(pd_total))
+    pd_todo = (('Prefetch data hits:', arc_stats['prefetch_data_hits']),
+               ('Prefetch data I/O hits:', arc_stats['prefetch_data_iohits']),
+               ('Prefetch data misses:', arc_stats['prefetch_data_misses']))
+    for title, value in pd_todo:
+        prt_i2(title, f_perc(value, pd_total), f_hits(value))
+    print()
+
+    pm_total = int(arc_stats['prefetch_metadata_hits']) +\
+        int(arc_stats['prefetch_metadata_iohits']) +\
+        int(arc_stats['prefetch_metadata_misses'])
+    prt_2('ARC prefetch metadata accesses:', f_perc(pm_total, all_accesses),
+          f_hits(pm_total))
+    pm_todo = (('Prefetch metadata hits:',
+                arc_stats['prefetch_metadata_hits']),
+               ('Prefetch metadata I/O hits:',
+                arc_stats['prefetch_metadata_iohits']),
+               ('Prefetch metadata misses:',
+                arc_stats['prefetch_metadata_misses']))
+    for title, value in pm_todo:
+        prt_i2(title, f_perc(value, pm_total), f_hits(value))
+    print()
+
+    all_prefetches = int(arc_stats['predictive_prefetch'])+\
+        int(arc_stats['prescient_prefetch'])
+    prt_2('ARC predictive prefetches:',
+           f_perc(arc_stats['predictive_prefetch'], all_prefetches),
+           f_hits(arc_stats['predictive_prefetch']))
+    prt_i2('Demand hits after predictive:',
+           f_perc(arc_stats['demand_hit_predictive_prefetch'],
+                  arc_stats['predictive_prefetch']),
+           f_hits(arc_stats['demand_hit_predictive_prefetch']))
+    prt_i2('Demand I/O hits after predictive:',
+           f_perc(arc_stats['demand_iohit_predictive_prefetch'],
+                  arc_stats['predictive_prefetch']),
+           f_hits(arc_stats['demand_iohit_predictive_prefetch']))
+    never = int(arc_stats['predictive_prefetch']) -\
+        int(arc_stats['demand_hit_predictive_prefetch']) -\
+        int(arc_stats['demand_iohit_predictive_prefetch'])
+    prt_i2('Never demanded after predictive:',
+           f_perc(never, arc_stats['predictive_prefetch']),
+           f_hits(never))
+    print()
+
+    prt_2('ARC prescient prefetches:',
+           f_perc(arc_stats['prescient_prefetch'], all_prefetches),
+           f_hits(arc_stats['prescient_prefetch']))
+    prt_i2('Demand hits after prescient:',
+           f_perc(arc_stats['demand_hit_prescient_prefetch'],
+                  arc_stats['prescient_prefetch']),
+           f_hits(arc_stats['demand_hit_prescient_prefetch']))
+    prt_i2('Demand I/O hits after prescient:',
+           f_perc(arc_stats['demand_iohit_prescient_prefetch'],
+                  arc_stats['prescient_prefetch']),
+           f_hits(arc_stats['demand_iohit_prescient_prefetch']))
+    never = int(arc_stats['prescient_prefetch'])-\
+        int(arc_stats['demand_hit_prescient_prefetch'])-\
+        int(arc_stats['demand_iohit_prescient_prefetch'])
+    prt_i2('Never demanded after prescient:',
+           f_perc(never, arc_stats['prescient_prefetch']),
+           f_hits(never))
+    print()
+
+    print('ARC states hits of all accesses:')
     cl_todo = (('Most frequently used (MFU):', arc_stats['mfu_hits']),
                ('Most recently used (MRU):', arc_stats['mru_hits']),
                ('Most frequently used (MFU) ghost:',
                 arc_stats['mfu_ghost_hits']),
                ('Most recently used (MRU) ghost:',
-                arc_stats['mru_ghost_hits']))
-
+                arc_stats['mru_ghost_hits']),
+               ('Uncached:', arc_stats['uncached_hits']))
     for title, value in cl_todo:
-        prt_i2(title, f_perc(value, arc_stats['hits']), f_hits(value))
-
-    # For some reason, anon_hits can turn negative, which is weird. Until we
-    # have figured out why this happens, we just hide the problem, following
-    # the behavior of the original arc_summary.
-    if anon_hits >= 0:
-        prt_i2('Anonymously used:',
-               f_perc(anon_hits, arc_stats['hits']), f_hits(anon_hits))
-
-    print()
-    print('Cache hits by data type:')
-    dt_todo = (('Demand data:', arc_stats['demand_data_hits']),
-               ('Prefetch data:', arc_stats['prefetch_data_hits']),
-               ('Demand metadata:', arc_stats['demand_metadata_hits']),
-               ('Prefetch metadata:',
-                arc_stats['prefetch_metadata_hits']))
-
-    for title, value in dt_todo:
-        prt_i2(title, f_perc(value, arc_stats['hits']), f_hits(value))
-
-    print()
-    print('Cache misses by data type:')
-    dm_todo = (('Demand data:', arc_stats['demand_data_misses']),
-               ('Prefetch data:',
-                arc_stats['prefetch_data_misses']),
-               ('Demand metadata:', arc_stats['demand_metadata_misses']),
-               ('Prefetch metadata:',
-                arc_stats['prefetch_metadata_misses']))
-
-    for title, value in dm_todo:
-        prt_i2(title, f_perc(value, arc_stats['misses']), f_hits(value))
-
+        prt_i2(title, f_perc(value, all_accesses), f_hits(value))
     print()
 
 
@@ -708,11 +759,17 @@ def section_dmu(kstats_dict):
 
     zfetch_access_total = int(zfetch_stats['hits'])+int(zfetch_stats['misses'])
 
-    prt_1('DMU prefetch efficiency:', f_hits(zfetch_access_total))
-    prt_i2('Hit ratio:', f_perc(zfetch_stats['hits'], zfetch_access_total),
+    prt_1('DMU predictive prefetcher calls:', f_hits(zfetch_access_total))
+    prt_i2('Stream hits:',
+           f_perc(zfetch_stats['hits'], zfetch_access_total),
            f_hits(zfetch_stats['hits']))
-    prt_i2('Miss ratio:', f_perc(zfetch_stats['misses'], zfetch_access_total),
+    prt_i2('Stream misses:',
+           f_perc(zfetch_stats['misses'], zfetch_access_total),
            f_hits(zfetch_stats['misses']))
+    prt_i2('Streams limit reached:',
+           f_perc(zfetch_stats['max_streams'], zfetch_stats['misses']),
+           f_hits(zfetch_stats['max_streams']))
+    prt_i1('Prefetches issued', f_hits(zfetch_stats['io_issued']))
     print()
 
 

--- a/cmd/arcstat.in
+++ b/cmd/arcstat.in
@@ -62,31 +62,64 @@ from signal import signal, SIGINT, SIGWINCH, SIG_DFL
 cols = {
     # HDR:        [Size, Scale, Description]
     "time":       [8, -1, "Time"],
-    "hits":       [4, 1000, "ARC reads per second"],
+    "hits":       [4, 1000, "ARC hits per second"],
+    "iohs":       [4, 1000, "ARC I/O hits per second"],
     "miss":       [4, 1000, "ARC misses per second"],
     "read":       [4, 1000, "Total ARC accesses per second"],
     "hit%":       [4, 100, "ARC hit percentage"],
+    "ioh%":       [4, 100, "ARC I/O hit percentage"],
     "miss%":      [5, 100, "ARC miss percentage"],
     "dhit":       [4, 1000, "Demand hits per second"],
+    "dioh":       [4, 1000, "Demand I/O hits per second"],
     "dmis":       [4, 1000, "Demand misses per second"],
     "dh%":        [3, 100, "Demand hit percentage"],
+    "di%":        [3, 100, "Demand I/O hit percentage"],
     "dm%":        [3, 100, "Demand miss percentage"],
+    "ddhit":      [5, 1000, "Demand data hits per second"],
+    "ddioh":      [5, 1000, "Demand data I/O hits per second"],
+    "ddmis":      [5, 1000, "Demand data misses per second"],
+    "ddh%":       [4, 100, "Demand data hit percentage"],
+    "ddi%":       [4, 100, "Demand data I/O hit percentage"],
+    "ddm%":       [4, 100, "Demand data miss percentage"],
+    "dmhit":      [5, 1000, "Demand metadata hits per second"],
+    "dmioh":      [5, 1000, "Demand metadata I/O hits per second"],
+    "dmmis":      [5, 1000, "Demand metadata misses per second"],
+    "dmh%":       [4, 100, "Demand metadata hit percentage"],
+    "dmi%":       [4, 100, "Demand metadata I/O hit percentage"],
+    "dmm%":       [4, 100, "Demand metadata miss percentage"],
     "phit":       [4, 1000, "Prefetch hits per second"],
+    "pioh":       [4, 1000, "Prefetch I/O hits per second"],
     "pmis":       [4, 1000, "Prefetch misses per second"],
     "ph%":        [3, 100, "Prefetch hits percentage"],
+    "pi%":        [3, 100, "Prefetch I/O hits percentage"],
     "pm%":        [3, 100, "Prefetch miss percentage"],
+    "pdhit":      [5, 1000, "Prefetch data hits per second"],
+    "pdioh":      [5, 1000, "Prefetch data I/O hits per second"],
+    "pdmis":      [5, 1000, "Prefetch data misses per second"],
+    "pdh%":       [4, 100, "Prefetch data hits percentage"],
+    "pdi%":       [4, 100, "Prefetch data I/O hits percentage"],
+    "pdm%":       [4, 100, "Prefetch data miss percentage"],
+    "pmhit":      [5, 1000, "Prefetch metadata hits per second"],
+    "pmioh":      [5, 1000, "Prefetch metadata I/O hits per second"],
+    "pmmis":      [5, 1000, "Prefetch metadata misses per second"],
+    "pmh%":       [4, 100, "Prefetch metadata hits percentage"],
+    "pmi%":       [4, 100, "Prefetch metadata I/O hits percentage"],
+    "pmm%":       [4, 100, "Prefetch metadata miss percentage"],
     "mhit":       [4, 1000, "Metadata hits per second"],
+    "mioh":       [4, 1000, "Metadata I/O hits per second"],
     "mmis":       [4, 1000, "Metadata misses per second"],
     "mread":      [5, 1000, "Metadata accesses per second"],
     "mh%":        [3, 100, "Metadata hit percentage"],
+    "mi%":        [3, 100, "Metadata I/O hit percentage"],
     "mm%":        [3, 100, "Metadata miss percentage"],
     "arcsz":      [5, 1024, "ARC size"],
-    "size":       [4, 1024, "ARC size"],
-    "c":          [4, 1024, "ARC target size"],
+    "size":       [5, 1024, "ARC size"],
+    "c":          [5, 1024, "ARC target size"],
     "mfu":        [4, 1000, "MFU list hits per second"],
     "mru":        [4, 1000, "MRU list hits per second"],
     "mfug":       [4, 1000, "MFU ghost list hits per second"],
     "mrug":       [4, 1000, "MRU ghost list hits per second"],
+    "unc":        [4, 1000, "Uncached list hits per second"],
     "eskip":      [5, 1000, "evict_skip per second"],
     "el2skip":    [7, 1000, "evict skip, due to l2 writes, per second"],
     "el2cach":    [7, 1024, "Size of L2 cached evictions per second"],
@@ -96,7 +129,11 @@ cols = {
     "el2inel":    [7, 1024, "Size of L2 ineligible evictions per second"],
     "mtxmis":     [6, 1000, "mutex_miss per second"],
     "dread":      [5, 1000, "Demand accesses per second"],
+    "ddread":     [6, 1000, "Demand data accesses per second"],
+    "dmread":     [6, 1000, "Demand metadata accesses per second"],
     "pread":      [5, 1000, "Prefetch accesses per second"],
+    "pdread":     [6, 1000, "Prefetch data accesses per second"],
+    "pmread":     [6, 1000, "Prefetch metadata accesses per second"],
     "l2hits":     [6, 1000, "L2ARC hits per second"],
     "l2miss":     [6, 1000, "L2ARC misses per second"],
     "l2read":     [6, 1000, "Total L2ARC accesses per second"],
@@ -116,23 +153,22 @@ cols = {
     "l2size":     [6, 1024, "Size of the L2ARC"],
     "l2bytes":    [7, 1024, "Bytes read per second from the L2ARC"],
     "grow":       [4, 1000, "ARC grow disabled"],
-    "need":       [4, 1024, "ARC reclaim need"],
-    "free":       [4, 1024, "ARC free memory"],
+    "need":       [5, 1024, "ARC reclaim need"],
+    "free":       [5, 1024, "ARC free memory"],
     "avail":      [5, 1024, "ARC available memory"],
     "waste":      [5, 1024, "Wasted memory due to round up to pagesize"],
 }
 
 v = {}
-hdr = ["time", "read", "miss", "miss%", "dmis", "dm%", "pmis", "pm%", "mmis",
-       "mm%", "size", "c", "avail"]
-xhdr = ["time", "mfu", "mru", "mfug", "mrug", "eskip", "mtxmis", "dread",
-        "pread", "read"]
+hdr = ["time", "read", "ddread", "ddh%", "dmread", "dmh%", "pread", "ph%",
+       "size", "c", "avail"]
+xhdr = ["time", "mfu", "mru", "mfug", "mrug", "unc", "eskip", "mtxmis",
+        "dread", "pread", "read"]
 sint = 1               # Default interval is 1 second
 count = 1              # Default count is 1
 hdr_intr = 20          # Print header every 20 lines of output
 opfile = None
 sep = "  "              # Default separator is 2 spaces
-version = "0.4"
 l2exist = False
 cmd = ("Usage: arcstat [-havxp] [-f fields] [-o file] [-s string] [interval "
        "[count]]\n")
@@ -442,34 +478,80 @@ def calculate():
     v = dict()
     v["time"] = time.strftime("%H:%M:%S", time.localtime())
     v["hits"] = d["hits"] // sint
+    v["iohs"] = d["iohits"] // sint
     v["miss"] = d["misses"] // sint
-    v["read"] = v["hits"] + v["miss"]
+    v["read"] = v["hits"] + v["iohs"] + v["miss"]
     v["hit%"] = 100 * v["hits"] // v["read"] if v["read"] > 0 else 0
-    v["miss%"] = 100 - v["hit%"] if v["read"] > 0 else 0
+    v["ioh%"] = 100 * v["iohs"] // v["read"] if v["read"] > 0 else 0
+    v["miss%"] = 100 - v["hit%"] - v["ioh%"] if v["read"] > 0 else 0
 
     v["dhit"] = (d["demand_data_hits"] + d["demand_metadata_hits"]) // sint
+    v["dioh"] = (d["demand_data_iohits"] + d["demand_metadata_iohits"]) // sint
     v["dmis"] = (d["demand_data_misses"] + d["demand_metadata_misses"]) // sint
 
-    v["dread"] = v["dhit"] + v["dmis"]
+    v["dread"] = v["dhit"] + v["dioh"] + v["dmis"]
     v["dh%"] = 100 * v["dhit"] // v["dread"] if v["dread"] > 0 else 0
-    v["dm%"] = 100 - v["dh%"] if v["dread"] > 0 else 0
+    v["di%"] = 100 * v["dioh"] // v["dread"] if v["dread"] > 0 else 0
+    v["dm%"] = 100 - v["dh%"] - v["di%"] if v["dread"] > 0 else 0
+
+    v["ddhit"] = d["demand_data_hits"] // sint
+    v["ddioh"] = d["demand_data_iohits"] // sint
+    v["ddmis"] = d["demand_data_misses"] // sint
+
+    v["ddread"] = v["ddhit"] + v["ddioh"] + v["ddmis"]
+    v["ddh%"] = 100 * v["ddhit"] // v["ddread"] if v["ddread"] > 0 else 0
+    v["ddi%"] = 100 * v["ddioh"] // v["ddread"] if v["ddread"] > 0 else 0
+    v["ddm%"] = 100 - v["ddh%"] - v["ddi%"] if v["ddread"] > 0 else 0
+
+    v["dmhit"] = d["demand_metadata_hits"] // sint
+    v["dmioh"] = d["demand_metadata_iohits"] // sint
+    v["dmmis"] = d["demand_metadata_misses"] // sint
+
+    v["dmread"] = v["dmhit"] + v["dmioh"] + v["dmmis"]
+    v["dmh%"] = 100 * v["dmhit"] // v["dmread"] if v["dmread"] > 0 else 0
+    v["dmi%"] = 100 * v["dmioh"] // v["dmread"] if v["dmread"] > 0 else 0
+    v["dmm%"] = 100 - v["dmh%"] - v["dmi%"] if v["dmread"] > 0 else 0
 
     v["phit"] = (d["prefetch_data_hits"] + d["prefetch_metadata_hits"]) // sint
+    v["pioh"] = (d["prefetch_data_iohits"] +
+                 d["prefetch_metadata_iohits"]) // sint
     v["pmis"] = (d["prefetch_data_misses"] +
                  d["prefetch_metadata_misses"]) // sint
 
-    v["pread"] = v["phit"] + v["pmis"]
+    v["pread"] = v["phit"] + v["pioh"] + v["pmis"]
     v["ph%"] = 100 * v["phit"] // v["pread"] if v["pread"] > 0 else 0
-    v["pm%"] = 100 - v["ph%"] if v["pread"] > 0 else 0
+    v["pi%"] = 100 * v["pioh"] // v["pread"] if v["pread"] > 0 else 0
+    v["pm%"] = 100 - v["ph%"] - v["pi%"] if v["pread"] > 0 else 0
+
+    v["pdhit"] = d["prefetch_data_hits"] // sint
+    v["pdioh"] = d["prefetch_data_iohits"] // sint
+    v["pdmis"] = d["prefetch_data_misses"] // sint
+
+    v["pdread"] = v["pdhit"] + v["pdioh"] + v["pdmis"]
+    v["pdh%"] = 100 * v["pdhit"] // v["pdread"] if v["pdread"] > 0 else 0
+    v["pdi%"] = 100 * v["pdioh"] // v["pdread"] if v["pdread"] > 0 else 0
+    v["pdm%"] = 100 - v["pdh%"] - v["pdi%"] if v["pdread"] > 0 else 0
+
+    v["pmhit"] = d["prefetch_metadata_hits"] // sint
+    v["pmioh"] = d["prefetch_metadata_iohits"] // sint
+    v["pmmis"] = d["prefetch_metadata_misses"] // sint
+
+    v["pmread"] = v["pmhit"] + v["pmioh"] + v["pmmis"]
+    v["pmh%"] = 100 * v["pmhit"] // v["pmread"] if v["pmread"] > 0 else 0
+    v["pmi%"] = 100 * v["pmioh"] // v["pmread"] if v["pmread"] > 0 else 0
+    v["pmm%"] = 100 - v["pmh%"] - v["pmi%"] if v["pmread"] > 0 else 0
 
     v["mhit"] = (d["prefetch_metadata_hits"] +
                  d["demand_metadata_hits"]) // sint
+    v["mioh"] = (d["prefetch_metadata_iohits"] +
+                 d["demand_metadata_iohits"]) // sint
     v["mmis"] = (d["prefetch_metadata_misses"] +
                  d["demand_metadata_misses"]) // sint
 
-    v["mread"] = v["mhit"] + v["mmis"]
+    v["mread"] = v["mhit"] + v["mioh"] + v["mmis"]
     v["mh%"] = 100 * v["mhit"] // v["mread"] if v["mread"] > 0 else 0
-    v["mm%"] = 100 - v["mh%"] if v["mread"] > 0 else 0
+    v["mi%"] = 100 * v["mioh"] // v["mread"] if v["mread"] > 0 else 0
+    v["mm%"] = 100 - v["mh%"] - v["mi%"] if v["mread"] > 0 else 0
 
     v["arcsz"] = cur["size"]
     v["size"] = cur["size"]
@@ -478,6 +560,7 @@ def calculate():
     v["mru"] = d["mru_hits"] // sint
     v["mrug"] = d["mru_ghost_hits"] // sint
     v["mfug"] = d["mfu_ghost_hits"] // sint
+    v["unc"] = d["uncached_hits"] // sint
     v["eskip"] = d["evict_skip"] // sint
     v["el2skip"] = d["evict_l2_skip"] // sint
     v["el2cach"] = d["evict_l2_cached"] // sint

--- a/man/man1/arcstat.1
+++ b/man/man1/arcstat.1
@@ -12,7 +12,7 @@
 .\" Copyright (c) 2015 by Delphix. All rights reserved.
 .\" Copyright (c) 2020 by AJ Jordan. All rights reserved.
 .\"
-.Dd May 26, 2021
+.Dd December 23, 2022
 .Dt ARCSTAT 1
 .Os
 .
@@ -35,33 +35,83 @@ prints various ZFS ARC and L2ARC statistics in vmstat-like fashion:
 .It Sy c
 ARC target size
 .It Sy dh%
-Demand data hit percentage
+Demand hit percentage
+.It Sy di%
+Demand I/O hit percentage
 .It Sy dm%
+Demand miss percentage
+.It Sy ddh%
+Demand data hit percentage
+.It Sy ddi%
+Demand data I/O hit percentage
+.It Sy ddm%
 Demand data miss percentage
+.It Sy dmh%
+Demand metadata hit percentage
+.It Sy dmi%
+Demand metadata I/O hit percentage
+.It Sy dmm%
+Demand metadata miss percentage
 .It Sy mfu
 MFU list hits per second
 .It Sy mh%
 Metadata hit percentage
+.It Sy mi%
+Metadata I/O hit percentage
 .It Sy mm%
 Metadata miss percentage
 .It Sy mru
 MRU list hits per second
 .It Sy ph%
 Prefetch hits percentage
+.It Sy pi%
+Prefetch I/O hits percentage
 .It Sy pm%
 Prefetch miss percentage
+.It Sy pdh%
+Prefetch data hits percentage
+.It Sy pdi%
+Prefetch data I/O hits percentage
+.It Sy pdm%
+Prefetch data miss percentage
+.It Sy pmh%
+Prefetch metadata hits percentage
+.It Sy pmi%
+Prefetch metadata I/O hits percentage
+.It Sy pmm%
+Prefetch metadata miss percentage
 .It Sy dhit
-Demand data hits per second
+Demand hits per second
+.It Sy dioh
+Demand I/O hits per second
 .It Sy dmis
+Demand misses per second
+.It Sy ddhit
+Demand data hits per second
+.It Sy ddioh
+Demand data I/O hits per second
+.It Sy ddmis
 Demand data misses per second
+.It Sy dmhit
+Demand metadata hits per second
+.It Sy dmioh
+Demand metadata I/O hits per second
+.It Sy dmmis
+Demand metadata misses per second
 .It Sy hit%
 ARC hit percentage
 .It Sy hits
-ARC reads per second
+ARC hits per second
+.It Sy ioh%
+ARC I/O hits percentage
+.It Sy iohs
+ARC I/O hits per second
 .It Sy mfug
 MFU ghost list hits per second
 .It Sy mhit
 Metadata hits per second
+.It Sy mioh
+Metadata I/O hits per second
 .It Sy miss
 ARC misses per second
 .It Sy mmis
@@ -70,8 +120,22 @@ Metadata misses per second
 MRU ghost list hits per second
 .It Sy phit
 Prefetch hits per second
+.It Sy pioh
+Prefetch I/O hits per second
 .It Sy pmis
 Prefetch misses per second
+.It Sy pdhit
+Prefetch data hits per second
+.It Sy pdioh
+Prefetch data I/O hits per second
+.It Sy pdmis
+Prefetch data misses per second
+.It Sy pmhit
+Prefetch metadata hits per second
+.It Sy pmioh
+Prefetch metadata I/O hits per second
+.It Sy pmmis
+Prefetch metadata misses per second
 .It Sy read
 Total ARC accesses per second
 .It Sy time
@@ -81,8 +145,14 @@ ARC size
 .It Sy arcsz
 Alias for
 .Sy size
+.It Sy unc
+Uncached list hits per second
 .It Sy dread
+Demand accesses per second
+.It Sy ddread
 Demand data accesses per second
+.It Sy dmread
+Demand metadata accesses per second
 .It Sy eskip
 evict_skip per second
 .It Sy miss%
@@ -91,6 +161,10 @@ ARC miss percentage
 Metadata accesses per second
 .It Sy pread
 Prefetch accesses per second
+.It Sy pdread
+Prefetch data accesses per second
+.It Sy pmread
+Prefetch metadata accesses per second
 .It Sy l2hit%
 L2ARC access hit percentage
 .It Sy l2hits


### PR DESCRIPTION
Recent ARC commits added new statistic counters, such as iohits, uncached state, etc.  Represent those.  Also some of previously reported numbers were confusing or even made no sense.  Those got some cleanup and restructuring.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
