### PR TITLE
zfs_receive_one: Check for the more likely error first

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -5084,14 +5084,14 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 			*cp = '@';
 			break;
 		case EINVAL:
-			if (flags->resumable) {
-				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "kernel modules must be upgraded to "
-				    "receive this stream."));
-			} else if (embedded && !raw) {
+			if (embedded && !raw) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "incompatible embedded data stream "
 				    "feature with encrypted receive."));
+			} else if (flags->resumable) {
+				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+				    "kernel modules must be upgraded to "
+				    "receive this stream."));
 			}
 			(void) zfs_error(hdl, EZFS_BADSTREAM, errbuf);
 			break;


### PR DESCRIPTION
### Motivation and Context
Went receiving an unencrypted replication stream, and enabling encryption on the receive side, if the sender enabled the `DMU_BACKUP_FEATURE_EMBED_DATA` flag, and the receive side enabled the resumable flag, the wrong error message is returned:
`kernel modules must be upgraded to receive this stream`
rather than
`incompatible embedded data stream feature with encrypted receive.`

### Description
If zfs_receive_one() gets back EINVAL, check for the more likely case, embedded block pointers + encryption and return that error, before falling back to the less likely case, a resumable stream when the kernel has not been upgraded to support resume.

Sponsored-by: rsync.net
Sponsored-by: Klara Inc.

### How Has This Been Tested?
It has not

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
