### PR TITLE
Revert "ztest fails assertion in zio_write_gang_member_ready()"

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2826,7 +2826,7 @@ zio_write_gang_block(zio_t *pio, metaslab_class_t *mc)
 	 * have a third copy.
 	 */
 	gbh_copies = MIN(copies + 1, spa_max_replication(spa));
-	if (BP_IS_ENCRYPTED(bp) && gbh_copies >= SPA_DVAS_PER_BP)
+	if (gio->io_prop.zp_encrypt && gbh_copies >= SPA_DVAS_PER_BP)
 		gbh_copies = SPA_DVAS_PER_BP - 1;
 
 	int flags = METASLAB_HINTBP_FAVOR | METASLAB_GANG_HEADER;


### PR DESCRIPTION
### Motivation and Context

This reverts commit 40d7e971ffc16b2ef993a6e9da40a8b3ca91ad01 due to potential regression.  Thus far we've been unable to reproduce the issue, additional investigation is needed.  Until then remove it from the source tree.

### Description

See issue #14413 for details.