### PR TITLE
Avoid passing an uninitialized index to dsl_prop_known_index

### DIFF
--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -123,7 +123,7 @@ dsl_prop_get_dd(dsl_dir_t *dd, const char *propname,
 		/* Check for a iuv value. */
 		err = zap_lookup(mos, dsl_dir_phys(dd)->dd_props_zapobj,
 		    iuvstr, intsz, numints, buf);
-		if (err == 0 && dsl_prop_known_index(zfs_name_to_prop(propname),
+		if (err == 0 && dsl_prop_known_index(prop,
 		    *(uint64_t *)buf) != 1)
 			err = ENOENT;
 		if (err != ENOENT) {

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -123,7 +123,7 @@ dsl_prop_get_dd(dsl_dir_t *dd, const char *propname,
 		/* Check for a iuv value. */
 		err = zap_lookup(mos, dsl_dir_phys(dd)->dd_props_zapobj,
 		    iuvstr, intsz, numints, buf);
-		if (dsl_prop_known_index(zfs_name_to_prop(propname),
+		if (err == 0 && dsl_prop_known_index(zfs_name_to_prop(propname),
 		    *(uint64_t *)buf) != 1)
 			err = ENOENT;
 		if (err != ENOENT) {


### PR DESCRIPTION
The change addresses a report from KMSAN on FreeBSD, triggered by FreeBSD's regression test suite.

### Description
If the ZAP object doesn't contain the "iuv" key, then we would end up looking up a property index using an uninitialized value for the index. I suspect that this won't cause any problems on its own, but is undefined behaviour and runs afoul of the uninitialized memory sanitizer.

### How Has This Been Tested?
Re-running the tests which triggered the report.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
