### PR TITLE
arc_summary: make `f_hits` result more distinguishable from other tools

### DIFF
--- a/cmd/arc_summary
+++ b/cmd/arc_summary
@@ -358,7 +358,7 @@ def f_hits(hits_string):
                 value = hits/limit
                 break
 
-        result = "%0.1f%s" % (value, symbol)
+        result = "%0.1f %s" % (value, symbol)
     else:
         result = "%d" % hits
 


### PR DESCRIPTION
### Motivation and Context
Make decimal-multiplicative human-readable large numbers printed by **arc_summary(1)** distinguishable from other command line tools.

### Description
Copied from commit message:

Most ZFS command line tools use a compact format to print human-readable byte vaules, such as `1.5G` for 1.5 GiB. However when **arc_summary(1)** printing large numbers that need decimal multiples, it uses the same format as the above, potentially creating confusion. Furthermore, the uses of the SI unit prefix names, aren't strictly correct; because a unit prefix is a 'prefix' for an unit, it shouldn't be used stand alone without an actual unit.

Unfortunately there isn't a better option:
* Printing raw numbers without dividing them down reduces readability of the output, especially for very large numbers.
* Using scientific notation could be unfriendly to most system administrators.
* Using similar notations such as `2.35*1000^3` has similar issues and takes too much screen space.
* Using English dictionary names results in 'long and short scales' problem, which already being explained in the function description.

Therefore the only change is to add a space between the number and the SI symbol, in an attempt to distinguish the format from the one used in other tools.

### How Has This Been Tested?
By reading its output, the output remains a good readability.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
