### PR TITLE
Prevent error messages when running tests with no timeout

### DIFF
--- a/tests/test-runner/bin/test-runner.py.in
+++ b/tests/test-runner/bin/test-runner.py.in
@@ -297,7 +297,7 @@ User: %s
         proc = Popen(privcmd, stdout=PIPE, stderr=PIPE)
         # Allow a special timeout value of 0 to mean infinity
         if int(self.timeout) == 0:
-            self.timeout = sys.maxsize
+            self.timeout = sys.maxsize / (10 ** 9)
         t = Timer(int(self.timeout), self.kill_cmd, [proc])
 
         try:


### PR DESCRIPTION
### Motivation and Context
When running tests using the test suite with no timeout (like performance tests), error messages pop up like:
```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 1252, in run
    self.finished.wait(self.interval)
  File "/usr/lib/python3.8/threading.py", line 558, in wait
    signaled = self._cond.wait(timeout)
  File "/usr/lib/python3.8/threading.py", line 306, in wait
    gotit = waiter.acquire(True, timeout)
OverflowError: timestamp too large to convert to C _PyTime_t
```
These do not cause problems with the test runs, but are annoying.

### Description
The `Timer` class in python 3's threading library takes a number of seconds to wait as the interval. It stores that value in a `_PyTime_t`. This type is effectively a signed 64-bit integer, and it stores in units of nanoseconds. Thus, when passing in `sys.maxsize` (which is effectively `INT64_MAX`), it would overflow the size of the interval after converting to nanoseconds. We need to downscale so that the value is representable.

### How Has This Been Tested?
Manual testing with zfs test suite runs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
