### PR TITLE
zdb: add decryption support

### DIFF
--- a/cmd/zdb/Makefile.am
+++ b/cmd/zdb/Makefile.am
@@ -1,4 +1,5 @@
 zdb_CPPFLAGS = $(AM_CPPFLAGS) $(FORCEDEBUG_CPPFLAGS)
+zdb_CFLAGS   = $(AM_CFLAGS) $(LIBCRYPTO_CFLAGS)
 
 sbin_PROGRAMS   += zdb
 CPPCHECKTARGETS += zdb
@@ -12,3 +13,5 @@ zdb_LDADD = \
 	libzpool.la \
 	libzfs_core.la \
 	libnvpair.la
+
+zdb_LDADD += $(LIBCRYPTO_LIBS)

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -3036,9 +3036,9 @@ zdb_derive_key(dsl_dir_t *dd, uint8_t *key_out)
 	int i;
 	unsigned char c;
 
-	zap_lookup(dd->dd_pool->dp_meta_objset, dd->dd_crypto_obj,
+	VERIFY0(zap_lookup(dd->dd_pool->dp_meta_objset, dd->dd_crypto_obj,
 	    zfs_prop_to_name(ZFS_PROP_KEYFORMAT), sizeof (uint64_t),
-	    1, &keyformat);
+	    1, &keyformat));
 
 	switch (keyformat) {
 	case ZFS_KEYFORMAT_HEX:
@@ -3053,12 +3053,12 @@ zdb_derive_key(dsl_dir_t *dd, uint8_t *key_out)
 		break;
 
 	case ZFS_KEYFORMAT_PASSPHRASE:
-		zap_lookup(dd->dd_pool->dp_meta_objset, dd->dd_crypto_obj,
-		    zfs_prop_to_name(ZFS_PROP_PBKDF2_SALT), sizeof (uint64_t),
-		    1, &salt);
-		zap_lookup(dd->dd_pool->dp_meta_objset, dd->dd_crypto_obj,
-		    zfs_prop_to_name(ZFS_PROP_PBKDF2_ITERS), sizeof (uint64_t),
-		    1, &iters);
+		VERIFY0(zap_lookup(dd->dd_pool->dp_meta_objset,
+		    dd->dd_crypto_obj, zfs_prop_to_name(ZFS_PROP_PBKDF2_SALT),
+		    sizeof (uint64_t), 1, &salt));
+		VERIFY0(zap_lookup(dd->dd_pool->dp_meta_objset,
+		    dd->dd_crypto_obj, zfs_prop_to_name(ZFS_PROP_PBKDF2_ITERS),
+		    sizeof (uint64_t), 1, &iters));
 
 		if (PKCS5_PBKDF2_HMAC_SHA1(key_material, strlen(key_material),
 		    ((uint8_t *)&salt), sizeof (uint64_t), iters,
@@ -3091,9 +3091,9 @@ zdb_load_key(objset_t *os)
 	dd = os->os_dsl_dataset->ds_dir;
 
 	dsl_pool_config_enter(dp, FTAG);
-	zap_lookup(dd->dd_pool->dp_meta_objset, dd->dd_crypto_obj,
-	    DSL_CRYPTO_KEY_ROOT_DDOBJ, sizeof (uint64_t), 1, &rddobj);
-	dsl_dir_hold_obj(dd->dd_pool, rddobj, NULL, FTAG, &rdd);
+	VERIFY0(zap_lookup(dd->dd_pool->dp_meta_objset, dd->dd_crypto_obj,
+	    DSL_CRYPTO_KEY_ROOT_DDOBJ, sizeof (uint64_t), 1, &rddobj));
+	VERIFY0(dsl_dir_hold_obj(dd->dd_pool, rddobj, NULL, FTAG, &rdd));
 	dsl_dir_name(rdd, encroot);
 	dsl_dir_rele(rdd, FTAG);
 
@@ -3110,8 +3110,8 @@ zdb_load_key(objset_t *os)
 	crypto_args = fnvlist_alloc();
 	fnvlist_add_uint8_array(crypto_args, "wkeydata",
 	    (uint8_t *)key, WRAPPING_KEY_LEN);
-	dsl_crypto_params_create_nvlist(DCP_CMD_NONE,
-	    NULL, crypto_args, &dcp);
+	VERIFY0(dsl_crypto_params_create_nvlist(DCP_CMD_NONE,
+	    NULL, crypto_args, &dcp));
 	err = spa_keystore_load_wkey(encroot, dcp, B_FALSE);
 
 	dsl_crypto_params_free(dcp, (err != 0));
@@ -3134,7 +3134,7 @@ zdb_unload_key(void)
 	if (!key_loaded)
 		return;
 
-	spa_keystore_unload_wkey(encroot);
+	VERIFY0(spa_keystore_unload_wkey(encroot));
 	key_loaded = B_FALSE;
 }
 

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -30,12 +30,14 @@
 .Op Fl t Ar txg
 .Op Fl U Ar cache
 .Op Fl x Ar dumpdir
+.Op Fl K Ar key
 .Op Ar poolname Ns Op / Ns Ar dataset Ns | Ns Ar objset-ID
 .Op Ar object Ns | Ns Ar range Ns …
 .Nm
 .Op Fl AdiPv
 .Op Fl e Oo Fl V Oc Oo Fl p Ar path Oc Ns …
 .Op Fl U Ar cache
+.Op Fl K Ar key
 .Ar poolname Ns Op Ar / Ns Ar dataset Ns | Ns Ar objset-ID
 .Op Ar object Ns | Ns Ar range Ns …
 .Nm
@@ -59,9 +61,11 @@
 .Ar poolname Op Ar vdev Oo Ar metaslab Oc Ns …
 .Nm
 .Fl O
+.Op Fl K Ar key
 .Ar dataset path
 .Nm
 .Fl r
+.Op Fl K Ar key
 .Ar dataset path destination
 .Nm
 .Fl R
@@ -418,6 +422,24 @@ The default value is 200.
 This option affects the performance of the
 .Fl c
 option.
+.It Fl K , -key Ns = Ns Ar key
+Decryption key needed to access an encrypted dataset.
+This will cause
+.Nm
+to attempt to unlock the dataset using the encryption root, key format and other
+encryption parameters on the given dataset.
+.Nm
+can still inspect pool and dataset structures on encrypted datasets without
+unlocking them, but will not be able to access file names and attributes and
+object contents. \fBWARNING:\fP The raw decryption key and any decrypted data
+will be in user memory while
+.Nm
+is running.
+Other user programs may be able to extract it by inspecting
+.Nm
+as it runs.
+Exercise extreme caution when using this option in shared or uncontrolled
+environments.
 .It Fl o , -option Ns = Ns Ar var Ns = Ns Ar value Ns …
 Set the given global libzpool variable to the provided value.
 The value must be an unsigned 32-bit integer.

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -126,9 +126,9 @@ tags = ['functional', 'clean_mirror']
 tests = ['zdb_002_pos', 'zdb_003_pos', 'zdb_004_pos', 'zdb_005_pos',
     'zdb_006_pos', 'zdb_args_neg', 'zdb_args_pos',
     'zdb_block_size_histogram', 'zdb_checksum', 'zdb_decompress',
-    'zdb_display_block', 'zdb_label_checksum', 'zdb_object_range_neg',
-    'zdb_object_range_pos', 'zdb_objset_id', 'zdb_decompress_zstd',
-    'zdb_recover', 'zdb_recover_2']
+    'zdb_display_block', 'zdb_encrypted', 'zdb_label_checksum',
+    'zdb_object_range_neg', 'zdb_object_range_pos', 'zdb_objset_id',
+    'zdb_decompress_zstd', 'zdb_recover', 'zdb_recover_2']
 pre =
 post =
 tags = ['functional', 'cli_root', 'zdb']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -573,6 +573,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zdb/zdb_decompress.ksh \
 	functional/cli_root/zdb/zdb_decompress_zstd.ksh \
 	functional/cli_root/zdb/zdb_display_block.ksh \
+	functional/cli_root/zdb/zdb_encrypted.ksh \
 	functional/cli_root/zdb/zdb_label_checksum.ksh \
 	functional/cli_root/zdb/zdb_object_range_neg.ksh \
 	functional/cli_root/zdb/zdb_object_range_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_neg.ksh
@@ -57,7 +57,7 @@ set -A args "create" "add" "destroy" "import fakepool" \
     "add raidz1 fakepool" "add raidz2 fakepool" \
     "setvprop" "blah blah" "-%" "--?" "-*" "-=" \
     "-a" "-f" "-g" "-j" "-n" "-o" "-p" "-p /tmp" \
-    "-t" "-w" "-z" "-E" "-H" "-I" "-J" "-K" \
+    "-t" "-w" "-z" "-E" "-H" "-I" "-J" \
     "-Q" "-R" "-T" "-W"
 
 log_assert "Execute zdb using invalid parameters."

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_encrypted.ksh
@@ -1,0 +1,69 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017, Datto, Inc. All rights reserved.
+# Copyright (c) 2023, Rob Norris <robn@despairlabs.com>
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_load-key/zfs_load-key_common.kshlib
+
+#
+# DESCRIPTION:
+# 'zdb -K ...' should enable reading from an encrypt dataset
+#
+# STRATEGY:
+# 1. Create an encrypted dataset
+# 2. Write some data to a file
+# 3. Run zdb -dddd on the file, confirm it can't be read
+# 4. Run zdb -K ... -ddddd on the file, confirm it can be read
+#
+
+verify_runnable "both"
+
+dataset="$TESTPOOL/$TESTFS2"
+file="$TESTDIR2/somefile"
+
+function cleanup
+{
+	datasetexists $dataset && destroy_dataset $dataset -f
+	default_cleanup_noexit
+}
+
+log_onexit cleanup
+
+log_must default_setup_noexit $DISKS
+
+log_assert "'zdb -K' should enable reading from an encrypted dataset"
+
+log_must eval "echo $PASSPHRASE | zfs create -o mountpoint=$TESTDIR2" \
+	"-o encryption=on -o keyformat=passphrase $dataset"
+
+echo 'my great encrypted text' > $file
+
+obj="$(ls -i $file | cut -d' ' -f1)"
+size="$(wc -c < $file)"
+
+log_note "test file $file is objid $obj, size $size"
+
+sync_pool $TESTPOOL true
+
+log_must eval "zdb -dddd $dataset $obj | grep -q 'object encrypted'"
+
+log_must eval "zdb -K $PASSPHRASE -dddd $dataset $obj | grep -q 'size\s$size$'"
+
+log_pass "'zdb -K' enables reading from an encrypted dataset"


### PR DESCRIPTION
The approach is straightforward: for dataset ops, if a key was offered, find the encryption root and the various encryption parameters, derive a wrapping key if necessary, and then unlock the encryption root. After that all the regular dataset ops will return unencrypted data, and that's kinda the whole thing.

Resolves #11551, resolves #12707.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
