### PR TITLE
Fix make deb utils

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -78,7 +78,7 @@ deb-utils: deb-local rpm-utils-initramfs
 ## Debianized packages from the auto-generated dependencies of the new debs,
 ## which should NOT be mixed with the alien-generated debs created here
 	chmod +x $${path_prepend}/dh_shlibdeps; \
-	env PATH=$${path_prepend}:$${PATH} \
+	env "PATH=$${path_prepend}:$${PATH}" \
 	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch \
 	    $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \
 	    $$pkg8 $$pkg9 $$pkg10 $$pkg11 || exit 1; \

--- a/config/deb.am
+++ b/config/deb.am
@@ -70,7 +70,7 @@ deb-utils: deb-local rpm-utils-initramfs
 ## to do this, so we install a shim onto the path which calls the real
 ## dh_shlibdeps with the required arguments.
 	path_prepend=`mktemp -d /tmp/intercept.XXXXXX`; \
-	echo "#$(SHELL)" > $${path_prepend}/dh_shlibdeps; \
+	echo "#!$(SHELL)" > $${path_prepend}/dh_shlibdeps; \
 	echo "`which dh_shlibdeps` -- \
 	 -xlibuutil3linux -xlibnvpair3linux -xlibzfs5linux -xlibzpool5linux" \
 	 >> $${path_prepend}/dh_shlibdeps; \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Fixes an error, where building the deb utils would fail, if there was a space in the `$PATH` environment variable (see https://github.com/openzfs/zfs/issues/14338)

### Description
- enclosed the `$PATH` in double quotes
- fixed the incomplete shebang by adding the missing `!`

### How Has This Been Tested?
I've applied the patch to my local source and run the build successfully, despite the path variable containing spaces:

```
name=zfs; \
version=2.1.0-rc4; \
arch=`rpm -qp ${name}-${version}.src.rpm --qf %{arch} | tail -1`; \
debarch=`dpkg --print-architecture`; \
pkg1=${name}-${version}.${arch}.rpm; \
pkg2=libnvpair3-${version}.${arch}.rpm; \
pkg3=libuutil3-${version}.${arch}.rpm; \
pkg4=libzfs5-${version}.${arch}.rpm; \
pkg5=libzpool5-${version}.${arch}.rpm; \
pkg6=libzfs5-devel-${version}.${arch}.rpm; \
pkg7=${name}-test-${version}.${arch}.rpm; \
pkg8=${name}-dracut-${version}.noarch.rpm; \
pkg9=${name}-initramfs-${version}.${arch}.rpm; \
pkg10=`ls python*-pyzfs-${version}* | tail -1`; \
path_prepend=`mktemp -d /tmp/intercept.XXXXXX`; \
echo "#!/bin/bash" > ${path_prepend}/dh_shlibdeps; \
echo "`which dh_shlibdeps` -- \
 -xlibuutil3linux -xlibnvpair3linux -xlibzfs5linux -xlibzpool5linux" \
 >> ${path_prepend}/dh_shlibdeps; \
chmod +x ${path_prepend}/dh_shlibdeps; \
env "PATH=${path_prepend}:${PATH}" \
fakeroot alien --bump=0 --scripts --to-deb --target=$debarch \
    $pkg1 $pkg2 $pkg3 $pkg4 $pkg5 $pkg6 $pkg7 \
    $pkg8 $pkg9 $pkg10 || exit 1; \
rm -f ${path_prepend}/dh_shlibdeps; \
rmdir ${path_prepend}; \
rm -f $pkg1 $pkg2 $pkg3 $pkg4 $pkg5 $pkg6 $pkg7 \
    $pkg8 $pkg9 $pkg10;
zfs_2.1.0-0_amd64.deb generated
libnvpair3_2.1.0-0_amd64.deb generated
libuutil3_2.1.0-0_amd64.deb generated
libzfs5_2.1.0-0_amd64.deb generated
libzpool5_2.1.0-0_amd64.deb generated
libzfs5-devel_2.1.0-0_amd64.deb generated
zfs-test_2.1.0-0_amd64.deb generated
zfs-dracut_2.1.0-0_amd64.deb generated
zfs-initramfs_2.1.0-0_amd64.deb generated
python3-pyzfs_2.1.0-0_amd64.deb generated
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
