### PR TITLE
change how d_alias is replaced by du.d_alias

### DIFF
--- a/include/os/linux/kernel/linux/dcache_compat.h
+++ b/include/os/linux/kernel/linux/dcache_compat.h
@@ -35,6 +35,10 @@
 #define	d_make_root(inode)	d_alloc_root(inode)
 #endif /* HAVE_D_MAKE_ROOT */
 
+#ifdef HAVE_DENTRY_D_U_ALIASES
+#define	d_alias			d_u.d_alias
+#endif
+
 /*
  * 2.6.30 API change,
  * The const keyword was added to the 'struct dentry_operations' in
@@ -70,11 +74,7 @@ zpl_d_drop_aliases(struct inode *inode)
 {
 	struct dentry *dentry;
 	spin_lock(&inode->i_lock);
-#ifdef HAVE_DENTRY_D_U_ALIASES
-	hlist_for_each_entry(dentry, &inode->i_dentry, d_u.d_alias) {
-#else
 	hlist_for_each_entry(dentry, &inode->i_dentry, d_alias) {
-#endif
 		if (!IS_ROOT(dentry) && !d_mountpoint(dentry) &&
 		    (dentry->d_inode == inode)) {
 			d_drop(dentry);


### PR DESCRIPTION
d_alias may need to be converted to du.d_alias
depending on the kernel version.
d_alias is currently in only one place in the code which changes
"hlist_for_each_entry(dentry, &inode->i_dentry, d_alias)" to
"hlist_for_each_entry(dentry, &inode->i_dentry, d_u.d_alias)" as neccesary.

This effectively results in a double macro expansion for code that uses the zfs headers but already has its own macro for just d_alias (lustre in this case).

Remove the conditional code for hlist_for_each_entry and have a macro for "d_alias -> du.d_alias" instead.

Signed-off-by: Gian-Carlo DeFazio <defazio1@llnl.gov>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
