### PR TITLE
CI: remove unused packages/snaps

### DIFF
--- a/.github/workflows/scripts/reclaim_disk_space.sh
+++ b/.github/workflows/scripts/reclaim_disk_space.sh
@@ -1,9 +1,12 @@
-#!/bin/sh
+#!/bin/sh -x
 
 set -eu
 
 # remove 4GiB of images
 sudo systemd-run docker system prune --force --all --volumes
+
+# remove unused packages
+sudo apt remove -q --purge firefox
 
 # remove unused software
 sudo systemd-run rm -rf \
@@ -11,10 +14,6 @@ sudo systemd-run rm -rf \
   /opt/* \
   /usr/local/* \
   /usr/share/az* \
-  /usr/share/dotnet \
   /usr/share/gradle* \
   /usr/share/miniconda \
-  /usr/share/swift \
-  /var/lib/gems \
-  /var/lib/mysql \
-  /var/lib/snapd
+  /usr/share/swift


### PR DESCRIPTION
### Motivation and Context

Attempt to resolve the frequent errors recently reported by `apt update` on the GitHub action builders.

### Description

Removing portions of packages/snaps directly with rm can result in unexpected errors when running `apt update`.  Free up the additional space by removing (most) packages with the proper tools.

This change frees up slightly less space than before, but it is expected to still be sufficient.

### How Has This Been Tested?

Tested the updated workflow `reclaim_disk_space.sh` script behaves as intended.  With this change I have been unable to reproduce the `apt update` errors.  A full CI run should confirm if after there change these is still enough free space in the image for a full ZTS run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
