### PR TITLE
libzpool: fix ddi_strtoull to update nptr

### DIFF
--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -770,10 +770,8 @@ random_get_pseudo_bytes(uint8_t *ptr, size_t len)
 int
 ddi_strtoull(const char *str, char **nptr, int base, u_longlong_t *result)
 {
-	(void) nptr;
-	char *end;
-
-	*result = strtoull(str, &end, base);
+	errno = 0;
+	*result = strtoull(str, nptr, base);
 	if (*result == 0)
 		return (errno);
 	return (0);


### PR DESCRIPTION
This matches the implementation of ddi_strtoull used in illumos-gate's libfakekernel.

Thanks to @ryao for this suggestion!

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

> _Background: I believe the Windows port is using this function to read partition offset and length information (which have been prepended to vdev disk paths) when running userland commands like `zpool`._

This function does not match the behavior as [documented](https://docs.oracle.com/cd/E36784_01/html/E36886/ddi-strtoull-9f.html) and as implemented in SPL in regards to the second argument `nptr`.

### Description
<!--- Describe your changes in detail -->

The second argument in `dii_strtoull` (if not null) should point to the final string of unrecognized characters.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

The following code currently does not work correctly, but works correctly after this change:

```c
#include <stdlib.h>
#include <stdio.h>

void main() {
	char* str = "0 1 2";
	
	char* end = str;
	u_longlong_t result;
	
	dii_strtoull(end, &end, 10, &result);
	printf("result should be 0: %llu\n", result);
	
	dii_strtoull(end, &end, 10, &result);
	printf("result should be 1: %llu\n", result);
	
	dii_strtoull(end, &end, 10, &result);
	printf("result should be 2: %llu\n", result);
}
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
