### PR TITLE
man: Add vdevprops.7 to the Makefile

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -15,6 +15,7 @@ dist_man_MANS = \
 	%D%/man4/zfs.4 \
 	\
 	%D%/man7/dracut.zfs.7 \
+	%D%/man7/vdevprops.7 \
 	%D%/man7/zfsconcepts.7 \
 	%D%/man7/zfsprops.7 \
 	%D%/man7/zpool-features.7 \


### PR DESCRIPTION
Adding vdevprops.7 to the Makefile ensures that it gets installed properly on FreeBSD.


### Motivation and Context
Without this change, there's no manual page for vdevprops shipped with the FreeBSD base system, and it's only available via the openzfs-docs.

### Description
I'm not sure I can add any more words to describe this tiny change.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
- [X] Documentation (a change to man pages or other documentation)
