### PR TITLE
zfs-2.1.9 patchset

### DIFF
--- a/META
+++ b/META
@@ -1,7 +1,7 @@
 Meta:          1
 Name:          zfs
 Branch:        1.0
-Version:       2.1.8
+Version:       2.1.9
 Release:       1
 Release-Tags:  relext
 License:       CDDL

--- a/config/kernel-acl.m4
+++ b/config/kernel-acl.m4
@@ -165,6 +165,9 @@ dnl #
 dnl # 5.15 API change,
 dnl # Added the bool rcu argument to get_acl for rcu path walk.
 dnl #
+dnl # 6.2 API change,
+dnl # get_acl() was renamed to get_inode_acl()
+dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_OPERATIONS_GET_ACL], [
 	ZFS_LINUX_TEST_SRC([inode_operations_get_acl], [
 		#include <linux/fs.h>
@@ -230,7 +233,22 @@ dnl #
 dnl # 5.12 API change,
 dnl # set_acl() added a user_namespace* parameter first
 dnl #
+dnl # 6.2 API change,
+dnl # set_acl() second paramter changed to a struct dentry *
+dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_OPERATIONS_SET_ACL], [
+	ZFS_LINUX_TEST_SRC([inode_operations_set_acl_userns_dentry], [
+		#include <linux/fs.h>
+
+		int set_acl_fn(struct user_namespace *userns,
+		    struct dentry *dent, struct posix_acl *acl,
+		    int type) { return 0; }
+
+		static const struct inode_operations
+		    iops __attribute__ ((unused)) = {
+			.set_acl = set_acl_fn,
+		};
+	],[])
 	ZFS_LINUX_TEST_SRC([inode_operations_set_acl_userns], [
 		#include <linux/fs.h>
 
@@ -263,11 +281,18 @@ AC_DEFUN([ZFS_AC_KERNEL_INODE_OPERATIONS_SET_ACL], [
 		AC_DEFINE(HAVE_SET_ACL, 1, [iops->set_acl() exists])
 		AC_DEFINE(HAVE_SET_ACL_USERNS, 1, [iops->set_acl() takes 4 args])
 	],[
-		ZFS_LINUX_TEST_RESULT([inode_operations_set_acl], [
+		ZFS_LINUX_TEST_RESULT([inode_operations_set_acl_userns_dentry], [
 			AC_MSG_RESULT(yes)
-			AC_DEFINE(HAVE_SET_ACL, 1, [iops->set_acl() exists, takes 3 args])
+			AC_DEFINE(HAVE_SET_ACL, 1, [iops->set_acl() exists])
+			AC_DEFINE(HAVE_SET_ACL_USERNS_DENTRY_ARG2, 1,
+			    [iops->set_acl() takes 4 args, arg2 is struct dentry *])
 		],[
-			AC_MSG_RESULT(no)
+			ZFS_LINUX_TEST_RESULT([inode_operations_set_acl], [
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_SET_ACL, 1, [iops->set_acl() exists, takes 3 args])
+			],[
+				ZFS_LINUX_REQUIRE_API([i_op->set_acl()], [3.14])
+			])
 		])
 	])
 ])

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -67,6 +67,9 @@ extern int zpl_xattr_security_init(struct inode *ip, struct inode *dip,
 #if defined(HAVE_SET_ACL_USERNS)
 extern int zpl_set_acl(struct user_namespace *userns, struct inode *ip,
     struct posix_acl *acl, int type);
+#elif defined(HAVE_SET_ACL_USERNS_DENTRY_ARG2)
+extern int zpl_set_acl(struct user_namespace *userns, struct dentry *dentry,
+    struct posix_acl *acl, int type);
 #else
 extern int zpl_set_acl(struct inode *ip, struct posix_acl *acl, int type);
 #endif /* HAVE_SET_ACL_USERNS */

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -1004,11 +1004,18 @@ int
 #ifdef HAVE_SET_ACL_USERNS
 zpl_set_acl(struct user_namespace *userns, struct inode *ip,
     struct posix_acl *acl, int type)
+#elif defined(HAVE_SET_ACL_USERNS_DENTRY_ARG2)
+zpl_set_acl(struct user_namespace *userns, struct dentry *dentry,
+    struct posix_acl *acl, int type)
 #else
 zpl_set_acl(struct inode *ip, struct posix_acl *acl, int type)
 #endif /* HAVE_SET_ACL_USERNS */
 {
+#ifdef HAVE_SET_ACL_USERNS_DENTRY_ARG2
+	return (zpl_set_acl_impl(d_inode(dentry), acl, type));
+#else
 	return (zpl_set_acl_impl(ip, acl, type));
+#endif /* HAVE_SET_ACL_USERNS_DENTRY_ARG2 */
 }
 #endif /* HAVE_SET_ACL */
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2827,7 +2827,7 @@ zio_write_gang_block(zio_t *pio, metaslab_class_t *mc)
 	 * have a third copy.
 	 */
 	gbh_copies = MIN(copies + 1, spa_max_replication(spa));
-	if (BP_IS_ENCRYPTED(bp) && gbh_copies >= SPA_DVAS_PER_BP)
+	if (gio->io_prop.zp_encrypt && gbh_copies >= SPA_DVAS_PER_BP)
 		gbh_copies = SPA_DVAS_PER_BP - 1;
 
 	int flags = METASLAB_HINTBP_FAVOR | METASLAB_GANG_HEADER;


### PR DESCRIPTION
### Motivation and Context
This is a very small fix-up release to revert 0156253d29a303bdcca3e535958e754d8f086e33.

### Description
A user reported IO errors on their encrypted dataset when they upgraded from zfs 2.1.7 -> 2.1.8.  They bisected it down to 0156253d29a303bdcca3e535958e754d8f086e33, so we are reverting it.  Full details are in https://github.com/openzfs/zfs/issues/14413

This also includes a 6.2 kernel fix.

### How Has This Been Tested?
Buildbot will test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
