### PR TITLE
initramfs: fix zpool get argument order

### DIFF
--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -194,7 +194,7 @@ import_pool()
 
 	# Verify that the pool isn't already imported
 	# Make as sure as we can to not require '-f' to import.
-	"${ZPOOL}" get name,guid -o value -H 2>/dev/null | grep -Fxq "$pool" && return 0
+	"${ZPOOL}" get -H -o value name,guid 2>/dev/null | grep -Fxq "$pool" && return 0
 
 	# For backwards compatibility, make sure that ZPOOL_IMPORT_PATH is set
 	# to something we can use later with the real import(s). We want to
@@ -902,12 +902,12 @@ mountroot()
 	fi
 
 	# In case the pool was specified as guid, resolve guid to name
-	pool="$("${ZPOOL}" get name,guid -o name,value -H | \
+	pool="$("${ZPOOL}" get -H -o name,value name,guid | \
 	    awk -v pool="${ZFS_RPOOL}" '$2 == pool { print $1 }')"
 	if [ -n "$pool" ]; then
 		# If $ZFS_BOOTFS contains guid, replace the guid portion with $pool
 		ZFS_BOOTFS=$(echo "$ZFS_BOOTFS" | \
-			sed -e "s/$("${ZPOOL}" get guid -o value "$pool" -H)/$pool/g")
+			sed -e "s/$("${ZPOOL}" get -H -o value guid "$pool")/$pool/g")
 		ZFS_RPOOL="${pool}"
 	fi
 


### PR DESCRIPTION
### Motivation and Context

When using the zfs initramfs scripts on my system, I get various errors at initramfs stage, such as:

```
cannot open '-o': name must begin with a letter
```

My zfs binaries are compiled with musl libc (as a part of the https://chimera-linux.org/ project, which utilizes `initramfs-tools`, and therefore also the supporting scripts here), which may be why this happens. Or maybe it never worked at all, I have no way to test this on a glibc system.

### Description

Fix the argument order to match the `zpool get` output, and to make my builds happy.

### How Has This Been Tested?

I rebuilt my initramfs with these changes applied, and there are no more error messages. Since it's a simple change to follow posixly-correct argument order, it will not break any other configurations.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
