### PR TITLE
Linux ppc64le ieee128 compat: Do not redefine __asm on external headers

### DIFF
--- a/module/zfs/vdev_raidz_math_powerpc_altivec_common.h
+++ b/module/zfs/vdev_raidz_math_powerpc_altivec_common.h
@@ -26,10 +26,6 @@
 #include <sys/types.h>
 #include <sys/simd.h>
 
-#ifdef __linux__
-#define	__asm __asm__ __volatile__
-#endif
-
 #define	_REG_CNT(_0, _1, _2, _3, _4, _5, _6, _7, N, ...) N
 #define	REG_CNT(r...) _REG_CNT(r, 8, 7, 6, 5, 4, 3, 2, 1)
 
@@ -142,7 +138,7 @@ typedef struct v {
 {								\
 	switch (REG_CNT(r)) {					\
 	case 8:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"lvx 21,0,%[SRC0]\n"				\
 		"lvx 20,0,%[SRC1]\n"				\
 		"lvx 19,0,%[SRC2]\n"				\
@@ -172,7 +168,7 @@ typedef struct v {
 		:	"v18", "v19", "v20", "v21");		\
 		break;						\
 	case 4:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"lvx 21,0,%[SRC0]\n"				\
 		"lvx 20,0,%[SRC1]\n"				\
 		"lvx 19,0,%[SRC2]\n"				\
@@ -189,7 +185,7 @@ typedef struct v {
 		:	"v18", "v19", "v20", "v21");		\
 		break;						\
 	case 2:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"lvx 21,0,%[SRC0]\n"				\
 		"lvx 20,0,%[SRC1]\n"				\
 		"vxor " VR0(r) "," VR0(r) ",21\n"		\
@@ -208,7 +204,7 @@ typedef struct v {
 {								\
 	switch (REG_CNT(r)) {					\
 	case 8:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"vxor " VR4(r) "," VR4(r) "," VR0(r) "\n"	\
 		"vxor " VR5(r) "," VR5(r) "," VR1(r) "\n"	\
 		"vxor " VR6(r) "," VR6(r) "," VR2(r) "\n"	\
@@ -217,7 +213,7 @@ typedef struct v {
 		:	RVR0(r), RVR1(r), RVR2(r), RVR3(r));	\
 		break;						\
 	case 4:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"vxor " VR2(r) "," VR2(r) "," VR0(r) "\n"	\
 		"vxor " VR3(r) "," VR3(r) "," VR1(r) "\n"	\
 		:	UVR2(r), UVR3(r)			\
@@ -232,7 +228,7 @@ typedef struct v {
 {								\
 	switch (REG_CNT(r)) {					\
 	case 8:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"vxor " VR0(r) "," VR0(r) "," VR0(r) "\n"	\
 		"vxor " VR1(r) "," VR1(r) "," VR1(r) "\n"	\
 		"vxor " VR2(r) "," VR2(r) "," VR2(r) "\n"	\
@@ -245,7 +241,7 @@ typedef struct v {
 			WVR4(r), WVR5(r), WVR6(r), WVR7(r));	\
 		break;						\
 	case 4:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"vxor " VR0(r) "," VR0(r) "," VR0(r) "\n"	\
 		"vxor " VR1(r) "," VR1(r) "," VR1(r) "\n"	\
 		"vxor " VR2(r) "," VR2(r) "," VR2(r) "\n"	\
@@ -253,7 +249,7 @@ typedef struct v {
 		:	WVR0(r), WVR1(r), WVR2(r), WVR3(r));	\
 		break;						\
 	case 2:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"vxor " VR0(r) "," VR0(r) "," VR0(r) "\n"	\
 		"vxor " VR1(r) "," VR1(r) "," VR1(r) "\n"	\
 		:	WVR0(r), WVR1(r));			\
@@ -267,7 +263,7 @@ typedef struct v {
 {								\
 	switch (REG_CNT(r)) {					\
 	case 8:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"vor " VR4(r) "," VR0(r) "," VR0(r) "\n"	\
 		"vor " VR5(r) "," VR1(r) "," VR1(r) "\n"	\
 		"vor " VR6(r) "," VR2(r) "," VR2(r) "\n"	\
@@ -276,7 +272,7 @@ typedef struct v {
 		:	RVR0(r), RVR1(r), RVR2(r), RVR3(r));	\
 		break;						\
 	case 4:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"vor " VR2(r) "," VR0(r) "," VR0(r) "\n"	\
 		"vor " VR3(r) "," VR1(r) "," VR1(r) "\n"	\
 		:	WVR2(r), WVR3(r)			\
@@ -291,7 +287,7 @@ typedef struct v {
 {								\
 	switch (REG_CNT(r)) {					\
 	case 8:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"lvx " VR0(r) " ,0,%[SRC0]\n"			\
 		"lvx " VR1(r) " ,0,%[SRC1]\n"			\
 		"lvx " VR2(r) " ,0,%[SRC2]\n"			\
@@ -312,7 +308,7 @@ typedef struct v {
 		[SRC7] "r" ((OFFSET(src, 112))));		\
 		break;						\
 	case 4:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"lvx " VR0(r) " ,0,%[SRC0]\n"			\
 		"lvx " VR1(r) " ,0,%[SRC1]\n"			\
 		"lvx " VR2(r) " ,0,%[SRC2]\n"			\
@@ -324,7 +320,7 @@ typedef struct v {
 		[SRC3] "r" ((OFFSET(src, 48))));		\
 		break;						\
 	case 2:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"lvx " VR0(r) " ,0,%[SRC0]\n"			\
 		"lvx " VR1(r) " ,0,%[SRC1]\n"			\
 		:	WVR0(r), WVR1(r)			\
@@ -340,7 +336,7 @@ typedef struct v {
 {								\
 	switch (REG_CNT(r)) {					\
 	case 8:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"stvx " VR0(r) " ,0,%[DST0]\n"			\
 		"stvx " VR1(r) " ,0,%[DST1]\n"			\
 		"stvx " VR2(r) " ,0,%[DST2]\n"			\
@@ -362,7 +358,7 @@ typedef struct v {
 		:	"memory");				\
 		break;						\
 	case 4:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"stvx " VR0(r) " ,0,%[DST0]\n"			\
 		"stvx " VR1(r) " ,0,%[DST1]\n"			\
 		"stvx " VR2(r) " ,0,%[DST2]\n"			\
@@ -375,7 +371,7 @@ typedef struct v {
 		: "memory");					\
 		break;						\
 	case 2:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"stvx " VR0(r) " ,0,%[DST0]\n"			\
 		"stvx " VR1(r) " ,0,%[DST1]\n"			\
 		: :	[DST0] "r" ((OFFSET(dst, 0))),		\
@@ -400,7 +396,7 @@ typedef struct v {
 
 #define	MUL2_SETUP()						\
 {								\
-	__asm(							\
+	__asm__ __volatile__(					\
 		"vspltisb " VR(16) ",14\n"			\
 		"vspltisb " VR(17) ",15\n"			\
 		"vaddubm " VR(16) "," VR(17) "," VR(16) "\n"	\
@@ -412,7 +408,7 @@ typedef struct v {
 {								\
 	switch (REG_CNT(r)) {					\
 	case 4:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"vcmpgtsb 19," VR(17) "," VR0(r) "\n"		\
 		"vcmpgtsb 18," VR(17) "," VR1(r) "\n"		\
 		"vcmpgtsb 21," VR(17) "," VR2(r) "\n"		\
@@ -434,7 +430,7 @@ typedef struct v {
 		:	"v18", "v19", "v20", "v21");		\
 		break;						\
 	case 2:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		"vcmpgtsb 19," VR(17) "," VR0(r) "\n"		\
 		"vcmpgtsb 18," VR(17) "," VR1(r) "\n"		\
 		"vand 19,19," VR(16) "\n"			\
@@ -478,7 +474,7 @@ typedef struct v {
 {								\
 	switch (REG_CNT(r)) {					\
 	case 2:							\
-		__asm(						\
+		__asm__ __volatile__(				\
 		/* lts for upper part */			\
 		"vspltisb 15,15\n"				\
 		"lvx 10,0,%[lt0]\n"				\


### PR DESCRIPTION
### Motivation and Context
There is an external assembly declaration extension in GNU C that glibc uses when building with ieee128 floating point support on ppc64le. Marking that as volatile makes no sense, so the build breaks.

### Description
It does not make sense to only mark this as volatile on Linux, since if do not want the compiler reordering things on Linux, we do not want the compiler reordering things on any other platform, so we stop treating Linux specially and just manually inline the CPP macro so that we can eliminate it. This should fix the build on ppc64le.

### How Has This Been Tested?
~~I plan to ask @gyakovlev to test it.~~

@gyakovlev has confirmed that applying this patch to 2.1.7 fixes the build.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
