### PR TITLE
create zap for root vdev

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -7630,6 +7630,9 @@ mos_leak_vdev(vdev_t *vd)
 		mos_obj_refd(space_map_object(ms->ms_sm));
 	}
 
+	if (vd->vdev_root_zap != 0)
+		mos_obj_refd(vd->vdev_root_zap);
+
 	if (vd->vdev_top_zap != 0) {
 		mos_obj_refd(vd->vdev_top_zap);
 		mos_leak_vdev_top_zap(vd);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -816,6 +816,7 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_FEATURES_FOR_READ	"features_for_read"
 #define	ZPOOL_CONFIG_FEATURE_STATS	"feature_stats"	/* not stored on disk */
 #define	ZPOOL_CONFIG_ERRATA		"errata"	/* not stored on disk */
+#define	ZPOOL_CONFIG_VDEV_ROOT_ZAP	"com.klarasystems:vdev_zap_root"
 #define	ZPOOL_CONFIG_VDEV_TOP_ZAP	"com.delphix:vdev_zap_top"
 #define	ZPOOL_CONFIG_VDEV_LEAF_ZAP	"com.delphix:vdev_zap_leaf"
 #define	ZPOOL_CONFIG_HAS_PER_VDEV_ZAPS	"com.delphix:has_per_vdev_zaps"

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -277,6 +277,7 @@ struct vdev {
 	kthread_t	*vdev_open_thread; /* thread opening children	*/
 	kthread_t	*vdev_validate_thread; /* thread validating children */
 	uint64_t	vdev_crtxg;	/* txg when top-level was added */
+	uint64_t	vdev_root_zap;
 
 	/*
 	 * Top-level vdev state.

--- a/include/zfeature_common.h
+++ b/include/zfeature_common.h
@@ -79,6 +79,7 @@ typedef enum spa_feature {
 	SPA_FEATURE_HEAD_ERRLOG,
 	SPA_FEATURE_BLAKE3,
 	SPA_FEATURE_BLOCK_CLONING,
+	SPA_FEATURE_AVZ_V2,
 	SPA_FEATURES
 } spa_feature_t;
 

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -587,7 +587,7 @@
     <elf-symbol name='fletcher_4_superscalar_ops' size='128' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='libzfs_config_ops' size='16' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='sa_protocol_names' size='16' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='spa_feature_table' size='2128' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='spa_feature_table' size='2184' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfeature_checks_disable' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_deleg_perm_tab' size='512' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_history_event_names' size='328' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -5748,7 +5748,8 @@
       <enumerator name='SPA_FEATURE_HEAD_ERRLOG' value='35'/>
       <enumerator name='SPA_FEATURE_BLAKE3' value='36'/>
       <enumerator name='SPA_FEATURE_BLOCK_CLONING' value='37'/>
-      <enumerator name='SPA_FEATURES' value='38'/>
+      <enumerator name='SPA_FEATURE_AVZ_V2' value='38'/>
+      <enumerator name='SPA_FEATURES' value='39'/>
     </enum-decl>
     <typedef-decl name='spa_feature_t' type-id='33ecb627' id='d6618c78'/>
     <qualified-type-def type-id='22cce67b' const='yes' id='d2816df0'/>
@@ -8634,8 +8635,8 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='module/zcommon/zfeature_common.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='83f29ca2' size-in-bits='17024' id='9944fffc'>
-      <subrange length='38' type-id='7359adad' id='aa4ccdac'/>
+    <array-type-def dimensions='1' type-id='83f29ca2' size-in-bits='17472' id='dd432c71'>
+      <subrange length='39' type-id='7359adad' id='ae4a9561'/>
     </array-type-def>
     <enum-decl name='zfeature_flags' id='6db816a4'>
       <underlying-type type-id='9cac1fee'/>
@@ -8712,7 +8713,7 @@
     <pointer-type-def type-id='611586a1' size-in-bits='64' id='2e243169'/>
     <qualified-type-def type-id='eaa32e2f' const='yes' id='83be723c'/>
     <pointer-type-def type-id='83be723c' size-in-bits='64' id='7acd98a2'/>
-    <var-decl name='spa_feature_table' type-id='9944fffc' mangled-name='spa_feature_table' visibility='default' elf-symbol-id='spa_feature_table'/>
+    <var-decl name='spa_feature_table' type-id='dd432c71' mangled-name='spa_feature_table' visibility='default' elf-symbol-id='spa_feature_table'/>
     <var-decl name='zfeature_checks_disable' type-id='c19b74c3' mangled-name='zfeature_checks_disable' visibility='default' elf-symbol-id='zfeature_checks_disable'/>
     <function-decl name='opendir' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='80f4b756'/>

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2859,6 +2859,7 @@ zpool_vdev_is_interior(const char *name)
 	    strncmp(name, VDEV_TYPE_SPARE, strlen(VDEV_TYPE_SPARE)) == 0 ||
 	    strncmp(name,
 	    VDEV_TYPE_REPLACING, strlen(VDEV_TYPE_REPLACING)) == 0 ||
+	    strncmp(name, VDEV_TYPE_ROOT, strlen(VDEV_TYPE_ROOT)) == 0 ||
 	    strncmp(name, VDEV_TYPE_MIRROR, strlen(VDEV_TYPE_MIRROR)) == 0)
 		return (B_TRUE);
 

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -1927,9 +1927,8 @@ for_each_vdev_cb(void *zhp, nvlist_t *nv, pool_vdev_iter_f func,
 	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE, &type) != 0)
 		return (ret);
 
-	/* Don't run our function on root or indirect vdevs */
-	if ((strcmp(type, VDEV_TYPE_ROOT) != 0) &&
-	    (strcmp(type, VDEV_TYPE_INDIRECT) != 0)) {
+	/* Don't run our function on indirect vdevs */
+	if (strcmp(type, VDEV_TYPE_INDIRECT) != 0) {
 		ret |= func(zhp, nv, data);
 	}
 

--- a/man/man7/zpool-features.7
+++ b/man/man7/zpool-features.7
@@ -858,6 +858,22 @@ by user and group.
 \*[instant-never]
 \*[remount-upgrade]
 .
+.feature com.klarasystems vdev_zaps_v2 no
+This feature creates a ZAP object for the root vdev.
+.Pp
+This feature becomes active after the next
+.Nm zpool Cm import
+or
+.Nm zpool reguid .
+.
+Properties can be retrieved or set on the root vdev using
+.Nm zpool Cm get
+and
+.Nm zpool Cm set
+with
+.Sy root
+as the vdev name which is an alias for
+.Sy root-0 .
 .feature org.openzfs zilsaxattr yes extensible_dataset
 This feature enables
 .Sy xattr Ns = Ns Sy sa

--- a/module/zcommon/zfeature_common.c
+++ b/module/zcommon/zfeature_common.c
@@ -731,6 +731,12 @@ zpool_feature_init(void)
 	    ZFEATURE_FLAG_READONLY_COMPAT, ZFEATURE_TYPE_BOOLEAN, NULL,
 	    sfeatures);
 
+	zfeature_register(SPA_FEATURE_AVZ_V2,
+	    "com.klarasystems:vdev_zaps_v2", "vdev_zaps_v2",
+	    "Support for root vdev ZAP.",
+	    ZFEATURE_FLAG_MOS, ZFEATURE_TYPE_BOOLEAN, NULL,
+	    sfeatures);
+
 	zfs_mod_list_supported_free(sfeatures);
 }
 

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3044,6 +3044,12 @@ vdev_count_verify_zaps(vdev_t *vd)
 	spa_t *spa = vd->vdev_spa;
 	uint64_t total = 0;
 
+	if (spa_feature_is_active(vd->vdev_spa, SPA_FEATURE_AVZ_V2) &&
+	    vd->vdev_root_zap != 0) {
+		total++;
+		ASSERT0(zap_lookup_int(spa->spa_meta_objset,
+		    spa->spa_all_vdev_zaps, vd->vdev_root_zap));
+	}
 	if (vd->vdev_top_zap != 0) {
 		total++;
 		ASSERT0(zap_lookup_int(spa->spa_meta_objset,
@@ -8625,6 +8631,11 @@ spa_avz_build(vdev_t *vd, uint64_t avz, dmu_tx_t *tx)
 {
 	spa_t *spa = vd->vdev_spa;
 
+	if (vd->vdev_root_zap != 0 &&
+	    spa_feature_is_active(spa, SPA_FEATURE_AVZ_V2)) {
+		VERIFY0(zap_add_int(spa->spa_meta_objset, avz,
+		    vd->vdev_root_zap, tx));
+	}
 	if (vd->vdev_top_zap != 0) {
 		VERIFY0(zap_add_int(spa->spa_meta_objset, avz,
 		    vd->vdev_top_zap, tx));

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -573,6 +573,12 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 			    vd->vdev_top_zap);
 		}
 
+		if (vd->vdev_ops == &vdev_root_ops && vd->vdev_root_zap != 0 &&
+		    spa_feature_is_active(vd->vdev_spa, SPA_FEATURE_AVZ_V2)) {
+			fnvlist_add_uint64(nv, ZPOOL_CONFIG_VDEV_ROOT_ZAP,
+			    vd->vdev_root_zap);
+		}
+
 		if (vd->vdev_resilver_deferred) {
 			ASSERT(vd->vdev_ops->vdev_op_leaf);
 			ASSERT(spa->spa_resilver_deferred);

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -393,7 +393,7 @@ tags = ['functional', 'cli_root', 'zpool_export']
 
 [tests/functional/cli_root/zpool_get]
 tests = ['zpool_get_001_pos', 'zpool_get_002_pos', 'zpool_get_003_pos',
-    'zpool_get_004_neg', 'zpool_get_005_pos']
+    'zpool_get_004_neg', 'zpool_get_005_pos', 'vdev_get_001_pos']
 tags = ['functional', 'cli_root', 'zpool_get']
 
 [tests/functional/cli_root/zpool_history]
@@ -481,7 +481,7 @@ tags = ['functional', 'cli_root', 'zpool_scrub']
 
 [tests/functional/cli_root/zpool_set]
 tests = ['zpool_set_001_pos', 'zpool_set_002_neg', 'zpool_set_003_neg',
-    'zpool_set_ashift', 'zpool_set_features']
+    'zpool_set_ashift', 'zpool_set_features', 'vdev_set_001_pos']
 tags = ['functional', 'cli_root', 'zpool_set']
 
 [tests/functional/cli_root/zpool_split]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -178,6 +178,7 @@ nobase_dist_datadir_zfs_tests_tests_DATA += \
 	functional/cli_root/zpool_expand/zpool_expand.cfg \
 	functional/cli_root/zpool_export/zpool_export.cfg \
 	functional/cli_root/zpool_export/zpool_export.kshlib \
+	functional/cli_root/zpool_get/vdev_get.cfg \
 	functional/cli_root/zpool_get/zpool_get.cfg \
 	functional/cli_root/zpool_get/zpool_get_parsable.cfg \
 	functional/cli_root/zpool_import/blockfiles/cryptv0.dat.bz2 \
@@ -1032,6 +1033,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_export/zpool_export_004_pos.ksh \
 	functional/cli_root/zpool_get/cleanup.ksh \
 	functional/cli_root/zpool_get/setup.ksh \
+	functional/cli_root/zpool_get/vdev_get_001_pos.ksh \
 	functional/cli_root/zpool_get/zpool_get_001_pos.ksh \
 	functional/cli_root/zpool_get/zpool_get_002_pos.ksh \
 	functional/cli_root/zpool_get/zpool_get_003_pos.ksh \
@@ -1146,6 +1148,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_set/cleanup.ksh \
 	functional/cli_root/zpool_set/setup.ksh \
 	functional/cli_root/zpool/setup.ksh \
+	functional/cli_root/zpool_set/vdev_set_001_pos.ksh \
 	functional/cli_root/zpool_set/zpool_set_001_pos.ksh \
 	functional/cli_root/zpool_set/zpool_set_002_neg.ksh \
 	functional/cli_root/zpool_set/zpool_set_003_neg.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/vdev_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/vdev_get.cfg
@@ -1,0 +1,73 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2022, Klara Inc.
+#
+
+# Set the expected properties of a vdev
+typeset -a properties=(
+    capacity
+    state
+    guid
+    asize
+    psize
+    ashift
+    size
+    free
+    allocated
+    comment
+    expandsize
+    fragmentation
+    bootsize
+    parity
+    path
+    devid
+    physpath
+    encpath
+    fru
+    parent
+    children
+    numchildren
+    read_errors
+    write_errors
+    checksum_errors
+    initialize_errors
+    null_ops
+    read_ops
+    write_ops
+    free_ops
+    claim_ops
+    trim_ops
+    null_bytes
+    read_bytes
+    write_bytes
+    free_bytes
+    claim_bytes
+    trim_bytes
+    removing
+    allocating
+    failfast
+    checksum_n
+    checksum_t
+    io_n
+    io_t
+)

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/vdev_get_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/vdev_get_001_pos.ksh
@@ -1,0 +1,62 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2022, Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_get/vdev_get.cfg
+
+#
+# DESCRIPTION:
+#
+# zpool get <pool> root works as expected
+#
+# STRATEGY:
+#
+# 1. use zpool get to retrieve properties from root vdev
+# 2. verify expected properties match detected properties
+#
+
+log_assert "zpool get all on root vdev"
+
+EXPECT="$(zpool get -H all ${TESTPOOL} root | wc -l)"
+if [ $? -ne 0 ]; then
+    log_fail "cannot retrieve properties from root vdev"
+fi
+
+i=0;
+while [ $i -lt "${#properties[@]}" ]
+do
+	log_must zpool get -H "${properties[$i]}" "$TESTPOOL" root
+	i=$(($i+1))
+done
+
+EXPECT=$((EXPECT))
+if [ $i -gt $EXPECT ]; then
+	log_fail "found vdev properties not in vdev_get.cfg: $i/$EXPECT."
+elif [ $i -lt $EXPECT ]; then
+    log_fail "expected properties not found in vdev_get.cfg: $i/$EXPECT."
+fi
+
+log_pass "zpool get all on root vdev"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -104,5 +104,6 @@ if is_linux || is_freebsd; then
 	    "feature@head_errlog"
 	    "feature@blake3"
 	    "feature@block_cloning"
+	    "feature@vdev_zaps_v2"
 	)
 fi

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/vdev_set_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/vdev_set_001_pos.ksh
@@ -1,0 +1,52 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2022, Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# zpool set comment property on root vdev
+#
+# STRATEGY:
+#	1. set a property on root vdev
+#	2. verify the property is set
+#
+
+log_assert "zpool set comment property on root vdev"
+
+log_must zpool set comment="openzfs" ${TESTPOOL} root
+
+COMMENT="$(zpool get -H -o value comment ${TESTPOOL} root)"
+if [ $? -ne 0 ]; then
+    log_fail "cant retrieve comment property from root vdev"
+fi
+
+if [ "$COMMENT" != "openzfs" ]; then
+    log_fail "unexpected value for comment property: $COMMENT != \"openzfs\""
+fi
+
+log_pass "zpool set comment property on root vdev"

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps.kshlib
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps.kshlib
@@ -34,6 +34,10 @@ function get_top_vd_zap # dsk conf
 {
         get_conf_section "$1" "$2" | awk '/com.delphix:vdev_zap_top: [0-9]+/ {print $2}'
 }
+function get_root_vd_zap # conf
+{
+        awk '/com.klarasystems:vdev_zap_root: [0-9]+/ {print $2}' "$1"
+}
 
 function assert_has_sentinel # conf
 {
@@ -52,6 +56,15 @@ function assert_zap_common # pool vd lvl zapobj
         elif ! zdb -d $pool $zapobj | grep -q 'zap'; then
                 log_fail "$vd on $pool has no $lvl ZAP in MOS"
         fi
+}
+
+function assert_root_zap # pool conf
+{
+        typeset pool=$1
+        typeset conf=$2
+
+        root_zap=$(get_root_vd_zap $conf)
+        assert_zap_common $pool "root vdev" "root" $root_zap
 }
 
 function assert_top_zap # pool vd conf

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_001_pos.ksh
@@ -21,7 +21,7 @@
 #
 # Strategy:
 # 1. Create a pool with one disk.
-# 2. Verify that the disk has a top and leaf ZAP in its config and the MOS.
+# 2. Verify that the disk has a root, top and leaf ZAP in its config and the MOS.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -35,6 +35,7 @@ log_must zpool create -f $TESTPOOL $DISK
 conf="$TESTDIR/vz001"
 log_must eval "zdb -PC $TESTPOOL > $conf"
 
+assert_root_zap $TESTPOOL "$conf"
 assert_top_zap $TESTPOOL $DISK "$conf"
 assert_leaf_zap $TESTPOOL $DISK "$conf"
 assert_has_sentinel "$conf"

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_002_pos.ksh
@@ -36,6 +36,7 @@ conf="$TESTDIR/vz002"
 log_must eval "zdb -PC $TESTPOOL > $conf"
 
 assert_has_sentinel "$conf"
+assert_root_zap $TESTPOOL "$conf"
 for DISK in $DISKS; do
 	assert_top_zap $TESTPOOL $DISK "$conf"
 	assert_leaf_zap $TESTPOOL $DISK "$conf"

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_003_pos.ksh
@@ -37,6 +37,7 @@ conf="$TESTDIR/vz003"
 log_must eval "zdb -PC $TESTPOOL > $conf"
 
 assert_has_sentinel "$conf"
+assert_root_zap $TESTPOOL "$conf"
 assert_top_zap $TESTPOOL "type: 'mirror'" "$conf"
 for DISK in $DISKS; do
 	assert_leaf_zap $TESTPOOL $DISK "$conf"

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_004_pos.ksh
@@ -40,6 +40,7 @@ log_must zpool create -f $TESTPOOL $DISK
 conf="$TESTDIR/vz004"
 log_must eval "zdb -PC $TESTPOOL > $conf"
 assert_has_sentinel "$conf"
+assert_root_zap $TESTPOOL "$conf"
 orig_top=$(get_top_vd_zap $DISK $conf)
 orig_leaf=$(get_leaf_vd_zap $DISK $conf)
 assert_zap_common $TESTPOOL $DISK "top" $orig_top

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_005_pos.ksh
@@ -37,6 +37,7 @@ log_must zpool create -f $TESTPOOL $DISK
 conf="$TESTDIR/vz005"
 log_must eval "zdb -PC $TESTPOOL > $conf"
 assert_has_sentinel "$conf"
+assert_root_zap $TESTPOOL "$conf"
 orig_top=$(get_top_vd_zap $DISK $conf)
 orig_leaf=$(get_leaf_vd_zap $DISK $conf)
 assert_zap_common $TESTPOOL $DISK "top" $orig_top

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_006_pos.ksh
@@ -39,6 +39,7 @@ conf="$TESTDIR/vz006"
 log_must eval "zdb -PC $TESTPOOL > $conf"
 
 assert_has_sentinel "$conf"
+assert_root_zap $TESTPOOL "$conf"
 orig_top=$(get_top_vd_zap ${DISK_ARR[1]} $conf)
 assert_zap_common $TESTPOOL ${DISK_ARR[1]} "top" $orig_top
 assert_leaf_zap $TESTPOOL ${DISK_ARR[1]} "$conf"

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_007_pos.ksh
@@ -39,6 +39,7 @@ conf="$TESTDIR/vz007"
 log_must eval "zdb -PC $TESTPOOL > $conf"
 
 assert_has_sentinel "$conf"
+assert_root_zap $TESTPOOL "$conf"
 orig_top=$(get_top_vd_zap "type: 'mirror'" $conf)
 orig_leaf0=$(get_leaf_vd_zap ${DISK_ARR[0]} $conf)
 orig_leaf1=$(get_leaf_vd_zap ${DISK_ARR[1]} $conf)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

Create a ZAP for the root vdev and the functionality to set/get properties on it.

To set a user property on the root vdev:

`zpool set user:prop=666 <pool> root-0`

The functionality already exists to set a property on a top-level vdev by specifying \<type\>-\<id\> (e.g., mirror-0). The changes were minimal to enable this pattern for the root vdev since the root vdev is of type 'root' with an id of '0'.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

These changes don't enable vdev property inheritance, however, this is a step towards achieving that.

<!--- If it fixes an open issue, please link to the issue here. -->

### Description

Create a ZAP for the root vdev and store the ZAP in spa_t as `spa_root_vdev_zap`

Modify libzutil's `for_each_vdev_cb()` to iterate over the root vdev. Previously, the root vdev was explicitly being filtered out, I looked around a bit to see why, I didn't find a solid answer - perhaps someone may know.

<!--- Describe your changes in detail -->

### How Has This Been Tested?

manual testing

test0:
    - import pool
    - set user property on the root vdev
    - export pool
    - import pool and verify property is set

test1:
    - use pool from test0
    - export the pool
    - unload openzfs kernel module with root vdev patch
    - load openzfs kernel module that doesnt have root vdev zap patch
    - verify the pool still imports
    - export the pool

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by)