### PR TITLE
[2.1.8] Add workaround for broken Linux pipes

### DIFF
--- a/lib/libzfs/os/linux/libzfs_sendrecv_os.c
+++ b/lib/libzfs/os/linux/libzfs_sendrecv_os.c
@@ -35,6 +35,22 @@
 void
 libzfs_set_pipe_max(int infd)
 {
+#if __linux__
+	/*
+	 * Sadly, Linux has an unfixed deadlock if you do SETPIPE_SZ on a pipe
+	 * with data in it.
+	 * cf. #13232, https://bugzilla.kernel.org/show_bug.cgi?id=212295
+	 *
+	 * And since the problem is in waking up the writer, there's nothing
+	 * we can do about it from here.
+	 *
+	 * So if people want to, they can set this, but they
+	 * may regret it...
+	 */
+	if (getenv("ZFS_SET_PIPE_MAX") == NULL)
+		return;
+#endif
+
 	FILE *procf = fopen("/proc/sys/fs/pipe-max-size", "re");
 
 	if (procf != NULL) {

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -713,6 +713,14 @@ to use
 to mount ZFS datasets.
 This option is provided for backwards compatibility with older ZFS versions.
 .El
+.Bl -tag -width "ZFS_SET_PIPE_MAX"
+.It Sy ZFS_SET_PIPE_MAX
+Tells
+.Nm zfs
+to set the maximum pipe size for sends/recieves.
+Disabled by default on Linux
+due to an unfixed deadlock in Linux's pipe size handling code.
+.El
 .
 .Sh INTERFACE STABILITY
 .Sy Committed .


### PR DESCRIPTION
### Motivation and Context
Just a cherrypick of #13309 for 2.1 after debugging someone else's issue led me to find it wasn't already backported.

(I say "just", but I ended up lobbing the code elsewhere since a refactor of it wasn't in 2.1...)

### Description
Force not using `F_SETPIPE_SZ` on Linux unless someone sets the same env variable as in master, because it might break, and there's no obvious way to tell a priori.

### How Has This Been Tested?
Isn't that what CI is for?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
