### PR TITLE
contrib: dracut: Do not timeout waiting for pw

### DIFF
--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -34,7 +34,7 @@ _load_key_cb() {
     case "${KEYLOCATION%%://*}" in
         prompt)
             for _ in 1 2 3; do
-                systemd-ask-password --no-tty "Encrypted ZFS password for ${dataset}" | zfs load-key "${ENCRYPTIONROOT}" && break
+                systemd-ask-password --timeout=0 --no-tty "Encrypted ZFS password for ${dataset}" | zfs load-key "${ENCRYPTIONROOT}" && break
             done
             ;;
         http*)


### PR DESCRIPTION
### Motivation and Context

systemd-ask-password has a default timeout of 90 seconds, which means that dracut will fall back to the rescue shell 4.5 minutes after boot if no password is entered.

This is undesirable when combined with, for example, unlocking remotely using dracut-sshd and systemd-tty-ask-password-agent. See also https://github.com/gsauthof/dracut-sshd#timeout and https://bugzilla.redhat.com/show_bug.cgi?id=868421.

Signed-off-by: Clemens Lang <neverpanic@gmail.com>

### How Has This Been Tested?
I did set up a new AlmaLinux machine following the RHEL Root on ZFS guide (https://openzfs.github.io/openzfs-docs/Getting%20Started/RHEL-based%20distro/RHEL-based%20distro%20Root%20on%20ZFS/1-preparation.html),  installed https://github.com/gsauthof/dracut-sshd and modified the dracut network configuration as explained in https://github.com/gsauthof/dracut-sshd#network.

Additionally, I had to manually `restorecon /var/run` for the VM to boot.

On reboot, the initramfs sshd would come up successfully, but it you were not fast enough in unlocking, the prompt would timeout after 90 seconds. Once the timeout happened three times, the system would drop into rescue mode, which is bad for remote systems.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly. (There does not seem to be specific documentation for dracut that would need updating.)
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).