### PR TITLE
Use .section .rodata instead of .rodata on FreeBSD

### DIFF
--- a/include/os/freebsd/spl/sys/ia32/asm_linkage.h
+++ b/include/os/freebsd/spl/sys/ia32/asm_linkage.h
@@ -36,7 +36,7 @@
 #define	ENDBR
 
 #define	SECTION_TEXT .text
-#define	SECTION_STATIC .rodata
+#define	SECTION_STATIC .section .rodata
 
 #ifdef	__cplusplus
 extern "C" {

--- a/lib/libspl/include/os/freebsd/sys/ia32/asm_linkage.h
+++ b/lib/libspl/include/os/freebsd/sys/ia32/asm_linkage.h
@@ -40,7 +40,7 @@
 #define	ENDBR
 
 #define	SECTION_TEXT .text
-#define	SECTION_STATIC .rodata
+#define	SECTION_STATIC .section .rodata
 
 #ifdef	__cplusplus
 extern "C" {


### PR DESCRIPTION
### Motivation and Context

This solves the problem of being able to build OpenZFS on FreeBSD using gcc and GNU binutils.

### Description
In commit 0a5b942d4 the FreeBSD `SECTION_STATIC` macro was set to ".rodata". This assembler directive is supported by LLVM (as a convenience alias for ".section .rodata") by not by GNU as.

This caused the FreeBSD builds that are done with gcc to fail (see https://ci.freebsd.org/job/FreeBSD-main-amd64-gcc12_build/492/, for instance). Therefore, use ".section .rodata" instead, similar to the other asm_linkage.h headers.

### How Has This Been Tested?
I compiled the openzfs code on FreeBSD 14-CURRENT with gcc. Before this change, it resulted in assembler errors, and afterwards they are solved.

There should be no impact to any other platform or toolchain combination.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
