### PR TITLE
Fix missing unlock issues in zstd_mempool_alloc()

### DIFF
--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -343,6 +343,7 @@ zstd_mempool_alloc(struct zstd_pool *zstd_mempool, size_t size)
 				pool->timeout = gethrestime_sec() +
 				    ZSTD_POOL_TIMEOUT;
 				mem = pool->mem;
+				mutex_exit(&pool->barrier);
 				return (mem);
 			}
 			mutex_exit(&pool->barrier);
@@ -380,6 +381,7 @@ zstd_mempool_alloc(struct zstd_pool *zstd_mempool, size_t size)
 				pool->timeout = gethrestime_sec() +
 				    ZSTD_POOL_TIMEOUT;
 
+				mutex_exit(&pool->barrier);
 				return (pool->mem);
 			}
 


### PR DESCRIPTION
### Motivation and Context
FreeBSD's coverity scan caught a pair of locking bugs in zstd_mempool_alloc() that the Linux coverity scans missed.

Reported-by: Coverity (CID-1432396)

### Description
Add missing mutex unlock calls to the zstd_mempool_alloc() function.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
