### PR TITLE
Cleanup suggested by Linux kernel's coccicheck

### DIFF
--- a/module/icp/algs/aes/aes_impl.c
+++ b/module/icp/algs/aes/aes_impl.c
@@ -211,7 +211,7 @@ aes_alloc_keysched(size_t *size, int kmflag)
 {
 	aes_key_t *keysched;
 
-	keysched = (aes_key_t *)kmem_alloc(sizeof (aes_key_t), kmflag);
+	keysched = kmem_alloc(sizeof (aes_key_t), kmflag);
 	if (keysched != NULL) {
 		*size = sizeof (aes_key_t);
 		return (keysched);

--- a/module/icp/algs/modes/ccm.c
+++ b/module/icp/algs/modes/ccm.c
@@ -657,7 +657,7 @@ ccm_format_initial_blocks(uchar_t *nonce, ulong_t nonceSize,
 	memset(&(b0[1+nonceSize]), 0, q);
 
 	payloadSize = aes_ctx->ccm_data_len;
-	limit = 8 < q ? 8 : q;
+	limit = MIN(8, q);
 
 	for (i = 0, j = 0, k = 15; i < limit; i++, j += 8, k--) {
 		b0[k] = (uint8_t)((payloadSize >> j) & 0xFF);

--- a/module/icp/algs/modes/gcm.c
+++ b/module/icp/algs/modes/gcm.c
@@ -653,7 +653,7 @@ gcm_init_ctx(gcm_ctx_t *gcm_ctx, char *param, size_t block_size,
 		}
 		gcm_ctx->gcm_htab_len = htab_len;
 		gcm_ctx->gcm_Htable =
-		    (uint64_t *)kmem_alloc(htab_len, KM_SLEEP);
+		    kmem_alloc(htab_len, KM_SLEEP);
 
 		if (gcm_ctx->gcm_Htable == NULL) {
 			return (CRYPTO_HOST_MEMORY);
@@ -728,7 +728,7 @@ gmac_init_ctx(gcm_ctx_t *gcm_ctx, char *param, size_t block_size,
 		}
 		gcm_ctx->gcm_htab_len = htab_len;
 		gcm_ctx->gcm_Htable =
-		    (uint64_t *)kmem_alloc(htab_len, KM_SLEEP);
+		    kmem_alloc(htab_len, KM_SLEEP);
 
 		if (gcm_ctx->gcm_Htable == NULL) {
 			return (CRYPTO_HOST_MEMORY);

--- a/module/icp/api/kcf_ctxops.c
+++ b/module/icp/api/kcf_ctxops.c
@@ -88,7 +88,7 @@ crypto_create_ctx_template(crypto_mechanism_t *mech, crypto_key_t *key,
 	if (error != CRYPTO_SUCCESS)
 		return (error);
 
-	if ((ctx_tmpl = (kcf_ctx_template_t *)kmem_alloc(
+	if ((ctx_tmpl = kmem_alloc(
 	    sizeof (kcf_ctx_template_t), KM_SLEEP)) == NULL) {
 		KCF_PROV_REFRELE(pd);
 		return (CRYPTO_HOST_MEMORY);

--- a/module/icp/core/kcf_callprov.c
+++ b/module/icp/core/kcf_callprov.c
@@ -63,7 +63,7 @@ is_in_triedlist(kcf_provider_desc_t *pd, kcf_prov_tried_t *triedl)
 		if (triedl->pt_pd == pd)
 			return (B_TRUE);
 		triedl = triedl->pt_next;
-	};
+	}
 
 	return (B_FALSE);
 }

--- a/module/lua/lfunc.h
+++ b/module/lua/lfunc.h
@@ -12,10 +12,10 @@
 
 
 #define sizeCclosure(n)	(cast(int, sizeof(CClosure)) + \
-                         cast(int, sizeof(TValue)*((n)-1)))
+                         cast(int, sizeof(TValue)*((n))))
 
 #define sizeLclosure(n)	(cast(int, sizeof(LClosure)) + \
-                         cast(int, sizeof(TValue *)*((n)-1)))
+                         cast(int, sizeof(TValue *)*((n))))
 
 
 LUAI_FUNC Proto *luaF_newproto (lua_State *L);

--- a/module/lua/lgc.c
+++ b/module/lua/lgc.c
@@ -1056,7 +1056,7 @@ static lu_mem singlestep (lua_State *L) {
         lu_mem work;
         int sw;
         g->gcstate = GCSatomic;  /* finish mark phase */
-        g->GCestimate = g->GCmemtrav;  /* save what was counted */;
+        g->GCestimate = g->GCmemtrav;  /* save what was counted */
         work = atomic(L);  /* add what was traversed by 'atomic' */
         g->GCestimate += work;  /* estimate of total memory traversed */
         sw = entersweep(L);

--- a/module/lua/lgc.h
+++ b/module/lua/lgc.h
@@ -120,7 +120,7 @@
 
 
 #define luaC_condGC(L,c) \
-	{if (G(L)->GCdebt > 0) {c;}; condchangemem(L);}
+	{if (G(L)->GCdebt > 0) {c;} condchangemem(L);}
 #define luaC_checkGC(L)		luaC_condGC(L, luaC_step(L);)
 
 

--- a/module/lua/lobject.h
+++ b/module/lua/lobject.h
@@ -513,14 +513,14 @@ typedef struct UpVal {
 typedef struct CClosure {
   ClosureHeader;
   lua_CFunction f;
-  TValue upvalue[1];  /* list of upvalues */
+  TValue upvalue[];  /* list of upvalues */
 } CClosure;
 
 
 typedef struct LClosure {
   ClosureHeader;
   struct Proto *p;
-  UpVal *upvals[1];  /* list of upvalues */
+  UpVal *upvals[];  /* list of upvalues */
 } LClosure;
 
 

--- a/module/lua/lvm.c
+++ b/module/lua/lvm.c
@@ -568,7 +568,7 @@ void luaV_finishOp (lua_State *L) {
 #define donextjump(ci)	{ i = *ci->u.l.savedpc; dojump(ci, i, 1); }
 
 
-#define Protect(x)	{ {x;}; base = ci->u.l.base; }
+#define Protect(x)	{ {x;} base = ci->u.l.base; }
 
 #define checkGC(L,c)  \
   Protect( luaC_condGC(L,{L->top = (c);  /* limit of live values */ \

--- a/module/os/freebsd/spl/callb.c
+++ b/module/os/freebsd/spl/callb.c
@@ -146,7 +146,7 @@ callb_add_common(boolean_t (*func)(void *arg, int code),
 		cv_wait(&ct->ct_busy_cv, &ct->ct_lock);
 	if ((cp = ct->ct_freelist) == NULL) {
 		ct->ct_ncallb++;
-		cp = (callb_t *)kmem_zalloc(sizeof (callb_t), KM_SLEEP);
+		cp = kmem_zalloc(sizeof (callb_t), KM_SLEEP);
 	}
 	ct->ct_freelist = cp->c_next;
 	cp->c_thread = t;

--- a/module/os/freebsd/spl/callb.c
+++ b/module/os/freebsd/spl/callb.c
@@ -263,7 +263,7 @@ callb_execute_class(int class, int code)
 	mutex_enter(&ct->ct_lock);
 
 	for (cp = ct->ct_first_cb[class];
-	    cp != NULL && ret == 0; cp = cp->c_next) {
+	    cp != NULL && ret == NULL; cp = cp->c_next) {
 		while (cp->c_flag & CALLB_EXECUTING)
 			cv_wait(&cp->c_done_cv, &ct->ct_lock);
 		/*

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -2041,8 +2041,7 @@ zfs_zaccess_dataset_check(znode_t *zp, uint32_t v4_mode)
 {
 	if ((v4_mode & WRITE_MASK) &&
 	    (zp->z_zfsvfs->z_vfs->vfs_flag & VFS_RDONLY) &&
-	    (!IS_DEVVP(ZTOV(zp)) ||
-	    (IS_DEVVP(ZTOV(zp)) && (v4_mode & WRITE_MASK_ATTRS)))) {
+	    (!IS_DEVVP(ZTOV(zp)) || (v4_mode & WRITE_MASK_ATTRS))) {
 		return (SET_ERROR(EROFS));
 	}
 

--- a/module/os/freebsd/zfs/zfs_debug.c
+++ b/module/os/freebsd/zfs/zfs_debug.c
@@ -30,7 +30,7 @@ typedef struct zfs_dbgmsg {
 	list_node_t zdm_node;
 	time_t zdm_timestamp;
 	uint_t zdm_size;
-	char zdm_msg[1]; /* variable length allocation */
+	char zdm_msg[];
 } zfs_dbgmsg_t;
 
 static list_t zfs_dbgmsgs;
@@ -159,7 +159,7 @@ __zfs_dbgmsg(char *buf)
 
 	DTRACE_PROBE1(zfs__dbgmsg, char *, buf);
 
-	size = sizeof (zfs_dbgmsg_t) + strlen(buf);
+	size = sizeof (zfs_dbgmsg_t) + strlen(buf) + 1;
 	zdm = kmem_zalloc(size, KM_SLEEP);
 	zdm->zdm_size = size;
 	zdm->zdm_timestamp = gethrestime_sec();

--- a/module/os/freebsd/zfs/zio_crypt.c
+++ b/module/os/freebsd/zfs/zio_crypt.c
@@ -1555,13 +1555,12 @@ zio_crypt_init_uios_normal(boolean_t encrypt, uint8_t *plainbuf,
 	iovec_t *plain_iovecs = NULL, *cipher_iovecs = NULL;
 	void *src, *dst;
 
-	cipher_iovecs = kmem_alloc(nr_cipher * sizeof (iovec_t),
+	cipher_iovecs = kmem_zalloc(nr_cipher * sizeof (iovec_t),
 	    KM_SLEEP);
 	if (!cipher_iovecs) {
 		ret = SET_ERROR(ENOMEM);
 		goto error;
 	}
-	memset(cipher_iovecs, 0, nr_cipher * sizeof (iovec_t));
 
 	if (encrypt) {
 		src = plainbuf;

--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -701,7 +701,7 @@ spl_kmem_cache_create(const char *name, size_t size, size_t align,
 
 	skc->skc_magic = SKC_MAGIC;
 	skc->skc_name_size = strlen(name) + 1;
-	skc->skc_name = (char *)kmalloc(skc->skc_name_size, lflags);
+	skc->skc_name = kmalloc(skc->skc_name_size, lflags);
 	if (skc->skc_name == NULL) {
 		kfree(skc);
 		return (NULL);

--- a/module/os/linux/spl/spl-zone.c
+++ b/module/os/linux/spl/spl-zone.c
@@ -50,7 +50,7 @@ typedef struct zone_datasets {
 typedef struct zone_dataset {
 	struct list_head zd_list;	/* zone_dataset linkage */
 	size_t zd_dsnamelen;		/* length of name */
-	char zd_dsname[0];		/* name of the member dataset */
+	char zd_dsname[];		/* name of the member dataset */
 } zone_dataset_t;
 
 #if defined(CONFIG_USER_NS) && defined(HAVE_USER_NS_COMMON_INUM)

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -71,7 +71,7 @@ typedef struct dio_request {
 	atomic_t		dr_ref;		/* References */
 	int			dr_error;	/* Bio error */
 	int			dr_bio_count;	/* Count of bio's */
-	struct bio		*dr_bio[0];	/* Attached bio's */
+	struct bio		*dr_bio[];	/* Attached bio's */
 } dio_request_t;
 
 /*

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -2233,8 +2233,7 @@ static int
 zfs_zaccess_dataset_check(znode_t *zp, uint32_t v4_mode)
 {
 	if ((v4_mode & WRITE_MASK) && (zfs_is_readonly(ZTOZSB(zp))) &&
-	    (!Z_ISDEV(ZTOI(zp)->i_mode) ||
-	    (Z_ISDEV(ZTOI(zp)->i_mode) && (v4_mode & WRITE_MASK_ATTRS)))) {
+	    (!Z_ISDEV(ZTOI(zp)->i_mode) || (v4_mode & WRITE_MASK_ATTRS))) {
 		return (SET_ERROR(EROFS));
 	}
 

--- a/module/os/linux/zfs/zfs_debug.c
+++ b/module/os/linux/zfs/zfs_debug.c
@@ -29,7 +29,7 @@
 typedef struct zfs_dbgmsg {
 	procfs_list_node_t	zdm_node;
 	uint64_t		zdm_timestamp;
-	uint_t		zdm_size;
+	uint_t			zdm_size;
 	char			zdm_msg[1]; /* variable length allocation */
 } zfs_dbgmsg_t;
 

--- a/module/os/linux/zfs/zfs_debug.c
+++ b/module/os/linux/zfs/zfs_debug.c
@@ -30,7 +30,7 @@ typedef struct zfs_dbgmsg {
 	procfs_list_node_t	zdm_node;
 	uint64_t		zdm_timestamp;
 	uint_t			zdm_size;
-	char			zdm_msg[1]; /* variable length allocation */
+	char			zdm_msg[]; /* variable length allocation */
 } zfs_dbgmsg_t;
 
 static procfs_list_t zfs_dbgmsgs;
@@ -135,7 +135,7 @@ __set_error(const char *file, const char *func, int line, int err)
 void
 __zfs_dbgmsg(char *buf)
 {
-	uint_t size = sizeof (zfs_dbgmsg_t) + strlen(buf);
+	uint_t size = sizeof (zfs_dbgmsg_t) + strlen(buf) + 1;
 	zfs_dbgmsg_t *zdm = kmem_zalloc(size, KM_SLEEP);
 	zdm->zdm_size = size;
 	zdm->zdm_timestamp = gethrestime_sec();

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4806,7 +4806,7 @@ arc_flush(spa_t *spa, boolean_t retry)
 	 * no good way to determine if all of a spa's buffers have been
 	 * evicted from an arc state.
 	 */
-	ASSERT(!retry || spa == 0);
+	ASSERT(!retry || spa == NULL);
 
 	if (spa != NULL)
 		guid = spa_load_guid(spa);

--- a/module/zfs/blake3_zfs.c
+++ b/module/zfs/blake3_zfs.c
@@ -47,7 +47,7 @@ void
 abd_checksum_blake3_native(abd_t *abd, uint64_t size, const void *ctx_template,
     zio_cksum_t *zcp)
 {
-	ASSERT(ctx_template != 0);
+	ASSERT(ctx_template != NULL);
 
 #if defined(_KERNEL)
 	BLAKE3_CTX *ctx = blake3_per_cpu_ctx[CPU_SEQID_UNSTABLE];
@@ -76,7 +76,7 @@ abd_checksum_blake3_byteswap(abd_t *abd, uint64_t size,
 {
 	zio_cksum_t tmp;
 
-	ASSERT(ctx_template != 0);
+	ASSERT(ctx_template != NULL);
 
 	abd_checksum_blake3_native(abd, size, ctx_template, &tmp);
 	zcp->zc_word[0] = BSWAP_64(tmp.zc_word[0]);

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -1842,8 +1842,7 @@ send_reader_thread(void *arg)
 				continue;
 			}
 			uint64_t file_max =
-			    (dn->dn_maxblkid < range->end_blkid ?
-			    dn->dn_maxblkid : range->end_blkid);
+			    MIN(dn->dn_maxblkid, range->end_blkid);
 			/*
 			 * The object exists, so we need to try to find the
 			 * blkptr for each block in the range we're processing.

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -281,7 +281,7 @@ typedef struct scan_io {
 	 * event of an error. This array must go at the end of the
 	 * struct to allow this for the variable number of elements.
 	 */
-	dva_t			sio_dva[0];
+	dva_t			sio_dva[];
 } scan_io_t;
 
 #define	SIO_SET_OFFSET(sio, x)		DVA_SET_OFFSET(&(sio)->sio_dva[0], x)

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -270,7 +270,7 @@ typedef struct indirect_split {
 	 */
 	indirect_child_t *is_good_child;
 
-	indirect_child_t is_child[1]; /* variable-length */
+	indirect_child_t is_child[];
 } indirect_split_t;
 
 /*

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -946,9 +946,9 @@ fzap_length(zap_name_t *zn,
 	if (err != 0)
 		goto out;
 
-	if (integer_size != 0)
+	if (integer_size != NULL)
 		*integer_size = zeh.zeh_integer_size;
-	if (num_integers != 0)
+	if (num_integers != NULL)
 		*num_integers = zeh.zeh_num_integers;
 out:
 	zap_put_leaf(l);

--- a/module/zfs/zfs_chksum.c
+++ b/module/zfs/zfs_chksum.c
@@ -251,7 +251,7 @@ chksum_benchmark(void)
 	/* space for the benchmark times */
 	chksum_stat_cnt = 4;
 	chksum_stat_cnt += blake3_impl_getcnt();
-	chksum_stat_data = (chksum_stat_t *)kmem_zalloc(
+	chksum_stat_data = kmem_zalloc(
 	    sizeof (chksum_stat_t) * chksum_stat_cnt, KM_SLEEP);
 
 	/* edonr - needs to be the first one here (slow CPU check) */

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -622,7 +622,7 @@ zfs_fuid_create(zfsvfs_t *zfsvfs, uint64_t id, cred_t *cr,
 			rid = FUID_RID(fuidp->z_fuid_group);
 			idx = FUID_INDEX(fuidp->z_fuid_group);
 			break;
-		};
+		}
 		domain = fuidp->z_domain_table[idx - 1];
 	} else {
 		if (type == ZFS_OWNER || type == ZFS_ACE_USER)

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -876,7 +876,7 @@ zfs_get_data(void *arg, uint64_t gen, lr_write_t *lr, char *buf,
 		return (SET_ERROR(ENOENT));
 	}
 
-	zgd = (zgd_t *)kmem_zalloc(sizeof (zgd_t), KM_SLEEP);
+	zgd = kmem_zalloc(sizeof (zgd_t), KM_SLEEP);
 	zgd->zgd_lwb = lwb;
 	zgd->zgd_private = zp;
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -646,7 +646,7 @@ zvol_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
 	ASSERT3P(zio, !=, NULL);
 	ASSERT3U(size, !=, 0);
 
-	zgd = (zgd_t *)kmem_zalloc(sizeof (zgd_t), KM_SLEEP);
+	zgd = kmem_zalloc(sizeof (zgd_t), KM_SLEEP);
 	zgd->zgd_lwb = lwb;
 
 	/*

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -784,9 +784,9 @@ create_fallback_mem(struct zstd_fallback_mem *mem, size_t size)
 static void __init
 zstd_mempool_init(void)
 {
-	zstd_mempool_cctx = (struct zstd_pool *)
+	zstd_mempool_cctx =
 	    kmem_zalloc(ZSTD_POOL_MAX * sizeof (struct zstd_pool), KM_SLEEP);
-	zstd_mempool_dctx = (struct zstd_pool *)
+	zstd_mempool_dctx =
 	    kmem_zalloc(ZSTD_POOL_MAX * sizeof (struct zstd_pool), KM_SLEEP);
 
 	for (int i = 0; i < ZSTD_POOL_MAX; i++) {


### PR DESCRIPTION
### Motivation and Context
Upon reading an article discussing the PVS Studio's developers most recent analysis of the Linux kernel, I noticed that it spoke well of Linux's "Coccinelle analyzer":

https://pvs-studio.com/en/blog/posts/cpp/0858/

I had not considered Coccinelle to be a static analyzer since its primarily purpose is semantic patching, but it appears that the Linux kernel has adopted it as a QA tool for detecting patterns in the kernel source code that probably merit cleanup:

https://www.kernel.org/doc/html/latest/dev-tools/coccinelle.html

Inspired by that, I tried running it on the OpenZFS kernel modules. Its devm_free.cocci, pci_free_consistent.cocci and of_table.cocci checks caused the spatch tool to crash. However, the rest of the checks worked. It only succeeded in identifying various cleanup opportunities. It tried to find some actual bugs, since it claimed to have caught 3 NULL pointer dereferences, but it was unsuccessful since the reports were false positives. In specific, it reported three NULL pointer dereferences on this:

```
                        IMPLY(lwb != NULL, 
                            lwb->lwb_state == LWB_STATE_ISSUED ||
                            lwb->lwb_state == LWB_STATE_WRITE_DONE ||
                            lwb->lwb_state == LWB_STATE_FLUSH_DONE);
```

However, it reported none on this:

```
IMPLY(lwb != NULL, lwb->lwb_state != LWB_STATE_CLOSED);
```

Interestingly, it scanned the FreeBSD code in the tree, and reported a few cleanup possibilities in it.

I have addressed most of the reports that it made. The ones that I did not address were:

* 9 suggestions to use `swap()` - that is not cross platform compatible
* 7 suggestions to use `ARRAY_SIZE()` - this appears to be cross platform compatible, but I wanted to double check the safety of our ARRAY_SIZE macro in the contexts it identified and was busy with other things.
* 4 suggestions that a NULL check before some freeing functions is not needed. - I am not sure if this is cross platform compatible
* 1 suggestion to use `kvfree()` in the SPL - this is not compatible with Linux 3.10; we might as well continue doing the equivalent of `kvfree()` to avoid unnecessary code bloat.
* 5 nonsensical suggestions from ./scripts/coccinelle/api/stream_open.cocci that are likely a bug in either the .cocci file or in spatch.
* 1 suggestion to use `MIN()` - 2 of these suggestions were taken elsewhere, but not in the zstd code since the headers currently used do not provide `MIN()`. More details are in the relevant commit message.
* 1 suggestion to use `kmem_cache_zalloc()` instead of `kmem_cache_alloc()`+`memset()` - kmem_cache_zalloc() is non-portable and while we could use a constructor, we might as well just continue using `memset()` to zero memory since that avoids a pointer indirection.
* 1 suggestion to convert `->i_count` in `struct inode` from `atomic_t` to `refcount_t` - this is up to mainline Linux. I would not be surprised if they change this at some point.
* The 3 false positives where it claimed `IMPLY` had 3 NULL pointer dereferences.

### Description
The changes are documented in the patch commit messages.

### How Has This Been Tested?
A local build test has been done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
