### PR TITLE
etc/systemd/zfs-mount-generator: avoid strndupa

### DIFF
--- a/etc/systemd/system-generators/zfs-mount-generator.c
+++ b/etc/systemd/system-generators/zfs-mount-generator.c
@@ -224,9 +224,10 @@ line_worker(char *line, const char *cachefile)
 	const char *p_systemd_ignore            = strtok_r(NULL, "\t", &toktmp) ?: "-";
 	/* END CSTYLED */
 
-	const char *pool = dataset;
-	if ((toktmp = strchr(pool, '/')) != NULL)
-		pool = strndupa(pool, toktmp - pool);
+	size_t pool_len = strlen(dataset);
+	if ((toktmp = strchr(dataset, '/')) != NULL)
+		pool_len = toktmp - dataset;
+	const char *pool = *(tofree++) = strndup(dataset, pool_len);
 
 	if (p_nbmand == NULL) {
 		fprintf(stderr, PROGNAME "[%d]: %s: not enough tokens!\n",
@@ -734,7 +735,7 @@ end:
 	if (tofree >= tofree_all + nitems(tofree_all)) {
 		/*
 		 * This won't happen as-is:
-		 * we've got 8 slots and allocate 4 things at most.
+		 * we've got 8 slots and allocate 5 things at most.
 		 */
 		fprintf(stderr,
 		    PROGNAME "[%d]: %s: need to free %zu > %zu!\n",


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The non-standard strndupa function is not implemented by musl libc, and can be dangerous due to its potential to blow the stack.  (musl _does_ implement strdupa, used elsewhere in this function.)

(Why care about musl when systemd only supports glibc?  Some distros patch systemd with portability fixes, and it would be nice to be able to use ZFS on those distros.)

### Description
<!--- Describe your changes in detail -->

With a similar amount of code, we can use a heap allocation to construct the pool name, which is musl-friendly and doesn't have potential stack problems.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

I set up and ran zfs-mount-generator before and after these changes, and checked that they produced the same result.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
