### PR TITLE
2.1.8-staging: Linux 6.2 compatibility

### DIFF
--- a/config/kernel-acl.m4
+++ b/config/kernel-acl.m4
@@ -189,6 +189,18 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_OPERATIONS_GET_ACL], [
 			.get_acl = get_acl_fn,
 		};
 	],[])
+
+	ZFS_LINUX_TEST_SRC([inode_operations_get_inode_acl], [
+		#include <linux/fs.h>
+
+		struct posix_acl *get_inode_acl_fn(struct inode *inode, int type,
+		    bool rcu) { return NULL; }
+
+		static const struct inode_operations
+		    iops __attribute__ ((unused)) = {
+			.get_inode_acl = get_inode_acl_fn,
+		};
+	],[])
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_INODE_OPERATIONS_GET_ACL], [
@@ -201,7 +213,12 @@ AC_DEFUN([ZFS_AC_KERNEL_INODE_OPERATIONS_GET_ACL], [
 			AC_MSG_RESULT(yes)
 			AC_DEFINE(HAVE_GET_ACL_RCU, 1, [iops->get_acl() takes rcu])
 		],[
-			ZFS_LINUX_TEST_ERROR([iops->get_acl()])
+			ZFS_LINUX_TEST_RESULT([inode_operations_get_inode_acl], [
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_GET_INODE_ACL, 1, [has iops->get_inode_acl()])
+			],[
+				ZFS_LINUX_TEST_ERROR([iops->get_acl() or iops->get_inode_acl()])
+			])
 		])
 	])
 ])

--- a/config/kernel-tmpfile.m4
+++ b/config/kernel-tmpfile.m4
@@ -60,7 +60,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TMPFILE], [
 				AC_DEFINE(HAVE_TMPFILE, 1, [i_op->tmpfile() exists])
 				AC_DEFINE(HAVE_TMPFILE_DENTRY, 1, [i_op->tmpfile() uses old dentry signature])
 			],[
-				AC_MSG_RESULT(no)
+				ZFS_LINUX_REQUIRE_API([i_op->tmpfile()], [3.11])
 			])
 		])
 	])

--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -946,3 +946,35 @@ AC_DEFUN([ZFS_LINUX_TRY_COMPILE_HEADER], [
 		    [test -f build/conftest/conftest.ko], [$3], [$4], [$5])
 	])
 ])
+
+dnl #
+dnl # AS_VERSION_COMPARE_LE
+dnl # like AS_VERSION_COMPARE_LE, but runs $3 if (and only if) $1 <= $2
+dnl # AS_VERSION_COMPARE_LE (version-1, version-2, [action-if-less-or-equal], [action-if-greater])
+dnl #
+AC_DEFUN([AS_VERSION_COMPARE_LE], [
+	AS_VERSION_COMPARE([$1], [$2], [$3], [$3], [$4])
+])
+
+dnl #
+dnl # ZFS_LINUX_REQUIRE_API
+dnl # like ZFS_LINUX_TEST_ERROR, except only fails if the kernel is
+dnl # at least some specified version.
+dnl #
+AC_DEFUN([ZFS_LINUX_REQUIRE_API], [
+	AS_VERSION_COMPARE_LE([$2], [$kernsrcver], [
+		AC_MSG_ERROR([
+		*** None of the expected "$1" interfaces were detected. This
+		*** interface is expected for kernels version "$2" and above.
+		*** This may be because your kernel version is newer than what is
+		*** supported, or you are using a patched custom kernel with
+		*** incompatible modifications.  Newer kernels may have incompatible
+		*** APIs.
+		***
+		*** ZFS Version: $ZFS_META_ALIAS
+		*** Compatible Kernels: $ZFS_META_KVER_MIN - $ZFS_META_KVER_MAX
+		])
+	], [
+		AC_MSG_RESULT(no)
+	])
+])

--- a/include/os/linux/kernel/linux/blkdev_compat.h
+++ b/include/os/linux/kernel/linux/blkdev_compat.h
@@ -357,7 +357,11 @@ vdev_lookup_bdev(const char *path, dev_t *dev)
 static inline void
 bio_set_op_attrs(struct bio *bio, unsigned rw, unsigned flags)
 {
+#if defined(HAVE_BIO_BI_OPF)
+	bio->bi_opf = rw | flags;
+#else
 	bio->bi_rw |= rw | flags;
+#endif /* HAVE_BIO_BI_OPF */
 }
 #endif
 

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -71,7 +71,7 @@ extern int zpl_set_acl(struct user_namespace *userns, struct inode *ip,
 extern int zpl_set_acl(struct inode *ip, struct posix_acl *acl, int type);
 #endif /* HAVE_SET_ACL_USERNS */
 #endif /* HAVE_SET_ACL */
-#if defined(HAVE_GET_ACL_RCU)
+#if defined(HAVE_GET_ACL_RCU) || defined(HAVE_GET_INODE_ACL)
 extern struct posix_acl *zpl_get_acl(struct inode *ip, int type, bool rcu);
 #elif defined(HAVE_GET_ACL)
 extern struct posix_acl *zpl_get_acl(struct inode *ip, int type);

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -726,7 +726,11 @@ const struct inode_operations zpl_inode_operations = {
 #if defined(HAVE_SET_ACL)
 	.set_acl	= zpl_set_acl,
 #endif /* HAVE_SET_ACL */
+#if defined(HAVE_GET_INODE_ACL)
+	.get_inode_acl	= zpl_get_acl,
+#else
 	.get_acl	= zpl_get_acl,
+#endif /* HAVE_GET_INODE_ACL */
 #endif /* CONFIG_FS_POSIX_ACL */
 };
 
@@ -759,7 +763,11 @@ const struct inode_operations zpl_dir_inode_operations = {
 #if defined(HAVE_SET_ACL)
 	.set_acl	= zpl_set_acl,
 #endif /* HAVE_SET_ACL */
+#if defined(HAVE_GET_INODE_ACL)
+	.get_inode_acl	= zpl_get_acl,
+#else
 	.get_acl	= zpl_get_acl,
+#endif /* HAVE_GET_INODE_ACL */
 #endif /* CONFIG_FS_POSIX_ACL */
 };
 
@@ -798,6 +806,10 @@ const struct inode_operations zpl_special_inode_operations = {
 #if defined(HAVE_SET_ACL)
 	.set_acl	= zpl_set_acl,
 #endif /* HAVE_SET_ACL */
+#if defined(HAVE_GET_INODE_ACL)
+	.get_inode_acl	= zpl_get_acl,
+#else
 	.get_acl	= zpl_get_acl,
+#endif /* HAVE_GET_INODE_ACL */
 #endif /* CONFIG_FS_POSIX_ACL */
 };

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -1067,7 +1067,7 @@ zpl_get_acl_impl(struct inode *ip, int type)
 	return (acl);
 }
 
-#if defined(HAVE_GET_ACL_RCU)
+#if defined(HAVE_GET_ACL_RCU) || defined(HAVE_GET_INODE_ACL)
 struct posix_acl *
 zpl_get_acl(struct inode *ip, int type, bool rcu)
 {


### PR DESCRIPTION
### Motivation and Context
Backporting some fixes for Linux 6.1 and 6.2 compatibility from master to 2.1.8-staging.