### PR TITLE
Use more detailed assertions where applicable

### DIFF
--- a/cmd/raidz_test/raidz_test.c
+++ b/cmd/raidz_test/raidz_test.c
@@ -523,8 +523,9 @@ vdev_raidz_map_alloc_expanded(abd_t *abd, uint64_t size, uint64_t offset,
 		 */
 		if (rr->rr_firstdatacol == 1 && rr->rr_cols > 1 &&
 		    (offset & (1ULL << 20))) {
-			ASSERT(rr->rr_cols >= 2);
-			ASSERT(rr->rr_col[0].rc_size == rr->rr_col[1].rc_size);
+			ASSERT3U(rr->rr_cols, >=, 2);
+			ASSERT3U(rr->rr_col[0].rc_size, ==,
+			    rr->rr_col[1].rc_size);
 			devidx = rr->rr_col[0].rc_devidx;
 			uint64_t o = rr->rr_col[0].rc_offset;
 			rr->rr_col[0].rc_devidx = rr->rr_col[1].rc_devidx;

--- a/cmd/raidz_test/raidz_test.c
+++ b/cmd/raidz_test/raidz_test.c
@@ -950,7 +950,7 @@ run_sweep(void)
 exit:
 	LOG(D_ALL, "\nWaiting for test threads to finish...\n");
 	mutex_enter(&sem_mtx);
-	VERIFY(free_slots <= max_free_slots);
+	VERIFY3S(free_slots, <=, max_free_slots);
 	while (free_slots < max_free_slots) {
 		(void) cv_wait(&sem_cv, &sem_mtx);
 	}

--- a/cmd/raidz_test/raidz_test.c
+++ b/cmd/raidz_test/raidz_test.c
@@ -842,7 +842,7 @@ sweep_thread(void *arg)
 {
 	int err = 0;
 	raidz_test_opts_t *opts = (raidz_test_opts_t *)arg;
-	VERIFY(opts != NULL);
+	VERIFY3P(opts, !=, NULL);
 
 	err = run_test(opts);
 

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1866,7 +1866,7 @@ print_vdev_indirect(vdev_t *vd)
 		objset_t *mos = vd->vdev_spa->spa_meta_objset;
 		(void) printf("obsolete space map object %llu:\n",
 		    (u_longlong_t)obsolete_sm_object);
-		ASSERT(vd->vdev_obsolete_sm != NULL);
+		ASSERT3P(vd->vdev_obsolete_sm, !=, NULL);
 		ASSERT3U(space_map_object(vd->vdev_obsolete_sm), ==,
 		    obsolete_sm_object);
 		dump_spacemap(mos, vd->vdev_obsolete_sm);
@@ -2909,7 +2909,7 @@ dsl_deadlist_entry_count_refd(void *arg, dsl_deadlist_entry_t *dle)
 static int
 dsl_deadlist_entry_dump(void *arg, dsl_deadlist_entry_t *dle)
 {
-	ASSERT(arg == NULL);
+	ASSERT3P(arg, ==, NULL);
 	if (dump_opt['d'] >= 5) {
 		char buf[128];
 		(void) snprintf(buf, sizeof (buf),
@@ -5794,7 +5794,7 @@ zdb_ddt_leak_init(spa_t *spa, zdb_cb_t *zcb)
 		}
 		ddt_t *ddt = spa->spa_ddt[ddb.ddb_checksum];
 		ddt_enter(ddt);
-		VERIFY(ddt_lookup(ddt, &blk, B_TRUE) != NULL);
+		VERIFY3P(ddt_lookup(ddt, &blk, B_TRUE), !=, NULL);
 		ddt_exit(ddt);
 	}
 
@@ -6198,7 +6198,7 @@ zdb_check_for_obsolete_leaks(vdev_t *vd, zdb_cb_t *zcb)
 	uint64_t total_leaked = 0;
 	boolean_t are_precise = B_FALSE;
 
-	ASSERT(vim != NULL);
+	ASSERT3P(vim, !=, NULL);
 
 	for (uint64_t i = 0; i < vdev_indirect_mapping_num_entries(vim); i++) {
 		vdev_indirect_mapping_entry_phys_t *vimep =
@@ -8843,8 +8843,8 @@ main(int argc, char **argv)
 
 	if (error == 0) {
 		if (dump_opt['k'] && (target_is_spa || dump_opt['R'])) {
-			ASSERT(checkpoint_pool != NULL);
-			ASSERT(checkpoint_target == NULL);
+			ASSERT3P(checkpoint_pool, !=, NULL);
+			ASSERT3P(checkpoint_target, ==, NULL);
 
 			error = spa_open(checkpoint_pool, &spa, FTAG);
 			if (error != 0) {

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1030,7 +1030,7 @@ dump_zap_stats(objset_t *os, uint64_t object)
 		return;
 
 	if (zs.zs_ptrtbl_len == 0) {
-		ASSERT(zs.zs_num_blocks == 1);
+		ASSERT3U(zs.zs_num_blocks, ==, 1);
 		(void) printf("\tmicrozap: %llu bytes, %llu entries\n",
 		    (u_longlong_t)zs.zs_blocksize,
 		    (u_longlong_t)zs.zs_num_entries);
@@ -2558,7 +2558,7 @@ dump_dsl_dataset(objset_t *os, uint64_t object, void *data, size_t size)
 	if (ds == NULL)
 		return;
 
-	ASSERT(size == sizeof (*ds));
+	ASSERT3U(size, ==, sizeof (*ds));
 	crtime = ds->ds_creation_time;
 	zdb_nicenum(ds->ds_referenced_bytes, used, sizeof (used));
 	zdb_nicenum(ds->ds_compressed_bytes, compressed, sizeof (compressed));
@@ -2650,7 +2650,7 @@ dump_bpobj_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 	(void) arg, (void) tx;
 	char blkbuf[BP_SPRINTF_LEN];
 
-	ASSERT(bp->blk_birth != 0);
+	ASSERT3U(bp->blk_birth, !=, 0);
 	snprintf_blkptr_compact(blkbuf, sizeof (blkbuf), bp, bp_freed);
 	(void) printf("\t%s\n", blkbuf);
 	return (0);
@@ -5315,7 +5315,7 @@ zdb_count_block(zdb_cb_t *zcb, zilog_t *zilog, const blkptr_t *bp,
 	uint64_t refcnt = 0;
 	int i;
 
-	ASSERT(type < ZDB_OT_TOTAL);
+	ASSERT3U(type, <, ZDB_OT_TOTAL);
 
 	if (zilog && zil_bp_tree_add(zilog, bp) != 0)
 		return;
@@ -5720,7 +5720,7 @@ increment_indirect_mapping_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
 	ASSERT3P(vd, !=, NULL);
 	spa_config_exit(spa, SCL_VDEV, FTAG);
 
-	ASSERT(vd->vdev_indirect_config.vic_mapping_object != 0);
+	ASSERT3U(vd->vdev_indirect_config.vic_mapping_object, !=, 0);
 	ASSERT3P(zcb->zcb_vd_obsolete_counts[vd->vdev_id], !=, NULL);
 
 	vdev_indirect_mapping_increment_obsolete_count(
@@ -5777,7 +5777,7 @@ zdb_ddt_leak_init(spa_t *spa, zdb_cb_t *zcb)
 		if (ddb.ddb_class == DDT_CLASS_UNIQUE)
 			return;
 
-		ASSERT(ddt_phys_total_refcnt(&dde) > 1);
+		ASSERT3U(ddt_phys_total_refcnt(&dde), >, 1);
 
 		for (p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
 			if (ddp->ddp_phys_birth == 0)
@@ -5814,7 +5814,7 @@ checkpoint_sm_exclude_entry_cb(space_map_entry_t *sme, void *arg)
 	metaslab_t *ms = vd->vdev_ms[sme->sme_offset >> vd->vdev_ms_shift];
 	uint64_t end = sme->sme_offset + sme->sme_run;
 
-	ASSERT(sme->sme_type == SM_FREE);
+	ASSERT3U(sme->sme_type, ==, SM_FREE);
 
 	/*
 	 * Since the vdev_checkpoint_sm exists in the vdev level
@@ -6854,7 +6854,7 @@ dump_simulated_ddt(spa_t *spa)
 	while ((zdde = avl_destroy_nodes(&t, &cookie)) != NULL) {
 		ddt_stat_t dds;
 		uint64_t refcnt = zdde->zdde_ref_blocks;
-		ASSERT(refcnt != 0);
+		ASSERT3U(refcnt, !=, 0);
 
 		dds.dds_blocks = zdde->zdde_ref_blocks / refcnt;
 		dds.dds_lsize = zdde->zdde_ref_lsize / refcnt;
@@ -6901,7 +6901,7 @@ verify_device_removal_feature_counts(spa_t *spa)
 	    &spa->spa_condensing_indirect_phys;
 	if (scip->scip_next_mapping_object != 0) {
 		vdev_t *vd = spa->spa_root_vdev->vdev_child[scip->scip_vdev];
-		ASSERT(scip->scip_prev_obsolete_sm_object != 0);
+		ASSERT3U(scip->scip_prev_obsolete_sm_object, !=, 0);
 		ASSERT3P(vd->vdev_ops, ==, &vdev_indirect_ops);
 
 		(void) printf("Condensing indirect vdev %llu: new mapping "
@@ -6940,14 +6940,14 @@ verify_device_removal_feature_counts(spa_t *spa)
 		boolean_t are_precise;
 		VERIFY0(vdev_obsolete_counts_are_precise(vd, &are_precise));
 		if (are_precise) {
-			ASSERT(vic->vic_mapping_object != 0);
+			ASSERT3U(vic->vic_mapping_object, !=, 0);
 			precise_vdev_count++;
 		}
 
 		uint64_t obsolete_sm_object;
 		VERIFY0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
 		if (obsolete_sm_object != 0) {
-			ASSERT(vic->vic_mapping_object != 0);
+			ASSERT3U(vic->vic_mapping_object, !=, 0);
 			obsolete_sm_count++;
 		}
 	}
@@ -7117,7 +7117,7 @@ verify_checkpoint_sm_entry_cb(space_map_entry_t *sme, void *arg)
 	metaslab_t *ms = vd->vdev_ms[sme->sme_offset >> vd->vdev_ms_shift];
 	uint64_t end = sme->sme_offset + sme->sme_run;
 
-	ASSERT(sme->sme_type == SM_FREE);
+	ASSERT3U(sme->sme_type, ==, SM_FREE);
 
 	if ((vcsec->vcsec_entryid % ENTRIES_PER_PROGRESS_UPDATE) == 0) {
 		(void) fprintf(stderr,
@@ -7317,7 +7317,7 @@ verify_checkpoint_blocks(spa_t *spa)
 	 */
 	checkpoint_pool = import_checkpointed_state(spa->spa_name, NULL,
 	    NULL);
-	ASSERT(strcmp(spa->spa_name, checkpoint_pool) != 0);
+	ASSERT3U(strcmp(spa->spa_name, checkpoint_pool), !=, 0);
 
 	error = spa_open(checkpoint_pool, &checkpoint_spa, FTAG);
 	if (error != 0) {
@@ -7883,7 +7883,7 @@ zdb_dump_block_raw(void *buf, uint64_t size, int flags)
 {
 	if (flags & ZDB_FLAG_BSWAP)
 		byteswap_uint64_array(buf, size);
-	VERIFY(write(fileno(stdout), buf, size) == size);
+	VERIFY3U(write(fileno(stdout), buf, size), ==, size);
 }
 
 static void

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -752,7 +752,7 @@ livelist_metaslab_validate(spa_t *spa)
 		int vdev_id = DVA_GET_VDEV(&svb->svb_dva);
 		ASSERT3U(vdev_id, <, rvd->vdev_children);
 		vdev_t *vd = rvd->vdev_child[vdev_id];
-		ASSERT(!vdev_is_concrete(vd));
+		ASSERT0(vdev_is_concrete(vd));
 		(void) printf("<%d:%llx:%llx> TXG %llx\n",
 		    vdev_id, (u_longlong_t)DVA_GET_OFFSET(&svb->svb_dva),
 		    (u_longlong_t)DVA_GET_ASIZE(&svb->svb_dva),
@@ -948,9 +948,9 @@ dump_packed_nvlist(objset_t *os, uint64_t object, void *data, size_t size)
 	size_t nvsize = *(uint64_t *)data;
 	char *packed = umem_alloc(nvsize, UMEM_NOFAIL);
 
-	VERIFY(0 == dmu_read(os, object, 0, nvsize, packed, DMU_READ_PREFETCH));
+	VERIFY0(dmu_read(os, object, 0, nvsize, packed, DMU_READ_PREFETCH));
 
-	VERIFY(nvlist_unpack(packed, nvsize, &nv, 0) == 0);
+	VERIFY0(nvlist_unpack(packed, nvsize, &nv, 0));
 
 	umem_free(packed, nvsize);
 
@@ -1368,9 +1368,9 @@ dump_sa_layouts(objset_t *os, uint64_t object, void *data, size_t size)
 		layout_attrs = umem_zalloc(attr.za_num_integers *
 		    attr.za_integer_length, UMEM_NOFAIL);
 
-		VERIFY(zap_lookup(os, object, attr.za_name,
-		    attr.za_integer_length,
-		    attr.za_num_integers, layout_attrs) == 0);
+		VERIFY0(zap_lookup(os, object, attr.za_name,
+		    attr.za_integer_length, attr.za_num_integers,
+		    layout_attrs));
 
 		for (i = 0; i != attr.za_num_integers; i++)
 			(void) printf(" %d ", (int)layout_attrs[i]);
@@ -1996,10 +1996,10 @@ dump_ddt(ddt_t *ddt, enum ddt_type type, enum ddt_class class)
 
 	if (error == ENOENT)
 		return;
-	ASSERT(error == 0);
+	ASSERT0(error);
 
 	error = ddt_object_count(ddt, type, class, &count);
-	ASSERT(error == 0);
+	ASSERT0(error);
 	if (count == 0)
 		return;
 
@@ -2433,7 +2433,7 @@ visit_indirect(spa_t *spa, const dnode_phys_t *dnp,
 		int epb = BP_GET_LSIZE(bp) >> SPA_BLKPTRSHIFT;
 		arc_buf_t *buf;
 		uint64_t fill = 0;
-		ASSERT(!BP_IS_REDACTED(bp));
+		ASSERT0(BP_IS_REDACTED(bp));
 
 		err = arc_read(NULL, spa, bp, arc_getbuf_func, &buf,
 		    ZIO_PRIORITY_ASYNC_READ, ZIO_FLAG_CANFAIL, &flags, zb);
@@ -2980,7 +2980,7 @@ verify_dd_livelist(objset_t *os)
 	dsl_pool_t *dp = spa_get_dsl(os->os_spa);
 	dsl_dir_t  *dd = os->os_dsl_dataset->ds_dir;
 
-	ASSERT(!dmu_objset_is_snapshot(os));
+	ASSERT0(dmu_objset_is_snapshot(os));
 	if (!dsl_deadlist_is_open(&dd->dd_livelist))
 		return (0);
 
@@ -3126,8 +3126,8 @@ dump_uidgid(objset_t *os, uint64_t uid, uint64_t gid)
 		uint64_t fuid_obj;
 
 		/* first find the fuid object.  It lives in the master node */
-		VERIFY(zap_lookup(os, MASTER_NODE_OBJ, ZFS_FUID_TABLES,
-		    8, 1, &fuid_obj) == 0);
+		VERIFY0(zap_lookup(os, MASTER_NODE_OBJ, ZFS_FUID_TABLES, 8, 1,
+		    &fuid_obj));
 		zfs_fuid_avl_tree_create(&idx_tree, &domain_tree);
 		(void) zfs_fuid_table_load(os, fuid_obj,
 		    &idx_tree, &domain_tree);
@@ -5711,8 +5711,8 @@ increment_indirect_mapping_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
 	vdev_t *vd;
 	const dva_t *dva = &bp->blk_dva[0];
 
-	ASSERT(!bp_freed);
-	ASSERT(!dump_opt['L']);
+	ASSERT0(bp_freed);
+	ASSERT0(dump_opt['L']);
 	ASSERT3U(BP_GET_NDVAS(bp), ==, 1);
 
 	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
@@ -5768,7 +5768,7 @@ zdb_ddt_leak_init(spa_t *spa, zdb_cb_t *zcb)
 	int error;
 	int p;
 
-	ASSERT(!dump_opt['L']);
+	ASSERT0(dump_opt['L']);
 
 	while ((error = ddt_walk(spa, &ddb, &dde)) == 0) {
 		blkptr_t blk;
@@ -5899,7 +5899,7 @@ zdb_leak_init_vdev_exclude_checkpoint(vdev_t *vd, zdb_cb_t *zcb)
 static void
 zdb_leak_init_exclude_checkpoint(spa_t *spa, zdb_cb_t *zcb)
 {
-	ASSERT(!dump_opt['L']);
+	ASSERT0(dump_opt['L']);
 
 	vdev_t *rvd = spa->spa_root_vdev;
 	for (uint64_t c = 0; c < rvd->vdev_children; c++) {
@@ -6075,7 +6075,7 @@ load_indirect_ms_allocatable_tree(vdev_t *vd, metaslab_t *msp,
 static void
 zdb_leak_init_prepare_indirect_vdevs(spa_t *spa, zdb_cb_t *zcb)
 {
-	ASSERT(!dump_opt['L']);
+	ASSERT0(dump_opt['L']);
 
 	vdev_t *rvd = spa->spa_root_vdev;
 	for (uint64_t c = 0; c < rvd->vdev_children; c++) {
@@ -6366,7 +6366,7 @@ static int
 bpobj_count_block_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx)
 {
-	ASSERT(!bp_freed);
+	ASSERT0(bp_freed);
 	return (count_block_cb(arg, bp, tx));
 }
 
@@ -7304,7 +7304,7 @@ verify_checkpoint_ms_spacemaps(spa_t *checkpoint, spa_t *current)
 static void
 verify_checkpoint_blocks(spa_t *spa)
 {
-	ASSERT(!dump_opt['L']);
+	ASSERT0(dump_opt['L']);
 
 	spa_t *checkpoint_spa;
 	char *checkpoint_pool;

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1364,7 +1364,7 @@ dump_sa_layouts(objset_t *os, uint64_t object, void *data, size_t size)
 			continue;
 		}
 
-		VERIFY(attr.za_integer_length == 2);
+		VERIFY3S(attr.za_integer_length, ==, 2);
 		layout_attrs = umem_zalloc(attr.za_num_integers *
 		    attr.za_integer_length, UMEM_NOFAIL);
 
@@ -2248,13 +2248,13 @@ blkid2offset(const dnode_phys_t *dnp, const blkptr_t *bp,
     const zbookmark_phys_t *zb)
 {
 	if (dnp == NULL) {
-		ASSERT(zb->zb_level < 0);
+		ASSERT3S(zb->zb_level, <, 0);
 		if (zb->zb_object == 0)
 			return (zb->zb_blkid);
 		return (zb->zb_blkid * BP_GET_LSIZE(bp));
 	}
 
-	ASSERT(zb->zb_level >= 0);
+	ASSERT3S(zb->zb_level, >=, 0);
 
 	return ((zb->zb_blkid <<
 	    (zb->zb_level * (dnp->dn_indblkshift - SPA_BLKPTRSHIFT))) *
@@ -2399,7 +2399,7 @@ print_indirect(spa_t *spa, blkptr_t *bp, const zbookmark_phys_t *zb,
 
 	(void) printf("%16llx ", (u_longlong_t)blkid2offset(dnp, bp, zb));
 
-	ASSERT(zb->zb_level >= 0);
+	ASSERT3S(zb->zb_level, >=, 0);
 
 	for (l = dnp->dn_nlevels - 1; l >= -1; l--) {
 		if (l == zb->zb_level) {
@@ -5798,7 +5798,7 @@ zdb_ddt_leak_init(spa_t *spa, zdb_cb_t *zcb)
 		ddt_exit(ddt);
 	}
 
-	ASSERT(error == ENOENT);
+	ASSERT3S(error, ==, ENOENT);
 }
 
 typedef struct checkpoint_sm_exclude_entry_arg {

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -5368,7 +5368,7 @@ parse_who_perm(who_perm_t *who_perm, nvlist_t *nvl, char locality)
 		deleg_perm_node_t *node =
 		    safe_malloc(sizeof (deleg_perm_node_t));
 
-		VERIFY(type == DATA_TYPE_BOOLEAN);
+		VERIFY3U(type, ==, DATA_TYPE_BOOLEAN);
 
 		uu_avl_node_init(node, &node->dpn_avl_node, avl_pool);
 		set_deleg_perm_node(avl, node, who_type, name, locality);
@@ -5498,7 +5498,7 @@ parse_fs_perm_set(fs_perm_set_t *fspset, nvlist_t *nvl)
 
 		fsperm = &node->fspn_fsperm;
 
-		VERIFY(DATA_TYPE_NVLIST == type);
+		VERIFY3U(DATA_TYPE_NVLIST, ==, type);
 
 		uu_list_node_init(node, &node->fspn_list_node,
 		    fspset->fsps_list_pool);

--- a/cmd/zhack.c
+++ b/cmd/zhack.c
@@ -202,7 +202,7 @@ dump_obj(objset_t *os, uint64_t obj, const char *name)
 	    zap_cursor_retrieve(&zc, &za) == 0;
 	    zap_cursor_advance(&zc)) {
 		if (za.za_integer_length == 8) {
-			ASSERT(za.za_num_integers == 1);
+			ASSERT3U(za.za_num_integers, ==, 1);
 			(void) printf("\t%s = %llu\n",
 			    za.za_name, (u_longlong_t)za.za_first_integer);
 		} else {

--- a/cmd/zhack.c
+++ b/cmd/zhack.c
@@ -206,7 +206,7 @@ dump_obj(objset_t *os, uint64_t obj, const char *name)
 			(void) printf("\t%s = %llu\n",
 			    za.za_name, (u_longlong_t)za.za_first_integer);
 		} else {
-			ASSERT(za.za_integer_length == 1);
+			ASSERT3S(za.za_integer_length, ==, 1);
 			char val[1024];
 			VERIFY0(zap_lookup(os, obj, za.za_name, 1,
 			    sizeof (val), val));

--- a/cmd/zhack.c
+++ b/cmd/zhack.c
@@ -152,9 +152,9 @@ zhack_import(char *target, boolean_t readonly)
 
 	props = NULL;
 	if (readonly) {
-		VERIFY(nvlist_alloc(&props, NV_UNIQUE_NAME, 0) == 0);
-		VERIFY(nvlist_add_uint64(props,
-		    zpool_prop_to_name(ZPOOL_PROP_READONLY), 1) == 0);
+		VERIFY0(nvlist_alloc(&props, NV_UNIQUE_NAME, 0));
+		VERIFY0(nvlist_add_uint64(props,
+		    zpool_prop_to_name(ZPOOL_PROP_READONLY), 1));
 	}
 
 	zfeature_checks_disable = B_TRUE;
@@ -208,8 +208,8 @@ dump_obj(objset_t *os, uint64_t obj, const char *name)
 		} else {
 			ASSERT(za.za_integer_length == 1);
 			char val[1024];
-			VERIFY(zap_lookup(os, obj, za.za_name,
-			    1, sizeof (val), val) == 0);
+			VERIFY0(zap_lookup(os, obj, za.za_name, 1,
+			    sizeof (val), val));
 			(void) printf("\t%s = %s\n", za.za_name, val);
 		}
 	}

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -9780,7 +9780,7 @@ zpool_do_events_next(ev_opts_t *opts)
 	char *pool;
 
 	zevent_fd = open(ZFS_DEV, O_RDWR);
-	VERIFY(zevent_fd >= 0);
+	VERIFY3S(zevent_fd, >=, 0);
 
 	if (!opts->scripted)
 		(void) printf(gettext("%-30s %s\n"), "TIME", "CLASS");

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -9810,7 +9810,7 @@ zpool_do_events_next(ev_opts_t *opts)
 		nvlist_free(nvl);
 	}
 
-	VERIFY(0 == close(zevent_fd));
+	VERIFY0(close(zevent_fd));
 
 	return (ret);
 }

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -6678,7 +6678,7 @@ join_strings(char **strings, const char *sep)
 		totallen += strlen(sep);
 	}
 	if (totallen > 0) {
-		ASSERT(totallen >= strlen(sep));
+		ASSERT3U(totallen, >=, strlen(sep));
 		totallen -= strlen(sep);
 	}
 

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2184,8 +2184,8 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 			    DMU_READ_PREFETCH : DMU_READ_NO_PREFETCH;
 			ztest_block_tag_t rbt;
 
-			VERIFY(dmu_read(os, lr->lr_foid, offset,
-			    sizeof (rbt), &rbt, prefetch) == 0);
+			VERIFY0(dmu_read(os, lr->lr_foid, offset, sizeof (rbt),
+			    &rbt, prefetch));
 			if (rbt.bt_magic == BT_MAGIC) {
 				ztest_bt_verify(&rbt, os, lr->lr_foid, 0,
 				    offset, gen, txg, crtxg);
@@ -5151,8 +5151,8 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 			}
 
 			if (i == 1) {
-				VERIFY(dmu_buf_hold(os, bigobj, off,
-				    FTAG, &dbt, DMU_READ_NO_PREFETCH) == 0);
+				VERIFY0(dmu_buf_hold(os, bigobj, off, FTAG,
+				    &dbt, DMU_READ_NO_PREFETCH));
 			}
 			if (i != 5 || chunksize < (SPA_MINBLOCKSIZE * 2)) {
 				VERIFY0(dmu_assign_arcbuf_by_dbuf(bonus_db,
@@ -5601,7 +5601,7 @@ ztest_commit_callback(void *arg, int error)
 
 	VERIFY3P(data, !=, NULL);
 	VERIFY3S(data->zcd_expected_err, ==, error);
-	VERIFY(!data->zcd_called);
+	VERIFY0(data->zcd_called);
 
 	synced_txg = spa_last_synced_txg(data->zcd_spa);
 	if (data->zcd_txg > synced_txg)
@@ -5614,7 +5614,7 @@ ztest_commit_callback(void *arg, int error)
 
 	if (error == ECANCELED) {
 		ASSERT0(data->zcd_txg);
-		ASSERT(!data->zcd_added);
+		ASSERT0(data->zcd_added);
 
 		/*
 		 * The private callback data should be destroyed here, but
@@ -5706,7 +5706,7 @@ ztest_dmu_commit_callbacks(ztest_ds_t *zd, uint64_t id)
 		 */
 		for (i = 0; i < 2; i++) {
 			cb_data[i]->zcd_expected_err = ECANCELED;
-			VERIFY(!cb_data[i]->zcd_called);
+			VERIFY0(cb_data[i]->zcd_called);
 		}
 
 		dmu_tx_abort(tx);
@@ -5780,7 +5780,7 @@ ztest_dmu_commit_callbacks(ztest_ds_t *zd, uint64_t id)
 			    cb_data[i]);
 
 		cb_data[i]->zcd_added = B_TRUE;
-		VERIFY(!cb_data[i]->zcd_called);
+		VERIFY0(cb_data[i]->zcd_called);
 
 		tmp_cb = cb_data[i];
 	}
@@ -8200,10 +8200,10 @@ main(int argc, char **argv)
 			(void) printf("Executing older ztest for "
 			    "initialization: %s\n", ztest_opts.zo_alt_ztest);
 		}
-		VERIFY(!exec_child(ztest_opts.zo_alt_ztest,
+		VERIFY0(exec_child(ztest_opts.zo_alt_ztest,
 		    ztest_opts.zo_alt_libpath, B_FALSE, NULL));
 	} else {
-		VERIFY(!exec_child(NULL, NULL, B_FALSE, NULL));
+		VERIFY0(exec_child(NULL, NULL, B_FALSE, NULL));
 	}
 	zs->zs_do_init = B_FALSE;
 

--- a/include/os/freebsd/spl/sys/proc.h
+++ b/include/os/freebsd/spl/sys/proc.h
@@ -76,7 +76,7 @@ do_thread_create(caddr_t stk, size_t stksize, void (*proc)(void *), void *arg,
 	 */
 	ASSERT(stk == NULL);
 	ASSERT(len == 0);
-	ASSERT(state == TS_RUN);
+	ASSERT3S(state, ==, TS_RUN);
 
 	if (pp == &p0)
 		ppp = &system_proc;

--- a/lib/libspl/list.c
+++ b/lib/libspl/list.c
@@ -122,7 +122,7 @@ void
 list_remove(list_t *list, void *object)
 {
 	list_node_t *lold = list_d2l(list, object);
-	ASSERT(!list_empty(list));
+	ASSERT0(list_empty(list));
 	ASSERT(lold->next != NULL);
 	list_remove_node(lold);
 }
@@ -213,7 +213,7 @@ void
 list_link_replace(list_node_t *lold, list_node_t *lnew)
 {
 	ASSERT(list_link_active(lold));
-	ASSERT(!list_link_active(lnew));
+	ASSERT0(list_link_active(lnew));
 
 	lnew->next = lold->next;
 	lnew->prev = lold->prev;

--- a/lib/libspl/list.c
+++ b/lib/libspl/list.c
@@ -62,8 +62,8 @@ void
 list_create(list_t *list, size_t size, size_t offset)
 {
 	ASSERT(list);
-	ASSERT(size > 0);
-	ASSERT(size >= offset + sizeof (list_node_t));
+	ASSERT3U(size, >, 0);
+	ASSERT3U(size, >=, offset + sizeof (list_node_t));
 
 	list->list_size = size;
 	list->list_offset = offset;
@@ -76,8 +76,8 @@ list_destroy(list_t *list)
 	list_node_t *node = &list->list_head;
 
 	ASSERT(list);
-	ASSERT(list->list_head.next == node);
-	ASSERT(list->list_head.prev == node);
+	ASSERT3U(list->list_head.next, ==, node);
+	ASSERT3U(list->list_head.prev, ==, node);
 
 	node->next = node->prev = NULL;
 }
@@ -194,8 +194,8 @@ list_move_tail(list_t *dst, list_t *src)
 	list_node_t *dstnode = &dst->list_head;
 	list_node_t *srcnode = &src->list_head;
 
-	ASSERT(dst->list_size == src->list_size);
-	ASSERT(dst->list_offset == src->list_offset);
+	ASSERT3U(dst->list_size, ==, src->list_size);
+	ASSERT3U(dst->list_offset, ==, src->list_offset);
 
 	if (list_empty(src))
 		return;

--- a/lib/libspl/list.c
+++ b/lib/libspl/list.c
@@ -123,7 +123,7 @@ list_remove(list_t *list, void *object)
 {
 	list_node_t *lold = list_d2l(list, object);
 	ASSERT0(list_empty(list));
-	ASSERT(lold->next != NULL);
+	ASSERT3P(lold->next, !=, NULL);
 	list_remove_node(lold);
 }
 

--- a/lib/libtpool/thread_pool.c
+++ b/lib/libtpool/thread_pool.c
@@ -413,7 +413,7 @@ tpool_dispatch(tpool_t *tpool, void (*func)(void *), void *arg)
 {
 	tpool_job_t *job;
 
-	ASSERT(!(tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
+	ASSERT0((tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
 
 	if ((job = calloc(1, sizeof (*job))) == NULL)
 		return (-1);
@@ -460,8 +460,8 @@ tpool_destroy(tpool_t *tpool)
 {
 	tpool_active_t *activep;
 
-	ASSERT(!tpool_member(tpool));
-	ASSERT(!(tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
+	ASSERT0(tpool_member(tpool));
+	ASSERT0((tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
 
 	pthread_mutex_lock(&tpool->tp_mutex);
 	pthread_cleanup_push(tpool_cleanup, tpool);
@@ -496,7 +496,7 @@ tpool_destroy(tpool_t *tpool)
 void
 tpool_abandon(tpool_t *tpool)
 {
-	ASSERT(!(tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
+	ASSERT0((tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
 
 	pthread_mutex_lock(&tpool->tp_mutex);
 	if (tpool->tp_current == 0) {
@@ -519,15 +519,15 @@ tpool_abandon(tpool_t *tpool)
 void
 tpool_wait(tpool_t *tpool)
 {
-	ASSERT(!tpool_member(tpool));
-	ASSERT(!(tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
+	ASSERT0(tpool_member(tpool));
+	ASSERT0((tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
 
 	pthread_mutex_lock(&tpool->tp_mutex);
 	pthread_cleanup_push(tpool_cleanup, tpool);
 	while (tpool->tp_head != NULL || tpool->tp_active != NULL) {
 		tpool->tp_flags |= TP_WAIT;
 		(void) pthread_cond_wait(&tpool->tp_waitcv, &tpool->tp_mutex);
-		ASSERT(!(tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
+		ASSERT0((tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
 	}
 	pthread_cleanup_pop(1);	/* pthread_mutex_unlock(&tpool->tp_mutex); */
 }
@@ -535,7 +535,7 @@ tpool_wait(tpool_t *tpool)
 void
 tpool_suspend(tpool_t *tpool)
 {
-	ASSERT(!(tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
+	ASSERT0((tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
 
 	pthread_mutex_lock(&tpool->tp_mutex);
 	tpool->tp_flags |= TP_SUSPEND;
@@ -547,7 +547,7 @@ tpool_suspended(tpool_t *tpool)
 {
 	int suspended;
 
-	ASSERT(!(tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
+	ASSERT0((tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
 
 	pthread_mutex_lock(&tpool->tp_mutex);
 	suspended = (tpool->tp_flags & TP_SUSPEND) != 0;
@@ -561,7 +561,7 @@ tpool_resume(tpool_t *tpool)
 {
 	int excess;
 
-	ASSERT(!(tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
+	ASSERT0((tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
 
 	pthread_mutex_lock(&tpool->tp_mutex);
 	if (!(tpool->tp_flags & TP_SUSPEND)) {
@@ -585,7 +585,7 @@ tpool_member(tpool_t *tpool)
 	pthread_t my_tid = pthread_self();
 	tpool_active_t *activep;
 
-	ASSERT(!(tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
+	ASSERT0((tpool->tp_flags & (TP_DESTROY | TP_ABANDON)));
 
 	pthread_mutex_lock(&tpool->tp_mutex);
 	for (activep = tpool->tp_active; activep; activep = activep->tpa_next) {

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -80,7 +80,7 @@ get_stats_for_obj(differ_info_t *di, const char *dsname, uint64_t obj,
 	/* we can get stats even if we failed to get a path */
 	(void) memcpy(sb, &zc.zc_stat, sizeof (zfs_stat_t));
 	if (error == 0) {
-		ASSERT(di->zerr == 0);
+		ASSERT0(di->zerr);
 		(void) strlcpy(pn, zc.zc_value, maxlen);
 		return (0);
 	}
@@ -403,7 +403,7 @@ write_free_diffs(FILE *fp, differ_info_t *di, dmu_diff_record_t *dr)
 	(void) strlcpy(zc.zc_name, di->fromsnap, sizeof (zc.zc_name));
 	zc.zc_obj = dr->ddr_first - 1;
 
-	ASSERT(di->zerr == 0);
+	ASSERT0(di->zerr);
 
 	while (zc.zc_obj < dr->ddr_last) {
 		int err;

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -490,7 +490,7 @@ differ(void *arg)
 	if (err)
 		return ((void *)-1);
 	if (di->zerr) {
-		ASSERT(di->zerr == EPIPE);
+		ASSERT3S(di->zerr, ==, EPIPE);
 		(void) snprintf(di->errbuf, sizeof (di->errbuf),
 		    dgettext(TEXT_DOMAIN,
 		    "Internal error: bad data from diff IOCTL"));
@@ -728,7 +728,7 @@ setup_differ_info(zfs_handle_t *zhp, const char *fromsnap,
 	di->zhp = zhp;
 
 	di->cleanupfd = open(ZFS_DEV, O_RDWR | O_CLOEXEC);
-	VERIFY(di->cleanupfd >= 0);
+	VERIFY3S(di->cleanupfd, >=, 0);
 
 	if (get_snapshot_names(di, fromsnap, tosnap) != 0)
 		return (-1);

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -577,7 +577,7 @@ get_snapshot_names(differ_info_t *di, const char *fromsnap,
 		}
 
 		atptrf = strchr(fromsnap, '@');
-		ASSERT(atptrf != NULL);
+		ASSERT3P(atptrf, !=, NULL);
 		fdslen = atptrf - fromsnap;
 
 		di->fromsnap = zfs_strdup(hdl, fromsnap);

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -121,7 +121,7 @@ const pool_config_ops_t libzfs_config_ops = {
 static uint64_t
 label_offset(uint64_t size, int l)
 {
-	ASSERT(P2PHASE_TYPED(size, sizeof (vdev_label_t), uint64_t) == 0);
+	ASSERT0(P2PHASE_TYPED(size, sizeof (vdev_label_t), uint64_t));
 	return (l * sizeof (vdev_label_t) + (l < VDEV_LABELS / 2 ?
 	    0 : size - VDEV_LABELS * sizeof (vdev_label_t)));
 }

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -516,7 +516,7 @@ zfs_mount_at(zfs_handle_t *zhp, const char *options, int flags,
 		} else if (rc == ENOTSUP) {
 			int spa_version;
 
-			VERIFY(zfs_spa_version(zhp, &spa_version) == 0);
+			VERIFY0(zfs_spa_version(zhp, &spa_version));
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 			    "Can't mount a version %llu "
 			    "file system on a version %d pool. Pool must be"

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -2437,7 +2437,7 @@ zfs_send_cb_impl(zfs_handle_t *zhp, const char *fromsnap, const char *tosnap,
 		err = ENOENT;
 
 	if (sdd.cleanup_fd != -1) {
-		VERIFY(0 == close(sdd.cleanup_fd));
+		VERIFY0(close(sdd.cleanup_fd));
 		sdd.cleanup_fd = -1;
 	}
 
@@ -2463,7 +2463,7 @@ err_out:
 	fnvlist_free(sdd.snapholds);
 
 	if (sdd.cleanup_fd != -1)
-		VERIFY(0 == close(sdd.cleanup_fd));
+		VERIFY0(close(sdd.cleanup_fd));
 	return (err);
 }
 
@@ -5020,7 +5020,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		nvlist_t *holds, *errors = NULL;
 		int cleanup_fd = -1;
 
-		VERIFY(0 == nvlist_alloc(&holds, 0, KM_SLEEP));
+		VERIFY0(nvlist_alloc(&holds, 0, KM_SLEEP));
 		for (pair = nvlist_next_nvpair(snapholds_nvlist, NULL);
 		    pair != NULL;
 		    pair = nvlist_next_nvpair(snapholds_nvlist, pair)) {

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -5466,7 +5466,7 @@ zfs_receive_impl(libzfs_handle_t *hdl, const char *tosnap,
 			if ((cp = strchr(nonpackage_sendfs, '@')) != NULL)
 				*cp = '\0';
 			sendfs = nonpackage_sendfs;
-			VERIFY(finalsnap == NULL);
+			VERIFY3P(finalsnap, ==, NULL);
 		}
 		return (zfs_receive_one(hdl, infd, tosnap, originsnap, flags,
 		    &drr, &drr_noswap, sendfs, stream_nv, stream_avl, top_zfs,

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3942,7 +3942,7 @@ out:
 static void
 trunc_prop_errs(int truncated)
 {
-	ASSERT(truncated != 0);
+	ASSERT3S(truncated, !=, 0);
 
 	if (truncated == 1)
 		(void) fprintf(stderr, dgettext(TEXT_DOMAIN,

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -4502,7 +4502,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		chopprefix = drrb->drr_toname + strlen(drrb->drr_toname);
 	}
 
-	ASSERT(strstr(drrb->drr_toname, sendfs) == drrb->drr_toname);
+	ASSERT3U(strstr(drrb->drr_toname, sendfs), ==, drrb->drr_toname);
 	ASSERT(chopprefix > drrb->drr_toname || strchr(sendfs, '/') == NULL);
 	ASSERT(chopprefix <= drrb->drr_toname + strlen(drrb->drr_toname) ||
 	    strchr(sendfs, '/') == NULL);

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -723,8 +723,10 @@ static int random_fd = -1, urandom_fd = -1;
 void
 random_init(void)
 {
-	VERIFY((random_fd = open(random_path, O_RDONLY | O_CLOEXEC)) != -1);
-	VERIFY((urandom_fd = open(urandom_path, O_RDONLY | O_CLOEXEC)) != -1);
+	VERIFY3S((random_fd = open(random_path, O_RDONLY | O_CLOEXEC)), !=,
+	    -1);
+	VERIFY3S((urandom_fd = open(urandom_path, O_RDONLY | O_CLOEXEC)), !=,
+	    -1);
 }
 
 void
@@ -743,7 +745,7 @@ random_get_bytes_common(uint8_t *ptr, size_t len, int fd)
 	size_t resid = len;
 	ssize_t bytes;
 
-	ASSERT(fd != -1);
+	ASSERT3S(fd, !=, -1);
 
 	while (resid != 0) {
 		bytes = read(fd, ptr, resid);
@@ -1276,7 +1278,7 @@ zfs_file_pread(zfs_file_t *fp, void *buf, size_t count, loff_t off,
 		int status;
 
 		status = pwrite64(fp->f_dump_fd, buf, rc, off);
-		ASSERT(status != -1);
+		ASSERT3S(status, !=, -1);
 	}
 
 	if (resid) {

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -938,7 +938,7 @@ kmem_vasprintf(const char *fmt, va_list adx)
 	va_list adx_copy;
 
 	va_copy(adx_copy, adx);
-	VERIFY(vasprintf(&buf, fmt, adx_copy) != -1);
+	VERIFY3U(vasprintf(&buf, fmt, adx_copy), !=, -1);
 	va_end(adx_copy);
 
 	return (buf);
@@ -951,7 +951,7 @@ kmem_asprintf(const char *fmt, ...)
 	va_list adx;
 
 	va_start(adx, fmt);
-	VERIFY(vasprintf(&buf, fmt, adx) != -1);
+	VERIFY3U(vasprintf(&buf, fmt, adx), !=, -1);
 	va_end(adx);
 
 	return (buf);

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -356,7 +356,7 @@ cv_timedwait(kcondvar_t *cv, kmutex_t *mp, clock_t abstime)
 	if (delta <= 0)
 		return (-1);
 
-	VERIFY(gettimeofday(&tv, NULL) == 0);
+	VERIFY0(gettimeofday(&tv, NULL));
 
 	ts.tv_sec = tv.tv_sec + delta / hz;
 	ts.tv_nsec = tv.tv_usec * NSEC_PER_USEC + (delta % hz) * (NANOSEC / hz);

--- a/lib/libzpool/taskq.c
+++ b/lib/libzpool/taskq.c
@@ -161,7 +161,7 @@ void
 taskq_dispatch_ent(taskq_t *tq, task_func_t func, void *arg, uint_t flags,
     taskq_ent_t *t)
 {
-	ASSERT(func != NULL);
+	ASSERT3P(func, !=, NULL);
 
 	/*
 	 * Mark it as a prealloc'd task.  This is important
@@ -295,8 +295,8 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 	}
 
 	for (t = 0; t < nthreads; t++)
-		VERIFY((tq->tq_threadlist[t] = thread_create(NULL, 0,
-		    taskq_thread, tq, 0, &p0, TS_RUN, pri)) != NULL);
+		VERIFY3P((tq->tq_threadlist[t] = thread_create(NULL, 0,
+		    taskq_thread, tq, 0, &p0, TS_RUN, pri)), !=, NULL);
 
 	return (tq);
 }
@@ -318,7 +318,7 @@ taskq_destroy(taskq_t *tq)
 
 	tq->tq_minalloc = 0;
 	while (tq->tq_nalloc != 0) {
-		ASSERT(tq->tq_freelist != NULL);
+		ASSERT3P(tq->tq_freelist, !=, NULL);
 		taskq_ent_t *tqent_nexttq = tq->tq_freelist->tqent_next;
 		task_free(tq, tq->tq_freelist);
 		tq->tq_freelist = tqent_nexttq;

--- a/lib/libzpool/taskq.c
+++ b/lib/libzpool/taskq.c
@@ -45,7 +45,7 @@ task_alloc(taskq_t *tq, int tqflags)
 	int rv;
 
 again:	if ((t = tq->tq_freelist) != NULL && tq->tq_nalloc >= tq->tq_minalloc) {
-		ASSERT(!(t->tqent_flags & TQENT_FLAG_PREALLOC));
+		ASSERT0((t->tqent_flags & TQENT_FLAG_PREALLOC));
 		tq->tq_freelist = t->tqent_next;
 	} else {
 		if (tq->tq_nalloc >= tq->tq_maxalloc) {

--- a/lib/libzpool/util.c
+++ b/lib/libzpool/util.c
@@ -135,12 +135,10 @@ show_pool_stats(spa_t *spa)
 	nvlist_t *config, *nvroot;
 	char *name;
 
-	VERIFY(spa_get_stats(spa_name(spa), &config, NULL, 0) == 0);
+	VERIFY0(spa_get_stats(spa_name(spa), &config, NULL, 0));
 
-	VERIFY(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
-	    &nvroot) == 0);
-	VERIFY(nvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME,
-	    &name) == 0);
+	VERIFY0(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE, &nvroot));
+	VERIFY0(nvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME, &name));
 
 	show_vdev_stats(name, ZPOOL_CONFIG_CHILDREN, nvroot, 0);
 	show_vdev_stats(NULL, ZPOOL_CONFIG_L2CACHE, nvroot, 0);

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -444,7 +444,7 @@ static int
 zutil_pool_active(libpc_handle_t *hdl, const char *name, uint64_t guid,
     boolean_t *isactive)
 {
-	ASSERT(hdl->lpc_ops->pco_pool_active != NULL);
+	ASSERT3P(hdl->lpc_ops->pco_pool_active, !=, NULL);
 
 	int error = hdl->lpc_ops->pco_pool_active(hdl->lpc_lib_handle, name,
 	    guid, isactive);
@@ -455,7 +455,7 @@ zutil_pool_active(libpc_handle_t *hdl, const char *name, uint64_t guid,
 static nvlist_t *
 zutil_refresh_config(libpc_handle_t *hdl, nvlist_t *tryconfig)
 {
-	ASSERT(hdl->lpc_ops->pco_refresh_config != NULL);
+	ASSERT3P(hdl->lpc_ops->pco_refresh_config, !=, NULL);
 
 	return (hdl->lpc_ops->pco_refresh_config(hdl->lpc_lib_handle,
 	    tryconfig));

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -916,7 +916,7 @@ error:
 static uint64_t
 label_offset(uint64_t size, int l)
 {
-	ASSERT(P2PHASE_TYPED(size, sizeof (vdev_label_t), uint64_t) == 0);
+	ASSERT0(P2PHASE_TYPED(size, sizeof (vdev_label_t), uint64_t));
 	return (l * sizeof (vdev_label_t) + (l < VDEV_LABELS / 2 ?
 	    0 : size - VDEV_LABELS * sizeof (vdev_label_t)));
 }

--- a/module/avl/avl.c
+++ b/module/avl/avl.c
@@ -220,7 +220,7 @@ avl_nearest(avl_tree_t *tree, avl_index_t where, int direction)
 	size_t off = tree->avl_offset;
 
 	if (node == NULL) {
-		ASSERT(tree->avl_root == NULL);
+		ASSERT3P(tree->avl_root, ==, NULL);
 		return (NULL);
 	}
 	data = AVL_NODE2DATA(node, off);
@@ -490,10 +490,10 @@ avl_insert(avl_tree_t *tree, void *new_data, avl_index_t where)
 	AVL_SETBALANCE(node, 0);
 	AVL_SETPARENT(node, parent);
 	if (parent != NULL) {
-		ASSERT(parent->avl_child[which_child] == NULL);
+		ASSERT3P(parent->avl_child[which_child], ==, NULL);
 		parent->avl_child[which_child] = node;
 	} else {
-		ASSERT(tree->avl_root == NULL);
+		ASSERT3P(tree->avl_root, ==, NULL);
 		tree->avl_root = node;
 	}
 	/*
@@ -564,9 +564,9 @@ avl_insert_here(
 	int diff;
 #endif
 
-	ASSERT(tree != NULL);
-	ASSERT(new_data != NULL);
-	ASSERT(here != NULL);
+	ASSERT3P(tree, !=, NULL);
+	ASSERT3P(new_data, !=, NULL);
+	ASSERT3P(here, !=, NULL);
 	ASSERT(direction == AVL_BEFORE || direction == AVL_AFTER);
 
 	/*
@@ -603,7 +603,7 @@ avl_insert_here(
 		ASSERT(diff > 0 ? child == 1 : child == 0);
 #endif
 	}
-	ASSERT(node->avl_child[child] == NULL);
+	ASSERT3P(node->avl_child[child], ==, NULL);
 
 	avl_insert(tree, new_data, AVL_MKINDEX(node, child));
 }
@@ -617,7 +617,7 @@ avl_add(avl_tree_t *tree, void *new_node)
 {
 	avl_index_t where = 0;
 
-	VERIFY(avl_find(tree, new_node, &where) == NULL);
+	VERIFY3P(avl_find(tree, new_node, &where), ==, NULL);
 
 	avl_insert(tree, new_node, where);
 }
@@ -893,7 +893,7 @@ avl_destroy(avl_tree_t *tree)
 {
 	ASSERT(tree);
 	ASSERT0(tree->avl_numnodes);
-	ASSERT(tree->avl_root == NULL);
+	ASSERT3P(tree->avl_root, ==, NULL);
 }
 
 
@@ -1020,7 +1020,7 @@ check_right_side:
 done:
 	if (parent == NULL) {
 		*cookie = (void *)CHILDBIT;
-		ASSERT(node == tree->avl_root);
+		ASSERT3P(node, ==, tree->avl_root);
 	} else {
 		*cookie = (void *)((uintptr_t)parent | AVL_XCHILD(node));
 	}

--- a/module/avl/avl.c
+++ b/module/avl/avl.c
@@ -724,7 +724,7 @@ avl_remove(avl_tree_t *tree, void *data)
 	 * Here we know "delete" is at least partially a leaf node. It can
 	 * be easily removed from the tree.
 	 */
-	ASSERT(tree->avl_numnodes > 0);
+	ASSERT3U(tree->avl_numnodes, >, 0);
 	--tree->avl_numnodes;
 	parent = AVL_XPARENT(delete);
 	which_child = AVL_XCHILD(delete);
@@ -873,8 +873,8 @@ avl_create(avl_tree_t *tree, int (*compar) (const void *, const void *),
 {
 	ASSERT(tree);
 	ASSERT(compar);
-	ASSERT(size > 0);
-	ASSERT(size >= offset + sizeof (avl_node_t));
+	ASSERT3U(size, >, 0);
+	ASSERT3U(size, >=, offset + sizeof (avl_node_t));
 #ifdef _LP64
 	ASSERT0((offset & 0x7));
 #endif
@@ -969,7 +969,7 @@ avl_destroy_nodes(avl_tree_t *tree, void **cookie)
 	parent = (avl_node_t *)((uintptr_t)(*cookie) & ~CHILDBIT);
 	if (parent == NULL) {
 		if (tree->avl_root != NULL) {
-			ASSERT(tree->avl_numnodes == 1);
+			ASSERT3U(tree->avl_numnodes, ==, 1);
 			tree->avl_root = NULL;
 			tree->avl_numnodes = 0;
 		}
@@ -981,7 +981,7 @@ avl_destroy_nodes(avl_tree_t *tree, void **cookie)
 	 */
 	child = (uintptr_t)(*cookie) & CHILDBIT;
 	parent->avl_child[child] = NULL;
-	ASSERT(tree->avl_numnodes > 1);
+	ASSERT3U(tree->avl_numnodes, >, 1);
 	--tree->avl_numnodes;
 
 	/*
@@ -1008,13 +1008,13 @@ avl_destroy_nodes(avl_tree_t *tree, void **cookie)
 	 */
 check_right_side:
 	if (node->avl_child[1] != NULL) {
-		ASSERT(AVL_XBALANCE(node) == 1);
+		ASSERT3U(AVL_XBALANCE(node), ==, 1);
 		parent = node;
 		node = node->avl_child[1];
 		ASSERT(node->avl_child[0] == NULL &&
 		    node->avl_child[1] == NULL);
 	} else {
-		ASSERT(AVL_XBALANCE(node) <= 0);
+		ASSERT3U(AVL_XBALANCE(node), <=, 0);
 	}
 
 done:

--- a/module/avl/avl.c
+++ b/module/avl/avl.c
@@ -578,7 +578,7 @@ avl_insert_here(
 #ifdef ZFS_DEBUG
 	diff = tree->avl_compar(new_data, here);
 	ASSERT(-1 <= diff && diff <= 1);
-	ASSERT(diff != 0);
+	ASSERT3S(diff, !=, 0);
 	ASSERT(diff > 0 ? child == 1 : child == 0);
 #endif
 
@@ -590,7 +590,7 @@ avl_insert_here(
 			diff = tree->avl_compar(new_data,
 			    AVL_NODE2DATA(node, tree->avl_offset));
 			ASSERT(-1 <= diff && diff <= 1);
-			ASSERT(diff != 0);
+			ASSERT3S(diff, !=, 0);
 			ASSERT(diff > 0 ? child == 1 : child == 0);
 #endif
 			node = node->avl_child[child];
@@ -599,7 +599,7 @@ avl_insert_here(
 		diff = tree->avl_compar(new_data,
 		    AVL_NODE2DATA(node, tree->avl_offset));
 		ASSERT(-1 <= diff && diff <= 1);
-		ASSERT(diff != 0);
+		ASSERT3S(diff, !=, 0);
 		ASSERT(diff > 0 ? child == 1 : child == 0);
 #endif
 	}

--- a/module/avl/avl.c
+++ b/module/avl/avl.c
@@ -473,7 +473,7 @@ avl_insert(avl_tree_t *tree, void *new_data, avl_index_t where)
 	size_t off = tree->avl_offset;
 
 #ifdef _LP64
-	ASSERT(((uintptr_t)new_data & 0x7) == 0);
+	ASSERT0(((uintptr_t)new_data & 0x7));
 #endif
 
 	node = AVL_DATA2NODE(new_data, off);
@@ -876,7 +876,7 @@ avl_create(avl_tree_t *tree, int (*compar) (const void *, const void *),
 	ASSERT(size > 0);
 	ASSERT(size >= offset + sizeof (avl_node_t));
 #ifdef _LP64
-	ASSERT((offset & 0x7) == 0);
+	ASSERT0((offset & 0x7));
 #endif
 
 	tree->avl_compar = compar;
@@ -892,7 +892,7 @@ void
 avl_destroy(avl_tree_t *tree)
 {
 	ASSERT(tree);
-	ASSERT(tree->avl_numnodes == 0);
+	ASSERT0(tree->avl_numnodes);
 	ASSERT(tree->avl_root == NULL);
 }
 

--- a/module/icp/algs/edonr/edonr.c
+++ b/module/icp/algs/edonr/edonr.c
@@ -516,7 +516,7 @@ EdonRUpdate(EdonRState *state, const uint8_t *data, size_t databitlen)
 			/* LastBytes = databitlen / 8 */
 			int LastBytes = (int)databitlen >> 3;
 
-			ASSERT(state->unprocessed_bits + databitlen <=
+			ASSERT3U(state->unprocessed_bits + databitlen, <=,
 			    EdonR256_BLOCK_SIZE * 8);
 
 			memcpy(hashState256(state)->LastPart
@@ -553,7 +553,7 @@ EdonRUpdate(EdonRState *state, const uint8_t *data, size_t databitlen)
 			/* LastBytes = databitlen / 8 */
 			int LastBytes = (int)databitlen >> 3;
 
-			ASSERT(state->unprocessed_bits + databitlen <=
+			ASSERT3U(state->unprocessed_bits + databitlen, <=,
 			    EdonR512_BLOCK_SIZE * 8);
 
 			memcpy(hashState512(state)->LastPart

--- a/module/icp/algs/modes/gcm.c
+++ b/module/icp/algs/modes/gcm.c
@@ -386,7 +386,7 @@ gcm_decrypt_final(gcm_ctx_t *ctx, crypto_data_t *out, size_t block_size,
 	uint64_t counter_mask = ntohll(0x00000000ffffffffULL);
 	int processed = 0, rv;
 
-	ASSERT(ctx->gcm_processed_data_len == ctx->gcm_pt_buf_len);
+	ASSERT3U(ctx->gcm_processed_data_len, ==, ctx->gcm_pt_buf_len);
 
 	gops = gcm_impl_get_ops();
 	pt_len = ctx->gcm_processed_data_len - ctx->gcm_tag_len;
@@ -1179,7 +1179,7 @@ gcm_mode_encrypt_contiguous_blocks_avx(gcm_ctx_t *ctx, char *data,
 	uint8_t *tmp = (uint8_t *)ctx->gcm_tmp;
 	int rv = CRYPTO_SUCCESS;
 
-	ASSERT(block_size == GCM_BLOCK_LEN);
+	ASSERT3U(block_size, ==, GCM_BLOCK_LEN);
 	/*
 	 * If the last call left an incomplete block, try to fill
 	 * it first.
@@ -1323,7 +1323,7 @@ gcm_encrypt_final_avx(gcm_ctx_t *ctx, crypto_data_t *out, size_t block_size)
 	int aes_rounds = ((aes_key_t *)keysched)->nr;
 	int rv;
 
-	ASSERT(block_size == GCM_BLOCK_LEN);
+	ASSERT3U(block_size, ==, GCM_BLOCK_LEN);
 
 	if (out->cd_length < (rem_len + ctx->gcm_tag_len)) {
 		return (CRYPTO_DATA_LEN_RANGE);
@@ -1421,7 +1421,7 @@ gcm_decrypt_final_avx(gcm_ctx_t *ctx, crypto_data_t *out, size_t block_size)
 		datap += done;
 		bleft -= done;
 	}
-	ASSERT(bleft < GCM_AVX_MIN_DECRYPT_BYTES);
+	ASSERT3U(bleft, <, GCM_AVX_MIN_DECRYPT_BYTES);
 
 	/*
 	 * Now less than GCM_AVX_MIN_DECRYPT_BYTES bytes remain,
@@ -1498,7 +1498,7 @@ gcm_init_avx(gcm_ctx_t *ctx, unsigned char *iv, size_t iv_len,
 	size_t chunk_size = (size_t)GCM_CHUNK_SIZE_READ;
 	size_t bleft;
 
-	ASSERT(block_size == GCM_BLOCK_LEN);
+	ASSERT3U(block_size, ==, GCM_BLOCK_LEN);
 
 	/* Init H (encrypt zero block) and create the initial counter block. */
 	memset(ctx->gcm_ghash, 0, sizeof (ctx->gcm_ghash));

--- a/module/icp/api/kcf_ctxops.c
+++ b/module/icp/api/kcf_ctxops.c
@@ -136,7 +136,7 @@ crypto_destroy_ctx_template(crypto_ctx_template_t tmpl)
 	if (ctx_tmpl == NULL)
 		return;
 
-	ASSERT(ctx_tmpl->ct_prov_tmpl != NULL);
+	ASSERT3P(ctx_tmpl->ct_prov_tmpl, !=, NULL);
 
 	memset(ctx_tmpl->ct_prov_tmpl, 0, ctx_tmpl->ct_size);
 	kmem_free(ctx_tmpl->ct_prov_tmpl, ctx_tmpl->ct_size);

--- a/module/icp/core/kcf_mech_tabs.c
+++ b/module/icp/core/kcf_mech_tabs.c
@@ -246,7 +246,7 @@ kcf_add_mech_provider(short mech_indx,
 	}
 
 	error = kcf_get_mech_entry(kcf_mech_type, &mech_entry);
-	ASSERT(error == KCF_SUCCESS);
+	ASSERT3S(error, ==, KCF_SUCCESS);
 
 	/* allocate and initialize new kcf_prov_mech_desc */
 	prov_mech = kmem_zalloc(sizeof (kcf_prov_mech_desc_t), KM_SLEEP);

--- a/module/icp/core/kcf_mech_tabs.c
+++ b/module/icp/core/kcf_mech_tabs.c
@@ -242,7 +242,7 @@ kcf_add_mech_provider(short mech_indx,
 		}
 		/* get the KCF mech type that was assigned to the mechanism */
 		kcf_mech_type = crypto_mech2id(mech_info->cm_mech_name);
-		ASSERT(kcf_mech_type != CRYPTO_MECH_INVALID);
+		ASSERT3U(kcf_mech_type, !=, CRYPTO_MECH_INVALID);
 	}
 
 	error = kcf_get_mech_entry(kcf_mech_type, &mech_entry);
@@ -423,7 +423,7 @@ crypto_mech2id(const char *mechname)
 	strlcpy(tmptab.me_name, mechname, CRYPTO_MAX_MECH_NAME);
 
 	if ((found = avl_find(&kcf_mech_hash, &tmptab, NULL))) {
-		ASSERT(found->me_mechid != CRYPTO_MECH_INVALID);
+		ASSERT3U(found->me_mechid, !=, CRYPTO_MECH_INVALID);
 		return (found->me_mechid);
 	}
 

--- a/module/icp/core/kcf_mech_tabs.c
+++ b/module/icp/core/kcf_mech_tabs.c
@@ -371,7 +371,7 @@ kcf_get_mech_entry(crypto_mech_type_t mech_type, kcf_mech_entry_t **mep)
 	int			index;
 	const kcf_mech_entry_tab_t	*me_tab;
 
-	ASSERT(mep != NULL);
+	ASSERT3P(mep, !=, NULL);
 
 	class = KCF_MECH2CLASS(mech_type);
 

--- a/module/icp/core/kcf_prov_lib.c
+++ b/module/icp/core/kcf_prov_lib.c
@@ -116,7 +116,7 @@ int
 crypto_update_iov(void *ctx, crypto_data_t *input, crypto_data_t *output,
     int (*cipher)(void *, caddr_t, size_t, crypto_data_t *))
 {
-	ASSERT(input != output);
+	ASSERT3P(input, !=, output);
 
 	if (input->cd_raw.iov_len < input->cd_length)
 		return (CRYPTO_ARGUMENTS_BAD);
@@ -135,7 +135,7 @@ crypto_update_uio(void *ctx, crypto_data_t *input, crypto_data_t *output,
 	uint_t vec_idx;
 	size_t cur_len;
 
-	ASSERT(input != output);
+	ASSERT3P(input, !=, output);
 
 	if (zfs_uio_segflg(input->cd_uio) != UIO_SYSSPACE) {
 		return (CRYPTO_ARGUMENTS_BAD);

--- a/module/icp/core/kcf_prov_lib.c
+++ b/module/icp/core/kcf_prov_lib.c
@@ -46,7 +46,7 @@ crypto_uio_copy_to_data(crypto_data_t *data, uchar_t *buf, int len)
 	size_t cur_len;
 	uchar_t *datap;
 
-	ASSERT(data->cd_format == CRYPTO_DATA_UIO);
+	ASSERT3U(data->cd_format, ==, CRYPTO_DATA_UIO);
 	if (zfs_uio_segflg(uiop) != UIO_SYSSPACE) {
 		return (CRYPTO_ARGUMENTS_BAD);
 	}

--- a/module/icp/core/kcf_prov_tabs.c
+++ b/module/icp/core/kcf_prov_tabs.c
@@ -252,7 +252,7 @@ kcf_free_provider_desc(kcf_provider_desc_t *desc)
 	mutex_enter(&prov_tab_mutex);
 	if (desc->pd_prov_id != KCF_PROVID_INVALID) {
 		/* release the associated providers table entry */
-		ASSERT(prov_tab[desc->pd_prov_id] != NULL);
+		ASSERT3P(prov_tab[desc->pd_prov_id], !=, NULL);
 		prov_tab[desc->pd_prov_id] = NULL;
 		prov_tab_num--;
 	}

--- a/module/icp/core/kcf_sched.c
+++ b/module/icp/core/kcf_sched.c
@@ -123,7 +123,7 @@ kcf_context_cache_destructor(void *buf, void *cdrarg)
 	(void) cdrarg;
 	kcf_context_t *kctx = (kcf_context_t *)buf;
 
-	ASSERT(kctx->kc_refcnt == 0);
+	ASSERT0(kctx->kc_refcnt);
 }
 
 void

--- a/module/icp/include/sys/crypto/impl.h
+++ b/module/icp/include/sys/crypto/impl.h
@@ -133,18 +133,18 @@ typedef struct kcf_provider_desc {
  */
 #define	KCF_PROV_REFHOLD(desc) {				\
 	int newval = atomic_add_32_nv(&(desc)->pd_refcnt, 1);	\
-	ASSERT(newval != 0);					\
+	ASSERT3S(newval, !=, 0);					\
 }
 
 #define	KCF_PROV_IREFHOLD(desc) {				\
 	int newval = atomic_add_32_nv(&(desc)->pd_irefcnt, 1);	\
-	ASSERT(newval != 0);					\
+	ASSERT3S(newval, !=, 0);					\
 }
 
 #define	KCF_PROV_IREFRELE(desc) {				\
 	membar_producer();					\
 	int newval = atomic_add_32_nv(&(desc)->pd_irefcnt, -1);	\
-	ASSERT(newval != -1);					\
+	ASSERT3S(newval, !=, -1);					\
 	if (newval == 0) {					\
 		cv_broadcast(&(desc)->pd_remove_cv);		\
 	}							\
@@ -155,7 +155,7 @@ typedef struct kcf_provider_desc {
 #define	KCF_PROV_REFRELE(desc) {				\
 	membar_producer();					\
 	int newval = atomic_add_32_nv(&(desc)->pd_refcnt, -1);	\
-	ASSERT(newval != -1);					\
+	ASSERT3S(newval, !=, -1);					\
 	if (newval == 0) {					\
 		kcf_provider_zero_refcnt((desc));		\
 	}							\
@@ -194,7 +194,7 @@ typedef	struct kcf_mech_entry {
  */
 #define	KCF_POLICY_REFHOLD(desc) {				\
 	int newval = atomic_add_32_nv(&(desc)->pd_refcnt, 1);	\
-	ASSERT(newval != 0);					\
+	ASSERT3S(newval, !=, 0);					\
 }
 
 /*
@@ -204,7 +204,7 @@ typedef	struct kcf_mech_entry {
 #define	KCF_POLICY_REFRELE(desc) {				\
 	membar_producer();					\
 	int newval = atomic_add_32_nv(&(desc)->pd_refcnt, -1);	\
-	ASSERT(newval != -1);					\
+	ASSERT3S(newval, !=, -1);					\
 	if (newval == 0)					\
 		kcf_policy_free_desc(desc);			\
 }

--- a/module/icp/include/sys/crypto/sched_impl.h
+++ b/module/icp/include/sys/crypto/sched_impl.h
@@ -75,7 +75,7 @@ typedef struct kcf_context {
 #define	KCF_CONTEXT_REFRELE(ictx) {				\
 	membar_producer();					\
 	int newval = atomic_add_32_nv(&(ictx)->kc_refcnt, -1);	\
-	ASSERT(newval != -1);					\
+	ASSERT3S(newval, !=, -1);					\
 	if (newval == 0)					\
 		kcf_free_context(ictx);				\
 }

--- a/module/icp/io/aes.c
+++ b/module/icp/io/aes.c
@@ -406,7 +406,7 @@ aes_encrypt(crypto_ctx_t *ctx, crypto_data_t *plaintext,
 		ciphertext->cd_offset = saved_offset;
 	}
 
-	ASSERT(aes_ctx->ac_remainder_len == 0);
+	ASSERT0(aes_ctx->ac_remainder_len);
 	(void) aes_free_context(ctx);
 
 	return (ret);
@@ -518,7 +518,7 @@ aes_decrypt(crypto_ctx_t *ctx, crypto_data_t *ciphertext,
 		plaintext->cd_offset = saved_offset;
 	}
 
-	ASSERT(aes_ctx->ac_remainder_len == 0);
+	ASSERT0(aes_ctx->ac_remainder_len);
 
 cleanup:
 	(void) aes_free_context(ctx);
@@ -911,7 +911,7 @@ aes_encrypt_atomic(crypto_mechanism_t *mechanism,
 			    aes_xor_block);
 			if (ret != CRYPTO_SUCCESS)
 				goto out;
-			ASSERT(aes_ctx.ac_remainder_len == 0);
+			ASSERT0(aes_ctx.ac_remainder_len);
 		} else if (mechanism->cm_type == AES_GCM_MECH_INFO_TYPE ||
 		    mechanism->cm_type == AES_GMAC_MECH_INFO_TYPE) {
 			ret = gcm_encrypt_final((gcm_ctx_t *)&aes_ctx,
@@ -919,7 +919,7 @@ aes_encrypt_atomic(crypto_mechanism_t *mechanism,
 			    aes_copy_block, aes_xor_block);
 			if (ret != CRYPTO_SUCCESS)
 				goto out;
-			ASSERT(aes_ctx.ac_remainder_len == 0);
+			ASSERT0(aes_ctx.ac_remainder_len);
 		} else if (mechanism->cm_type == AES_CTR_MECH_INFO_TYPE) {
 			if (aes_ctx.ac_remainder_len > 0) {
 				ret = ctr_mode_final((ctr_ctx_t *)&aes_ctx,
@@ -928,7 +928,7 @@ aes_encrypt_atomic(crypto_mechanism_t *mechanism,
 					goto out;
 			}
 		} else {
-			ASSERT(aes_ctx.ac_remainder_len == 0);
+			ASSERT0(aes_ctx.ac_remainder_len);
 		}
 
 		if (plaintext != ciphertext) {
@@ -1046,7 +1046,7 @@ aes_decrypt_atomic(crypto_mechanism_t *mechanism,
 			ret = ccm_decrypt_final((ccm_ctx_t *)&aes_ctx,
 			    plaintext, AES_BLOCK_LEN, aes_encrypt_block,
 			    aes_copy_block, aes_xor_block);
-			ASSERT(aes_ctx.ac_remainder_len == 0);
+			ASSERT0(aes_ctx.ac_remainder_len);
 			if ((ret == CRYPTO_SUCCESS) &&
 			    (ciphertext != plaintext)) {
 				plaintext->cd_length =
@@ -1059,7 +1059,7 @@ aes_decrypt_atomic(crypto_mechanism_t *mechanism,
 			ret = gcm_decrypt_final((gcm_ctx_t *)&aes_ctx,
 			    plaintext, AES_BLOCK_LEN, aes_encrypt_block,
 			    aes_xor_block);
-			ASSERT(aes_ctx.ac_remainder_len == 0);
+			ASSERT0(aes_ctx.ac_remainder_len);
 			if ((ret == CRYPTO_SUCCESS) &&
 			    (ciphertext != plaintext)) {
 				plaintext->cd_length =
@@ -1068,7 +1068,7 @@ aes_decrypt_atomic(crypto_mechanism_t *mechanism,
 				plaintext->cd_length = saved_length;
 			}
 		} else if (mechanism->cm_type != AES_CTR_MECH_INFO_TYPE) {
-			ASSERT(aes_ctx.ac_remainder_len == 0);
+			ASSERT0(aes_ctx.ac_remainder_len);
 			if (ciphertext != plaintext)
 				plaintext->cd_length =
 				    plaintext->cd_offset - saved_offset;

--- a/module/icp/io/aes.c
+++ b/module/icp/io/aes.c
@@ -479,8 +479,10 @@ aes_decrypt(crypto_ctx_t *ctx, crypto_data_t *ciphertext,
 	}
 
 	if (aes_ctx->ac_flags & CCM_MODE) {
-		ASSERT(aes_ctx->ac_processed_data_len == aes_ctx->ac_data_len);
-		ASSERT(aes_ctx->ac_processed_mac_len == aes_ctx->ac_mac_len);
+		ASSERT3U(aes_ctx->ac_processed_data_len, ==,
+		    aes_ctx->ac_data_len);
+		ASSERT3U(aes_ctx->ac_processed_mac_len, ==,
+		    aes_ctx->ac_mac_len);
 
 		/* order of following 2 lines MUST not be reversed */
 		plaintext->cd_offset = plaintext->cd_length;
@@ -771,8 +773,9 @@ aes_decrypt_final(crypto_ctx_t *ctx, crypto_data_t *data)
 			return (CRYPTO_BUFFER_TOO_SMALL);
 		}
 
-		ASSERT(aes_ctx->ac_processed_data_len == pt_len);
-		ASSERT(aes_ctx->ac_processed_mac_len == aes_ctx->ac_mac_len);
+		ASSERT3U(aes_ctx->ac_processed_data_len, ==, pt_len);
+		ASSERT3U(aes_ctx->ac_processed_mac_len, ==,
+		    aes_ctx->ac_mac_len);
 		saved_offset = data->cd_offset;
 		saved_length = data->cd_length;
 		ret = ccm_decrypt_final((ccm_ctx_t *)aes_ctx, data,
@@ -1039,10 +1042,10 @@ aes_decrypt_atomic(crypto_mechanism_t *mechanism,
 
 	if (ret == CRYPTO_SUCCESS) {
 		if (mechanism->cm_type == AES_CCM_MECH_INFO_TYPE) {
-			ASSERT(aes_ctx.ac_processed_data_len
-			    == aes_ctx.ac_data_len);
-			ASSERT(aes_ctx.ac_processed_mac_len
-			    == aes_ctx.ac_mac_len);
+			ASSERT3U(aes_ctx.ac_processed_data_len, ==,
+			    aes_ctx.ac_data_len);
+			ASSERT3U(aes_ctx.ac_processed_mac_len, ==,
+			    aes_ctx.ac_mac_len);
 			ret = ccm_decrypt_final((ccm_ctx_t *)&aes_ctx,
 			    plaintext, AES_BLOCK_LEN, aes_encrypt_block,
 			    aes_copy_block, aes_xor_block);
@@ -1165,7 +1168,7 @@ aes_free_context(crypto_ctx_t *ctx)
 
 	if (aes_ctx != NULL) {
 		if (aes_ctx->ac_flags & PROVIDER_OWNS_KEY_SCHEDULE) {
-			ASSERT(aes_ctx->ac_keysched_len != 0);
+			ASSERT3U(aes_ctx->ac_keysched_len, !=, 0);
 			memset(aes_ctx->ac_keysched, 0,
 			    aes_ctx->ac_keysched_len);
 			kmem_free(aes_ctx->ac_keysched,

--- a/module/icp/io/aes.c
+++ b/module/icp/io/aes.c
@@ -307,7 +307,7 @@ aes_encrypt(crypto_ctx_t *ctx, crypto_data_t *plaintext,
 	aes_ctx_t *aes_ctx;
 	size_t saved_length, saved_offset, length_needed;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 	aes_ctx = ctx->cc_provider_private;
 
 	/*
@@ -318,7 +318,7 @@ aes_encrypt(crypto_ctx_t *ctx, crypto_data_t *plaintext,
 	    == 0) && (plaintext->cd_length & (AES_BLOCK_LEN - 1)) != 0)
 		return (CRYPTO_DATA_LEN_RANGE);
 
-	ASSERT(ciphertext != NULL);
+	ASSERT3P(ciphertext, !=, NULL);
 
 	/*
 	 * We need to just return the length needed to store the output.
@@ -423,7 +423,7 @@ aes_decrypt(crypto_ctx_t *ctx, crypto_data_t *ciphertext,
 	off_t saved_offset;
 	size_t saved_length, length_needed;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 	aes_ctx = ctx->cc_provider_private;
 
 	/*
@@ -435,7 +435,7 @@ aes_decrypt(crypto_ctx_t *ctx, crypto_data_t *ciphertext,
 		return (CRYPTO_ENCRYPTED_DATA_LEN_RANGE);
 	}
 
-	ASSERT(plaintext != NULL);
+	ASSERT3P(plaintext, !=, NULL);
 
 	/*
 	 * Return length needed to store the output.
@@ -536,10 +536,10 @@ aes_encrypt_update(crypto_ctx_t *ctx, crypto_data_t *plaintext,
 	int ret = CRYPTO_SUCCESS;
 	aes_ctx_t *aes_ctx;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 	aes_ctx = ctx->cc_provider_private;
 
-	ASSERT(ciphertext != NULL);
+	ASSERT3P(ciphertext, !=, NULL);
 
 	/* compute number of bytes that will hold the ciphertext */
 	out_len = aes_ctx->ac_remainder_len;
@@ -604,10 +604,10 @@ aes_decrypt_update(crypto_ctx_t *ctx, crypto_data_t *ciphertext,
 	int ret = CRYPTO_SUCCESS;
 	aes_ctx_t *aes_ctx;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 	aes_ctx = ctx->cc_provider_private;
 
-	ASSERT(plaintext != NULL);
+	ASSERT3P(plaintext, !=, NULL);
 
 	/*
 	 * Compute number of bytes that will hold the plaintext.
@@ -677,7 +677,7 @@ aes_encrypt_final(crypto_ctx_t *ctx, crypto_data_t *data)
 	aes_ctx_t *aes_ctx;
 	int ret;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 	aes_ctx = ctx->cc_provider_private;
 
 	if (data->cd_format != CRYPTO_DATA_RAW &&
@@ -734,7 +734,7 @@ aes_decrypt_final(crypto_ctx_t *ctx, crypto_data_t *data)
 	off_t saved_offset;
 	size_t saved_length;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 	aes_ctx = ctx->cc_provider_private;
 
 	if (data->cd_format != CRYPTO_DATA_RAW &&
@@ -838,7 +838,7 @@ aes_encrypt_atomic(crypto_mechanism_t *mechanism,
 	size_t length_needed;
 	int ret;
 
-	ASSERT(ciphertext != NULL);
+	ASSERT3P(ciphertext, !=, NULL);
 
 	/*
 	 * CTR, CCM, GCM, and GMAC modes do not require that plaintext
@@ -970,7 +970,7 @@ aes_decrypt_atomic(crypto_mechanism_t *mechanism,
 	size_t length_needed;
 	int ret;
 
-	ASSERT(plaintext != NULL);
+	ASSERT3P(plaintext, !=, NULL);
 
 	/*
 	 * CCM, GCM, CTR, and GMAC modes do not require that ciphertext

--- a/module/icp/io/sha2_mod.c
+++ b/module/icp/io/sha2_mod.c
@@ -367,7 +367,7 @@ sha2_digest(crypto_ctx_t *ctx, crypto_data_t *data, crypto_data_t *digest)
 	int ret = CRYPTO_SUCCESS;
 	uint_t sha_digest_len;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 
 	switch (PROV_SHA2_CTX(ctx)->sc_mech_type) {
 	case SHA256_MECH_INFO_TYPE:
@@ -452,7 +452,7 @@ sha2_digest_update(crypto_ctx_t *ctx, crypto_data_t *data)
 {
 	int ret = CRYPTO_SUCCESS;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 
 	/*
 	 * Do the SHA2 update on the specified input data.
@@ -480,7 +480,7 @@ sha2_digest_final(crypto_ctx_t *ctx, crypto_data_t *digest)
 	int ret = CRYPTO_SUCCESS;
 	uint_t sha_digest_len;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 
 	switch (PROV_SHA2_CTX(ctx)->sc_mech_type) {
 	case SHA256_MECH_INFO_TYPE:
@@ -762,7 +762,7 @@ sha2_mac_update(crypto_ctx_t *ctx, crypto_data_t *data)
 {
 	int ret = CRYPTO_SUCCESS;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 
 	/*
 	 * Do a SHA2 update of the inner context using the specified
@@ -792,7 +792,7 @@ sha2_mac_final(crypto_ctx_t *ctx, crypto_data_t *mac)
 	uchar_t digest[SHA512_DIGEST_LENGTH];
 	uint32_t digest_len, sha_digest_len;
 
-	ASSERT(ctx->cc_provider_private != NULL);
+	ASSERT3P(ctx->cc_provider_private, !=, NULL);
 
 	/* Set the digest lengths to values appropriate to the mechanism */
 	switch (PROV_SHA2_HMAC_CTX(ctx)->hc_mech_type) {

--- a/module/icp/io/skein_mod.c
+++ b/module/icp/io/skein_mod.c
@@ -365,7 +365,7 @@ skein_digest(crypto_ctx_t *ctx, crypto_data_t *data, crypto_data_t *digest)
 {
 	int error = CRYPTO_SUCCESS;
 
-	ASSERT(SKEIN_CTX(ctx) != NULL);
+	ASSERT3P(SKEIN_CTX(ctx), !=, NULL);
 
 	if (digest->cd_length <
 	    CRYPTO_BITS2BYTES(SKEIN_CTX(ctx)->sc_digest_bitlen)) {
@@ -397,7 +397,7 @@ skein_update(crypto_ctx_t *ctx, crypto_data_t *data)
 {
 	int error = CRYPTO_SUCCESS;
 
-	ASSERT(SKEIN_CTX(ctx) != NULL);
+	ASSERT3P(SKEIN_CTX(ctx), !=, NULL);
 
 	switch (data->cd_format) {
 	case CRYPTO_DATA_RAW:
@@ -425,7 +425,7 @@ skein_final_nofree(crypto_ctx_t *ctx, crypto_data_t *digest)
 {
 	int error = CRYPTO_SUCCESS;
 
-	ASSERT(SKEIN_CTX(ctx) != NULL);
+	ASSERT3P(SKEIN_CTX(ctx), !=, NULL);
 
 	if (digest->cd_length <
 	    CRYPTO_BITS2BYTES(SKEIN_CTX(ctx)->sc_digest_bitlen)) {

--- a/module/icp/spi/kcf_spi.c
+++ b/module/icp/spi/kcf_spi.c
@@ -210,7 +210,7 @@ init_prov_mechs(const crypto_provider_info_t *info, kcf_provider_desc_t *desc)
 	 * mechanism, SUN_RANDOM, in this case.
 	 */
 	if (info != NULL) {
-		ASSERT(info->pi_mechanisms != NULL);
+		ASSERT3P(info->pi_mechanisms, !=, NULL);
 		desc->pd_mech_list_count = info->pi_mech_list_count;
 		desc->pd_mechanisms = info->pi_mechanisms;
 	}

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -337,7 +337,7 @@ nvt_lookup_name_type(const nvlist_t *nvl, const char *name, data_type_t type)
 		ASSERT0(priv->nvp_nentries);
 		return (NULL);
 	} else {
-		ASSERT(priv->nvp_nbuckets != 0);
+		ASSERT3U(priv->nvp_nbuckets, !=, 0);
 	}
 
 	uint64_t hash = nvt_hash(name);
@@ -1199,7 +1199,7 @@ nvlist_add_common(nvlist_t *nvl, const char *name,
 	if ((nvp = nvp_buf_alloc(nvl, nvp_sz)) == NULL)
 		return (ENOMEM);
 
-	ASSERT(nvp->nvp_size == nvp_sz);
+	ASSERT3U(nvp->nvp_size, ==, nvp_sz);
 	nvp->nvp_name_sz = name_sz;
 	nvp->nvp_value_elem = nelem;
 	nvp->nvp_type = type;

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -327,7 +327,7 @@ static nvpair_t *
 nvt_lookup_name_type(const nvlist_t *nvl, const char *name, data_type_t type)
 {
 	const nvpriv_t *priv = (const nvpriv_t *)(uintptr_t)nvl->nvl_priv;
-	ASSERT(priv != NULL);
+	ASSERT3P(priv, !=, NULL);
 
 	i_nvp_t **tab = priv->nvp_hashtable;
 
@@ -3304,7 +3304,7 @@ nvs_xdr_nvp_op(nvstream_t *nvs, nvpair_t *nvp)
 	bool_t	ret = FALSE;
 	XDR	*xdr = nvs->nvs_private;
 
-	ASSERT(xdr != NULL);
+	ASSERT3P(xdr, !=, NULL);
 
 	/* name string */
 	if ((buf = NVP_NAME(nvp)) >= buf_end)

--- a/module/os/freebsd/spl/callb.c
+++ b/module/os/freebsd/spl/callb.c
@@ -350,7 +350,7 @@ void
 callb_lock_table(void)
 {
 	mutex_enter(&ct->ct_lock);
-	ASSERT(!ct->ct_busy);
+	ASSERT0(ct->ct_busy);
 	ct->ct_busy = B_TRUE;
 	mutex_exit(&ct->ct_lock);
 }

--- a/module/os/freebsd/spl/list.c
+++ b/module/os/freebsd/spl/list.c
@@ -122,7 +122,7 @@ void
 list_remove(list_t *list, void *object)
 {
 	list_node_t *lold = list_d2l(list, object);
-	ASSERT(!list_empty(list));
+	ASSERT0(list_empty(list));
 	ASSERT3P(lold->list_next, !=, NULL);
 	list_remove_node(lold);
 }
@@ -213,7 +213,7 @@ void
 list_link_replace(list_node_t *lold, list_node_t *lnew)
 {
 	ASSERT(list_link_active(lold));
-	ASSERT(!list_link_active(lnew));
+	ASSERT0(list_link_active(lnew));
 
 	lnew->list_next = lold->list_next;
 	lnew->list_prev = lold->list_prev;

--- a/module/os/freebsd/zfs/abd_os.c
+++ b/module/os/freebsd/zfs/abd_os.c
@@ -123,7 +123,7 @@ abd_chunkcnt_for_bytes(size_t size)
 static inline uint_t
 abd_scatter_chunkcnt(abd_t *abd)
 {
-	ASSERT(!abd_is_linear(abd));
+	ASSERT0(abd_is_linear(abd));
 	return (abd_chunkcnt_for_bytes(
 	    ABD_SCATTER(abd).abd_offset + abd->abd_size));
 }
@@ -175,7 +175,7 @@ abd_verify_scatter(abd_t *abd)
 	 * There is no scatter linear pages in FreeBSD so there is
 	 * an error if the ABD has been marked as a linear page.
 	 */
-	ASSERT(!abd_is_linear_page(abd));
+	ASSERT0(abd_is_linear_page(abd));
 	ASSERT3U(ABD_SCATTER(abd).abd_offset, <, PAGE_SIZE);
 	n = abd_scatter_chunkcnt(abd);
 	for (i = 0; i < n; i++) {
@@ -415,7 +415,7 @@ abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off,
 void
 abd_iter_init(struct abd_iter *aiter, abd_t *abd)
 {
-	ASSERT(!abd_is_gang(abd));
+	ASSERT0(abd_is_gang(abd));
 	abd_verify(abd);
 	aiter->iter_abd = abd;
 	aiter->iter_pos = 0;

--- a/module/os/freebsd/zfs/dmu_os.c
+++ b/module/os/freebsd/zfs/dmu_os.c
@@ -184,7 +184,7 @@ dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
 			break;
 		}
 		ASSERT3U(m->dirty, ==, 0);
-		ASSERT(!pmap_page_is_write_mapped(m));
+		ASSERT0(pmap_page_is_write_mapped(m));
 
 		ASSERT3U(db->db_size, >, PAGE_SIZE);
 		bufoff = IDX_TO_OFF(m->pindex) % db->db_size;
@@ -211,7 +211,7 @@ dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
 				vm_page_assert_xbusied(m);
 				ASSERT(vm_page_none_valid(m));
 				ASSERT3U(m->dirty, ==, 0);
-				ASSERT(!pmap_page_is_write_mapped(m));
+				ASSERT0(pmap_page_is_write_mapped(m));
 				va = zfs_map_page(m, &sf);
 			}
 		}
@@ -303,7 +303,7 @@ dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
 			break;
 		}
 		ASSERT3U(m->dirty, ==, 0);
-		ASSERT(!pmap_page_is_write_mapped(m));
+		ASSERT0(pmap_page_is_write_mapped(m));
 
 		ASSERT3U(db->db_size, >, PAGE_SIZE);
 		bufoff = IDX_TO_OFF(m->pindex) % db->db_size;

--- a/module/os/freebsd/zfs/vdev_file.c
+++ b/module/os/freebsd/zfs/vdev_file.c
@@ -138,7 +138,7 @@ vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	 * to local zone users, so the underlying devices should be as well.
 	 */
 	ASSERT3P(vd->vdev_path, !=, NULL);
-	ASSERT(vd->vdev_path[0] == '/');
+	ASSERT3U(vd->vdev_path[0], ==, '/');
 
 	error = zfs_file_open(vd->vdev_path,
 	    vdev_file_open_mode(spa_mode(vd->vdev_spa)), 0, &fp);

--- a/module/os/freebsd/zfs/zfs_ctldir.c
+++ b/module/os/freebsd/zfs/zfs_ctldir.c
@@ -1366,7 +1366,7 @@ zfsctl_snapshot_unmount(const char *snapname, int flags __unused)
 	}
 	vfsp = zfsvfs->z_vfs;
 
-	ASSERT(!dsl_pool_config_held(dmu_objset_pool(zfsvfs->z_os)));
+	ASSERT0(dsl_pool_config_held(dmu_objset_pool(zfsvfs->z_os)));
 
 	vfs_ref(vfsp);
 	vfs_unbusy(vfsp);

--- a/module/os/freebsd/zfs/zfs_dir.c
+++ b/module/os/freebsd/zfs/zfs_dir.c
@@ -190,7 +190,7 @@ zfs_dirent_lookup(znode_t *dzp, const char *name, znode_t **zpp, int flag)
 		error = zfs_zget(zfsvfs, zoid, &zp);
 		if (error)
 			return (error);
-		ASSERT(!zp->z_unlinked);
+		ASSERT0(zp->z_unlinked);
 		*zpp = zp;
 	}
 
@@ -593,7 +593,7 @@ zfs_link_create(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 	}
 	if (!(flag & ZRENAMING)) {
 		if (zp->z_unlinked) {	/* no new links to unlinked zp */
-			ASSERT(!(flag & (ZNEW | ZEXISTS)));
+			ASSERT0((flag & (ZNEW | ZEXISTS)));
 			return (SET_ERROR(ENOENT));
 		}
 		if (zp->z_links >= ZFS_LINK_MAX - zp_is_dir) {
@@ -604,7 +604,7 @@ zfs_link_create(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 		    &zp->z_links, sizeof (zp->z_links));
 
 	} else {
-		ASSERT(!zp->z_unlinked);
+		ASSERT0(zp->z_unlinked);
 	}
 	value = zfs_dirent(zp, zp->z_mode);
 	error = zap_add(zp->z_zfsvfs->z_os, dzp->z_id, name,
@@ -763,7 +763,7 @@ zfs_link_destroy(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 		count = 0;
 		ASSERT0(error);
 	} else {
-		ASSERT(!zp->z_unlinked);
+		ASSERT0(zp->z_unlinked);
 		error = zfs_dropname(dzp, name, zp, tx, flag);
 		if (error != 0)
 			return (error);

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -348,7 +348,7 @@ page_busy(vnode_t *vp, int64_t start, int64_t off, int64_t nbytes)
 			}
 			vm_page_sbusy(pp);
 		} else if (pp != NULL) {
-			ASSERT(!pp->valid);
+			ASSERT0(pp->valid);
 			pp = NULL;
 		}
 		if (pp != NULL) {
@@ -3071,7 +3071,7 @@ zfs_rename_check(znode_t *szp, znode_t *sdzp, znode_t *tdzp)
 		return (0);
 	zp = tdzp;
 	for (;;) {
-		ASSERT(!zp->z_unlinked);
+		ASSERT0(zp->z_unlinked);
 		if ((error = sa_lookup(zp->z_sa_hdl,
 		    SA_ZPL_PARENT(zfsvfs), &parent, sizeof (parent))) != 0)
 			break;

--- a/module/os/freebsd/zfs/zfs_znode.c
+++ b/module/os/freebsd/zfs/zfs_znode.c
@@ -165,9 +165,9 @@ zfs_znode_cache_destructor(void *buf, void *arg)
 	(void) arg;
 	znode_t *zp = buf;
 
-	ASSERT(!POINTER_IS_VALID(zp->z_zfsvfs));
+	ASSERT0(POINTER_IS_VALID(zp->z_zfsvfs));
 	ASSERT3P(zp->z_vnode, ==, NULL);
-	ASSERT(!list_link_active(&zp->z_link_node));
+	ASSERT0(list_link_active(&zp->z_link_node));
 	mutex_destroy(&zp->z_lock);
 	mutex_destroy(&zp->z_acl_lock);
 	rw_destroy(&zp->z_xattr_lock);
@@ -291,7 +291,7 @@ zfs_create_share_dir(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 	vattr.va_gid = crgetgid(kcred);
 
 	sharezp = zfs_znode_alloc_kmem(KM_SLEEP);
-	ASSERT(!POINTER_IS_VALID(sharezp->z_zfsvfs));
+	ASSERT0(POINTER_IS_VALID(sharezp->z_zfsvfs));
 	sharezp->z_unlinked = 0;
 	sharezp->z_atime_dirty = 0;
 	sharezp->z_zfsvfs = zfsvfs;
@@ -448,7 +448,7 @@ zfs_znode_alloc(zfsvfs_t *zfsvfs, dmu_buf_t *db, int blksz,
 	zp->z_vnode = vp;
 	vp->v_data = zp;
 
-	ASSERT(!POINTER_IS_VALID(zp->z_zfsvfs));
+	ASSERT0(POINTER_IS_VALID(zp->z_zfsvfs));
 
 	zp->z_sa_hdl = NULL;
 	zp->z_unlinked = 0;
@@ -1227,7 +1227,7 @@ zfs_znode_delete(znode_t *zp, dmu_tx_t *tx)
 
 	ZFS_OBJ_HOLD_ENTER(zfsvfs, obj);
 	if (acl_obj) {
-		VERIFY(!zp->z_is_sa);
+		VERIFY0(zp->z_is_sa);
 		VERIFY0(dmu_object_free(os, acl_obj, tx));
 	}
 	VERIFY0(dmu_object_free(os, obj, tx));
@@ -1258,7 +1258,7 @@ zfs_zinactive(znode_t *zp)
 	 * closed.  The file will remain in the unlinked set.
 	 */
 	if (zp->z_unlinked) {
-		ASSERT(!zfsvfs->z_issnap);
+		ASSERT0(zfsvfs->z_issnap);
 		if ((zfsvfs->z_vfs->vfs_flag & VFS_RDONLY) == 0) {
 			ZFS_OBJ_HOLD_EXIT(zfsvfs, z_id);
 			zfs_rmnode(zp);
@@ -1424,7 +1424,7 @@ zfs_extend(znode_t *zp, uint64_t end)
 			 * "recordsize" property.  Only let it grow to
 			 * the next power of 2.
 			 */
-			ASSERT(!ISP2(zp->z_blksz));
+			ASSERT0(ISP2(zp->z_blksz));
 			newblksz = MIN(end, 1 << highbit64(zp->z_blksz));
 		} else {
 			newblksz = MIN(end, zp->z_zfsvfs->z_max_blksz);
@@ -1743,7 +1743,7 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	zfsvfs = kmem_zalloc(sizeof (zfsvfs_t), KM_SLEEP);
 
 	rootzp = zfs_znode_alloc_kmem(KM_SLEEP);
-	ASSERT(!POINTER_IS_VALID(rootzp->z_zfsvfs));
+	ASSERT0(POINTER_IS_VALID(rootzp->z_zfsvfs));
 	rootzp->z_unlinked = 0;
 	rootzp->z_atime_dirty = 0;
 	rootzp->z_is_sa = USE_SA(version, os);

--- a/module/os/freebsd/zfs/zio_crypt.c
+++ b/module/os/freebsd/zfs/zio_crypt.c
@@ -1200,7 +1200,7 @@ zio_crypt_do_indirect_mac_checksum(boolean_t generate, void *buf,
 	ret = zio_crypt_do_indirect_mac_checksum_impl(generate, buf,
 	    datalen, ZIO_CRYPT_KEY_CURRENT_VERSION, byteswap, cksum);
 	if (ret == ECKSUM) {
-		ASSERT(!generate);
+		ASSERT0(generate);
 		ret = zio_crypt_do_indirect_mac_checksum_impl(generate,
 		    buf, datalen, 0, byteswap, cksum);
 	}

--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -1336,8 +1336,8 @@ zvol_os_rename_minor(zvol_state_t *zv, const char *newname)
 void
 zvol_os_free(zvol_state_t *zv)
 {
-	ASSERT(!RW_LOCK_HELD(&zv->zv_suspend_lock));
-	ASSERT(!MUTEX_HELD(&zv->zv_state_lock));
+	ASSERT0(RW_LOCK_HELD(&zv->zv_suspend_lock));
+	ASSERT0(MUTEX_HELD(&zv->zv_state_lock));
 	ASSERT0(zv->zv_open_count);
 
 	ZFS_LOG(1, "ZVOL %s destroyed.", zv->zv_name);
@@ -1541,7 +1541,7 @@ zvol_os_clear_private(zvol_state_t *zv)
 			msleep(&zsg->zsg_state, &zsg->zsg_queue_mtx,
 			    0, "zvol:w", 0);
 		mtx_unlock(&zsg->zsg_queue_mtx);
-		ASSERT(!RW_LOCK_HELD(&zv->zv_suspend_lock));
+		ASSERT0(RW_LOCK_HELD(&zv->zv_suspend_lock));
 	} else if (zv->zv_volmode == ZFS_VOLMODE_DEV) {
 		struct zvol_state_dev *zsd = &zv->zv_zso->zso_dev;
 		struct cdev *dev = zsd->zsd_cdev;

--- a/module/os/linux/spl/spl-condvar.c
+++ b/module/os/linux/spl/spl-condvar.c
@@ -69,7 +69,7 @@ __cv_init(kcondvar_t *cvp, char *name, kcv_type_t type, void *arg)
 {
 	ASSERT(cvp);
 	ASSERT3P(name, ==, NULL);
-	ASSERT(type == CV_DEFAULT);
+	ASSERT3U(type, ==, CV_DEFAULT);
 	ASSERT3P(arg, ==, NULL);
 
 	cvp->cv_magic = CV_MAGIC;
@@ -97,7 +97,7 @@ void
 __cv_destroy(kcondvar_t *cvp)
 {
 	ASSERT(cvp);
-	ASSERT(cvp->cv_magic == CV_MAGIC);
+	ASSERT3U(cvp->cv_magic, ==, CV_MAGIC);
 
 	cvp->cv_magic = CV_DESTROY;
 	atomic_dec(&cvp->cv_refs);
@@ -121,7 +121,7 @@ cv_wait_common(kcondvar_t *cvp, kmutex_t *mp, int state, int io)
 
 	ASSERT(cvp);
 	ASSERT(mp);
-	ASSERT(cvp->cv_magic == CV_MAGIC);
+	ASSERT3U(cvp->cv_magic, ==, CV_MAGIC);
 	ASSERT(mutex_owned(mp));
 	atomic_inc(&cvp->cv_refs);
 
@@ -265,7 +265,7 @@ __cv_timedwait_common(kcondvar_t *cvp, kmutex_t *mp, clock_t expire_time,
 
 	ASSERT(cvp);
 	ASSERT(mp);
-	ASSERT(cvp->cv_magic == CV_MAGIC);
+	ASSERT3U(cvp->cv_magic, ==, CV_MAGIC);
 	ASSERT(mutex_owned(mp));
 
 	/* XXX - Does not handle jiffie wrap properly */
@@ -373,7 +373,7 @@ __cv_timedwait_hires(kcondvar_t *cvp, kmutex_t *mp, hrtime_t expire_time,
 
 	ASSERT(cvp);
 	ASSERT(mp);
-	ASSERT(cvp->cv_magic == CV_MAGIC);
+	ASSERT3U(cvp->cv_magic, ==, CV_MAGIC);
 	ASSERT(mutex_owned(mp));
 
 	time_left = expire_time - gethrtime();
@@ -474,7 +474,7 @@ void
 __cv_signal(kcondvar_t *cvp)
 {
 	ASSERT(cvp);
-	ASSERT(cvp->cv_magic == CV_MAGIC);
+	ASSERT3U(cvp->cv_magic, ==, CV_MAGIC);
 	atomic_inc(&cvp->cv_refs);
 
 	/*
@@ -494,7 +494,7 @@ void
 __cv_broadcast(kcondvar_t *cvp)
 {
 	ASSERT(cvp);
-	ASSERT(cvp->cv_magic == CV_MAGIC);
+	ASSERT3U(cvp->cv_magic, ==, CV_MAGIC);
 	atomic_inc(&cvp->cv_refs);
 
 	/*

--- a/module/os/linux/spl/spl-condvar.c
+++ b/module/os/linux/spl/spl-condvar.c
@@ -86,7 +86,7 @@ cv_destroy_wakeup(kcondvar_t *cvp)
 {
 	if (!atomic_read(&cvp->cv_waiters) && !atomic_read(&cvp->cv_refs)) {
 		ASSERT(cvp->cv_mutex == NULL);
-		ASSERT(!waitqueue_active(&cvp->cv_event));
+		ASSERT0(waitqueue_active(&cvp->cv_event));
 		return (1);
 	}
 

--- a/module/os/linux/spl/spl-condvar.c
+++ b/module/os/linux/spl/spl-condvar.c
@@ -68,9 +68,9 @@ void
 __cv_init(kcondvar_t *cvp, char *name, kcv_type_t type, void *arg)
 {
 	ASSERT(cvp);
-	ASSERT(name == NULL);
+	ASSERT3P(name, ==, NULL);
 	ASSERT(type == CV_DEFAULT);
-	ASSERT(arg == NULL);
+	ASSERT3P(arg, ==, NULL);
 
 	cvp->cv_magic = CV_MAGIC;
 	init_waitqueue_head(&cvp->cv_event);
@@ -85,7 +85,7 @@ static int
 cv_destroy_wakeup(kcondvar_t *cvp)
 {
 	if (!atomic_read(&cvp->cv_waiters) && !atomic_read(&cvp->cv_refs)) {
-		ASSERT(cvp->cv_mutex == NULL);
+		ASSERT3P(cvp->cv_mutex, ==, NULL);
 		ASSERT0(waitqueue_active(&cvp->cv_event));
 		return (1);
 	}

--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -309,11 +309,11 @@ spl_slab_free(spl_kmem_slab_t *sks,
 {
 	spl_kmem_cache_t *skc;
 
-	ASSERT(sks->sks_magic == SKS_MAGIC);
+	ASSERT3U(sks->sks_magic, ==, SKS_MAGIC);
 	ASSERT0(sks->sks_ref);
 
 	skc = sks->sks_cache;
-	ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
 
 	/*
 	 * Update slab/objects counters in the cache, then remove the
@@ -365,11 +365,11 @@ spl_slab_reclaim(spl_kmem_cache_t *skc)
 	 */
 
 	list_for_each_entry_safe(sko, n, &sko_list, sko_list) {
-		ASSERT(sko->sko_magic == SKO_MAGIC);
+		ASSERT3U(sko->sko_magic, ==, SKO_MAGIC);
 	}
 
 	list_for_each_entry_safe(sks, m, &sks_list, sks_list) {
-		ASSERT(sks->sks_magic == SKS_MAGIC);
+		ASSERT3U(sks->sks_magic, ==, SKS_MAGIC);
 		kv_free(skc, sks, skc->skc_slab_size);
 	}
 }
@@ -505,8 +505,8 @@ spl_cache_flush(spl_kmem_cache_t *skc, spl_kmem_magazine_t *skm, int flush)
 {
 	spin_lock(&skc->skc_lock);
 
-	ASSERT(skc->skc_magic == SKC_MAGIC);
-	ASSERT(skm->skm_magic == SKM_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
+	ASSERT3U(skm->skm_magic, ==, SKM_MAGIC);
 
 	int count = MIN(flush, skm->skm_avail);
 	for (int i = 0; i < count; i++)
@@ -609,7 +609,7 @@ spl_magazine_alloc(spl_kmem_cache_t *skc, int cpu)
 static void
 spl_magazine_free(spl_kmem_magazine_t *skm)
 {
-	ASSERT(skm->skm_magic == SKM_MAGIC);
+	ASSERT3U(skm->skm_magic, ==, SKM_MAGIC);
 	ASSERT0(skm->skm_avail);
 	kfree(skm);
 }
@@ -851,7 +851,7 @@ spl_kmem_cache_destroy(spl_kmem_cache_t *skc)
 	DECLARE_WAIT_QUEUE_HEAD(wq);
 	taskqid_t id;
 
-	ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
 	ASSERT(skc->skc_flags & (KMC_KVMEM | KMC_SLAB));
 
 	down_write(&spl_kmem_cache_sem);
@@ -914,11 +914,11 @@ spl_cache_obj(spl_kmem_cache_t *skc, spl_kmem_slab_t *sks)
 {
 	spl_kmem_obj_t *sko;
 
-	ASSERT(skc->skc_magic == SKC_MAGIC);
-	ASSERT(sks->sks_magic == SKS_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
+	ASSERT3U(sks->sks_magic, ==, SKS_MAGIC);
 
 	sko = list_entry(sks->sks_free_list.next, spl_kmem_obj_t, sko_list);
-	ASSERT(sko->sko_magic == SKO_MAGIC);
+	ASSERT3U(sko->sko_magic, ==, SKO_MAGIC);
 	ASSERT3P(sko->sko_addr, !=, NULL);
 
 	/* Remove from sks_free_list */
@@ -1010,7 +1010,7 @@ spl_cache_grow(spl_kmem_cache_t *skc, int flags, void **obj)
 	int remaining, rc = 0;
 
 	ASSERT0(flags & ~KM_PUBLIC_MASK);
-	ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
 	ASSERT0((skc->skc_flags & KMC_SLAB));
 	might_sleep();
 	*obj = NULL;
@@ -1103,8 +1103,8 @@ spl_cache_refill(spl_kmem_cache_t *skc, spl_kmem_magazine_t *skm, int flags)
 	int count = 0, rc, refill;
 	void *obj = NULL;
 
-	ASSERT(skc->skc_magic == SKC_MAGIC);
-	ASSERT(skm->skm_magic == SKM_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
+	ASSERT3U(skm->skm_magic, ==, SKM_MAGIC);
 
 	refill = MIN(skm->skm_refill, skm->skm_size - skm->skm_avail);
 	spin_lock(&skc->skc_lock);
@@ -1143,8 +1143,8 @@ spl_cache_refill(spl_kmem_cache_t *skc, spl_kmem_magazine_t *skm, int flags)
 		/* Grab the next available slab */
 		sks = list_entry((&skc->skc_partial_list)->next,
 		    spl_kmem_slab_t, sks_list);
-		ASSERT(sks->sks_magic == SKS_MAGIC);
-		ASSERT(sks->sks_ref < sks->sks_objs);
+		ASSERT3U(sks->sks_magic, ==, SKS_MAGIC);
+		ASSERT3U(sks->sks_ref, <, sks->sks_objs);
 		ASSERT0(list_empty(&sks->sks_free_list));
 
 		/*
@@ -1153,8 +1153,8 @@ spl_cache_refill(spl_kmem_cache_t *skc, spl_kmem_magazine_t *skm, int flags)
 		 */
 		while (sks->sks_ref < sks->sks_objs && refill-- > 0 &&
 		    ++count) {
-			ASSERT(skm->skm_avail < skm->skm_size);
-			ASSERT(count < skm->skm_size);
+			ASSERT3U(skm->skm_avail, <, skm->skm_size);
+			ASSERT3U(count, <, skm->skm_size);
 			skm->skm_objs[skm->skm_avail++] =
 			    spl_cache_obj(skc, sks);
 		}
@@ -1180,12 +1180,12 @@ spl_cache_shrink(spl_kmem_cache_t *skc, void *obj)
 	spl_kmem_slab_t *sks = NULL;
 	spl_kmem_obj_t *sko = NULL;
 
-	ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
 
 	sko = spl_sko_from_obj(skc, obj);
-	ASSERT(sko->sko_magic == SKO_MAGIC);
+	ASSERT3U(sko->sko_magic, ==, SKO_MAGIC);
 	sks = sko->sko_slab;
-	ASSERT(sks->sks_magic == SKS_MAGIC);
+	ASSERT3U(sks->sks_magic, ==, SKS_MAGIC);
 	ASSERT3P(sks->sks_cache, ==, skc);
 	list_add(&sko->sko_list, &sks->sks_free_list);
 
@@ -1225,7 +1225,7 @@ spl_kmem_cache_alloc(spl_kmem_cache_t *skc, int flags)
 	void *obj = NULL;
 
 	ASSERT0(flags & ~KM_PUBLIC_MASK);
-	ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
 	ASSERT0(test_bit(KMC_BIT_DESTROY, &skc->skc_flags));
 
 	/*
@@ -1261,7 +1261,7 @@ restart:
 	 * when we need to grow the cache.
 	 */
 	skm = skc->skc_mag[smp_processor_id()];
-	ASSERT(skm->skm_magic == SKM_MAGIC);
+	ASSERT3U(skm->skm_magic, ==, SKM_MAGIC);
 
 	if (likely(skm->skm_avail)) {
 		/* Object available in CPU cache, use it */
@@ -1306,7 +1306,7 @@ spl_kmem_cache_free(spl_kmem_cache_t *skc, void *obj)
 	int do_reclaim = 0;
 	int do_emergency = 0;
 
-	ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
 	ASSERT0(test_bit(KMC_BIT_DESTROY, &skc->skc_flags));
 
 	/*
@@ -1348,7 +1348,7 @@ spl_kmem_cache_free(spl_kmem_cache_t *skc, void *obj)
 	 * CPU cache and return it to another.
 	 */
 	skm = skc->skc_mag[smp_processor_id()];
-	ASSERT(skm->skm_magic == SKM_MAGIC);
+	ASSERT3U(skm->skm_magic, ==, SKM_MAGIC);
 
 	/*
 	 * Per-CPU cache full, flush it to make space for this object,
@@ -1380,7 +1380,7 @@ EXPORT_SYMBOL(spl_kmem_cache_free);
 void
 spl_kmem_cache_reap_now(spl_kmem_cache_t *skc)
 {
-	ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
 	ASSERT0(test_bit(KMC_BIT_DESTROY, &skc->skc_flags));
 
 	if (skc->skc_flags & KMC_SLAB)

--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -690,8 +690,8 @@ spl_kmem_cache_create(const char *name, size_t size, size_t align,
 	/*
 	 * Unsupported flags
 	 */
-	ASSERT(vmp == NULL);
-	ASSERT(reclaim == NULL);
+	ASSERT3P(vmp, ==, NULL);
+	ASSERT3P(reclaim, ==, NULL);
 
 	might_sleep();
 
@@ -838,7 +838,7 @@ void
 spl_kmem_cache_set_move(spl_kmem_cache_t *skc,
     kmem_cbrc_t (move)(void *, void *, size_t, void *))
 {
-	ASSERT(move != NULL);
+	ASSERT3P(move, !=, NULL);
 }
 EXPORT_SYMBOL(spl_kmem_cache_set_move);
 
@@ -919,7 +919,7 @@ spl_cache_obj(spl_kmem_cache_t *skc, spl_kmem_slab_t *sks)
 
 	sko = list_entry(sks->sks_free_list.next, spl_kmem_obj_t, sko_list);
 	ASSERT(sko->sko_magic == SKO_MAGIC);
-	ASSERT(sko->sko_addr != NULL);
+	ASSERT3P(sko->sko_addr, !=, NULL);
 
 	/* Remove from sks_free_list */
 	list_del_init(&sko->sko_list);
@@ -1186,7 +1186,7 @@ spl_cache_shrink(spl_kmem_cache_t *skc, void *obj)
 	ASSERT(sko->sko_magic == SKO_MAGIC);
 	sks = sko->sko_slab;
 	ASSERT(sks->sks_magic == SKS_MAGIC);
-	ASSERT(sks->sks_cache == skc);
+	ASSERT3P(sks->sks_cache, ==, skc);
 	list_add(&sko->sko_list, &sks->sks_free_list);
 
 	sks->sks_age = jiffies;

--- a/module/os/linux/spl/spl-kstat.c
+++ b/module/os/linux/spl/spl-kstat.c
@@ -265,7 +265,7 @@ restart:
 static int
 kstat_default_update(kstat_t *ksp, int rw)
 {
-	ASSERT(ksp != NULL);
+	ASSERT3P(ksp, !=, NULL);
 
 	if (rw == KSTAT_WRITE)
 		return (EACCES);

--- a/module/os/linux/spl/spl-kstat.c
+++ b/module/os/linux/spl/spl-kstat.c
@@ -56,7 +56,7 @@ kstat_seq_show_headers(struct seq_file *f)
 	kstat_t *ksp = (kstat_t *)f->private;
 	int rc = 0;
 
-	ASSERT(ksp->ks_magic == KS_MAGIC);
+	ASSERT3U(ksp->ks_magic, ==, KS_MAGIC);
 
 	seq_printf(f, "%d %d 0x%02x %d %d %lld %lld\n",
 	    ksp->ks_kid, ksp->ks_type, ksp->ks_flags,
@@ -225,7 +225,7 @@ kstat_seq_show(struct seq_file *f, void *p)
 	kstat_t *ksp = (kstat_t *)f->private;
 	int rc = 0;
 
-	ASSERT(ksp->ks_magic == KS_MAGIC);
+	ASSERT3U(ksp->ks_magic, ==, KS_MAGIC);
 
 	switch (ksp->ks_type) {
 		case KSTAT_TYPE_RAW:
@@ -238,7 +238,7 @@ restart:
 				if (!rc)
 					seq_puts(f, ksp->ks_raw_buf);
 			} else {
-				ASSERT(ksp->ks_ndata == 1);
+				ASSERT3U(ksp->ks_ndata, ==, 1);
 				rc = kstat_seq_show_raw(f, ksp->ks_data,
 				    ksp->ks_data_size);
 			}
@@ -309,7 +309,7 @@ kstat_seq_start(struct seq_file *f, loff_t *pos)
 {
 	loff_t n = *pos;
 	kstat_t *ksp = (kstat_t *)f->private;
-	ASSERT(ksp->ks_magic == KS_MAGIC);
+	ASSERT3U(ksp->ks_magic, ==, KS_MAGIC);
 
 	mutex_enter(ksp->ks_lock);
 
@@ -337,7 +337,7 @@ static void *
 kstat_seq_next(struct seq_file *f, void *p, loff_t *pos)
 {
 	kstat_t *ksp = (kstat_t *)f->private;
-	ASSERT(ksp->ks_magic == KS_MAGIC);
+	ASSERT3U(ksp->ks_magic, ==, KS_MAGIC);
 
 	++*pos;
 	if (*pos >= ksp->ks_ndata)
@@ -350,7 +350,7 @@ static void
 kstat_seq_stop(struct seq_file *f, void *v)
 {
 	kstat_t *ksp = (kstat_t *)f->private;
-	ASSERT(ksp->ks_magic == KS_MAGIC);
+	ASSERT3U(ksp->ks_magic, ==, KS_MAGIC);
 
 	if (ksp->ks_type == KSTAT_TYPE_RAW)
 		vmem_free(ksp->ks_raw_buf, ksp->ks_raw_bufsize);
@@ -431,7 +431,7 @@ proc_kstat_write(struct file *filp, const char __user *buf, size_t len,
 	kstat_t *ksp = f->private;
 	int rc;
 
-	ASSERT(ksp->ks_magic == KS_MAGIC);
+	ASSERT3U(ksp->ks_magic, ==, KS_MAGIC);
 
 	mutex_enter(ksp->ks_lock);
 	rc = ksp->ks_update(ksp, KSTAT_WRITE);
@@ -496,7 +496,7 @@ __kstat_create(const char *ks_module, int ks_instance, const char *ks_name,
 	ASSERT(ks_name);
 
 	if ((ks_type == KSTAT_TYPE_INTR) || (ks_type == KSTAT_TYPE_IO))
-		ASSERT(ks_ndata == 1);
+		ASSERT3U(ks_ndata, ==, 1);
 
 	ksp = kmem_zalloc(sizeof (*ksp), KM_SLEEP);
 	if (ksp == NULL)

--- a/module/os/linux/spl/spl-kstat.c
+++ b/module/os/linux/spl/spl-kstat.c
@@ -492,7 +492,7 @@ __kstat_create(const char *ks_module, int ks_instance, const char *ks_name,
 	kstat_t *ksp;
 
 	ASSERT(ks_module);
-	ASSERT(ks_instance == 0);
+	ASSERT0(ks_instance);
 	ASSERT(ks_name);
 
 	if ((ks_type == KSTAT_TYPE_INTR) || (ks_type == KSTAT_TYPE_IO))

--- a/module/os/linux/spl/spl-proc.c
+++ b/module/os/linux/spl/spl-proc.c
@@ -726,6 +726,6 @@ spl_proc_fini(void)
 	remove_proc_entry("taskq", proc_spl);
 	remove_proc_entry("spl", NULL);
 
-	ASSERT(spl_header != NULL);
+	ASSERT3P(spl_header, !=, NULL);
 	unregister_sysctl_table(spl_header);
 }

--- a/module/os/linux/spl/spl-proc.c
+++ b/module/os/linux/spl/spl-proc.c
@@ -375,7 +375,7 @@ slab_seq_show(struct seq_file *f, void *p)
 {
 	spl_kmem_cache_t *skc = p;
 
-	ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT3U(skc->skc_magic, ==, SKC_MAGIC);
 
 	if (skc->skc_flags & KMC_SLAB) {
 		/*

--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -1046,7 +1046,7 @@ taskq_create(const char *name, int threads_arg, pri_t pri,
 	unsigned long irqflags;
 	int nthreads = threads_arg;
 
-	ASSERT(name != NULL);
+	ASSERT3P(name, !=, NULL);
 	ASSERT(minalloc >= 0);
 	ASSERT0((flags & (TASKQ_CPR_SAFE))); /* Unsupported */
 

--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -1047,13 +1047,13 @@ taskq_create(const char *name, int threads_arg, pri_t pri,
 	int nthreads = threads_arg;
 
 	ASSERT3P(name, !=, NULL);
-	ASSERT(minalloc >= 0);
+	ASSERT3S(minalloc, >=, 0);
 	ASSERT0((flags & (TASKQ_CPR_SAFE))); /* Unsupported */
 
 	/* Scale the number of threads using nthreads as a percentage */
 	if (flags & TASKQ_THREADS_CPU_PCT) {
-		ASSERT(nthreads <= 100);
-		ASSERT(nthreads >= 0);
+		ASSERT3S(nthreads, <=, 100);
+		ASSERT3S(nthreads, >=, 0);
 		nthreads = MIN(threads_arg, 100);
 		nthreads = MAX(nthreads, 0);
 		nthreads = MAX((num_online_cpus() * nthreads) /100, 1);

--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -298,7 +298,7 @@ taskq_lowest_id(taskq_t *tq)
 	if (!list_empty(&tq->tq_active_list)) {
 		tqt = list_entry(tq->tq_active_list.next, taskq_thread_t,
 		    tqt_active_list);
-		ASSERT(tqt->tqt_id != TASKQID_INVALID);
+		ASSERT3U(tqt->tqt_id, !=, TASKQID_INVALID);
 		lowest_id = MIN(lowest_id, tqt->tqt_id);
 	}
 
@@ -585,7 +585,7 @@ taskq_dispatch(taskq_t *tq, task_func_t func, void *arg, uint_t flags)
 		goto out;
 
 	/* Do not queue the task unless there is idle thread for it */
-	ASSERT(tq->tq_nactive <= tq->tq_nthreads);
+	ASSERT3U(tq->tq_nactive, <=, tq->tq_nthreads);
 	if ((flags & TQ_NOQUEUE) && (tq->tq_nactive == tq->tq_nthreads)) {
 		/* Dynamic taskq may be able to spawn another thread */
 		if (!(tq->tq_flags & TASKQ_DYNAMIC) ||

--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -123,9 +123,9 @@ retry:
 	if (!list_empty(&tq->tq_free_list) && !(flags & TQ_NEW)) {
 		t = list_entry(tq->tq_free_list.next, taskq_ent_t, tqent_list);
 
-		ASSERT(!(t->tqent_flags & TQENT_FLAG_PREALLOC));
-		ASSERT(!(t->tqent_flags & TQENT_FLAG_CANCEL));
-		ASSERT(!timer_pending(&t->tqent_timer));
+		ASSERT0((t->tqent_flags & TQENT_FLAG_PREALLOC));
+		ASSERT0((t->tqent_flags & TQENT_FLAG_CANCEL));
+		ASSERT0(timer_pending(&t->tqent_timer));
 
 		list_del_init(&t->tqent_list);
 		return (t);
@@ -183,7 +183,7 @@ task_free(taskq_t *tq, taskq_ent_t *t)
 	ASSERT(tq);
 	ASSERT(t);
 	ASSERT(list_empty(&t->tqent_list));
-	ASSERT(!timer_pending(&t->tqent_timer));
+	ASSERT0(timer_pending(&t->tqent_timer));
 
 	kmem_free(t, sizeof (taskq_ent_t));
 	tq->tq_nalloc--;
@@ -618,7 +618,7 @@ taskq_dispatch(taskq_t *tq, task_func_t func, void *arg, uint_t flags)
 	t->tqent_birth = jiffies;
 	DTRACE_PROBE1(taskq_ent__birth, taskq_ent_t *, t);
 
-	ASSERT(!(t->tqent_flags & TQENT_FLAG_PREALLOC));
+	ASSERT0((t->tqent_flags & TQENT_FLAG_PREALLOC));
 
 	spin_unlock(&t->tqent_lock);
 
@@ -667,7 +667,7 @@ taskq_dispatch_delay(taskq_t *tq, task_func_t func, void *arg,
 	t->tqent_timer.expires = (unsigned long)expire_time;
 	add_timer(&t->tqent_timer);
 
-	ASSERT(!(t->tqent_flags & TQENT_FLAG_PREALLOC));
+	ASSERT0((t->tqent_flags & TQENT_FLAG_PREALLOC));
 
 	spin_unlock(&t->tqent_lock);
 out:
@@ -1048,7 +1048,7 @@ taskq_create(const char *name, int threads_arg, pri_t pri,
 
 	ASSERT(name != NULL);
 	ASSERT(minalloc >= 0);
-	ASSERT(!(flags & (TASKQ_CPR_SAFE))); /* Unsupported */
+	ASSERT0((flags & (TASKQ_CPR_SAFE))); /* Unsupported */
 
 	/* Scale the number of threads using nthreads as a percentage */
 	if (flags & TASKQ_THREADS_CPU_PCT) {
@@ -1207,7 +1207,7 @@ taskq_destroy(taskq_t *tq)
 	while (!list_empty(&tq->tq_free_list)) {
 		t = list_entry(tq->tq_free_list.next, taskq_ent_t, tqent_list);
 
-		ASSERT(!(t->tqent_flags & TQENT_FLAG_PREALLOC));
+		ASSERT0((t->tqent_flags & TQENT_FLAG_PREALLOC));
 
 		list_del_init(&t->tqent_list);
 		task_free(tq, t);

--- a/module/os/linux/spl/spl-thread.c
+++ b/module/os/linux/spl/spl-thread.c
@@ -48,7 +48,7 @@ thread_generic_wrapper(void *arg)
 	void (*func)(void *);
 	void *args;
 
-	ASSERT(tp->tp_magic == TP_MAGIC);
+	ASSERT3U(tp->tp_magic, ==, TP_MAGIC);
 	func = tp->tp_func;
 	args = tp->tp_args;
 	set_current_state(tp->tp_state);

--- a/module/os/linux/spl/spl-thread.c
+++ b/module/os/linux/spl/spl-thread.c
@@ -77,7 +77,7 @@ __thread_create(caddr_t stk, size_t  stksize, thread_func_t func,
 
 	/* Option pp is simply ignored */
 	/* Variable stack size unsupported */
-	ASSERT(stk == NULL);
+	ASSERT3P(stk, ==, NULL);
 
 	tp = kmem_alloc(sizeof (thread_priv_t), KM_PUSHPAGE);
 	if (tp == NULL)

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -334,7 +334,7 @@ abd_alloc_chunks(abd_t *abd, size_t size)
 	 * These conditions ensure that a possible transformation to a linear
 	 * ABD would be valid.
 	 */
-	ASSERT(!PageHighMem(sg_page(table.sgl)));
+	ASSERT0(PageHighMem(sg_page(table.sgl)));
 	ASSERT0(ABD_SCATTER(abd).abd_offset);
 
 	if (table.nents == 1) {
@@ -552,7 +552,7 @@ sg_set_page(struct scatterlist *sg, struct page *page, unsigned int len,
     unsigned int offset)
 {
 	/* currently we don't use offset */
-	ASSERT(offset == 0);
+	ASSERT0(offset);
 	sg->page = page;
 	sg->length = len;
 }
@@ -882,7 +882,7 @@ abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off,
 void
 abd_iter_init(struct abd_iter *aiter, abd_t *abd)
 {
-	ASSERT(!abd_is_gang(abd));
+	ASSERT0(abd_is_gang(abd));
 	abd_verify(abd);
 	aiter->iter_abd = abd;
 	aiter->iter_mapaddr = NULL;
@@ -1109,7 +1109,7 @@ abd_bio_map_off(struct bio *bio, abd_t *abd,
 	if (abd_is_linear(abd))
 		return (bio_map(bio, ((char *)abd_to_buf(abd)) + off, io_size));
 
-	ASSERT(!abd_is_linear(abd));
+	ASSERT0(abd_is_linear(abd));
 	if (abd_is_gang(abd))
 		return (abd_gang_bio_map_off(bio, abd, io_size, off));
 

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -1128,7 +1128,7 @@ abd_bio_map_off(struct bio *bio, abd_t *abd,
 		sgoff = aiter.iter_offset;
 		pgoff = sgoff & (PAGESIZE - 1);
 		len = MIN(io_size, PAGESIZE - pgoff);
-		ASSERT(len > 0);
+		ASSERT3U(len, >, 0);
 
 		pg = nth_page(sg_page(sg), sgoff >> PAGE_SHIFT);
 		if (bio_add_page(bio, pg, len, pgoff) != len)

--- a/module/os/linux/zfs/arc_os.c
+++ b/module/os/linux/zfs/arc_os.c
@@ -206,7 +206,7 @@ arc_shrinker_count(struct shrinker *shrink, struct shrink_control *sc)
 static unsigned long
 arc_shrinker_scan(struct shrinker *shrink, struct shrink_control *sc)
 {
-	ASSERT((sc->gfp_mask & __GFP_FS) != 0);
+	ASSERT3U((sc->gfp_mask & __GFP_FS), !=, 0);
 
 	/* The arc is considered warm once reclaim has occurred */
 	if (unlikely(arc_warm == B_FALSE))

--- a/module/os/linux/zfs/vdev_file.c
+++ b/module/os/linux/zfs/vdev_file.c
@@ -59,13 +59,13 @@ static uint_t vdev_file_physical_ashift = SPA_MINBLOCKSHIFT;
 static void
 vdev_file_hold(vdev_t *vd)
 {
-	ASSERT(vd->vdev_path != NULL);
+	ASSERT3P(vd->vdev_path, !=, NULL);
 }
 
 static void
 vdev_file_rele(vdev_t *vd)
 {
-	ASSERT(vd->vdev_path != NULL);
+	ASSERT3P(vd->vdev_path, !=, NULL);
 }
 
 static mode_t

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -804,7 +804,7 @@ zfs_acl_xform(znode_t *zp, zfs_acl_t *aclp, cred_t *cr)
 	void *cookie = NULL;
 	zfs_acl_node_t *newaclnode;
 
-	ASSERT(aclp->z_version == ZFS_ACL_VERSION_INITIAL);
+	ASSERT3U(aclp->z_version, ==, ZFS_ACL_VERSION_INITIAL);
 	/*
 	 * First create the ACE in a contiguous piece of memory
 	 * for zfs_copy_ace_2_fuid().
@@ -1392,7 +1392,7 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 		if ((aclp->z_version == ZFS_ACL_VERSION_INITIAL) &&
 		    (zfsvfs->z_version >= ZPL_VERSION_FUID))
 			zfs_acl_xform(zp, aclp, cr);
-		ASSERT(aclp->z_version >= ZFS_ACL_VERSION_FUID);
+		ASSERT3U(aclp->z_version, >=, ZFS_ACL_VERSION_FUID);
 		otype = DMU_OT_ACL;
 	}
 
@@ -1746,8 +1746,8 @@ zfs_acl_inherit(zfsvfs_t *zfsvfs, umode_t va_mode, zfs_acl_t *paclp,
 		 * Copy special opaque data if any
 		 */
 		if ((data1sz = paclp->z_ops->ace_data(pacep, &data1)) != 0) {
-			VERIFY((data2sz = aclp->z_ops->ace_data(acep,
-			    &data2)) == data1sz);
+			VERIFY3U((data2sz = aclp->z_ops->ace_data(acep,
+			    &data2)), ==, data1sz);
 			memcpy(data2, data1, data2sz);
 		}
 
@@ -2044,8 +2044,8 @@ zfs_getacl(znode_t *zp, vsecattr_t *vsecp, boolean_t skipaclchk, cred_t *cr)
 				    aclnode->z_size);
 				start = (caddr_t)start + aclnode->z_size;
 			}
-			ASSERT((caddr_t)start - (caddr_t)vsecp->vsa_aclentp ==
-			    aclp->z_acl_bytes);
+			ASSERT3U((caddr_t)start - (caddr_t)vsecp->vsa_aclentp,
+			    ==, aclp->z_acl_bytes);
 		}
 	}
 	if (mask & VSA_ACE_ACLFLAGS) {
@@ -2718,7 +2718,7 @@ zfs_zaccess(znode_t *zp, int mode, int flags, boolean_t skipaclchk, cred_t *cr,
 		 * read_acl/read_attributes
 		 */
 
-		ASSERT(working_mode != 0);
+		ASSERT3U(working_mode, !=, 0);
 
 		if ((working_mode & (ACE_READ_ACL|ACE_READ_ATTRIBUTES) &&
 		    owner == crgetuid(cr)))

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -826,9 +826,9 @@ zfs_acl_xform(znode_t *zp, zfs_acl_t *aclp, cred_t *cr)
 	newaclnode = zfs_acl_node_alloc(aclp->z_acl_count *
 	    sizeof (zfs_object_ace_t));
 	aclp->z_ops = &zfs_acl_fuid_ops;
-	VERIFY(zfs_copy_ace_2_fuid(ZTOZSB(zp), ZTOI(zp)->i_mode,
-	    aclp, oldaclp, newaclnode->z_acldata, aclp->z_acl_count,
-	    &newaclnode->z_size, NULL, cr) == 0);
+	VERIFY0(zfs_copy_ace_2_fuid(ZTOZSB(zp), ZTOI(zp)->i_mode, aclp,
+	    oldaclp, newaclnode->z_acldata, aclp->z_acl_count,
+	    &newaclnode->z_size, NULL, cr));
 	newaclnode->z_ace_count = aclp->z_acl_count;
 	aclp->z_version = ZFS_ACL_VERSION;
 	kmem_free(oldaclp, aclp->z_acl_count * sizeof (zfs_oldace_t));
@@ -1901,8 +1901,8 @@ zfs_acl_ids_create(znode_t *dzp, int flag, vattr_t *vap, cred_t *cr,
 		if (!(flag & IS_ROOT_NODE) &&
 		    (dzp->z_pflags & ZFS_INHERIT_ACE) &&
 		    !(dzp->z_pflags & ZFS_XATTR)) {
-			VERIFY(0 == zfs_acl_node_read(dzp, B_TRUE,
-			    &paclp, B_FALSE));
+			VERIFY0(zfs_acl_node_read(dzp, B_TRUE, &paclp,
+			    B_FALSE));
 			acl_ids->z_aclp = zfs_acl_inherit(zfsvfs,
 			    vap->va_mode, paclp, acl_ids->z_mode, &need_chmod);
 			inherited = B_TRUE;
@@ -2205,7 +2205,7 @@ top:
 	}
 
 	error = zfs_aclset_common(zp, aclp, cr, tx);
-	ASSERT(error == 0);
+	ASSERT0(error);
 	ASSERT(zp->z_acl_cached == NULL);
 	zp->z_acl_cached = aclp;
 

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -2206,7 +2206,7 @@ top:
 
 	error = zfs_aclset_common(zp, aclp, cr, tx);
 	ASSERT0(error);
-	ASSERT(zp->z_acl_cached == NULL);
+	ASSERT3P(zp->z_acl_cached, ==, NULL);
 	zp->z_acl_cached = aclp;
 
 	if (fuid_dirtied)

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -563,7 +563,7 @@ zfsctl_inode_lookup(zfsvfs_t *zfsvfs, uint64_t id,
 int
 zfsctl_create(zfsvfs_t *zfsvfs)
 {
-	ASSERT(zfsvfs->z_ctldir == NULL);
+	ASSERT3P(zfsvfs->z_ctldir, ==, NULL);
 
 	zfsvfs->z_ctldir = zfsctl_inode_alloc(zfsvfs, ZFSCTL_INO_ROOT,
 	    &zpl_fops_root, &zpl_ops_root);

--- a/module/os/linux/zfs/zfs_dir.c
+++ b/module/os/linux/zfs/zfs_dir.c
@@ -459,7 +459,7 @@ zfs_unlinked_add(znode_t *zp, dmu_tx_t *tx)
 	zfsvfs_t *zfsvfs = ZTOZSB(zp);
 
 	ASSERT(zp->z_unlinked);
-	ASSERT(ZTOI(zp)->i_nlink == 0);
+	ASSERT0(ZTOI(zp)->i_nlink);
 
 	VERIFY3U(0, ==,
 	    zap_add_int(zfsvfs->z_os, zfsvfs->z_unlinkedobj, zp->z_id, tx));
@@ -656,8 +656,8 @@ zfs_rmnode(znode_t *zp)
 	uint64_t	links;
 	int		error;
 
-	ASSERT(ZTOI(zp)->i_nlink == 0);
-	ASSERT(atomic_read(&ZTOI(zp)->i_count) == 0);
+	ASSERT0(ZTOI(zp)->i_nlink);
+	ASSERT0(atomic_read(&ZTOI(zp)->i_count));
 
 	/*
 	 * If this is an attribute directory, purge its contents.
@@ -704,7 +704,7 @@ zfs_rmnode(znode_t *zp)
 	    &xattr_obj, sizeof (xattr_obj));
 	if (error == 0 && xattr_obj) {
 		error = zfs_zget(zfsvfs, xattr_obj, &xzp);
-		ASSERT(error == 0);
+		ASSERT0(error);
 	}
 
 	acl_obj = zfs_external_acl(zp);
@@ -738,13 +738,13 @@ zfs_rmnode(znode_t *zp)
 	}
 
 	if (xzp) {
-		ASSERT(error == 0);
+		ASSERT0(error);
 		mutex_enter(&xzp->z_lock);
 		xzp->z_unlinked = B_TRUE;	/* mark xzp for deletion */
 		clear_nlink(ZTOI(xzp));		/* no more links to it */
 		links = 0;
-		VERIFY(0 == sa_update(xzp->z_sa_hdl, SA_ZPL_LINKS(zfsvfs),
-		    &links, sizeof (links), tx));
+		VERIFY0(sa_update(xzp->z_sa_hdl, SA_ZPL_LINKS(zfsvfs), &links,
+		    sizeof (links), tx));
 		mutex_exit(&xzp->z_lock);
 		zfs_unlinked_add(xzp, tx);
 	}
@@ -812,7 +812,7 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 
 	if (!(flag & ZRENAMING)) {
 		if (zp->z_unlinked) {	/* no new links to unlinked zp */
-			ASSERT(!(flag & (ZNEW | ZEXISTS)));
+			ASSERT0((flag & (ZNEW | ZEXISTS)));
 			mutex_exit(&zp->z_lock);
 			return (SET_ERROR(ENOENT));
 		}
@@ -857,7 +857,7 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 		    ctime);
 	}
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
-	ASSERT(error == 0);
+	ASSERT0(error);
 
 	mutex_exit(&zp->z_lock);
 
@@ -879,7 +879,7 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 	    &dzp->z_pflags, sizeof (dzp->z_pflags));
 	zfs_tstamp_update_setup(dzp, CONTENT_MODIFIED, mtime, ctime);
 	error = sa_bulk_update(dzp->z_sa_hdl, bulk, count, tx);
-	ASSERT(error == 0);
+	ASSERT0(error);
 	mutex_exit(&dzp->z_lock);
 
 	return (0);
@@ -1068,7 +1068,7 @@ zfs_link_destroy(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag,
 	    NULL, &dzp->z_pflags, sizeof (dzp->z_pflags));
 	zfs_tstamp_update_setup(dzp, CONTENT_MODIFIED, mtime, ctime);
 	error = sa_bulk_update(dzp->z_sa_hdl, bulk, count, tx);
-	ASSERT(error == 0);
+	ASSERT0(error);
 	mutex_exit(&dzp->z_lock);
 
 	if (unlinkedp != NULL)
@@ -1152,7 +1152,7 @@ zfs_make_xattrdir(znode_t *zp, vattr_t *vap, znode_t **xzpp, cred_t *cr)
 	ASSERT(error == 0 && parent == zp->z_id);
 #endif
 
-	VERIFY(0 == sa_update(zp->z_sa_hdl, SA_ZPL_XATTR(zfsvfs), &xzp->z_id,
+	VERIFY0(sa_update(zp->z_sa_hdl, SA_ZPL_XATTR(zfsvfs), &xzp->z_id,
 	    sizeof (xzp->z_id), tx));
 
 	if (!zp->z_unlinked)

--- a/module/os/linux/zfs/zfs_sysfs.c
+++ b/module/os/linux/zfs/zfs_sysfs.c
@@ -221,8 +221,9 @@ static int
 zfs_kobj_add(zfs_mod_kobj_t *zkobj, struct kobject *parent, const char *name)
 {
 	/* zko_default_group.attrs must be NULL terminated */
-	ASSERT(zkobj->zko_default_group.attrs != NULL);
-	ASSERT(zkobj->zko_default_group.attrs[zkobj->zko_attr_count] == NULL);
+	ASSERT3P(zkobj->zko_default_group.attrs, !=, NULL);
+	ASSERT3P(zkobj->zko_default_group.attrs[zkobj->zko_attr_count], ==,
+	    NULL);
 
 	kobject_init(&zkobj->zko_kobj, &zkobj->zko_kobj_type);
 	return (kobject_add(&zkobj->zko_kobj, parent, name));

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -687,7 +687,7 @@ zfsvfs_init(zfsvfs_t *zfsvfs, objset_t *os)
 	    &zfsvfs->z_root);
 	if (error != 0)
 		return (error);
-	ASSERT(zfsvfs->z_root != 0);
+	ASSERT3U(zfsvfs->z_root, !=, 0);
 
 	error = zap_lookup(os, MASTER_NODE_OBJ, ZFS_UNLINKED_SET, 8, 1,
 	    &zfsvfs->z_unlinkedobj);
@@ -2147,7 +2147,7 @@ zfs_get_vfs_flag_unmounted(objset_t *os)
 	zfsvfs_t *zfvp;
 	boolean_t unmounted = B_FALSE;
 
-	ASSERT(dmu_objset_type(os) == DMU_OST_ZFS);
+	ASSERT3U(dmu_objset_type(os), ==, DMU_OST_ZFS);
 
 	mutex_enter(&os->os_user_ptr_lock);
 	zfvp = dmu_objset_get_user(os);

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1638,7 +1638,7 @@ zfs_umount(struct super_block *sb)
 
 	if (zfsvfs->z_arc_prune != NULL)
 		arc_remove_prune_callback(zfsvfs->z_arc_prune);
-	VERIFY(zfsvfs_teardown(zfsvfs, B_TRUE) == 0);
+	VERIFY0(zfsvfs_teardown(zfsvfs, B_TRUE));
 	os = zfsvfs->z_os;
 	zpl_bdi_destroy(sb);
 
@@ -1758,8 +1758,8 @@ zfs_vget(struct super_block *sb, struct inode **ipp, fid_t *fidp)
 		*ipp = zfsvfs->z_ctldir;
 		ASSERT(*ipp != NULL);
 		if (object == ZFSCTL_INO_SNAPDIR) {
-			VERIFY(zfsctl_root_lookup(*ipp, "snapshot", ipp,
-			    0, kcred, NULL, NULL) == 0);
+			VERIFY0(zfsctl_root_lookup(*ipp, "snapshot", ipp, 0,
+			    kcred, NULL, NULL));
 		} else {
 			/*
 			 * Must have an existing ref, so igrab()
@@ -1861,7 +1861,7 @@ zfs_resume_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 		goto bail;
 
 	ds->ds_dir->dd_activity_cancelled = B_FALSE;
-	VERIFY(zfsvfs_setup(zfsvfs, B_FALSE) == 0);
+	VERIFY0(zfsvfs_setup(zfsvfs, B_FALSE));
 
 	zfs_set_fuid_feature(zfsvfs);
 	zfsvfs->z_rollback_time = jiffies;
@@ -2034,7 +2034,7 @@ zfs_set_version(zfsvfs_t *zfsvfs, uint64_t newvers)
 		    ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
 		ASSERT0(error);
 
-		VERIFY(0 == sa_set_sa_object(os, sa_obj));
+		VERIFY0(sa_set_sa_object(os, sa_obj));
 		sa_register_update_callback(os, zfs_sa_upgrade);
 	}
 

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1756,7 +1756,7 @@ zfs_vget(struct super_block *sb, struct inode **ipp, fid_t *fidp)
 	if (fid_gen == 0 &&
 	    (object == ZFSCTL_INO_ROOT || object == ZFSCTL_INO_SNAPDIR)) {
 		*ipp = zfsvfs->z_ctldir;
-		ASSERT(*ipp != NULL);
+		ASSERT3P(*ipp, !=, NULL);
 		if (object == ZFSCTL_INO_SNAPDIR) {
 			VERIFY0(zfsctl_root_lookup(*ipp, "snapshot", ipp, 0,
 			    kcred, NULL, NULL));

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -381,7 +381,7 @@ zfs_zrele_async(znode_t *zp)
 	objset_t *os = ITOZSB(ip)->z_os;
 
 	ASSERT(atomic_read(&ip->i_count) > 0);
-	ASSERT(os != NULL);
+	ASSERT3P(os, !=, NULL);
 
 	/*
 	 * If decrementing the count would put us at 0, we can't do it inline

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -2392,10 +2392,10 @@ top:
 			new_mode = zp->z_mode;
 		}
 		err = zfs_acl_chown_setattr(zp);
-		ASSERT(err == 0);
+		ASSERT0(err);
 		if (attrzp) {
 			err = zfs_acl_chown_setattr(attrzp);
-			ASSERT(err == 0);
+			ASSERT0(err);
 		}
 	}
 
@@ -2508,7 +2508,7 @@ out:
 	if (err == 0 && xattr_count > 0) {
 		err2 = sa_bulk_update(attrzp->z_sa_hdl, xattr_bulk,
 		    xattr_count, tx);
-		ASSERT(err2 == 0);
+		ASSERT0(err2);
 	}
 
 	if (aclp)
@@ -3559,8 +3559,8 @@ top:
 		 * operation are sync safe.
 		 */
 		if (is_tmpfile) {
-			VERIFY(zap_remove_int(zfsvfs->z_os,
-			    zfsvfs->z_unlinkedobj, szp->z_id, tx) == 0);
+			VERIFY0(zap_remove_int(zfsvfs->z_os,
+			    zfsvfs->z_unlinkedobj, szp->z_id, tx));
 		} else {
 			if (flags & FIGNORECASE)
 				txtype |= TX_CI;

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -380,7 +380,7 @@ zfs_zrele_async(znode_t *zp)
 	struct inode *ip = ZTOI(zp);
 	objset_t *os = ITOZSB(ip)->z_os;
 
-	ASSERT(atomic_read(&ip->i_count) > 0);
+	ASSERT3U(atomic_read(&ip->i_count), >, 0);
 	ASSERT3P(os, !=, NULL);
 
 	/*
@@ -392,8 +392,9 @@ zfs_zrele_async(znode_t *zp)
 	 * header comment of this file.
 	 */
 	if (!atomic_add_unless(&ip->i_count, -1, 1)) {
-		VERIFY(taskq_dispatch(dsl_pool_zrele_taskq(dmu_objset_pool(os)),
-		    zfs_rele_async_task, ip, TQ_SLEEP) != TASKQID_INVALID);
+		VERIFY3U(taskq_dispatch(dsl_pool_zrele_taskq(
+		    dmu_objset_pool(os)), zfs_rele_async_task, ip, TQ_SLEEP),
+		    !=, TASKQID_INVALID);
 	}
 }
 

--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -191,12 +191,12 @@ zfs_znode_init(void)
 	 * backed by kmalloc() when on the Linux slab in order that any
 	 * wait_on_bit() operations on the related inode operate properly.
 	 */
-	ASSERT(znode_cache == NULL);
+	ASSERT3P(znode_cache, ==, NULL);
 	znode_cache = kmem_cache_create("zfs_znode_cache",
 	    sizeof (znode_t), 0, zfs_znode_cache_constructor,
 	    zfs_znode_cache_destructor, NULL, NULL, NULL, KMC_SLAB);
 
-	ASSERT(znode_hold_cache == NULL);
+	ASSERT3P(znode_hold_cache, ==, NULL);
 	znode_hold_cache = kmem_cache_create("zfs_znode_hold_cache",
 	    sizeof (znode_hold_t), 0, zfs_znode_hold_cache_constructor,
 	    zfs_znode_hold_cache_destructor, NULL, NULL, NULL, 0);
@@ -339,8 +339,8 @@ zfs_znode_sa_init(zfsvfs_t *zfsvfs, znode_t *zp,
 
 	mutex_enter(&zp->z_lock);
 
-	ASSERT(zp->z_sa_hdl == NULL);
-	ASSERT(zp->z_acl_cached == NULL);
+	ASSERT3P(zp->z_sa_hdl, ==, NULL);
+	ASSERT3P(zp->z_acl_cached, ==, NULL);
 	if (sa_hdl == NULL) {
 		VERIFY0(sa_handle_get_from_db(zfsvfs->z_os, db, zp,
 		    SA_HDL_SHARED, &zp->z_sa_hdl));
@@ -499,7 +499,7 @@ zfs_znode_update_vfs(znode_t *zp)
 	uint32_t	blksize;
 	u_longlong_t	i_blocks;
 
-	ASSERT(zp != NULL);
+	ASSERT3P(zp, !=, NULL);
 	ip = ZTOI(zp);
 
 	/* Skip .zfs control nodes which do not exist on disk. */
@@ -539,14 +539,14 @@ zfs_znode_alloc(zfsvfs_t *zfsvfs, dmu_buf_t *db, int blksz,
 	sa_bulk_attr_t bulk[12];
 	int count = 0;
 
-	ASSERT(zfsvfs != NULL);
+	ASSERT3P(zfsvfs, !=, NULL);
 
 	ip = new_inode(zfsvfs->z_sb);
 	if (ip == NULL)
 		return (NULL);
 
 	zp = ITOZ(ip);
-	ASSERT(zp->z_dirlocks == NULL);
+	ASSERT3P(zp->z_dirlocks, ==, NULL);
 	ASSERT3P(zp->z_acl_cached, ==, NULL);
 	ASSERT3P(zp->z_xattr_cached, ==, NULL);
 	zp->z_unlinked = B_FALSE;
@@ -932,8 +932,8 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 			*zpp = zfs_znode_alloc(zfsvfs, db, 0, obj_type, sa_hdl);
 		} while (*zpp == NULL);
 
-		VERIFY(*zpp != NULL);
-		VERIFY(dzp != NULL);
+		VERIFY3P(*zpp, !=, NULL);
+		VERIFY3P(dzp, !=, NULL);
 	} else {
 		/*
 		 * If we are creating the root node, the "parent" we
@@ -1216,7 +1216,7 @@ zfs_rezget(znode_t *zp)
 	}
 	rw_exit(&zp->z_xattr_lock);
 
-	ASSERT(zp->z_sa_hdl == NULL);
+	ASSERT3P(zp->z_sa_hdl, ==, NULL);
 	err = sa_buf_hold(zfsvfs->z_os, obj_num, NULL, &db);
 	if (err) {
 		zfs_znode_hold_exit(zfsvfs, zh);
@@ -2145,7 +2145,7 @@ zfs_obj_to_path_impl(objset_t *osp, uint64_t obj, sa_handle_t *hdl,
 		int is_xattrdir = 0;
 
 		if (prevdb) {
-			ASSERT(prevhdl != NULL);
+			ASSERT3P(prevhdl, !=, NULL);
 			zfs_release_sa_handle(prevhdl, prevdb, FTAG);
 		}
 
@@ -2188,7 +2188,7 @@ zfs_obj_to_path_impl(objset_t *osp, uint64_t obj, sa_handle_t *hdl,
 	}
 
 	if (sa_hdl != NULL && sa_hdl != hdl) {
-		ASSERT(sa_db != NULL);
+		ASSERT3P(sa_db, !=, NULL);
 		zfs_release_sa_handle(sa_hdl, sa_db, FTAG);
 	}
 

--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -1578,7 +1578,7 @@ zfs_zero_partial_page(znode_t *zp, uint64_t start, uint64_t len)
 	int64_t	off;
 	void *pb;
 
-	ASSERT((start & PAGE_MASK) == ((start + len - 1) & PAGE_MASK));
+	ASSERT3U((start & PAGE_MASK), ==, ((start + len - 1) & PAGE_MASK));
 
 	off = start & (PAGE_SIZE - 1);
 	start &= PAGE_MASK;
@@ -1866,7 +1866,7 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 		uint64_t val;
 		char *name;
 
-		ASSERT(nvpair_type(elem) == DATA_TYPE_UINT64);
+		ASSERT3U(nvpair_type(elem), ==, DATA_TYPE_UINT64);
 		VERIFY0(nvpair_value_uint64(elem, &val));
 		name = nvpair_name(elem);
 		if (strcmp(name, zfs_prop_to_name(ZFS_PROP_VERSION)) == 0) {
@@ -1881,7 +1881,7 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 		else if (strcmp(name, zfs_prop_to_name(ZFS_PROP_CASE)) == 0)
 			sense = val;
 	}
-	ASSERT(version != 0);
+	ASSERT3U(version, !=, 0);
 	error = zap_update(os, moid, ZPL_VERSION_STR, 8, 1, &version, tx);
 	ASSERT0(error);
 
@@ -2171,7 +2171,7 @@ zfs_obj_to_path_impl(objset_t *osp, uint64_t obj, sa_handle_t *hdl,
 
 		complen = strlen(component);
 		path -= complen;
-		ASSERT(path >= buf);
+		ASSERT3U(path, >=, buf);
 		memcpy(path, component, complen);
 		obj = pobj;
 

--- a/module/os/linux/zfs/zio_crypt.c
+++ b/module/os/linux/zfs/zio_crypt.c
@@ -409,7 +409,7 @@ zio_do_crypt_uio(boolean_t encrypt, uint64_t crypt, crypto_key_t *key,
 	/* the mac will always be the last iovec_t in the cipher uio */
 	maclen = cuio->uio_iov[cuio->uio_iovcnt - 1].iov_len;
 
-	ASSERT(maclen <= ZIO_DATA_MAC_LEN);
+	ASSERT3U(maclen, <=, ZIO_DATA_MAC_LEN);
 
 	/* setup encryption mechanism (same as crypt) */
 	mech.cm_type = crypto_mech2id(crypt_info.ci_mechname);

--- a/module/os/linux/zfs/zio_crypt.c
+++ b/module/os/linux/zfs/zio_crypt.c
@@ -1368,7 +1368,7 @@ zio_crypt_do_indirect_mac_checksum(boolean_t generate, void *buf,
 	ret = zio_crypt_do_indirect_mac_checksum_impl(generate, buf,
 	    datalen, ZIO_CRYPT_KEY_CURRENT_VERSION, byteswap, cksum);
 	if (ret == ECKSUM) {
-		ASSERT(!generate);
+		ASSERT0(generate);
 		ret = zio_crypt_do_indirect_mac_checksum_impl(generate,
 		    buf, datalen, 0, byteswap, cksum);
 	}

--- a/module/os/linux/zfs/zio_crypt.c
+++ b/module/os/linux/zfs/zio_crypt.c
@@ -226,7 +226,7 @@ zio_crypt_key_init(uint64_t crypt, zio_crypt_key_t *key)
 	crypto_mechanism_t mech;
 	uint_t keydata_len;
 
-	ASSERT(key != NULL);
+	ASSERT3P(key, !=, NULL);
 	ASSERT3U(crypt, <, ZIO_CRYPT_FUNCTIONS);
 
 /*

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -738,7 +738,7 @@ zpl_putpage(struct page *pp, struct writeback_control *wbc, void *data)
 	fstrans_cookie_t cookie;
 
 	ASSERT(PageLocked(pp));
-	ASSERT(!PageWriteback(pp));
+	ASSERT0(PageWriteback(pp));
 
 	cookie = spl_fstrans_mark();
 	(void) zfs_putpage(pp->mapping->host, pp, wbc, *for_sync);

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -200,7 +200,7 @@ zpl_mknod(struct inode *dir, struct dentry *dentry, umode_t mode,
 	 * and fifos, but we want to know if this behavior ever changes.
 	 */
 	if (S_ISSOCK(mode) || S_ISFIFO(mode))
-		ASSERT(rdev == 0);
+		ASSERT0(rdev);
 
 	crhold(cr);
 	vap = kmem_zalloc(sizeof (vattr_t), KM_SLEEP);

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -44,7 +44,7 @@ zpl_inode_alloc(struct super_block *sb)
 static void
 zpl_inode_destroy(struct inode *ip)
 {
-	ASSERT(atomic_read(&ip->i_count) == 0);
+	ASSERT0(atomic_read(&ip->i_count));
 	zfs_inode_destroy(ip);
 }
 

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -504,7 +504,7 @@ zpl_xattr_set_dir(struct inode *ip, const char *name, const void *value,
 			goto out;
 	}
 
-	ASSERT(xzp != NULL);
+	ASSERT3P(xzp, !=, NULL);
 
 	error = -zfs_freesp(xzp, 0, 0, xattr_mode, TRUE);
 	if (error)

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -1221,8 +1221,8 @@ void
 zvol_os_free(zvol_state_t *zv)
 {
 
-	ASSERT(!RW_LOCK_HELD(&zv->zv_suspend_lock));
-	ASSERT(!MUTEX_HELD(&zv->zv_state_lock));
+	ASSERT0(RW_LOCK_HELD(&zv->zv_suspend_lock));
+	ASSERT0(MUTEX_HELD(&zv->zv_state_lock));
 	ASSERT0(zv->zv_open_count);
 	ASSERT3P(zv->zv_zso->zvo_disk->private_data, ==, NULL);
 

--- a/module/zcommon/zfeature_common.c
+++ b/module/zcommon/zfeature_common.c
@@ -327,8 +327,8 @@ zfeature_register(spa_feature_t fid, const char *guid, const char *name,
 	zfeature_info_t *feature = &spa_feature_table[fid];
 	static const spa_feature_t nodeps[] = { SPA_FEATURE_NONE };
 
-	ASSERT(name != NULL);
-	ASSERT(desc != NULL);
+	ASSERT3P(name, !=, NULL);
+	ASSERT3P(desc, !=, NULL);
 	ASSERT((flags & ZFEATURE_FLAG_READONLY_COMPAT) == 0 ||
 	    (flags & ZFEATURE_FLAG_MOS) == 0);
 	ASSERT3U(fid, <, SPA_FEATURES);

--- a/module/zcommon/zprop_common.c
+++ b/module/zcommon/zprop_common.c
@@ -366,7 +366,7 @@ zprop_random_value(int prop, uint64_t seed, zfs_type_t type)
 	zprop_desc_t *prop_tbl;
 	const zprop_index_t *idx_tbl;
 
-	ASSERT((uint_t)prop < zprop_get_numprops(type));
+	ASSERT3U((uint_t)prop, <, zprop_get_numprops(type));
 	prop_tbl = zprop_get_proptable(type);
 	idx_tbl = prop_tbl[prop].pd_table;
 

--- a/module/zcommon/zprop_common.c
+++ b/module/zcommon/zprop_common.c
@@ -316,7 +316,7 @@ zprop_string_to_index(int prop, const char *string, uint64_t *index,
 	if (prop == ZPROP_INVAL || prop == ZPROP_CONT)
 		return (-1);
 
-	ASSERT(prop < zprop_get_numprops(type));
+	ASSERT3S(prop, <, zprop_get_numprops(type));
 	prop_tbl = zprop_get_proptable(type);
 	if ((idx_tbl = prop_tbl[prop].pd_table) == NULL)
 		return (-1);
@@ -342,7 +342,7 @@ zprop_index_to_string(int prop, uint64_t index, const char **string,
 	if (prop == ZPROP_INVAL || prop == ZPROP_CONT)
 		return (-1);
 
-	ASSERT(prop < zprop_get_numprops(type));
+	ASSERT3S(prop, <, zprop_get_numprops(type));
 	prop_tbl = zprop_get_proptable(type);
 	if ((idx_tbl = prop_tbl[prop].pd_table) == NULL)
 		return (-1);
@@ -382,7 +382,7 @@ zprop_values(int prop, zfs_type_t type)
 	zprop_desc_t *prop_tbl;
 
 	ASSERT(prop != ZPROP_INVAL && prop != ZPROP_CONT);
-	ASSERT(prop < zprop_get_numprops(type));
+	ASSERT3S(prop, <, zprop_get_numprops(type));
 
 	prop_tbl = zprop_get_proptable(type);
 
@@ -404,7 +404,7 @@ zprop_valid_for_type(int prop, zfs_type_t type, boolean_t headcheck)
 	if (prop == ZPROP_INVAL || prop == ZPROP_CONT)
 		return (B_FALSE);
 
-	ASSERT(prop < zprop_get_numprops(type));
+	ASSERT3S(prop, <, zprop_get_numprops(type));
 	prop_tbl = zprop_get_proptable(type);
 	if (headcheck && prop_tbl[prop].pd_types == ZFS_TYPE_SNAPSHOT)
 		return (B_TRUE);
@@ -438,7 +438,7 @@ zprop_width(int prop, boolean_t *fixed, zfs_type_t type)
 	int i;
 
 	ASSERT(prop != ZPROP_INVAL && prop != ZPROP_CONT);
-	ASSERT(prop < zprop_get_numprops(type));
+	ASSERT3S(prop, <, zprop_get_numprops(type));
 
 	prop_tbl = zprop_get_proptable(type);
 	pd = &prop_tbl[prop];

--- a/module/zcommon/zprop_common.c
+++ b/module/zcommon/zprop_common.c
@@ -107,8 +107,8 @@ zprop_register_impl(int prop, const char *name, zprop_type_t type,
 	pd = &prop_tbl[prop];
 
 	ASSERT(pd->pd_name == NULL || pd->pd_name == name);
-	ASSERT(name != NULL);
-	ASSERT(colname != NULL);
+	ASSERT3P(name, !=, NULL);
+	ASSERT3P(colname, !=, NULL);
 
 	pd->pd_name = name;
 	pd->pd_propnum = prop;
@@ -253,7 +253,7 @@ propname_match(const char *p, size_t len, zprop_desc_t *prop_entry)
 	int c;
 #endif
 
-	ASSERT(propname != NULL);
+	ASSERT3P(propname, !=, NULL);
 
 	if (len == strlen(propname) &&
 	    strncmp(p, propname, len) == 0)

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -152,7 +152,7 @@ static void
 abd_fini_struct(abd_t *abd)
 {
 	mutex_destroy(&abd->abd_mtx);
-	ASSERT(!list_link_active(&abd->abd_gang_link));
+	ASSERT0(list_link_active(&abd->abd_gang_link));
 #ifdef ZFS_DEBUG
 	zfs_refcount_destroy(&abd->abd_children);
 #endif
@@ -406,11 +406,11 @@ abd_gang_add(abd_t *pabd, abd_t *cabd, boolean_t free_on_free)
 	 * for the offset correctly in the parent gang ABD.
 	 */
 	if (abd_is_gang(cabd)) {
-		ASSERT(!list_link_active(&cabd->abd_gang_link));
-		ASSERT(!list_is_empty(&ABD_GANG(cabd).abd_gang_chain));
+		ASSERT0(list_link_active(&cabd->abd_gang_link));
+		ASSERT0(list_is_empty(&ABD_GANG(cabd).abd_gang_chain));
 		return (abd_gang_add_gang(pabd, cabd, free_on_free));
 	}
-	ASSERT(!abd_is_gang(cabd));
+	ASSERT0(abd_is_gang(cabd));
 
 	/*
 	 * In order to verify that an ABD is not already part of
@@ -700,7 +700,7 @@ abd_release_ownership_of_buf(abd_t *abd)
 	 * abd_take_ownership_of_buf() sequence, we don't allow releasing
 	 * these "linear but not zio_[data_]buf_alloc()'ed" ABD's.
 	 */
-	ASSERT(!abd_is_linear_page(abd));
+	ASSERT0(abd_is_linear_page(abd));
 
 	abd_verify(abd);
 
@@ -722,7 +722,7 @@ void
 abd_take_ownership_of_buf(abd_t *abd, boolean_t is_metadata)
 {
 	ASSERT(abd_is_linear(abd));
-	ASSERT(!(abd->abd_flags & ABD_FLAG_OWNER));
+	ASSERT0((abd->abd_flags & ABD_FLAG_OWNER));
 	abd_verify(abd);
 
 	abd->abd_flags |= ABD_FLAG_OWNER;

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1050,7 +1050,7 @@ buf_hash_insert(arc_buf_hdr_t *hdr, kmutex_t **lockp)
 	uint32_t i;
 
 	ASSERT(!DVA_IS_EMPTY(&hdr->b_dva));
-	ASSERT(hdr->b_birth != 0);
+	ASSERT3U(hdr->b_birth, !=, 0);
 	ASSERT(!HDR_IN_HASH_TABLE(hdr));
 
 	if (lockp != NULL) {
@@ -1281,7 +1281,7 @@ retry:
 	    kmem_zalloc(hsize * sizeof (void*), KM_NOSLEEP);
 #endif
 	if (buf_hash_table.ht_table == NULL) {
-		ASSERT(hsize > (1ULL << 8));
+		ASSERT3U(hsize, >, (1ULL << 8));
 		hsize >>= 1;
 		goto retry;
 	}
@@ -1749,7 +1749,7 @@ arc_buf_alloc_l2only(size_t size, arc_buf_contents_t type, l2arc_dev_t *dev,
 {
 	arc_buf_hdr_t	*hdr;
 
-	ASSERT(size != 0);
+	ASSERT3U(size, !=, 0);
 	hdr = kmem_cache_alloc(hdr_l2only_cache, KM_SLEEP);
 	hdr->b_birth = birth;
 	hdr->b_type = type;
@@ -2977,7 +2977,7 @@ arc_hdr_free_on_write(arc_buf_hdr_t *hdr, boolean_t free_rdata)
 	if (type == ARC_BUFC_METADATA) {
 		arc_space_return(size, ARC_SPACE_META);
 	} else {
-		ASSERT(type == ARC_BUFC_DATA);
+		ASSERT3U(type, ==, ARC_BUFC_DATA);
 		arc_space_return(size, ARC_SPACE_DATA);
 	}
 
@@ -3126,7 +3126,7 @@ arc_buf_destroy_impl(arc_buf_t *buf)
 		}
 		buf->b_data = NULL;
 
-		ASSERT(hdr->b_l1hdr.b_bufcnt > 0);
+		ASSERT3U(hdr->b_l1hdr.b_bufcnt, >, 0);
 		hdr->b_l1hdr.b_bufcnt -= 1;
 
 		if (ARC_BUF_ENCRYPTED(buf)) {
@@ -3885,7 +3885,7 @@ arc_buf_destroy(arc_buf_t *buf, const void *tag)
 	mutex_enter(hash_lock);
 
 	ASSERT3P(hdr, ==, buf->b_hdr);
-	ASSERT(hdr->b_l1hdr.b_bufcnt > 0);
+	ASSERT3U(hdr->b_l1hdr.b_bufcnt, >, 0);
 	ASSERT3P(hash_lock, ==, HDR_LOCK(hdr));
 	ASSERT3P(hdr->b_l1hdr.b_state, !=, arc_anon);
 	ASSERT3P(buf->b_data, !=, NULL);
@@ -4824,8 +4824,8 @@ arc_reduce_target_size(int64_t to_free)
 		atomic_add_64(&arc_p, -(arc_p >> arc_shrink_shift));
 		if (arc_p > arc_c)
 			arc_p = (arc_c >> 1);
-		ASSERT(arc_c >= arc_c_min);
-		ASSERT((int64_t)arc_p >= 0);
+		ASSERT3U(arc_c, >=, arc_c_min);
+		ASSERT3U((int64_t)arc_p, >=, 0);
 	} else {
 		arc_c = arc_c_min;
 	}
@@ -5174,7 +5174,7 @@ arc_adapt(int bytes, arc_state_t *state)
 		delta = MIN(bytes * mult, arc_p);
 		arc_p = MAX(arc_p_min, arc_p - delta);
 	}
-	ASSERT((int64_t)arc_p >= 0);
+	ASSERT3U((int64_t)arc_p, >=, 0);
 
 	/*
 	 * Wake reap thread if we do not have any available memory
@@ -5205,7 +5205,7 @@ arc_adapt(int bytes, arc_state_t *state)
 		if (arc_p > arc_c)
 			arc_p = arc_c;
 	}
-	ASSERT((int64_t)arc_p >= 0);
+	ASSERT3U((int64_t)arc_p, >=, 0);
 }
 
 /*
@@ -5258,7 +5258,7 @@ arc_get_data_buf(arc_buf_hdr_t *hdr, uint64_t size, const void *tag)
 	if (type == ARC_BUFC_METADATA) {
 		return (zio_buf_alloc(size));
 	} else {
-		ASSERT(type == ARC_BUFC_DATA);
+		ASSERT3U(type, ==, ARC_BUFC_DATA);
 		return (zio_data_buf_alloc(size));
 	}
 }
@@ -5434,7 +5434,7 @@ arc_free_data_buf(arc_buf_hdr_t *hdr, void *buf, uint64_t size, const void *tag)
 	if (type == ARC_BUFC_METADATA) {
 		zio_buf_free(buf, size);
 	} else {
-		ASSERT(type == ARC_BUFC_DATA);
+		ASSERT3U(type, ==, ARC_BUFC_DATA);
 		zio_data_buf_free(buf, size);
 	}
 }
@@ -5462,7 +5462,7 @@ arc_free_data_impl(arc_buf_hdr_t *hdr, uint64_t size, const void *tag)
 	if (type == ARC_BUFC_METADATA) {
 		arc_space_return(size, ARC_SPACE_META);
 	} else {
-		ASSERT(type == ARC_BUFC_DATA);
+		ASSERT3U(type, ==, ARC_BUFC_DATA);
 		arc_space_return(size, ARC_SPACE_DATA);
 	}
 }
@@ -6760,7 +6760,7 @@ arc_release(arc_buf_t *buf, const void *tag)
 		(void) zfs_refcount_add_many(&arc_anon->arcs_size,
 		    arc_buf_size(buf), buf);
 	} else {
-		ASSERT(zfs_refcount_count(&hdr->b_l1hdr.b_refcnt) == 1);
+		ASSERT3U(zfs_refcount_count(&hdr->b_l1hdr.b_refcnt), ==, 1);
 		/* protected by hash lock, or hdr is on arc_anon */
 		ASSERT(!multilist_link_active(&hdr->b_l1hdr.b_arc_node));
 		ASSERT(!HDR_IO_IN_PROGRESS(hdr));
@@ -6804,7 +6804,7 @@ arc_write_ready(zio_t *zio)
 
 	ASSERT(HDR_HAS_L1HDR(hdr));
 	ASSERT(!zfs_refcount_is_zero(&buf->b_hdr->b_l1hdr.b_refcnt));
-	ASSERT(hdr->b_l1hdr.b_bufcnt > 0);
+	ASSERT3U(hdr->b_l1hdr.b_bufcnt, >, 0);
 
 	/*
 	 * If we're reexecuting this zio because the pool suspended, then
@@ -7038,10 +7038,10 @@ arc_write_done(zio_t *zio)
 					    (void *)hdr, (void *)exists);
 			} else {
 				/* Dedup */
-				ASSERT(hdr->b_l1hdr.b_bufcnt == 1);
+				ASSERT3U(hdr->b_l1hdr.b_bufcnt, ==, 1);
 				ASSERT3P(hdr->b_l1hdr.b_state, ==, arc_anon);
 				ASSERT(BP_GET_DEDUP(zio->io_bp));
-				ASSERT(BP_GET_LEVEL(zio->io_bp) == 0);
+				ASSERT3U(BP_GET_LEVEL(zio->io_bp), ==, 0);
 			}
 		}
 		arc_hdr_clear_flags(hdr, ARC_FLAG_IO_IN_PROGRESS);
@@ -7161,7 +7161,7 @@ void
 arc_tempreserve_clear(uint64_t reserve)
 {
 	atomic_add_64(&arc_tempreserve, -reserve);
-	ASSERT((int64_t)arc_tempreserve >= 0);
+	ASSERT3U((int64_t)arc_tempreserve, >=, 0);
 }
 
 int
@@ -10776,7 +10776,7 @@ l2arc_log_blk_fetch(vdev_t *vd, const l2arc_log_blkptr_t *lbp,
 
 	/* L2BLK_GET_PSIZE returns aligned size for log blocks */
 	asize = L2BLK_GET_PSIZE((lbp)->lbp_prop);
-	ASSERT(asize <= sizeof (l2arc_log_blk_phys_t));
+	ASSERT3U(asize, <=, sizeof (l2arc_log_blk_phys_t));
 
 	cb = kmem_zalloc(sizeof (l2arc_read_callback_t), KM_SLEEP);
 	cb->l2rcb_abd = abd_get_from_buf(lb, asize);
@@ -10886,9 +10886,9 @@ l2arc_log_blk_commit(l2arc_dev_t *dev, zio_t *pio, l2arc_write_callback_t *cb)
 	    abd_buf->abd, tmpbuf, sizeof (*lb), 0);
 
 	/* a log block is never entirely zero */
-	ASSERT(psize != 0);
+	ASSERT3U(psize, !=, 0);
 	asize = vdev_psize_to_asize(dev->l2ad_vdev, psize);
-	ASSERT(asize <= sizeof (*lb));
+	ASSERT3U(asize, <=, sizeof (*lb));
 
 	/*
 	 * Update the start log block pointer in the device header to point

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2313,7 +2313,7 @@ add_reference(arc_buf_hdr_t *hdr, const void *tag)
 
 	ASSERT(HDR_HAS_L1HDR(hdr));
 	if (!HDR_EMPTY(hdr) && !MUTEX_HELD(HDR_LOCK(hdr))) {
-		ASSERT(state == arc_anon);
+		ASSERT3P(state, ==, arc_anon);
 		ASSERT(zfs_refcount_is_zero(&hdr->b_l1hdr.b_refcnt));
 		ASSERT3P(hdr->b_l1hdr.b_buf, ==, NULL);
 	}
@@ -3954,7 +3954,7 @@ arc_evict_hdr(arc_buf_hdr_t *hdr, uint64_t *real_evicted)
 		DTRACE_PROBE1(arc__delete, arc_buf_hdr_t *, hdr);
 
 		if (HDR_HAS_L2HDR(hdr)) {
-			ASSERT(hdr->b_l1hdr.b_pabd == NULL);
+			ASSERT3P(hdr->b_l1hdr.b_pabd, ==, NULL);
 			ASSERT(!HDR_HAS_RABD(hdr));
 			/*
 			 * This buffer is cached on the 2nd Level ARC;
@@ -5687,7 +5687,7 @@ arc_getbuf_func(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 	} else {
 		ASSERT(zio == NULL || zio->io_error == 0);
 		*bufp = buf;
-		ASSERT(buf->b_data != NULL);
+		ASSERT3P(buf->b_data, !=, NULL);
 	}
 }
 
@@ -7039,7 +7039,7 @@ arc_write_done(zio_t *zio)
 			} else {
 				/* Dedup */
 				ASSERT(hdr->b_l1hdr.b_bufcnt == 1);
-				ASSERT(hdr->b_l1hdr.b_state == arc_anon);
+				ASSERT3P(hdr->b_l1hdr.b_state, ==, arc_anon);
 				ASSERT(BP_GET_DEDUP(zio->io_bp));
 				ASSERT(BP_GET_LEVEL(zio->io_bp) == 0);
 			}
@@ -8787,7 +8787,7 @@ top:
 	kmem_cache_free(hdr_l2only_cache, head);
 	mutex_exit(&dev->l2ad_mtx);
 
-	ASSERT(dev->l2ad_vdev != NULL);
+	ASSERT3P(dev->l2ad_vdev, !=, NULL);
 	vdev_space_update(dev->l2ad_vdev, -bytes_dropped, 0, 0);
 
 	l2arc_do_free_on_write();
@@ -9284,7 +9284,7 @@ retry:
 			arc_change_state(arc_anon, hdr);
 			arc_hdr_destroy(hdr);
 		} else {
-			ASSERT(hdr->b_l1hdr.b_state != arc_l2c_only);
+			ASSERT3P(hdr->b_l1hdr.b_state, !=, arc_l2c_only);
 			ARCSTAT_BUMP(arcstat_l2_evict_l1cached);
 			/*
 			 * Invalidate issued or about to be issued

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2701,14 +2701,14 @@ arc_space_return(uint64_t space, arc_space_type_t type)
 	}
 
 	if (type != ARC_SPACE_DATA && type != ARC_SPACE_ABD_CHUNK_WASTE) {
-		ASSERT(aggsum_compare(&arc_sums.arcstat_meta_used,
-		    space) >= 0);
+		ASSERT3S(aggsum_compare(&arc_sums.arcstat_meta_used, space),
+		    >=, 0);
 		ARCSTAT_MAX(arcstat_meta_max,
 		    aggsum_upper_bound(&arc_sums.arcstat_meta_used));
 		aggsum_add(&arc_sums.arcstat_meta_used, -space);
 	}
 
-	ASSERT(aggsum_compare(&arc_sums.arcstat_size, space) >= 0);
+	ASSERT3S(aggsum_compare(&arc_sums.arcstat_size, space), >=, 0);
 	aggsum_add(&arc_sums.arcstat_size, -space);
 }
 
@@ -5149,7 +5149,7 @@ arc_adapt(int bytes, arc_state_t *state)
 	int64_t mrug_size = zfs_refcount_count(&arc_mru_ghost->arcs_size);
 	int64_t mfug_size = zfs_refcount_count(&arc_mfu_ghost->arcs_size);
 
-	ASSERT(bytes > 0);
+	ASSERT3S(bytes, >, 0);
 	/*
 	 * Adapt the target size of the MRU list:
 	 *	- if we just hit in the MRU ghost list, then increase

--- a/module/zfs/blake3_zfs.c
+++ b/module/zfs/blake3_zfs.c
@@ -94,7 +94,7 @@ abd_checksum_blake3_tmpl_init(const zio_cksum_salt_t *salt)
 {
 	BLAKE3_CTX *ctx;
 
-	ASSERT(sizeof (salt->zcs_bytes) == 32);
+	ASSERT3S(sizeof (salt->zcs_bytes), ==, 32);
 
 	/* init reference object */
 	ctx = kmem_zalloc(sizeof (*ctx), KM_SLEEP);

--- a/module/zfs/blake3_zfs.c
+++ b/module/zfs/blake3_zfs.c
@@ -47,7 +47,7 @@ void
 abd_checksum_blake3_native(abd_t *abd, uint64_t size, const void *ctx_template,
     zio_cksum_t *zcp)
 {
-	ASSERT(ctx_template != NULL);
+	ASSERT3P(ctx_template, !=, NULL);
 
 #if defined(_KERNEL)
 	BLAKE3_CTX *ctx = blake3_per_cpu_ctx[CPU_SEQID_UNSTABLE];
@@ -76,7 +76,7 @@ abd_checksum_blake3_byteswap(abd_t *abd, uint64_t size,
 {
 	zio_cksum_t tmp;
 
-	ASSERT(ctx_template != NULL);
+	ASSERT3P(ctx_template, !=, NULL);
 
 	abd_checksum_blake3_native(abd, size, ctx_template, &tmp);
 	zcp->zc_word[0] = BSWAP_64(tmp.zc_word[0]);

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -491,7 +491,7 @@ bpobj_iterate_impl(bpobj_t *initial_bpo, bpobj_itor_t func, void *arg,
 	 */
 	while ((bpi = list_remove_head(&stack)) != NULL) {
 		bpobj_t *bpo = bpi->bpi_bpo;
-		ASSERT(err != 0);
+		ASSERT3S(err, !=, 0);
 		ASSERT3P(bpo, !=, NULL);
 
 		mutex_exit(&bpo->bpo_lock);

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -45,10 +45,9 @@ bpobj_alloc_empty(objset_t *os, int blocksize, dmu_tx_t *tx)
 			ASSERT0(dp->dp_empty_bpobj);
 			dp->dp_empty_bpobj =
 			    bpobj_alloc(os, SPA_OLD_MAXBLOCKSIZE, tx);
-			VERIFY(zap_add(os,
-			    DMU_POOL_DIRECTORY_OBJECT,
+			VERIFY0(zap_add(os, DMU_POOL_DIRECTORY_OBJECT,
 			    DMU_POOL_EMPTY_BPOBJ, sizeof (uint64_t), 1,
-			    &dp->dp_empty_bpobj, tx) == 0);
+			    &dp->dp_empty_bpobj, tx));
 		}
 		spa_feature_incr(spa, SPA_FEATURE_EMPTY_BPOBJ, tx);
 		ASSERT(dp->dp_empty_bpobj != 0);
@@ -790,7 +789,7 @@ bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
 	blkptr_t *bparray;
 
 	ASSERT(bpobj_is_open(bpo));
-	ASSERT(!BP_IS_HOLE(bp));
+	ASSERT0(BP_IS_HOLE(bp));
 	ASSERT(bpo->bpo_object != dmu_objset_pool(bpo->bpo_os)->dp_empty_bpobj);
 
 	if (BP_IS_EMBEDDED(bp)) {

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -158,8 +158,8 @@ bpobj_open(bpobj_t *bpo, objset_t *os, uint64_t object)
 	memset(bpo, 0, sizeof (*bpo));
 	mutex_init(&bpo->bpo_lock, NULL, MUTEX_DEFAULT, NULL);
 
-	ASSERT(bpo->bpo_dbuf == NULL);
-	ASSERT(bpo->bpo_phys == NULL);
+	ASSERT3P(bpo->bpo_dbuf, ==, NULL);
+	ASSERT3P(bpo->bpo_phys, ==, NULL);
 	ASSERT(object != 0);
 	ASSERT3U(doi.doi_type, ==, DMU_OT_BPOBJ);
 	ASSERT3U(doi.doi_bonus_type, ==, DMU_OT_BPOBJ_HDR);

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -50,7 +50,7 @@ bpobj_alloc_empty(objset_t *os, int blocksize, dmu_tx_t *tx)
 			    &dp->dp_empty_bpobj, tx));
 		}
 		spa_feature_incr(spa, SPA_FEATURE_EMPTY_BPOBJ, tx);
-		ASSERT(dp->dp_empty_bpobj != 0);
+		ASSERT3U(dp->dp_empty_bpobj, !=, 0);
 		return (dp->dp_empty_bpobj);
 	} else {
 		return (bpobj_alloc(os, blocksize, tx));
@@ -101,7 +101,7 @@ bpobj_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 	int epb;
 	dmu_buf_t *dbuf = NULL;
 
-	ASSERT(obj != dmu_objset_pool(os)->dp_empty_bpobj);
+	ASSERT3U(obj, !=, dmu_objset_pool(os)->dp_empty_bpobj);
 	VERIFY3U(0, ==, bpobj_open(&bpo, os, obj));
 
 	mutex_enter(&bpo.bpo_lock);
@@ -160,7 +160,7 @@ bpobj_open(bpobj_t *bpo, objset_t *os, uint64_t object)
 
 	ASSERT3P(bpo->bpo_dbuf, ==, NULL);
 	ASSERT3P(bpo->bpo_phys, ==, NULL);
-	ASSERT(object != 0);
+	ASSERT3U(object, !=, 0);
 	ASSERT3U(doi.doi_type, ==, DMU_OT_BPOBJ);
 	ASSERT3U(doi.doi_bonus_type, ==, DMU_OT_BPOBJ_HDR);
 
@@ -651,10 +651,11 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 	boolean_t copy_bps = B_TRUE;
 
 	ASSERT(bpobj_is_open(bpo));
-	ASSERT(subobj != 0);
+	ASSERT3U(subobj, !=, 0);
 	ASSERT(bpo->bpo_havesubobj);
 	ASSERT(bpo->bpo_havecomp);
-	ASSERT(bpo->bpo_object != dmu_objset_pool(bpo->bpo_os)->dp_empty_bpobj);
+	ASSERT3U(bpo->bpo_object, !=,
+	    dmu_objset_pool(bpo->bpo_os)->dp_empty_bpobj);
 
 	if (subobj == dmu_objset_pool(bpo->bpo_os)->dp_empty_bpobj) {
 		bpobj_decr_empty(bpo->bpo_os, tx);
@@ -790,7 +791,8 @@ bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
 
 	ASSERT(bpobj_is_open(bpo));
 	ASSERT0(BP_IS_HOLE(bp));
-	ASSERT(bpo->bpo_object != dmu_objset_pool(bpo->bpo_os)->dp_empty_bpobj);
+	ASSERT3U(bpo->bpo_object, !=,
+	    dmu_objset_pool(bpo->bpo_os)->dp_empty_bpobj);
 
 	if (BP_IS_EMBEDDED(bp)) {
 		/*

--- a/module/zfs/btree.c
+++ b/module/zfs/btree.c
@@ -473,7 +473,7 @@ bt_shift_leaf(zfs_btree_t *tree, zfs_btree_leaf_t *node, uint32_t idx,
 {
 	size_t size = tree->bt_elem_size;
 	zfs_btree_hdr_t *hdr = &node->btl_hdr;
-	ASSERT(!zfs_btree_is_core(hdr));
+	ASSERT0(zfs_btree_is_core(hdr));
 
 	if (count == 0)
 		return;
@@ -491,7 +491,7 @@ bt_grow_leaf(zfs_btree_t *tree, zfs_btree_leaf_t *leaf, uint32_t idx,
     uint32_t n)
 {
 	zfs_btree_hdr_t *hdr = &leaf->btl_hdr;
-	ASSERT(!zfs_btree_is_core(hdr));
+	ASSERT0(zfs_btree_is_core(hdr));
 	ASSERT3U(idx, <=, hdr->bth_count);
 	uint32_t capacity = tree->bt_leaf_cap;
 	ASSERT3U(hdr->bth_count + n, <=, capacity);
@@ -526,7 +526,7 @@ bt_shrink_leaf(zfs_btree_t *tree, zfs_btree_leaf_t *leaf, uint32_t idx,
     uint32_t n)
 {
 	zfs_btree_hdr_t *hdr = &leaf->btl_hdr;
-	ASSERT(!zfs_btree_is_core(hdr));
+	ASSERT0(zfs_btree_is_core(hdr));
 	ASSERT3U(idx, <=, hdr->bth_count);
 	ASSERT3U(idx + n, <=, hdr->bth_count);
 
@@ -569,8 +569,8 @@ bt_transfer_leaf(zfs_btree_t *tree, zfs_btree_leaf_t *source, uint32_t sidx,
     uint32_t count, zfs_btree_leaf_t *dest, uint32_t didx)
 {
 	size_t size = tree->bt_elem_size;
-	ASSERT(!zfs_btree_is_core(&source->btl_hdr));
-	ASSERT(!zfs_btree_is_core(&dest->btl_hdr));
+	ASSERT0(zfs_btree_is_core(&source->btl_hdr));
+	ASSERT0(zfs_btree_is_core(&dest->btl_hdr));
 
 	bcpy(source->btl_elems + (source->btl_hdr.bth_first + sidx) * size,
 	    dest->btl_elems + (dest->btl_hdr.bth_first + didx) * size,
@@ -591,7 +591,7 @@ zfs_btree_first_helper(zfs_btree_t *tree, zfs_btree_hdr_t *hdr,
 	    node = ((zfs_btree_core_t *)node)->btc_children[0])
 		;
 
-	ASSERT(!zfs_btree_is_core(node));
+	ASSERT0(zfs_btree_is_core(node));
 	zfs_btree_leaf_t *leaf = (zfs_btree_leaf_t *)node;
 	if (where != NULL) {
 		where->bti_node = node;
@@ -953,7 +953,7 @@ zfs_btree_bulk_finish(zfs_btree_t *tree)
 		uint32_t common_idx = idx.bti_offset;
 
 		VERIFY3P(zfs_btree_prev(tree, &idx, &idx), !=, NULL);
-		ASSERT(!zfs_btree_is_core(idx.bti_node));
+		ASSERT0(zfs_btree_is_core(idx.bti_node));
 		zfs_btree_leaf_t *l_neighbor = (zfs_btree_leaf_t *)idx.bti_node;
 		zfs_btree_hdr_t *l_hdr = idx.bti_node;
 		uint32_t move_count = (capacity / 2) - hdr->bth_count;
@@ -1154,7 +1154,7 @@ zfs_btree_add_idx(zfs_btree_t *tree, const void *value,
 		VERIFY3P(zfs_btree_first_helper(tree, subtree, &new_idx), !=,
 		    NULL);
 		ASSERT0(new_idx.bti_offset);
-		ASSERT(!zfs_btree_is_core(new_idx.bti_node));
+		ASSERT0(zfs_btree_is_core(new_idx.bti_node));
 		zfs_btree_insert_into_leaf(tree,
 		    (zfs_btree_leaf_t *)new_idx.bti_node, buf, 0);
 		kmem_free(buf, size);
@@ -1378,7 +1378,7 @@ zfs_btree_prev(zfs_btree_t *tree, const zfs_btree_index_t *idx,
 void *
 zfs_btree_get(zfs_btree_t *tree, zfs_btree_index_t *idx)
 {
-	ASSERT(!idx->bti_before);
+	ASSERT0(idx->bti_before);
 	size_t size = tree->bt_elem_size;
 	if (!zfs_btree_is_core(idx->bti_node)) {
 		zfs_btree_leaf_t *leaf = (zfs_btree_leaf_t *)idx->bti_node;
@@ -1646,7 +1646,7 @@ zfs_btree_remove_idx(zfs_btree_t *tree, zfs_btree_index_t *where)
 	zfs_btree_hdr_t *hdr = where->bti_node;
 	uint32_t idx = where->bti_offset;
 
-	ASSERT(!where->bti_before);
+	ASSERT0(where->bti_before);
 	if (tree->bt_bulk != NULL) {
 		/*
 		 * Leave bulk insert mode. Note that our index would be
@@ -1682,7 +1682,7 @@ zfs_btree_remove_idx(zfs_btree_t *tree, zfs_btree_index_t *where)
 
 		hdr = where->bti_node;
 		idx = where->bti_offset;
-		ASSERT(!where->bti_before);
+		ASSERT0(where->bti_before);
 	}
 
 	/*
@@ -1690,7 +1690,7 @@ zfs_btree_remove_idx(zfs_btree_t *tree, zfs_btree_index_t *where)
 	 * elements after the idx to the left. After that, we rebalance if
 	 * needed.
 	 */
-	ASSERT(!zfs_btree_is_core(hdr));
+	ASSERT0(zfs_btree_is_core(hdr));
 	zfs_btree_leaf_t *leaf = (zfs_btree_leaf_t *)hdr;
 	ASSERT3U(hdr->bth_count, >, 0);
 
@@ -1735,7 +1735,7 @@ zfs_btree_remove_idx(zfs_btree_t *tree, zfs_btree_index_t *where)
 	    parent->btc_children[parent_idx - 1]);
 	if (l_hdr != NULL && l_hdr->bth_count > min_count) {
 		/* We can take a node from the left neighbor. */
-		ASSERT(!zfs_btree_is_core(l_hdr));
+		ASSERT0(zfs_btree_is_core(l_hdr));
 		zfs_btree_leaf_t *neighbor = (zfs_btree_leaf_t *)l_hdr;
 
 		/*
@@ -1764,7 +1764,7 @@ zfs_btree_remove_idx(zfs_btree_t *tree, zfs_btree_index_t *where)
 	    NULL : parent->btc_children[parent_idx + 1]);
 	if (r_hdr != NULL && r_hdr->bth_count > min_count) {
 		/* We can take a node from the right neighbor. */
-		ASSERT(!zfs_btree_is_core(r_hdr));
+		ASSERT0(zfs_btree_is_core(r_hdr));
 		zfs_btree_leaf_t *neighbor = (zfs_btree_leaf_t *)r_hdr;
 
 		/*
@@ -1811,8 +1811,8 @@ zfs_btree_remove_idx(zfs_btree_t *tree, zfs_btree_index_t *where)
 		rm_hdr = r_hdr;
 		parent_idx++;
 	}
-	ASSERT(!zfs_btree_is_core(k_hdr));
-	ASSERT(!zfs_btree_is_core(rm_hdr));
+	ASSERT0(zfs_btree_is_core(k_hdr));
+	ASSERT0(zfs_btree_is_core(rm_hdr));
 	ASSERT3U(k_hdr->bth_count, ==, min_count);
 	ASSERT3U(rm_hdr->bth_count, ==, min_count);
 	zfs_btree_leaf_t *keep = (zfs_btree_leaf_t *)k_hdr;

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -437,7 +437,7 @@ ddt_stat_update(ddt_t *ddt, ddt_entry_t *dde, uint64_t neg)
 	ddt_stat_generate(ddt, dde, &dds);
 
 	bucket = highbit64(dds.dds_ref_blocks) - 1;
-	ASSERT(bucket >= 0);
+	ASSERT3S(bucket, >=, 0);
 
 	ddh = &ddt->ddt_histogram[dde->dde_type][dde->dde_class];
 
@@ -1044,7 +1044,8 @@ ddt_sync_entry(ddt_t *ddt, ddt_entry_t *dde, dmu_tx_t *tx, uint64_t txg)
 	if (otype != DDT_TYPES &&
 	    (otype != ntype || oclass != nclass || total_refcnt == 0)) {
 		VERIFY0(ddt_object_remove(ddt, otype, oclass, dde, tx));
-		ASSERT(ddt_object_lookup(ddt, otype, oclass, dde) == ENOENT);
+		ASSERT3S(ddt_object_lookup(ddt, otype, oclass, dde), ==,
+		    ENOENT);
 	}
 
 	if (total_refcnt != 0) {

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -71,7 +71,7 @@ ddt_object_create(ddt_t *ddt, enum ddt_type type, enum ddt_class class,
 
 	ASSERT0(*objectp);
 	VERIFY0(ddt_ops[type]->ddt_op_create(os, objectp, tx, prehash));
-	ASSERT(*objectp != 0);
+	ASSERT3U(*objectp, !=, 0);
 
 	VERIFY0(zap_add(os, DMU_POOL_DIRECTORY_OBJECT, name, sizeof (uint64_t),
 	    1, objectp, tx));
@@ -93,7 +93,7 @@ ddt_object_destroy(ddt_t *ddt, enum ddt_type type, enum ddt_class class,
 
 	ddt_object_name(ddt, type, class, name);
 
-	ASSERT(*objectp != 0);
+	ASSERT3U(*objectp, !=, 0);
 	ASSERT(ddt_histogram_empty(&ddt->ddt_histogram[type][class]));
 	VERIFY(ddt_object_count(ddt, type, class, &count) == 0 && count == 0);
 	VERIFY0(zap_remove(os, DMU_POOL_DIRECTORY_OBJECT, name, tx));
@@ -261,7 +261,7 @@ ddt_object_name(ddt_t *ddt, enum ddt_type type, enum ddt_class class,
 void
 ddt_bp_fill(const ddt_phys_t *ddp, blkptr_t *bp, uint64_t txg)
 {
-	ASSERT(txg != 0);
+	ASSERT3U(txg, !=, 0);
 
 	for (int d = 0; d < SPA_DVAS_PER_BP; d++)
 		bp->blk_dva[d] = ddp->ddp_dva[d];
@@ -335,7 +335,7 @@ void
 ddt_phys_decref(ddt_phys_t *ddp)
 {
 	if (ddp) {
-		ASSERT(ddp->ddp_refcnt > 0);
+		ASSERT3U(ddp->ddp_refcnt, >, 0);
 		ddp->ddp_refcnt--;
 	}
 }
@@ -560,7 +560,7 @@ ddt_compress(void *src, uchar_t *dst, size_t s_len, size_t d_len)
 	zio_compress_info_t *ci = &zio_compress_table[cpfunc];
 	size_t c_len;
 
-	ASSERT(d_len >= s_len + 1);	/* no compression plus version byte */
+	ASSERT3U(d_len, >=, s_len + 1);	/* no compression plus version byte */
 
 	c_len = ci->ci_compress(src, dst, s_len, d_len - 1, ci->ci_level);
 
@@ -712,8 +712,8 @@ ddt_lookup(ddt_t *ddt, const blkptr_t *bp, boolean_t add)
 
 	ddt_enter(ddt);
 
-	ASSERT(dde->dde_loaded == B_FALSE);
-	ASSERT(dde->dde_loading == B_TRUE);
+	ASSERT3U(dde->dde_loaded, ==, B_FALSE);
+	ASSERT3U(dde->dde_loading, ==, B_TRUE);
 
 	dde->dde_type = type;	/* will be DDT_TYPES if no entry found */
 	dde->dde_class = class;	/* will be DDT_CLASSES if no entry found */
@@ -1080,7 +1080,7 @@ ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx, uint64_t txg)
 	if (avl_numnodes(&ddt->ddt_tree) == 0)
 		return;
 
-	ASSERT(spa->spa_uberblock.ub_version >= SPA_VERSION_DEDUP);
+	ASSERT3U(spa->spa_uberblock.ub_version, >=, SPA_VERSION_DEDUP);
 
 	if (spa->spa_ddt_stat_object == 0) {
 		spa->spa_ddt_stat_object = zap_create_link(ddt->ddt_os,
@@ -1121,7 +1121,7 @@ ddt_sync(spa_t *spa, uint64_t txg)
 	dmu_tx_t *tx;
 	zio_t *rio;
 
-	ASSERT(spa_syncing_txg(spa) == txg);
+	ASSERT3U(spa_syncing_txg(spa), ==, txg);
 
 	tx = dmu_tx_create_assigned(spa->spa_dsl_pool, txg);
 

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -647,7 +647,7 @@ ddt_free(ddt_entry_t *dde)
 	ASSERT0(dde->dde_loading);
 
 	for (int p = 0; p < DDT_PHYS_TYPES; p++)
-		ASSERT(dde->dde_lead_zio[p] == NULL);
+		ASSERT3P(dde->dde_lead_zio[p], ==, NULL);
 
 	if (dde->dde_repair_abd != NULL)
 		abd_free(dde->dde_repair_abd);
@@ -1016,7 +1016,7 @@ ddt_sync_entry(ddt_t *ddt, ddt_entry_t *dde, dmu_tx_t *tx, uint64_t txg)
 	ASSERT0(dde->dde_loading);
 
 	for (int p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
-		ASSERT(dde->dde_lead_zio[p] == NULL);
+		ASSERT3P(dde->dde_lead_zio[p], ==, NULL);
 		if (ddp->ddp_phys_birth == 0) {
 			ASSERT0(ddp->ddp_refcnt);
 			continue;

--- a/module/zfs/ddt_zap.c
+++ b/module/zfs/ddt_zap.c
@@ -136,7 +136,7 @@ ddt_zap_walk(objset_t *os, uint64_t object, ddt_entry_t *dde, uint64_t *walk)
 		ASSERT(za.za_integer_length == 1);
 		error = zap_lookup_uint64(os, object, (uint64_t *)za.za_name,
 		    DDT_KEY_WORDS, 1, csize, cbuf);
-		ASSERT(error == 0);
+		ASSERT0(error);
 		if (error == 0) {
 			ddt_decompress(cbuf, dde->dde_phys, csize,
 			    sizeof (dde->dde_phys));

--- a/module/zfs/ddt_zap.c
+++ b/module/zfs/ddt_zap.c
@@ -69,8 +69,8 @@ ddt_zap_lookup(objset_t *os, uint64_t object, ddt_entry_t *dde)
 	if (error)
 		goto out;
 
-	ASSERT(one == 1);
-	ASSERT(csize <= (sizeof (dde->dde_phys) + 1));
+	ASSERT3U(one, ==, 1);
+	ASSERT3U(csize, <=, sizeof (dde->dde_phys) + 1);
 
 	error = zap_lookup_uint64(os, object, (uint64_t *)&dde->dde_key,
 	    DDT_KEY_WORDS, 1, csize, cbuf);

--- a/module/zfs/ddt_zap.c
+++ b/module/zfs/ddt_zap.c
@@ -133,7 +133,7 @@ ddt_zap_walk(objset_t *os, uint64_t object, ddt_entry_t *dde, uint64_t *walk)
 	if ((error = zap_cursor_retrieve(&zc, &za)) == 0) {
 		uchar_t cbuf[sizeof (dde->dde_phys) + 1];
 		uint64_t csize = za.za_num_integers;
-		ASSERT(za.za_integer_length == 1);
+		ASSERT3S(za.za_integer_length, ==, 1);
 		error = zap_lookup_uint64(os, object, (uint64_t *)za.za_name,
 		    DDT_KEY_WORDS, 1, csize, cbuf);
 		ASSERT0(error);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1737,7 +1737,7 @@ dmu_sync(zio_t *pio, uint64_t txg, dmu_sync_cb_t *done, zgd_t *zgd)
 	zio_prop_t zp;
 	dnode_t *dn;
 
-	ASSERT(pio != NULL);
+	ASSERT3P(pio, !=, NULL);
 	ASSERT(txg != 0);
 
 	SET_BOOKMARK(&zb, ds->ds_object,

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1167,8 +1167,8 @@ dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	if (size == 0)
 		return;
 
-	VERIFY(0 == dmu_buf_hold_array(os, object, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp));
+	VERIFY0(dmu_buf_hold_array(os, object, offset, size, FALSE, FTAG,
+	    &numbufs, &dbp));
 
 	for (i = 0; i < numbufs; i++) {
 		dmu_buf_t *db = dbp[i];
@@ -1489,7 +1489,7 @@ dmu_assign_arcbuf_by_dnode(dnode_t *dn, uint64_t offset, arc_buf_t *buf,
 	} else {
 		/* compressed bufs must always be assignable to their dbuf */
 		ASSERT3U(arc_get_compression(buf), ==, ZIO_COMPRESS_OFF);
-		ASSERT(!(buf->b_flags & ARC_BUF_FLAG_COMPRESSED));
+		ASSERT0((buf->b_flags & ARC_BUF_FLAG_COMPRESSED));
 
 		dbuf_rele(db, FTAG);
 		dmu_write(os, object, offset, blksz, buf->b_data, tx);
@@ -1536,7 +1536,7 @@ dmu_sync_ready(zio_t *zio, arc_buf_t *buf, void *varg)
 			 */
 			BP_SET_LSIZE(bp, db->db_size);
 		} else if (!BP_IS_EMBEDDED(bp)) {
-			ASSERT(BP_GET_LEVEL(bp) == 0);
+			ASSERT0(BP_GET_LEVEL(bp));
 			BP_SET_FILL(bp, 1);
 		}
 	}
@@ -1624,7 +1624,7 @@ dmu_sync_late_arrival_done(zio_t *zio)
 
 		if (!BP_IS_HOLE(bp)) {
 			blkptr_t *bp_orig __maybe_unused = &zio->io_bp_orig;
-			ASSERT(!(zio->io_flags & ZIO_FLAG_NOPWRITE));
+			ASSERT0((zio->io_flags & ZIO_FLAG_NOPWRITE));
 			ASSERT(BP_IS_HOLE(bp_orig) || !BP_EQUAL(bp, bp_orig));
 			ASSERT(zio->io_bp->blk_birth == zio->io_txg);
 			ASSERT(zio->io_txg > spa_syncing_txg(zio->io_spa));
@@ -2018,7 +2018,7 @@ dmu_write_policy(objset_t *os, dnode_t *dn, int level, int wp, zio_prop_t *zp)
 			break;
 		}
 	} else if (wp & WP_NOFILL) {
-		ASSERT(level == 0);
+		ASSERT0(level);
 
 		/*
 		 * If we're writing preallocated blocks, we aren't actually
@@ -2270,7 +2270,7 @@ byteswap_uint64_array(void *vbuf, size_t size)
 	size_t count = size >> 3;
 	int i;
 
-	ASSERT((size & 7) == 0);
+	ASSERT0((size & 7));
 
 	for (i = 0; i < count; i++)
 		buf[i] = BSWAP_64(buf[i]);
@@ -2283,7 +2283,7 @@ byteswap_uint32_array(void *vbuf, size_t size)
 	size_t count = size >> 2;
 	int i;
 
-	ASSERT((size & 3) == 0);
+	ASSERT0((size & 3));
 
 	for (i = 0; i < count; i++)
 		buf[i] = BSWAP_32(buf[i]);
@@ -2296,7 +2296,7 @@ byteswap_uint16_array(void *vbuf, size_t size)
 	size_t count = size >> 1;
 	int i;
 
-	ASSERT((size & 1) == 0);
+	ASSERT0((size & 1));
 
 	for (i = 0; i < count; i++)
 		buf[i] = BSWAP_16(buf[i]);

--- a/module/zfs/dmu_diff.c
+++ b/module/zfs/dmu_diff.c
@@ -88,7 +88,7 @@ report_free_dnode_range(dmu_diffarg_t *da, uint64_t first, uint64_t last)
 static int
 report_dnode(dmu_diffarg_t *da, uint64_t object, dnode_phys_t *dnp)
 {
-	ASSERT(dnp != NULL);
+	ASSERT3P(dnp, !=, NULL);
 	if (dnp->dn_type == DMU_OT_NONE)
 		return (report_free_dnode_range(da, object, object));
 

--- a/module/zfs/dmu_diff.c
+++ b/module/zfs/dmu_diff.c
@@ -71,7 +71,7 @@ write_record(dmu_diffarg_t *da)
 static int
 report_free_dnode_range(dmu_diffarg_t *da, uint64_t first, uint64_t last)
 {
-	ASSERT(first <= last);
+	ASSERT3U(first, <=, last);
 	if (da->da_ddr.ddr_type != DDR_FREE ||
 	    first != da->da_ddr.ddr_last + 1) {
 		if (write_record(da) != 0)

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -369,7 +369,7 @@ dmu_object_free(objset_t *os, uint64_t object, dmu_tx_t *tx)
 	if (err)
 		return (err);
 
-	ASSERT(dn->dn_type != DMU_OT_NONE);
+	ASSERT3U(dn->dn_type, !=, DMU_OT_NONE);
 	/*
 	 * If we don't create this free range, we'll leak indirect blocks when
 	 * we get to freeing the dnode in syncing context.

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -456,7 +456,7 @@ dmu_objset_open_impl(spa_t *spa, dsl_dataset_t *ds, blkptr_t *bp,
 	int i, err;
 
 	ASSERT(ds == NULL || MUTEX_HELD(&ds->ds_opening_lock));
-	ASSERT(!BP_IS_REDACTED(bp));
+	ASSERT0(BP_IS_REDACTED(bp));
 
 	/*
 	 * We need the pool config lock to get properties.
@@ -981,7 +981,7 @@ dmu_objset_evict(objset_t *os)
 	dsl_dataset_t *ds = os->os_dsl_dataset;
 
 	for (int t = 0; t < TXG_SIZE; t++)
-		ASSERT(!dmu_objset_is_dirty(os, t));
+		ASSERT0(dmu_objset_is_dirty(os, t));
 
 	if (ds)
 		dsl_prop_unregister_all(ds, os);
@@ -1575,7 +1575,7 @@ dmu_objset_write_ready(zio_t *zio, arc_buf_t *abuf, void *arg)
 	dnode_phys_t *dnp = &os->os_phys->os_meta_dnode;
 	uint64_t fill = 0;
 
-	ASSERT(!BP_IS_EMBEDDED(bp));
+	ASSERT0(BP_IS_EMBEDDED(bp));
 	ASSERT3U(BP_GET_TYPE(bp), ==, DMU_OT_OBJSET);
 	ASSERT0(BP_GET_LEVEL(bp));
 
@@ -2001,7 +2001,7 @@ userquota_updates_task(void *arg)
 
 	while ((dn = multilist_sublist_head(list)) != NULL) {
 		int flags;
-		ASSERT(!DMU_OBJECT_IS_SPECIAL(dn->dn_object));
+		ASSERT0(DMU_OBJECT_IS_SPECIAL(dn->dn_object));
 		ASSERT(dn->dn_phys->dn_type == DMU_OT_NONE ||
 		    dn->dn_phys->dn_flags &
 		    DNODE_FLAG_USERUSED_ACCOUNTED);
@@ -2228,7 +2228,7 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 			error = dmu_spill_hold_by_dnode(dn,
 			    rf | DB_RF_MUST_SUCCEED,
 			    FTAG, (dmu_buf_t **)&db);
-			ASSERT(error == 0);
+			ASSERT0(error);
 			mutex_enter(&db->db_mtx);
 			data = (before) ? db->db.db_data :
 			    dmu_objset_userquota_find_data(db, tx);

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -702,7 +702,7 @@ dmu_objset_from_ds(dsl_dataset_t *ds, objset_t **osp)
 
 		if (err == 0) {
 			mutex_enter(&ds->ds_lock);
-			ASSERT(ds->ds_objset == NULL);
+			ASSERT3P(ds->ds_objset, ==, NULL);
 			ds->ds_objset = os;
 			mutex_exit(&ds->ds_lock);
 		}

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -182,7 +182,7 @@ checksum_changed_cb(void *arg, uint64_t newval)
 	/*
 	 * Inheritance should have been done by now.
 	 */
-	ASSERT(newval != ZIO_CHECKSUM_INHERIT);
+	ASSERT3U(newval, !=, ZIO_CHECKSUM_INHERIT);
 
 	os->os_checksum = zio_checksum_select(newval, ZIO_CHECKSUM_ON_VALUE);
 }
@@ -195,7 +195,7 @@ compression_changed_cb(void *arg, uint64_t newval)
 	/*
 	 * Inheritance and range checking should have been done by now.
 	 */
-	ASSERT(newval != ZIO_COMPRESS_INHERIT);
+	ASSERT3U(newval, !=, ZIO_COMPRESS_INHERIT);
 
 	os->os_compress = zio_compress_select(os->os_spa,
 	    ZIO_COMPRESS_ALGO(newval), ZIO_COMPRESS_ON);
@@ -211,8 +211,8 @@ copies_changed_cb(void *arg, uint64_t newval)
 	/*
 	 * Inheritance and range checking should have been done by now.
 	 */
-	ASSERT(newval > 0);
-	ASSERT(newval <= spa_max_replication(os->os_spa));
+	ASSERT3U(newval, >, 0);
+	ASSERT3U(newval, <=, spa_max_replication(os->os_spa));
 
 	os->os_copies = newval;
 }
@@ -227,7 +227,7 @@ dedup_changed_cb(void *arg, uint64_t newval)
 	/*
 	 * Inheritance should have been done by now.
 	 */
-	ASSERT(newval != ZIO_CHECKSUM_INHERIT);
+	ASSERT3U(newval, !=, ZIO_CHECKSUM_INHERIT);
 
 	checksum = zio_checksum_dedup_select(spa, newval, ZIO_CHECKSUM_OFF);
 
@@ -331,7 +331,7 @@ smallblk_changed_cb(void *arg, uint64_t newval)
 	/*
 	 * Inheritance and range checking should have been done by now.
 	 */
-	ASSERT(newval <= SPA_MAXBLOCKSIZE);
+	ASSERT3U(newval, <=, SPA_MAXBLOCKSIZE);
 	ASSERT(ISP2(newval));
 
 	os->os_zpl_special_smallblock = newval;
@@ -385,7 +385,7 @@ dnode_hash(const objset_t *os, uint64_t obj)
 	uintptr_t osv = (uintptr_t)os;
 	uint64_t crc = -1ULL;
 
-	ASSERT(zfs_crc64_table[128] == ZFS_CRC64_POLY);
+	ASSERT3U(zfs_crc64_table[128], ==, ZFS_CRC64_POLY);
 	/*
 	 * The low 6 bits of the pointer don't have much entropy, because
 	 * the objset_t is larger than 2^6 bytes long.
@@ -1108,9 +1108,9 @@ dmu_objset_create_impl_dnstats(spa_t *spa, dsl_dataset_t *ds, blkptr_t *bp,
 		    mdn->dn_nlevels = levels;
 	}
 
-	ASSERT(type != DMU_OST_NONE);
-	ASSERT(type != DMU_OST_ANY);
-	ASSERT(type < DMU_OST_NUMTYPES);
+	ASSERT3U(type, !=, DMU_OST_NONE);
+	ASSERT3U(type, !=, DMU_OST_ANY);
+	ASSERT3U(type, <, DMU_OST_NUMTYPES);
 	os->os_phys->os_type = type;
 
 	/*
@@ -1541,7 +1541,7 @@ dmu_objset_sync_dnodes(multilist_sublist_t *list, dmu_tx_t *tx)
 	dnode_t *dn;
 
 	while ((dn = multilist_sublist_head(list)) != NULL) {
-		ASSERT(dn->dn_object != DMU_META_DNODE_OBJECT);
+		ASSERT3U(dn->dn_object, !=, DMU_META_DNODE_OBJECT);
 		ASSERT(dn->dn_dbuf->db_data_pending);
 		/*
 		 * Initialize dn_zio outside dnode_sync() because the
@@ -1903,7 +1903,7 @@ userquota_update_cache(avl_tree_t *avl, const char *id, int64_t delta)
 	userquota_node_t *uqn;
 	avl_index_t idx;
 
-	ASSERT(strlen(id) < sizeof (uqn->uqn_id));
+	ASSERT3U(strlen(id), <, sizeof (uqn->uqn_id));
 	/*
 	 * Use id directly for searching because uqn_id is the first field of
 	 * userquota_node_t and fields after uqn_id won't be accessed in

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -1569,13 +1569,13 @@ save_resume_state(struct receive_writer_arg *rwa,
 	 * We use ds_resume_bytes[] != 0 to indicate that we need to
 	 * update this on disk, so it must not be 0.
 	 */
-	ASSERT(rwa->bytes_read != 0);
+	ASSERT3U(rwa->bytes_read, !=, 0);
 
 	/*
 	 * We only resume from write records, which have a valid
 	 * (non-meta-dnode) object number.
 	 */
-	ASSERT(object != 0);
+	ASSERT3U(object, !=, 0);
 
 	/*
 	 * For resuming to work correctly, we must receive records in order,

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -3098,7 +3098,7 @@ receive_process_record(struct receive_writer_arg *rwa,
 			 * EAGAIN to indicate that we do not want to free
 			 * the rrd or arc_buf.
 			 */
-			ASSERT(err != 0);
+			ASSERT3S(err, !=, 0);
 			abd_free(rrd->abd);
 			rrd->abd = NULL;
 		}

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -621,7 +621,7 @@ dmu_recv_begin_check(void *arg, dmu_tx_t *tx)
 
 	/* already checked */
 	ASSERT3U(drrb->drr_magic, ==, DMU_BACKUP_MAGIC);
-	ASSERT(!(featureflags & DMU_BACKUP_FEATURE_RESUMING));
+	ASSERT0((featureflags & DMU_BACKUP_FEATURE_RESUMING));
 
 	if (DMU_GET_STREAM_HDRTYPE(drrb->drr_versioninfo) ==
 	    DMU_COMPOUNDSTREAM ||

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -495,7 +495,7 @@ dmu_dump_write(dmu_send_cookie_t *dscp, dmu_object_type_t type, uint64_t object,
 	if (raw || compressed) {
 		ASSERT(raw || dscp->dsc_featureflags &
 		    DMU_BACKUP_FEATURE_COMPRESSED);
-		ASSERT(!BP_IS_EMBEDDED(bp));
+		ASSERT0(BP_IS_EMBEDDED(bp));
 		ASSERT3S(psize, >, 0);
 
 		if (raw) {
@@ -516,8 +516,8 @@ dmu_dump_write(dmu_send_cookie_t *dscp, dmu_object_type_t type, uint64_t object,
 			/* this is a compressed block */
 			ASSERT(dscp->dsc_featureflags &
 			    DMU_BACKUP_FEATURE_COMPRESSED);
-			ASSERT(!BP_SHOULD_BYTESWAP(bp));
-			ASSERT(!DMU_OT_IS_METADATA(BP_GET_TYPE(bp)));
+			ASSERT0(BP_SHOULD_BYTESWAP(bp));
+			ASSERT0(DMU_OT_IS_METADATA(BP_GET_TYPE(bp)));
 			ASSERT3U(BP_GET_COMPRESS(bp), !=, ZIO_COMPRESS_OFF);
 			ASSERT3S(lsize, >=, psize);
 		}
@@ -1890,7 +1890,7 @@ send_reader_thread(void *arg)
 				    NULL, NULL);
 				if (err != 0)
 					break;
-				ASSERT(!BP_IS_HOLE(&bp));
+				ASSERT0(BP_IS_HOLE(&bp));
 				enqueue_range(srta, outq, dn, blkid, 1, &bp,
 				    datablksz);
 			}

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -202,7 +202,7 @@ traverse_prefetch_metadata(traverse_data_t *td,
 		return (B_FALSE);
 	if (BP_GET_LEVEL(bp) == 0 && BP_GET_TYPE(bp) != DMU_OT_DNODE)
 		return (B_FALSE);
-	ASSERT(!BP_IS_REDACTED(bp));
+	ASSERT0(BP_IS_REDACTED(bp));
 
 	if ((td->td_flags & TRAVERSE_NO_DECRYPT) && BP_IS_PROTECTED(bp))
 		zio_flags |= ZIO_FLAG_RAW;
@@ -307,7 +307,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		int32_t epb = BP_GET_LSIZE(bp) >> SPA_BLKPTRSHIFT;
 		zbookmark_phys_t *czb;
 
-		ASSERT(!BP_IS_PROTECTED(bp));
+		ASSERT0(BP_IS_PROTECTED(bp));
 
 		err = arc_read(NULL, td->td_spa, bp, arc_getbuf_func, &buf,
 		    ZIO_PRIORITY_ASYNC_READ, ZIO_FLAG_CANFAIL, &flags, zb);
@@ -676,7 +676,7 @@ traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
 		uint32_t flags = ARC_FLAG_WAIT;
 		objset_phys_t *osp;
 		arc_buf_t *buf;
-		ASSERT(!BP_IS_REDACTED(rootbp));
+		ASSERT0(BP_IS_REDACTED(rootbp));
 
 		if ((td->td_flags & TRAVERSE_NO_DECRYPT) &&
 		    BP_IS_PROTECTED(rootbp))

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -276,7 +276,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 	if (pd != NULL && !pd->pd_exited && prefetch_needed(pd, bp)) {
 		uint64_t size = BP_GET_LSIZE(bp);
 		mutex_enter(&pd->pd_mtx);
-		ASSERT(pd->pd_bytes_fetched >= 0);
+		ASSERT3U(pd->pd_bytes_fetched, >=, 0);
 		while (pd->pd_bytes_fetched < size && !pd->pd_exited)
 			cv_wait_sig(&pd->pd_cv, &pd->pd_mtx);
 		pd->pd_bytes_fetched -= size;
@@ -572,7 +572,7 @@ traverse_prefetcher(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 	arc_flags_t aflags = ARC_FLAG_NOWAIT | ARC_FLAG_PREFETCH |
 	    ARC_FLAG_PRESCIENT_PREFETCH;
 
-	ASSERT(pfd->pd_bytes_fetched >= 0);
+	ASSERT3U(pfd->pd_bytes_fetched, >=, 0);
 	if (zb->zb_level == ZB_DNODE_LEVEL)
 		return (0);
 	if (pfd->pd_cancel)

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -529,7 +529,7 @@ dmu_tx_hold_zap_by_dnode(dmu_tx_t *tx, dnode_t *dn, int add, const char *name)
 	dmu_tx_hold_t *txh;
 
 	ASSERT0(tx->tx_txg);
-	ASSERT(dn != NULL);
+	ASSERT3P(dn, !=, NULL);
 
 	txh = dmu_tx_hold_dnode_impl(tx, dn, THT_ZAP, add, (uintptr_t)name);
 	if (txh != NULL)
@@ -1239,7 +1239,7 @@ dmu_tx_get_txg(dmu_tx_t *tx)
 dsl_pool_t *
 dmu_tx_pool(dmu_tx_t *tx)
 {
-	ASSERT(tx->tx_pool != NULL);
+	ASSERT3P(tx->tx_pool, !=, NULL);
 	return (tx->tx_pool);
 }
 
@@ -1358,7 +1358,7 @@ dmu_tx_hold_sa(dmu_tx_t *tx, sa_handle_t *hdl, boolean_t may_grow)
 	uint64_t object;
 	sa_os_t *sa = tx->tx_objset->os_sa;
 
-	ASSERT(hdl != NULL);
+	ASSERT3P(hdl, !=, NULL);
 
 	object = sa_handle_object(hdl);
 

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -396,7 +396,7 @@ dmu_tx_hold_free_impl(dmu_tx_hold_t *txh, uint64_t off, uint64_t len)
 		uint64_t start = off >> shift;
 		uint64_t end = (off + len) >> shift;
 
-		ASSERT(dn->dn_indblkshift != 0);
+		ASSERT3U(dn->dn_indblkshift, !=, 0);
 
 		/*
 		 * dnode_reallocate() can result in an object with indirect
@@ -585,7 +585,7 @@ dmu_tx_dirty_buf(dmu_tx_t *tx, dmu_buf_impl_t *db)
 
 	DB_DNODE_ENTER(db);
 	dnode_t *dn = DB_DNODE(db);
-	ASSERT(tx->tx_txg != 0);
+	ASSERT3U(tx->tx_txg, !=, 0);
 	ASSERT(tx->tx_objset == NULL || dn->dn_objset == tx->tx_objset);
 	ASSERT3U(dn->dn_object, ==, db->db.db_object);
 
@@ -1180,7 +1180,7 @@ dmu_tx_destroy(dmu_tx_t *tx)
 void
 dmu_tx_commit(dmu_tx_t *tx)
 {
-	ASSERT(tx->tx_txg != 0);
+	ASSERT3U(tx->tx_txg, !=, 0);
 
 	/*
 	 * Go through the transaction's hold list and remove holds on
@@ -1232,7 +1232,7 @@ dmu_tx_abort(dmu_tx_t *tx)
 uint64_t
 dmu_tx_get_txg(dmu_tx_t *tx)
 {
-	ASSERT(tx->tx_txg != 0);
+	ASSERT3U(tx->tx_txg, !=, 0);
 	return (tx->tx_txg);
 }
 

--- a/module/zfs/dmu_zfetch.c
+++ b/module/zfs/dmu_zfetch.c
@@ -162,7 +162,7 @@ dmu_zfetch_init(zfetch_t *zf, dnode_t *dno)
 static void
 dmu_zfetch_stream_fini(zstream_t *zs)
 {
-	ASSERT(!list_link_active(&zs->zs_node));
+	ASSERT0(list_link_active(&zs->zs_node));
 	zfs_refcount_destroy(&zs->zs_callers);
 	zfs_refcount_destroy(&zs->zs_refs);
 	kmem_free(zs, sizeof (*zs));

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -296,7 +296,7 @@ dnode_kstats_update(kstat_t *ksp, int rw)
 void
 dnode_init(void)
 {
-	ASSERT(dnode_cache == NULL);
+	ASSERT3P(dnode_cache, ==, NULL);
 	dnode_cache = kmem_cache_create("dnode_t", sizeof (dnode_t),
 	    0, dnode_cons, dnode_dest, NULL, NULL, NULL, 0);
 	kmem_cache_set_move(dnode_cache, dnode_move);
@@ -1066,7 +1066,9 @@ dnode_move(void *buf, void *newbuf, size_t size, void *arg)
 		DNODE_STAT_BUMP(dnode_move_special);
 		return (KMEM_CBRC_NO);
 	}
-	ASSERT(odn->dn_dbuf != NULL); /* only "special" dnodes have no parent */
+
+	/* only "special" dnodes have no parent */
+	ASSERT3P(odn->dn_dbuf, !=, NULL);
 
 	/*
 	 * Lock the dnode handle to prevent the dnode from obtaining any new
@@ -1951,7 +1953,7 @@ dnode_set_nlevels_impl(dnode_t *dn, int new_nlevels, dmu_tx_t *tx)
 
 	/* dirty the left indirects */
 	db = dbuf_hold_level(dn, old_nlevels, 0, FTAG);
-	ASSERT(db != NULL);
+	ASSERT3P(db, !=, NULL);
 	new = dbuf_dirty(db, tx);
 	dbuf_rele(db, FTAG);
 

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -55,7 +55,7 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 	ASSERT(new_level > 1 && dn->dn_phys->dn_nlevels > 0);
 
 	db = dbuf_hold_level(dn, dn->dn_phys->dn_nlevels, 0, FTAG);
-	ASSERT(db != NULL);
+	ASSERT3P(db, !=, NULL);
 
 	dn->dn_phys->dn_nlevels = new_level;
 	dprintf("os=%p obj=%llu, increase to %d\n", dn->dn_objset,
@@ -99,7 +99,7 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 #endif	/* DEBUG */
 		if (child->db_parent && child->db_parent != dn->dn_dbuf) {
 			ASSERT(child->db_parent->db_level == db->db_level);
-			ASSERT(child->db_blkptr !=
+			ASSERT3P(child->db_blkptr, !=,
 			    &dn->dn_phys->dn_blkptr[child->db_blkid]);
 			mutex_exit(&child->db_mtx);
 			continue;
@@ -193,7 +193,7 @@ free_verify(dmu_buf_impl_t *db, uint64_t start, uint64_t end, dmu_tx_t *tx)
 	ASSERT3U(db->db_level, >, 0);
 	ASSERT3U(db->db.db_size, ==, 1 << dn->dn_phys->dn_indblkshift);
 	ASSERT3U(off+num, <=, db->db.db_size >> SPA_BLKPTRSHIFT);
-	ASSERT(db->db_blkptr != NULL);
+	ASSERT3P(db->db_blkptr, !=, NULL);
 
 	for (i = off; i < off+num; i++) {
 		uint64_t *buf;
@@ -547,7 +547,7 @@ dnode_undirty_dbufs(list_t *list)
 		mutex_enter(&db->db_mtx);
 		/* XXX - use dbuf_undirty()? */
 		list_remove(list, dr);
-		ASSERT(list_head(&db->db_dirty_records) == dr);
+		ASSERT3P(list_head(&db->db_dirty_records), ==, dr);
 		list_remove_head(&db->db_dirty_records);
 		ASSERT(list_is_empty(&db->db_dirty_records));
 		db->db_dirtycnt -= 1;

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -208,8 +208,8 @@ free_verify(dmu_buf_impl_t *db, uint64_t start, uint64_t end, dmu_tx_t *tx)
 		rw_exit(&dn->dn_struct_rwlock);
 		if (err == ENOENT)
 			continue;
-		ASSERT(err == 0);
-		ASSERT(child->db_level == 0);
+		ASSERT0(err);
+		ASSERT0(child->db_level);
 		dr = dbuf_find_dirty_eq(child, txg);
 
 		/* data_old better be zeroed */
@@ -669,9 +669,9 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 		 * to account for it until the receiving dataset has been
 		 * mounted.
 		 */
-		ASSERT(!(dn->dn_phys->dn_flags &
+		ASSERT0((dn->dn_phys->dn_flags &
 		    DNODE_FLAG_USERUSED_ACCOUNTED));
-		ASSERT(!(dn->dn_phys->dn_flags &
+		ASSERT0((dn->dn_phys->dn_flags &
 		    DNODE_FLAG_USEROBJUSED_ACCOUNTED));
 	}
 
@@ -706,8 +706,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 	}
 
 	if (dn->dn_next_blksz[txgoff] != 0) {
-		ASSERT(P2PHASE(dn->dn_next_blksz[txgoff],
-		    SPA_MINBLOCKSIZE) == 0);
+		ASSERT0(P2PHASE(dn->dn_next_blksz[txgoff], SPA_MINBLOCKSIZE));
 		ASSERT(BP_IS_HOLE(&dnp->dn_blkptr[0]) ||
 		    dn->dn_maxblkid == 0 || list_head(list) != NULL ||
 		    dn->dn_next_blksz[txgoff] >> SPA_MINBLOCKSHIFT ==

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -827,7 +827,7 @@ dsl_bookmark_init_ds(dsl_dataset_t *ds)
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
 	objset_t *mos = dp->dp_meta_objset;
 
-	ASSERT(!ds->ds_is_snapshot);
+	ASSERT0(ds->ds_is_snapshot);
 
 	avl_create(&ds->ds_bookmarks, dsl_bookmark_compare,
 	    sizeof (dsl_bookmark_node_t),
@@ -1344,7 +1344,7 @@ dsl_bookmark_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 	    dsl_dataset_phys(ds)->ds_creation_txg;
 	    dbn = AVL_NEXT(&head->ds_bookmarks, dbn)) {
 		if (!(dbn->dbn_phys.zbm_flags & ZBM_FLAG_HAS_FBN)) {
-			ASSERT(!(dbn->dbn_phys.zbm_flags &
+			ASSERT0((dbn->dbn_phys.zbm_flags &
 			    ZBM_FLAG_SNAPSHOT_EXISTS));
 			continue;
 		}
@@ -1541,7 +1541,7 @@ dsl_bookmark_sync_done(dsl_dataset_t *ds, dmu_tx_t *tx)
 #ifdef ZFS_DEBUG
 	for (dsl_bookmark_node_t *dbn = avl_first(&ds->ds_bookmarks);
 	    dbn != NULL; dbn = AVL_NEXT(&ds->ds_bookmarks, dbn)) {
-		ASSERT(!dbn->dbn_dirty);
+		ASSERT0(dbn->dbn_dirty);
 	}
 #endif
 }

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -993,7 +993,7 @@ dsl_bookmark_destroy_sync_impl(dsl_dataset_t *ds, const char *name,
 
 	search.dbn_name = realname;
 	dsl_bookmark_node_t *dbn = avl_find(&ds->ds_bookmarks, &search, NULL);
-	ASSERT(dbn != NULL);
+	ASSERT3P(dbn, !=, NULL);
 
 	if (dbn->dbn_phys.zbm_flags & ZBM_FLAG_HAS_FBN) {
 		/*

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -499,7 +499,7 @@ out:
 static void
 dsl_crypto_key_free(dsl_crypto_key_t *dck)
 {
-	ASSERT(zfs_refcount_count(&dck->dck_holds) == 0);
+	ASSERT0(zfs_refcount_count(&dck->dck_holds));
 
 	/* destroy the zio_crypt_key_t */
 	zio_crypt_key_destroy(&dck->dck_key);
@@ -1511,7 +1511,7 @@ spa_keystore_change_key_sync(void *arg, dmu_tx_t *tx)
 
 	/* create and initialize the wrapping key */
 	VERIFY0(dsl_dataset_hold(dp, skcka->skcka_dsname, FTAG, &ds));
-	ASSERT(!ds->ds_is_snapshot);
+	ASSERT0(ds->ds_is_snapshot);
 
 	if (dcp->cp_cmd == DCP_CMD_NEW_KEY ||
 	    dcp->cp_cmd == DCP_CMD_FORCE_NEW_KEY) {

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -2390,7 +2390,7 @@ dsl_crypto_populate_key_nvlist(objset_t *os, uint64_t from_ivset_guid,
 	uint8_t iv[WRAPPING_IV_LEN];
 	uint8_t mac[WRAPPING_MAC_LEN];
 
-	ASSERT(dckobj != 0);
+	ASSERT3U(dckobj, !=, 0);
 
 	mdn = DMU_META_DNODE(os);
 

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -227,7 +227,7 @@ dsl_dataset_block_remapped(dsl_dataset_t *ds, uint64_t vdev, uint64_t offset,
 		blkptr_t fakebp;
 		dva_t *dva = &fakebp.blk_dva[0];
 
-		ASSERT(ds != NULL);
+		ASSERT3P(ds, !=, NULL);
 
 		mutex_enter(&ds->ds_remap_deadlist_lock);
 		if (!dsl_dataset_remap_deadlist_exists(ds)) {
@@ -423,7 +423,7 @@ dsl_dataset_evict_sync(void *dbu)
 {
 	dsl_dataset_t *ds = dbu;
 
-	ASSERT(ds->ds_owner == NULL);
+	ASSERT3P(ds->ds_owner, ==, NULL);
 
 	unique_remove(ds->ds_fsid_guid);
 }
@@ -433,7 +433,7 @@ dsl_dataset_evict_async(void *dbu)
 {
 	dsl_dataset_t *ds = dbu;
 
-	ASSERT(ds->ds_owner == NULL);
+	ASSERT3P(ds->ds_owner, ==, NULL);
 
 	ds->ds_dbuf = NULL;
 
@@ -1001,7 +1001,7 @@ void
 dsl_dataset_disown(dsl_dataset_t *ds, ds_hold_flags_t flags, const void *tag)
 {
 	ASSERT3P(ds->ds_owner, ==, tag);
-	ASSERT(ds->ds_dbuf != NULL);
+	ASSERT3P(ds->ds_dbuf, !=, NULL);
 
 	mutex_enter(&ds->ds_lock);
 	ds->ds_owner = NULL;
@@ -1434,7 +1434,7 @@ dsl_dataset_dirty(dsl_dataset_t *ds, dmu_tx_t *tx)
 	if (ds == NULL) /* this is the meta-objset */
 		return;
 
-	ASSERT(ds->ds_objset != NULL);
+	ASSERT3P(ds->ds_objset, !=, NULL);
 
 	if (dsl_dataset_phys(ds)->ds_next_snap_obj != 0)
 		panic("dirtying snapshot!");
@@ -2095,7 +2095,7 @@ void
 dsl_dataset_sync(dsl_dataset_t *ds, zio_t *zio, dmu_tx_t *tx)
 {
 	ASSERT(dmu_tx_is_syncing(tx));
-	ASSERT(ds->ds_objset != NULL);
+	ASSERT3P(ds->ds_objset, !=, NULL);
 	ASSERT0(dsl_dataset_phys(ds)->ds_next_snap_obj);
 
 	/*
@@ -3349,7 +3349,7 @@ dsl_dataset_promote_check(void *arg, dmu_tx_t *tx)
 
 	/* compute origin's new unique space */
 	snap = list_tail(&ddpa->clone_snaps);
-	ASSERT(snap != NULL);
+	ASSERT3P(snap, !=, NULL);
 	ASSERT3U(dsl_dataset_phys(snap->ds)->ds_prev_snap_obj, ==,
 	    origin_ds->ds_object);
 	dsl_deadlist_space_range(&snap->ds->ds_deadlist,

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -3766,7 +3766,7 @@ snaplist_make(dsl_pool_t *dp,
 		int err;
 
 		err = dsl_dataset_hold_obj(dp, obj, tag, &ds);
-		ASSERT(err != ENOENT);
+		ASSERT3S(err, !=, ENOENT);
 		if (err != 0)
 			return (err);
 

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -148,7 +148,7 @@ dsl_dataset_block_born(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx)
 	/* It could have been compressed away to nothing */
 	if (BP_IS_HOLE(bp) || BP_IS_REDACTED(bp))
 		return;
-	ASSERT(BP_GET_TYPE(bp) != DMU_OT_NONE);
+	ASSERT3U(BP_GET_TYPE(bp), !=, DMU_OT_NONE);
 	ASSERT(DMU_OT_IS_VALID(BP_GET_TYPE(bp)));
 	if (ds == NULL) {
 		dsl_pool_mos_diduse_space(tx->tx_pool,
@@ -218,7 +218,7 @@ dsl_dataset_block_remapped(dsl_dataset_t *ds, uint64_t vdev, uint64_t offset,
 	spa_t *spa = ds->ds_dir->dd_pool->dp_spa;
 
 	ASSERT(dmu_tx_is_syncing(tx));
-	ASSERT(birth <= tx->tx_txg);
+	ASSERT3U(birth, <=, tx->tx_txg);
 	ASSERT0(ds->ds_is_snapshot);
 
 	if (birth > dsl_dataset_phys(ds)->ds_prev_snap_txg) {
@@ -259,7 +259,7 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
 		return (0);
 
 	ASSERT(dmu_tx_is_syncing(tx));
-	ASSERT(bp->blk_birth <= tx->tx_txg);
+	ASSERT3U(bp->blk_birth, <=, tx->tx_txg);
 
 	if (ds == NULL) {
 		dsl_free(tx->tx_pool, tx->tx_txg, bp);
@@ -316,7 +316,7 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
 		}
 		ASSERT3U(ds->ds_prev->ds_object, ==,
 		    dsl_dataset_phys(ds)->ds_prev_snap_obj);
-		ASSERT(dsl_dataset_phys(ds->ds_prev)->ds_num_children > 0);
+		ASSERT3U(dsl_dataset_phys(ds->ds_prev)->ds_num_children, >, 0);
 		/* if (bp->blk_birth > prev prev snap txg) prev unique += bs */
 		if (dsl_dataset_phys(ds->ds_prev)->ds_next_snap_obj ==
 		    ds->ds_object && bp->blk_birth >
@@ -1289,7 +1289,7 @@ dsl_dataset_create_sync(dsl_dir_t *pdd, const char *lastname,
 	dsl_dir_t *dd;
 
 	ASSERT(dmu_tx_is_syncing(tx));
-	ASSERT(lastname[0] != '@');
+	ASSERT3U(lastname[0], !=, '@');
 	/*
 	 * Filesystems will eventually have their origin set to dp_origin_snap,
 	 * but that's taken care of in dsl_dataset_create_sync_dd. When
@@ -1393,7 +1393,7 @@ dsl_dataset_remove_from_next_clones(dsl_dataset_t *ds, uint64_t obj,
 	uint64_t count __maybe_unused;
 	int err;
 
-	ASSERT(dsl_dataset_phys(ds)->ds_num_children >= 2);
+	ASSERT3U(dsl_dataset_phys(ds)->ds_num_children, >=, 2);
 	err = zap_remove_int(mos, dsl_dataset_phys(ds)->ds_next_clones_obj,
 	    obj, tx);
 	/*
@@ -1629,7 +1629,7 @@ dsl_dataset_snapshot_check(void *arg, dmu_tx_t *tx)
 
 			name = nvpair_name(pair);
 			cnt = fnvpair_value_uint64(pair);
-			ASSERT(cnt > 0);
+			ASSERT3U(cnt, >, 0);
 
 			error = dsl_dataset_hold(dp, name, FTAG, &ds);
 			if (error == 0) {
@@ -4872,7 +4872,7 @@ dsl_dataset_get_remap_deadlist_object(dsl_dataset_t *ds)
 		return (0);
 	}
 
-	ASSERT(remap_deadlist_obj != 0);
+	ASSERT3U(remap_deadlist_obj, !=, 0);
 	return (remap_deadlist_obj);
 }
 
@@ -4888,7 +4888,7 @@ static void
 dsl_dataset_set_remap_deadlist_object(dsl_dataset_t *ds, uint64_t obj,
     dmu_tx_t *tx)
 {
-	ASSERT(obj != 0);
+	ASSERT3U(obj, !=, 0);
 	dsl_dataset_zapify(ds, tx);
 	VERIFY0(zap_add(ds->ds_dir->dd_pool->dp_meta_objset, ds->ds_object,
 	    DS_FIELD_REMAP_DEADLIST, sizeof (obj), 1, &obj, tx));

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -219,7 +219,7 @@ dsl_dataset_block_remapped(dsl_dataset_t *ds, uint64_t vdev, uint64_t offset,
 
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(birth <= tx->tx_txg);
-	ASSERT(!ds->ds_is_snapshot);
+	ASSERT0(ds->ds_is_snapshot);
 
 	if (birth > dsl_dataset_phys(ds)->ds_prev_snap_txg) {
 		spa_vdev_indirect_mark_obsolete(spa, vdev, offset, size, tx);
@@ -269,7 +269,7 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
 	}
 	ASSERT3P(tx->tx_pool, ==, ds->ds_dir->dd_pool);
 
-	ASSERT(!ds->ds_is_snapshot);
+	ASSERT0(ds->ds_is_snapshot);
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);
 
 	/*
@@ -455,7 +455,7 @@ dsl_dataset_evict_async(void *dbu)
 	if (ds->ds_dir)
 		dsl_dir_async_rele(ds->ds_dir, ds);
 
-	ASSERT(!list_link_active(&ds->ds_synced_link));
+	ASSERT0(list_link_active(&ds->ds_synced_link));
 
 	for (spa_feature_t f = 0; f < SPA_FEATURES; f++) {
 		if (dsl_dataset_feature_is_active(ds, f))
@@ -1154,7 +1154,7 @@ dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 	ASSERT(origin == NULL || origin->ds_dir->dd_pool == dp);
 	ASSERT(origin == NULL || dsl_dataset_phys(origin)->ds_num_children > 0);
 	ASSERT(dmu_tx_is_syncing(tx));
-	ASSERT(dsl_dir_phys(dd)->dd_head_dataset_obj == 0);
+	ASSERT0(dsl_dir_phys(dd)->dd_head_dataset_obj);
 
 	dsobj = dmu_object_alloc(mos, DMU_OT_DSL_DATASET, 0,
 	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx);
@@ -1367,7 +1367,7 @@ dsl_dataset_recalc_head_uniq(dsl_dataset_t *ds)
 	uint64_t mrs_used;
 	uint64_t dlused, dlcomp, dluncomp;
 
-	ASSERT(!ds->ds_is_snapshot);
+	ASSERT0(ds->ds_is_snapshot);
 
 	if (dsl_dataset_phys(ds)->ds_prev_snap_obj != 0)
 		mrs_used = dsl_dataset_phys(ds->ds_prev)->ds_referenced_bytes;
@@ -1712,8 +1712,8 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	    sizeof (zero_zil)) == 0);
 
 	/* Should not snapshot a dirty dataset. */
-	ASSERT(!txg_list_member(&ds->ds_dir->dd_pool->dp_dirty_datasets,
-	    ds, tx->tx_txg));
+	ASSERT0(txg_list_member(&ds->ds_dir->dd_pool->dp_dirty_datasets, ds,
+	    tx->tx_txg));
 
 	dsl_fs_ss_count_adjust(ds->ds_dir, 1, DD_FIELD_SNAPSHOT_COUNT, tx);
 
@@ -2096,7 +2096,7 @@ dsl_dataset_sync(dsl_dataset_t *ds, zio_t *zio, dmu_tx_t *tx)
 {
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(ds->ds_objset != NULL);
-	ASSERT(dsl_dataset_phys(ds)->ds_next_snap_obj == 0);
+	ASSERT0(dsl_dataset_phys(ds)->ds_next_snap_obj);
 
 	/*
 	 * in case we had to change ds_fsid_guid when we opened it,
@@ -2300,7 +2300,7 @@ dsl_dataset_sync_done(dsl_dataset_t *ds, dmu_tx_t *tx)
 	else
 		ASSERT0(os->os_next_write_raw[tx->tx_txg & TXG_MASK]);
 
-	ASSERT(!dmu_objset_is_dirty(os, dmu_tx_get_txg(tx)));
+	ASSERT0(dmu_objset_is_dirty(os, dmu_tx_get_txg(tx)));
 
 	dmu_buf_rele(ds->ds_dbuf, ds);
 }
@@ -3692,7 +3692,7 @@ dsl_dataset_promote_sync(void *arg, dmu_tx_t *tx)
 			zap_cursor_fini(&zc);
 		}
 
-		ASSERT(!dsl_prop_hascb(ds));
+		ASSERT0(dsl_prop_hascb(ds));
 	}
 
 	/*
@@ -4039,7 +4039,7 @@ dsl_dataset_clone_swap_sync_impl(dsl_dataset_t *clone,
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	int64_t unused_refres_delta;
 
-	ASSERT(clone->ds_reserved == 0);
+	ASSERT0(clone->ds_reserved);
 	/*
 	 * NOTE: On DEBUG kernels there could be a race between this and
 	 * the check function if spa_asize_inflation is adjusted...
@@ -4057,8 +4057,8 @@ dsl_dataset_clone_swap_sync_impl(dsl_dataset_t *clone,
 	for (spa_feature_t f = 0; f < SPA_FEATURES; f++) {
 		if (!(spa_feature_table[f].fi_flags &
 		    ZFEATURE_FLAG_PER_DATASET)) {
-			ASSERT(!dsl_dataset_feature_is_active(clone, f));
-			ASSERT(!dsl_dataset_feature_is_active(origin_head, f));
+			ASSERT0(dsl_dataset_feature_is_active(clone, f));
+			ASSERT0(dsl_dataset_feature_is_active(origin_head, f));
 			continue;
 		}
 

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -138,7 +138,7 @@ dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 
 	ASSERT(MUTEX_HELD(&dl->dl_lock));
 
-	ASSERT(!dl->dl_oldfmt);
+	ASSERT0(dl->dl_oldfmt);
 	if (dl->dl_havecache) {
 		/*
 		 * After loading the tree, the caller may modify the tree,
@@ -212,7 +212,7 @@ dsl_deadlist_load_cache(dsl_deadlist_t *dl)
 
 	ASSERT(MUTEX_HELD(&dl->dl_lock));
 
-	ASSERT(!dl->dl_oldfmt);
+	ASSERT0(dl->dl_oldfmt);
 	if (dl->dl_havecache)
 		return;
 
@@ -300,7 +300,7 @@ dsl_deadlist_open(dsl_deadlist_t *dl, objset_t *os, uint64_t object)
 {
 	dmu_object_info_t doi;
 
-	ASSERT(!dsl_deadlist_is_open(dl));
+	ASSERT0(dsl_deadlist_is_open(dl));
 
 	mutex_init(&dl->dl_lock, NULL, MUTEX_DEFAULT, NULL);
 	dl->dl_os = os;
@@ -872,7 +872,7 @@ dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
 	dsl_deadlist_entry_t *dle;
 	avl_index_t where;
 
-	ASSERT(!dl->dl_oldfmt);
+	ASSERT0(dl->dl_oldfmt);
 
 	mutex_enter(&dl->dl_lock);
 	dmu_buf_will_dirty(dl->dl_dbuf, tx);

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -960,7 +960,7 @@ dsl_livelist_iterate(void *arg, const blkptr_t *bp, boolean_t bp_freed,
 	avl_tree_t *avl = lia->avl;
 	bplist_t *to_free = lia->to_free;
 	zthr_t *t = lia->t;
-	ASSERT(tx == NULL);
+	ASSERT3P(tx, ==, NULL);
 
 	if ((t != NULL) && (zthr_has_waiters(t) || zthr_iscancelled(t)))
 		return (SET_ERROR(EINTR));

--- a/module/zfs/dsl_deleg.c
+++ b/module/zfs/dsl_deleg.c
@@ -101,7 +101,7 @@ dsl_deleg_can_allow(char *ddname, nvlist_t *nvp, cred_t *cr)
 		nvlist_t *perms;
 		nvpair_t *permpair = NULL;
 
-		VERIFY(nvpair_value_nvlist(whopair, &perms) == 0);
+		VERIFY0(nvpair_value_nvlist(whopair, &perms));
 
 		while ((permpair = nvlist_next_nvpair(perms, permpair))) {
 			const char *perm = nvpair_name(permpair);
@@ -188,8 +188,7 @@ dsl_deleg_set_sync(void *arg, dmu_tx_t *tx)
 			const char *perm = nvpair_name(permpair);
 			uint64_t n = 0;
 
-			VERIFY(zap_update(mos, jumpobj,
-			    perm, 8, 1, &n, tx) == 0);
+			VERIFY0(zap_update(mos, jumpobj, perm, 8, 1, &n, tx));
 			spa_history_log_internal_dd(dd, "permission update", tx,
 			    "%s %s", whokey, perm);
 		}
@@ -224,7 +223,7 @@ dsl_deleg_unset_sync(void *arg, dmu_tx_t *tx)
 			if (zap_lookup(mos, zapobj, whokey, 8,
 			    1, &jumpobj) == 0) {
 				(void) zap_remove(mos, zapobj, whokey, tx);
-				VERIFY(0 == zap_destroy(mos, jumpobj, tx));
+				VERIFY0(zap_destroy(mos, jumpobj, tx));
 			}
 			spa_history_log_internal_dd(dd, "permission who remove",
 			    tx, "%s", whokey);
@@ -242,8 +241,7 @@ dsl_deleg_unset_sync(void *arg, dmu_tx_t *tx)
 			if (zap_count(mos, jumpobj, &n) == 0 && n == 0) {
 				(void) zap_remove(mos, zapobj,
 				    whokey, tx);
-				VERIFY(0 == zap_destroy(mos,
-				    jumpobj, tx));
+				VERIFY0(zap_destroy(mos, jumpobj, tx));
 			}
 			spa_history_log_internal_dd(dd, "permission remove", tx,
 			    "%s %s", whokey, perm);
@@ -331,7 +329,7 @@ dsl_deleg_get(const char *ddname, nvlist_t **nvp)
 	basezc = kmem_alloc(sizeof (zap_cursor_t), KM_SLEEP);
 	baseza = kmem_alloc(sizeof (zap_attribute_t), KM_SLEEP);
 	source = kmem_alloc(ZFS_MAX_DATASET_NAME_LEN, KM_SLEEP);
-	VERIFY(nvlist_alloc(nvp, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+	VERIFY0(nvlist_alloc(nvp, NV_UNIQUE_NAME, KM_SLEEP));
 
 	for (dd = startdd; dd != NULL; dd = dd->dd_parent) {
 		nvlist_t *sp_nvp;
@@ -703,7 +701,7 @@ copy_create_perms(dsl_dir_t *dd, uint64_t pzapobj,
 	    ZFS_DELEG_LOCAL, &uid);
 	if (zap_lookup(mos, zapobj, whokey, 8, 1, &jumpobj) == ENOENT) {
 		jumpobj = zap_create(mos, DMU_OT_DSL_PERMS, DMU_OT_NONE, 0, tx);
-		VERIFY(zap_add(mos, zapobj, whokey, 8, 1, &jumpobj, tx) == 0);
+		VERIFY0(zap_add(mos, zapobj, whokey, 8, 1, &jumpobj, tx));
 	}
 
 	for (zap_cursor_init(&zc, mos, pjumpobj);
@@ -712,8 +710,7 @@ copy_create_perms(dsl_dir_t *dd, uint64_t pzapobj,
 		uint64_t zero = 0;
 		ASSERT(za.za_integer_length == 8 && za.za_num_integers == 1);
 
-		VERIFY(zap_update(mos, jumpobj, za.za_name,
-		    8, 1, &zero, tx) == 0);
+		VERIFY0(zap_update(mos, jumpobj, za.za_name, 8, 1, &zero, tx));
 	}
 	zap_cursor_fini(&zc);
 }
@@ -755,10 +752,10 @@ dsl_deleg_destroy(objset_t *mos, uint64_t zapobj, dmu_tx_t *tx)
 	    zap_cursor_retrieve(&zc, &za) == 0;
 	    zap_cursor_advance(&zc)) {
 		ASSERT(za.za_integer_length == 8 && za.za_num_integers == 1);
-		VERIFY(0 == zap_destroy(mos, za.za_first_integer, tx));
+		VERIFY0(zap_destroy(mos, za.za_first_integer, tx));
 	}
 	zap_cursor_fini(&zc);
-	VERIFY(0 == zap_destroy(mos, zapobj, tx));
+	VERIFY0(zap_destroy(mos, zapobj, tx));
 	return (0);
 }
 

--- a/module/zfs/dsl_deleg.c
+++ b/module/zfs/dsl_deleg.c
@@ -347,7 +347,7 @@ dsl_deleg_get(const char *ddname, nvlist_t **nvp)
 		    zap_cursor_advance(basezc)) {
 			nvlist_t *perms_nvp;
 
-			ASSERT(baseza->za_integer_length == 8);
+			ASSERT3S(baseza->za_integer_length, ==, 8);
 			ASSERT(baseza->za_num_integers == 1);
 
 			perms_nvp = fnvlist_alloc();

--- a/module/zfs/dsl_deleg.c
+++ b/module/zfs/dsl_deleg.c
@@ -348,7 +348,7 @@ dsl_deleg_get(const char *ddname, nvlist_t **nvp)
 			nvlist_t *perms_nvp;
 
 			ASSERT3S(baseza->za_integer_length, ==, 8);
-			ASSERT(baseza->za_num_integers == 1);
+			ASSERT3U(baseza->za_num_integers, ==, 1);
 
 			perms_nvp = fnvlist_alloc();
 			for (zap_cursor_init(zc, mos, baseza->za_first_integer);

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -130,7 +130,7 @@ process_old_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed, dmu_tx_t *tx)
 	struct process_old_arg *poa = arg;
 	dsl_pool_t *dp = poa->ds->ds_dir->dd_pool;
 
-	ASSERT(!BP_IS_HOLE(bp));
+	ASSERT0(BP_IS_HOLE(bp));
 
 	if (bp->blk_birth <= dsl_dataset_phys(poa->ds)->ds_prev_snap_txg) {
 		dsl_deadlist_insert(&poa->ds->ds_deadlist, bp, bp_freed, tx);
@@ -523,7 +523,7 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 
 	/* remove from snapshot namespace */
 	dsl_dataset_t *ds_head;
-	ASSERT(dsl_dataset_phys(ds)->ds_snapnames_zapobj == 0);
+	ASSERT0(dsl_dataset_phys(ds)->ds_snapnames_zapobj);
 	VERIFY0(dsl_dataset_hold_obj(dp,
 	    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &ds_head));
 	VERIFY0(dsl_dataset_get_snapname(ds));
@@ -767,7 +767,7 @@ dsl_destroy_head_check_impl(dsl_dataset_t *ds, int expected_holds)
 	uint64_t count;
 	objset_t *mos;
 
-	ASSERT(!ds->ds_is_snapshot);
+	ASSERT0(ds->ds_is_snapshot);
 	if (ds->ds_is_snapshot)
 		return (SET_ERROR(EINVAL));
 
@@ -982,7 +982,7 @@ dsl_async_dataset_destroy(dsl_dataset_t *ds, dmu_tx_t *tx)
 		    DMU_POOL_DIRECTORY_OBJECT,
 		    DMU_POOL_BPTREE_OBJ, sizeof (uint64_t), 1,
 		    &dp->dp_bptree_obj, tx));
-		ASSERT(!scn->scn_async_destroying);
+		ASSERT0(scn->scn_async_destroying);
 		scn->scn_async_destroying = B_TRUE;
 	}
 

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -289,7 +289,7 @@ dsl_destroy_snapshot_handle_remaps(dsl_dataset_t *ds, dsl_dataset_t *ds_next,
 	if (dsl_dataset_remap_deadlist_exists(ds)) {
 		uint64_t remap_deadlist_object =
 		    dsl_dataset_get_remap_deadlist_object(ds);
-		ASSERT(remap_deadlist_object != 0);
+		ASSERT3U(remap_deadlist_object, !=, 0);
 
 		mutex_enter(&ds_next->ds_remap_deadlist_lock);
 		if (!dsl_dataset_remap_deadlist_exists(ds_next))
@@ -320,7 +320,7 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	if (defer &&
 	    (ds->ds_userrefs > 0 ||
 	    dsl_dataset_phys(ds)->ds_num_children > 1)) {
-		ASSERT(spa_version(dp->dp_spa) >= SPA_VERSION_USERREFS);
+		ASSERT3U(spa_version(dp->dp_spa), >=, SPA_VERSION_USERREFS);
 		dmu_buf_will_dirty(ds->ds_dbuf, tx);
 		dsl_dataset_phys(ds)->ds_flags |= DS_FLAG_DEFER_DESTROY;
 		if (zfs_snapshot_history_enabled) {
@@ -503,7 +503,7 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 			uint64_t new_unique =
 			    dsl_dataset_phys(ds_next)->ds_unique_bytes;
 
-			ASSERT(old_unique <= new_unique);
+			ASSERT3U(old_unique, <=, new_unique);
 			mrsdelta = MIN(new_unique - old_unique,
 			    ds_next->ds_reserved - old_unique);
 			dsl_dir_diduse_space(ds->ds_dir,
@@ -1114,7 +1114,7 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 	dmu_buf_will_dirty(ds->ds_dir->dd_dbuf, tx);
 	dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj = 0;
 	ddobj = ds->ds_dir->dd_object;
-	ASSERT(dsl_dataset_phys(ds)->ds_snapnames_zapobj != 0);
+	ASSERT3U(dsl_dataset_phys(ds)->ds_snapnames_zapobj, !=, 0);
 	VERIFY0(zap_destroy(mos,
 	    dsl_dataset_phys(ds)->ds_snapnames_zapobj, tx));
 

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -719,14 +719,14 @@ kill_blkptr(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 		return (0);
 
 	if (zb->zb_level == ZB_ZIL_LEVEL) {
-		ASSERT(zilog != NULL);
+		ASSERT3P(zilog, !=, NULL);
 		/*
 		 * It's a block in the intent log.  It has no
 		 * accounting, so just free it.
 		 */
 		dsl_free(ka->tx->tx_pool, ka->tx->tx_txg, bp);
 	} else {
-		ASSERT(zilog == NULL);
+		ASSERT3P(zilog, ==, NULL);
 		ASSERT3U(bp->blk_birth, >,
 		    dsl_dataset_phys(ka->ds)->ds_prev_snap_txg);
 		(void) dsl_dataset_block_kill(ka->ds, bp, tx, B_FALSE);
@@ -1047,7 +1047,7 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 
 	if (dsl_dataset_phys(ds)->ds_prev_snap_obj != 0) {
 		/* This is a clone */
-		ASSERT(ds->ds_prev != NULL);
+		ASSERT3P(ds->ds_prev, !=, NULL);
 		ASSERT3U(dsl_dataset_phys(ds->ds_prev)->ds_next_snap_obj, !=,
 		    obj);
 		ASSERT0(dsl_dataset_phys(ds)->ds_next_snap_obj);

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -147,9 +147,9 @@ dsl_dir_evict_async(void *dbu)
 	dd->dd_dbuf = NULL;
 
 	for (t = 0; t < TXG_SIZE; t++) {
-		ASSERT(!txg_list_member(&dp->dp_dirty_dirs, dd, t));
-		ASSERT(dd->dd_tempreserved[t] == 0);
-		ASSERT(dd->dd_space_towrite[t] == 0);
+		ASSERT0(txg_list_member(&dp->dp_dirty_dirs, dd, t));
+		ASSERT0(dd->dd_tempreserved[t]);
+		ASSERT0(dd->dd_space_towrite[t]);
 	}
 
 	if (dd->dd_parent)

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -497,7 +497,7 @@ dsl_dir_hold(dsl_pool_t *dp, const char *name, const void *tag,
 		err = getcomponent(next, buf, &nextnext);
 		if (err != 0)
 			break;
-		ASSERT(next[0] != '\0');
+		ASSERT3U(next[0], !=, '\0');
 		if (next[0] == '@')
 			break;
 		dprintf("looking up %s in obj%lld\n",
@@ -1237,8 +1237,8 @@ dsl_dir_space_available(dsl_dir_t *dd,
 	}
 
 	if (dd == ancestor) {
-		ASSERT(delta <= 0);
-		ASSERT(used >= -delta);
+		ASSERT3U(delta, <=, 0);
+		ASSERT3U(used, >=, -delta);
 		used += delta;
 		if (parentspace != UINT64_MAX)
 			parentspace -= delta;
@@ -1549,7 +1549,7 @@ dsl_dir_diduse_space(dsl_dir_t *dd, dd_used_t type,
 	int64_t accounted_delta;
 
 	ASSERT(dmu_tx_is_syncing(tx));
-	ASSERT(type < DD_USED_NUM);
+	ASSERT3U(type, <, DD_USED_NUM);
 
 	dmu_buf_will_dirty(dd->dd_dbuf, tx);
 
@@ -1601,8 +1601,8 @@ dsl_dir_transfer_space(dsl_dir_t *dd, int64_t delta,
     dd_used_t oldtype, dd_used_t newtype, dmu_tx_t *tx)
 {
 	ASSERT(dmu_tx_is_syncing(tx));
-	ASSERT(oldtype < DD_USED_NUM);
-	ASSERT(newtype < DD_USED_NUM);
+	ASSERT3U(oldtype, <, DD_USED_NUM);
+	ASSERT3U(newtype, <, DD_USED_NUM);
 
 	dsl_dir_phys_t *ddp = dsl_dir_phys(dd);
 	if (delta == 0 ||
@@ -1614,7 +1614,7 @@ dsl_dir_transfer_space(dsl_dir_t *dd, int64_t delta,
 	ASSERT(delta > 0 ?
 	    ddp->dd_used_breakdown[oldtype] >= delta :
 	    ddp->dd_used_breakdown[newtype] >= -delta);
-	ASSERT(ddp->dd_used_bytes >= ABS(delta));
+	ASSERT3U(ddp->dd_used_bytes, >=, ABS(delta));
 	ddp->dd_used_breakdown[oldtype] -= delta;
 	ddp->dd_used_breakdown[newtype] += delta;
 	mutex_exit(&dd->dd_lock);
@@ -1628,8 +1628,8 @@ dsl_dir_diduse_transfer_space(dsl_dir_t *dd, int64_t used,
 	int64_t accounted_delta;
 
 	ASSERT(dmu_tx_is_syncing(tx));
-	ASSERT(oldtype < DD_USED_NUM);
-	ASSERT(newtype < DD_USED_NUM);
+	ASSERT3U(oldtype, <, DD_USED_NUM);
+	ASSERT3U(newtype, <, DD_USED_NUM);
 
 	dmu_buf_will_dirty(dd->dd_dbuf, tx);
 

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -520,8 +520,8 @@ dsl_pool_create(spa_t *spa, nvlist_t *zplprops __attribute__((unused)),
 
 		/* create and open the free_bplist */
 		obj = bpobj_alloc(dp->dp_meta_objset, SPA_OLD_MAXBLOCKSIZE, tx);
-		VERIFY(zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_FREE_BPOBJ, sizeof (uint64_t), 1, &obj, tx) == 0);
+		VERIFY0(zap_add(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
+		    DMU_POOL_FREE_BPOBJ, sizeof (uint64_t), 1, &obj, tx));
 		VERIFY0(bpobj_open(&dp->dp_free_bpobj,
 		    dp->dp_meta_objset, obj));
 	}
@@ -713,7 +713,7 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 		 * we may have taken a snapshot of them.  However, we
 		 * may sync newly-created datasets on pass 2.
 		 */
-		ASSERT(!list_link_active(&ds->ds_synced_link));
+		ASSERT0(list_link_active(&ds->ds_synced_link));
 		list_insert_tail(&synced_datasets, ds);
 		dsl_dataset_sync(ds, zio, tx);
 	}
@@ -869,13 +869,13 @@ dsl_pool_sync_done(dsl_pool_t *dp, uint64_t txg)
 		 */
 		zil_clean(zilog, txg);
 		(void) txg_list_remove_this(&dp->dp_dirty_zilogs, zilog, txg);
-		ASSERT(!dmu_objset_is_dirty(zilog->zl_os, txg));
+		ASSERT0(dmu_objset_is_dirty(zilog->zl_os, txg));
 		dmu_buf_rele(ds->ds_dbuf, zilog);
 	}
 
 	dsl_pool_wrlog_clear(dp, txg);
 
-	ASSERT(!dmu_objset_is_dirty(dp->dp_meta_objset, txg));
+	ASSERT0(dmu_objset_is_dirty(dp->dp_meta_objset, txg));
 }
 
 /*
@@ -1244,7 +1244,7 @@ dsl_pool_user_hold_create_obj(dsl_pool_t *dp, dmu_tx_t *tx)
 {
 	objset_t *mos = dp->dp_meta_objset;
 
-	ASSERT(dp->dp_tmp_userrefs_obj == 0);
+	ASSERT0(dp->dp_tmp_userrefs_obj);
 	ASSERT(dmu_tx_is_syncing(tx));
 
 	dp->dp_tmp_userrefs_obj = zap_create_link(mos, DMU_OT_USERREFS,
@@ -1421,14 +1421,14 @@ dsl_pool_config_enter(dsl_pool_t *dp, const void *tag)
 	 * read, but not *which* threads, so rw_held(RW_READER) returns TRUE
 	 * if any thread holds it for read, even if this thread doesn't).
 	 */
-	ASSERT(!rrw_held(&dp->dp_config_rwlock, RW_READER));
+	ASSERT0(rrw_held(&dp->dp_config_rwlock, RW_READER));
 	rrw_enter(&dp->dp_config_rwlock, RW_READER, tag);
 }
 
 void
 dsl_pool_config_enter_prio(dsl_pool_t *dp, const void *tag)
 {
-	ASSERT(!rrw_held(&dp->dp_config_rwlock, RW_READER));
+	ASSERT0(rrw_held(&dp->dp_config_rwlock, RW_READER));
 	rrw_enter_read_prio(&dp->dp_config_rwlock, tag);
 }
 

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -1209,7 +1209,7 @@ dsl_pool_clean_tmp_userrefs(dsl_pool_t *dp)
 
 	if (zapobj == 0)
 		return;
-	ASSERT(spa_version(dp->dp_spa) >= SPA_VERSION_USERREFS);
+	ASSERT3U(spa_version(dp->dp_spa), >=, SPA_VERSION_USERREFS);
 
 	holds = fnvlist_alloc();
 
@@ -1260,7 +1260,7 @@ dsl_pool_user_hold_rele_impl(dsl_pool_t *dp, uint64_t dsobj,
 	char *name;
 	int error;
 
-	ASSERT(spa_version(dp->dp_spa) >= SPA_VERSION_USERREFS);
+	ASSERT3U(spa_version(dp->dp_spa), >=, SPA_VERSION_USERREFS);
 	ASSERT(dmu_tx_is_syncing(tx));
 
 	/*

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -1073,7 +1073,7 @@ upgrade_clones_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 		dsl_dataset_phys(prev)->ds_num_children++;
 
 		if (dsl_dataset_phys(ds)->ds_next_snap_obj == 0) {
-			ASSERT(ds->ds_prev == NULL);
+			ASSERT3P(ds->ds_prev, ==, NULL);
 			VERIFY0(dsl_dataset_hold_obj(dp,
 			    dsl_dataset_phys(ds)->ds_prev_snap_obj,
 			    ds, &ds->ds_prev));
@@ -1102,7 +1102,7 @@ void
 dsl_pool_upgrade_clones(dsl_pool_t *dp, dmu_tx_t *tx)
 {
 	ASSERT(dmu_tx_is_syncing(tx));
-	ASSERT(dp->dp_origin_snap != NULL);
+	ASSERT3P(dp->dp_origin_snap, !=, NULL);
 
 	VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj, upgrade_clones_cb,
 	    tx, DS_FIND_CHILDREN | DS_FIND_SERIALIZE));
@@ -1169,7 +1169,7 @@ dsl_pool_create_origin(dsl_pool_t *dp, dmu_tx_t *tx)
 	dsl_dataset_t *ds;
 
 	ASSERT(dmu_tx_is_syncing(tx));
-	ASSERT(dp->dp_origin_snap == NULL);
+	ASSERT3P(dp->dp_origin_snap, ==, NULL);
 	ASSERT(rrw_held(&dp->dp_config_rwlock, RW_WRITER));
 
 	/* create the origin dir, ds, & snap-ds */

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -810,7 +810,7 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		 */
 		err = zap_update(mos, zapobj, recvdstr,
 		    intsz, numints, value, tx);
-		ASSERT(err == 0);
+		ASSERT0(err);
 		break;
 	case (ZPROP_SRC_NONE | ZPROP_SRC_LOCAL | ZPROP_SRC_RECEIVED):
 		/*
@@ -1161,7 +1161,7 @@ dsl_prop_get_all_impl(objset_t *mos, uint64_t propobj,
 		if (nvlist_exists(nv, propname))
 			continue;
 
-		VERIFY(nvlist_alloc(&propval, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+		VERIFY0(nvlist_alloc(&propval, NV_UNIQUE_NAME, KM_SLEEP));
 		if (za.za_integer_length == 1) {
 			/*
 			 * String property
@@ -1174,8 +1174,7 @@ dsl_prop_get_all_impl(objset_t *mos, uint64_t propobj,
 				kmem_free(tmp, za.za_num_integers);
 				break;
 			}
-			VERIFY(nvlist_add_string(propval, ZPROP_VALUE,
-			    tmp) == 0);
+			VERIFY0(nvlist_add_string(propval, ZPROP_VALUE, tmp));
 			kmem_free(tmp, za.za_num_integers);
 		} else {
 			/*
@@ -1186,8 +1185,8 @@ dsl_prop_get_all_impl(objset_t *mos, uint64_t propobj,
 			    za.za_first_integer);
 		}
 
-		VERIFY(nvlist_add_string(propval, ZPROP_SOURCE, source) == 0);
-		VERIFY(nvlist_add_nvlist(nv, propname, propval) == 0);
+		VERIFY0(nvlist_add_string(propval, ZPROP_SOURCE, source));
+		VERIFY0(nvlist_add_nvlist(nv, propname, propval));
 		nvlist_free(propval);
 	}
 	zap_cursor_fini(&zc);
@@ -1209,7 +1208,7 @@ dsl_prop_get_all_ds(dsl_dataset_t *ds, nvlist_t **nvp,
 	int err = 0;
 	char setpoint[ZFS_MAX_DATASET_NAME_LEN];
 
-	VERIFY(nvlist_alloc(nvp, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+	VERIFY0(nvlist_alloc(nvp, NV_UNIQUE_NAME, KM_SLEEP));
 
 	if (ds->ds_is_snapshot)
 		flags |= DSL_PROP_GET_SNAPSHOT;
@@ -1327,18 +1326,18 @@ dsl_prop_nvlist_add_uint64(nvlist_t *nv, zfs_prop_t prop, uint64_t value)
 	uint64_t default_value;
 
 	if (nvlist_lookup_nvlist(nv, propname, &propval) == 0) {
-		VERIFY(nvlist_add_uint64(propval, ZPROP_VALUE, value) == 0);
+		VERIFY0(nvlist_add_uint64(propval, ZPROP_VALUE, value));
 		return;
 	}
 
-	VERIFY(nvlist_alloc(&propval, NV_UNIQUE_NAME, KM_SLEEP) == 0);
-	VERIFY(nvlist_add_uint64(propval, ZPROP_VALUE, value) == 0);
+	VERIFY0(nvlist_alloc(&propval, NV_UNIQUE_NAME, KM_SLEEP));
+	VERIFY0(nvlist_add_uint64(propval, ZPROP_VALUE, value));
 	/* Indicate the default source if we can. */
 	if (dodefault(prop, 8, 1, &default_value) == 0 &&
 	    value == default_value) {
-		VERIFY(nvlist_add_string(propval, ZPROP_SOURCE, "") == 0);
+		VERIFY0(nvlist_add_string(propval, ZPROP_SOURCE, ""));
 	}
-	VERIFY(nvlist_add_nvlist(nv, propname, propval) == 0);
+	VERIFY0(nvlist_add_nvlist(nv, propname, propval));
 	nvlist_free(propval);
 }
 
@@ -1349,13 +1348,13 @@ dsl_prop_nvlist_add_string(nvlist_t *nv, zfs_prop_t prop, const char *value)
 	const char *propname = zfs_prop_to_name(prop);
 
 	if (nvlist_lookup_nvlist(nv, propname, &propval) == 0) {
-		VERIFY(nvlist_add_string(propval, ZPROP_VALUE, value) == 0);
+		VERIFY0(nvlist_add_string(propval, ZPROP_VALUE, value));
 		return;
 	}
 
-	VERIFY(nvlist_alloc(&propval, NV_UNIQUE_NAME, KM_SLEEP) == 0);
-	VERIFY(nvlist_add_string(propval, ZPROP_VALUE, value) == 0);
-	VERIFY(nvlist_add_nvlist(nv, propname, propval) == 0);
+	VERIFY0(nvlist_alloc(&propval, NV_UNIQUE_NAME, KM_SLEEP));
+	VERIFY0(nvlist_add_string(propval, ZPROP_VALUE, value));
+	VERIFY0(nvlist_add_nvlist(nv, propname, propval));
 	nvlist_free(propval);
 }
 

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -734,7 +734,7 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 	isint = (dodefault(zfs_name_to_prop(propname), 8, 1, &intval) == 0);
 
 	if (ds->ds_is_snapshot) {
-		ASSERT(version >= SPA_VERSION_SNAP_PROPS);
+		ASSERT3U(version, >=, SPA_VERSION_SNAP_PROPS);
 		if (dsl_dataset_phys(ds)->ds_props_obj == 0 &&
 		    (source & ZPROP_SRC_NONE) == 0) {
 			dmu_buf_will_dirty(ds->ds_dbuf, tx);

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -1180,7 +1180,7 @@ dsl_prop_get_all_impl(objset_t *mos, uint64_t propobj,
 			/*
 			 * Integer property
 			 */
-			ASSERT(za.za_integer_length == 8);
+			ASSERT3S(za.za_integer_length, ==, 8);
 			(void) nvlist_add_uint64(propval, ZPROP_VALUE,
 			    za.za_first_integer);
 		}

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -1215,7 +1215,7 @@ scan_ds_queue_remove(dsl_scan_t *scn, uint64_t dsobj)
 	srch.sds_dsobj = dsobj;
 
 	sds = avl_find(&scn->scn_queue, &srch, NULL);
-	VERIFY(sds != NULL);
+	VERIFY3P(sds, !=, NULL);
 	avl_remove(&scn->scn_queue, sds);
 	kmem_free(sds, sizeof (*sds));
 }
@@ -2693,7 +2693,7 @@ dsl_scan_ddt(dsl_scan_t *scn, dmu_tx_t *tx)
 
 		/* There should be no pending changes to the dedup table */
 		ddt = scn->scn_dp->dp_spa->spa_ddt[ddb->ddb_checksum];
-		ASSERT(avl_first(&ddt->ddt_tree) == NULL);
+		ASSERT3P(avl_first(&ddt->ddt_tree), ==, NULL);
 
 		dsl_scan_ddt_entry(scn, ddb->ddb_checksum, &dde, tx);
 		n++;
@@ -2914,7 +2914,7 @@ scan_io_queue_gather(dsl_scan_io_queue_t *queue, range_seg_t *rs, list_t *list)
 	uint_t num_sios = 0;
 	int64_t bytes_issued = 0;
 
-	ASSERT(rs != NULL);
+	ASSERT3P(rs, !=, NULL);
 	ASSERT(MUTEX_HELD(&queue->q_vd->vdev_scan_io_queue_lock));
 
 	srch_sio = sio_alloc(1);
@@ -3963,12 +3963,12 @@ dsl_scan_enqueue(dsl_pool_t *dp, const blkptr_t *bp, int zio_flags,
 
 		dva = bp->blk_dva[i];
 		vdev = vdev_lookup_top(spa, DVA_GET_VDEV(&dva));
-		ASSERT(vdev != NULL);
+		ASSERT3P(vdev, !=, NULL);
 
 		mutex_enter(&vdev->vdev_scan_io_queue_lock);
 		if (vdev->vdev_scan_io_queue == NULL)
 			vdev->vdev_scan_io_queue = scan_io_queue_create(vdev);
-		ASSERT(dp->dp_scan != NULL);
+		ASSERT3P(dp->dp_scan, !=, NULL);
 		scan_io_queue_insert(vdev->vdev_scan_io_queue, bp,
 		    i, zio_flags, zb);
 		mutex_exit(&vdev->vdev_scan_io_queue_lock);
@@ -4103,7 +4103,7 @@ scan_exec_io(dsl_pool_t *dp, const blkptr_t *bp, int zio_flags,
 		mutex_exit(q_lock);
 	}
 
-	ASSERT(pio != NULL);
+	ASSERT3P(pio, !=, NULL);
 	count_block_issued(spa, bp, queue == NULL);
 	zio_nowait(zio_read(pio, spa, bp, data, size, dsl_scan_scrub_done,
 	    queue, ZIO_PRIORITY_SCRUB, zio_flags, zb));
@@ -4337,7 +4337,7 @@ dsl_scan_freed_dva(spa_t *spa, const blkptr_t *bp, int dva_i)
 	uint64_t start, size;
 
 	vdev = vdev_lookup_top(spa, DVA_GET_VDEV(&bp->blk_dva[dva_i]));
-	ASSERT(vdev != NULL);
+	ASSERT3P(vdev, !=, NULL);
 	q_lock = &vdev->vdev_scan_io_queue_lock;
 	queue = vdev->vdev_scan_io_queue;
 
@@ -4409,7 +4409,7 @@ dsl_scan_freed(spa_t *spa, const blkptr_t *bp)
 	dsl_scan_t *scn = dp->dp_scan;
 
 	ASSERT0(BP_IS_EMBEDDED(bp));
-	ASSERT(scn != NULL);
+	ASSERT3P(scn, !=, NULL);
 	if (!dsl_scan_is_running(scn))
 		return;
 

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -1229,7 +1229,7 @@ scan_ds_queue_sync(dsl_scan_t *scn, dmu_tx_t *tx)
 	    DMU_OT_SCAN_QUEUE : DMU_OT_ZAP_OTHER;
 
 	ASSERT0(scn->scn_queues_pending);
-	ASSERT(scn->scn_phys.scn_queue_obj != 0);
+	ASSERT3U(scn->scn_phys.scn_queue_obj, !=, 0);
 
 	VERIFY0(dmu_object_free(dp->dp_meta_objset,
 	    scn->scn_phys.scn_queue_obj, tx));
@@ -2224,7 +2224,7 @@ dsl_scan_ds_snapshotted(dsl_dataset_t *ds, dmu_tx_t *tx)
 	if (!dsl_scan_is_running(scn))
 		return;
 
-	ASSERT(dsl_dataset_phys(ds)->ds_prev_snap_obj != 0);
+	ASSERT3U(dsl_dataset_phys(ds)->ds_prev_snap_obj, !=, 0);
 
 	ds_snapshotted_bookmark(ds, &scn->scn_phys.scn_bookmark);
 	ds_snapshotted_bookmark(ds, &scn->scn_phys_cached.scn_bookmark);
@@ -3174,9 +3174,9 @@ scan_io_queues_run(dsl_scan_t *scn)
 
 		mutex_enter(&vd->vdev_scan_io_queue_lock);
 		if (vd->vdev_scan_io_queue != NULL) {
-			VERIFY(taskq_dispatch(scn->scn_taskq,
+			VERIFY3U(taskq_dispatch(scn->scn_taskq,
 			    scan_io_queues_run_one, vd->vdev_scan_io_queue,
-			    TQ_SLEEP) != TASKQID_INVALID);
+			    TQ_SLEEP), !=, TASKQID_INVALID);
 		}
 		mutex_exit(&vd->vdev_scan_io_queue_lock);
 	}
@@ -3746,7 +3746,7 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 		scn->scn_prefetch_stop = B_FALSE;
 		prefetch_tqid = taskq_dispatch(dp->dp_sync_taskq,
 		    dsl_scan_prefetch_thread, scn, TQ_SLEEP);
-		ASSERT(prefetch_tqid != TASKQID_INVALID);
+		ASSERT3U(prefetch_tqid, !=, TASKQID_INVALID);
 
 		dsl_pool_config_enter(dp, FTAG);
 		dsl_scan_visit(scn, tx);

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -244,7 +244,7 @@ dsl_onexit_hold_cleanup(spa_t *spa, nvlist_t *holds, minor_t minor)
 		return;
 	}
 
-	ASSERT(spa != NULL);
+	ASSERT3P(spa, !=, NULL);
 	ca = kmem_alloc(sizeof (*ca), KM_SLEEP);
 
 	(void) strlcpy(ca->zhca_spaname, spa_name(spa),
@@ -650,7 +650,7 @@ dsl_dataset_user_release(nvlist_t *holds, nvlist_t *errlist)
 void
 dsl_dataset_user_release_tmp(struct dsl_pool *dp, nvlist_t *holds)
 {
-	ASSERT(dp != NULL);
+	ASSERT3P(dp, !=, NULL);
 	(void) dsl_dataset_user_release_impl(holds, NULL, dp);
 }
 

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -334,7 +334,7 @@ dsl_dataset_user_hold(nvlist_t *holds, minor_t cleanup_minor, nvlist_t *errlist)
 
 	dduha.dduha_holds = holds;
 	/* chkholds can have non-unique name */
-	VERIFY(0 == nvlist_alloc(&dduha.dduha_chkholds, 0, KM_SLEEP));
+	VERIFY0(nvlist_alloc(&dduha.dduha_chkholds, 0, KM_SLEEP));
 	dduha.dduha_errlist = errlist;
 	dduha.dduha_minor = cleanup_minor;
 

--- a/module/zfs/edonr_zfs.c
+++ b/module/zfs/edonr_zfs.c
@@ -52,7 +52,7 @@ abd_checksum_edonr_native(abd_t *abd, uint64_t size,
 	uint8_t		digest[EDONR_MODE / 8];
 	EdonRState	ctx;
 
-	ASSERT(ctx_template != NULL);
+	ASSERT3P(ctx_template, !=, NULL);
 	memcpy(&ctx, ctx_template, sizeof (ctx));
 	(void) abd_iterate_func(abd, 0, size, edonr_incremental, &ctx);
 	EdonRFinal(&ctx, digest);

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -337,7 +337,7 @@ zfs_zevent_next(zfs_zevent_t *ze, nvlist_t **event, uint64_t *event_size,
 		}
 	}
 
-	VERIFY(nvlist_size(ev->ev_nvl, &size, NV_ENCODE_NATIVE) == 0);
+	VERIFY0(nvlist_size(ev->ev_nvl, &size, NV_ENCODE_NATIVE));
 	if (size > *event_size) {
 		*event_size = size;
 		error = ENOMEM;

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -207,7 +207,7 @@ zfs_zevent_post(nvlist_t *nvl, nvlist_t *detector, zevent_cb_t *cb)
 	zevent_t *ev;
 	int error;
 
-	ASSERT(cb != NULL);
+	ASSERT3P(cb, !=, NULL);
 
 	gethrestime(&tv);
 	tv_array[0] = tv.tv_sec;

--- a/module/zfs/gzip.c
+++ b/module/zfs/gzip.c
@@ -53,7 +53,7 @@ gzip_compress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 	int ret;
 	zlen_t dstlen = d_len;
 
-	ASSERT(d_len <= s_len);
+	ASSERT3U(d_len, <=, s_len);
 
 	/* check if hardware accelerator can be used */
 	if (qat_dc_use_accel(s_len)) {
@@ -88,7 +88,7 @@ gzip_decompress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 	(void) n;
 	zlen_t dstlen = d_len;
 
-	ASSERT(d_len >= s_len);
+	ASSERT3U(d_len, >=, s_len);
 
 	/* check if hardware accelerator can be used */
 	if (qat_dc_use_accel(d_len)) {

--- a/module/zfs/lz4_zfs.c
+++ b/module/zfs/lz4_zfs.c
@@ -60,7 +60,7 @@ lz4_compress_zfs(void *s_start, void *d_start, size_t s_len,
 	uint32_t bufsiz;
 	char *dest = d_start;
 
-	ASSERT(d_len >= sizeof (bufsiz));
+	ASSERT3U(d_len, >=, sizeof (bufsiz));
 
 	bufsiz = real_LZ4_compress(s_start, &dest[sizeof (bufsiz)], s_len,
 	    d_len - sizeof (bufsiz));

--- a/module/zfs/lz4_zfs.c
+++ b/module/zfs/lz4_zfs.c
@@ -842,7 +842,7 @@ real_LZ4_compress(const char *source, char *dest, int isize, int osize)
 	void *ctx;
 	int result;
 
-	ASSERT(lz4_cache != NULL);
+	ASSERT3P(lz4_cache, !=, NULL);
 	ctx = kmem_cache_alloc(lz4_cache, KM_SLEEP);
 
 	/*

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -375,7 +375,7 @@ static kstat_t *metaslab_ksp;
 void
 metaslab_stat_init(void)
 {
-	ASSERT(metaslab_alloc_trace_cache == NULL);
+	ASSERT3P(metaslab_alloc_trace_cache, ==, NULL);
 	metaslab_alloc_trace_cache = kmem_cache_create(
 	    "metaslab_alloc_trace_cache", sizeof (metaslab_alloc_trace_t),
 	    0, NULL, NULL, NULL, NULL, NULL, 0);
@@ -439,7 +439,7 @@ metaslab_class_destroy(metaslab_class_t *mc)
 
 	for (int i = 0; i < spa->spa_alloc_count; i++) {
 		metaslab_class_allocator_t *mca = &mc->mc_allocator[i];
-		ASSERT(mca->mca_rotor == NULL);
+		ASSERT3P(mca->mca_rotor, ==, NULL);
 		zfs_refcount_destroy(&mca->mca_alloc_slots);
 	}
 	mutex_destroy(&mc->mc_lock);
@@ -465,7 +465,7 @@ metaslab_class_validate(metaslab_class_t *mc)
 
 	do {
 		vd = mg->mg_vd;
-		ASSERT(vd->vdev_mg != NULL);
+		ASSERT3P(vd->vdev_mg, !=, NULL);
 		ASSERT3P(vd->vdev_top, ==, vd);
 		ASSERT3P(mg->mg_class, ==, mc);
 		ASSERT3P(vd->vdev_ops, !=, &vdev_hole_ops);
@@ -742,7 +742,7 @@ metaslab_group_alloc_update(metaslab_group_t *mg)
 	boolean_t was_allocatable;
 	boolean_t was_initialized;
 
-	ASSERT(vd == vd->vdev_top);
+	ASSERT3P(vd, ==, vd->vdev_top);
 	ASSERT3U(spa_config_held(mc->mc_spa, SCL_ALLOC, RW_READER), ==,
 	    SCL_ALLOC);
 
@@ -860,8 +860,8 @@ metaslab_group_create(metaslab_class_t *mc, vdev_t *vd, int allocators)
 void
 metaslab_group_destroy(metaslab_group_t *mg)
 {
-	ASSERT(mg->mg_prev == NULL);
-	ASSERT(mg->mg_next == NULL);
+	ASSERT3P(mg->mg_prev, ==, NULL);
+	ASSERT3P(mg->mg_next, ==, NULL);
 	/*
 	 * We may have gone below zero with the activation count
 	 * either because we never activated in the first place or
@@ -892,8 +892,8 @@ metaslab_group_activate(metaslab_group_t *mg)
 
 	ASSERT3U(spa_config_held(spa, SCL_ALLOC, RW_WRITER), !=, 0);
 
-	ASSERT(mg->mg_prev == NULL);
-	ASSERT(mg->mg_next == NULL);
+	ASSERT3P(mg->mg_prev, ==, NULL);
+	ASSERT3P(mg->mg_next, ==, NULL);
 	ASSERT(mg->mg_activation_count <= 0);
 
 	if (++mg->mg_activation_count <= 0)
@@ -939,8 +939,8 @@ metaslab_group_passivate(metaslab_group_t *mg)
 	if (--mg->mg_activation_count != 0) {
 		for (int i = 0; i < spa->spa_alloc_count; i++)
 			ASSERT(mc->mc_allocator[i].mca_rotor != mg);
-		ASSERT(mg->mg_prev == NULL);
-		ASSERT(mg->mg_next == NULL);
+		ASSERT3P(mg->mg_prev, ==, NULL);
+		ASSERT3P(mg->mg_next, ==, NULL);
 		ASSERT(mg->mg_activation_count < 0);
 		return;
 	}
@@ -1115,7 +1115,7 @@ metaslab_group_histogram_remove(metaslab_group_t *mg, metaslab_t *msp)
 static void
 metaslab_group_add(metaslab_group_t *mg, metaslab_t *msp)
 {
-	ASSERT(msp->ms_group == NULL);
+	ASSERT3P(msp->ms_group, ==, NULL);
 	mutex_enter(&mg->mg_lock);
 	msp->ms_group = mg;
 	msp->ms_weight = 0;
@@ -1822,7 +1822,7 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size)
 		rs = zfs_btree_find(t, &rsearch, &where);
 		if (rs == NULL)
 			rs = zfs_btree_next(t, &where, &where);
-		ASSERT(rs != NULL);
+		ASSERT3P(rs, !=, NULL);
 	}
 
 	if ((rs_get_end(rs, rt) - rs_get_start(rs, rt)) >= size) {
@@ -2004,7 +2004,7 @@ static void
 metaslab_aux_histograms_update(metaslab_t *msp)
 {
 	space_map_t *sm = msp->ms_sm;
-	ASSERT(sm != NULL);
+	ASSERT3P(sm, !=, NULL);
 
 	/*
 	 * This is similar to the metaslab's space map histogram updates
@@ -2683,7 +2683,7 @@ metaslab_init(metaslab_group_t *mg, uint64_t id, uint64_t object,
 			return (error);
 		}
 
-		ASSERT(ms->ms_sm != NULL);
+		ASSERT3P(ms->ms_sm, !=, NULL);
 		ms->ms_allocated_space = space_map_allocated(ms->ms_sm);
 	}
 
@@ -2784,7 +2784,7 @@ metaslab_fini(metaslab_t *msp)
 	metaslab_group_remove(mg, msp);
 
 	mutex_enter(&msp->ms_lock);
-	VERIFY(msp->ms_group == NULL);
+	VERIFY3P(msp->ms_group, ==, NULL);
 
 	/*
 	 * If this metaslab hasn't been through metaslab_sync_done() yet its
@@ -3084,7 +3084,7 @@ metaslab_weight_from_spacemap(metaslab_t *msp)
 {
 	space_map_t *sm = msp->ms_sm;
 	ASSERT0(msp->ms_loaded);
-	ASSERT(sm != NULL);
+	ASSERT3P(sm, !=, NULL);
 	ASSERT3U(space_map_object(sm), !=, 0);
 	ASSERT3U(sm->sm_dbuf->db_size, ==, sizeof (space_map_phys_t));
 
@@ -3565,7 +3565,7 @@ metaslab_should_condense(metaslab_t *msp)
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	ASSERT(msp->ms_loaded);
-	ASSERT(sm != NULL);
+	ASSERT3P(sm, !=, NULL);
 	ASSERT3U(spa_sync_pass(vd->vdev_spa), ==, 1);
 
 	/*
@@ -3603,7 +3603,7 @@ metaslab_condense(metaslab_t *msp, dmu_tx_t *tx)
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	ASSERT(msp->ms_loaded);
-	ASSERT(msp->ms_sm != NULL);
+	ASSERT3P(msp->ms_sm, !=, NULL);
 
 	/*
 	 * In order to condense the space map, we need to change it so it
@@ -3743,8 +3743,8 @@ static void
 metaslab_unflushed_add(metaslab_t *msp, dmu_tx_t *tx)
 {
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
-	ASSERT(spa_syncing_log_sm(spa) != NULL);
-	ASSERT(msp->ms_sm != NULL);
+	ASSERT3P(spa_syncing_log_sm(spa), !=, NULL);
+	ASSERT3P(msp->ms_sm, !=, NULL);
 	ASSERT(range_tree_is_empty(msp->ms_unflushed_allocs));
 	ASSERT(range_tree_is_empty(msp->ms_unflushed_frees));
 
@@ -3762,8 +3762,8 @@ void
 metaslab_unflushed_bump(metaslab_t *msp, dmu_tx_t *tx, boolean_t dirty)
 {
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
-	ASSERT(spa_syncing_log_sm(spa) != NULL);
-	ASSERT(msp->ms_sm != NULL);
+	ASSERT3P(spa_syncing_log_sm(spa), !=, NULL);
+	ASSERT3P(msp->ms_sm, !=, NULL);
 	ASSERT(metaslab_unflushed_txg(msp) != 0);
 	ASSERT3P(avl_find(&spa->spa_metaslabs_by_flushed, msp, NULL), ==, msp);
 	ASSERT(range_tree_is_empty(msp->ms_unflushed_allocs));
@@ -3837,9 +3837,10 @@ metaslab_flush(metaslab_t *msp, dmu_tx_t *tx)
 	ASSERT3U(spa_sync_pass(spa), ==, 1);
 	ASSERT(spa_feature_is_active(spa, SPA_FEATURE_LOG_SPACEMAP));
 
-	ASSERT(msp->ms_sm != NULL);
+	ASSERT3P(msp->ms_sm, !=, NULL);
 	ASSERT(metaslab_unflushed_txg(msp) != 0);
-	ASSERT(avl_find(&spa->spa_metaslabs_by_flushed, msp, NULL) != NULL);
+	ASSERT3P(avl_find(&spa->spa_metaslabs_by_flushed, msp, NULL), !=,
+	    NULL);
 
 	/*
 	 * There is nothing wrong with flushing the same metaslab twice, as
@@ -4034,7 +4035,7 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 
 		VERIFY0(space_map_open(&msp->ms_sm, mos, new_object,
 		    msp->ms_start, msp->ms_size, vd->vdev_ashift));
-		ASSERT(msp->ms_sm != NULL);
+		ASSERT3P(msp->ms_sm, !=, NULL);
 
 		ASSERT(range_tree_is_empty(msp->ms_unflushed_allocs));
 		ASSERT(range_tree_is_empty(msp->ms_unflushed_frees));
@@ -5158,7 +5159,7 @@ metaslab_alloc_dva(spa_t *spa, metaslab_class_t *mc, uint64_t psize,
 		} while ((fast_mg = fast_mg->mg_next) != mca->mca_rotor);
 
 	} else {
-		ASSERT(mca->mca_rotor != NULL);
+		ASSERT3P(mca->mca_rotor, !=, NULL);
 		mg = mca->mca_rotor;
 	}
 

--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -289,7 +289,7 @@ mmp_next_leaf(spa_t *spa)
 	ASSERT(MUTEX_HELD(&spa->spa_mmp.mmp_io_lock));
 	ASSERT(spa_config_held(spa, SCL_STATE, RW_READER));
 	ASSERT(list_link_active(&spa->spa_leaf_list.list_head) == B_TRUE);
-	ASSERT(!list_is_empty(&spa->spa_leaf_list));
+	ASSERT0(list_is_empty(&spa->spa_leaf_list));
 
 	if (spa->spa_mmp.mmp_leaf_last_gen != spa->spa_leaf_list_gen) {
 		spa->spa_mmp.mmp_last_leaf = list_head(&spa->spa_leaf_list);

--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -288,7 +288,7 @@ mmp_next_leaf(spa_t *spa)
 
 	ASSERT(MUTEX_HELD(&spa->spa_mmp.mmp_io_lock));
 	ASSERT(spa_config_held(spa, SCL_STATE, RW_READER));
-	ASSERT(list_link_active(&spa->spa_leaf_list.list_head) == B_TRUE);
+	ASSERT3U(list_link_active(&spa->spa_leaf_list.list_head), ==, B_TRUE);
 	ASSERT0(list_is_empty(&spa->spa_leaf_list));
 
 	if (spa->spa_mmp.mmp_leaf_last_gen != spa->spa_leaf_list_gen) {

--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -220,7 +220,7 @@ mmp_thread_enter(mmp_thread_t *mmp, callb_cpr_t *cpr)
 static void
 mmp_thread_exit(mmp_thread_t *mmp, kthread_t **mpp, callb_cpr_t *cpr)
 {
-	ASSERT(*mpp != NULL);
+	ASSERT3P(*mpp, !=, NULL);
 	*mpp = NULL;
 	cv_broadcast(&mmp->mmp_thread_cv);
 	CALLB_CPR_EXIT(cpr);		/* drops &mmp->mmp_thread_lock */
@@ -259,7 +259,7 @@ mmp_thread_stop(spa_t *spa)
 	zfs_dbgmsg("MMP thread stopped pool '%s' gethrtime %llu",
 	    spa_name(spa), gethrtime());
 
-	ASSERT(mmp->mmp_thread == NULL);
+	ASSERT3P(mmp->mmp_thread, ==, NULL);
 	mmp->mmp_thread_exiting = 0;
 }
 

--- a/module/zfs/multilist.c
+++ b/module/zfs/multilist.c
@@ -178,7 +178,7 @@ multilist_insert(multilist_t *ml, void *obj)
 	if (need_lock)
 		mutex_enter(&mls->mls_lock);
 
-	ASSERT(!multilist_link_active(multilist_d2l(ml, obj)));
+	ASSERT0(multilist_link_active(multilist_d2l(ml, obj)));
 
 	multilist_sublist_insert_head(mls, obj);
 
@@ -346,7 +346,7 @@ multilist_sublist_move_forward(multilist_sublist_t *mls, void *obj)
 	void *prev = list_prev(&mls->mls_list, obj);
 
 	ASSERT(MUTEX_HELD(&mls->mls_lock));
-	ASSERT(!list_is_empty(&mls->mls_list));
+	ASSERT0(list_is_empty(&mls->mls_list));
 
 	/* 'obj' must be at the head of the list, nothing to do */
 	if (prev == NULL)
@@ -378,7 +378,7 @@ multilist_sublist_is_empty_idx(multilist_t *ml, unsigned int sublist_idx)
 
 	ASSERT3U(sublist_idx, <, ml->ml_num_sublists);
 	mls = &ml->ml_sublists[sublist_idx];
-	ASSERT(!MUTEX_HELD(&mls->mls_lock));
+	ASSERT0(MUTEX_HELD(&mls->mls_lock));
 	mutex_enter(&mls->mls_lock);
 	empty = list_is_empty(&mls->mls_list);
 	mutex_exit(&mls->mls_lock);

--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -735,7 +735,7 @@ range_tree_numsegs(range_tree_t *rt)
 boolean_t
 range_tree_is_empty(range_tree_t *rt)
 {
-	ASSERT(rt != NULL);
+	ASSERT3P(rt, !=, NULL);
 	return (range_tree_space(rt) == 0);
 }
 

--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -129,7 +129,7 @@ range_tree_stat_incr(range_tree_t *rt, range_seg_t *rs)
 	uint64_t size = rs_get_end(rs, rt) - rs_get_start(rs, rt);
 	int idx = highbit64(size) - 1;
 
-	ASSERT(size != 0);
+	ASSERT3U(size, !=, 0);
 	ASSERT3U(idx, <,
 	    sizeof (rt->rt_histogram) / sizeof (*rt->rt_histogram));
 
@@ -143,7 +143,7 @@ range_tree_stat_decr(range_tree_t *rt, range_seg_t *rs)
 	uint64_t size = rs_get_end(rs, rt) - rs_get_start(rs, rt);
 	int idx = highbit64(size) - 1;
 
-	ASSERT(size != 0);
+	ASSERT3U(size, !=, 0);
 	ASSERT3U(idx, <,
 	    sizeof (rt->rt_histogram) / sizeof (*rt->rt_histogram));
 
@@ -576,7 +576,7 @@ range_tree_find_impl(range_tree_t *rt, uint64_t start, uint64_t size)
 	range_seg_max_t rsearch;
 	uint64_t end = start + size;
 
-	VERIFY(size != 0);
+	VERIFY3U(size, !=, 0);
 
 	rs_set_start(&rsearch, rt, start);
 	rs_set_end(&rsearch, rt, end);

--- a/module/zfs/rrwlock.c
+++ b/module/zfs/rrwlock.c
@@ -107,7 +107,7 @@ rrn_add(rrwlock_t *rrl, const void *tag)
 	rn->rn_rrl = rrl;
 	rn->rn_next = tsd_get(rrw_tsd_key);
 	rn->rn_tag = tag;
-	VERIFY(tsd_set(rrw_tsd_key, rn) == 0);
+	VERIFY0(tsd_set(rrw_tsd_key, rn));
 }
 
 /*
@@ -128,7 +128,7 @@ rrn_find_and_remove(rrwlock_t *rrl, const void *tag)
 			if (prev)
 				prev->rn_next = rn->rn_next;
 			else
-				VERIFY(tsd_set(rrw_tsd_key, rn->rn_next) == 0);
+				VERIFY0(tsd_set(rrw_tsd_key, rn->rn_next));
 			kmem_free(rn, sizeof (*rn));
 			return (B_TRUE);
 		}
@@ -260,7 +260,7 @@ rrw_exit(rrwlock_t *rrl, const void *tag)
 			count = zfs_refcount_remove(
 			    &rrl->rr_linked_rcount, tag);
 		} else {
-			ASSERT(!rrl->rr_track_all);
+			ASSERT0(rrl->rr_track_all);
 			count = zfs_refcount_remove(&rrl->rr_anon_rcount, tag);
 		}
 		if (count == 0)

--- a/module/zfs/rrwlock.c
+++ b/module/zfs/rrwlock.c
@@ -154,7 +154,7 @@ rrw_destroy(rrwlock_t *rrl)
 {
 	mutex_destroy(&rrl->rr_lock);
 	cv_destroy(&rrl->rr_cv);
-	ASSERT(rrl->rr_writer == NULL);
+	ASSERT3P(rrl->rr_writer, ==, NULL);
 	zfs_refcount_destroy(&rrl->rr_anon_rcount);
 	zfs_refcount_destroy(&rrl->rr_linked_rcount);
 }
@@ -187,7 +187,7 @@ rrw_enter_read_impl(rrwlock_t *rrl, boolean_t prio, const void *tag)
 	} else {
 		(void) zfs_refcount_add(&rrl->rr_anon_rcount, tag);
 	}
-	ASSERT(rrl->rr_writer == NULL);
+	ASSERT3P(rrl->rr_writer, ==, NULL);
 	mutex_exit(&rrl->rr_lock);
 }
 

--- a/module/zfs/rrwlock.c
+++ b/module/zfs/rrwlock.c
@@ -172,8 +172,8 @@ rrw_enter_read_impl(rrwlock_t *rrl, boolean_t prio, const void *tag)
 	}
 	DTRACE_PROBE(zfs__rrwfastpath__rdmiss);
 #endif
-	ASSERT(rrl->rr_writer != curthread);
-	ASSERT(zfs_refcount_count(&rrl->rr_anon_rcount) >= 0);
+	ASSERT3U(rrl->rr_writer, !=, curthread);
+	ASSERT3U(zfs_refcount_count(&rrl->rr_anon_rcount), >=, 0);
 
 	while (rrl->rr_writer != NULL || (rrl->rr_writer_wanted &&
 	    zfs_refcount_is_zero(&rrl->rr_anon_rcount) && !prio &&
@@ -214,7 +214,7 @@ void
 rrw_enter_write(rrwlock_t *rrl)
 {
 	mutex_enter(&rrl->rr_lock);
-	ASSERT(rrl->rr_writer != curthread);
+	ASSERT3U(rrl->rr_writer, !=, curthread);
 
 	while (zfs_refcount_count(&rrl->rr_anon_rcount) > 0 ||
 	    zfs_refcount_count(&rrl->rr_linked_rcount) > 0 ||
@@ -266,7 +266,7 @@ rrw_exit(rrwlock_t *rrl, const void *tag)
 		if (count == 0)
 			cv_broadcast(&rrl->rr_cv);
 	} else {
-		ASSERT(rrl->rr_writer == curthread);
+		ASSERT3U(rrl->rr_writer, ==, curthread);
 		ASSERT(zfs_refcount_is_zero(&rrl->rr_anon_rcount) &&
 		    zfs_refcount_is_zero(&rrl->rr_linked_rcount));
 		rrl->rr_writer = NULL;

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -302,7 +302,7 @@ sa_get_spill(sa_handle_t *hdl)
 	if (hdl->sa_spill == NULL) {
 		if ((rc = dmu_spill_hold_existing(hdl->sa_bonus, NULL,
 		    &hdl->sa_spill)) == 0)
-			VERIFY(0 == sa_build_index(hdl, SA_SPILL));
+			VERIFY0(sa_build_index(hdl, SA_SPILL));
 	} else {
 		rc = 0;
 	}
@@ -430,7 +430,7 @@ sa_add_layout_entry(objset_t *os, const sa_attr_type_t *attrs, int attr_count,
 
 		(void) snprintf(attr_name, sizeof (attr_name),
 		    "%d", (int)lot_num);
-		VERIFY(0 == zap_update(os, os->os_sa->sa_layout_attr_obj,
+		VERIFY0(zap_update(os, os->os_sa->sa_layout_attr_obj,
 		    attr_name, 2, attr_count, attrs, tx));
 	}
 
@@ -503,7 +503,7 @@ sa_resize_spill(sa_handle_t *hdl, uint32_t size, dmu_tx_t *tx)
 	}
 
 	error = dbuf_spill_set_blksz(hdl->sa_spill, blocksize, tx);
-	ASSERT(error == 0);
+	ASSERT0(error);
 	return (error);
 }
 
@@ -701,8 +701,8 @@ sa_build_layouts(sa_handle_t *hdl, sa_bulk_attr_t *attr_desc, int attr_count,
 		boolean_t dummy;
 
 		if (hdl->sa_spill == NULL) {
-			VERIFY(dmu_spill_hold_by_bonus(hdl->sa_bonus, 0, NULL,
-			    &hdl->sa_spill) == 0);
+			VERIFY0(dmu_spill_hold_by_bonus(hdl->sa_bonus, 0, NULL,
+			    &hdl->sa_spill));
 		}
 		dmu_buf_will_dirty(hdl->sa_spill, tx);
 
@@ -715,7 +715,7 @@ sa_build_layouts(sa_handle_t *hdl, sa_bulk_attr_t *attr_desc, int attr_count,
 
 		if (BUF_SPACE_NEEDED(spill_used, spillhdrsize) >
 		    hdl->sa_spill->db_size)
-			VERIFY(0 == sa_resize_spill(hdl,
+			VERIFY0(sa_resize_spill(hdl,
 			    BUF_SPACE_NEEDED(spill_used, spillhdrsize), tx));
 	}
 
@@ -789,7 +789,7 @@ sa_build_layouts(sa_handle_t *hdl, sa_bulk_attr_t *attr_desc, int attr_count,
 		hdl->sa_bonus_tab = NULL;
 	}
 	if (!sa->sa_force_spill)
-		VERIFY(0 == sa_build_index(hdl, SA_BONUS));
+		VERIFY0(sa_build_index(hdl, SA_BONUS));
 	if (hdl->sa_spill) {
 		sa_idx_tab_rele(hdl->sa_os, hdl->sa_spill_tab);
 		if (!spilling) {
@@ -799,10 +799,10 @@ sa_build_layouts(sa_handle_t *hdl, sa_bulk_attr_t *attr_desc, int attr_count,
 			dmu_buf_rele(hdl->sa_spill, NULL);
 			hdl->sa_spill = NULL;
 			hdl->sa_spill_tab = NULL;
-			VERIFY(0 == dmu_rm_spill(hdl->sa_os,
-			    sa_handle_object(hdl), tx));
+			VERIFY0(dmu_rm_spill(hdl->sa_os, sa_handle_object(hdl),
+			    tx));
 		} else {
-			VERIFY(0 == sa_build_index(hdl, SA_SPILL));
+			VERIFY0(sa_build_index(hdl, SA_SPILL));
 		}
 	}
 
@@ -1672,10 +1672,10 @@ sa_add_projid(sa_handle_t *hdl, dmu_tx_t *tx, uint64_t projid)
 		zp->z_pflags &= ~ZFS_BONUS_SCANSTAMP;
 	}
 
-	VERIFY(dmu_set_bonustype(db, DMU_OT_SA, tx) == 0);
-	VERIFY(sa_replace_all_by_template_locked(hdl, attrs, count, tx) == 0);
+	VERIFY0(dmu_set_bonustype(db, DMU_OT_SA, tx));
+	VERIFY0(sa_replace_all_by_template_locked(hdl, attrs, count, tx));
 	if (znode_acl.z_acl_extern_obj) {
-		VERIFY(0 == dmu_object_free(zfsvfs->z_os,
+		VERIFY0(dmu_object_free(zfsvfs->z_os,
 		    znode_acl.z_acl_extern_obj, tx));
 	}
 
@@ -1795,7 +1795,7 @@ sa_attr_register_sync(sa_handle_t *hdl, dmu_tx_t *tx)
 			continue;
 		ATTR_ENCODE(attr_value, tb[i].sa_attr, tb[i].sa_length,
 		    tb[i].sa_byteswap);
-		VERIFY(0 == zap_update(hdl->sa_os, sa->sa_reg_attr_obj,
+		VERIFY0(zap_update(hdl->sa_os, sa->sa_reg_attr_obj,
 		    tb[i].sa_name, 8, 1, &attr_value, tx));
 		tb[i].sa_registered = B_TRUE;
 	}

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -329,7 +329,7 @@ sa_attr_op(sa_handle_t *hdl, sa_bulk_attr_t *bulk, int count,
 
 	ASSERT3S(count, >, 0);
 	for (i = 0; i != count; i++) {
-		ASSERT(bulk[i].sa_attr <= hdl->sa_os->os_sa->sa_num_attrs);
+		ASSERT3U(bulk[i].sa_attr, <=, hdl->sa_os->os_sa->sa_num_attrs);
 
 		bulk[i].sa_addr = NULL;
 		/* First check the bonus buffer */
@@ -619,7 +619,7 @@ sa_find_sizes(sa_os_t *sa, sa_bulk_attr_t *attr_desc, int attr_count,
 				if (*index != -1 || might_spill_here)
 					extra_hdrsize += sizeof (uint16_t);
 			} else {
-				ASSERT(buftype == SA_BONUS);
+				ASSERT3U(buftype, ==, SA_BONUS);
 				if (*index == -1)
 					*index = i;
 				*will_spill = B_TRUE;
@@ -738,7 +738,7 @@ sa_build_layouts(sa_handle_t *hdl, sa_bulk_attr_t *attr_desc, int attr_count,
 			length = attr_desc[i].sa_length;
 
 		if (spilling && i == spill_idx) { /* switch to spill buffer */
-			VERIFY(bonustype == DMU_OT_SA);
+			VERIFY3U(bonustype, ==, DMU_OT_SA);
 			if (buftype == SA_BONUS && !sa->sa_force_spill) {
 				sa_find_layout(hdl->sa_os, hash, attrs_start,
 				    lot_count, tx, &lot);

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -327,7 +327,7 @@ sa_attr_op(sa_handle_t *hdl, sa_bulk_attr_t *bulk, int count,
 
 	buftypes = 0;
 
-	ASSERT(count > 0);
+	ASSERT3S(count, >, 0);
 	for (i = 0; i != count; i++) {
 		ASSERT(bulk[i].sa_attr <= hdl->sa_os->os_sa->sa_num_attrs);
 
@@ -939,7 +939,7 @@ sa_attr_table_setup(objset_t *os, const sa_attr_reg_t *reg_attrs, int count)
 		 * attributes
 		 */
 		if (registered_count != sa_reg_count) {
-			ASSERT(error != 0);
+			ASSERT3S(error, !=, 0);
 			goto bail;
 		}
 
@@ -986,7 +986,7 @@ bail:
 	kmem_free(sa->sa_user_table, count * sizeof (sa_attr_type_t));
 	sa->sa_user_table = NULL;
 	sa_free_attr_table(sa);
-	ASSERT(error != 0);
+	ASSERT3S(error, !=, 0);
 	return (error);
 }
 
@@ -1085,7 +1085,7 @@ sa_setup(objset_t *os, uint64_t sa_obj, const sa_attr_reg_t *reg_attrs,
 		 * to AVL tree
 		 */
 		if (avl_numnodes(&sa->sa_layout_num_tree) != layout_count) {
-			ASSERT(error != 0);
+			ASSERT3S(error, !=, 0);
 			goto fail;
 		}
 	}

--- a/module/zfs/skein_zfs.c
+++ b/module/zfs/skein_zfs.c
@@ -47,7 +47,7 @@ abd_checksum_skein_native(abd_t *abd, uint64_t size,
 {
 	Skein_512_Ctxt_t ctx;
 
-	ASSERT(ctx_template != NULL);
+	ASSERT3P(ctx_template, !=, NULL);
 	memcpy(&ctx, ctx_template, sizeof (ctx));
 	(void) abd_iterate_func(abd, 0, size, skein_incremental, &ctx);
 	(void) Skein_512_Final(&ctx, (uint8_t *)zcp);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -698,7 +698,7 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 			}
 
 			slash = strrchr(strval, '/');
-			ASSERT(slash != NULL);
+			ASSERT3P(slash, !=, NULL);
 
 			if (slash[1] == '\0' || strcmp(slash, "/.") == 0 ||
 			    strcmp(slash, "/..") == 0)
@@ -1372,9 +1372,9 @@ static void
 spa_deactivate(spa_t *spa)
 {
 	ASSERT(spa->spa_sync_on == B_FALSE);
-	ASSERT(spa->spa_dsl_pool == NULL);
-	ASSERT(spa->spa_root_vdev == NULL);
-	ASSERT(spa->spa_async_zio_root == NULL);
+	ASSERT3P(spa->spa_dsl_pool, ==, NULL);
+	ASSERT3P(spa->spa_root_vdev, ==, NULL);
+	ASSERT3P(spa->spa_async_zio_root, ==, NULL);
 	ASSERT(spa->spa_state != POOL_STATE_UNINITIALIZED);
 
 	spa_evicting_os_wait(spa);
@@ -1513,7 +1513,7 @@ spa_config_parse(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent,
 		}
 	}
 
-	ASSERT(*vdp != NULL);
+	ASSERT3P(*vdp, !=, NULL);
 
 	return (0);
 }
@@ -1695,7 +1695,7 @@ spa_unload(spa_t *spa)
 	 */
 	if (spa->spa_root_vdev)
 		vdev_free(spa->spa_root_vdev);
-	ASSERT(spa->spa_root_vdev == NULL);
+	ASSERT3P(spa->spa_root_vdev, ==, NULL);
 
 	/*
 	 * Close the dsl pool.
@@ -1830,7 +1830,7 @@ spa_load_spares(spa_t *spa)
 	for (i = 0; i < spa->spa_spares.sav_count; i++) {
 		VERIFY0(spa_config_parse(spa, &vd, spares[i], NULL, 0,
 		    VDEV_ALLOC_SPARE));
-		ASSERT(vd != NULL);
+		ASSERT3P(vd, !=, NULL);
 
 		spa->spa_spares.sav_vdevs[i] = vd;
 
@@ -1958,7 +1958,7 @@ spa_load_l2cache(spa_t *spa)
 			 */
 			VERIFY0(spa_config_parse(spa, &vd, l2cache[i], NULL, 0,
 			    VDEV_ALLOC_L2CACHE));
-			ASSERT(vd != NULL);
+			ASSERT3P(vd, !=, NULL);
 			newvdevs[i] = vd;
 
 			/*
@@ -2683,7 +2683,7 @@ static int
 livelist_track_new_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx)
 {
-	ASSERT(tx == NULL);
+	ASSERT3P(tx, ==, NULL);
 	livelist_new_arg_t *lna = arg;
 	if (bp_freed) {
 		bplist_append(lna->frees, bp);
@@ -3422,11 +3422,11 @@ spa_ld_parse_config(spa_t *spa, spa_import_type_t type)
 	nvlist_free(spa->spa_load_info);
 	spa->spa_load_info = fnvlist_alloc();
 
-	ASSERT(spa->spa_comment == NULL);
+	ASSERT3P(spa->spa_comment, ==, NULL);
 	if (nvlist_lookup_string(config, ZPOOL_CONFIG_COMMENT, &comment) == 0)
 		spa->spa_comment = spa_strdup(comment);
 
-	ASSERT(spa->spa_compatibility == NULL);
+	ASSERT3P(spa->spa_compatibility, ==, NULL);
 	if (nvlist_lookup_string(config, ZPOOL_CONFIG_COMPATIBILITY,
 	    &compatibility) == 0)
 		spa->spa_compatibility = spa_strdup(compatibility);
@@ -5420,7 +5420,7 @@ spa_add_l2cache(spa_t *spa, nvlist_t *config)
 					break;
 				}
 			}
-			ASSERT(vd != NULL);
+			ASSERT3P(vd, !=, NULL);
 
 			VERIFY0(nvlist_lookup_uint64_array(l2cache[i],
 			    ZPOOL_CONFIG_VDEV_STATS, (uint64_t **)&vs, &vsc));
@@ -5736,7 +5736,7 @@ spa_l2cache_drop(spa_t *spa)
 		uint64_t pool;
 
 		vd = sav->sav_vdevs[i];
-		ASSERT(vd != NULL);
+		ASSERT3P(vd, !=, NULL);
 
 		if (spa_l2cache_exists(vd->vdev_guid, &pool) &&
 		    pool != 0ULL && l2arc_vdev_present(vd))
@@ -8784,7 +8784,7 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			 * 'altroot' is a non-persistent property. It should
 			 * have been set temporarily at creation or import time.
 			 */
-			ASSERT(spa->spa_root != NULL);
+			ASSERT3P(spa->spa_root, !=, NULL);
 			break;
 
 		case ZPOOL_PROP_READONLY:
@@ -8987,14 +8987,14 @@ vdev_indirect_state_sync_verify(vdev_t *vd)
 	vdev_indirect_births_t *vib __maybe_unused = vd->vdev_indirect_births;
 
 	if (vd->vdev_ops == &vdev_indirect_ops) {
-		ASSERT(vim != NULL);
-		ASSERT(vib != NULL);
+		ASSERT3P(vim, !=, NULL);
+		ASSERT3P(vib, !=, NULL);
 	}
 
 	uint64_t obsolete_sm_object = 0;
 	ASSERT0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
 	if (obsolete_sm_object != 0) {
-		ASSERT(vd->vdev_obsolete_sm != NULL);
+		ASSERT3P(vd->vdev_obsolete_sm, !=, NULL);
 		ASSERT(vd->vdev_removing ||
 		    vd->vdev_ops == &vdev_indirect_ops);
 		ASSERT(vdev_indirect_mapping_num_entries(vim) > 0);
@@ -9004,7 +9004,7 @@ vdev_indirect_state_sync_verify(vdev_t *vd)
 		ASSERT3U(vdev_indirect_mapping_bytes_mapped(vim), >=,
 		    space_map_allocated(vd->vdev_obsolete_sm));
 	}
-	ASSERT(vd->vdev_obsolete_segments != NULL);
+	ASSERT3P(vd->vdev_obsolete_segments, !=, NULL);
 
 	/*
 	 * Since frees / remaps to an indirect vdev can only

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2841,7 +2841,7 @@ spa_livelist_condense_cb(void *arg, zthr_t *t)
 	 * space. In the second case, we'll just end up trying to condense
 	 * again in a later txg.
 	 */
-	ASSERT(err != 0);
+	ASSERT3S(err, !=, 0);
 	bplist_clear(&lca->to_keep);
 	bplist_destroy(&lca->to_keep);
 	kmem_free(lca, sizeof (livelist_condense_arg_t));
@@ -3147,7 +3147,7 @@ spa_activity_check_duration(spa_t *spa, uberblock_t *ub)
 	 * these cases and times.
 	 */
 
-	ASSERT(MMP_IMPORT_SAFETY_FACTOR >= 100);
+	ASSERT3S(MMP_IMPORT_SAFETY_FACTOR, >=, 100);
 
 	if (MMP_INTERVAL_VALID(ub) && MMP_FAIL_INT_VALID(ub) &&
 	    MMP_FAIL_INT(ub) > 0) {

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -789,7 +789,7 @@ spa_prop_set(spa_t *spa, nvlist_t *nvp)
 			uint64_t ver = 0;
 
 			if (prop == ZPOOL_PROP_VERSION) {
-				VERIFY(nvpair_value_uint64(elem, &ver) == 0);
+				VERIFY0(nvpair_value_uint64(elem, &ver));
 			} else {
 				ASSERT(zpool_prop_feature(nvpair_name(elem)));
 				ver = SPA_VERSION_FEATURES;
@@ -833,9 +833,9 @@ void
 spa_prop_clear_bootfs(spa_t *spa, uint64_t dsobj, dmu_tx_t *tx)
 {
 	if (spa->spa_bootfs == dsobj && spa->spa_pool_props_object != 0) {
-		VERIFY(zap_remove(spa->spa_meta_objset,
+		VERIFY0(zap_remove(spa->spa_meta_objset,
 		    spa->spa_pool_props_object,
-		    zpool_prop_to_name(ZPOOL_PROP_BOOTFS), tx) == 0);
+		    zpool_prop_to_name(ZPOOL_PROP_BOOTFS), tx));
 		spa->spa_bootfs = 0;
 	}
 }
@@ -1828,8 +1828,8 @@ spa_load_spares(spa_t *spa)
 	spa->spa_spares.sav_vdevs = kmem_zalloc(nspares * sizeof (void *),
 	    KM_SLEEP);
 	for (i = 0; i < spa->spa_spares.sav_count; i++) {
-		VERIFY(spa_config_parse(spa, &vd, spares[i], NULL, 0,
-		    VDEV_ALLOC_SPARE) == 0);
+		VERIFY0(spa_config_parse(spa, &vd, spares[i], NULL, 0,
+		    VDEV_ALLOC_SPARE));
 		ASSERT(vd != NULL);
 
 		spa->spa_spares.sav_vdevs[i] = vd;
@@ -1956,8 +1956,8 @@ spa_load_l2cache(spa_t *spa)
 			/*
 			 * Create new vdev
 			 */
-			VERIFY(spa_config_parse(spa, &vd, l2cache[i], NULL, 0,
-			    VDEV_ALLOC_L2CACHE) == 0);
+			VERIFY0(spa_config_parse(spa, &vd, l2cache[i], NULL, 0,
+			    VDEV_ALLOC_L2CACHE));
 			ASSERT(vd != NULL);
 			newvdevs[i] = vd;
 
@@ -4216,7 +4216,7 @@ spa_ld_get_props(spa_t *spa)
 	    &spa->spa_all_vdev_zaps, B_FALSE);
 
 	if (error == ENOENT) {
-		VERIFY(!nvlist_exists(mos_config,
+		VERIFY0(nvlist_exists(mos_config,
 		    ZPOOL_CONFIG_HAS_PER_VDEV_ZAPS));
 		spa->spa_avz_action = AVZ_ACTION_INITIALIZE;
 		ASSERT0(vdev_count_verify_zaps(spa->spa_root_vdev));
@@ -8061,7 +8061,7 @@ spa_vdev_setfru(spa_t *spa, uint64_t guid, const char *newfru)
 int
 spa_scrub_pause_resume(spa_t *spa, pool_scrub_cmd_t cmd)
 {
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == 0);
+	ASSERT0(spa_config_held(spa, SCL_ALL, RW_WRITER));
 
 	if (dsl_scan_resilvering(spa->spa_dsl_pool))
 		return (SET_ERROR(EBUSY));
@@ -8072,7 +8072,7 @@ spa_scrub_pause_resume(spa_t *spa, pool_scrub_cmd_t cmd)
 int
 spa_scan_stop(spa_t *spa)
 {
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == 0);
+	ASSERT0(spa_config_held(spa, SCL_ALL, RW_WRITER));
 	if (dsl_scan_resilvering(spa->spa_dsl_pool))
 		return (SET_ERROR(EBUSY));
 	return (dsl_scan_cancel(spa->spa_dsl_pool));
@@ -8081,7 +8081,7 @@ spa_scan_stop(spa_t *spa)
 int
 spa_scan(spa_t *spa, pool_scan_func_t func)
 {
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == 0);
+	ASSERT0(spa_config_held(spa, SCL_ALL, RW_WRITER));
 
 	if (func >= POOL_SCAN_FUNCS || func == POOL_SCAN_NONE)
 		return (SET_ERROR(ENOTSUP));
@@ -8458,7 +8458,7 @@ static int
 bpobj_spa_free_sync_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
     dmu_tx_t *tx)
 {
-	ASSERT(!bp_freed);
+	ASSERT0(bp_freed);
 	return (spa_free_sync_cb(arg, bp, tx));
 }
 
@@ -8471,7 +8471,7 @@ spa_sync_frees(spa_t *spa, bplist_t *bpl, dmu_tx_t *tx)
 {
 	zio_t *zio = zio_root(spa, NULL, NULL, 0);
 	bplist_iterate(bpl, spa_free_sync_cb, zio, tx);
-	VERIFY(zio_wait(zio) == 0);
+	VERIFY0(zio_wait(zio));
 }
 
 /*
@@ -8510,7 +8510,7 @@ spa_sync_nvlist(spa_t *spa, uint64_t obj, nvlist_t *nv, dmu_tx_t *tx)
 	size_t nvsize = 0;
 	dmu_buf_t *db;
 
-	VERIFY(nvlist_size(nv, &nvsize, NV_ENCODE_XDR) == 0);
+	VERIFY0(nvlist_size(nv, &nvsize, NV_ENCODE_XDR));
 
 	/*
 	 * Write full (SPA_CONFIG_BLOCKSIZE) blocks of configuration
@@ -8520,15 +8520,14 @@ spa_sync_nvlist(spa_t *spa, uint64_t obj, nvlist_t *nv, dmu_tx_t *tx)
 	bufsize = P2ROUNDUP((uint64_t)nvsize, SPA_CONFIG_BLOCKSIZE);
 	packed = vmem_alloc(bufsize, KM_SLEEP);
 
-	VERIFY(nvlist_pack(nv, &packed, &nvsize, NV_ENCODE_XDR,
-	    KM_SLEEP) == 0);
+	VERIFY0(nvlist_pack(nv, &packed, &nvsize, NV_ENCODE_XDR, KM_SLEEP));
 	memset(packed + nvsize, 0, bufsize - nvsize);
 
 	dmu_write(spa->spa_meta_objset, obj, 0, bufsize, packed, tx);
 
 	vmem_free(packed, bufsize);
 
-	VERIFY(0 == dmu_bonus_hold(spa->spa_meta_objset, obj, FTAG, &db));
+	VERIFY0(dmu_bonus_hold(spa->spa_meta_objset, obj, FTAG, &db));
 	dmu_buf_will_dirty(db, tx);
 	*(uint64_t *)db->db_data = nvsize;
 	dmu_buf_rele(db, FTAG);
@@ -8554,9 +8553,9 @@ spa_sync_aux_dev(spa_t *spa, spa_aux_vdev_t *sav, dmu_tx_t *tx,
 		sav->sav_object = dmu_object_alloc(spa->spa_meta_objset,
 		    DMU_OT_PACKED_NVLIST, 1 << 14, DMU_OT_PACKED_NVLIST_SIZE,
 		    sizeof (uint64_t), tx);
-		VERIFY(zap_update(spa->spa_meta_objset,
+		VERIFY0(zap_update(spa->spa_meta_objset,
 		    DMU_POOL_DIRECTORY_OBJECT, entry, sizeof (uint64_t), 1,
-		    &sav->sav_object, tx) == 0);
+		    &sav->sav_object, tx));
 	}
 
 	nvroot = fnvlist_alloc();

--- a/module/zfs/spa_checkpoint.c
+++ b/module/zfs/spa_checkpoint.c
@@ -368,7 +368,7 @@ spa_checkpoint_discard_is_done(spa_t *spa)
 {
 	vdev_t *rvd = spa->spa_root_vdev;
 
-	ASSERT(!spa_has_checkpoint(spa));
+	ASSERT0(spa_has_checkpoint(spa));
 	ASSERT(spa_feature_is_active(spa, SPA_FEATURE_POOL_CHECKPOINT));
 
 	for (uint64_t c = 0; c < rvd->vdev_children; c++) {

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -426,7 +426,7 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 		spa_config_enter(spa, SCL_CONFIG | SCL_STATE, FTAG, RW_READER);
 	}
 
-	ASSERT(spa_config_held(spa, SCL_CONFIG | SCL_STATE, RW_READER) ==
+	ASSERT3U(spa_config_held(spa, SCL_CONFIG | SCL_STATE, RW_READER), ==,
 	    (SCL_CONFIG | SCL_STATE));
 
 	/*

--- a/module/zfs/spa_errlog.c
+++ b/module/zfs/spa_errlog.c
@@ -109,13 +109,13 @@ static void
 name_to_errphys(char *buf, zbookmark_err_phys_t *zep)
 {
 	zep->zb_object = zfs_strtonum(buf, &buf);
-	ASSERT(*buf == ':');
+	ASSERT3U(*buf, ==, ':');
 	zep->zb_level = (int)zfs_strtonum(buf + 1, &buf);
-	ASSERT(*buf == ':');
+	ASSERT3U(*buf, ==, ':');
 	zep->zb_blkid = zfs_strtonum(buf + 1, &buf);
-	ASSERT(*buf == ':');
+	ASSERT3U(*buf, ==, ':');
 	zep->zb_birth = zfs_strtonum(buf + 1, &buf);
-	ASSERT(*buf == '\0');
+	ASSERT3U(*buf, ==, '\0');
 }
 
 /*
@@ -125,13 +125,13 @@ static void
 name_to_bookmark(char *buf, zbookmark_phys_t *zb)
 {
 	zb->zb_objset = zfs_strtonum(buf, &buf);
-	ASSERT(*buf == ':');
+	ASSERT3U(*buf, ==, ':');
 	zb->zb_object = zfs_strtonum(buf + 1, &buf);
-	ASSERT(*buf == ':');
+	ASSERT3U(*buf, ==, ':');
 	zb->zb_level = (int)zfs_strtonum(buf + 1, &buf);
-	ASSERT(*buf == ':');
+	ASSERT3U(*buf, ==, ':');
 	zb->zb_blkid = zfs_strtonum(buf + 1, &buf);
-	ASSERT(*buf == '\0');
+	ASSERT3U(*buf, ==, '\0');
 }
 
 #ifdef _KERNEL
@@ -149,7 +149,7 @@ static void
 name_to_object(char *buf, uint64_t *obj)
 {
 	*obj = zfs_strtonum(buf, &buf);
-	ASSERT(*buf == '\0');
+	ASSERT3U(*buf, ==, '\0');
 }
 
 static int
@@ -1220,7 +1220,7 @@ find_txg_ancestor_snapshot(spa_t *spa, uint64_t new_head, uint64_t old_head,
 		prev_obj = dsl_dataset_phys(ds)->ds_prev_snap_obj;
 	}
 	dsl_dataset_rele(ds, FTAG);
-	ASSERT(prev_obj != 0);
+	ASSERT3U(prev_obj, !=, 0);
 	*txg = prev_obj_txg;
 	return (0);
 }

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -577,7 +577,7 @@ spa_history_log_internal_ds(dsl_dataset_t *ds, const char *operation,
 	char namebuf[ZFS_MAX_DATASET_NAME_LEN];
 	nvlist_t *nvl = fnvlist_alloc();
 
-	ASSERT(tx != NULL);
+	ASSERT3P(tx, !=, NULL);
 
 	dsl_dataset_name(ds, namebuf);
 	fnvlist_add_string(nvl, ZPOOL_HIST_DSNAME, namebuf);
@@ -596,7 +596,7 @@ spa_history_log_internal_dd(dsl_dir_t *dd, const char *operation,
 	char namebuf[ZFS_MAX_DATASET_NAME_LEN];
 	nvlist_t *nvl = fnvlist_alloc();
 
-	ASSERT(tx != NULL);
+	ASSERT3P(tx, !=, NULL);
 
 	dsl_dir_name(dd, namebuf);
 	fnvlist_add_string(nvl, ZPOOL_HIST_DSNAME, namebuf);

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -1093,7 +1093,7 @@ spa_ld_log_sm_cb(space_map_entry_t *sme, void *arg)
 		return (0);
 
 	metaslab_t *ms = vd->vdev_ms[offset >> vd->vdev_ms_shift];
-	ASSERT(!ms->ms_loaded);
+	ASSERT0(ms->ms_loaded);
 
 	/*
 	 * If we have already flushed entries for this TXG to this

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -1053,7 +1053,7 @@ spa_ld_log_sm_metadata(spa_t *spa)
 		 * lenient. Thus, for DEBUG bits we always cause a panic, while
 		 * in production we log the error and just fail the import.
 		 */
-		ASSERT(sls != NULL);
+		ASSERT3P(sls, !=, NULL);
 		if (sls == NULL) {
 			spa_load_failed(spa, "spa_ld_log_sm_metadata(): bug "
 			    "encountered: could not find log spacemap for "
@@ -1293,7 +1293,7 @@ spa_ld_unflushed_txgs(vdev_t *vd)
 
 	for (uint64_t m = 0; m < vd->vdev_ms_count; m++) {
 		metaslab_t *ms = vd->vdev_ms[m];
-		ASSERT(ms != NULL);
+		ASSERT3P(ms, !=, NULL);
 
 		metaslab_unflushed_phys_t entry;
 		uint64_t entry_size = sizeof (entry);

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -559,7 +559,7 @@ spa_log_sm_decrement_mscount(spa_t *spa, uint64_t txg)
 		return;
 	}
 
-	ASSERT(sls->sls_mscount > 0);
+	ASSERT3U(sls->sls_mscount, >, 0);
 	sls->sls_mscount--;
 }
 
@@ -638,7 +638,7 @@ spa_estimate_metaslabs_to_flush(spa_t *spa)
 {
 	ASSERT(spa_feature_is_active(spa, SPA_FEATURE_LOG_SPACEMAP));
 	ASSERT3U(spa_sync_pass(spa), ==, 1);
-	ASSERT(spa_log_sm_blocklimit(spa) != 0);
+	ASSERT3U(spa_log_sm_blocklimit(spa), !=, 0);
 
 	/*
 	 * This variable contains the incoming rate that will be projected
@@ -887,7 +887,7 @@ spa_sync_close_syncing_log_sm(spa_t *spa)
 	 * in spa_metaslabs_by_flushed is loading and we were
 	 * not able to flush any metaslabs the current TXG.
 	 */
-	ASSERT(sls->sls_nblocks != 0);
+	ASSERT3U(sls->sls_nblocks, !=, 0);
 
 	spa_log_summary_add_incoming_blocks(spa, sls->sls_nblocks);
 	spa_log_summary_verify_counts(spa);

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2091,7 +2091,7 @@ dva_get_dsize_sync(spa_t *spa, const dva_t *dva)
 	uint64_t asize = DVA_GET_ASIZE(dva);
 	uint64_t dsize = asize;
 
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_READER) != 0);
+	ASSERT3S(spa_config_held(spa, SCL_ALL, RW_READER), !=, 0);
 
 	if (asize != 0 && spa->spa_deflate) {
 		vdev_t *vd = vdev_lookup_top(spa, DVA_GET_VDEV(dva));

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -455,7 +455,7 @@ spa_config_lock_destroy(spa_t *spa)
 		spa_config_lock_t *scl = &spa->spa_config_lock[i];
 		mutex_destroy(&scl->scl_lock);
 		cv_destroy(&scl->scl_cv);
-		ASSERT(scl->scl_writer == NULL);
+		ASSERT3P(scl->scl_writer, ==, NULL);
 		ASSERT0(scl->scl_write_wanted);
 		ASSERT0(scl->scl_count);
 	}
@@ -977,7 +977,7 @@ spa_aux_remove(vdev_t *vd, avl_tree_t *avl)
 	search.aux_guid = vd->vdev_guid;
 	aux = avl_find(avl, &search, &where);
 
-	ASSERT(aux != NULL);
+	ASSERT3P(aux, !=, NULL);
 
 	if (--aux->aux_count == 0) {
 		avl_remove(avl, aux);
@@ -1020,7 +1020,7 @@ spa_aux_activate(vdev_t *vd, avl_tree_t *avl)
 
 	search.aux_guid = vd->vdev_guid;
 	found = avl_find(avl, &search, &where);
-	ASSERT(found != NULL);
+	ASSERT3P(found, !=, NULL);
 	ASSERT(found->aux_pool == 0ULL);
 
 	found->aux_pool = spa_guid(vd->vdev_spa);

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -456,8 +456,8 @@ spa_config_lock_destroy(spa_t *spa)
 		mutex_destroy(&scl->scl_lock);
 		cv_destroy(&scl->scl_cv);
 		ASSERT(scl->scl_writer == NULL);
-		ASSERT(scl->scl_write_wanted == 0);
-		ASSERT(scl->scl_count == 0);
+		ASSERT0(scl->scl_write_wanted);
+		ASSERT0(scl->scl_count);
 	}
 }
 
@@ -725,24 +725,23 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	dp->scd_path = altroot ? NULL : spa_strdup(spa_config_path);
 	list_insert_head(&spa->spa_config_list, dp);
 
-	VERIFY(nvlist_alloc(&spa->spa_load_info, NV_UNIQUE_NAME,
-	    KM_SLEEP) == 0);
+	VERIFY0(nvlist_alloc(&spa->spa_load_info, NV_UNIQUE_NAME, KM_SLEEP));
 
 	if (config != NULL) {
 		nvlist_t *features;
 
 		if (nvlist_lookup_nvlist(config, ZPOOL_CONFIG_FEATURES_FOR_READ,
 		    &features) == 0) {
-			VERIFY(nvlist_dup(features, &spa->spa_label_features,
-			    0) == 0);
+			VERIFY0(nvlist_dup(features, &spa->spa_label_features,
+			    0));
 		}
 
-		VERIFY(nvlist_dup(config, &spa->spa_config, 0) == 0);
+		VERIFY0(nvlist_dup(config, &spa->spa_config, 0));
 	}
 
 	if (spa->spa_label_features == NULL) {
-		VERIFY(nvlist_alloc(&spa->spa_label_features, NV_UNIQUE_NAME,
-		    KM_SLEEP) == 0);
+		VERIFY0(nvlist_alloc(&spa->spa_label_features, NV_UNIQUE_NAME,
+		    KM_SLEEP));
 	}
 
 	spa->spa_min_ashift = INT_MAX;
@@ -1059,7 +1058,7 @@ void
 spa_spare_add(vdev_t *vd)
 {
 	mutex_enter(&spa_spare_lock);
-	ASSERT(!vd->vdev_isspare);
+	ASSERT0(vd->vdev_isspare);
 	spa_aux_add(vd, &spa_spare_avl);
 	vd->vdev_isspare = B_TRUE;
 	mutex_exit(&spa_spare_lock);
@@ -1112,7 +1111,7 @@ void
 spa_l2cache_add(vdev_t *vd)
 {
 	mutex_enter(&spa_l2cache_lock);
-	ASSERT(!vd->vdev_isl2cache);
+	ASSERT0(vd->vdev_isl2cache);
 	spa_aux_add(vd, &spa_l2cache_avl);
 	vd->vdev_isl2cache = B_TRUE;
 	mutex_exit(&spa_l2cache_lock);
@@ -1239,11 +1238,11 @@ spa_vdev_config_exit(spa_t *spa, vdev_t *vd, uint64_t txg, int error,
 	/*
 	 * Verify the metaslab classes.
 	 */
-	ASSERT(metaslab_class_validate(spa_normal_class(spa)) == 0);
-	ASSERT(metaslab_class_validate(spa_log_class(spa)) == 0);
-	ASSERT(metaslab_class_validate(spa_embedded_log_class(spa)) == 0);
-	ASSERT(metaslab_class_validate(spa_special_class(spa)) == 0);
-	ASSERT(metaslab_class_validate(spa_dedup_class(spa)) == 0);
+	ASSERT0(metaslab_class_validate(spa_normal_class(spa)));
+	ASSERT0(metaslab_class_validate(spa_log_class(spa)));
+	ASSERT0(metaslab_class_validate(spa_embedded_log_class(spa)));
+	ASSERT0(metaslab_class_validate(spa_special_class(spa)));
+	ASSERT0(metaslab_class_validate(spa_dedup_class(spa)));
 
 	spa_config_exit(spa, SCL_ALL, spa);
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -477,7 +477,7 @@ spa_config_tryenter(spa_t *spa, int locks, const void *tag, krw_t rw)
 				return (0);
 			}
 		} else {
-			ASSERT(scl->scl_writer != curthread);
+			ASSERT3U(scl->scl_writer, !=, curthread);
 			if (scl->scl_count != 0) {
 				mutex_exit(&scl->scl_lock);
 				spa_config_exit(spa, locks & ((1 << i) - 1),
@@ -512,7 +512,7 @@ spa_config_enter(spa_t *spa, int locks, const void *tag, krw_t rw)
 				cv_wait(&scl->scl_cv, &scl->scl_lock);
 			}
 		} else {
-			ASSERT(scl->scl_writer != curthread);
+			ASSERT3U(scl->scl_writer, !=, curthread);
 			while (scl->scl_count != 0) {
 				scl->scl_write_wanted++;
 				cv_wait(&scl->scl_cv, &scl->scl_lock);
@@ -535,7 +535,7 @@ spa_config_exit(spa_t *spa, int locks, const void *tag)
 		if (!(locks & (1 << i)))
 			continue;
 		mutex_enter(&scl->scl_lock);
-		ASSERT(scl->scl_count > 0);
+		ASSERT3U(scl->scl_count, >, 0);
 		if (--scl->scl_count == 0) {
 			ASSERT(scl->scl_writer == NULL ||
 			    scl->scl_writer == curthread);
@@ -777,7 +777,7 @@ spa_remove(spa_t *spa)
 	spa_config_dirent_t *dp;
 
 	ASSERT(MUTEX_HELD(&spa_namespace_lock));
-	ASSERT(spa_state(spa) == POOL_STATE_UNINITIALIZED);
+	ASSERT3U(spa_state(spa), ==, POOL_STATE_UNINITIALIZED);
 	ASSERT3U(zfs_refcount_count(&spa->spa_refcount), ==, 0);
 	ASSERT0(spa->spa_waiters);
 
@@ -1021,7 +1021,7 @@ spa_aux_activate(vdev_t *vd, avl_tree_t *avl)
 	search.aux_guid = vd->vdev_guid;
 	found = avl_find(avl, &search, &where);
 	ASSERT3P(found, !=, NULL);
-	ASSERT(found->aux_pool == 0ULL);
+	ASSERT3U(found->aux_pool, ==, 0ULL);
 
 	found->aux_pool = spa_guid(vd->vdev_spa);
 }
@@ -1221,7 +1221,7 @@ spa_vdev_config_exit(spa_t *spa, vdev_t *vd, uint64_t txg, int error,
 
 	int config_changed = B_FALSE;
 
-	ASSERT(txg > spa_last_synced_txg(spa));
+	ASSERT3U(txg, >, spa_last_synced_txg(spa));
 
 	spa->spa_pending_vdev = NULL;
 
@@ -1926,7 +1926,7 @@ spa_preferred_class(spa_t *spa, uint64_t size, dmu_object_type_t objtype,
 	/*
 	 * ZIL allocations determine their class in zio_alloc_zil().
 	 */
-	ASSERT(objtype != DMU_OT_INTENT_LOG);
+	ASSERT3U(objtype, !=, DMU_OT_INTENT_LOG);
 
 	boolean_t has_special_class = spa->spa_special_class->mc_groups != 0;
 

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -717,7 +717,7 @@ spa_mmp_history_set(spa_t *spa, uint64_t mmp_node_id, int io_error,
 	for (smh = list_tail(&shl->procfs_list.pl_list); smh != NULL;
 	    smh = list_prev(&shl->procfs_list.pl_list, smh)) {
 		if (smh->mmp_node_id == mmp_node_id) {
-			ASSERT(smh->io_error == 0);
+			ASSERT0(smh->io_error);
 			smh->io_error = io_error;
 			smh->duration = duration;
 			error = 0;

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -815,7 +815,7 @@ space_map_open(space_map_t **smp, objset_t *os, uint64_t object,
 
 	ASSERT3P(*smp, ==, NULL);
 	ASSERT3P(os, !=, NULL);
-	ASSERT(object != 0);
+	ASSERT3U(object, !=, 0);
 
 	sm = kmem_alloc(sizeof (space_map_t), KM_SLEEP);
 

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -220,7 +220,7 @@ space_map_reversed_last_block_entries(space_map_t *sm, uint64_t *buf,
 	ASSERT3U(sm->sm_object, ==, db->db_object);
 	ASSERT3U(sm->sm_blksz, ==, db->db_size);
 	ASSERT3U(bufsz, >=, db->db_size);
-	ASSERT(nwords != NULL);
+	ASSERT3P(nwords, !=, NULL);
 
 	uint64_t *words = db->db_data;
 	*nwords =
@@ -813,8 +813,8 @@ space_map_open(space_map_t **smp, objset_t *os, uint64_t object,
 	space_map_t *sm;
 	int error;
 
-	ASSERT(*smp == NULL);
-	ASSERT(os != NULL);
+	ASSERT3P(*smp, ==, NULL);
+	ASSERT3P(os, !=, NULL);
 	ASSERT(object != 0);
 
 	sm = kmem_alloc(sizeof (space_map_t), KM_SLEEP);

--- a/module/zfs/space_reftree.c
+++ b/module/zfs/space_reftree.c
@@ -140,7 +140,7 @@ space_reftree_generate_map(avl_tree_t *t, range_tree_t *rt, int64_t minref)
 		} else {
 			if (start != -1ULL) {
 				uint64_t end = sr->sr_offset;
-				ASSERT(start <= end);
+				ASSERT3U(start, <=, end);
 				if (end > start)
 					range_tree_add(rt, start, end - start);
 				start = -1ULL;
@@ -148,5 +148,5 @@ space_reftree_generate_map(avl_tree_t *t, range_tree_t *rt, int64_t minref)
 		}
 	}
 	ASSERT0(refcnt);
-	ASSERT(start == -1ULL);
+	ASSERT3U(start, ==, -1ULL);
 }

--- a/module/zfs/space_reftree.c
+++ b/module/zfs/space_reftree.c
@@ -147,6 +147,6 @@ space_reftree_generate_map(avl_tree_t *t, range_tree_t *rt, int64_t minref)
 			}
 		}
 	}
-	ASSERT(refcnt == 0);
+	ASSERT0(refcnt);
 	ASSERT(start == -1ULL);
 }

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -346,7 +346,7 @@ txg_rele_to_quiesce(txg_handle_t *th)
 {
 	tx_cpu_t *tc = th->th_cpu;
 
-	ASSERT(!MUTEX_HELD(&tc->tc_lock));
+	ASSERT0(MUTEX_HELD(&tc->tc_lock));
 	mutex_exit(&tc->tc_open_lock);
 }
 
@@ -694,7 +694,7 @@ txg_wait_synced_impl(dsl_pool_t *dp, uint64_t txg, boolean_t wait_sig)
 {
 	tx_state_t *tx = &dp->dp_tx;
 
-	ASSERT(!dsl_pool_config_held(dp));
+	ASSERT0(dsl_pool_config_held(dp));
 
 	mutex_enter(&tx->tx_sync_lock);
 	ASSERT3U(tx->tx_threads, ==, 2);
@@ -755,7 +755,7 @@ txg_wait_open(dsl_pool_t *dp, uint64_t txg, boolean_t should_quiesce)
 {
 	tx_state_t *tx = &dp->dp_tx;
 
-	ASSERT(!dsl_pool_config_held(dp));
+	ASSERT0(dsl_pool_config_held(dp));
 
 	mutex_enter(&tx->tx_sync_lock);
 	ASSERT3U(tx->tx_threads, ==, 2);
@@ -792,7 +792,7 @@ txg_kick(dsl_pool_t *dp, uint64_t txg)
 {
 	tx_state_t *tx = &dp->dp_tx;
 
-	ASSERT(!dsl_pool_config_held(dp));
+	ASSERT0(dsl_pool_config_held(dp));
 
 	if (tx->tx_sync_txg_waiting >= txg)
 		return;

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -368,7 +368,7 @@ txg_rele_to_sync(txg_handle_t *th)
 	int g = th->th_txg & TXG_MASK;
 
 	mutex_enter(&tc->tc_lock);
-	ASSERT(tc->tc_count[g] != 0);
+	ASSERT3U(tc->tc_count[g], !=, 0);
 	if (--tc->tc_count[g] == 0)
 		cv_broadcast(&tc->tc_cv[g]);
 	mutex_exit(&tc->tc_lock);
@@ -396,7 +396,7 @@ txg_quiesce(dsl_pool_t *dp, uint64_t txg)
 	for (c = 0; c < max_ncpus; c++)
 		mutex_enter(&tx->tx_cpu[c].tc_open_lock);
 
-	ASSERT(txg == tx->tx_open_txg);
+	ASSERT3U(txg, ==, tx->tx_open_txg);
 	tx->tx_open_txg++;
 	tx->tx_open_time = tx_open_time = gethrtime();
 
@@ -574,7 +574,7 @@ txg_sync_thread(void *arg)
 		 * us.  This may cause the quiescing thread to now be
 		 * able to quiesce another txg, so we must signal it.
 		 */
-		ASSERT(tx->tx_quiesced_txg != 0);
+		ASSERT3U(tx->tx_quiesced_txg, !=, 0);
 		txg = tx->tx_quiesced_txg;
 		tx->tx_quiesced_txg = 0;
 		tx->tx_syncing_txg = txg;

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -229,7 +229,7 @@ txg_thread_enter(tx_state_t *tx, callb_cpr_t *cpr)
 static void
 txg_thread_exit(tx_state_t *tx, callb_cpr_t *cpr, kthread_t **tpp)
 {
-	ASSERT(*tpp != NULL);
+	ASSERT3P(*tpp, !=, NULL);
 	*tpp = NULL;
 	tx->tx_threads--;
 	cv_broadcast(&tx->tx_exit_cv);

--- a/module/zfs/uberblock.c
+++ b/module/zfs/uberblock.c
@@ -47,7 +47,7 @@ uberblock_verify(uberblock_t *ub)
 boolean_t
 uberblock_update(uberblock_t *ub, vdev_t *rvd, uint64_t txg, uint64_t mmp_delay)
 {
-	ASSERT(ub->ub_txg < txg);
+	ASSERT3U(ub->ub_txg, <, txg);
 
 	/*
 	 * We explicitly do not set ub_version here, so that older versions

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -433,7 +433,7 @@ vdev_lookup_top(spa_t *spa, uint64_t vdev)
 {
 	vdev_t *rvd = spa->spa_root_vdev;
 
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_READER) != 0);
+	ASSERT3S(spa_config_held(spa, SCL_ALL, RW_READER), !=, 0);
 
 	if (vdev < rvd->vdev_children) {
 		ASSERT3P(rvd->vdev_child[vdev], !=, NULL);
@@ -1655,7 +1655,7 @@ vdev_probe_done(zio_t *zio)
 		    (vdev_writeable(vd) || !spa_writeable(spa))) {
 			zio->io_error = 0;
 		} else {
-			ASSERT(zio->io_error != 0);
+			ASSERT3S(zio->io_error, !=, 0);
 			vdev_dbgmsg(vd, "failed probe");
 			(void) zfs_ereport_post(FM_EREPORT_ZFS_PROBE_FAILURE,
 			    spa, vd, NULL, NULL, 0);
@@ -3054,7 +3054,7 @@ vdev_dtl_reassess(vdev_t *vd, uint64_t txg, uint64_t scrub_txg,
 	avl_tree_t reftree;
 	int minref;
 
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_READER) != 0);
+	ASSERT3S(spa_config_held(spa, SCL_ALL, RW_READER), !=, 0);
 
 	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_dtl_reassess(vd->vdev_child[c], txg,
@@ -5588,7 +5588,7 @@ vdev_name(vdev_t *vd, char *buf, int buflen)
 boolean_t
 vdev_replace_in_progress(vdev_t *vdev)
 {
-	ASSERT(spa_config_held(vdev->vdev_spa, SCL_ALL, RW_READER) != 0);
+	ASSERT3S(spa_config_held(vdev->vdev_spa, SCL_ALL, RW_READER), !=, 0);
 
 	if (vdev->vdev_ops == &vdev_replacing_ops)
 		return (B_TRUE);

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -492,7 +492,8 @@ vdev_add_child(vdev_t *pvd, vdev_t *cvd)
 	uint64_t id = cvd->vdev_id;
 	vdev_t **newchild;
 
-	ASSERT(spa_config_held(cvd->vdev_spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(spa_config_held(cvd->vdev_spa, SCL_ALL, RW_WRITER), ==,
+	    SCL_ALL);
 	ASSERT3P(cvd->vdev_parent, ==, NULL);
 
 	cvd->vdev_parent = pvd;
@@ -536,13 +537,13 @@ vdev_remove_child(vdev_t *pvd, vdev_t *cvd)
 	int c;
 	uint_t id = cvd->vdev_id;
 
-	ASSERT(cvd->vdev_parent == pvd);
+	ASSERT3U(cvd->vdev_parent, ==, pvd);
 
 	if (pvd == NULL)
 		return;
 
-	ASSERT(id < pvd->vdev_children);
-	ASSERT(pvd->vdev_child[id] == cvd);
+	ASSERT3U(id, <, pvd->vdev_children);
+	ASSERT3U(pvd->vdev_child[id], ==, cvd);
 
 	pvd->vdev_child[id] = NULL;
 	cvd->vdev_parent = NULL;
@@ -580,7 +581,8 @@ vdev_compact_children(vdev_t *pvd)
 	int oldc = pvd->vdev_children;
 	int newc;
 
-	ASSERT(spa_config_held(pvd->vdev_spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(spa_config_held(pvd->vdev_spa, SCL_ALL, RW_WRITER), ==,
+	    SCL_ALL);
 
 	if (oldc == 0)
 		return;
@@ -736,7 +738,7 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 	vdev_alloc_bias_t alloc_bias = VDEV_BIAS_NONE;
 	boolean_t top_level = (parent && !parent->vdev_parent);
 
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(spa_config_held(spa, SCL_ALL, RW_WRITER), ==, SCL_ALL);
 
 	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE, &type) != 0)
 		return (SET_ERROR(EINVAL));
@@ -1051,7 +1053,7 @@ vdev_free(vdev_t *vd)
 		vdev_free(vd->vdev_child[c]);
 
 	ASSERT3P(vd->vdev_child, ==, NULL);
-	ASSERT(vd->vdev_guid_sum == vd->vdev_guid);
+	ASSERT3U(vd->vdev_guid_sum, ==, vd->vdev_guid);
 
 	if (vd->vdev_ops->vdev_op_fini != NULL)
 		vd->vdev_ops->vdev_op_fini(vd);
@@ -1303,7 +1305,7 @@ vdev_add_parent(vdev_t *cvd, vdev_ops_t *ops)
 	vdev_t *pvd = cvd->vdev_parent;
 	vdev_t *mvd;
 
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(spa_config_held(spa, SCL_ALL, RW_WRITER), ==, SCL_ALL);
 
 	mvd = vdev_alloc_common(spa, cvd->vdev_id, 0, ops);
 
@@ -1338,9 +1340,10 @@ vdev_remove_parent(vdev_t *cvd)
 	vdev_t *mvd = cvd->vdev_parent;
 	vdev_t *pvd = mvd->vdev_parent;
 
-	ASSERT(spa_config_held(cvd->vdev_spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(spa_config_held(cvd->vdev_spa, SCL_ALL, RW_WRITER), ==,
+	    SCL_ALL);
 
-	ASSERT(mvd->vdev_children == 1);
+	ASSERT3U(mvd->vdev_children, ==, 1);
 	ASSERT(mvd->vdev_ops == &vdev_mirror_ops ||
 	    mvd->vdev_ops == &vdev_replacing_ops ||
 	    mvd->vdev_ops == &vdev_spare_ops);
@@ -1462,7 +1465,7 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 
 	ASSERT0(vd->vdev_ishole);
 
-	ASSERT(oldc <= newc);
+	ASSERT3U(oldc, <=, newc);
 
 	mspp = vmem_zalloc(newc * sizeof (*mspp), KM_SLEEP);
 
@@ -1663,7 +1666,7 @@ vdev_probe_done(zio_t *zio)
 		}
 
 		mutex_enter(&vd->vdev_probe_lock);
-		ASSERT(vd->vdev_probe_zio == zio);
+		ASSERT3U(vd->vdev_probe_zio, ==, zio);
 		vd->vdev_probe_zio = NULL;
 		mutex_exit(&vd->vdev_probe_lock);
 
@@ -1840,8 +1843,8 @@ vdev_open_children_impl(vdev_t *vd, vdev_open_children_func_t *open_func)
 		if (tq == NULL || vdev_uses_zvols(vd)) {
 			cvd->vdev_open_error = vdev_open(cvd);
 		} else {
-			VERIFY(taskq_dispatch(tq, vdev_open_child,
-			    cvd, TQ_SLEEP) != TASKQID_INVALID);
+			VERIFY3U(taskq_dispatch(tq, vdev_open_child, cvd,
+			    TQ_SLEEP), !=, TASKQID_INVALID);
 		}
 
 		vd->vdev_nonrot &= cvd->vdev_nonrot;
@@ -2260,8 +2263,8 @@ vdev_validate(vdev_t *vd)
 		if (tq == NULL || vdev_uses_zvols(cvd)) {
 			vdev_validate_child(cvd);
 		} else {
-			VERIFY(taskq_dispatch(tq, vdev_validate_child, cvd,
-			    TQ_SLEEP) != TASKQID_INVALID);
+			VERIFY3U(taskq_dispatch(tq, vdev_validate_child, cvd,
+			    TQ_SLEEP), !=, TASKQID_INVALID);
 		}
 	}
 	if (tq != NULL) {
@@ -2535,7 +2538,7 @@ vdev_copy_path_strict(vdev_t *svd, vdev_t *dvd)
 static void
 vdev_copy_path_search(vdev_t *stvd, vdev_t *dvd)
 {
-	ASSERT(stvd->vdev_top == stvd);
+	ASSERT3U(stvd->vdev_top, ==, stvd);
 	ASSERT3U(stvd->vdev_id, ==, dvd->vdev_top->vdev_id);
 
 	for (uint64_t i = 0; i < dvd->vdev_children; i++) {
@@ -2570,8 +2573,8 @@ void
 vdev_copy_path_relaxed(vdev_t *srvd, vdev_t *drvd)
 {
 	uint64_t children = MIN(srvd->vdev_children, drvd->vdev_children);
-	ASSERT(srvd->vdev_ops == &vdev_root_ops);
-	ASSERT(drvd->vdev_ops == &vdev_root_ops);
+	ASSERT3U(srvd->vdev_ops, ==, &vdev_root_ops);
+	ASSERT3U(drvd->vdev_ops, ==, &vdev_root_ops);
 
 	for (uint64_t i = 0; i < children; i++) {
 		vdev_copy_path_search(srvd->vdev_child[i],
@@ -2655,7 +2658,8 @@ vdev_reopen(vdev_t *vd)
 {
 	spa_t *spa = vd->vdev_spa;
 
-	ASSERT(spa_config_held(spa, SCL_STATE_ALL, RW_WRITER) == SCL_STATE_ALL);
+	ASSERT3U(spa_config_held(spa, SCL_STATE_ALL, RW_WRITER), ==,
+	    SCL_STATE_ALL);
 
 	/* set the reopening flag unless we're taking the vdev offline */
 	vd->vdev_reopening = !vd->vdev_offline;
@@ -2866,7 +2870,7 @@ vdev_dtl_dirty(vdev_t *vd, vdev_dtl_type_t t, uint64_t txg, uint64_t size)
 {
 	range_tree_t *rt = vd->vdev_dtl[t];
 
-	ASSERT(t < DTL_TYPES);
+	ASSERT3U(t, <, DTL_TYPES);
 	ASSERT3P(vd, !=, vd->vdev_spa->spa_root_vdev);
 	ASSERT(spa_writeable(vd->vdev_spa));
 
@@ -2882,7 +2886,7 @@ vdev_dtl_contains(vdev_t *vd, vdev_dtl_type_t t, uint64_t txg, uint64_t size)
 	range_tree_t *rt = vd->vdev_dtl[t];
 	boolean_t dirty = B_FALSE;
 
-	ASSERT(t < DTL_TYPES);
+	ASSERT3U(t, <, DTL_TYPES);
 	ASSERT3P(vd, !=, vd->vdev_spa->spa_root_vdev);
 
 	/*
@@ -3290,7 +3294,7 @@ vdev_zap_allocation_data(vdev_t *vd, dmu_tx_t *tx)
 	vdev_alloc_bias_t alloc_bias = vd->vdev_alloc_bias;
 	const char *string;
 
-	ASSERT(alloc_bias != VDEV_BIAS_NONE);
+	ASSERT3U(alloc_bias, !=, VDEV_BIAS_NONE);
 
 	string =
 	    (alloc_bias == VDEV_BIAS_LOG) ? VDEV_ALLOC_BIAS_LOG :
@@ -3323,7 +3327,7 @@ vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx)
 	uint64_t zap = zap_create(spa->spa_meta_objset, DMU_OTN_ZAP_METADATA,
 	    DMU_OT_NONE, 0, tx);
 
-	ASSERT(zap != 0);
+	ASSERT3U(zap, !=, 0);
 	VERIFY0(zap_add_int(spa->spa_meta_objset, spa->spa_all_vdev_zaps,
 	    zap, tx));
 
@@ -3439,7 +3443,8 @@ vdev_dtl_required(vdev_t *vd)
 	uint8_t cant_read = vd->vdev_cant_read;
 	boolean_t required;
 
-	ASSERT(spa_config_held(spa, SCL_STATE_ALL, RW_WRITER) == SCL_STATE_ALL);
+	ASSERT3U(spa_config_held(spa, SCL_STATE_ALL, RW_WRITER), ==,
+	    SCL_STATE_ALL);
 
 	if (vd == spa->spa_root_vdev || vd == tvd)
 		return (B_TRUE);
@@ -3554,8 +3559,8 @@ vdev_load(vdev_t *vd)
 		if (tq == NULL || vdev_uses_zvols(cvd)) {
 			cvd->vdev_load_error = vdev_load(cvd);
 		} else {
-			VERIFY(taskq_dispatch(tq, vdev_load_child,
-			    cvd, TQ_SLEEP) != TASKQID_INVALID);
+			VERIFY3U(taskq_dispatch(tq, vdev_load_child, cvd,
+			    TQ_SLEEP), !=, TASKQID_INVALID);
 		}
 	}
 
@@ -3584,7 +3589,7 @@ vdev_load(vdev_t *vd)
 		    VDEV_TOP_ZAP_ALLOCATION_BIAS, 1, sizeof (bias_str),
 		    bias_str);
 		if (error == 0) {
-			ASSERT(vd->vdev_alloc_bias == VDEV_BIAS_NONE);
+			ASSERT3U(vd->vdev_alloc_bias, ==, VDEV_BIAS_NONE);
 			vd->vdev_alloc_bias = vdev_derive_alloc_bias(bias_str);
 		} else if (error != ENOENT) {
 			vdev_set_state(vd, B_FALSE, VDEV_STATE_CANT_OPEN,
@@ -3691,7 +3696,7 @@ vdev_load(vdev_t *vd)
 		error = vdev_checkpoint_sm_object(vd, &checkpoint_sm_obj);
 		if (error == 0 && checkpoint_sm_obj != 0) {
 			objset_t *mos = spa_meta_objset(vd->vdev_spa);
-			ASSERT(vd->vdev_asize != 0);
+			ASSERT3U(vd->vdev_asize, !=, 0);
 			ASSERT3P(vd->vdev_checkpoint_sm, ==, NULL);
 
 			error = space_map_open(&vd->vdev_checkpoint_sm,
@@ -3739,7 +3744,7 @@ vdev_load(vdev_t *vd)
 	error = vdev_obsolete_sm_object(vd, &obsolete_sm_object);
 	if (error == 0 && obsolete_sm_object != 0) {
 		objset_t *mos = vd->vdev_spa->spa_meta_objset;
-		ASSERT(vd->vdev_asize != 0);
+		ASSERT3U(vd->vdev_asize, !=, 0);
 		ASSERT3P(vd->vdev_obsolete_sm, ==, NULL);
 
 		if ((error = space_map_open(&vd->vdev_obsolete_sm, mos,
@@ -3927,7 +3932,7 @@ vdev_sync(vdev_t *vd, uint64_t txg)
 		ASSERT0(vd->vdev_indirect_config.vic_mapping_object);
 		vd->vdev_ms_array = dmu_object_alloc(spa->spa_meta_objset,
 		    DMU_OT_OBJECT_ARRAY, 0, DMU_OT_NONE, 0, tx);
-		ASSERT(vd->vdev_ms_array != 0);
+		ASSERT3U(vd->vdev_ms_array, !=, 0);
 		vdev_config_dirty(vd);
 	}
 
@@ -4321,7 +4326,8 @@ vdev_clear(spa_t *spa, vdev_t *vd)
 {
 	vdev_t *rvd = spa->spa_root_vdev;
 
-	ASSERT(spa_config_held(spa, SCL_STATE_ALL, RW_WRITER) == SCL_STATE_ALL);
+	ASSERT3U(spa_config_held(spa, SCL_STATE_ALL, RW_WRITER), ==,
+	    SCL_STATE_ALL);
 
 	if (vd == NULL)
 		vd = rvd;
@@ -4439,7 +4445,7 @@ vdev_allocatable(vdev_t *vd)
 boolean_t
 vdev_accessible(vdev_t *vd, zio_t *zio)
 {
-	ASSERT(zio->io_vd == vd);
+	ASSERT3U(zio->io_vd, ==, vd);
 
 	if (vdev_is_dead(vd) || vd->vdev_remove_wanted)
 		return (B_FALSE);
@@ -4882,14 +4888,14 @@ vdev_stat_update(zio_t *zio, uint64_t psize)
 			uint64_t commit_txg = txg;
 			if (flags & ZIO_FLAG_SCAN_THREAD) {
 				ASSERT(flags & ZIO_FLAG_IO_REPAIR);
-				ASSERT(spa_sync_pass(spa) == 1);
+				ASSERT3U(spa_sync_pass(spa), ==, 1);
 				vdev_dtl_dirty(vd, DTL_SCRUB, txg, 1);
 				commit_txg = spa_syncing_txg(spa);
 			} else if (spa->spa_claiming) {
 				ASSERT(flags & ZIO_FLAG_IO_REPAIR);
 				commit_txg = spa_first_txg(spa);
 			}
-			ASSERT(commit_txg >= spa_syncing_txg(spa));
+			ASSERT3U(commit_txg, >=, spa_syncing_txg(spa));
 			if (vdev_dtl_contains(vd, DTL_MISSING, txg, 1))
 				return;
 			for (pvd = vd; pvd != rvd; pvd = pvd->vdev_parent)
@@ -4988,7 +4994,7 @@ vdev_config_dirty(vdev_t *vd)
 			/*
 			 * We're being removed.  There's nothing more to do.
 			 */
-			ASSERT(sav->sav_sync == B_TRUE);
+			ASSERT3U(sav->sav_sync, ==, B_TRUE);
 			return;
 		}
 
@@ -5000,7 +5006,7 @@ vdev_config_dirty(vdev_t *vd)
 			    ZPOOL_CONFIG_SPARES, &aux, &naux));
 		}
 
-		ASSERT(c < naux);
+		ASSERT3U(c, <, naux);
 
 		/*
 		 * Setting the nvlist in the middle if the array is a little
@@ -5374,8 +5380,9 @@ vdev_log_state_valid(vdev_t *vd)
 void
 vdev_expand(vdev_t *vd, uint64_t txg)
 {
-	ASSERT(vd->vdev_top == vd);
-	ASSERT(spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(vd->vdev_top, ==, vd);
+	ASSERT3U(spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER), ==,
+	    SCL_ALL);
 	ASSERT(vdev_is_concrete(vd));
 
 	vdev_set_deflate_ratio(vd);
@@ -5694,7 +5701,7 @@ vdev_props_set_sync(void *arg, dmu_tx_t *tx)
 			proptype = vdev_prop_get_type(prop);
 
 			if (nvpair_type(elem) == DATA_TYPE_STRING) {
-				ASSERT(proptype == PROP_TYPE_STRING);
+				ASSERT3U(proptype, ==, PROP_TYPE_STRING);
 				strval = fnvpair_value_string(elem);
 				VERIFY0(zap_update(mos, objid, propname,
 				    1, strlen(strval) + 1, strval, tx));
@@ -5877,7 +5884,7 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 	} else {
 		return (SET_ERROR(EINVAL));
 	}
-	ASSERT(objid != 0);
+	ASSERT3U(objid, !=, 0);
 
 	mutex_enter(&spa->spa_props_lock);
 

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -2056,7 +2056,7 @@ vdev_draid_io_start(zio_t *zio)
 			vdev_draid_io_start_write(zio, rm->rm_row[i]);
 		}
 	} else {
-		ASSERT(zio->io_type == ZIO_TYPE_READ);
+		ASSERT3U(zio->io_type, ==, ZIO_TYPE_READ);
 
 		for (int i = 0; i < rm->rm_nrows; i++) {
 			vdev_draid_io_start_read(zio, rm->rm_row[i]);
@@ -2080,7 +2080,7 @@ static void
 vdev_draid_state_change(vdev_t *vd, int faulted, int degraded)
 {
 	vdev_draid_config_t *vdc = vd->vdev_tsd;
-	ASSERT(vd->vdev_ops == &vdev_draid_ops);
+	ASSERT3U(vd->vdev_ops, ==, &vdev_draid_ops);
 
 	if (faulted > vdc->vdc_nparity)
 		vdev_set_state(vd, B_FALSE, VDEV_STATE_CANT_OPEN,
@@ -2096,7 +2096,7 @@ vdev_draid_xlate(vdev_t *cvd, const range_seg64_t *logical_rs,
     range_seg64_t *physical_rs, range_seg64_t *remain_rs)
 {
 	vdev_t *raidvd = cvd->vdev_parent;
-	ASSERT(raidvd->vdev_ops == &vdev_draid_ops);
+	ASSERT3U(raidvd->vdev_ops, ==, &vdev_draid_ops);
 
 	vdev_draid_config_t *vdc = raidvd->vdev_tsd;
 	uint64_t ashift = raidvd->vdev_top->vdev_ashift;

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -821,7 +821,7 @@ vdev_draid_map_alloc_empty(zio_t *zio, raidz_row_t *rr)
 			ASSERT3U(rc->rc_size + skip_size, ==, parity_size);
 			ASSERT3U(rr->rr_nempty, !=, 0);
 			ASSERT3P(rc->rc_abd, !=, NULL);
-			ASSERT(!abd_is_gang(rc->rc_abd));
+			ASSERT0(abd_is_gang(rc->rc_abd));
 			abd_t *read_abd = rc->rc_abd;
 			rc->rc_abd = abd_alloc_gang();
 			abd_gang_add(rc->rc_abd, read_abd, B_TRUE);

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -328,8 +328,8 @@ vdev_indirect_mark_obsolete(vdev_t *vd, uint64_t offset, uint64_t size)
 	ASSERT3U(vd->vdev_indirect_config.vic_mapping_object, !=, 0);
 	ASSERT(vd->vdev_removing || vd->vdev_ops == &vdev_indirect_ops);
 	ASSERT(size > 0);
-	VERIFY(vdev_indirect_mapping_entry_for_offset(
-	    vd->vdev_indirect_mapping, offset) != NULL);
+	VERIFY3P(vdev_indirect_mapping_entry_for_offset(
+	    vd->vdev_indirect_mapping, offset), !=, NULL);
 
 	if (spa_feature_is_enabled(spa, SPA_FEATURE_OBSOLETE_COUNTS)) {
 		mutex_enter(&vd->vdev_obsolete_lock);
@@ -427,7 +427,7 @@ vdev_indirect_should_condense(vdev_t *vd)
 		return (B_FALSE);
 	}
 
-	ASSERT(vd->vdev_obsolete_sm != NULL);
+	ASSERT3P(vd->vdev_obsolete_sm, !=, NULL);
 
 	ASSERT3U(obsolete_sm_obj, ==, space_map_object(vd->vdev_obsolete_sm));
 
@@ -839,7 +839,7 @@ vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 		    0, vd->vdev_asize, 0));
 	}
 
-	ASSERT(vd->vdev_obsolete_sm != NULL);
+	ASSERT3P(vd->vdev_obsolete_sm, !=, NULL);
 	ASSERT3U(obsolete_sm_object, ==,
 	    space_map_object(vd->vdev_obsolete_sm));
 

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -1069,7 +1069,7 @@ vdev_indirect_remap(vdev_t *vd, uint64_t offset, uint64_t asize,
 		vdev_t *v = rs->rs_vd;
 		uint64_t num_entries = 0;
 
-		ASSERT(spa_config_held(spa, SCL_ALL, RW_READER) != 0);
+		ASSERT3S(spa_config_held(spa, SCL_ALL, RW_READER), !=, 0);
 		ASSERT(rs->rs_asize > 0);
 
 		/*
@@ -1304,7 +1304,7 @@ vdev_indirect_io_start(zio_t *zio)
 	zio->io_vsd = iv;
 	zio->io_vsd_ops = &vdev_indirect_vsd_ops;
 
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_READER) != 0);
+	ASSERT3S(spa_config_held(spa, SCL_ALL, RW_READER), !=, 0);
 	if (zio->io_type != ZIO_TYPE_READ) {
 		ASSERT3U(zio->io_type, ==, ZIO_TYPE_WRITE);
 		/*

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -327,7 +327,7 @@ vdev_indirect_mark_obsolete(vdev_t *vd, uint64_t offset, uint64_t size)
 
 	ASSERT3U(vd->vdev_indirect_config.vic_mapping_object, !=, 0);
 	ASSERT(vd->vdev_removing || vd->vdev_ops == &vdev_indirect_ops);
-	ASSERT(size > 0);
+	ASSERT3U(size, >, 0);
 	VERIFY3P(vdev_indirect_mapping_entry_for_offset(
 	    vd->vdev_indirect_mapping, offset), !=, NULL);
 
@@ -497,10 +497,10 @@ spa_condense_indirect_complete_sync(void *arg, dmu_tx_t *tx)
 	for (int i = 0; i < TXG_SIZE; i++) {
 		ASSERT(list_is_empty(&sci->sci_new_mapping_entries[i]));
 	}
-	ASSERT(vic->vic_mapping_object != 0);
+	ASSERT3U(vic->vic_mapping_object, !=, 0);
 	ASSERT3U(vd->vdev_id, ==, scip->scip_vdev);
-	ASSERT(scip->scip_next_mapping_object != 0);
-	ASSERT(scip->scip_prev_obsolete_sm_object != 0);
+	ASSERT3U(scip->scip_next_mapping_object, !=, 0);
+	ASSERT3U(scip->scip_prev_obsolete_sm_object, !=, 0);
 
 	/*
 	 * Reset vdev_indirect_mapping to refer to the new object.
@@ -667,8 +667,8 @@ spa_condense_indirect_thread(void *arg, zthr_t *zthr)
 	space_map_t *prev_obsolete_sm = NULL;
 
 	ASSERT3U(vd->vdev_id, ==, scip->scip_vdev);
-	ASSERT(scip->scip_next_mapping_object != 0);
-	ASSERT(scip->scip_prev_obsolete_sm_object != 0);
+	ASSERT3U(scip->scip_next_mapping_object, !=, 0);
+	ASSERT3U(scip->scip_prev_obsolete_sm_object, !=, 0);
 	ASSERT3P(vd->vdev_ops, ==, &vdev_indirect_ops);
 
 	for (int i = 0; i < TXG_SIZE; i++) {
@@ -816,7 +816,7 @@ vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 	vdev_indirect_config_t *vic __maybe_unused = &vd->vdev_indirect_config;
 
 	ASSERT3U(vic->vic_mapping_object, !=, 0);
-	ASSERT(range_tree_space(vd->vdev_obsolete_segments) > 0);
+	ASSERT3U(range_tree_space(vd->vdev_obsolete_segments), >, 0);
 	ASSERT(vd->vdev_removing || vd->vdev_ops == &vdev_indirect_ops);
 	ASSERT(spa_feature_is_enabled(spa, SPA_FEATURE_OBSOLETE_COUNTS));
 
@@ -826,7 +826,7 @@ vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 		obsolete_sm_object = space_map_alloc(spa->spa_meta_objset,
 		    zfs_vdev_standard_sm_blksz, tx);
 
-		ASSERT(vd->vdev_top_zap != 0);
+		ASSERT3U(vd->vdev_top_zap, !=, 0);
 		VERIFY0(zap_add(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_INDIRECT_OBSOLETE_SM,
 		    sizeof (obsolete_sm_object), 1, &obsolete_sm_object, tx));
@@ -1070,7 +1070,7 @@ vdev_indirect_remap(vdev_t *vd, uint64_t offset, uint64_t asize,
 		uint64_t num_entries = 0;
 
 		ASSERT3S(spa_config_held(spa, SCL_ALL, RW_READER), !=, 0);
-		ASSERT(rs->rs_asize > 0);
+		ASSERT3U(rs->rs_asize, >, 0);
 
 		/*
 		 * Note: As this function can be called from open context
@@ -1311,8 +1311,8 @@ vdev_indirect_io_start(zio_t *zio)
 		 * Note: this code can handle other kinds of writes,
 		 * but we don't expect them.
 		 */
-		ASSERT((zio->io_flags & (ZIO_FLAG_SELF_HEAL |
-		    ZIO_FLAG_RESILVER | ZIO_FLAG_INDUCE_DAMAGE)) != 0);
+		ASSERT3U((zio->io_flags & (ZIO_FLAG_SELF_HEAL |
+		    ZIO_FLAG_RESILVER | ZIO_FLAG_INDUCE_DAMAGE)), !=, 0);
 	}
 
 	vdev_indirect_remap(zio->io_vd, zio->io_offset, zio->io_size,

--- a/module/zfs/vdev_indirect_births.c
+++ b/module/zfs/vdev_indirect_births.c
@@ -29,7 +29,7 @@ vdev_indirect_births_verify(vdev_indirect_births_t *vib)
 {
 	ASSERT3P(vib, !=, NULL);
 
-	ASSERT(vib->vib_object != 0);
+	ASSERT3U(vib->vib_object, !=, 0);
 	ASSERT3P(vib->vib_objset, !=, NULL);
 	ASSERT3P(vib->vib_phys, !=, NULL);
 	ASSERT3P(vib->vib_dbuf, !=, NULL);
@@ -163,7 +163,7 @@ uint64_t
 vdev_indirect_births_last_entry_txg(vdev_indirect_births_t *vib)
 {
 	ASSERT(vdev_indirect_births_verify(vib));
-	ASSERT(vib->vib_phys->vib_count > 0);
+	ASSERT3U(vib->vib_phys->vib_count, >, 0);
 
 	vdev_indirect_birth_entry_phys_t *last =
 	    &vib->vib_entries[vib->vib_phys->vib_count - 1];
@@ -191,7 +191,7 @@ vdev_indirect_births_physbirth(vdev_indirect_births_t *vib, uint64_t offset,
 	vdev_indirect_birth_entry_phys_t *last;
 
 	ASSERT(vdev_indirect_births_verify(vib));
-	ASSERT(vib->vib_phys->vib_count > 0);
+	ASSERT3U(vib->vib_phys->vib_count, >, 0);
 
 	base = vib->vib_entries;
 	last = base + vib->vib_phys->vib_count - 1;

--- a/module/zfs/vdev_indirect_births.c
+++ b/module/zfs/vdev_indirect_births.c
@@ -27,12 +27,12 @@
 static boolean_t
 vdev_indirect_births_verify(vdev_indirect_births_t *vib)
 {
-	ASSERT(vib != NULL);
+	ASSERT3P(vib, !=, NULL);
 
 	ASSERT(vib->vib_object != 0);
-	ASSERT(vib->vib_objset != NULL);
-	ASSERT(vib->vib_phys != NULL);
-	ASSERT(vib->vib_dbuf != NULL);
+	ASSERT3P(vib->vib_objset, !=, NULL);
+	ASSERT3P(vib->vib_phys, !=, NULL);
+	ASSERT3P(vib->vib_dbuf, !=, NULL);
 
 	EQUIV(vib->vib_phys->vib_count > 0, vib->vib_entries != NULL);
 

--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -403,7 +403,7 @@ vdev_indirect_mapping_add_entries(vdev_indirect_mapping_t *vim,
 	ASSERT(vdev_indirect_mapping_verify(vim));
 	ASSERT(dmu_tx_is_syncing(tx));
 	ASSERT(dsl_pool_sync_context(dmu_tx_pool(tx)));
-	ASSERT(!list_is_empty(list));
+	ASSERT0(list_is_empty(list));
 
 	old_size = vdev_indirect_mapping_size(vim);
 	old_entries = vim->vim_entries;

--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -31,7 +31,7 @@ vdev_indirect_mapping_verify(vdev_indirect_mapping_t *vim)
 {
 	ASSERT3P(vim, !=, NULL);
 
-	ASSERT(vim->vim_object != 0);
+	ASSERT3U(vim->vim_object, !=, 0);
 	ASSERT3P(vim->vim_objset, !=, NULL);
 	ASSERT3P(vim->vim_phys, !=, NULL);
 	ASSERT3P(vim->vim_dbuf, !=, NULL);
@@ -49,7 +49,7 @@ vdev_indirect_mapping_verify(vdev_indirect_mapping_t *vim)
 		ASSERT3U(vim->vim_phys->vimp_max_offset, >=, offset + size);
 	}
 	if (vim->vim_havecounts) {
-		ASSERT(vim->vim_phys->vimp_counts_object != 0);
+		ASSERT3U(vim->vim_phys->vimp_counts_object, !=, 0);
 	}
 
 	return (B_TRUE);
@@ -177,7 +177,7 @@ vdev_indirect_mapping_entry_for_offset_impl(vdev_indirect_mapping_t *vim,
     uint64_t offset, boolean_t next_if_missing)
 {
 	ASSERT(vdev_indirect_mapping_verify(vim));
-	ASSERT(vim->vim_phys->vimp_num_entries > 0);
+	ASSERT3U(vim->vim_phys->vimp_num_entries, >, 0);
 
 	vdev_indirect_mapping_entry_phys_t *entry = NULL;
 
@@ -511,7 +511,7 @@ vdev_indirect_mapping_increment_obsolete_count(vdev_indirect_mapping_t *vim,
 
 	mapping = vdev_indirect_mapping_entry_for_offset(vim,  offset);
 
-	ASSERT(length > 0);
+	ASSERT3U(length, >, 0);
 	ASSERT3P(mapping, !=, NULL);
 
 	index = mapping - vim->vim_entries;

--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -29,12 +29,12 @@
 static boolean_t
 vdev_indirect_mapping_verify(vdev_indirect_mapping_t *vim)
 {
-	ASSERT(vim != NULL);
+	ASSERT3P(vim, !=, NULL);
 
 	ASSERT(vim->vim_object != 0);
-	ASSERT(vim->vim_objset != NULL);
-	ASSERT(vim->vim_phys != NULL);
-	ASSERT(vim->vim_dbuf != NULL);
+	ASSERT3P(vim->vim_objset, !=, NULL);
+	ASSERT3P(vim->vim_phys, !=, NULL);
+	ASSERT3P(vim->vim_dbuf, !=, NULL);
 
 	EQUIV(vim->vim_phys->vimp_num_entries > 0,
 	    vim->vim_entries != NULL);

--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -585,9 +585,9 @@ vdev_initialize(vdev_t *vd)
 	ASSERT(vd->vdev_ops->vdev_op_leaf);
 	ASSERT(vdev_is_concrete(vd));
 	ASSERT3P(vd->vdev_initialize_thread, ==, NULL);
-	ASSERT(!vd->vdev_detached);
-	ASSERT(!vd->vdev_initialize_exit_wanted);
-	ASSERT(!vd->vdev_top->vdev_removing);
+	ASSERT0(vd->vdev_detached);
+	ASSERT0(vd->vdev_initialize_exit_wanted);
+	ASSERT0(vd->vdev_top->vdev_removing);
 
 	vdev_initialize_change_state(vd, VDEV_INITIALIZE_ACTIVE);
 	vd->vdev_initialize_thread = thread_create(NULL, 0,
@@ -640,7 +640,8 @@ void
 vdev_initialize_stop(vdev_t *vd, vdev_initializing_state_t tgt_state,
     list_t *vd_list)
 {
-	ASSERT(!spa_config_held(vd->vdev_spa, SCL_CONFIG|SCL_STATE, RW_WRITER));
+	ASSERT0(spa_config_held(vd->vdev_spa, SCL_CONFIG | SCL_STATE,
+	    RW_WRITER));
 	ASSERT(MUTEX_HELD(&vd->vdev_initialize_lock));
 	ASSERT(vd->vdev_ops->vdev_op_leaf);
 	ASSERT(vdev_is_concrete(vd));
@@ -712,7 +713,7 @@ void
 vdev_initialize_restart(vdev_t *vd)
 {
 	ASSERT(MUTEX_HELD(&spa_namespace_lock));
-	ASSERT(!spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER));
+	ASSERT0(spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER));
 
 	if (vd->vdev_leaf_zap != 0) {
 		mutex_enter(&vd->vdev_initialize_lock);

--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -73,7 +73,7 @@ vdev_initialize_zap_update_sync(void *arg, dmu_tx_t *tx)
 	uint64_t last_offset = vd->vdev_initialize_offset[txg & TXG_MASK];
 	vd->vdev_initialize_offset[txg & TXG_MASK] = 0;
 
-	VERIFY(vd->vdev_leaf_zap != 0);
+	VERIFY3U(vd->vdev_leaf_zap, !=, 0);
 
 	objset_t *mos = vd->vdev_spa->spa_meta_objset;
 
@@ -343,7 +343,7 @@ vdev_initialize_calculate_progress(vdev_t *vd)
 {
 	ASSERT(spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_READER) ||
 	    spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_WRITER));
-	ASSERT(vd->vdev_leaf_zap != 0);
+	ASSERT3U(vd->vdev_leaf_zap, !=, 0);
 
 	vd->vdev_initialize_bytes_est = 0;
 	vd->vdev_initialize_bytes_done = 0;
@@ -416,7 +416,7 @@ vdev_initialize_load(vdev_t *vd)
 	int err = 0;
 	ASSERT(spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_READER) ||
 	    spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_WRITER));
-	ASSERT(vd->vdev_leaf_zap != 0);
+	ASSERT3U(vd->vdev_leaf_zap, !=, 0);
 
 	if (vd->vdev_initialize_state == VDEV_INITIALIZE_ACTIVE ||
 	    vd->vdev_initialize_state == VDEV_INITIALIZE_SUSPENDED) {

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -161,7 +161,7 @@ uint64_t
 vdev_label_offset(uint64_t psize, int l, uint64_t offset)
 {
 	ASSERT(offset < sizeof (vdev_label_t));
-	ASSERT(P2PHASE_TYPED(psize, sizeof (vdev_label_t), uint64_t) == 0);
+	ASSERT0(P2PHASE_TYPED(psize, sizeof (vdev_label_t), uint64_t));
 
 	return (offset + l * sizeof (vdev_label_t) + (l < VDEV_LABELS / 2 ?
 	    0 : psize - VDEV_LABELS * sizeof (vdev_label_t)));
@@ -646,7 +646,7 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 		nvlist_t **child;
 		int c, idx;
 
-		ASSERT(!vd->vdev_ishole);
+		ASSERT0(vd->vdev_ishole);
 
 		child = kmem_alloc(vd->vdev_children * sizeof (nvlist_t *),
 		    KM_SLEEP);
@@ -753,12 +753,12 @@ vdev_top_config_generate(spa_t *spa, nvlist_t *config)
 	}
 
 	if (idx) {
-		VERIFY(nvlist_add_uint64_array(config, ZPOOL_CONFIG_HOLE_ARRAY,
-		    array, idx) == 0);
+		VERIFY0(nvlist_add_uint64_array(config,
+		    ZPOOL_CONFIG_HOLE_ARRAY, array, idx));
 	}
 
-	VERIFY(nvlist_add_uint64(config, ZPOOL_CONFIG_VDEV_CHILDREN,
-	    rvd->vdev_children) == 0);
+	VERIFY0(nvlist_add_uint64(config, ZPOOL_CONFIG_VDEV_CHILDREN,
+	    rvd->vdev_children));
 
 	kmem_free(array, rvd->vdev_children * sizeof (uint64_t));
 }
@@ -1116,27 +1116,27 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 		 * active hot spare (in which case we want to revert the
 		 * labels).
 		 */
-		VERIFY(nvlist_alloc(&label, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+		VERIFY0(nvlist_alloc(&label, NV_UNIQUE_NAME, KM_SLEEP));
 
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_VERSION,
-		    spa_version(spa)) == 0);
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_POOL_STATE,
-		    POOL_STATE_SPARE) == 0);
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_GUID,
-		    vd->vdev_guid) == 0);
+		VERIFY0(nvlist_add_uint64(label, ZPOOL_CONFIG_VERSION,
+		    spa_version(spa)));
+		VERIFY0(nvlist_add_uint64(label, ZPOOL_CONFIG_POOL_STATE,
+		    POOL_STATE_SPARE));
+		VERIFY0(nvlist_add_uint64(label, ZPOOL_CONFIG_GUID,
+		    vd->vdev_guid));
 	} else if (reason == VDEV_LABEL_L2CACHE ||
 	    (reason == VDEV_LABEL_REMOVE && vd->vdev_isl2cache)) {
 		/*
 		 * For level 2 ARC devices, add a special label.
 		 */
-		VERIFY(nvlist_alloc(&label, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+		VERIFY0(nvlist_alloc(&label, NV_UNIQUE_NAME, KM_SLEEP));
 
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_VERSION,
-		    spa_version(spa)) == 0);
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_POOL_STATE,
-		    POOL_STATE_L2CACHE) == 0);
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_GUID,
-		    vd->vdev_guid) == 0);
+		VERIFY0(nvlist_add_uint64(label, ZPOOL_CONFIG_VERSION,
+		    spa_version(spa)));
+		VERIFY0(nvlist_add_uint64(label, ZPOOL_CONFIG_POOL_STATE,
+		    POOL_STATE_L2CACHE));
+		VERIFY0(nvlist_add_uint64(label, ZPOOL_CONFIG_GUID,
+		    vd->vdev_guid));
 	} else {
 		uint64_t txg = 0ULL;
 
@@ -1149,8 +1149,8 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 		 * vdev uses as described above, and automatically expires if we
 		 * fail.
 		 */
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_CREATE_TXG,
-		    crtxg) == 0);
+		VERIFY0(nvlist_add_uint64(label, ZPOOL_CONFIG_CREATE_TXG,
+		    crtxg));
 	}
 
 	buf = vp->vp_nvlist;
@@ -1866,7 +1866,7 @@ vdev_label_sync_list(spa_t *spa, int l, uint64_t txg, int flags)
 	for (vd = list_head(dl); vd != NULL; vd = list_next(dl, vd)) {
 		uint64_t *good_writes;
 
-		ASSERT(!vd->vdev_ishole);
+		ASSERT0(vd->vdev_ishole);
 
 		good_writes = kmem_zalloc(sizeof (uint64_t), KM_SLEEP);
 		zio_t *vio = zio_null(zio, spa, NULL,

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -160,7 +160,7 @@
 uint64_t
 vdev_label_offset(uint64_t psize, int l, uint64_t offset)
 {
-	ASSERT(offset < sizeof (vdev_label_t));
+	ASSERT3U(offset, <, sizeof (vdev_label_t));
 	ASSERT0(P2PHASE_TYPED(psize, sizeof (vdev_label_t), uint64_t));
 
 	return (offset + l * sizeof (vdev_label_t) + (l < VDEV_LABELS / 2 ?
@@ -1023,7 +1023,7 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 	uint64_t spare_guid = 0, l2cache_guid = 0;
 	int flags = ZIO_FLAG_CONFIG_WRITER | ZIO_FLAG_CANFAIL;
 
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(spa_config_held(spa, SCL_ALL, RW_WRITER), ==, SCL_ALL);
 
 	for (int c = 0; c < vd->vdev_children; c++)
 		if ((error = vdev_label_init(vd->vdev_child[c],
@@ -1091,7 +1091,7 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 		 */
 		if (reason == VDEV_LABEL_L2CACHE)
 			return (0);
-		ASSERT(reason == VDEV_LABEL_REPLACE);
+		ASSERT3U(reason, ==, VDEV_LABEL_REPLACE);
 	}
 
 	/*
@@ -1293,7 +1293,7 @@ vdev_label_read_bootenv(vdev_t *rvd, nvlist_t *bootenv)
 	    ZIO_FLAG_SPECULATIVE | ZIO_FLAG_TRYHARD;
 
 	ASSERT(bootenv);
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(spa_config_held(spa, SCL_ALL, RW_WRITER), ==, SCL_ALL);
 
 	zio_t *zio = zio_root(spa, NULL, &abd, flags);
 	vdev_label_read_bootenv_impl(zio, rvd, flags);
@@ -1368,7 +1368,7 @@ vdev_label_write_bootenv(vdev_t *vd, nvlist_t *env)
 		return (SET_ERROR(E2BIG));
 	}
 
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(spa_config_held(spa, SCL_ALL, RW_WRITER), ==, SCL_ALL);
 
 	error = ENXIO;
 	for (int c = 0; c < vd->vdev_children; c++) {
@@ -1619,7 +1619,7 @@ vdev_copy_uberblocks(vdev_t *vd)
 	int flags = ZIO_FLAG_CONFIG_WRITER | ZIO_FLAG_CANFAIL |
 	    ZIO_FLAG_SPECULATIVE;
 
-	ASSERT(spa_config_held(vd->vdev_spa, SCL_STATE, RW_READER) ==
+	ASSERT3U(spa_config_held(vd->vdev_spa, SCL_STATE, RW_READER), ==,
 	    SCL_STATE);
 	ASSERT(vd->vdev_ops->vdev_op_leaf);
 
@@ -1926,7 +1926,7 @@ retry:
 		flags |= ZIO_FLAG_TRYHARD;
 	}
 
-	ASSERT(ub->ub_txg <= txg);
+	ASSERT3U(ub->ub_txg, <=, txg);
 
 	/*
 	 * If this isn't a resync due to I/O errors,
@@ -1945,7 +1945,7 @@ retry:
 	if (txg > spa_freeze_txg(spa))
 		return (0);
 
-	ASSERT(txg <= spa->spa_final_txg);
+	ASSERT3U(txg, <=, spa->spa_final_txg);
 
 	/*
 	 * Flush the write cache of every disk that's been written to

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -563,7 +563,7 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 		}
 
 		if (vd->vdev_top_zap != 0) {
-			ASSERT(vd == vd->vdev_top);
+			ASSERT3P(vd, ==, vd->vdev_top);
 			fnvlist_add_uint64(nv, ZPOOL_CONFIG_VDEV_TOP_ZAP,
 			    vd->vdev_top_zap);
 		}
@@ -588,7 +588,7 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 		 */
 		rw_enter(&vd->vdev_indirect_rwlock, RW_READER);
 		if (vd->vdev_indirect_mapping != NULL) {
-			ASSERT(vd->vdev_indirect_births != NULL);
+			ASSERT3P(vd->vdev_indirect_births, !=, NULL);
 			vdev_indirect_mapping_t *vim =
 			    vd->vdev_indirect_mapping;
 			fnvlist_add_uint64(nv, ZPOOL_CONFIG_INDIRECT_SIZE,

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -1911,7 +1911,7 @@ vdev_config_sync(vdev_t **svd, int svdcount, uint64_t txg)
 	int error = 0;
 	int flags = ZIO_FLAG_CONFIG_WRITER | ZIO_FLAG_CANFAIL;
 
-	ASSERT(svdcount != 0);
+	ASSERT3S(svdcount, !=, 0);
 retry:
 	/*
 	 * Normally, we don't want to try too hard to write every label and

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -612,7 +612,7 @@ vdev_mirror_io_start(zio_t *zio)
 	zio->io_vsd_ops = &vdev_mirror_vsd_ops;
 
 	if (mm == NULL) {
-		ASSERT(!spa_trust_config(zio->io_spa));
+		ASSERT0(spa_trust_config(zio->io_spa));
 		ASSERT(zio->io_type == ZIO_TYPE_READ);
 		zio_execute(zio);
 		return;

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -613,7 +613,7 @@ vdev_mirror_io_start(zio_t *zio)
 
 	if (mm == NULL) {
 		ASSERT0(spa_trust_config(zio->io_spa));
-		ASSERT(zio->io_type == ZIO_TYPE_READ);
+		ASSERT3U(zio->io_type, ==, ZIO_TYPE_READ);
 		zio_execute(zio);
 		return;
 	}
@@ -658,7 +658,7 @@ vdev_mirror_io_start(zio_t *zio)
 		c = vdev_mirror_child_select(zio);
 		children = (c >= 0);
 	} else {
-		ASSERT(zio->io_type == ZIO_TYPE_WRITE);
+		ASSERT3U(zio->io_type, ==, ZIO_TYPE_WRITE);
 
 		/*
 		 * Writes go to all children.
@@ -762,7 +762,7 @@ vdev_mirror_io_done(zio_t *zio)
 		return;
 	}
 
-	ASSERT(zio->io_type == ZIO_TYPE_READ);
+	ASSERT3U(zio->io_type, ==, ZIO_TYPE_READ);
 
 	/*
 	 * If we don't have a good copy yet, keep trying other children.

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -854,7 +854,7 @@ vdev_mirror_io_done(zio_t *zio)
 
 	if (good_copies == 0) {
 		zio->io_error = vdev_mirror_worst_error(mm);
-		ASSERT(zio->io_error != 0);
+		ASSERT3S(zio->io_error, !=, 0);
 	}
 
 	if (good_copies && spa_writeable(zio->io_spa) &&

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -631,7 +631,7 @@ vdev_queue_aggregate(vdev_queue_t *vq, zio_t *zio)
 	 * leaf vdevs for aggregation.  See the comment at the end of the
 	 * zio_vdev_io_start() function.
 	 */
-	ASSERT(vq->vq_vdev->vdev_ops != &vdev_draid_spare_ops);
+	ASSERT3U(vq->vq_vdev->vdev_ops, !=, &vdev_draid_spare_ops);
 
 	first = last = zio;
 
@@ -882,7 +882,7 @@ vdev_queue_io(zio_t *zio)
 	 * not match the child's i/o type.  Fix it up here.
 	 */
 	if (zio->io_type == ZIO_TYPE_READ) {
-		ASSERT(zio->io_priority != ZIO_PRIORITY_TRIM);
+		ASSERT3U(zio->io_priority, !=, ZIO_PRIORITY_TRIM);
 
 		if (zio->io_priority != ZIO_PRIORITY_SYNC_READ &&
 		    zio->io_priority != ZIO_PRIORITY_ASYNC_READ &&
@@ -893,7 +893,7 @@ vdev_queue_io(zio_t *zio)
 			zio->io_priority = ZIO_PRIORITY_ASYNC_READ;
 		}
 	} else if (zio->io_type == ZIO_TYPE_WRITE) {
-		ASSERT(zio->io_priority != ZIO_PRIORITY_TRIM);
+		ASSERT3U(zio->io_priority, !=, ZIO_PRIORITY_TRIM);
 
 		if (zio->io_priority != ZIO_PRIORITY_SYNC_WRITE &&
 		    zio->io_priority != ZIO_PRIORITY_ASYNC_WRITE &&
@@ -903,8 +903,8 @@ vdev_queue_io(zio_t *zio)
 			zio->io_priority = ZIO_PRIORITY_ASYNC_WRITE;
 		}
 	} else {
-		ASSERT(zio->io_type == ZIO_TYPE_TRIM);
-		ASSERT(zio->io_priority == ZIO_PRIORITY_TRIM);
+		ASSERT3U(zio->io_type, ==, ZIO_TYPE_TRIM);
+		ASSERT3U(zio->io_priority, ==, ZIO_PRIORITY_TRIM);
 	}
 
 	zio->io_flags |= ZIO_FLAG_DONT_CACHE | ZIO_FLAG_DONT_QUEUE;
@@ -988,7 +988,7 @@ vdev_queue_change_io_priority(zio_t *zio, zio_priority_t priority)
 		    priority != ZIO_PRIORITY_SCRUB)
 			priority = ZIO_PRIORITY_ASYNC_READ;
 	} else {
-		ASSERT(zio->io_type == ZIO_TYPE_WRITE);
+		ASSERT3U(zio->io_type, ==, ZIO_TYPE_WRITE);
 		if (priority != ZIO_PRIORITY_SYNC_WRITE &&
 		    priority != ZIO_PRIORITY_ASYNC_WRITE)
 			priority = ZIO_PRIORITY_ASYNC_WRITE;

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -672,7 +672,7 @@ vdev_queue_aggregate(vdev_queue_t *vq, zio_t *zio)
 	 */
 	while ((first->io_flags & ZIO_FLAG_OPTIONAL) && first != last) {
 		first = AVL_NEXT(t, first);
-		ASSERT(first != NULL);
+		ASSERT3P(first, !=, NULL);
 	}
 
 
@@ -732,7 +732,7 @@ vdev_queue_aggregate(vdev_queue_t *vq, zio_t *zio)
 		while (last != mandatory && last != first) {
 			ASSERT(last->io_flags & ZIO_FLAG_OPTIONAL);
 			last = AVL_PREV(t, last);
-			ASSERT(last != NULL);
+			ASSERT3P(last, !=, NULL);
 		}
 	}
 

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -2298,7 +2298,7 @@ vdev_raidz_io_done_reconstruct_known_missing(zio_t *zio, raidz_map_t *rm,
 		 * also have been fewer parity errors than parity
 		 * columns or, again, we wouldn't be in this code path.
 		 */
-		ASSERT(parity_untried == 0);
+		ASSERT0(parity_untried);
 		ASSERT(parity_errors < rr->rr_firstdatacol);
 
 		/*

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -802,7 +802,7 @@ vdev_raidz_reconstruct_q(raidz_row_t *rr, int *tgts, int ntgts)
 	int c, exp;
 	abd_t *dst, *src;
 
-	ASSERT(ntgts == 1);
+	ASSERT3S(ntgts, ==, 1);
 
 	ASSERT(rr->rr_col[x].rc_size <= rr->rr_col[VDEV_RAIDZ_Q].rc_size);
 
@@ -848,8 +848,8 @@ vdev_raidz_reconstruct_pq(raidz_row_t *rr, int *tgts, int ntgts)
 	int y = tgts[1];
 	abd_t *xd, *yd;
 
-	ASSERT(ntgts == 2);
-	ASSERT(x < y);
+	ASSERT3S(ntgts, ==, 2);
+	ASSERT3S(x, <, y);
 	ASSERT(x >= rr->rr_firstdatacol);
 	ASSERT(y < rr->rr_cols);
 
@@ -1097,7 +1097,7 @@ vdev_raidz_matrix_init(raidz_row_t *rr, int n, int nmap, int *map,
 		pow = map[i] * n;
 		if (pow > 255)
 			pow -= 255;
-		ASSERT(pow <= 255);
+		ASSERT3S(pow, <=, 255);
 
 		for (j = 0; j < n; j++) {
 			pow -= map[i];
@@ -1338,7 +1338,7 @@ vdev_raidz_reconstruct_general(raidz_row_t *rr, int *tgts, int ntgts)
 	 * data columns.
 	 */
 	for (tt = 0, c = 0, i = 0; i < nmissing_rows; c++) {
-		ASSERT(tt < ntgts);
+		ASSERT3S(tt, <, ntgts);
 		ASSERT(c < rr->rr_firstdatacol);
 
 		/*
@@ -1447,9 +1447,9 @@ vdev_raidz_reconstruct_row(raidz_map_t *rm, raidz_row_t *rr,
 		}
 	}
 
-	ASSERT(ntgts >= nt);
-	ASSERT(nbaddata >= 0);
-	ASSERT(nbaddata + nbadparity == ntgts);
+	ASSERT3S(ntgts, >=, nt);
+	ASSERT3S(nbaddata, >=, 0);
+	ASSERT3S(nbaddata + nbadparity, ==, ntgts);
 
 	dt = &tgts[nbadparity];
 
@@ -2309,7 +2309,7 @@ vdev_raidz_io_done_reconstruct_known_missing(zio_t *zio, raidz_map_t *rm,
 		for (int c = rr->rr_firstdatacol; c < rr->rr_cols; c++) {
 			raidz_col_t *rc = &rr->rr_col[c];
 			if (rc->rc_error != 0) {
-				ASSERT(n < VDEV_RAIDZ_MAXPARITY);
+				ASSERT3S(n, <, VDEV_RAIDZ_MAXPARITY);
 				tgts[n++] = c;
 			}
 		}

--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -282,7 +282,7 @@ vdev_rebuild_initiate(vdev_t *vd)
 
 	ASSERT(vd->vdev_top == vd);
 	ASSERT(MUTEX_HELD(&vd->vdev_rebuild_lock));
-	ASSERT(!vd->vdev_rebuilding);
+	ASSERT0(vd->vdev_rebuilding);
 
 	dmu_tx_t *tx = dmu_tx_create_dd(spa_get_dsl(spa)->dp_mos_dir);
 	VERIFY0(dmu_tx_assign(tx, TXG_WAIT));
@@ -1002,7 +1002,7 @@ vdev_rebuild(vdev_t *vd)
 
 	ASSERT(vd->vdev_top == vd);
 	ASSERT(vdev_is_concrete(vd));
-	ASSERT(!vd->vdev_removing);
+	ASSERT0(vd->vdev_removing);
 	ASSERT(spa_feature_is_enabled(vd->vdev_spa,
 	    SPA_FEATURE_DEVICE_REBUILD));
 

--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -1080,7 +1080,7 @@ vdev_rebuild_stop_wait(vdev_t *vd)
 			vdev_rebuild_stop_wait(vd->vdev_child[i]);
 
 	} else if (vd->vdev_top_zap != 0) {
-		ASSERT(vd == vd->vdev_top);
+		ASSERT3P(vd, ==, vd->vdev_top);
 
 		mutex_enter(&vd->vdev_rebuild_lock);
 		if (vd->vdev_rebuild_thread != NULL) {

--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -280,7 +280,7 @@ vdev_rebuild_initiate(vdev_t *vd)
 {
 	spa_t *spa = vd->vdev_spa;
 
-	ASSERT(vd->vdev_top == vd);
+	ASSERT3U(vd->vdev_top, ==, vd);
 	ASSERT(MUTEX_HELD(&vd->vdev_rebuild_lock));
 	ASSERT0(vd->vdev_rebuilding);
 
@@ -406,7 +406,7 @@ vdev_rebuild_reset_sync(void *arg, dmu_tx_t *tx)
 
 	mutex_enter(&vd->vdev_rebuild_lock);
 
-	ASSERT(vrp->vrp_rebuild_state == VDEV_REBUILD_ACTIVE);
+	ASSERT3U(vrp->vrp_rebuild_state, ==, VDEV_REBUILD_ACTIVE);
 	ASSERT3P(vd->vdev_rebuild_thread, ==, NULL);
 
 	vrp->vrp_last_offset = 0;
@@ -719,7 +719,7 @@ vdev_rebuild_load(vdev_t *vd)
 		return (SET_ERROR(ENOTSUP));
 	}
 
-	ASSERT(vd->vdev_top == vd);
+	ASSERT3U(vd->vdev_top, ==, vd);
 
 	err = zap_lookup(spa->spa_meta_objset, vd->vdev_top_zap,
 	    VDEV_TOP_ZAP_VDEV_REBUILD_PHYS, sizeof (uint64_t),
@@ -948,7 +948,7 @@ vdev_rebuild_thread(void *arg)
 		 * when detaching a child vdev or when exporting the pool.  The
 		 * rebuild is left in the active state so it will be resumed.
 		 */
-		ASSERT(vrp->vrp_rebuild_state == VDEV_REBUILD_ACTIVE);
+		ASSERT3U(vrp->vrp_rebuild_state, ==, VDEV_REBUILD_ACTIVE);
 		vd->vdev_rebuilding = B_FALSE;
 	}
 
@@ -1000,7 +1000,7 @@ vdev_rebuild(vdev_t *vd)
 	vdev_rebuild_t *vr = &vd->vdev_rebuild_config;
 	vdev_rebuild_phys_t *vrp __maybe_unused = &vr->vr_rebuild_phys;
 
-	ASSERT(vd->vdev_top == vd);
+	ASSERT3U(vd->vdev_top, ==, vd);
 	ASSERT(vdev_is_concrete(vd));
 	ASSERT0(vd->vdev_removing);
 	ASSERT(spa_feature_is_enabled(vd->vdev_spa,

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -175,7 +175,7 @@ vdev_activate(vdev_t *vd)
 	uint64_t vdev_space = spa_deflate(spa) ?
 	    vd->vdev_stat.vs_dspace : vd->vdev_stat.vs_space;
 
-	ASSERT(!vd->vdev_islog);
+	ASSERT0(vd->vdev_islog);
 	ASSERT(vd->vdev_noalloc);
 
 	metaslab_group_activate(mg);
@@ -194,7 +194,7 @@ vdev_passivate(vdev_t *vd, uint64_t *txg)
 	spa_t *spa = vd->vdev_spa;
 	int error;
 
-	ASSERT(!vd->vdev_noalloc);
+	ASSERT0(vd->vdev_noalloc);
 
 	vdev_t *rvd = spa->spa_root_vdev;
 	metaslab_group_t *mg = vd->vdev_mg;
@@ -227,7 +227,7 @@ vdev_passivate(vdev_t *vd, uint64_t *txg)
 	}
 
 	metaslab_group_passivate(mg);
-	ASSERT(!vd->vdev_islog);
+	ASSERT0(vd->vdev_islog);
 	metaslab_group_passivate(vd->vdev_log_mg);
 
 	/*
@@ -249,7 +249,7 @@ vdev_passivate(vdev_t *vd, uint64_t *txg)
 
 	if (error != 0) {
 		metaslab_group_activate(mg);
-		ASSERT(!vd->vdev_islog);
+		ASSERT0(vd->vdev_islog);
 		if (vd->vdev_log_mg != NULL)
 			metaslab_group_activate(vd->vdev_log_mg);
 		return (error);
@@ -278,7 +278,7 @@ spa_vdev_noalloc(spa_t *spa, uint64_t guid)
 	uint64_t txg;
 	int error = 0;
 
-	ASSERT(!MUTEX_HELD(&spa_namespace_lock));
+	ASSERT0(MUTEX_HELD(&spa_namespace_lock));
 	ASSERT(spa_writeable(spa));
 
 	txg = spa_vdev_enter(spa);
@@ -311,7 +311,7 @@ spa_vdev_alloc(spa_t *spa, uint64_t guid)
 	uint64_t txg;
 	int error = 0;
 
-	ASSERT(!MUTEX_HELD(&spa_namespace_lock));
+	ASSERT0(MUTEX_HELD(&spa_namespace_lock));
 	ASSERT(spa_writeable(spa));
 
 	txg = spa_vdev_enter(spa);
@@ -349,10 +349,10 @@ spa_vdev_remove_aux(nvlist_t *config, const char *name, nvlist_t **dev,
 	for (int i = 0, j = 0; i < count; i++) {
 		if (dev[i] == dev_to_remove)
 			continue;
-		VERIFY(nvlist_dup(dev[i], &newdev[j++], KM_SLEEP) == 0);
+		VERIFY0(nvlist_dup(dev[i], &newdev[j++], KM_SLEEP));
 	}
 
-	VERIFY(nvlist_remove(config, name, DATA_TYPE_NVLIST_ARRAY) == 0);
+	VERIFY0(nvlist_remove(config, name, DATA_TYPE_NVLIST_ARRAY));
 	fnvlist_add_nvlist_array(config, name, (const nvlist_t * const *)newdev,
 	    count - 1);
 
@@ -689,7 +689,7 @@ free_from_removing_vdev(vdev_t *vd, uint64_t offset, uint64_t size)
 	 * a checkpoint and removing a device can't happen at the same
 	 * time.
 	 */
-	ASSERT(!spa_has_checkpoint(spa));
+	ASSERT0(spa_has_checkpoint(spa));
 	metaslab_free_concrete(vd, offset, size, B_FALSE);
 
 	uint64_t synced_size = 0;
@@ -1331,7 +1331,7 @@ vdev_remove_replace_with_indirect(vdev_t *vd, uint64_t txg)
 	vdev_remove_child(ivd, vd);
 	vdev_compact_children(ivd);
 
-	ASSERT(!list_link_active(&vd->vdev_state_dirty_node));
+	ASSERT0(list_link_active(&vd->vdev_state_dirty_node));
 
 	mutex_enter(&svr->svr_lock);
 	svr->svr_thread = NULL;
@@ -2240,7 +2240,7 @@ spa_vdev_remove_top_check(vdev_t *vd)
 	/*
 	 * A removed special/dedup vdev must have same ashift as normal class.
 	 */
-	ASSERT(!vd->vdev_islog);
+	ASSERT0(vd->vdev_islog);
 	if (vd->vdev_alloc_bias != VDEV_BIAS_NONE &&
 	    vd->vdev_ashift != spa->spa_max_ashift) {
 		return (SET_ERROR(EINVAL));
@@ -2472,13 +2472,13 @@ spa_vdev_remove(spa_t *spa, uint64_t guid, boolean_t unspare)
 		spa_load_l2cache(spa);
 		spa->spa_l2cache.sav_sync = B_TRUE;
 	} else if (vd != NULL && vd->vdev_islog) {
-		ASSERT(!locked);
+		ASSERT0(locked);
 		vd_type = VDEV_TYPE_LOG;
 		vd_path = spa_strdup((vd->vdev_path != NULL) ?
 		    vd->vdev_path : "-");
 		error = spa_vdev_remove_log(vd, &txg);
 	} else if (vd != NULL) {
-		ASSERT(!locked);
+		ASSERT0(locked);
 		error = spa_vdev_remove_top(vd, &txg);
 	} else {
 		/*

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -1608,7 +1608,7 @@ spa_vdev_remove_thread(void *arg)
 	ASSERT(vdev_is_concrete(vd));
 	ASSERT(vd->vdev_removing);
 	ASSERT(vd->vdev_indirect_config.vic_mapping_object != 0);
-	ASSERT(vim != NULL);
+	ASSERT3P(vim, !=, NULL);
 
 	mutex_init(&vca.vca_lock, NULL, MUTEX_DEFAULT, NULL);
 	cv_init(&vca.vca_cv, NULL, CV_DEFAULT, NULL);
@@ -1862,7 +1862,7 @@ spa_vdev_remove_cancel_sync(void *arg, dmu_tx_t *tx)
 	uint64_t obsolete_sm_object;
 	VERIFY0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
 	if (obsolete_sm_object != 0) {
-		ASSERT(vd->vdev_obsolete_sm != NULL);
+		ASSERT3P(vd->vdev_obsolete_sm, !=, NULL);
 		ASSERT3U(obsolete_sm_object, ==,
 		    space_map_object(vd->vdev_obsolete_sm));
 
@@ -2060,7 +2060,7 @@ spa_vdev_remove_log(vdev_t *vd, uint64_t *txg)
 	int error = 0;
 
 	ASSERT(vd->vdev_islog);
-	ASSERT(vd == vd->vdev_top);
+	ASSERT3P(vd, ==, vd->vdev_top);
 	ASSERT3P(vd->vdev_log_mg, ==, NULL);
 	ASSERT(MUTEX_HELD(&spa_namespace_lock));
 

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -666,7 +666,7 @@ free_from_removing_vdev(vdev_t *vd, uint64_t offset, uint64_t size)
 	uint64_t txg = spa_syncing_txg(spa);
 	uint64_t max_offset_yet = 0;
 
-	ASSERT(vd->vdev_indirect_config.vic_mapping_object != 0);
+	ASSERT3U(vd->vdev_indirect_config.vic_mapping_object, !=, 0);
 	ASSERT3U(vd->vdev_indirect_config.vic_mapping_object, ==,
 	    vdev_indirect_mapping_object(vim));
 	ASSERT3U(vd->vdev_id, ==, svr->svr_vdev_id);
@@ -902,7 +902,7 @@ vdev_mapping_sync(void *arg, dmu_tx_t *tx)
 	uint64_t txg = dmu_tx_get_txg(tx);
 	vdev_indirect_mapping_t *vim = vd->vdev_indirect_mapping;
 
-	ASSERT(vic->vic_mapping_object != 0);
+	ASSERT3U(vic->vic_mapping_object, !=, 0);
 	ASSERT3U(txg, ==, spa_syncing_txg(spa));
 
 	vdev_indirect_mapping_add_entries(vim,
@@ -1607,7 +1607,7 @@ spa_vdev_remove_thread(void *arg)
 	ASSERT3P(vd->vdev_ops, !=, &vdev_indirect_ops);
 	ASSERT(vdev_is_concrete(vd));
 	ASSERT(vd->vdev_removing);
-	ASSERT(vd->vdev_indirect_config.vic_mapping_object != 0);
+	ASSERT3U(vd->vdev_indirect_config.vic_mapping_object, !=, 0);
 	ASSERT3P(vim, !=, NULL);
 
 	mutex_init(&vca.vca_lock, NULL, MUTEX_DEFAULT, NULL);
@@ -2035,7 +2035,7 @@ vdev_remove_make_hole_and_free(vdev_t *vd)
 	vdev_t *rvd = spa->spa_root_vdev;
 
 	ASSERT(MUTEX_HELD(&spa_namespace_lock));
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(spa_config_held(spa, SCL_ALL, RW_WRITER), ==, SCL_ALL);
 
 	vdev_free(vd);
 
@@ -2139,7 +2139,7 @@ spa_vdev_remove_log(vdev_t *vd, uint64_t *txg)
 	sysevent_t *ev = spa_event_create(spa, vd, NULL,
 	    ESC_ZFS_VDEV_REMOVE_DEV);
 	ASSERT(MUTEX_HELD(&spa_namespace_lock));
-	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
+	ASSERT3U(spa_config_held(spa, SCL_ALL, RW_WRITER), ==, SCL_ALL);
 
 	/* The top ZAP should have been destroyed by vdev_remove_empty. */
 	ASSERT0(vd->vdev_top_zap);

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -640,7 +640,7 @@ vdev_trim_calculate_progress(vdev_t *vd)
 {
 	ASSERT(spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_READER) ||
 	    spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_WRITER));
-	ASSERT(vd->vdev_leaf_zap != 0);
+	ASSERT3U(vd->vdev_leaf_zap, !=, 0);
 
 	vd->vdev_trim_bytes_est = 0;
 	vd->vdev_trim_bytes_done = 0;
@@ -716,7 +716,7 @@ vdev_trim_load(vdev_t *vd)
 	int err = 0;
 	ASSERT(spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_READER) ||
 	    spa_config_held(vd->vdev_spa, SCL_CONFIG, RW_WRITER));
-	ASSERT(vd->vdev_leaf_zap != 0);
+	ASSERT3U(vd->vdev_leaf_zap, !=, 0);
 
 	if (vd->vdev_trim_state == VDEV_TRIM_ACTIVE ||
 	    vd->vdev_trim_state == VDEV_TRIM_SUSPENDED) {

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -973,9 +973,9 @@ vdev_trim(vdev_t *vd, uint64_t rate, boolean_t partial, boolean_t secure)
 	ASSERT(vd->vdev_ops->vdev_op_leaf);
 	ASSERT(vdev_is_concrete(vd));
 	ASSERT3P(vd->vdev_trim_thread, ==, NULL);
-	ASSERT(!vd->vdev_detached);
-	ASSERT(!vd->vdev_trim_exit_wanted);
-	ASSERT(!vd->vdev_top->vdev_removing);
+	ASSERT0(vd->vdev_detached);
+	ASSERT0(vd->vdev_trim_exit_wanted);
+	ASSERT0(vd->vdev_top->vdev_removing);
 
 	vdev_trim_change_state(vd, VDEV_TRIM_ACTIVE, rate, partial, secure);
 	vd->vdev_trim_thread = thread_create(NULL, 0,
@@ -1027,7 +1027,8 @@ vdev_trim_stop_wait(spa_t *spa, list_t *vd_list)
 void
 vdev_trim_stop(vdev_t *vd, vdev_trim_state_t tgt_state, list_t *vd_list)
 {
-	ASSERT(!spa_config_held(vd->vdev_spa, SCL_CONFIG|SCL_STATE, RW_WRITER));
+	ASSERT0(spa_config_held(vd->vdev_spa, SCL_CONFIG | SCL_STATE,
+	    RW_WRITER));
 	ASSERT(MUTEX_HELD(&vd->vdev_trim_lock));
 	ASSERT(vd->vdev_ops->vdev_op_leaf);
 	ASSERT(vdev_is_concrete(vd));
@@ -1115,7 +1116,7 @@ void
 vdev_trim_restart(vdev_t *vd)
 {
 	ASSERT(MUTEX_HELD(&spa_namespace_lock));
-	ASSERT(!spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER));
+	ASSERT0(spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER));
 
 	if (vd->vdev_leaf_zap != 0) {
 		mutex_enter(&vd->vdev_trim_lock);
@@ -1636,9 +1637,9 @@ vdev_trim_l2arc(spa_t *spa)
 		ASSERT(vd->vdev_ops->vdev_op_leaf);
 		ASSERT(vdev_is_concrete(vd));
 		ASSERT3P(vd->vdev_trim_thread, ==, NULL);
-		ASSERT(!vd->vdev_detached);
-		ASSERT(!vd->vdev_trim_exit_wanted);
-		ASSERT(!vd->vdev_top->vdev_removing);
+		ASSERT0(vd->vdev_detached);
+		ASSERT0(vd->vdev_trim_exit_wanted);
+		ASSERT0(vd->vdev_top->vdev_removing);
 		vdev_trim_change_state(vd, VDEV_TRIM_ACTIVE, 0, 0, 0);
 		vd->vdev_trim_thread = thread_create(NULL, 0,
 		    vdev_trim_l2arc_thread, vd, 0, &p0, TS_RUN, maxclsyspri);
@@ -1661,8 +1662,8 @@ vdev_trim_simple(vdev_t *vd, uint64_t start, uint64_t size)
 
 	ASSERT(vdev_is_concrete(vd));
 	ASSERT(vd->vdev_ops->vdev_op_leaf);
-	ASSERT(!vd->vdev_detached);
-	ASSERT(!vd->vdev_top->vdev_removing);
+	ASSERT0(vd->vdev_detached);
+	ASSERT0(vd->vdev_top->vdev_removing);
 
 	ta.trim_vdev = vd;
 	ta.trim_tree = range_tree_create(NULL, RANGE_SEG64, NULL, 0, 0);

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -1433,7 +1433,7 @@ vdev_autotrim_thread(void *arg)
 	}
 
 	mutex_enter(&vd->vdev_autotrim_lock);
-	ASSERT(vd->vdev_autotrim_thread != NULL);
+	ASSERT3P(vd->vdev_autotrim_thread, !=, NULL);
 	vd->vdev_autotrim_thread = NULL;
 	cv_broadcast(&vd->vdev_autotrim_cv);
 	mutex_exit(&vd->vdev_autotrim_lock);
@@ -1461,7 +1461,7 @@ vdev_autotrim(spa_t *spa)
 			tvd->vdev_autotrim_thread = thread_create(NULL, 0,
 			    vdev_autotrim_thread, tvd, 0, &p0, TS_RUN,
 			    maxclsyspri);
-			ASSERT(tvd->vdev_autotrim_thread != NULL);
+			ASSERT3P(tvd->vdev_autotrim_thread, !=, NULL);
 		}
 		mutex_exit(&tvd->vdev_autotrim_lock);
 	}

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -173,8 +173,8 @@ zap_table_grow(zap_t *zap, zap_table_phys_t *tbl,
 	/* hepb = half the number of entries in a block */
 
 	ASSERT(RW_WRITE_HELD(&zap->zap_rwlock));
-	ASSERT(tbl->zt_blk != 0);
-	ASSERT(tbl->zt_numblks > 0);
+	ASSERT3U(tbl->zt_blk, !=, 0);
+	ASSERT3U(tbl->zt_numblks, >, 0);
 
 	if (tbl->zt_nextblk != 0) {
 		newblk = tbl->zt_nextblk;
@@ -246,7 +246,7 @@ zap_table_store(zap_t *zap, zap_table_phys_t *tbl, uint64_t idx, uint64_t val,
 	int bs = FZAP_BLOCK_SHIFT(zap);
 
 	ASSERT(RW_LOCK_HELD(&zap->zap_rwlock));
-	ASSERT(tbl->zt_blk != 0);
+	ASSERT3U(tbl->zt_blk, !=, 0);
 
 	dprintf("storing %llx at index %llx\n", (u_longlong_t)val,
 	    (u_longlong_t)idx);
@@ -471,7 +471,7 @@ zap_put_leaf(zap_leaf_t *l)
 static zap_leaf_t *
 zap_open_leaf(uint64_t blkid, dmu_buf_t *db)
 {
-	ASSERT(blkid != 0);
+	ASSERT3U(blkid, !=, 0);
 
 	zap_leaf_t *l = kmem_zalloc(sizeof (zap_leaf_t), KM_SLEEP);
 	rw_init(&l->l_rwlock, NULL, RW_DEFAULT, NULL);
@@ -543,7 +543,7 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
 	ASSERT3U(db->db_object, ==, zap->zap_object);
 	ASSERT3U(db->db_offset, ==, blkid << bs);
 	ASSERT3U(db->db_size, ==, 1 << bs);
-	ASSERT(blkid != 0);
+	ASSERT3U(blkid, !=, 0);
 
 	zap_leaf_t *l = dmu_buf_get_user(db);
 
@@ -1007,7 +1007,7 @@ zap_create_link_dnsize(objset_t *os, dmu_object_type_t ot, uint64_t parent_obj,
 	uint64_t new_obj;
 
 	new_obj = zap_create_dnsize(os, ot, DMU_OT_NONE, 0, dnodesize, tx);
-	VERIFY(new_obj != 0);
+	VERIFY3U(new_obj, !=, 0);
 	VERIFY0(zap_add(os, parent_obj, name, sizeof (uint64_t), 1, &new_obj,
 	    tx));
 

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -585,7 +585,7 @@ zap_idx_to_blk(zap_t *zap, uint64_t idx, uint64_t *valp)
 static int
 zap_set_idx_to_blk(zap_t *zap, uint64_t idx, uint64_t blk, dmu_tx_t *tx)
 {
-	ASSERT(tx != NULL);
+	ASSERT3P(tx, !=, NULL);
 	ASSERT(RW_WRITE_HELD(&zap->zap_rwlock));
 
 	if (zap_f_phys(zap)->zap_ptrtbl.zt_blk == 0) {

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -450,7 +450,7 @@ zap_create_leaf(zap_t *zap, dmu_tx_t *tx)
 int
 fzap_count(zap_t *zap, uint64_t *count)
 {
-	ASSERT(!zap->zap_ismicro);
+	ASSERT0(zap->zap_ismicro);
 	mutex_enter(&zap->zap_f.zap_num_entries_mtx); /* unnecessary */
 	*count = zap_f_phys(zap)->zap_num_entries;
 	mutex_exit(&zap->zap_f.zap_num_entries_mtx);
@@ -652,7 +652,7 @@ zap_expand_leaf(zap_name_t *zn, zap_leaf_t *l,
 		zap = zn->zn_zap;
 		if (err != 0)
 			return (err);
-		ASSERT(!zap->zap_ismicro);
+		ASSERT0(zap->zap_ismicro);
 
 		while (old_prefix_len ==
 		    zap_f_phys(zap)->zap_ptrtbl.zt_shift) {
@@ -832,8 +832,8 @@ fzap_add_cd(zap_name_t *zn,
 	zap_t *zap = zn->zn_zap;
 
 	ASSERT(RW_LOCK_HELD(&zap->zap_rwlock));
-	ASSERT(!zap->zap_ismicro);
-	ASSERT(fzap_check(zn, integer_size, num_integers) == 0);
+	ASSERT0(zap->zap_ismicro);
+	ASSERT0(fzap_check(zn, integer_size, num_integers));
 
 	err = zap_deref_leaf(zap, zn->zn_hash, tx, RW_WRITER, &l);
 	if (err != 0)
@@ -1289,7 +1289,7 @@ again:
 		}
 		err = zap_entry_read_name(zap, &zeh,
 		    sizeof (za->za_name), za->za_name);
-		ASSERT(err == 0);
+		ASSERT0(err);
 
 		za->za_normalization_conflict =
 		    zap_entry_normalization_conflict(&zeh,

--- a/module/zfs/zap_leaf.c
+++ b/module/zfs/zap_leaf.c
@@ -183,7 +183,7 @@ zap_leaf_init(zap_leaf_t *l, boolean_t sort)
 static uint16_t
 zap_leaf_chunk_alloc(zap_leaf_t *l)
 {
-	ASSERT(zap_leaf_phys(l)->l_hdr.lh_nfree > 0);
+	ASSERT3U(zap_leaf_phys(l)->l_hdr.lh_nfree, >, 0);
 
 	int chunk = zap_leaf_phys(l)->l_hdr.lh_freelist;
 	ASSERT3U(chunk, <, ZAP_LEAF_NUMCHUNKS(l));
@@ -203,7 +203,7 @@ zap_leaf_chunk_free(zap_leaf_t *l, uint16_t chunk)
 	struct zap_leaf_free *zlf = &ZAP_LEAF_CHUNK(l, chunk).l_free;
 	ASSERT3U(zap_leaf_phys(l)->l_hdr.lh_nfree, <, ZAP_LEAF_NUMCHUNKS(l));
 	ASSERT3U(chunk, <, ZAP_LEAF_NUMCHUNKS(l));
-	ASSERT(zlf->lf_type != ZAP_CHUNK_FREE);
+	ASSERT3U(zlf->lf_type, !=, ZAP_CHUNK_FREE);
 
 	zlf->lf_type = ZAP_CHUNK_FREE;
 	zlf->lf_next = zap_leaf_phys(l)->l_hdr.lh_freelist;
@@ -340,7 +340,7 @@ zap_leaf_array_match(zap_leaf_t *l, zap_name_t *zn,
 	if (zap_getflags(zn->zn_zap) & ZAP_FLAG_UINT64_KEY) {
 		uint64_t *thiskey =
 		    kmem_alloc(array_numints * sizeof (*thiskey), KM_SLEEP);
-		ASSERT(zn->zn_key_intlen == sizeof (*thiskey));
+		ASSERT3U(zn->zn_key_intlen, ==, sizeof (*thiskey));
 
 		zap_leaf_array_read(l, chunk, sizeof (*thiskey), array_numints,
 		    sizeof (*thiskey), array_numints, thiskey);

--- a/module/zfs/zap_leaf.c
+++ b/module/zfs/zap_leaf.c
@@ -350,7 +350,7 @@ zap_leaf_array_match(zap_leaf_t *l, zap_name_t *zn,
 		return (match);
 	}
 
-	ASSERT(zn->zn_key_intlen == 1);
+	ASSERT3S(zn->zn_key_intlen, ==, 1);
 	if (zn->zn_matchtype & MT_NORMALIZE) {
 		char *thisname = kmem_alloc(array_numints, KM_SLEEP);
 

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -1282,7 +1282,7 @@ zap_add_impl(zap_t *zap, const char *key,
 			mzap_addent(zn, *intval);
 		}
 	}
-	ASSERT(zap == zn->zn_zap);
+	ASSERT3P(zap, ==, zn->zn_zap);
 	zap_name_free(zn);
 	if (zap != NULL)	/* may be NULL if fzap_add() failed */
 		zap_unlockdir(zap, tag);
@@ -1385,7 +1385,7 @@ zap_update(objset_t *os, uint64_t zapobj, const char *name,
 			mzap_addent(zn, *intval);
 		}
 	}
-	ASSERT(zap == zn->zn_zap);
+	ASSERT3P(zap, ==, zn->zn_zap);
 	zap_name_free(zn);
 	if (zap != NULL)	/* may be NULL if fzap_upgrade() failed */
 		zap_unlockdir(zap, FTAG);

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -133,7 +133,7 @@ zap_hash(zap_name_t *zn)
 static int
 zap_normalize(zap_t *zap, const char *name, char *namenorm, int normflags)
 {
-	ASSERT(!(zap_getflags(zap) & ZAP_FLAG_UINT64_KEY));
+	ASSERT0((zap_getflags(zap) & ZAP_FLAG_UINT64_KEY));
 
 	size_t inlen = strlen(name) + 1;
 	size_t outlen = ZAP_MAXNAMELEN;
@@ -149,7 +149,7 @@ zap_normalize(zap_t *zap, const char *name, char *namenorm, int normflags)
 boolean_t
 zap_match(zap_name_t *zn, const char *matchname)
 {
-	ASSERT(!(zap_getflags(zn->zn_zap) & ZAP_FLAG_UINT64_KEY));
+	ASSERT0((zap_getflags(zn->zn_zap) & ZAP_FLAG_UINT64_KEY));
 
 	if (zn->zn_matchtype & MT_NORMALIZE) {
 		char norm[ZAP_MAXNAMELEN];
@@ -246,7 +246,7 @@ zap_name_alloc_uint64(zap_t *zap, const uint64_t *key, int numints)
 {
 	zap_name_t *zn = kmem_alloc(sizeof (zap_name_t), KM_SLEEP);
 
-	ASSERT(zap->zap_normflags == 0);
+	ASSERT0(zap->zap_normflags);
 	zn->zn_zap = zap;
 	zn->zn_key_intlen = sizeof (*key);
 	zn->zn_key_orig = zn->zn_key_norm = key;
@@ -1565,7 +1565,7 @@ zap_cursor_serialize(zap_cursor_t *zc)
 		return (-1ULL);
 	if (zc->zc_zap == NULL)
 		return (zc->zc_serialized);
-	ASSERT((zc->zc_hash & zap_maxcd(zc->zc_zap)) == 0);
+	ASSERT0((zc->zc_hash & zap_maxcd(zc->zc_zap)));
 	ASSERT(zc->zc_cd < zap_maxcd(zc->zc_zap));
 
 	/*
@@ -1600,7 +1600,7 @@ zap_cursor_retrieve(zap_cursor_t *zc, zap_attribute_t *za)
 		 * we must add to the existing zc_cd, which may already
 		 * be 1 due to the zap_cursor_advance.
 		 */
-		ASSERT(zc->zc_hash == 0);
+		ASSERT0(zc->zc_hash);
 		hb = zap_hashbits(zc->zc_zap);
 		zc->zc_hash = zc->zc_serialized << (64 - hb);
 		zc->zc_cd += zc->zc_serialized >> hb;

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -83,13 +83,13 @@ zap_hash(zap_name_t *zn)
 		h = *(uint64_t *)zn->zn_key_orig;
 	} else {
 		h = zap->zap_salt;
-		ASSERT(h != 0);
-		ASSERT(zfs_crc64_table[128] == ZFS_CRC64_POLY);
+		ASSERT3U(h, !=, 0);
+		ASSERT3U(zfs_crc64_table[128], ==, ZFS_CRC64_POLY);
 
 		if (zap_getflags(zap) & ZAP_FLAG_UINT64_KEY) {
 			const uint64_t *wp = zn->zn_key_norm;
 
-			ASSERT(zn->zn_key_intlen == 8);
+			ASSERT3U(zn->zn_key_intlen, ==, 8);
 			for (int i = 0; i < zn->zn_key_norm_numints;
 			    wp++, i++) {
 				uint64_t word = *wp;
@@ -112,7 +112,7 @@ zap_hash(zap_name_t *zn)
 			 */
 			int len = zn->zn_key_norm_numints - 1;
 
-			ASSERT(zn->zn_key_intlen == 1);
+			ASSERT3U(zn->zn_key_intlen, ==, 1);
 			for (int i = 0; i < len; cp++, i++) {
 				h = (h >> 8) ^
 				    zfs_crc64_table[(h ^ *cp) & 0xFF];
@@ -308,7 +308,7 @@ mze_insert(zap_t *zap, uint16_t chunkid, uint64_t hash)
 	mze.mze_hash = hash >> 32;
 	ASSERT3U(MZE_PHYS(zap, &mze)->mze_cd, <=, 0xffff);
 	mze.mze_cd = (uint16_t)MZE_PHYS(zap, &mze)->mze_cd;
-	ASSERT(MZE_PHYS(zap, &mze)->mze_name[0] != 0);
+	ASSERT3U(MZE_PHYS(zap, &mze)->mze_name[0], !=, 0);
 	zfs_btree_add(&zap->zap_m.zap_tree, &mze);
 }
 
@@ -551,9 +551,9 @@ zap_lockdir_impl(dmu_buf_t *db, const void *tag, dmu_tx_t *tx,
 	rw_enter(&zap->zap_rwlock, lt);
 	if (lt != ((!zap->zap_ismicro && fatreader) ? RW_READER : lti)) {
 		/* it was upgraded, now we only need reader */
-		ASSERT(lt == RW_WRITER);
-		ASSERT(RW_READER ==
-		    ((!zap->zap_ismicro && fatreader) ? RW_READER : lti));
+		ASSERT3U(lt, ==, RW_WRITER);
+		ASSERT3U(RW_READER, ==, ((!zap->zap_ismicro && fatreader) ?
+		    RW_READER : lti));
 		rw_downgrade(&zap->zap_rwlock);
 		lt = RW_READER;
 	}
@@ -1217,13 +1217,13 @@ mzap_addent(zap_name_t *zn, uint64_t value)
 #ifdef ZFS_DEBUG
 	for (int i = 0; i < zap->zap_m.zap_num_chunks; i++) {
 		mzap_ent_phys_t *mze = &zap_m_phys(zap)->mz_chunk[i];
-		ASSERT(strcmp(zn->zn_key_orig, mze->mze_name) != 0);
+		ASSERT3U(strcmp(zn->zn_key_orig, mze->mze_name), !=, 0);
 	}
 #endif
 
 	uint32_t cd = mze_find_unused_cd(zap, zn->zn_hash);
 	/* given the limited size of the microzap, this can't happen */
-	ASSERT(cd < zap_maxcd(zap));
+	ASSERT3U(cd, <, zap_maxcd(zap));
 
 again:
 	for (uint16_t i = start; i < zap->zap_m.zap_num_chunks; i++) {
@@ -1566,7 +1566,7 @@ zap_cursor_serialize(zap_cursor_t *zc)
 	if (zc->zc_zap == NULL)
 		return (zc->zc_serialized);
 	ASSERT0((zc->zc_hash & zap_maxcd(zc->zc_zap)));
-	ASSERT(zc->zc_cd < zap_maxcd(zc->zc_zap));
+	ASSERT3U(zc->zc_cd, <, zap_maxcd(zc->zc_zap));
 
 	/*
 	 * We want to keep the high 32 bits of the cursor zero if we can, so

--- a/module/zfs/zcp.c
+++ b/module/zfs/zcp.c
@@ -1059,7 +1059,7 @@ zcp_eval(const char *poolname, const char *program, boolean_t sync,
 	 * This should never fail.
 	 */
 	state = lua_newstate(zcp_lua_alloc, &allocargs);
-	VERIFY(state != NULL);
+	VERIFY3P(state, !=, NULL);
 	(void) lua_atpanic(state, zcp_panic_cb);
 
 	/*

--- a/module/zfs/zcp_get.c
+++ b/module/zfs/zcp_get.c
@@ -305,7 +305,7 @@ get_special_prop(lua_State *state, dsl_dataset_t *ds, const char *dsname,
 		break;
 	case ZFS_PROP_VERSION:
 		/* should be a snapshot or filesystem */
-		ASSERT(ds_type != ZFS_TYPE_VOLUME);
+		ASSERT3U(ds_type, !=, ZFS_TYPE_VOLUME);
 		error = dmu_objset_from_ds(ds, &os);
 		/* look in the master node for the version */
 		if (error == 0) {
@@ -366,7 +366,7 @@ get_special_prop(lua_State *state, dsl_dataset_t *ds, const char *dsname,
 
 		break;
 	case ZFS_PROP_VOLBLOCKSIZE: {
-		ASSERT(ds_type == ZFS_TYPE_VOLUME);
+		ASSERT3U(ds_type, ==, ZFS_TYPE_VOLUME);
 		dmu_object_info_t doi;
 		error = dmu_objset_from_ds(ds, &os);
 		if (error == 0) {

--- a/module/zfs/zfeature.c
+++ b/module/zfs/zfeature.c
@@ -209,8 +209,8 @@ spa_features_check(spa_t *spa, boolean_t for_write,
 				    za->za_name, 1, MAXPATHLEN, buf) == 0)
 					desc = buf;
 
-				VERIFY(nvlist_add_string(unsup_feat,
-				    za->za_name, desc) == 0);
+				VERIFY0(nvlist_add_string(unsup_feat,
+				    za->za_name, desc));
 			}
 		}
 	}

--- a/module/zfs/zfeature.c
+++ b/module/zfs/zfeature.c
@@ -288,7 +288,7 @@ feature_get_enabled_txg(spa_t *spa, zfeature_info_t *feature, uint64_t *res)
 		return (SET_ERROR(ENOTSUP));
 	}
 
-	ASSERT(enabled_txg_obj != 0);
+	ASSERT3U(enabled_txg_obj, !=, 0);
 
 	VERIFY0(zap_lookup(spa->spa_meta_objset, spa->spa_feat_enabled_txg_obj,
 	    feature->fi_guid, sizeof (uint64_t), 1, res));
@@ -342,7 +342,7 @@ feature_enable_sync(spa_t *spa, zfeature_info_t *feature, dmu_tx_t *tx)
 	uint64_t zapobj = (feature->fi_flags & ZFEATURE_FLAG_READONLY_COMPAT) ?
 	    spa->spa_feat_for_write_obj : spa->spa_feat_for_read_obj;
 
-	ASSERT(0 != zapobj);
+	ASSERT3U(0, !=, zapobj);
 	ASSERT(zfeature_is_valid_guid(feature->fi_guid));
 	ASSERT3U(spa_version(spa), >=, SPA_VERSION_FEATURES);
 
@@ -409,7 +409,7 @@ feature_do_action(spa_t *spa, spa_feature_t fid, feature_action_t action,
 	    spa->spa_feat_for_write_obj : spa->spa_feat_for_read_obj;
 
 	ASSERT(VALID_FEATURE_FID(fid));
-	ASSERT(0 != zapobj);
+	ASSERT3U(0, !=, zapobj);
 	ASSERT(zfeature_is_valid_guid(feature->fi_guid));
 
 	ASSERT(dmu_tx_is_syncing(tx));

--- a/module/zfs/zfs_byteswap.c
+++ b/module/zfs/zfs_byteswap.c
@@ -157,7 +157,7 @@ zfs_znode_byteswap(void *buf, size_t size)
 {
 	znode_phys_t *zp = buf;
 
-	ASSERT(size >= sizeof (znode_phys_t));
+	ASSERT3U(size, >=, sizeof (znode_phys_t));
 
 	zp->zp_crtime[0] = BSWAP_64(zp->zp_crtime[0]);
 	zp->zp_crtime[1] = BSWAP_64(zp->zp_crtime[1]);

--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -396,7 +396,7 @@ zfs_ereport_is_duplicate(const char *subclass, spa_t *spa, vdev_t *vd,
 	if (avl_numnodes(&recent_events_tree) >= zfs_zevent_retain_max) {
 		/* recycle oldest node */
 		entry = list_tail(&recent_events_list);
-		ASSERT(entry != NULL);
+		ASSERT3P(entry, !=, NULL);
 		list_remove(&recent_events_list, entry);
 		avl_remove(&recent_events_tree, entry);
 	} else {

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -417,7 +417,7 @@ zfs_fuid_map_id(zfsvfs_t *zfsvfs, uint64_t fuid,
 		return (fuid);
 
 	domain = zfs_fuid_find_by_idx(zfsvfs, index);
-	ASSERT(domain != NULL);
+	ASSERT3P(domain, !=, NULL);
 
 	if (type == ZFS_OWNER || type == ZFS_ACE_USER) {
 		(void) kidmap_getuidbysid(crgetzone(cr), domain,
@@ -744,7 +744,7 @@ zfs_groupmember(zfsvfs_t *zfsvfs, uint64_t id, cred_t *cr)
 				const char *domain;
 
 				domain = zfs_fuid_find_by_idx(zfsvfs, idx);
-				ASSERT(domain != NULL);
+				ASSERT3P(domain, !=, NULL);
 
 				if (strcmp(domain,
 				    IDMAP_WK_CREATOR_SID_AUTHORITY) == 0)

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -111,8 +111,7 @@ zfs_fuid_table_load(objset_t *os, uint64_t fuid_obj, avl_tree_t *idx_tree,
 	uint64_t fuid_size;
 
 	ASSERT(fuid_obj != 0);
-	VERIFY(0 == dmu_bonus_hold(os, fuid_obj,
-	    FTAG, &db));
+	VERIFY0(dmu_bonus_hold(os, fuid_obj, FTAG, &db));
 	fuid_size = *(uint64_t *)db->db_data;
 	dmu_buf_rele(db, FTAG);
 
@@ -124,22 +123,21 @@ zfs_fuid_table_load(objset_t *os, uint64_t fuid_obj, avl_tree_t *idx_tree,
 		int i;
 
 		packed = kmem_alloc(fuid_size, KM_SLEEP);
-		VERIFY(dmu_read(os, fuid_obj, 0,
-		    fuid_size, packed, DMU_READ_PREFETCH) == 0);
-		VERIFY(nvlist_unpack(packed, fuid_size,
-		    &nvp, 0) == 0);
-		VERIFY(nvlist_lookup_nvlist_array(nvp, FUID_NVP_ARRAY,
-		    &fuidnvp, &count) == 0);
+		VERIFY0(dmu_read(os, fuid_obj, 0, fuid_size, packed,
+		    DMU_READ_PREFETCH));
+		VERIFY0(nvlist_unpack(packed, fuid_size, &nvp, 0));
+		VERIFY0(nvlist_lookup_nvlist_array(nvp, FUID_NVP_ARRAY,
+		    &fuidnvp, &count));
 
 		for (i = 0; i != count; i++) {
 			fuid_domain_t *domnode;
 			char *domain;
 			uint64_t idx;
 
-			VERIFY(nvlist_lookup_string(fuidnvp[i], FUID_DOMAIN,
-			    &domain) == 0);
-			VERIFY(nvlist_lookup_uint64(fuidnvp[i], FUID_IDX,
-			    &idx) == 0);
+			VERIFY0(nvlist_lookup_string(fuidnvp[i], FUID_DOMAIN,
+			    &domain));
+			VERIFY0(nvlist_lookup_uint64(fuidnvp[i], FUID_IDX,
+			    &idx));
 
 			domnode = kmem_alloc(sizeof (fuid_domain_t), KM_SLEEP);
 
@@ -240,40 +238,36 @@ zfs_fuid_sync(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 		zfsvfs->z_fuid_obj = dmu_object_alloc(zfsvfs->z_os,
 		    DMU_OT_FUID, 1 << 14, DMU_OT_FUID_SIZE,
 		    sizeof (uint64_t), tx);
-		VERIFY(zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
-		    ZFS_FUID_TABLES, sizeof (uint64_t), 1,
-		    &zfsvfs->z_fuid_obj, tx) == 0);
+		VERIFY0(zap_add(zfsvfs->z_os, MASTER_NODE_OBJ, ZFS_FUID_TABLES,
+		    sizeof (uint64_t), 1, &zfsvfs->z_fuid_obj, tx));
 	}
 
-	VERIFY(nvlist_alloc(&nvp, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+	VERIFY0(nvlist_alloc(&nvp, NV_UNIQUE_NAME, KM_SLEEP));
 
 	numnodes = avl_numnodes(&zfsvfs->z_fuid_idx);
 	fuids = kmem_alloc(numnodes * sizeof (void *), KM_SLEEP);
 	for (i = 0, domnode = avl_first(&zfsvfs->z_fuid_domain); domnode; i++,
 	    domnode = AVL_NEXT(&zfsvfs->z_fuid_domain, domnode)) {
-		VERIFY(nvlist_alloc(&fuids[i], NV_UNIQUE_NAME, KM_SLEEP) == 0);
-		VERIFY(nvlist_add_uint64(fuids[i], FUID_IDX,
-		    domnode->f_idx) == 0);
-		VERIFY(nvlist_add_uint64(fuids[i], FUID_OFFSET, 0) == 0);
-		VERIFY(nvlist_add_string(fuids[i], FUID_DOMAIN,
-		    domnode->f_ksid->kd_name) == 0);
+		VERIFY0(nvlist_alloc(&fuids[i], NV_UNIQUE_NAME, KM_SLEEP));
+		VERIFY0(nvlist_add_uint64(fuids[i], FUID_IDX, domnode->f_idx));
+		VERIFY0(nvlist_add_uint64(fuids[i], FUID_OFFSET, 0));
+		VERIFY0(nvlist_add_string(fuids[i], FUID_DOMAIN,
+		    domnode->f_ksid->kd_name));
 	}
 	fnvlist_add_nvlist_array(nvp, FUID_NVP_ARRAY,
 	    (const nvlist_t * const *)fuids, numnodes);
 	for (i = 0; i != numnodes; i++)
 		nvlist_free(fuids[i]);
 	kmem_free(fuids, numnodes * sizeof (void *));
-	VERIFY(nvlist_size(nvp, &nvsize, NV_ENCODE_XDR) == 0);
+	VERIFY0(nvlist_size(nvp, &nvsize, NV_ENCODE_XDR));
 	packed = kmem_alloc(nvsize, KM_SLEEP);
-	VERIFY(nvlist_pack(nvp, &packed, &nvsize,
-	    NV_ENCODE_XDR, KM_SLEEP) == 0);
+	VERIFY0(nvlist_pack(nvp, &packed, &nvsize, NV_ENCODE_XDR, KM_SLEEP));
 	nvlist_free(nvp);
 	zfsvfs->z_fuid_size = nvsize;
 	dmu_write(zfsvfs->z_os, zfsvfs->z_fuid_obj, 0,
 	    zfsvfs->z_fuid_size, packed, tx);
 	kmem_free(packed, zfsvfs->z_fuid_size);
-	VERIFY(0 == dmu_bonus_hold(zfsvfs->z_os, zfsvfs->z_fuid_obj,
-	    FTAG, &db));
+	VERIFY0(dmu_bonus_hold(zfsvfs->z_os, zfsvfs->z_fuid_obj, FTAG, &db));
 	dmu_buf_will_dirty(db, tx);
 	*(uint64_t *)db->db_data = zfsvfs->z_fuid_size;
 	dmu_buf_rele(db, FTAG);

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -110,7 +110,7 @@ zfs_fuid_table_load(objset_t *os, uint64_t fuid_obj, avl_tree_t *idx_tree,
 	dmu_buf_t *db;
 	uint64_t fuid_size;
 
-	ASSERT(fuid_obj != 0);
+	ASSERT3U(fuid_obj, !=, 0);
 	VERIFY0(dmu_bonus_hold(os, fuid_obj, FTAG, &db));
 	fuid_size = *(uint64_t *)db->db_data;
 	dmu_buf_rele(db, FTAG);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1484,7 +1484,7 @@ zfs_ioc_pool_create(zfs_cmd_t *zc)
 			goto pool_props_bad;
 		(void) nvlist_remove_all(props, ZPOOL_HIDDEN_ARGS);
 
-		VERIFY(nvlist_alloc(&zplprops, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+		VERIFY0(nvlist_alloc(&zplprops, NV_UNIQUE_NAME, KM_SLEEP));
 		error = zfs_fill_zplprops_root(version, rootprops,
 		    zplprops, NULL);
 		if (error != 0)
@@ -2138,7 +2138,7 @@ nvl_add_zplprop(objset_t *os, nvlist_t *props, zfs_prop_t prop)
 	 */
 	if ((error = zfs_get_zplprop(os, prop, &value)) != 0)
 		return (error);
-	VERIFY(nvlist_add_uint64(props, zfs_prop_to_name(prop), value) == 0);
+	VERIFY0(nvlist_add_uint64(props, zfs_prop_to_name(prop), value));
 	return (0);
 }
 
@@ -2173,7 +2173,7 @@ zfs_ioc_objset_zplprops(zfs_cmd_t *zc)
 	    dmu_objset_type(os) == DMU_OST_ZFS) {
 		nvlist_t *nv;
 
-		VERIFY(nvlist_alloc(&nv, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+		VERIFY0(nvlist_alloc(&nv, NV_UNIQUE_NAME, KM_SLEEP));
 		if ((err = nvl_add_zplprop(os, nv, ZFS_PROP_VERSION)) == 0 &&
 		    (err = nvl_add_zplprop(os, nv, ZFS_PROP_NORMALIZE)) == 0 &&
 		    (err = nvl_add_zplprop(os, nv, ZFS_PROP_UTF8ONLY)) == 0 &&
@@ -2364,7 +2364,7 @@ zfs_prop_set_userquota(const char *dsname, nvpair_t *pair)
 
 	if (nvpair_type(pair) == DATA_TYPE_NVLIST) {
 		nvlist_t *attrs;
-		VERIFY(nvpair_value_nvlist(pair, &attrs) == 0);
+		VERIFY0(nvpair_value_nvlist(pair, &attrs));
 		if (nvlist_lookup_nvpair(attrs, ZPROP_VALUE,
 		    &pair) != 0)
 			return (SET_ERROR(EINVAL));
@@ -2419,9 +2419,8 @@ zfs_prop_set_special(const char *dsname, zprop_source_t source,
 
 	if (nvpair_type(pair) == DATA_TYPE_NVLIST) {
 		nvlist_t *attrs;
-		VERIFY(nvpair_value_nvlist(pair, &attrs) == 0);
-		VERIFY(nvlist_lookup_nvpair(attrs, ZPROP_VALUE,
-		    &pair) == 0);
+		VERIFY0(nvpair_value_nvlist(pair, &attrs));
+		VERIFY0(nvlist_lookup_nvpair(attrs, ZPROP_VALUE, &pair));
 	}
 
 	/* all special properties are numeric except for keylocation */
@@ -2748,14 +2747,14 @@ props_skip(nvlist_t *props, nvlist_t *skipped, nvlist_t **newprops)
 {
 	nvpair_t *pair;
 
-	VERIFY(nvlist_alloc(newprops, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+	VERIFY0(nvlist_alloc(newprops, NV_UNIQUE_NAME, KM_SLEEP));
 
 	pair = NULL;
 	while ((pair = nvlist_next_nvpair(props, pair)) != NULL) {
 		if (nvlist_exists(skipped, nvpair_name(pair)))
 			continue;
 
-		VERIFY(nvlist_add_nvpair(*newprops, pair) == 0);
+		VERIFY0(nvlist_add_nvpair(*newprops, pair));
 	}
 }
 
@@ -2880,11 +2879,11 @@ zfs_ioc_inherit_prop(zfs_cmd_t *zc)
 
 	switch (type) {
 	case PROP_TYPE_STRING:
-		VERIFY(0 == nvlist_add_string(dummy, propname, ""));
+		VERIFY0(nvlist_add_string(dummy, propname, ""));
 		break;
 	case PROP_TYPE_NUMBER:
 	case PROP_TYPE_INDEX:
-		VERIFY(0 == nvlist_add_uint64(dummy, propname, 0));
+		VERIFY0(nvlist_add_uint64(dummy, propname, 0));
 		break;
 	default:
 		err = SET_ERROR(EINVAL);
@@ -3226,14 +3225,14 @@ zfs_fill_zplprops_impl(objset_t *os, uint64_t zplver,
 	/*
 	 * Put the version in the zplprops
 	 */
-	VERIFY(nvlist_add_uint64(zplprops,
-	    zfs_prop_to_name(ZFS_PROP_VERSION), zplver) == 0);
+	VERIFY0(nvlist_add_uint64(zplprops, zfs_prop_to_name(ZFS_PROP_VERSION),
+	    zplver));
 
 	if (norm == ZFS_PROP_UNDEFINED &&
 	    (error = zfs_get_zplprop(os, ZFS_PROP_NORMALIZE, &norm)) != 0)
 		return (error);
-	VERIFY(nvlist_add_uint64(zplprops,
-	    zfs_prop_to_name(ZFS_PROP_NORMALIZE), norm) == 0);
+	VERIFY0(nvlist_add_uint64(zplprops,
+	    zfs_prop_to_name(ZFS_PROP_NORMALIZE), norm));
 
 	/*
 	 * If we're normalizing, names must always be valid UTF-8 strings.
@@ -3243,14 +3242,14 @@ zfs_fill_zplprops_impl(objset_t *os, uint64_t zplver,
 	if (u8 == ZFS_PROP_UNDEFINED &&
 	    (error = zfs_get_zplprop(os, ZFS_PROP_UTF8ONLY, &u8)) != 0)
 		return (error);
-	VERIFY(nvlist_add_uint64(zplprops,
-	    zfs_prop_to_name(ZFS_PROP_UTF8ONLY), u8) == 0);
+	VERIFY0(nvlist_add_uint64(zplprops,
+	    zfs_prop_to_name(ZFS_PROP_UTF8ONLY), u8));
 
 	if (sense == ZFS_PROP_UNDEFINED &&
 	    (error = zfs_get_zplprop(os, ZFS_PROP_CASE, &sense)) != 0)
 		return (error);
-	VERIFY(nvlist_add_uint64(zplprops,
-	    zfs_prop_to_name(ZFS_PROP_CASE), sense) == 0);
+	VERIFY0(nvlist_add_uint64(zplprops, zfs_prop_to_name(ZFS_PROP_CASE),
+	    sense));
 
 	if (is_ci)
 		*is_ci = (sense == ZFS_CASE_INSENSITIVE);
@@ -3399,8 +3398,8 @@ zfs_ioc_create(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl)
 		 * file system creation, so go figure them out
 		 * now.
 		 */
-		VERIFY(nvlist_alloc(&zct.zct_zplprops,
-		    NV_UNIQUE_NAME, KM_SLEEP) == 0);
+		VERIFY0(nvlist_alloc(&zct.zct_zplprops, NV_UNIQUE_NAME,
+		    KM_SLEEP));
 		error = zfs_fill_zplprops(fsname, nvprops,
 		    zct.zct_zplprops, &is_insensitive);
 		if (error != 0) {
@@ -4555,9 +4554,8 @@ zfs_check_settable(const char *dsname, nvpair_t *pair, cred_t *cr)
 		 * format.
 		 */
 		nvlist_t *attrs;
-		VERIFY(nvpair_value_nvlist(pair, &attrs) == 0);
-		VERIFY(nvlist_lookup_nvpair(attrs, ZPROP_VALUE,
-		    &pair) == 0);
+		VERIFY0(nvpair_value_nvlist(pair, &attrs));
+		VERIFY0(nvlist_lookup_nvpair(attrs, ZPROP_VALUE, &pair));
 	}
 
 	/*
@@ -4751,7 +4749,7 @@ zfs_check_clearable(const char *dataset, nvlist_t *props, nvlist_t **errlist)
 	if (props == NULL)
 		return (0);
 
-	VERIFY(nvlist_alloc(&errors, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+	VERIFY0(nvlist_alloc(&errors, NV_UNIQUE_NAME, KM_SLEEP));
 
 	zc = kmem_alloc(sizeof (zfs_cmd_t), KM_SLEEP);
 	(void) strlcpy(zc->zc_name, dataset, sizeof (zc->zc_name));
@@ -4763,9 +4761,8 @@ zfs_check_clearable(const char *dataset, nvlist_t *props, nvlist_t **errlist)
 		    sizeof (zc->zc_value));
 		if ((err = zfs_check_settable(dataset, pair, CRED())) != 0 ||
 		    (err = zfs_secpolicy_inherit_prop(zc, NULL, CRED())) != 0) {
-			VERIFY(nvlist_remove_nvpair(props, pair) == 0);
-			VERIFY(nvlist_add_int32(errors,
-			    zc->zc_value, err) == 0);
+			VERIFY0(nvlist_remove_nvpair(props, pair));
+			VERIFY0(nvlist_add_int32(errors, zc->zc_value, err));
 		}
 		pair = next_pair;
 	}
@@ -4775,7 +4772,7 @@ zfs_check_clearable(const char *dataset, nvlist_t *props, nvlist_t **errlist)
 		nvlist_free(errors);
 		errors = NULL;
 	} else {
-		VERIFY(nvpair_value_int32(pair, &rv) == 0);
+		VERIFY0(nvpair_value_int32(pair, &rv));
 	}
 
 	if (errlist == NULL)
@@ -4792,16 +4789,14 @@ propval_equals(nvpair_t *p1, nvpair_t *p2)
 	if (nvpair_type(p1) == DATA_TYPE_NVLIST) {
 		/* dsl_prop_get_all_impl() format */
 		nvlist_t *attrs;
-		VERIFY(nvpair_value_nvlist(p1, &attrs) == 0);
-		VERIFY(nvlist_lookup_nvpair(attrs, ZPROP_VALUE,
-		    &p1) == 0);
+		VERIFY0(nvpair_value_nvlist(p1, &attrs));
+		VERIFY0(nvlist_lookup_nvpair(attrs, ZPROP_VALUE, &p1));
 	}
 
 	if (nvpair_type(p2) == DATA_TYPE_NVLIST) {
 		nvlist_t *attrs;
-		VERIFY(nvpair_value_nvlist(p2, &attrs) == 0);
-		VERIFY(nvlist_lookup_nvpair(attrs, ZPROP_VALUE,
-		    &p2) == 0);
+		VERIFY0(nvpair_value_nvlist(p2, &attrs));
+		VERIFY0(nvlist_lookup_nvpair(attrs, ZPROP_VALUE, &p2));
 	}
 
 	if (nvpair_type(p1) != nvpair_type(p2))
@@ -4810,14 +4805,14 @@ propval_equals(nvpair_t *p1, nvpair_t *p2)
 	if (nvpair_type(p1) == DATA_TYPE_STRING) {
 		char *valstr1, *valstr2;
 
-		VERIFY(nvpair_value_string(p1, (char **)&valstr1) == 0);
-		VERIFY(nvpair_value_string(p2, (char **)&valstr2) == 0);
+		VERIFY0(nvpair_value_string(p1, (char **)&valstr1));
+		VERIFY0(nvpair_value_string(p2, (char **)&valstr2));
 		return (strcmp(valstr1, valstr2) == 0);
 	} else {
 		uint64_t intval1, intval2;
 
-		VERIFY(nvpair_value_uint64(p1, &intval1) == 0);
-		VERIFY(nvpair_value_uint64(p2, &intval2) == 0);
+		VERIFY0(nvpair_value_uint64(p1, &intval1));
+		VERIFY0(nvpair_value_uint64(p2, &intval2));
 		return (intval1 == intval2);
 	}
 }
@@ -4885,7 +4880,7 @@ extract_delay_props(nvlist_t *props)
 	};
 	int i;
 
-	VERIFY(nvlist_alloc(&delayprops, NV_UNIQUE_NAME, KM_SLEEP) == 0);
+	VERIFY0(nvlist_alloc(&delayprops, NV_UNIQUE_NAME, KM_SLEEP));
 
 	for (nvp = nvlist_next_nvpair(props, NULL); nvp != NULL;
 	    nvp = nvlist_next_nvpair(props, nvp)) {
@@ -4901,8 +4896,8 @@ extract_delay_props(nvlist_t *props)
 		}
 		if (delayable[i] != 0) {
 			tmp = nvlist_prev_nvpair(props, nvp);
-			VERIFY(nvlist_add_nvpair(delayprops, nvp) == 0);
-			VERIFY(nvlist_remove_nvpair(props, nvp) == 0);
+			VERIFY0(nvlist_add_nvpair(delayprops, nvp));
+			VERIFY0(nvlist_remove_nvpair(props, nvp));
 			nvp = tmp;
 		}
 	}
@@ -5133,15 +5128,15 @@ zfs_ioc_recv_impl(char *tofs, char *tosnap, char *origin, nvlist_t *recvprops,
 	 * using ASSERT() will be just like a VERIFY.
 	 */
 	if (recv_delayprops != NULL) {
-		ASSERT(nvlist_merge(recvprops, recv_delayprops, 0) == 0);
+		ASSERT0(nvlist_merge(recvprops, recv_delayprops, 0));
 		nvlist_free(recv_delayprops);
 	}
 	if (local_delayprops != NULL) {
-		ASSERT(nvlist_merge(localprops, local_delayprops, 0) == 0);
+		ASSERT0(nvlist_merge(localprops, local_delayprops, 0));
 		nvlist_free(local_delayprops);
 	}
 	if (inherited_delayprops != NULL) {
-		ASSERT(nvlist_merge(localprops, inherited_delayprops, 0) == 0);
+		ASSERT0(nvlist_merge(localprops, inherited_delayprops, 0));
 		nvlist_free(inherited_delayprops);
 	}
 	*read_bytes = off - noff;
@@ -7461,7 +7456,7 @@ zfsdev_getminor(zfs_file_t *fp, minor_t *minorp)
 {
 	zfsdev_state_t *zs, *fpd;
 
-	ASSERT(!MUTEX_HELD(&zfsdev_state_lock));
+	ASSERT0(MUTEX_HELD(&zfsdev_state_lock));
 
 	fpd = zfs_file_private(fp);
 	if (fpd == NULL)

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3182,7 +3182,7 @@ zfs_fill_zplprops_impl(objset_t *os, uint64_t zplver,
 	uint64_t u8 = ZFS_PROP_UNDEFINED;
 	int error;
 
-	ASSERT(zplprops != NULL);
+	ASSERT3P(zplprops, !=, NULL);
 
 	/* parent dataset must be a filesystem */
 	if (os != NULL && os->os_phys->os_type != DMU_OST_ZFS)
@@ -7581,7 +7581,7 @@ zfsdev_state_destroy(void *priv)
 {
 	zfsdev_state_t *zs = zfsdev_private_get_state(priv);
 
-	ASSERT(zs != NULL);
+	ASSERT3P(zs, !=, NULL);
 	ASSERT3S(zs->zs_minor, >, 0);
 
 	/*
@@ -7725,7 +7725,7 @@ zfsdev_ioctl_common(uint_t vecnum, zfs_cmd_t *zc, int flag)
 		spa_t *spa;
 		nvlist_t *lognv = NULL;
 
-		ASSERT(vec->zvec_legacy_func == NULL);
+		ASSERT3P(vec->zvec_legacy_func, ==, NULL);
 
 		/*
 		 * Add the innvl to the lognv before calling the func,

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -159,7 +159,7 @@ zfs_log_xvattr(lr_attr_t *lrattr, xvattr_t *xvap)
 	if (XVA_ISSET_REQ(xvap, XAT_CREATETIME))
 		ZFS_TIME_ENCODE(&xoap->xoa_createtime, end->lr_attr_crtime);
 	if (XVA_ISSET_REQ(xvap, XAT_AV_SCANSTAMP)) {
-		ASSERT(!XVA_ISSET_REQ(xvap, XAT_PROJID));
+		ASSERT0(XVA_ISSET_REQ(xvap, XAT_PROJID));
 
 		memcpy(end->lr_attr_scanstamp, xoap->xoa_av_scanstamp,
 		    AV_SCANSTAMP_SZ);

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -433,7 +433,7 @@ zfs_log_remove(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 	 * the new file data and flushes a write record for the old object.
 	 */
 	if (unlinked) {
-		ASSERT((txtype & ~TX_CI) == TX_REMOVE);
+		ASSERT3U((txtype & ~TX_CI), ==, TX_REMOVE);
 		zil_remove_async(zilog, foid);
 	}
 	zil_itx_assign(zilog, itx, tx);

--- a/module/zfs/zfs_quota.c
+++ b/module/zfs/zfs_quota.c
@@ -348,7 +348,7 @@ zfs_set_userquota(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
 	if (*objp == 0) {
 		*objp = zap_create(zfsvfs->z_os, DMU_OT_USERGROUP_QUOTA,
 		    DMU_OT_NONE, 0, tx);
-		VERIFY(0 == zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
+		VERIFY0(zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
 		    zfs_userquota_prop_prefixes[type], 8, 1, objp, tx));
 	}
 	mutex_exit(&zfsvfs->z_lock);
@@ -360,7 +360,7 @@ zfs_set_userquota(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
 	} else {
 		err = zap_update(zfsvfs->z_os, *objp, buf, 8, 1, &quota, tx);
 	}
-	ASSERT(err == 0);
+	ASSERT0(err);
 	if (fuid_dirtied)
 		zfs_fuid_sync(zfsvfs, tx);
 	dmu_tx_commit(tx);

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -105,7 +105,7 @@ zfs_replay_xvattr(lr_attr_t *lrattr, xvattr_t *xvap)
 		return;
 	}
 
-	ASSERT(lrattr->lr_attr_masksize == xvap->xva_mapsize);
+	ASSERT3U(lrattr->lr_attr_masksize, ==, xvap->xva_mapsize);
 
 	bitmap = &lrattr->lr_attr_bitmap;
 	for (i = 0; i != lrattr->lr_attr_masksize; i++, bitmap++)

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -141,7 +141,7 @@ zfs_replay_xvattr(lr_attr_t *lrattr, xvattr_t *xvap)
 	if (XVA_ISSET_REQ(xvap, XAT_CREATETIME))
 		ZFS_TIME_DECODE(&xoap->xoa_createtime, crtime);
 	if (XVA_ISSET_REQ(xvap, XAT_AV_SCANSTAMP)) {
-		ASSERT(!XVA_ISSET_REQ(xvap, XAT_PROJID));
+		ASSERT0(XVA_ISSET_REQ(xvap, XAT_PROJID));
 
 		memcpy(xoap->xoa_av_scanstamp, scanstamp, AV_SCANSTAMP_SZ);
 	} else if (XVA_ISSET_REQ(xvap, XAT_PROJID)) {

--- a/module/zfs/zfs_rlock.c
+++ b/module/zfs/zfs_rlock.c
@@ -236,8 +236,8 @@ zfs_rangelock_proxify(avl_tree_t *tree, zfs_locked_range_t *lr)
 		return (lr); /* already a proxy */
 
 	ASSERT3U(lr->lr_count, ==, 1);
-	ASSERT(lr->lr_write_wanted == B_FALSE);
-	ASSERT(lr->lr_read_wanted == B_FALSE);
+	ASSERT3U(lr->lr_write_wanted, ==, B_FALSE);
+	ASSERT3U(lr->lr_read_wanted, ==, B_FALSE);
 	avl_remove(tree, lr);
 	lr->lr_count = 0;
 
@@ -267,8 +267,8 @@ zfs_rangelock_split(avl_tree_t *tree, zfs_locked_range_t *lr, uint64_t off)
 	ASSERT3U(lr->lr_length, >, 1);
 	ASSERT3U(off, >, lr->lr_offset);
 	ASSERT3U(off, <, lr->lr_offset + lr->lr_length);
-	ASSERT(lr->lr_write_wanted == B_FALSE);
-	ASSERT(lr->lr_read_wanted == B_FALSE);
+	ASSERT3U(lr->lr_write_wanted, ==, B_FALSE);
+	ASSERT3U(lr->lr_read_wanted, ==, B_FALSE);
 
 	/* create the rear proxy range lock */
 	rear = kmem_alloc(sizeof (zfs_locked_range_t), KM_SLEEP);
@@ -295,7 +295,7 @@ zfs_rangelock_new_proxy(avl_tree_t *tree, uint64_t off, uint64_t len)
 {
 	zfs_locked_range_t *lr;
 
-	ASSERT(len != 0);
+	ASSERT3U(len, !=, 0);
 	lr = kmem_alloc(sizeof (zfs_locked_range_t), KM_SLEEP);
 	lr->lr_offset = off;
 	lr->lr_length = len;

--- a/module/zfs/zfs_rlock.c
+++ b/module/zfs/zfs_rlock.c
@@ -620,7 +620,7 @@ zfs_rangelock_exit(zfs_locked_range_t *lr)
 
 	ASSERT(lr->lr_type == RL_WRITER || lr->lr_type == RL_READER);
 	ASSERT(lr->lr_count == 1 || lr->lr_count == 0);
-	ASSERT(!lr->lr_proxy);
+	ASSERT0(lr->lr_proxy);
 
 	/*
 	 * The free list is used to defer the cv_destroy() and
@@ -667,7 +667,7 @@ zfs_rangelock_reduce(zfs_locked_range_t *lr, uint64_t off, uint64_t len)
 	ASSERT3U(avl_numnodes(&rl->rl_tree), ==, 1);
 	ASSERT3U(lr->lr_offset, ==, 0);
 	ASSERT3U(lr->lr_type, ==, RL_WRITER);
-	ASSERT(!lr->lr_proxy);
+	ASSERT0(lr->lr_proxy);
 	ASSERT3U(lr->lr_length, ==, UINT64_MAX);
 	ASSERT3U(lr->lr_count, ==, 1);
 

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -168,9 +168,9 @@ zfs_sa_set_scanstamp(znode_t *zp, xvattr_t *xvap, dmu_tx_t *tx)
 	ASSERT(MUTEX_HELD(&zp->z_lock));
 	VERIFY((xoap = xva_getxoptattr(xvap)) != NULL);
 	if (zp->z_is_sa)
-		VERIFY(0 == sa_update(zp->z_sa_hdl, SA_ZPL_SCANSTAMP(zfsvfs),
-		    &xoap->xoa_av_scanstamp,
-		    sizeof (xoap->xoa_av_scanstamp), tx));
+		VERIFY0(sa_update(zp->z_sa_hdl, SA_ZPL_SCANSTAMP(zfsvfs),
+		    &xoap->xoa_av_scanstamp, sizeof (xoap->xoa_av_scanstamp),
+		    tx));
 	else {
 		dmu_object_info_t doi;
 		dmu_buf_t *db = sa_get_db(zp->z_sa_hdl);
@@ -180,12 +180,12 @@ zfs_sa_set_scanstamp(znode_t *zp, xvattr_t *xvap, dmu_tx_t *tx)
 		len = sizeof (xoap->xoa_av_scanstamp) +
 		    ZFS_OLD_ZNODE_PHYS_SIZE;
 		if (len > doi.doi_bonus_size)
-			VERIFY(dmu_set_bonus(db, len, tx) == 0);
+			VERIFY0(dmu_set_bonus(db, len, tx));
 		(void) memcpy((caddr_t)db->db_data + ZFS_OLD_ZNODE_PHYS_SIZE,
 		    xoap->xoa_av_scanstamp, sizeof (xoap->xoa_av_scanstamp));
 
 		zp->z_pflags |= ZFS_BONUS_SCANSTAMP;
-		VERIFY(0 == sa_update(zp->z_sa_hdl, SA_ZPL_FLAGS(zfsvfs),
+		VERIFY0(sa_update(zp->z_sa_hdl, SA_ZPL_FLAGS(zfsvfs),
 		    &zp->z_pflags, sizeof (uint64_t), tx));
 	}
 }
@@ -199,7 +199,7 @@ zfs_sa_get_xattr(znode_t *zp)
 	int error;
 
 	ASSERT(RW_LOCK_HELD(&zp->z_xattr_lock));
-	ASSERT(!zp->z_xattr_cached);
+	ASSERT(zp->z_xattr_cached);
 	ASSERT(zp->z_is_sa);
 
 	error = sa_size(zp->z_sa_hdl, SA_ZPL_DXATTR(zfsvfs), &size);
@@ -426,11 +426,10 @@ zfs_sa_upgrade(sa_handle_t *hdl, dmu_tx_t *tx)
 		zp->z_pflags &= ~ZFS_BONUS_SCANSTAMP;
 	}
 
-	VERIFY(dmu_set_bonustype(db, DMU_OT_SA, tx) == 0);
-	VERIFY(sa_replace_all_by_template_locked(hdl, sa_attrs,
-	    count, tx) == 0);
+	VERIFY0(dmu_set_bonustype(db, DMU_OT_SA, tx));
+	VERIFY0(sa_replace_all_by_template_locked(hdl, sa_attrs, count, tx));
 	if (znode_acl.z_acl_extern_obj)
-		VERIFY(0 == dmu_object_free(zfsvfs->z_os,
+		VERIFY0(dmu_object_free(zfsvfs->z_os,
 		    znode_acl.z_acl_extern_obj, tx));
 
 	zp->z_is_sa = B_TRUE;

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -132,7 +132,7 @@ zfs_sa_get_scanstamp(znode_t *zp, xvattr_t *xvap)
 	xoptattr_t *xoap;
 
 	ASSERT(MUTEX_HELD(&zp->z_lock));
-	VERIFY((xoap = xva_getxoptattr(xvap)) != NULL);
+	VERIFY3P((xoap = xva_getxoptattr(xvap)), !=, NULL);
 	if (zp->z_is_sa) {
 		if (sa_lookup(zp->z_sa_hdl, SA_ZPL_SCANSTAMP(zfsvfs),
 		    &xoap->xoa_av_scanstamp,
@@ -166,7 +166,7 @@ zfs_sa_set_scanstamp(znode_t *zp, xvattr_t *xvap, dmu_tx_t *tx)
 	xoptattr_t *xoap;
 
 	ASSERT(MUTEX_HELD(&zp->z_lock));
-	VERIFY((xoap = xva_getxoptattr(xvap)) != NULL);
+	VERIFY3P((xoap = xva_getxoptattr(xvap)), !=, NULL);
 	if (zp->z_is_sa)
 		VERIFY0(sa_update(zp->z_sa_hdl, SA_ZPL_SCANSTAMP(zfsvfs),
 		    &xoap->xoa_av_scanstamp, sizeof (xoap->xoa_av_scanstamp),
@@ -199,7 +199,7 @@ zfs_sa_get_xattr(znode_t *zp)
 	int error;
 
 	ASSERT(RW_LOCK_HELD(&zp->z_xattr_lock));
-	ASSERT(zp->z_xattr_cached);
+	ASSERT3P(zp->z_xattr_cached, !=, NULL);
 	ASSERT(zp->z_is_sa);
 
 	error = sa_size(zp->z_sa_hdl, SA_ZPL_DXATTR(zfsvfs), &size);
@@ -233,7 +233,7 @@ zfs_sa_set_xattr(znode_t *zp, const char *name, const void *value, size_t vsize)
 	int error, logsaxattr = 0;
 
 	ASSERT(RW_WRITE_HELD(&zp->z_xattr_lock));
-	ASSERT(zp->z_xattr_cached);
+	ASSERT3P(zp->z_xattr_cached, !=, NULL);
 	ASSERT(zp->z_is_sa);
 
 	error = nvlist_size(zp->z_xattr_cached, &size, NV_ENCODE_XDR);

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -335,8 +335,8 @@ zfs_clear_setid_bits_if_necessary(zfsvfs_t *zfsvfs, znode_t *zp, cred_t *cr,
 	zilog_t *zilog = zfsvfs->z_log;
 	const uint64_t uid = KUID_TO_SUID(ZTOUID(zp));
 
-	ASSERT(clear_setid_bits_txgp != NULL);
-	ASSERT(tx != NULL);
+	ASSERT3P(clear_setid_bits_txgp, !=, NULL);
+	ASSERT3P(tx, !=, NULL);
 
 	/*
 	 * Clear Set-UID/Set-GID bits on successful write if not
@@ -556,7 +556,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 
 			abuf = dmu_request_arcbuf(sa_get_db(zp->z_sa_hdl),
 			    max_blksz);
-			ASSERT(abuf != NULL);
+			ASSERT3P(abuf, !=, NULL);
 			ASSERT(arc_buf_size(abuf) == max_blksz);
 			if ((error = zfs_uiocopy(abuf->b_data, max_blksz,
 			    UIO_WRITE, uio, &cbytes))) {

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -709,7 +709,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			(void) sa_update(zp->z_sa_hdl, SA_ZPL_SIZE(zfsvfs),
 			    (void *)&zp->z_size, sizeof (uint64_t), tx);
 			dmu_tx_commit(tx);
-			ASSERT(error != 0);
+			ASSERT3S(error, !=, 0);
 			break;
 		}
 

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -273,7 +273,7 @@ zfs_read(struct znode *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 		goto out;
 	}
 
-	ASSERT(zfs_uio_offset(uio) < zp->z_size);
+	ASSERT3U(zfs_uio_offset(uio), <, zp->z_size);
 #if defined(__linux__)
 	ssize_t start_offset = zfs_uio_offset(uio);
 #endif
@@ -557,7 +557,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			abuf = dmu_request_arcbuf(sa_get_db(zp->z_sa_hdl),
 			    max_blksz);
 			ASSERT3P(abuf, !=, NULL);
-			ASSERT(arc_buf_size(abuf) == max_blksz);
+			ASSERT3U(arc_buf_size(abuf), ==, max_blksz);
 			if ((error = zfs_uiocopy(abuf->b_data, max_blksz,
 			    UIO_WRITE, uio, &cbytes))) {
 				dmu_return_arcbuf(abuf);
@@ -936,8 +936,8 @@ zfs_get_data(void *arg, uint64_t gen, lr_write_t *lr, char *buf,
 			zgd->zgd_db = db;
 			zgd->zgd_bp = bp;
 
-			ASSERT(db->db_offset == offset);
-			ASSERT(db->db_size == size);
+			ASSERT3U(db->db_offset, ==, offset);
+			ASSERT3U(db->db_size, ==, size);
 
 			error = dmu_sync(zio, lr->lr_common.lrc_txg,
 			    zfs_get_done, zgd);

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -605,7 +605,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 				 * "recordsize" property.  Only let it grow to
 				 * the next power of 2.
 				 */
-				ASSERT(!ISP2(zp->z_blksz));
+				ASSERT0(ISP2(zp->z_blksz));
 				new_blksz = MIN(end_size,
 				    1 << highbit64(zp->z_blksz));
 			} else {

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1389,8 +1389,8 @@ zil_lwb_flush_wait_all(zilog_t *zilog, uint64_t txg)
 	lwb_t *lwb = list_head(&zilog->zl_lwb_list);
 	while (lwb != NULL && lwb->lwb_max_txg <= txg) {
 		if (lwb->lwb_issued_txg <= txg) {
-			ASSERT(lwb->lwb_state != LWB_STATE_ISSUED);
-			ASSERT(lwb->lwb_state != LWB_STATE_WRITE_DONE);
+			ASSERT3U(lwb->lwb_state, !=, LWB_STATE_ISSUED);
+			ASSERT3U(lwb->lwb_state, !=, LWB_STATE_WRITE_DONE);
 			IMPLY(lwb->lwb_issued_txg > 0,
 			    lwb->lwb_state == LWB_STATE_FLUSH_DONE);
 		}
@@ -1429,10 +1429,10 @@ zil_lwb_write_done(zio_t *zio)
 
 	ASSERT3S(spa_config_held(spa, SCL_STATE, RW_READER), !=, 0);
 
-	ASSERT(BP_GET_COMPRESS(zio->io_bp) == ZIO_COMPRESS_OFF);
-	ASSERT(BP_GET_TYPE(zio->io_bp) == DMU_OT_INTENT_LOG);
+	ASSERT3U(BP_GET_COMPRESS(zio->io_bp), ==, ZIO_COMPRESS_OFF);
+	ASSERT3U(BP_GET_TYPE(zio->io_bp), ==, DMU_OT_INTENT_LOG);
 	ASSERT0(BP_GET_LEVEL(zio->io_bp));
-	ASSERT(BP_GET_BYTEORDER(zio->io_bp) == ZFS_HOST_BYTEORDER);
+	ASSERT3U(BP_GET_BYTEORDER(zio->io_bp), ==, ZFS_HOST_BYTEORDER);
 	ASSERT0(BP_IS_GANG(zio->io_bp));
 	ASSERT0(BP_IS_HOLE(zio->io_bp));
 	ASSERT0(BP_GET_FILL(zio->io_bp));
@@ -1691,7 +1691,7 @@ zil_lwb_write_issue(zilog_t *zilog, lwb_t *lwb)
 		bp = &zilc->zc_next_blk;
 	}
 
-	ASSERT(lwb->lwb_nused <= lwb->lwb_sz);
+	ASSERT3U(lwb->lwb_nused, <=, lwb->lwb_sz);
 
 	/*
 	 * Allocate the next block and save its address in this block
@@ -2128,7 +2128,7 @@ zil_remove_async(zilog_t *zilog, uint64_t oid)
 	list_t clean_list;
 	itx_t *itx;
 
-	ASSERT(oid != 0);
+	ASSERT3U(oid, !=, 0);
 	list_create(&clean_list, sizeof (itx_t), offsetof(itx_t, itx_node));
 
 	if (spa_freeze_txg(zilog->zl_spa) != UINT64_MAX) /* ziltest support */
@@ -3290,7 +3290,7 @@ zil_sync(zilog_t *zilog, dmu_tx_t *tx)
 	ASSERT0(zilog->zl_stop_sync);
 
 	if (*replayed_seq != 0) {
-		ASSERT(zh->zh_replay_seq < *replayed_seq);
+		ASSERT3U(zh->zh_replay_seq, <, *replayed_seq);
 		zh->zh_replay_seq = *replayed_seq;
 		*replayed_seq = 0;
 	}
@@ -3754,7 +3754,7 @@ zil_resume(void *cookie)
 	zilog_t *zilog = dmu_objset_zil(os);
 
 	mutex_enter(&zilog->zl_lock);
-	ASSERT(zilog->zl_suspend != 0);
+	ASSERT3U(zilog->zl_suspend, !=, 0);
 	zilog->zl_suspend--;
 	mutex_exit(&zilog->zl_lock);
 	dsl_dataset_long_rele(dmu_objset_ds(os), suspend_tag);

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1077,7 +1077,7 @@ zil_check_log_chain(dsl_pool_t *dp, dsl_dataset_t *ds, void *tx)
 	blkptr_t *bp;
 	int error;
 
-	ASSERT(tx == NULL);
+	ASSERT3P(tx, ==, NULL);
 
 	error = dmu_objset_from_ds(ds, &os);
 	if (error != 0) {
@@ -3299,7 +3299,7 @@ zil_sync(zilog_t *zilog, dmu_tx_t *tx)
 		blkptr_t blk = zh->zh_log;
 		dsl_dataset_t *ds = dmu_objset_ds(zilog->zl_os);
 
-		ASSERT(list_head(&zilog->zl_lwb_list) == NULL);
+		ASSERT3P(list_head(&zilog->zl_lwb_list), ==, NULL);
 
 		memset(zh, 0, sizeof (zil_header_t));
 		memset(zilog->zl_replayed_seq, 0,
@@ -3688,7 +3688,7 @@ zil_suspend(const char *osname, void **cookiep)
 	 * to clean up.
 	 */
 	if (BP_IS_HOLE(&zh->zh_log)) {
-		ASSERT(cookiep != NULL); /* fast path already handled */
+		ASSERT3P(cookiep, !=, NULL); /* fast path already handled */
 
 		*cookiep = os;
 		mutex_exit(&zilog->zl_lock);

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -228,11 +228,11 @@ zio_init(void)
 	}
 
 	while (--c != 0) {
-		ASSERT(zio_buf_cache[c] != NULL);
+		ASSERT3P(zio_buf_cache[c], !=, NULL);
 		if (zio_buf_cache[c - 1] == NULL)
 			zio_buf_cache[c - 1] = zio_buf_cache[c];
 
-		ASSERT(zio_data_buf_cache[c] != NULL);
+		ASSERT3P(zio_data_buf_cache[c], !=, NULL);
 		if (zio_data_buf_cache[c - 1] == NULL)
 			zio_data_buf_cache[c - 1] = zio_data_buf_cache[c];
 	}
@@ -681,7 +681,7 @@ zio_wait_for_children(zio_t *zio, uint8_t childbits, enum zio_wait_type wait)
 	boolean_t waiting = B_FALSE;
 
 	mutex_enter(&zio->io_lock);
-	ASSERT(zio->io_stall == NULL);
+	ASSERT3P(zio->io_stall, ==, NULL);
 	for (int c = 0; c < ZIO_CHILD_TYPES; c++) {
 		if (!(ZIO_CHILD_BIT_IS_SET(childbits, c)))
 			continue;
@@ -1458,7 +1458,7 @@ zio_vdev_child_io(zio_t *pio, blkptr_t *bp, vdev_t *vd, uint64_t offset,
 	 */
 	if (flags & ZIO_FLAG_IO_ALLOCATING &&
 	    (vd != vd->vdev_top || (flags & ZIO_FLAG_IO_RETRY))) {
-		ASSERT(pio->io_metaslab_class != NULL);
+		ASSERT3P(pio->io_metaslab_class, !=, NULL);
 		ASSERT(pio->io_metaslab_class->mc_alloc_throttle_enabled);
 		ASSERT(type == ZIO_TYPE_WRITE);
 		ASSERT(priority == ZIO_PRIORITY_ASYNC_WRITE);
@@ -1675,7 +1675,7 @@ zio_write_compress(zio_t *zio)
 	}
 
 	ASSERT(zio->io_child_type != ZIO_CHILD_DDT);
-	ASSERT(zio->io_bp_override == NULL);
+	ASSERT3P(zio->io_bp_override, ==, NULL);
 
 	if (!BP_IS_HOLE(bp) && bp->blk_birth == zio->io_txg) {
 		/*
@@ -2171,7 +2171,7 @@ __zio_execute(zio_t *zio)
 
 		ASSERT0(MUTEX_HELD(&zio->io_lock));
 		ASSERT(ISP2(stage));
-		ASSERT(zio->io_stall == NULL);
+		ASSERT3P(zio->io_stall, ==, NULL);
 
 		do {
 			stage <<= 1;
@@ -2319,8 +2319,8 @@ zio_reexecute(void *arg)
 
 	ASSERT(pio->io_child_type == ZIO_CHILD_LOGICAL);
 	ASSERT(pio->io_orig_stage == ZIO_STAGE_OPEN);
-	ASSERT(pio->io_gang_leader == NULL);
-	ASSERT(pio->io_gang_tree == NULL);
+	ASSERT3P(pio->io_gang_leader, ==, NULL);
+	ASSERT3P(pio->io_gang_tree, ==, NULL);
 
 	pio->io_flags = pio->io_orig_flags;
 	pio->io_stage = pio->io_orig_stage;
@@ -2392,9 +2392,9 @@ zio_suspend(spa_t *spa, zio_t *zio, zio_suspend_reason_t reason)
 
 	if (zio != NULL) {
 		ASSERT0((zio->io_flags & ZIO_FLAG_GODFATHER));
-		ASSERT(zio != spa->spa_suspend_zio_root);
+		ASSERT3P(zio, !=, spa->spa_suspend_zio_root);
 		ASSERT(zio->io_child_type == ZIO_CHILD_LOGICAL);
-		ASSERT(zio_unique_parent(zio) == NULL);
+		ASSERT3P(zio_unique_parent(zio), ==, NULL);
 		ASSERT(zio->io_stage == ZIO_STAGE_DONE);
 		zio_add_child(spa->spa_suspend_zio_root, zio);
 	}
@@ -2604,7 +2604,7 @@ zio_gang_node_alloc(zio_gang_node_t **gnpp)
 {
 	zio_gang_node_t *gn;
 
-	ASSERT(*gnpp == NULL);
+	ASSERT3P(*gnpp, ==, NULL);
 
 	gn = kmem_zalloc(sizeof (*gn), KM_SLEEP);
 	gn->gn_gbh = zio_buf_alloc(SPA_GANGBLOCKSIZE);
@@ -2619,7 +2619,7 @@ zio_gang_node_free(zio_gang_node_t **gnpp)
 	zio_gang_node_t *gn = *gnpp;
 
 	for (int g = 0; g < SPA_GBH_NBLKPTRS; g++)
-		ASSERT(gn->gn_child[g] == NULL);
+		ASSERT3P(gn->gn_child[g], ==, NULL);
 
 	zio_buf_free(gn->gn_gbh, SPA_GANGBLOCKSIZE);
 	kmem_free(gn, sizeof (*gn));
@@ -2661,7 +2661,7 @@ zio_gang_tree_assemble_done(zio_t *zio)
 	zio_gang_node_t *gn = zio->io_private;
 	blkptr_t *bp = zio->io_bp;
 
-	ASSERT(gio == zio_unique_parent(zio));
+	ASSERT3P(gio, ==, zio_unique_parent(zio));
 	ASSERT0(zio->io_child_count);
 
 	if (zio->io_error)
@@ -2982,7 +2982,7 @@ zio_nop_write(zio_t *zio)
 	ASSERT0((zio->io_flags & ZIO_FLAG_IO_REWRITE));
 	ASSERT(zp->zp_nopwrite);
 	ASSERT0(zp->zp_dedup);
-	ASSERT(zio->io_bp_override == NULL);
+	ASSERT3P(zio->io_bp_override, ==, NULL);
 	ASSERT(IO_IS_ALLOCATING(zio));
 
 	/*
@@ -3078,7 +3078,7 @@ zio_ddt_read_start(zio_t *zio)
 		ddt_phys_t *ddp_self = ddt_phys_select(dde, bp);
 		blkptr_t blk;
 
-		ASSERT(zio->io_vsd == NULL);
+		ASSERT3P(zio->io_vsd, ==, NULL);
 		zio->io_vsd = dde;
 
 		if (ddp_self == NULL)
@@ -3139,7 +3139,7 @@ zio_ddt_read_done(zio_t *zio)
 		zio->io_vsd = NULL;
 	}
 
-	ASSERT(zio->io_vsd == NULL);
+	ASSERT3P(zio->io_vsd, ==, NULL);
 
 	return (zio);
 }
@@ -3624,7 +3624,7 @@ static void
 zio_dva_unallocate(zio_t *zio, zio_gang_node_t *gn, blkptr_t *bp)
 {
 	ASSERT(bp->blk_birth == zio->io_txg || BP_IS_HOLE(bp));
-	ASSERT(zio->io_bp_override == NULL);
+	ASSERT3P(zio->io_bp_override, ==, NULL);
 
 	if (!BP_IS_HOLE(bp))
 		metaslab_free(zio->io_spa, bp, bp->blk_birth, B_TRUE);
@@ -3781,7 +3781,7 @@ zio_vdev_io_start(zio_t *zio)
 		/* Transform logical writes to be a full physical block size. */
 		uint64_t asize = P2ROUNDUP(zio->io_size, align);
 		abd_t *abuf = abd_alloc_sametype(zio->io_abd, asize);
-		ASSERT(vd == vd->vdev_top);
+		ASSERT3P(vd, ==, vd->vdev_top);
 		if (zio->io_type == ZIO_TYPE_WRITE) {
 			abd_copy(abuf, zio->io_abd, zio->io_size);
 			abd_zero_off(abuf, zio->io_size, asize - zio->io_size);
@@ -3930,7 +3930,7 @@ zio_vdev_io_done(zio_t *zio)
 	ops->vdev_op_io_done(zio);
 
 	if (unexpected_error && vd->vdev_remove_wanted == B_FALSE)
-		VERIFY(vdev_probe(vd, zio) == NULL);
+		VERIFY3P(vdev_probe(vd, zio), ==, NULL);
 
 	return (zio);
 }
@@ -4299,7 +4299,7 @@ zio_checksum_verify(zio_t *zio)
 	blkptr_t *bp = zio->io_bp;
 	int error;
 
-	ASSERT(zio->io_vd != NULL);
+	ASSERT3P(zio->io_vd, !=, NULL);
 
 	if (bp == NULL) {
 		/*
@@ -4398,7 +4398,7 @@ zio_ready(zio_t *zio)
 		if (zio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 			ASSERT(IO_IS_ALLOCATING(zio));
 			ASSERT(zio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
-			ASSERT(zio->io_metaslab_class != NULL);
+			ASSERT3P(zio->io_metaslab_class, !=, NULL);
 
 			/*
 			 * We were unable to allocate anything, unreserve and
@@ -4459,7 +4459,7 @@ zio_dva_throttle_done(zio_t *zio)
 	ASSERT3U(zio->io_type, ==, ZIO_TYPE_WRITE);
 	ASSERT3U(zio->io_priority, ==, ZIO_PRIORITY_ASYNC_WRITE);
 	ASSERT3U(zio->io_child_type, ==, ZIO_CHILD_VDEV);
-	ASSERT(vd != NULL);
+	ASSERT3P(vd, !=, NULL);
 	ASSERT3P(vd, ==, vd->vdev_top);
 	ASSERT(zio_injection_enabled || !(zio->io_flags & ZIO_FLAG_IO_RETRY));
 	ASSERT0((zio->io_flags & ZIO_FLAG_IO_REPAIR));
@@ -4486,10 +4486,10 @@ zio_dva_throttle_done(zio_t *zio)
 
 	ASSERT(IO_IS_ALLOCATING(pio));
 	ASSERT3P(zio, !=, zio->io_logical);
-	ASSERT(zio->io_logical != NULL);
+	ASSERT3P(zio->io_logical, !=, NULL);
 	ASSERT0((zio->io_flags & ZIO_FLAG_IO_REPAIR));
 	ASSERT0(zio->io_flags & ZIO_FLAG_NOPWRITE);
-	ASSERT(zio->io_metaslab_class != NULL);
+	ASSERT3P(zio->io_metaslab_class, !=, NULL);
 
 	mutex_enter(&pio->io_lock);
 	metaslab_group_alloc_decrement(zio->io_spa, vd->vdev_id, pio, flags,
@@ -4534,7 +4534,7 @@ zio_done(zio_t *zio)
 	 */
 	if (zio->io_flags & ZIO_FLAG_IO_ALLOCATING &&
 	    zio->io_child_type == ZIO_CHILD_VDEV) {
-		ASSERT(zio->io_metaslab_class != NULL);
+		ASSERT3P(zio->io_metaslab_class, !=, NULL);
 		ASSERT(zio->io_metaslab_class->mc_alloc_throttle_enabled);
 		zio_dva_throttle_done(zio);
 	}
@@ -4546,7 +4546,7 @@ zio_done(zio_t *zio)
 	if (zio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 		ASSERT(zio->io_type == ZIO_TYPE_WRITE);
 		ASSERT(zio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
-		ASSERT(zio->io_bp != NULL);
+		ASSERT3P(zio->io_bp, !=, NULL);
 
 		metaslab_group_alloc_verify(zio->io_spa, zio->io_bp, zio,
 		    zio->io_allocator);

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1460,7 +1460,7 @@ zio_vdev_child_io(zio_t *pio, blkptr_t *bp, vdev_t *vd, uint64_t offset,
 	    (vd != vd->vdev_top || (flags & ZIO_FLAG_IO_RETRY))) {
 		ASSERT3P(pio->io_metaslab_class, !=, NULL);
 		ASSERT(pio->io_metaslab_class->mc_alloc_throttle_enabled);
-		ASSERT(type == ZIO_TYPE_WRITE);
+		ASSERT3S(type, ==, ZIO_TYPE_WRITE);
 		ASSERT(priority == ZIO_PRIORITY_ASYNC_WRITE);
 		ASSERT0((flags & ZIO_FLAG_IO_REPAIR));
 		ASSERT(!(pio->io_flags & ZIO_FLAG_IO_REWRITE) ||

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -208,7 +208,7 @@ zio_checksum_info_t zio_checksum_table[ZIO_CHECKSUM_FUNCTIONS] = {
 spa_feature_t
 zio_checksum_to_feature(enum zio_checksum cksum)
 {
-	VERIFY((cksum & ~ZIO_CHECKSUM_MASK) == 0);
+	VERIFY0((cksum & ~ZIO_CHECKSUM_MASK));
 
 	switch (cksum) {
 	case ZIO_CHECKSUM_BLAKE3:

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -304,12 +304,12 @@ zio_checksum_template_init(enum zio_checksum checksum, spa_t *spa)
 	if (spa->spa_cksum_tmpls[checksum] != NULL)
 		return;
 
-	VERIFY(ci->ci_tmpl_free != NULL);
+	VERIFY3P(ci->ci_tmpl_free, !=, NULL);
 	mutex_enter(&spa->spa_cksum_tmpls_lock);
 	if (spa->spa_cksum_tmpls[checksum] == NULL) {
 		spa->spa_cksum_tmpls[checksum] =
 		    ci->ci_tmpl_init(&spa->spa_cksum_salt);
-		VERIFY(spa->spa_cksum_tmpls[checksum] != NULL);
+		VERIFY3P(spa->spa_cksum_tmpls[checksum], !=, NULL);
 	}
 	mutex_exit(&spa->spa_cksum_tmpls_lock);
 }
@@ -349,7 +349,7 @@ zio_checksum_compute(zio_t *zio, enum zio_checksum checksum,
 	boolean_t insecure = (ci->ci_flags & ZCHECKSUM_FLAG_DEDUP) == 0;
 
 	ASSERT((uint_t)checksum < ZIO_CHECKSUM_FUNCTIONS);
-	ASSERT(ci->ci_func[0] != NULL);
+	ASSERT3P(ci->ci_func[0], !=, NULL);
 
 	zio_checksum_template_init(checksum, spa);
 
@@ -564,7 +564,7 @@ zio_checksum_templates_free(spa_t *spa)
 		if (spa->spa_cksum_tmpls[checksum] != NULL) {
 			zio_checksum_info_t *ci = &zio_checksum_table[checksum];
 
-			VERIFY(ci->ci_tmpl_free != NULL);
+			VERIFY3P(ci->ci_tmpl_free, !=, NULL);
 			ci->ci_tmpl_free(spa->spa_cksum_tmpls[checksum]);
 			spa->spa_cksum_tmpls[checksum] = NULL;
 		}

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -227,8 +227,8 @@ zio_checksum_to_feature(enum zio_checksum cksum)
 enum zio_checksum
 zio_checksum_select(enum zio_checksum child, enum zio_checksum parent)
 {
-	ASSERT(child < ZIO_CHECKSUM_FUNCTIONS);
-	ASSERT(parent < ZIO_CHECKSUM_FUNCTIONS);
+	ASSERT3U(child, <, ZIO_CHECKSUM_FUNCTIONS);
+	ASSERT3U(parent, <, ZIO_CHECKSUM_FUNCTIONS);
 	ASSERT(parent != ZIO_CHECKSUM_INHERIT && parent != ZIO_CHECKSUM_ON);
 
 	if (child == ZIO_CHECKSUM_INHERIT)
@@ -244,8 +244,8 @@ enum zio_checksum
 zio_checksum_dedup_select(spa_t *spa, enum zio_checksum child,
     enum zio_checksum parent)
 {
-	ASSERT((child & ZIO_CHECKSUM_MASK) < ZIO_CHECKSUM_FUNCTIONS);
-	ASSERT((parent & ZIO_CHECKSUM_MASK) < ZIO_CHECKSUM_FUNCTIONS);
+	ASSERT3U((child & ZIO_CHECKSUM_MASK), <, ZIO_CHECKSUM_FUNCTIONS);
+	ASSERT3U((parent & ZIO_CHECKSUM_MASK), <, ZIO_CHECKSUM_FUNCTIONS);
 	ASSERT(parent != ZIO_CHECKSUM_INHERIT && parent != ZIO_CHECKSUM_ON);
 
 	if (child == ZIO_CHECKSUM_INHERIT)
@@ -348,7 +348,7 @@ zio_checksum_compute(zio_t *zio, enum zio_checksum checksum,
 	spa_t *spa = zio->io_spa;
 	boolean_t insecure = (ci->ci_flags & ZCHECKSUM_FLAG_DEDUP) == 0;
 
-	ASSERT((uint_t)checksum < ZIO_CHECKSUM_FUNCTIONS);
+	ASSERT3U((uint_t)checksum, <, ZIO_CHECKSUM_FUNCTIONS);
 	ASSERT3P(ci->ci_func[0], !=, NULL);
 
 	zio_checksum_template_init(checksum, spa);

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -93,9 +93,9 @@ zio_compress_select(spa_t *spa, enum zio_compress child,
 {
 	enum zio_compress result;
 
-	ASSERT(child < ZIO_COMPRESS_FUNCTIONS);
-	ASSERT(parent < ZIO_COMPRESS_FUNCTIONS);
-	ASSERT(parent != ZIO_COMPRESS_INHERIT);
+	ASSERT3U(child, <, ZIO_COMPRESS_FUNCTIONS);
+	ASSERT3U(parent, <, ZIO_COMPRESS_FUNCTIONS);
+	ASSERT3U(parent, !=, ZIO_COMPRESS_INHERIT);
 
 	result = child;
 	if (result == ZIO_COMPRESS_INHERIT)
@@ -132,7 +132,7 @@ zio_compress_data(enum zio_compress c, abd_t *src, void *dst, size_t s_len,
 	uint8_t complevel;
 	zio_compress_info_t *ci = &zio_compress_table[c];
 
-	ASSERT((uint_t)c < ZIO_COMPRESS_FUNCTIONS);
+	ASSERT3U((uint_t)c, <, ZIO_COMPRESS_FUNCTIONS);
 	ASSERT((uint_t)c == ZIO_COMPRESS_EMPTY || ci->ci_compress != NULL);
 
 	/*

--- a/module/zfs/zthr.c
+++ b/module/zfs/zthr.c
@@ -313,8 +313,8 @@ zthr_create_timer(const char *zthr_name, zthr_checkfunc_t *checkfunc,
 void
 zthr_destroy(zthr_t *t)
 {
-	ASSERT(!MUTEX_HELD(&t->zthr_state_lock));
-	ASSERT(!MUTEX_HELD(&t->zthr_request_lock));
+	ASSERT0(MUTEX_HELD(&t->zthr_state_lock));
+	ASSERT0(MUTEX_HELD(&t->zthr_request_lock));
 	VERIFY3P(t->zthr_thread, ==, NULL);
 	mutex_destroy(&t->zthr_request_lock);
 	mutex_destroy(&t->zthr_state_lock);
@@ -392,7 +392,7 @@ zthr_cancel(zthr_t *t)
 		while (t->zthr_thread != NULL)
 			cv_wait(&t->zthr_cv, &t->zthr_state_lock);
 
-		ASSERT(!t->zthr_cancel);
+		ASSERT0(t->zthr_cancel);
 	}
 
 	mutex_exit(&t->zthr_state_lock);
@@ -412,8 +412,8 @@ zthr_resume(zthr_t *t)
 
 	ASSERT3P(&t->zthr_checkfunc, !=, NULL);
 	ASSERT3P(&t->zthr_func, !=, NULL);
-	ASSERT(!t->zthr_cancel);
-	ASSERT(!t->zthr_haswaiters);
+	ASSERT0(t->zthr_cancel);
+	ASSERT0(t->zthr_haswaiters);
 
 	/*
 	 * There are 4 states that we find the zthr in at this point
@@ -515,7 +515,7 @@ zthr_wait_cycle_done(zthr_t *t)
 		while ((t->zthr_haswaiters) && (t->zthr_thread != NULL))
 			cv_wait(&t->zthr_wait_cv, &t->zthr_state_lock);
 
-		ASSERT(!t->zthr_haswaiters);
+		ASSERT0(t->zthr_haswaiters);
 	}
 
 	mutex_exit(&t->zthr_state_lock);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -679,7 +679,7 @@ zvol_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
 			zgd->zgd_db = db;
 			zgd->zgd_bp = bp;
 
-			ASSERT(db != NULL);
+			ASSERT3P(db, !=, NULL);
 			ASSERT(db->db_offset == offset);
 			ASSERT(db->db_size == size);
 
@@ -773,7 +773,7 @@ zvol_shutdown_zv(zvol_state_t *zv)
 	    RW_LOCK_HELD(&zv->zv_suspend_lock));
 
 	if (zv->zv_flags & ZVOL_WRITTEN_TO) {
-		ASSERT(zv->zv_zilog != NULL);
+		ASSERT3P(zv->zv_zilog, !=, NULL);
 		zil_close(zv->zv_zilog);
 	}
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -191,8 +191,8 @@ zvol_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
 	int error;
 	uint64_t volblocksize, volsize;
 
-	VERIFY(nvlist_lookup_uint64(nvprops,
-	    zfs_prop_to_name(ZFS_PROP_VOLSIZE), &volsize) == 0);
+	VERIFY0(nvlist_lookup_uint64(nvprops,
+	    zfs_prop_to_name(ZFS_PROP_VOLSIZE), &volsize));
 	if (nvlist_lookup_uint64(nvprops,
 	    zfs_prop_to_name(ZFS_PROP_VOLBLOCKSIZE), &volblocksize) != 0)
 		volblocksize = zfs_prop_default_numeric(ZFS_PROP_VOLBLOCKSIZE);
@@ -201,21 +201,20 @@ zvol_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
 	 * These properties must be removed from the list so the generic
 	 * property setting step won't apply to them.
 	 */
-	VERIFY(nvlist_remove_all(nvprops,
-	    zfs_prop_to_name(ZFS_PROP_VOLSIZE)) == 0);
+	VERIFY0(nvlist_remove_all(nvprops, zfs_prop_to_name(ZFS_PROP_VOLSIZE)));
 	(void) nvlist_remove_all(nvprops,
 	    zfs_prop_to_name(ZFS_PROP_VOLBLOCKSIZE));
 
 	error = dmu_object_claim(os, ZVOL_OBJ, DMU_OT_ZVOL, volblocksize,
 	    DMU_OT_NONE, 0, tx);
-	ASSERT(error == 0);
+	ASSERT0(error);
 
 	error = zap_create_claim(os, ZVOL_ZAP_OBJ, DMU_OT_ZVOL_PROP,
 	    DMU_OT_NONE, 0, tx);
-	ASSERT(error == 0);
+	ASSERT0(error);
 
 	error = zap_update(os, ZVOL_ZAP_OBJ, "size", 8, 1, &volsize, tx);
-	ASSERT(error == 0);
+	ASSERT0(error);
 }
 
 /*

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -114,7 +114,7 @@ zvol_name_hash(const char *name)
 	int i;
 	uint64_t crc = -1ULL;
 	const uint8_t *p = (const uint8_t *)name;
-	ASSERT(zfs_crc64_table[128] == ZFS_CRC64_POLY);
+	ASSERT3U(zfs_crc64_table[128], ==, ZFS_CRC64_POLY);
 	for (i = 0; i < MAXNAMELEN - 1 && *p; i++, p++) {
 		crc = (crc >> 8) ^ zfs_crc64_table[(crc ^ (*p)) & 0xFF];
 	}
@@ -680,8 +680,8 @@ zvol_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
 			zgd->zgd_bp = bp;
 
 			ASSERT3P(db, !=, NULL);
-			ASSERT(db->db_offset == offset);
-			ASSERT(db->db_size == size);
+			ASSERT3U(db->db_offset, ==, offset);
+			ASSERT3U(db->db_size, ==, size);
 
 			error = dmu_sync(zio, lr->lr_common.lrc_txg,
 			    zvol_get_done, zgd);

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -109,7 +109,7 @@ static zstd_stats_t zstd_stats = {
 static int
 kstat_zstd_update(kstat_t *ksp, int rw)
 {
-	ASSERT(ksp != NULL);
+	ASSERT3P(ksp, !=, NULL);
 
 	if (rw == KSTAT_WRITE && ksp == zstd_ksp) {
 		ZSTDSTAT_ZERO(zstd_stat_alloc_fail);


### PR DESCRIPTION
### Motivation and Context
Whenever assertions go off, the older style ASSERT()/VERIFY() just tells us where it went off, but not what the values were, which is not helpful.

### Description
I used a mix of coccinelle scripts and sed to do this. One weakness of this approach is that getting signed/unsigned right is difficult for coccinelle since it does not actually parse headers properly. For equality/inequality, this is not a big problem and some existing use of `ASSERT3S()` and `ASSERT3U()` does not appear to be quite right. For greater than / less than and their or equal to variants, this does matter. I fixed the obvious ones, but I still need to do another pass.

### How Has This Been Tested?
It is being put into a PR to get test data from the buildbot.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
