### PR TITLE
Update space reclaim script

### DIFF
--- a/.github/workflows/scripts/reclaim_disk_space.sh
+++ b/.github/workflows/scripts/reclaim_disk_space.sh
@@ -6,7 +6,7 @@ set -eu
 sudo systemd-run docker system prune --force --all --volumes
 
 # remove unused software
-sudo systemd-run rm -rf \
+sudo systemd-run --wait rm -rf \
   "$AGENT_TOOLSDIRECTORY" \
   /opt/* \
   /usr/local/* \
@@ -18,3 +18,6 @@ sudo systemd-run rm -rf \
   /var/lib/gems \
   /var/lib/mysql \
   /var/lib/snapd
+
+# trim the cleaned space
+sudo fstrim /


### PR DESCRIPTION
### Motivation and Context

The `reclaim_disk_space.sh` script uses systemd-run, which does the job in background. We should take the the time and wait for the job to finish.

Maybe some functional tests suffer from not really freed disk space and fail because of this.

We add also some trimming in the end of the script.

### How Has This Been Tested?

Some local testing was done, but I hope that CI will fully test this :-)

### disk usage

-  before patch:
![2023-02-28_205722](https://user-images.githubusercontent.com/1430535/221980649-9d3963e5-2231-4b46-87e1-d8cb414221ec.png)

-  afterwards:
![2023-02-28_220530](https://user-images.githubusercontent.com/1430535/221980685-06ae6523-1f80-421f-ad40-60a74f61db11.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
