### PR TITLE
Improve resilver ETAs

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1890,6 +1890,13 @@ I/O.
 In this case (unless the metadata scan is done) we stop issuing verification I/O
 and start scanning metadata again until we get to the hard limit.
 .
+.It Sy zfs_scan_report_txgs Ns = Ns Sy 0 Ns | Ns 1 Pq uint
+When reporting resilver throughput and estimated completion time use the
+performance observed over roughly the last
+.Sy zfs_scan_report_txgs
+TXGs.
+When set to zero performance is calculated over the time between checkpoints.
+.
 .It Sy zfs_scan_strict_mem_lim Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Enforce tight memory limits on pool scans when a sequential scan is in progress.
 When disabled, the memory limit may be exceeded by fast disks.

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2556,7 +2556,6 @@ spa_scan_stat_init(spa_t *spa)
 	spa->spa_scan_pass_scrub_spent_paused = 0;
 	spa->spa_scan_pass_exam = 0;
 	spa->spa_scan_pass_issued = 0;
-	vdev_scan_stat_init(spa->spa_root_vdev);
 }
 
 /*


### PR DESCRIPTION
### Motivation and Context

When resilvering the estimated time remaining is calculated using the average issue rate over the current pass.  Where the current pass begins when a scan was started or restarted if the pool was exported/imported.

For dRAID pools in particular this can result in wildly optimistic estimates since the issue rate will be very high while scanning non-degraded regions of the pool.  Once repair I/O starts being issued performance drops to a realistic number but the estimated performance is still significantly skewed.

### Description

To address this we redefine a pass such that it starts after a scanning phase completes so the issue rate is more reflective of recent performance.  This has the advantage that it's backwards compatible with previous versions of the `zpool` binary.  Additionally, the `zfs_scan_report_txgs` module option can be set to reset the pass statistics more often.

### How Has This Been Tested?

Locally rebuilding a `draid2:11d:94c:2s` pool with approximately 33 TB of data.  In this configuration when a single drive fails roughly 86% of the pool is still fully intact.  Furthermore, the node has sufficient memory to fully scan the pool before starting to issue I/O.  This means that when using the unpatched code the `zpool status` percent complete quickly jumps to 86% during the scan phase, and then reports an optimistic estimated resilver time of less than a singe minute.  In reality, we know the failed disk contains about 350GB of data to rebuild which at 200MB/s will take at best about 30 minutes.  With this change, while performing the first scan phase no estimate is reported.  After transitioning to the issue phase the estimated resilver time is roughly 31 minutes which is inline with the expected hardware performance.

Before:
```
  scan: resilver in progress since Fri Jan 20 15:09:03 2023
        33.1T scanned at 112G/s, 28.5T issued at 96.4G/s, 33.1T total
        1.22G resilvered, 86.18% done, 00:00:48 to go
```

After:
```
  scan: resilver in progress since Fri Jan 20 15:09:03 2023
        33.1T scanned at 0B/s, 29.0T issued at 2.26G/s, 33.1T total
        37.8G resilvered, 87.57% done, 00:31:01 to go
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate t
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
