### PR TITLE
initramfs: Make mountpoint=none work [2.1.10]

### DIFF
--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -341,9 +341,11 @@ mount_fs()
 				# isn't the root fs.
 				return 0
 			fi
-			ZFS_CMD="mount.zfs"
 			# Last hail-mary: Hope 'rootmnt' is set!
 			mountpoint=""
+			if [ "$mountpoint" = "legacy" ]; then
+				ZFS_CMD="mount.zfs"
+			fi
 		else
 			mountpoint="$mountpoint1"
 		fi


### PR DESCRIPTION
In initramfs, mount.zfs fails to mount a dataset with mountpoint=none, but mount.zfs -o zfsutil works.  Use -o zfsutil when mountpoint=none.

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed-by: Richard Yao <richard.yao@alumni.stonybrook.edu>
Signed-off-by: Ryan Moeller <ryan@iXsystems.com>
Closes #14455
(cherry picked from commit eb823cbc76d28a7cafdf6a7aafdefe7e74fe26bc)