### PR TITLE
2.1.8-staging: ztest fails assertion in zio_write_gang_member_ready()

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2827,7 +2827,7 @@ zio_write_gang_block(zio_t *pio, metaslab_class_t *mc)
 	 * have a third copy.
 	 */
 	gbh_copies = MIN(copies + 1, spa_max_replication(spa));
-	if (gio->io_prop.zp_encrypt && gbh_copies >= SPA_DVAS_PER_BP)
+	if (BP_IS_ENCRYPTED(bp) && gbh_copies >= SPA_DVAS_PER_BP)
 		gbh_copies = SPA_DVAS_PER_BP - 1;
 
 	int flags = METASLAB_HINTBP_FAVOR | METASLAB_GANG_HEADER;


### PR DESCRIPTION
### Motivation and Context
This fixes a real issue that has been observed in production on a fleet of machines run by a customer of Klara Systems. It had been applied in production to their fleet weeks ago with good results, so I highly recommend bringing it into 2.1.8.