### PR TITLE
Failed to build on powerpc* if Linux was configured without CONFIG_ALTIVEC or CONFIG_VSX

### DIFF
--- a/include/os/linux/kernel/linux/simd_powerpc.h
+++ b/include/os/linux/kernel/linux/simd_powerpc.h
@@ -66,32 +66,46 @@
 #define	kfpu_allowed()			1
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+#ifdef	CONFIG_ALTIVEC
+#define	ENABLE_KERNEL_ALTIVEC	enable_kernel_altivec()
+#define	DISABLE_KERNEL_ALTIVEC	disable_kernel_altivec()
+#else
+#define	ENABLE_KERNEL_ALTIVEC
+#define	DISABLE_KERNEL_ALTIVEC
+#endif
+#ifdef	CONFIG_VSX
+#define	ENABLE_KERNEL_VSX	enable_kernel_vsx()
+#define	DISABLE_KERNEL_VSX	disable_kernel_vsx()
+#else
+#define	ENABLE_KERNEL_VSX
+#define	DISABLE_KERNEL_VSX
+#endif
 #ifdef CONFIG_SPE
 #define	kfpu_begin()				\
 	{					\
 		preempt_disable();		\
-		enable_kernel_altivec();	\
-		enable_kernel_vsx();		\
+		ENABLE_KERNEL_ALTIVEC		\
+		ENABLE_KERNEL_VSX		\
 		enable_kernel_spe();		\
 	}
 #define	kfpu_end()				\
 	{					\
 		disable_kernel_spe();		\
-		disable_kernel_vsx();		\
-		disable_kernel_altivec();	\
+		DISABLE_KERNEL_VSX		\
+		DISABLE_KERNEL_ALTIVEC		\
 		preempt_enable();		\
 	}
 #else /* CONFIG_SPE */
 #define	kfpu_begin()				\
 	{					\
 		preempt_disable();		\
-		enable_kernel_altivec();	\
-		enable_kernel_vsx();		\
+		ENABLE_KERNEL_ALTIVEC		\
+		ENABLE_KERNEL_VSX		\
 	}
 #define	kfpu_end()				\
 	{					\
-		disable_kernel_vsx();		\
-		disable_kernel_altivec();	\
+		DISABLE_KERNEL_VSX		\
+		DISABLE_KERNEL_ALTIVEC		\
 		preempt_enable();		\
 	}
 #endif


### PR DESCRIPTION
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
This fixes building ZFS for Linux 4.7+ powerpc* architecture, where Linux was configured without `CONFIG_ALTIVEC` or `CONFIG_VSX`.

### Description
`simd_powerpc.h` defines `kfpu_begin()` and `kfpu_end()` to call `(enable|disable)_kernel_(altivec|vsx)\(\)`, but they are unavailable from Linux without `CONFIG_(ALTIVEC|VSX)=y`, causing build failure:
```
In file included from /home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../include/os/linux/kernel/linux/simd.h:38,
                 from /home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../include/os/linux/spl/sys/simd.h:28,
                 from /home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../module/icp/algs/sha2/sha256_impl.c:29:
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../module/icp/algs/sha2/sha256_impl.c: In function ‘tf_sha256_ppc’:
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../include/os/linux/kernel/linux/simd_powerpc.h:88:3: error: implicit declaration of function ‘enable_kernel_altivec’; did you mean ‘enable_kernel_fp’? [-Werror=implicit-function-declaration]
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../module/icp/algs/sha2/sha256_impl.c:37:2: note: in expansion of macro ‘kfpu_begin’
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../module/icp/algs/sha2/sha256_impl.c:159:1: note: in expansion of macro ‘TF’
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../include/os/linux/kernel/linux/simd_powerpc.h:89:3: error: implicit declaration of function ‘enable_kernel_vsx’; did you mean ‘enable_kernel_fp’? [-Werror=implicit-function-declaration]
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../module/icp/algs/sha2/sha256_impl.c:37:2: note: in expansion of macro ‘kfpu_begin’
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../module/icp/algs/sha2/sha256_impl.c:159:1: note: in expansion of macro ‘TF’
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../include/os/linux/kernel/linux/simd_powerpc.h:93:3: error: implicit declaration of function ‘disable_kernel_vsx’; did you mean ‘disable_kernel_fp’? [-Werror=implicit-function-declaration]
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../module/icp/algs/sha2/sha256_impl.c:37:28: note: in expansion of macro ‘kfpu_end’
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../module/icp/algs/sha2/sha256_impl.c:159:1: note: in expansion of macro ‘TF’
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../include/os/linux/kernel/linux/simd_powerpc.h:94:3: error: implicit declaration of function ‘disable_kernel_altivec’; did you mean ‘disable_kernel_fp’? [-Werror=implicit-function-declaration]
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../module/icp/algs/sha2/sha256_impl.c:37:28: note: in expansion of macro ‘kfpu_end’
/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/../module/icp/algs/sha2/sha256_impl.c:159:1: note: in expansion of macro ‘TF’
cc1: some warnings being treated as errors
make[4]: *** [../scripts/Makefile.build:304: /home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/module/icp/algs/sha2/sha256_impl.o] Error 1
make[3]: *** [/home/whr/src/linux-4.19.271/Makefile:1555: _module_/home/whr/src/zfs/build.4.19.271-powerpc64-noaltivec/module] Error 2
make[2]: *** [Makefile:146: sub-make] Error 2
make[1]: *** [Makefile:24: __sub-make] Error 2
make[1]: Leaving directory '/home/whr/src/linux-4.19.271/build.rivoreo-powerpc64-noaltivec'
make: *** [Makefile:56: modules-Linux] Error 2
```

### How Has This Been Tested?
Tested with Linux 4.19.271 configured:
* `CONFIG_ALTIVEC=n` and `CONFIG_VSX=n`.
* `CONFIG_ALTIVEC=y` and `CONFIG_VSX=n`.
* `CONFIG_ALTIVEC=y` and `CONFIG_VSX=y`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
