### PR TITLE
Linux 6.2 compat: set_acl arg2 is "struct dentry *" and no longer "struct inode *"

### DIFF
--- a/config/kernel-acl.m4
+++ b/config/kernel-acl.m4
@@ -165,6 +165,9 @@ dnl #
 dnl # 5.15 API change,
 dnl # Added the bool rcu argument to get_acl for rcu path walk.
 dnl #
+dnl # 6.2 API change,
+dnl # get_acl() was renamed to get_inode_acl()
+dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_OPERATIONS_GET_ACL], [
 	ZFS_LINUX_TEST_SRC([inode_operations_get_acl], [
 		#include <linux/fs.h>
@@ -230,7 +233,22 @@ dnl #
 dnl # 5.12 API change,
 dnl # set_acl() added a user_namespace* parameter first
 dnl #
+dnl # 6.2 API change,
+dnl # set_acl() second paramter changed to a struct dentry *
+dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_OPERATIONS_SET_ACL], [
+	ZFS_LINUX_TEST_SRC([inode_operations_set_acl_userns_dentry], [
+		#include <linux/fs.h>
+
+		int set_acl_fn(struct user_namespace *userns,
+		    struct dentry *dent, struct posix_acl *acl,
+		    int type) { return 0; }
+
+		static const struct inode_operations
+		    iops __attribute__ ((unused)) = {
+			.set_acl = set_acl_fn,
+		};
+	],[])
 	ZFS_LINUX_TEST_SRC([inode_operations_set_acl_userns], [
 		#include <linux/fs.h>
 
@@ -263,11 +281,18 @@ AC_DEFUN([ZFS_AC_KERNEL_INODE_OPERATIONS_SET_ACL], [
 		AC_DEFINE(HAVE_SET_ACL, 1, [iops->set_acl() exists])
 		AC_DEFINE(HAVE_SET_ACL_USERNS, 1, [iops->set_acl() takes 4 args])
 	],[
-		ZFS_LINUX_TEST_RESULT([inode_operations_set_acl], [
+		ZFS_LINUX_TEST_RESULT([inode_operations_set_acl_userns_dentry], [
 			AC_MSG_RESULT(yes)
-			AC_DEFINE(HAVE_SET_ACL, 1, [iops->set_acl() exists, takes 3 args])
+			AC_DEFINE(HAVE_SET_ACL, 1, [iops->set_acl() exists])
+			AC_DEFINE(HAVE_SET_ACL_USERNS_DENTRY_ARG2, 1,
+			    [iops->set_acl() takes 4 args, arg2 is struct dentry *])
 		],[
-			AC_MSG_RESULT(no)
+			ZFS_LINUX_TEST_RESULT([inode_operations_set_acl], [
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_SET_ACL, 1, [iops->set_acl() exists, takes 3 args])
+			],[
+				ZFS_LINUX_REQUIRE_API([i_op->set_acl()], [3.14])
+			])
 		])
 	])
 ])

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -71,6 +71,9 @@ extern int zpl_xattr_security_init(struct inode *ip, struct inode *dip,
 #if defined(HAVE_SET_ACL_USERNS)
 extern int zpl_set_acl(struct user_namespace *userns, struct inode *ip,
     struct posix_acl *acl, int type);
+#elif defined(HAVE_SET_ACL_USERNS_DENTRY_ARG2)
+extern int zpl_set_acl(struct user_namespace *userns, struct dentry *dentry,
+    struct posix_acl *acl, int type);
 #else
 extern int zpl_set_acl(struct inode *ip, struct posix_acl *acl, int type);
 #endif /* HAVE_SET_ACL_USERNS */

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -1061,11 +1061,18 @@ int
 #ifdef HAVE_SET_ACL_USERNS
 zpl_set_acl(struct user_namespace *userns, struct inode *ip,
     struct posix_acl *acl, int type)
+#elif defined(HAVE_SET_ACL_USERNS_DENTRY_ARG2)
+zpl_set_acl(struct user_namespace *userns, struct dentry *dentry,
+    struct posix_acl *acl, int type)
 #else
 zpl_set_acl(struct inode *ip, struct posix_acl *acl, int type)
 #endif /* HAVE_SET_ACL_USERNS */
 {
+#ifdef HAVE_SET_ACL_USERNS_DENTRY_ARG2
+	return (zpl_set_acl_impl(d_inode(dentry), acl, type));
+#else
 	return (zpl_set_acl_impl(ip, acl, type));
+#endif /* HAVE_SET_ACL_USERNS_DENTRY_ARG2 */
 }
 #endif /* HAVE_SET_ACL */
 


### PR DESCRIPTION
### Motivation and Context
As of (at least) Linux 6.2rc4, the ZFS kernel module is no longer compiling the `set_acl` implementation as all of the `HAVE_SET_ACL` and related tests are failing in `configure`.

Results in the following:
```
[ckane@system foo]$ sudo setfacl -m u:root:w a
[sudo] password for ckane: 
setfacl: a: Operation not supported
```

### Description
Linux 6.2 changes the second argument of the set_acl operation to be a "struct dentry *" rather than a "struct inode *". The inode* parameter is still available as dentry->d_inode, so adjust the call to the _impl function call to dereference and pass that pointer to it.

Related to: #14403 

### How Has This Been Tested?
Testing on my machine, and it doesn't break. However, I still experience the failure when attempting to run `setfacl` on my system. However, I have not really made use of ACLs so I am putting together the PR to discuss the issue and diagnose further, tracking source code commits.

Need to also run the ZFS test suite and ensure that `tests/zfs-tests/tests/functional/acl/posix` yield a PASS, which I suspect to not be the case presently.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
