### PR TITLE
CI: Reclaim space after package operations

### DIFF
--- a/.github/workflows/scripts/reclaim_disk_space.sh
+++ b/.github/workflows/scripts/reclaim_disk_space.sh
@@ -1,12 +1,9 @@
-#!/bin/sh -x
+#!/bin/sh
 
 set -eu
 
 # remove 4GiB of images
 sudo systemd-run docker system prune --force --all --volumes
-
-# remove unused packages
-sudo apt remove -q --purge firefox
 
 # remove unused software
 sudo systemd-run rm -rf \
@@ -14,6 +11,10 @@ sudo systemd-run rm -rf \
   /opt/* \
   /usr/local/* \
   /usr/share/az* \
+  /usr/share/dotnet \
   /usr/share/gradle* \
   /usr/share/miniconda \
-  /usr/share/swift
+  /usr/share/swift \
+  /var/lib/gems \
+  /var/lib/mysql \
+  /var/lib/snapd

--- a/.github/workflows/zfs-tests-functional.yml
+++ b/.github/workflows/zfs-tests-functional.yml
@@ -15,9 +15,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-    - name: Reclaim disk space
-      run: |
-        ${{ github.workspace }}/.github/workflows/scripts/reclaim_disk_space.sh
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -58,8 +55,9 @@ jobs:
     - name: Clear the kernel ring buffer
       run: |
         sudo dmesg -c >/var/tmp/dmesg-prerun
-    - name: Report disk space
+    - name: Reclaim and report disk space
       run: |
+        ${{ github.workspace }}/.github/workflows/scripts/reclaim_disk_space.sh
         df -h /
     - name: Tests
       run: |

--- a/.github/workflows/zfs-tests-sanity.yml
+++ b/.github/workflows/zfs-tests-sanity.yml
@@ -11,9 +11,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-    - name: Reclaim disk space
-      run: |
-        ${{ github.workspace }}/.github/workflows/scripts/reclaim_disk_space.sh
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -54,8 +51,9 @@ jobs:
     - name: Clear the kernel ring buffer
       run: |
         sudo dmesg -c >/var/tmp/dmesg-prerun
-    - name: Report disk space
+    - name: Reclaim and report disk space
       run: |
+        ${{ github.workspace }}/.github/workflows/scripts/reclaim_disk_space.sh
         df -h /
     - name: Tests
       run: |


### PR DESCRIPTION
### Motivation and Context

Follow up to 6320b9e68e03cdf390b444693e06aaa51a49f0ca.  We may want to iterate on this more after observing additional CI test runs and what issue they encounter.

### Description

Removing portions of packages/snaps directly with rm can result in unexpected errors when running `apt update`.  For example:

  Unpacking powershell (7.3.1-1.deb) over (7.2.8-1.deb) ...
  dpkg: error processing archive 22-powershell_7.3.1-1.deb_amd64.deb
  unable to open '/usr/local/share/man/man1/pwsh.1.gz.dpkg-new':
     No such file or directory

Remove powershell with apt and leave the contents of /usr/local/.

### How Has This Been Tested?

A few CI invocations.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
