### PR TITLE
Colorize zpool iostat output

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -4213,6 +4213,8 @@ print_iostat_header_impl(iostat_cbdata_t *cb, unsigned int force_column_width,
 	unsigned int namewidth;
 	const char *title;
 
+	color_start(ANSI_BOLD);
+
 	if (cb->cb_flags & IOS_ANYHISTO_M) {
 		title = histo_to_title[IOS_HISTO_IDX(cb->cb_flags)];
 	} else if (cb->cb_vdevs.cb_names_count) {
@@ -4246,6 +4248,8 @@ print_iostat_header_impl(iostat_cbdata_t *cb, unsigned int force_column_width,
 	if (cb->vcdl != NULL)
 		print_cmd_columns(cb->vcdl, 1);
 
+	color_end();
+
 	printf("\n");
 }
 
@@ -4255,6 +4259,35 @@ print_iostat_header(iostat_cbdata_t *cb)
 	print_iostat_header_impl(cb, 0, NULL);
 }
 
+/*
+ * Prints a size string (i.e. 120M) with the suffix ("M") colored
+ * by order of magnitude. Uses column_size to add padding.
+ */
+static void
+print_stat_color(char *statbuf, unsigned int column_size)
+{
+	fputs("  ", stdout);
+	if (*statbuf == '0') {
+		color_start(ANSI_GRAY);
+		fputc('0', stdout);
+		column_size--;
+	} else {
+		for (; *statbuf; statbuf++) {
+			if (*statbuf == 'K') color_start(ANSI_GREEN);
+			else if (*statbuf == 'M') color_start(ANSI_YELLOW);
+			else if (*statbuf == 'G') color_start(ANSI_RED);
+			else if (*statbuf == 'T') color_start(ANSI_BLUE);
+			else if (*statbuf == 'P') color_start(ANSI_MAGENTA);
+			else if (*statbuf == 'E') color_start(ANSI_CYAN);
+			fputc(*statbuf, stdout);
+			if (--column_size <= 0)
+				break;
+		}
+	}
+	color_end();
+	for (; column_size > 0; column_size--)
+		fputc(' ', stdout);
+}
 
 /*
  * Display a single statistic.
@@ -4270,7 +4303,7 @@ print_one_stat(uint64_t value, enum zfs_nicenum_format format,
 	if (scripted)
 		printf("\t%s", buf);
 	else
-		printf("  %*s", column_size, buf);
+		print_stat_color(buf, column_size);
 }
 
 /*

--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -173,6 +173,10 @@ struct zfs_cmd;
 #define	ANSI_GREEN	"\033[0;32m"
 #define	ANSI_YELLOW	"\033[0;33m"
 #define	ANSI_BLUE	"\033[0;34m"
+#define	ANSI_MAGENTA	"\033[0;34m"
+#define	ANSI_CYAN	"\033[0;34m"
+
+#define	ANSI_GRAY	"\033[0;37m"
 #define	ANSI_RESET	"\033[0m"
 #define	ANSI_BOLD	"\033[1m"
 

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -445,6 +445,8 @@ to dump core on exit for the purposes of running
 .It Sy ZFS_COLOR
 Use ANSI color in
 .Nm zpool Cm status
+and
+.Nm zpool Cm iostat
 output.
 .It Sy ZPOOL_IMPORT_PATH
 The search path for devices or files to use with the pool.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add colored output to `zpool iostat` to improve readability and allow users to quickly see relative sizes of various entries. Addresses https://github.com/openzfs/zfs/issues/13168 by coloring space suffixes.

### Description
<!--- Describe your changes in detail -->
Uses the interface introduced in https://github.com/openzfs/zfs/pull/9340 to add color to `zpool iostat`.

If the `ZFS_COLOR` env variable is set, then the output of `zpool iostat` is colored as follows:
- Header rows are bold
- 0 space is colored gray
- Size suffixes are colored by order of magnitude 
    - K is green 
    - M is yellow 
    - G is red 
    - T is blue 
    - P is magenta 
    - E is cyan

**Screenshots**
<img width="561" alt="Screen Shot 2023-02-03 at 13 16 33" src="https://user-images.githubusercontent.com/44591535/216712254-dbd87d7d-891f-45bf-8323-dd77963b8ee8.png">
<img width="561" alt="Screen Shot 2023-02-03 at 13 17 14" src="https://user-images.githubusercontent.com/44591535/216712367-d5690790-5b6c-48fb-add7-726574993c42.png">


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Manually tested

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
