### PR TITLE
zdb: zero-pad checksum output

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2377,7 +2377,8 @@ snprintf_blkptr_compact(char *blkbuf, size_t buflen, const blkptr_t *bp,
 			(void) snprintf(blkbuf + strlen(blkbuf),
 			    buflen - strlen(blkbuf), " %s", "FREE");
 		(void) snprintf(blkbuf + strlen(blkbuf),
-		    buflen - strlen(blkbuf), " cksum=%llx:%llx:%llx:%llx",
+		    buflen - strlen(blkbuf),
+		    " cksum=%016llx:%016llx:%016llx:%016llx",
 		    (u_longlong_t)bp->blk_cksum.zc_word[0],
 		    (u_longlong_t)bp->blk_cksum.zc_word[1],
 		    (u_longlong_t)bp->blk_cksum.zc_word[2],
@@ -8383,7 +8384,9 @@ zdb_read_block(char *thing, spa_t *spa)
 				    DVA_GET_OFFSET(&bp->blk_dva[0]);
 				ck_zio->io_bp = bp;
 				zio_checksum_compute(ck_zio, ck, pabd, lsize);
-				printf("%12s\tcksum=%llx:%llx:%llx:%llx\n",
+				printf(
+				    "%12s\t"
+				    "cksum=%016llx:%016llx:%016llx:%016llx\n",
 				    zio_checksum_table[ck].ci_name,
 				    (u_longlong_t)bp->blk_cksum.zc_word[0],
 				    (u_longlong_t)bp->blk_cksum.zc_word[1],


### PR DESCRIPTION
The leading zeroes are part of the checksum so we should show them.

Before:

```
Dataset lucy/home/robn [ZPL], ID 273, cr_txg 54, 235G, 3273379 objects, rootbp DVA[0]=<0:4f4e631000:1000> DVA[1]=<0:2bda1b3000:1000> [L0 DMU objset] fletcher4 uncompressed authenticated LE contiguous unique double size=1000L/1000P birth=700533L/700533P fill=3273379 cksum=2413d7af5d:694ddef576ad:a1a2bac4720869:ac311ceb50e0894a
```

```
Indirect blocks:
               0 L0 0:2195de3000:1000 800L/800P F=1 B=5868/5868 cksum=abb8133a5241dc:556ecc7fe01909b2:865775cbea98211f:65ee76b451e52fb0
```

```
   fletcher2	cksum=7cf3bd75f2d60526:245f96cc28acfa04:f38520b50acd67e9:e6fb6c2c119f3773
   fletcher4	cksum=febcd652ec:101f8a047bbce:abb8ed86841330:556fcd87405eb27c
      sha256	cksum=64daaca0fe39c792:c722926fc2a969:fc083aa8588c1398:ce98b8642078d4c9
      sha512	cksum=248186becb0ed3c7:3bcf93b6e3cf34fd:549d6bdb697ced79:492eeb41eea45b55
       skein	cksum=41d3579d5fde5fa1:507de1c9f91d4528:fd0bf582d512e90a:e958ae1d8e36e3a9
       edonr	cksum=5a6e2dea1106becf:6e73bbc5a3232523:515f53d6537a31d7:e93d32bbd4dfc91f
```

After:

```
Dataset lucy/home/robn [ZPL], ID 273, cr_txg 54, 235G, 3273389 objects, rootbp DVA[0]=<0:4f4e4ed000:1000> DVA[1]=<0:2bda1a7000:1000> [L0 DMU objset] fletcher4 uncompressed authenticated LE contiguous unique double size=1000L/1000P birth=700532L/700532P fill=3273389 cksum=0000002089d5acfc:0000604c9de83213:009577d294beed0e:a0a2ea86487089aa
```

```
Indirect blocks:
               0 L0 0:2195de3000:1000 800L/800P F=1 B=5868/5868 cksum=00abb8133a5241dc:556ecc7fe01909b2:865775cbea98211f:65ee76b451e52fb0
```

```
   fletcher2	cksum=7cf3bd75f2d60526:245f96cc28acfa04:f38520b50acd67e9:e6fb6c2c119f3773
   fletcher4	cksum=000000febcd652ec:000101f8a047bbce:00abb8ed86841330:556fcd87405eb27c
      sha256	cksum=64daaca0fe39c792:00c722926fc2a969:fc083aa8588c1398:ce98b8642078d4c9
      sha512	cksum=248186becb0ed3c7:3bcf93b6e3cf34fd:549d6bdb697ced79:492eeb41eea45b55
       skein	cksum=41d3579d5fde5fa1:507de1c9f91d4528:fd0bf582d512e90a:e958ae1d8e36e3a9
       edonr	cksum=5a6e2dea1106becf:6e73bbc5a3232523:515f53d6537a31d7:e93d32bbd4dfc91f
      blake3	cksum=be741194b8aa076f:d72edc9ce76c983f:32f090feaf97ee00:bab55526bd6e2b61
```

Signed-off-by: Rob Norris <robn@despairlabs.com>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
