### PR TITLE
Detect concurrent execution of the same ZIO in debug builds

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2167,9 +2167,16 @@ __zio_execute(zio_t *zio)
 		enum zio_stage pipeline = zio->io_pipeline;
 		enum zio_stage stage = zio->io_stage;
 
+#ifdef DEBUG
+		mutex_enter(&zio->io_lock);
+		ASSERT(zio->io_executor == NULL ||
+		    zio->io_executor == curthread);
 		zio->io_executor = curthread;
+		mutex_exit(&zio->io_lock);
+#else
+		zio->io_executor = curthread;
+#endif
 
-		ASSERT(!MUTEX_HELD(&zio->io_lock));
 		ASSERT(ISP2(stage));
 		ASSERT(zio->io_stall == NULL);
 


### PR DESCRIPTION
### Motivation and Context
FreeBSD's Coverity scan states that we have a data race condition on ->io_executor in __zio_execute(). While this is technically correct, the way that the code is structured should make this a non-issue in practice.

However, it occurs to me that if we somehow did invoke zio_execute() on the same zio in two separate threads, this data race would occur and without any logic to detect the race, it would be very hard to identify the cause of the problem.

Reported-by: Coverity (CID-1431999)

### Description
Therefore, when debugging is enabled, we lock the mutex and assert that another thread is not executing this zio before setting ->io_executor. Taking the lock also does an assertion that makes ASSERT(!MUTEX_HELD(&zio->io_lock)) redundant, so we drop that assertion.

We continue to permit the data race on non-debug builds because locking on non-debug builds does not give us any benefit. No matter which thread comes first or second when modifying ->io_executor, bad things would still happen should two threads attempt to execute the same zio simultaneously.

Unfortunately, FreeBSD's coverity scan appears to be done without assertions enabled, so this will not silence the report in the open FreeBSD coverity defects. That will need to be done manually.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
