### PR TITLE
Workaround GitHub Action failure

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -13,8 +13,10 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get -qq upgrade
+        # https://github.com/orgs/community/discussions/47863
+        sudo apt-mark hold grub-efi-amd64-signed
+        sudo apt-get update --fix-missing
+        sudo apt-get upgrade
         sudo xargs --arg-file=${{ github.workspace }}/.github/workflows/build-dependencies.txt apt-get install -qq
         sudo xargs --arg-file=${{ github.workspace }}/.github/workflows/checkstyle-dependencies.txt apt-get install -qq
         sudo python3 -m pip install --quiet flake8

--- a/.github/workflows/zfs-tests-functional.yml
+++ b/.github/workflows/zfs-tests-functional.yml
@@ -17,8 +17,10 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get -qq upgrade
+        # https://github.com/orgs/community/discussions/47863
+        sudo apt-mark hold grub-efi-amd64-signed
+        sudo apt-get update --fix-missing
+        sudo apt-get upgrade
         sudo xargs --arg-file=${{ github.workspace }}/.github/workflows/build-dependencies.txt apt-get install -qq
         sudo apt-get clean
     - name: Autogen.sh

--- a/.github/workflows/zfs-tests-sanity.yml
+++ b/.github/workflows/zfs-tests-sanity.yml
@@ -13,8 +13,10 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get -qq upgrade
+        # https://github.com/orgs/community/discussions/47863
+        sudo apt-mark hold grub-efi-amd64-signed
+        sudo apt-get update --fix-missing
+        sudo apt-get upgrade
         sudo xargs --arg-file=${{ github.workspace }}/.github/workflows/build-dependencies.txt apt-get install -qq
         sudo apt-get clean
     - name: Autogen.sh

--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -15,8 +15,10 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get -qq upgrade
+        # https://github.com/orgs/community/discussions/47863
+        sudo apt-mark hold grub-efi-amd64-signed
+        sudo apt-get update --fix-missing
+        sudo apt-get upgrade
         sudo xargs --arg-file=${{ github.workspace }}/.github/workflows/build-dependencies.txt apt-get install -qq
         sudo apt-get clean
     - name: Autogen.sh


### PR DESCRIPTION
### Motivation and Context

All Ubuntu 20.04 and 22.04 workflows are failing.

### Description

Ubuntu 20.04 and 22.04 workflows are failing due to an error which is hit when running `apt-get update`.  Until the problematic package is fixed apply the suggested workaround described here:

  https://github.com/orgs/community/discussions/47863

### How Has This Been Tested?

This should work, but we shall see.