### PR TITLE
spl: Add cmn_err_once() to log a message only on the first call

### DIFF
--- a/include/os/freebsd/spl/sys/cmn_err.h
+++ b/include/os/freebsd/spl/sys/cmn_err.h
@@ -33,6 +33,7 @@
 
 #if !defined(_ASM)
 #include <sys/_stdarg.h>
+#include <sys/atomic.h>
 #endif
 
 #ifdef	__cplusplus
@@ -72,6 +73,38 @@ extern void vuprintf(const char *, __va_list)
 
 extern void panic(const char *, ...)
     __attribute__((format(printf, 1, 2), __noreturn__));
+
+#define	cmn_err_once(ce, ...)				\
+{							\
+	static volatile uint32_t printed = 0;		\
+	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
+		cmn_err(ce, __VA_ARGS__);		\
+	}						\
+}
+
+#define	vcmn_err_once(ce, fmt, ap)			\
+{							\
+	static volatile uint32_t printed = 0;		\
+	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
+		vcmn_err(ce, fmt, ap);			\
+	}						\
+}
+
+#define	zcmn_err_once(zone, ce, ...)			\
+{							\
+	static volatile uint32_t printed = 0;		\
+	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
+		zcmn_err(zone, ce, __VA_ARGS__);	\
+	}						\
+}
+
+#define	vzcmn_err_once(zone, ce, fmt, ap)		\
+{							\
+	static volatile uint32_t printed = 0;		\
+	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
+		vzcmn_err(zone, ce, fmt, ap);		\
+	}						\
+}
 
 #endif /* !_ASM */
 

--- a/include/os/linux/spl/sys/cmn_err.h
+++ b/include/os/linux/spl/sys/cmn_err.h
@@ -29,6 +29,7 @@
 #else
 #include <stdarg.h>
 #endif
+#include <sys/atomic.h>
 
 #define	CE_CONT		0 /* continuation */
 #define	CE_NOTE		1 /* notice */
@@ -44,5 +45,21 @@ extern void vpanic(const char *, va_list)
     __attribute__((format(printf, 1, 0), __noreturn__));
 
 #define	fm_panic	panic
+
+#define	cmn_err_once(ce, ...)				\
+{							\
+	static volatile uint32_t printed = 0;		\
+	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
+		cmn_err(ce, __VA_ARGS__);		\
+	}						\
+}
+
+#define	vcmn_err_once(ce, fmt, ap)			\
+{							\
+	static volatile uint32_t printed = 0;		\
+	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
+		vcmn_err(ce, fmt, ap);			\
+	}						\
+}
 
 #endif /* SPL_CMN_ERR_H */

--- a/lib/libspl/include/sys/cmn_err.h
+++ b/lib/libspl/include/sys/cmn_err.h
@@ -27,4 +27,38 @@
 #ifndef _LIBSPL_SYS_CMN_ERR_H
 #define	_LIBSPL_SYS_CMN_ERR_H
 
+#include <atomic.h>
+
+#define	cmn_err_once(ce, ...)				\
+{							\
+	static volatile uint32_t printed = 0;		\
+	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
+		cmn_err(ce, __VA_ARGS__);		\
+	}						\
+}
+
+#define	vcmn_err_once(ce, fmt, ap)			\
+{							\
+	static volatile uint32_t printed = 0;		\
+	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
+		vcmn_err(ce, fmt, ap);			\
+	}						\
+}
+
+#define	zcmn_err_once(zone, ce, ...)			\
+{							\
+	static volatile uint32_t printed = 0;		\
+	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
+		zcmn_err(zone, ce, __VA_ARGS__);	\
+	}						\
+}
+
+#define	vzcmn_err_once(zone, ce, fmt, ap)		\
+{							\
+	static volatile uint32_t printed = 0;		\
+	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
+		vzcmn_err(zone, ce, fmt, ap);		\
+	}						\
+}
+
 #endif


### PR DESCRIPTION

### Motivation and Context

Sometimes it is useful to log a message only once and not to flood the syslog, see #14565.

### How Has This Been Tested?

Manually made sure that multiple invocations of `cmn_err_once()` logged exactly one message to the syslog.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
