### PR TITLE
Do not hold spa_config in ZIL while blocked on IO

### DIFF
--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1287,8 +1287,6 @@ zil_lwb_flush_vdevs_done(zio_t *zio)
 	itx_t *itx;
 	uint64_t txg;
 
-	spa_config_exit(zilog->zl_spa, SCL_STATE, lwb);
-
 	zio_buf_free(lwb->lwb_buf, lwb->lwb_sz);
 
 	mutex_enter(&zilog->zl_lock);
@@ -1427,8 +1425,6 @@ zil_lwb_write_done(zio_t *zio)
 	zil_vdev_node_t *zv;
 	lwb_t *nlwb;
 
-	ASSERT3S(spa_config_held(spa, SCL_STATE, RW_READER), !=, 0);
-
 	ASSERT(BP_GET_COMPRESS(zio->io_bp) == ZIO_COMPRESS_OFF);
 	ASSERT(BP_GET_TYPE(zio->io_bp) == DMU_OT_INTENT_LOG);
 	ASSERT(BP_GET_LEVEL(zio->io_bp) == 0);
@@ -1490,6 +1486,7 @@ zil_lwb_write_done(zio_t *zio)
 		return;
 	}
 
+	spa_config_enter(spa, SCL_STATE, FTAG, RW_READER);
 	while ((zv = avl_destroy_nodes(t, &cookie)) != NULL) {
 		vdev_t *vd = vdev_lookup_top(spa, zv->zv_vdev);
 		if (vd != NULL) {
@@ -1505,6 +1502,7 @@ zil_lwb_write_done(zio_t *zio)
 		}
 		kmem_free(zv, sizeof (*zv));
 	}
+	spa_config_exit(spa, SCL_STATE, FTAG);
 }
 
 static void
@@ -1782,8 +1780,6 @@ zil_lwb_write_issue(zilog_t *zilog, lwb_t *lwb)
 	 * clear unused data for security
 	 */
 	memset(lwb->lwb_buf + lwb->lwb_nused, 0, wsz - lwb->lwb_nused);
-
-	spa_config_enter(zilog->zl_spa, SCL_STATE, lwb, RW_READER);
 
 	zil_lwb_add_block(lwb, &lwb->lwb_blk);
 	lwb->lwb_issued_timestamp = gethrtime();


### PR DESCRIPTION
### Motivation and Context
Otherwise, we can get a deadlock that looks like this:

1. fsync() grabs spa_config_enter(zilog->zl_spa, SCL_STATE, lwb, RW_READER) as part of zil_lwb_write_issue() . It then blocks on the txg_sync when a flush fails from a drive power cycling.

2. The txg_sync then blocks on the pool suspending due to the loss of too many disks.

3. zpool clear then blocks on spa_config_enter(spa, SCL_STATE | SCL_L2ARC | SCL_ZIO, spa, RW_WRITER)  because it is a writer.

The disks cannot be brought online due to fsync() holding that lock and the user gets upset since fsync() is uninterruptibly blocked inside the kernel.

We need to grab the lock for vdev_lookup_top(), but we do not need to hold it while there is outstanding IO.

This fixes a regression introduced by 1ce23dcaff6c3d777cb0d9a4a2cf02b43f777d78.

This was done by Klara Systems and sponsored by Wasabi Technology, Inc.

### Description
1ce23dcaff6c3d777cb0d9a4a2cf02b43f777d78 changed ZIL to hold the spa_config lock while IO is in-flight. This partially reverts that to grab it only when necessary for `vdev_lookup_top()`.

### How Has This Been Tested?
At Klara, I am working on making ZIL resilient against flush failures that can occur when drives power cycle. We have a system with a 14 disk pool (typically all in a single raidz3 vdev, but also sometimes all as individual top level vdevs for testing purposes) and a script that will:

* Run a ZIL intensive workload that creates dozens of gigabytes of data
* Power-off 5 drives at the backplane while the workload is running
* After some time has elapsed and the pool has long faulted, power-on the drives
* Run `zpool clear` on the pool to unsuspend it.
* (As of a few weeks ago) Do a scrub.

Occasionally, this script would deadlock because ZIL was holding the zpool config lock. After writing this patch, the code has been subjected to numerous test runs over months with no apparent regressions from this change. At least 700 have been done in the past 2 weeks.

The logic to add resilience to ZIL in that branch intercepts IOs at the block layer and does replay in txg_sync. The branch contains no significant changes to ZIL beyond this patch, so our testing on that branch is expected to be applicable to master.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
