### PR TITLE
3 backported patches for 2.1.8

### DIFF
--- a/config/kernel-tmpfile.m4
+++ b/config/kernel-tmpfile.m4
@@ -4,10 +4,24 @@ dnl # Add support for i_op->tmpfile
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_TMPFILE], [
 	dnl #
+	dnl # 6.1 API change
+	dnl # use struct file instead of struct dentry
+	dnl #
+	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile], [
+		#include <linux/fs.h>
+		int tmpfile(struct user_namespace *userns,
+		    struct inode *inode, struct file *file,
+		    umode_t mode) { return 0; }
+		static struct inode_operations
+		    iops __attribute__ ((unused)) = {
+			.tmpfile = tmpfile,
+		};
+	],[])
+	dnl #
 	dnl # 5.11 API change
 	dnl # add support for userns parameter to tmpfile
 	dnl #
-	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile_userns], [
+	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile_dentry_userns], [
 		#include <linux/fs.h>
 		int tmpfile(struct user_namespace *userns,
 		    struct inode *inode, struct dentry *dentry,
@@ -17,7 +31,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_TMPFILE], [
 			.tmpfile = tmpfile,
 		};
 	],[])
-	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile], [
+	ZFS_LINUX_TEST_SRC([inode_operations_tmpfile_dentry], [
 			#include <linux/fs.h>
 			int tmpfile(struct inode *inode, struct dentry *dentry,
 			    umode_t mode) { return 0; }
@@ -30,16 +44,24 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_TMPFILE], [
 
 AC_DEFUN([ZFS_AC_KERNEL_TMPFILE], [
 	AC_MSG_CHECKING([whether i_op->tmpfile() exists])
-	ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile_userns], [
+	ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
 		AC_DEFINE(HAVE_TMPFILE_USERNS, 1, [i_op->tmpfile() has userns])
 	],[
-		ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile], [
+		ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile_dentry_userns], [
 			AC_MSG_RESULT(yes)
 			AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
+			AC_DEFINE(HAVE_TMPFILE_USERNS, 1, [i_op->tmpfile() has userns])
+			AC_DEFINE(HAVE_TMPFILE_DENTRY, 1, [i_op->tmpfile() uses old dentry signature])
 		],[
-			AC_MSG_RESULT(no)
+			ZFS_LINUX_TEST_RESULT([inode_operations_tmpfile_dentry], [
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
+				AC_DEFINE(HAVE_TMPFILE_DENTRY, 1, [i_op->tmpfile() uses old dentry signature])
+			],[
+				AC_MSG_RESULT(no)
+			])
 		])
 	])
 ])

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -224,11 +224,16 @@ zpl_mknod(struct inode *dir, struct dentry *dentry, umode_t mode,
 
 #ifdef HAVE_TMPFILE
 static int
+#ifndef HAVE_TMPFILE_DENTRY
+zpl_tmpfile(struct user_namespace *userns, struct inode *dir,
+    struct file *file, umode_t mode)
+#else
 #ifdef HAVE_TMPFILE_USERNS
 zpl_tmpfile(struct user_namespace *userns, struct inode *dir,
     struct dentry *dentry, umode_t mode)
 #else
 zpl_tmpfile(struct inode *dir, struct dentry *dentry, umode_t mode)
+#endif
 #endif
 {
 	cred_t *cr = CRED();
@@ -252,11 +257,21 @@ zpl_tmpfile(struct inode *dir, struct dentry *dentry, umode_t mode)
 	if (error == 0) {
 		/* d_tmpfile will do drop_nlink, so we should set it first */
 		set_nlink(ip, 1);
+#ifndef HAVE_TMPFILE_DENTRY
+		d_tmpfile(file, ip);
+
+		error = zpl_xattr_security_init(ip, dir,
+		    &file->f_path.dentry->d_name);
+#else
 		d_tmpfile(dentry, ip);
 
 		error = zpl_xattr_security_init(ip, dir, &dentry->d_name);
+#endif
 		if (error == 0)
 			error = zpl_init_acl(ip, dir);
+#ifndef HAVE_TMPFILE_DENTRY
+		error = finish_open_simple(file, error);
+#endif
 		/*
 		 * don't need to handle error here, file is already in
 		 * unlinked set.

--- a/tests/zfs-tests/cmd/mmapwrite/mmapwrite.c
+++ b/tests/zfs-tests/cmd/mmapwrite/mmapwrite.c
@@ -52,6 +52,7 @@
  */
 
 #define	NORMAL_WRITE_TH_NUM	2
+#define	MAX_WRITE_BYTES	262144000
 
 static void *
 normal_writer(void *filename)
@@ -67,18 +68,25 @@ normal_writer(void *filename)
 	}
 
 	char *buf = malloc(1);
-	while (1) {
+	off_t bytes_written = 0;
+
+	while (bytes_written < MAX_WRITE_BYTES) {
 		write_num = write(fd, buf, 1);
 		if (write_num == 0) {
 			err(1, "write failed!");
 			break;
 		}
-		lseek(fd, page_size, SEEK_CUR);
+		if ((bytes_written = lseek(fd, page_size, SEEK_CUR)) == -1) {
+			err(1, "lseek failed on %s: %s", file_path,
+			    strerror(errno));
+			break;
+		}
 	}
 
 	if (buf) {
 		free(buf);
 	}
+	return (NULL);
 }
 
 static void *

--- a/tests/zfs-tests/cmd/mmapwrite/mmapwrite.c
+++ b/tests/zfs-tests/cmd/mmapwrite/mmapwrite.c
@@ -86,6 +86,10 @@ normal_writer(void *filename)
 	if (buf) {
 		free(buf);
 	}
+
+	if (close(fd) != 0)
+		err(1, "failed to close file");
+
 	return (NULL);
 }
 


### PR DESCRIPTION
### Motivation and Context

These three recent patches are low-risk, and fix significant issues that are present in the stable release.  One provides Linux 6.1 compatibility, and the other two enhance the ZTS, improving independent users ability to identify issues with the stable kernel.

### Description

One patch re-adds support for O_TMPFILE for Linux 6.1, and the other two limit the file size of the mmapwriter ZTS, preventing spurious test failures.

### How Has This Been Tested?

An earlier backport of these patches was run locally.  I'm now using the CI pipeline for additional testing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
