### PR TITLE
initramfs: Make mountpoint=legacy work

### DIFF
--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -360,9 +360,10 @@ mount_fs()
 				return 0
 			fi
 			# Last hail-mary: Hope 'rootmnt' is set!
-			mountpoint=""
 			if [ "$mountpoint" = "legacy" ]; then
 				ZFS_CMD="mount.zfs"
+			else
+				mountpoint=""
 			fi
 		else
 			mountpoint="$mountpoint1"


### PR DESCRIPTION
### Motivation and Context
eb823cbc76d28a7cafdf6a7aafdefe7e74fe26bc fix for mountpoint=none broke mountpoint=legacy because we did not notice during review that `mountpoint=""` was set before `if [ "$mountpoint" = "legacy" ];`.

### Description
When the mountpoint is not legacy, we clear mountpoint so that mountpoint=none works instead of clearing it unconditionally, which breaks mountpoint=legacy.

### How Has This Been Tested?
No testing has been done. Based on the user's report that deleting `mountpoint=""` fixes mountpoint=legacy and the original commit that fixed `mountpoint=none`, this is expected to do the correct thing in both cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
