### PR TITLE
Reduce implicit padding in kernel module's structures by a few cachelines

### DIFF
--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -899,7 +899,14 @@ typedef struct arc_stats {
 	kstat_named_t arcstat_abd_chunk_waste_size;
 } arc_stats_t;
 
+/*
+ * We place aggsum_t members first to reduce structure padding.
+ */
 typedef struct arc_sums {
+	aggsum_t arcstat_size;
+	aggsum_t arcstat_dnode_size;
+	aggsum_t arcstat_l2_hdr_size;
+	aggsum_t arcstat_meta_used;
 	wmsum_t arcstat_hits;
 	wmsum_t arcstat_iohits;
 	wmsum_t arcstat_misses;
@@ -933,7 +940,6 @@ typedef struct arc_sums {
 	wmsum_t arcstat_evict_l2_skip;
 	wmsum_t arcstat_hash_collisions;
 	wmsum_t arcstat_hash_chains;
-	aggsum_t arcstat_size;
 	wmsum_t arcstat_compressed_size;
 	wmsum_t arcstat_uncompressed_size;
 	wmsum_t arcstat_overhead_size;
@@ -941,7 +947,6 @@ typedef struct arc_sums {
 	wmsum_t arcstat_data_size;
 	wmsum_t arcstat_metadata_size;
 	wmsum_t arcstat_dbuf_size;
-	aggsum_t arcstat_dnode_size;
 	wmsum_t arcstat_bonus_size;
 	wmsum_t arcstat_l2_hits;
 	wmsum_t arcstat_l2_misses;
@@ -967,7 +972,6 @@ typedef struct arc_sums {
 	wmsum_t arcstat_l2_io_error;
 	wmsum_t arcstat_l2_lsize;
 	wmsum_t arcstat_l2_psize;
-	aggsum_t arcstat_l2_hdr_size;
 	wmsum_t arcstat_l2_log_blk_writes;
 	wmsum_t arcstat_l2_log_blk_asize;
 	wmsum_t arcstat_l2_log_blk_count;
@@ -986,7 +990,6 @@ typedef struct arc_sums {
 	wmsum_t arcstat_memory_direct_count;
 	wmsum_t arcstat_memory_indirect_count;
 	wmsum_t arcstat_prune;
-	aggsum_t arcstat_meta_used;
 	wmsum_t arcstat_async_upgrade_sync;
 	wmsum_t arcstat_predictive_prefetch;
 	wmsum_t arcstat_demand_hit_predictive_prefetch;

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -221,8 +221,8 @@ static boolean_t dbuf_evict_thread_exit;
  * by those caches' matching enum values (from dbuf_cached_state_t).
  */
 typedef struct dbuf_cache {
-	multilist_t cache;
 	zfs_refcount_t size ____cacheline_aligned;
+	multilist_t cache;
 } dbuf_cache_t;
 dbuf_cache_t dbuf_caches[DB_CACHE_MAX];
 


### PR DESCRIPTION
### Motivation and Context
Clang's static analyzer's optin.performance.Padding checker reports excessive padding in 13 structures used in the kernel module:

```
File	Function/Method	Line
home/richard/zfs/include/sys/sa.h	sa_attr_reg	51
home/richard/zfs/include/sys/arc_impl.h	arc_sums	902
home/richard/zfs/module/zfs/dbuf.c	dbuf_cache	223
usr/src/linux-5.16.14-gentoo/include/linux/mmzone.h	pglist_data	809
usr/src/linux-5.16.14-gentoo/include/linux/sbitmap.h	sbitmap_word	29
usr/src/linux-5.16.14-gentoo/include/linux/srcutree.h	srcu_data	24
usr/src/linux-5.16.14-gentoo/include/linux/module.h	module	364
usr/src/linux-5.16.14-gentoo/include/linux/blkdev.h	request_queue	189
usr/src/linux-5.16.14-gentoo/include/linux/mmzone.h	zone	499
home/richard/zfs/include/zfeature_common.h	zfeature_info	106
home/richard/zfs/include/sys/spa_impl.h	spa	206
home/richard/zfs/include/sys/dsl_pool.h	dsl_pool	89
home/richard/zfs/include/sys/sa.h	sa_bulk_attr	74
```

6 out of 13 are from the Linux kernel, which we cannot touch. Of the 7 that we can touch:

* sa_attr_reg: this would give us 8 bytes of savings that would add up to a few hundred bytes.
* arc_sums: this would save two cachelines in a hot data structure
* dbuf_cache: this would save two cachelines in a hot data structure
* zfeature_info: this would save 8 bytes that would add up to a few hundred bytes
* spa: this would save a cacheline per pool, at the expense of documentation that relies on the structure member ordering
* dsl_pool: this would save a cacheline per pool, at the expense of documentation that relies on the structure member ordering
* sa_bulk_attr: this would save a multiple of 8 bytes on the stack.

Of these, there are only two that appear to matter for performance. We have the opportunity to shrink them by multiple cachelines, which seems like a worthwhile change to make.

Savings in spa_t and dsl_pool_t does not seem worth it given what we would give up in terms of documentation. As for the other three, if we were to tackle them, we could probably save close to a kilobyte of memory. Tackling them would probably be a good first issue for a new contributor.

### Description
The ordering of members in arc_sums and dbuf_cache_t have been changed to save a few cache lines. We save 2 cachelines in arc_sums. Since dbuf_cache_t is used twice in memory, the single cacheline savings we have in it becomes 2 cache lines of savings.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
