### PR TITLE
Linux 4.12 compat: PF_FSTRANS became PF_MEMALLOC_NOFS

### DIFF
--- a/include/os/linux/spl/sys/kmem.h
+++ b/include/os/linux/spl/sys/kmem.h
@@ -97,9 +97,11 @@ typedef struct {
 #endif
 
 /*
- * PF_FSTRANS is removed from Linux 4.12
+ * Linux 4.12 replaced PF_FSTRANS with PF_MEMALLOC_NOFS
  */
-#ifdef PF_FSTRANS
+#ifdef PF_MEMALLOC_NOFS
+#define	__SPL_PF_FSTRANS (PF_MEMALLOC_NOFS)
+#elif defined(PF_FSTRANS)
 #define	__SPL_PF_FSTRANS (PF_FSTRANS)
 #else
 #define	__SPL_PF_FSTRANS (0)


### PR DESCRIPTION
### Motivation and Context
When Linux 4.12 support was initially implemented, we had not noticed that PF_FSTRANS had been removed in favor of PF_MEMALLOC_NOFS, so we have only had the benefit of PF_MEMALLOC_NOIO so far. That might have been enough had it been a superset of PF_MEMALLOC_NOFS, but to be certain, we should use PF_MEMALLOC_NOFS too.

### Description
If PF_MEMALLOC_NOFS is defined, we use it as part of `spl_fstrans_mark()`/`spl_fstrans_unmark()`.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
