### PR TITLE
Fix memory leak in ztest

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4639,8 +4639,11 @@ ztest_dmu_object_alloc_free(ztest_ds_t *zd, uint64_t id)
 	 * Destroy the previous batch of objects, create a new batch,
 	 * and do some I/O on the new objects.
 	 */
-	if (ztest_object_init(zd, od, size, B_TRUE) != 0)
+	if (ztest_object_init(zd, od, size, B_TRUE) != 0) {
+		zd->zd_od = NULL;
+		umem_free(od, size);
 		return;
+	}
 
 	while (ztest_random(4 * batchsize) != 0)
 		ztest_io(zd, od[ztest_random(batchsize)].od_object,


### PR DESCRIPTION
### Motivation and Context
This is tripping LeakSanitizer, which causes zloop test failures on pull requests.

https://github.com/openzfs/zfs/actions/runs/4339196990
https://github.com/openzfs/zfs/actions/runs/4328310768

### Description
Add a missing `umem_free()` to an error path in `ztest_dmu_object_alloc_free()` and zero the pointer to it. Inspection of the code reveals that nothing uses the `zd->zd_od` pointer after calling `ztest_dmu_object_alloc_free()`, so this should be fine.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
