### PR TITLE
Linux 6.1 compat: open inside tmpfile()

### DIFF
--- a/config/kernel-tmpfile.m4
+++ b/config/kernel-tmpfile.m4
@@ -4,10 +4,24 @@ dnl # Add support for i_op->tmpfile
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_TMPFILE], [
 	dnl #
+	dnl # 6.1 API change
+	dnl # use struct file instead of struct dentry
+	dnl #
+	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile], [
+		#include <linux/fs.h>
+		int tmpfile(struct user_namespace *userns,
+		    struct inode *inode, struct file *file,
+		    umode_t mode) { return 0; }
+		static struct inode_operations
+		    iops __attribute__ ((unused)) = {
+			.tmpfile = tmpfile,
+		};
+	],[])
+	dnl #
 	dnl # 5.11 API change
 	dnl # add support for userns parameter to tmpfile
 	dnl #
-	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile_userns], [
+	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile_dentry_userns], [
 		#include <linux/fs.h>
 		int tmpfile(struct user_namespace *userns,
 		    struct inode *inode, struct dentry *dentry,
@@ -17,7 +31,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_TMPFILE], [
 			.tmpfile = tmpfile,
 		};
 	],[])
-	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile], [
+	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile_dentry], [
 			#include <linux/fs.h>
 			int tmpfile(struct inode *inode, struct dentry *dentry,
 			    umode_t mode) { return 0; }
@@ -30,16 +44,24 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_TMPFILE], [
 
 AC_DEFUN([ZFS_AC_KERNEL_TMPFILE], [
 	AC_MSG_CHECKING([whether i_op->tmpfile() exists])
-	ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile_userns], [
+	ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
 		AC_DEFINE(HAVE_TMPFILE_USERNS, 1, [i_op->tmpfile() has userns])
 	],[
-		ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile], [
+		ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile_dentry_userns], [
 			AC_MSG_RESULT(yes)
 			AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
+			AC_DEFINE(HAVE_TMPFILE_USERNS, 1, [i_op->tmpfile() has userns])
+			AC_DEFINE(HAVE_TMPFILE_DENTRY, 1, [i_op->tmpfile() uses old dentry signature])
 		],[
-			AC_MSG_RESULT(no)
+			ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile_dentry], [
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
+				AC_DEFINE(HAVE_TMPFILE_DENTRY, 1, [i_op->tmpfile() uses old dentry signature])
+			],[
+				AC_MSG_RESULT(no)
+			])
 		])
 	])
 ])

--- a/config/kernel-tmpfile.m4
+++ b/config/kernel-tmpfile.m4
@@ -60,7 +60,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TMPFILE], [
 				AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
 				AC_DEFINE(HAVE_TMPFILE_DENTRY, 1, [i_op->tmpfile() uses old dentry signature])
 			],[
-				AC_MSG_RESULT(no)
+				ZFS_LINUX_REQUIRE_API([i_op->tmpfile()], [3.11])
 			])
 		])
 	])

--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -958,3 +958,35 @@ AC_DEFUN([ZFS_LINUX_TRY_COMPILE_HEADER], [
 		    [test -f build/conftest/conftest.ko], [$3], [$4], [$5])
 	])
 ])
+
+dnl #
+dnl # AS_VERSION_COMPARE_LE
+dnl # like AS_VERSION_COMPARE_LE, but runs $3 if (and only if) $1 <= $2
+dnl # AS_VERSION_COMPARE_LE (version-1, version-2, [action-if-less-or-equal], [action-if-greater])
+dnl #
+AC_DEFUN([AS_VERSION_COMPARE_LE], [
+	AS_VERSION_COMPARE([$1], [$2], [$3], [$3], [$4])
+])
+
+dnl #
+dnl # ZFS_LINUX_REQUIRE_API
+dnl # like ZFS_LINUX_TEST_ERROR, except only fails if the kernel is
+dnl # at least some specified version.
+dnl #
+AC_DEFUN([ZFS_LINUX_REQUIRE_API], [
+	AS_VERSION_COMPARE_LE([$2], [$kernsrcver], [
+		AC_MSG_ERROR([
+		*** None of the expected "$1" interfaces were detected. This
+		*** interface is expected for kernels version "$2" and above.
+		*** This may be because your kernel version is newer than what is
+		*** supported, or you are using a patched custom kernel with
+		*** incompatible modifications.  Newer kernels may have incompatible
+		*** APIs.
+		***
+		*** ZFS Version: $ZFS_META_ALIAS
+		*** Compatible Kernels: $ZFS_META_KVER_MIN - $ZFS_META_KVER_MAX
+		])
+	], [
+		AC_MSG_RESULT(no)
+	])
+])


### PR DESCRIPTION
### Motivation and Context

Linux 863f144 modified the `.tmpfile` interface to pass a `struct file`, rather than a `struct dentry`, and expect the tmpfile implementation to open inside of `tmpfile()`. 

The current implementation neither detects this new API, nor properly implements it.  See #14301.

### Description
This patch implements a configuration test that checks for this new API and appropriately sets a `HAVE_TMPFILE_DENTRY` flag that tracks the old API.  Contingent on this flag, the appropriate API is implemented.

### How Has This Been Tested?


It compiles on 6.1 and passes the `tests/functional/tmpfile` tests (backported 2.1.7 on Debian testing).  I am using this pull request for the other kernel versions).  I am currently running the full ZTS on Linux 6.1/ZFS 2.1.7 on that same Debian machine.

As an aside: the CI testbed seems to be malfunctioning.  It's failing at "install dependencies".

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions). **Please let me know about the nested AC_ macros, I would think they should not be indented additionally to reduce diff size when adding new options, but that doesn't seem to be the style used.**
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied. **IN PROGRESS, but the relevant section does pass.**
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
