### PR TITLE
Address several minor ztest issues

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3597,6 +3597,7 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	int newvd_is_spare = B_FALSE;
 	int newvd_is_dspare = B_FALSE;
 	int oldvd_is_log;
+	int oldvd_is_special;
 	int error, expected_error;
 
 	if (ztest_opts.zo_mmp_test)
@@ -3671,6 +3672,9 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	oldguid = oldvd->vdev_guid;
 	oldsize = vdev_get_min_asize(oldvd);
 	oldvd_is_log = oldvd->vdev_top->vdev_islog;
+	oldvd_is_special =
+	    oldvd->vdev_top->vdev_alloc_bias == VDEV_BIAS_SPECIAL ||
+	    oldvd->vdev_top->vdev_alloc_bias == VDEV_BIAS_DEDUP;
 	(void) strlcpy(oldpath, oldvd->vdev_path, MAXPATHLEN);
 	pvd = oldvd->vdev_parent;
 	pguid = pvd->vdev_guid;
@@ -3749,7 +3753,8 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	    pvd->vdev_ops == &vdev_replacing_ops ||
 	    pvd->vdev_ops == &vdev_spare_ops))
 		expected_error = ENOTSUP;
-	else if (newvd_is_spare && (!replacing || oldvd_is_log))
+	else if (newvd_is_spare &&
+	    (!replacing || oldvd_is_log || oldvd_is_special))
 		expected_error = ENOTSUP;
 	else if (newvd == oldvd)
 		expected_error = replacing ? 0 : EBUSY;

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -443,7 +443,7 @@ static ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_dmu_commit_callbacks, 1, &zopt_always),
 	ZTI_INIT(ztest_zap, 30, &zopt_always),
 	ZTI_INIT(ztest_zap_parallel, 100, &zopt_always),
-	ZTI_INIT(ztest_split_pool, 1, &zopt_always),
+	ZTI_INIT(ztest_split_pool, 1, &zopt_sometimes),
 	ZTI_INIT(ztest_zil_commit, 1, &zopt_incessant),
 	ZTI_INIT(ztest_zil_remount, 1, &zopt_sometimes),
 	ZTI_INIT(ztest_dmu_read_write_zcopy, 1, &zopt_often),


### PR DESCRIPTION
### Motivation and Context

The `zloop.sh` testing done by the CI should reliably pass.  These changes are intended to resolve the most common failures I've observed in my testing but they don't address everything.  In all of these cases `ztest` itself was updated to properly handle legitimate, but unlikely, scenarios.  Additional detail provided in the commit comments.

### Description

ae2ab756c ztest: update ztest_dmu_snapshot_create_destroy()
476988760 ztest: ztest_dsl_prop_set_uint64() ENOSPC consistency
2e597fa4a ztest: reduce `zpool split` frequency
bbc9e7fe0 Update ztest special spare expectation

### How Has This Been Tested?

Locally by running `zloop.sh` and verifying that the specific issues address by these patches cannot be reproduced.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
