### PR TITLE
Linux x86 SIMD: Add XSAVEC support to kfpu_begin()

### DIFF
--- a/config/toolchain-simd.m4
+++ b/config/toolchain-simd.m4
@@ -27,6 +27,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_TOOLCHAIN_SIMD], [
 			ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVE
 			ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVEOPT
 			ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVES
+			ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVEC
 			;;
 	esac
 ])
@@ -484,6 +485,27 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVES], [
 	]])], [
 		AC_MSG_RESULT([yes])
 		AC_DEFINE([HAVE_XSAVES], 1, [Define if host toolchain supports XSAVES])
+	], [
+		AC_MSG_RESULT([no])
+	])
+])
+
+dnl #
+dnl # ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVEC
+dnl #
+AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVEC], [
+	AC_MSG_CHECKING([whether host toolchain supports XSAVEC])
+
+	AC_LINK_IFELSE([AC_LANG_SOURCE([
+	[
+		void main()
+		{
+		  char b[4096] __attribute__ ((aligned (64)));
+		  __asm__ __volatile__("xsavec %[b]\n" : : [b] "m" (*b) : "memory");
+		}
+	]])], [
+		AC_MSG_RESULT([yes])
+		AC_DEFINE([HAVE_XSAVEC], 1, [Define if host toolchain supports XSAVEC])
 	], [
 		AC_MSG_RESULT([no])
 	])

--- a/include/os/linux/kernel/linux/simd_x86.h
+++ b/include/os/linux/kernel/linux/simd_x86.h
@@ -311,6 +311,12 @@ kfpu_begin(void)
 	 * FPU state to be correctly preserved and restored.
 	 */
 	uint8_t *state = zfs_kfpu_fpregs[smp_processor_id()];
+#if defined(HAVE_XSAVEC)
+	if (static_cpu_has(X86_FEATURE_XSAVEC)) {
+		kfpu_do_xsave("xsavec", state, ~0);
+		return;
+	}
+#endif
 #if defined(HAVE_XSAVES)
 	if (static_cpu_has(X86_FEATURE_XSAVES)) {
 		kfpu_do_xsave("xsaves", state, ~0);


### PR DESCRIPTION
### Motivation and Context

Since there is a register restore bug in XSAVES and XRSTORS add and use XSAVEC if available.


### How Has This Been Tested?

Builds,, more tests needed.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
