### PR TITLE
Fix Regressions caught by CodeQL and Coverity

### DIFF
--- a/module/icp/algs/sha2/sha2_generic.c
+++ b/module/icp/algs/sha2/sha2_generic.c
@@ -400,8 +400,8 @@ SHA2Init(int algotype, SHA2_CTX *ctx)
 	sha256_ctx *ctx256 = &ctx->sha256;
 	sha512_ctx *ctx512 = &ctx->sha512;
 
-	ASSERT3U(algotype, >=, SHA256_MECH_INFO_TYPE);
-	ASSERT3U(algotype, <=, SHA512_256_MECH_INFO_TYPE);
+	ASSERT3S(algotype, >=, SHA256_MECH_INFO_TYPE);
+	ASSERT3S(algotype, <=, SHA512_256_MECH_INFO_TYPE);
 
 	memset(ctx, 0, sizeof (*ctx));
 	ctx->algotype = algotype;

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -943,7 +943,7 @@ dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
 	 * Prefetch up to 128 deadlists first and then more as we progress.
 	 * The limit is a balance between ARC use and diminishing returns.
 	 */
-	for (pdle = dle, i = 0; pdle && i < 128; ) {
+	for (pdle = dle, i = 0; pdle && i < 128; i++) {
 		bpobj_prefetch_subobj(bpo, pdle->dle_bpobj.bpo_object);
 		pdle = AVL_NEXT(&dl->dl_tree, pdle);
 	}


### PR DESCRIPTION
### Motivation and Context
A few recently merged patches introduced regressions.

4c5fec01a48acc184614ab8735e6954961990235 introduced a regression caught by Coverity.

dc5c8006f684b1df3f2d4b6b8c121447d2db0017 introduced a regression caught by CodeQL in a development branch where I am tuning a more aggressive CodeQL configuration than the one we run on pull requests.

### Description
The individual patches have descriptions, but in summary, we switch from `ASSERT3U()` to `ASSERT3S()` in one and add a missing loop counter increment in another.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
