### PR TITLE
Address static analyzer complaints in nvpair code and constify string functions

### DIFF
--- a/cmd/mount_zfs.c
+++ b/cmd/mount_zfs.c
@@ -74,7 +74,7 @@ parse_dataset(const char *target, char **dataset)
 
 	nvlist_t *cfg = NULL;
 	if (zpool_read_label(fd, &cfg, NULL) == 0) {
-		char *nm = NULL;
+		const char *nm = NULL;
 		if (!nvlist_lookup_string(cfg, ZPOOL_CONFIG_POOL_NAME, &nm))
 			strlcpy(*dataset, nm, PATH_MAX);
 		nvlist_free(cfg);

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -4209,7 +4209,7 @@ collect_nvlist_stats(nvlist_t *nvl, zdb_nvl_stats_t *stats)
 {
 	nvlist_t *list, **array;
 	nvpair_t *nvp = NULL;
-	char *name;
+	const char *name;
 	uint_t i, items;
 
 	stats->zns_list_count++;

--- a/cmd/zed/agents/fmd_api.c
+++ b/cmd/zed/agents/fmd_api.c
@@ -359,7 +359,7 @@ static void
 zed_log_fault(nvlist_t *nvl, const char *uuid, const char *code)
 {
 	nvlist_t *rsrc;
-	char *strval;
+	const char *strval;
 	uint64_t guid;
 	uint8_t byte;
 
@@ -389,7 +389,7 @@ zed_log_fault(nvlist_t *nvl, const char *uuid, const char *code)
 static const char *
 fmd_fault_mkcode(nvlist_t *fault)
 {
-	char *class;
+	const char *class;
 	const char *code = "-";
 
 	/*
@@ -708,7 +708,7 @@ int
 fmd_nvl_class_match(fmd_hdl_t *hdl, nvlist_t *nvl, const char *pattern)
 {
 	(void) hdl;
-	char *class;
+	const char *class;
 
 	return (nvl != NULL &&
 	    nvlist_lookup_string(nvl, FM_CLASS, &class) == 0 &&

--- a/cmd/zed/agents/zfs_agents.c
+++ b/cmd/zed/agents/zfs_agents.c
@@ -64,7 +64,7 @@ typedef enum device_type {
 typedef struct guid_search {
 	uint64_t	gs_pool_guid;
 	uint64_t	gs_vdev_guid;
-	char		*gs_devid;
+	const char	*gs_devid;
 	device_type_t	gs_vdev_type;
 	uint64_t	gs_vdev_expandtime;	/* vdev expansion time */
 } guid_search_t;
@@ -77,7 +77,7 @@ static boolean_t
 zfs_agent_iter_vdev(zpool_handle_t *zhp, nvlist_t *nvl, void *arg)
 {
 	guid_search_t *gsp = arg;
-	char *path = NULL;
+	const char *path = NULL;
 	uint_t c, children;
 	nvlist_t **child;
 	uint64_t vdev_guid;
@@ -211,7 +211,7 @@ zfs_agent_post_event(const char *class, const char *subclass, nvlist_t *nvl)
 		uint64_t pool_guid = 0, vdev_guid = 0;
 		guid_search_t search = { 0 };
 		device_type_t devtype = DEVICE_TYPE_PRIMARY;
-		char *devid = NULL;
+		const char *devid = NULL;
 
 		class = "resource.fs.zfs.removed";
 		subclass = "";

--- a/cmd/zed/agents/zfs_diagnosis.c
+++ b/cmd/zed/agents/zfs_diagnosis.c
@@ -464,7 +464,7 @@ zfs_fm_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl, const char *class)
 	nvlist_t *detector;
 	boolean_t pool_found = B_FALSE;
 	boolean_t isresource;
-	char *type;
+	const char *type;
 
 	/*
 	 * We subscribe to notifications for vdev or pool removal.  In these
@@ -780,7 +780,7 @@ zfs_fm_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl, const char *class)
 	    ZFS_MAKE_EREPORT(FM_EREPORT_ZFS_IO_FAILURE)) ||
 	    fmd_nvl_class_match(hdl, nvl,
 	    ZFS_MAKE_EREPORT(FM_EREPORT_ZFS_PROBE_FAILURE))) {
-		char *failmode = NULL;
+		const char *failmode = NULL;
 		boolean_t checkremove = B_FALSE;
 		uint32_t pri = 0;
 		int32_t flags = 0;

--- a/cmd/zed/agents/zfs_mod.c
+++ b/cmd/zed/agents/zfs_mod.c
@@ -183,7 +183,7 @@ zfs_unavail_pool(zpool_handle_t *zhp, void *data)
 static void
 zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 {
-	char *path;
+	const char *path;
 	vdev_state_t newstate;
 	nvlist_t *nvroot, *newvd;
 	pendingdev_t *device;
@@ -191,7 +191,7 @@ zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 	uint64_t offline = 0ULL, faulted = 0ULL;
 	uint64_t guid = 0ULL;
 	uint64_t is_spare = 0;
-	char *physpath = NULL, *new_devid = NULL, *enc_sysfs_path = NULL;
+	const char *physpath = NULL, *new_devid = NULL, *enc_sysfs_path = NULL;
 	char rawpath[PATH_MAX], fullpath[PATH_MAX];
 	char devpath[PATH_MAX];
 	int ret;
@@ -549,7 +549,7 @@ static void
 zfs_iter_vdev(zpool_handle_t *zhp, nvlist_t *nvl, void *data)
 {
 	dev_data_t *dp = data;
-	char *path = NULL;
+	const char *path = NULL;
 	uint_t c, children;
 	nvlist_t **child;
 	uint64_t guid = 0;
@@ -851,7 +851,7 @@ guid_iter(uint64_t pool_guid, uint64_t vdev_guid, const char *devid,
 static int
 zfs_deliver_add(nvlist_t *nvl)
 {
-	char *devpath = NULL, *devid = NULL;
+	const char *devpath = NULL, *devid = NULL;
 	uint64_t pool_guid = 0, vdev_guid = 0;
 	boolean_t is_slice;
 
@@ -999,7 +999,8 @@ zfsdle_vdev_online(zpool_handle_t *zhp, void *data)
 	nvlist_t *tgt;
 	int error;
 
-	char *tmp_devname, devname[MAXPATHLEN] = "";
+	const char *tmp_devname;
+	char devname[MAXPATHLEN] = "";
 	uint64_t guid;
 
 	if (nvlist_lookup_uint64(udev_nvl, ZFS_EV_VDEV_GUID, &guid) == 0) {
@@ -1017,7 +1018,8 @@ zfsdle_vdev_online(zpool_handle_t *zhp, void *data)
 
 	if ((tgt = zpool_find_vdev_by_physpath(zhp, devname,
 	    &avail_spare, &l2cache, NULL)) != NULL) {
-		char *path, fullpath[MAXPATHLEN];
+		const char *path;
+		char fullpath[MAXPATHLEN];
 		uint64_t wholedisk = 0;
 
 		error = nvlist_lookup_string(tgt, ZPOOL_CONFIG_PATH, &path);
@@ -1030,10 +1032,11 @@ zfsdle_vdev_online(zpool_handle_t *zhp, void *data)
 		    &wholedisk);
 
 		if (wholedisk) {
+			char *tmp;
 			path = strrchr(path, '/');
 			if (path != NULL) {
-				path = zfs_strip_partition(path + 1);
-				if (path == NULL) {
+				tmp = zfs_strip_partition(path + 1);
+				if (tmp == NULL) {
 					zpool_close(zhp);
 					return (0);
 				}
@@ -1042,8 +1045,8 @@ zfsdle_vdev_online(zpool_handle_t *zhp, void *data)
 				return (0);
 			}
 
-			(void) strlcpy(fullpath, path, sizeof (fullpath));
-			free(path);
+			(void) strlcpy(fullpath, tmp, sizeof (fullpath));
+			free(tmp);
 
 			/*
 			 * We need to reopen the pool associated with this
@@ -1148,7 +1151,8 @@ zfsdle_vdev_online(zpool_handle_t *zhp, void *data)
 static int
 zfs_deliver_dle(nvlist_t *nvl)
 {
-	char *devname, name[MAXPATHLEN];
+	const char *devname;
+	char name[MAXPATHLEN];
 	uint64_t guid;
 
 	if (nvlist_lookup_uint64(nvl, ZFS_EV_VDEV_GUID, &guid) == 0) {

--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -282,7 +282,7 @@ replace_with_spare(fmd_hdl_t *hdl, zpool_handle_t *zhp, nvlist_t *vdev)
 	 */
 	for (s = 0; s < nspares; s++) {
 		boolean_t rebuild = B_FALSE;
-		char *spare_name, *type;
+		const char *spare_name, *type;
 
 		if (nvlist_lookup_string(spares[s], ZPOOL_CONFIG_PATH,
 		    &spare_name) != 0)
@@ -377,9 +377,9 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 	boolean_t is_repair;
 	boolean_t l2arc = B_FALSE;
 	boolean_t spare = B_FALSE;
-	char *scheme;
+	const char *scheme;
 	nvlist_t *vdev = NULL;
-	char *uuid;
+	const char *uuid;
 	int repair_done = 0;
 	boolean_t retire;
 	boolean_t is_disk;
@@ -401,7 +401,7 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 	if (strcmp(class, "resource.fs.zfs.removed") == 0 ||
 	    (strcmp(class, "resource.fs.zfs.statechange") == 0 &&
 	    (state == VDEV_STATE_REMOVED || state == VDEV_STATE_FAULTED))) {
-		char *devtype;
+		const char *devtype;
 		char *devname;
 
 		if (nvlist_lookup_string(nvl, FM_EREPORT_PAYLOAD_ZFS_VDEV_TYPE,

--- a/cmd/zed/zed_disk_event.c
+++ b/cmd/zed/zed_disk_event.c
@@ -60,7 +60,7 @@ struct udev_monitor *g_mon;
 static void
 zed_udev_event(const char *class, const char *subclass, nvlist_t *nvl)
 {
-	char *strval;
+	const char *strval;
 	uint64_t numval;
 
 	zed_log_msg(LOG_INFO, "zed_disk_event:");
@@ -178,7 +178,8 @@ static void *
 zed_udev_monitor(void *arg)
 {
 	struct udev_monitor *mon = arg;
-	char *tmp, *tmp2;
+	const char *tmp;
+	char *tmp2;
 
 	zed_log_msg(LOG_INFO, "Waiting for new udev disk events...");
 
@@ -336,7 +337,7 @@ zed_udev_monitor(void *arg)
 		if (strcmp(class, EC_DEV_STATUS) == 0 &&
 		    udev_device_get_property_value(dev, "DM_UUID") &&
 		    udev_device_get_property_value(dev, "MPATH_SBIN_PATH")) {
-			tmp = (char *)udev_device_get_devnode(dev);
+			tmp = udev_device_get_devnode(dev);
 			tmp2 = zfs_get_underlying_path(tmp);
 			if (tmp && tmp2 && (strcmp(tmp, tmp2) != 0)) {
 				/*
@@ -353,8 +354,7 @@ zed_udev_monitor(void *arg)
 				class = EC_DEV_ADD;
 				subclass = ESC_DISK;
 			} else {
-				tmp = (char *)
-				    udev_device_get_property_value(dev,
+				tmp = udev_device_get_property_value(dev,
 				    "DM_NR_VALID_PATHS");
 				/* treat as a multipath remove */
 				if (tmp != NULL && strcmp(tmp, "0") == 0) {

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -612,7 +612,7 @@ _zed_event_add_string_array(uint64_t eid, zed_strings_t *zsp,
 	char buf[MAXBUF];
 	int buflen = sizeof (buf);
 	const char *name;
-	char **strp;
+	const char **strp;
 	uint_t nelem;
 	uint_t i;
 	char *p;
@@ -652,7 +652,7 @@ _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
 	uint16_t i16;
 	uint32_t i32;
 	uint64_t i64;
-	char *str;
+	const char *str;
 
 	assert(zsp != NULL);
 	assert(nvp != NULL);
@@ -935,7 +935,7 @@ zed_event_service(struct zed_conf *zcp)
 	uint64_t eid;
 	int64_t *etime;
 	uint_t nelem;
-	char *class;
+	const char *class;
 	const char *subclass;
 	int rv;
 

--- a/cmd/zfs/zfs_iter.c
+++ b/cmd/zfs/zfs_iter.c
@@ -348,7 +348,7 @@ zfs_sort(const void *larg, const void *rarg, void *data)
 
 	for (psc = sc; psc != NULL; psc = psc->sc_next) {
 		char lbuf[ZFS_MAXPROPLEN], rbuf[ZFS_MAXPROPLEN];
-		char *lstr, *rstr;
+		const char *lstr, *rstr;
 		uint64_t lnum = 0, rnum = 0;
 		boolean_t lvalid, rvalid;
 		int ret = 0;

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -1049,7 +1049,7 @@ zfs_do_create(int argc, char **argv)
 	int ret = 1;
 	nvlist_t *props;
 	uint64_t intval;
-	char *strval;
+	const char *strval;
 
 	if (nvlist_alloc(&props, NV_UNIQUE_NAME, 0) != 0)
 		nomem();
@@ -1173,11 +1173,12 @@ zfs_do_create(int argc, char **argv)
 
 		if (volblocksize != ZVOL_DEFAULT_BLOCKSIZE &&
 		    nvlist_lookup_string(props, prop, &strval) != 0) {
-			if (asprintf(&strval, "%llu",
+			char *tmp;
+			if (asprintf(&tmp, "%llu",
 			    (u_longlong_t)volblocksize) == -1)
 				nomem();
-			nvlist_add_string(props, prop, strval);
-			free(strval);
+			nvlist_add_string(props, prop, tmp);
+			free(tmp);
 		}
 
 		/*
@@ -1252,7 +1253,7 @@ zfs_do_create(int argc, char **argv)
 		    dryrun ? "would create %s\n" : "create %s\n", argv[0]);
 		while ((nvp = nvlist_next_nvpair(props, nvp)) != NULL) {
 			uint64_t uval;
-			char *sval;
+			const char *sval;
 
 			switch (nvpair_type(nvp)) {
 			case DATA_TYPE_UINT64:
@@ -2701,8 +2702,8 @@ us_compare(const void *larg, const void *rarg, void *unused)
 	boolean_t lvb, rvb;
 
 	for (; sortcol != NULL; sortcol = sortcol->sc_next) {
-		char *lvstr = (char *)"";
-		char *rvstr = (char *)"";
+		const char *lvstr = "";
+		const char *rvstr = "";
 		uint32_t lv32 = 0;
 		uint32_t rv32 = 0;
 		uint64_t lv64 = 0;
@@ -6495,7 +6496,7 @@ print_holds(boolean_t scripted, int nwidth, int tagwidth, nvlist_t *nvl,
 	}
 
 	while ((nvp = nvlist_next_nvpair(nvl, nvp)) != NULL) {
-		char *zname = nvpair_name(nvp);
+		const char *zname = nvpair_name(nvp);
 		nvlist_t *nvl2;
 		nvpair_t *nvp2 = NULL;
 		(void) nvpair_value_nvlist(nvp, &nvl2);
@@ -8095,7 +8096,7 @@ zfs_do_channel_program(int argc, char **argv)
 		const char *msg = gettext("Channel program execution failed");
 		uint64_t instructions = 0;
 		if (outnvl != NULL && nvlist_exists(outnvl, ZCP_RET_ERROR)) {
-			char *es = NULL;
+			const char *es = NULL;
 			(void) nvlist_lookup_string(outnvl,
 			    ZCP_RET_ERROR, &es);
 			if (es == NULL)

--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -564,9 +564,9 @@ for_each_vdev_run_cb(void *zhp_data, nvlist_t *nv, void *cb_vcdl)
 {
 	vdev_cmd_data_list_t *vcdl = cb_vcdl;
 	vdev_cmd_data_t *data;
-	char *path = NULL;
+	const char *path = NULL;
 	char *vname = NULL;
-	char *vdev_enc_sysfs_path = NULL;
+	const char *vdev_enc_sysfs_path = NULL;
 	int i, match = 0;
 	zpool_handle_t *zhp = zhp_data;
 

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -712,7 +712,7 @@ print_vdev_tree(zpool_handle_t *zhp, const char *name, nvlist_t *nv, int indent,
 
 	for (c = 0; c < children; c++) {
 		uint64_t is_log = B_FALSE, is_hole = B_FALSE;
-		char *class = (char *)"";
+		const char *class = "";
 
 		(void) nvlist_lookup_uint64(child[c], ZPOOL_CONFIG_IS_HOLE,
 		    &is_hole);
@@ -724,7 +724,7 @@ print_vdev_tree(zpool_handle_t *zhp, const char *name, nvlist_t *nv, int indent,
 		(void) nvlist_lookup_uint64(child[c], ZPOOL_CONFIG_IS_LOG,
 		    &is_log);
 		if (is_log)
-			class = (char *)VDEV_ALLOC_BIAS_LOG;
+			class = VDEV_ALLOC_BIAS_LOG;
 		(void) nvlist_lookup_string(child[c],
 		    ZPOOL_CONFIG_ALLOCATION_BIAS, &class);
 		if (strcmp(match, class) != 0)
@@ -811,7 +811,7 @@ add_prop_list(const char *propname, const char *propval, nvlist_t **props,
 	zpool_prop_t prop = ZPOOL_PROP_INVAL;
 	nvlist_t *proplist;
 	const char *normnm;
-	char *strval;
+	const char *strval;
 
 	if (*props == NULL &&
 	    nvlist_alloc(props, NV_UNIQUE_NAME, 0) != 0) {
@@ -909,7 +909,7 @@ static int
 add_prop_list_default(const char *propname, const char *propval,
     nvlist_t **props)
 {
-	char *pval;
+	const char *pval;
 
 	if (nvlist_lookup_string(*props, propname, &pval) == 0)
 		return (0);
@@ -1761,7 +1761,7 @@ zpool_do_create(int argc, char **argv)
 		 */
 		for (spa_feature_t i = 0; i < SPA_FEATURES; i++) {
 			char propname[MAXPATHLEN];
-			char *propval;
+			const char *propval;
 			zfeature_info_t *feat = &spa_feature_table[i];
 
 			(void) snprintf(propname, sizeof (propname),
@@ -2089,7 +2089,7 @@ is_blank_str(const char *str)
 
 /* Print command output lines for specific vdev in a specific pool */
 static void
-zpool_print_cmd(vdev_cmd_data_list_t *vcdl, const char *pool, char *path)
+zpool_print_cmd(vdev_cmd_data_list_t *vcdl, const char *pool, const char *path)
 {
 	vdev_cmd_data_t *data;
 	int i, j;
@@ -2281,8 +2281,8 @@ print_status_config(zpool_handle_t *zhp, status_cbdata_t *cb, const char *name,
 	uint64_t notpresent;
 	spare_cbdata_t spare_cb;
 	const char *state;
-	char *type;
-	char *path = NULL;
+	const char *type;
+	const char *path = NULL;
 	const char *rcolor = NULL, *wcolor = NULL, *ccolor = NULL;
 
 	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN,
@@ -2550,7 +2550,8 @@ print_import_config(status_cbdata_t *cb, const char *name, nvlist_t *nv,
 	nvlist_t **child;
 	uint_t c, children;
 	vdev_stat_t *vs;
-	char *type, *vname;
+	const char *type;
+	char *vname;
 
 	verify(nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE, &type) == 0);
 	if (strcmp(type, VDEV_TYPE_MISSING) == 0 ||
@@ -2678,8 +2679,8 @@ print_class_vdevs(zpool_handle_t *zhp, status_cbdata_t *cb, nvlist_t *nv,
 
 	for (c = 0; c < children; c++) {
 		uint64_t is_log = B_FALSE;
-		char *bias = NULL;
-		char *type = NULL;
+		const char *bias = NULL;
+		const char *type = NULL;
 
 		(void) nvlist_lookup_uint64(child[c], ZPOOL_CONFIG_IS_LOG,
 		    &is_log);
@@ -2722,7 +2723,7 @@ show_import(nvlist_t *config, boolean_t report_error)
 {
 	uint64_t pool_state;
 	vdev_stat_t *vs;
-	char *name;
+	const char *name;
 	uint64_t guid;
 	uint64_t hostid = 0;
 	const char *msgid;
@@ -2732,7 +2733,7 @@ show_import(nvlist_t *config, boolean_t report_error)
 	zpool_errata_t errata;
 	const char *health;
 	uint_t vsc;
-	char *comment;
+	const char *comment;
 	status_cbdata_t cb = { 0 };
 
 	verify(nvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME,
@@ -3285,7 +3286,7 @@ import_pools(nvlist_t *pools, nvlist_t *props, char *mntopts, int flags,
 					(void) show_import(config, B_TRUE);
 			}
 		} else if (import->poolname != NULL) {
-			char *name;
+			const char *name;
 
 			/*
 			 * We are searching for a pool based on name.
@@ -3360,7 +3361,7 @@ name_or_guid_exists(zpool_handle_t *zhp, void *data)
 		return (0);
 
 	if (args->poolname != NULL) {
-		char *pool_name;
+		const char *pool_name;
 
 		verify(nvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME,
 		    &pool_name) == 0);
@@ -4796,7 +4797,7 @@ print_vdev_stats(zpool_handle_t *zhp, const char *name, nvlist_t *oldnv,
 	}
 
 	if (cb->vcdl != NULL) {
-		char *path;
+		const char *path;
 		if (nvlist_lookup_string(newnv, ZPOOL_CONFIG_PATH,
 		    &path) == 0) {
 			printf("  ");
@@ -4861,13 +4862,13 @@ children:
 
 		for (c = 0; c < children; c++) {
 			uint64_t islog = B_FALSE;
-			char *bias = NULL;
-			char *type = NULL;
+			const char *bias = NULL;
+			const char *type = NULL;
 
 			(void) nvlist_lookup_uint64(newchild[c],
 			    ZPOOL_CONFIG_IS_LOG, &islog);
 			if (islog) {
-				bias = (char *)VDEV_ALLOC_CLASS_LOGS;
+				bias = VDEV_ALLOC_CLASS_LOGS;
 			} else {
 				(void) nvlist_lookup_string(newchild[c],
 				    ZPOOL_CONFIG_ALLOCATION_BIAS, &bias);
@@ -6227,12 +6228,12 @@ print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		boolean_t printed = B_FALSE;
 
 		for (c = 0; c < children; c++) {
-			char *bias = NULL;
-			char *type = NULL;
+			const char *bias = NULL;
+			const char *type = NULL;
 
 			if (nvlist_lookup_uint64(child[c], ZPOOL_CONFIG_IS_LOG,
 			    &islog) == 0 && islog) {
-				bias = (char *)VDEV_ALLOC_CLASS_LOGS;
+				bias = VDEV_ALLOC_CLASS_LOGS;
 			} else {
 				(void) nvlist_lookup_string(child[c],
 				    ZPOOL_CONFIG_ALLOCATION_BIAS, &bias);
@@ -9531,7 +9532,8 @@ typedef struct ev_opts {
 static void
 zpool_do_events_short(nvlist_t *nvl, ev_opts_t *opts)
 {
-	char ctime_str[26], str[32], *ptr;
+	char ctime_str[26], str[32];
+	const char *ptr;
 	int64_t *tv;
 	uint_t n;
 
@@ -9567,7 +9569,7 @@ zpool_do_events_nvprint(nvlist_t *nvl, int depth)
 		uint16_t i16;
 		uint32_t i32;
 		uint64_t i64;
-		char *str;
+		const char *str;
 		nvlist_t *cnv;
 
 		printf(gettext("%*s%s = "), depth, "", name);
@@ -9765,7 +9767,7 @@ zpool_do_events_nvprint(nvlist_t *nvl, int depth)
 			}
 
 		case DATA_TYPE_STRING_ARRAY: {
-			char **str;
+			const char **str;
 			uint_t i, nelem;
 
 			(void) nvpair_value_string_array(nvp, &str, &nelem);
@@ -9794,7 +9796,7 @@ zpool_do_events_next(ev_opts_t *opts)
 {
 	nvlist_t *nvl;
 	int zevent_fd, ret, dropped;
-	char *pool;
+	const char *pool;
 
 	zevent_fd = open(ZFS_DEV, O_RDWR);
 	VERIFY(zevent_fd >= 0);
@@ -10443,7 +10445,7 @@ vdev_any_spare_replacing(nvlist_t *nv)
 {
 	nvlist_t **child;
 	uint_t c, children;
-	char *vdev_type;
+	const char *vdev_type;
 
 	(void) nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE, &vdev_type);
 

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -380,7 +380,7 @@ make_leaf_vdev(nvlist_t *props, const char *arg, boolean_t is_primary)
 	 * Override defaults if custom properties are provided.
 	 */
 	if (props != NULL) {
-		char *value = NULL;
+		const char *value = NULL;
 
 		if (nvlist_lookup_string(props,
 		    zpool_prop_to_name(ZPOOL_PROP_ASHIFT), &value) == 0) {
@@ -435,7 +435,7 @@ make_leaf_vdev(nvlist_t *props, const char *arg, boolean_t is_primary)
  *	one general purpose vdev.
  */
 typedef struct replication_level {
-	char *zprl_type;
+	const char *zprl_type;
 	uint64_t zprl_children;
 	uint64_t zprl_parity;
 } replication_level_t;
@@ -489,7 +489,7 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 	nvlist_t **child;
 	uint_t c, children;
 	nvlist_t *nv;
-	char *type;
+	const char *type;
 	replication_level_t lastrep = {0};
 	replication_level_t rep;
 	replication_level_t *ret;
@@ -567,10 +567,10 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 			vdev_size = -1LL;
 			for (c = 0; c < children; c++) {
 				nvlist_t *cnv = child[c];
-				char *path;
+				const char *path;
 				struct stat64 statbuf;
 				int64_t size = -1LL;
-				char *childtype;
+				const char *childtype;
 				int fd, err;
 
 				rep.zprl_children++;
@@ -904,7 +904,7 @@ check_replication(nvlist_t *config, nvlist_t *newroot)
 }
 
 static int
-zero_label(char *path)
+zero_label(const char *path)
 {
 	const int size = 4096;
 	char buf[size];
@@ -951,7 +951,7 @@ make_disks(zpool_handle_t *zhp, nvlist_t *nv)
 {
 	nvlist_t **child;
 	uint_t c, children;
-	char *type, *path;
+	const char *type, *path;
 	char devpath[MAXPATHLEN];
 	char udevpath[MAXPATHLEN];
 	uint64_t wholedisk;
@@ -1110,7 +1110,7 @@ is_device_in_use(nvlist_t *config, nvlist_t *nv, boolean_t force,
 {
 	nvlist_t **child;
 	uint_t c, children;
-	char *type, *path;
+	const char *type, *path;
 	int ret = 0;
 	char buf[MAXPATHLEN];
 	uint64_t wholedisk = B_FALSE;
@@ -1761,7 +1761,7 @@ split_mirror_vdev(zpool_handle_t *zhp, char *newname, nvlist_t *props,
 		verify(nvlist_lookup_nvlist_array(newroot,
 		    ZPOOL_CONFIG_CHILDREN, &child, &children) == 0);
 		for (c = 0; c < children; c++) {
-			char *path;
+			const char *path;
 			const char *type;
 			int min, max;
 

--- a/cmd/zpool_influxdb/zpool_influxdb.c
+++ b/cmd/zpool_influxdb/zpool_influxdb.c
@@ -264,7 +264,7 @@ get_vdev_name(nvlist_t *nvroot, const char *parent_name)
 	static char vdev_name[256];
 	uint64_t vdev_id = 0;
 
-	char *vdev_type = (char *)"unknown";
+	const char *vdev_type = "unknown";
 	(void) nvlist_lookup_string(nvroot, ZPOOL_CONFIG_TYPE, &vdev_type);
 
 	if (nvlist_lookup_uint64(
@@ -299,9 +299,9 @@ get_vdev_desc(nvlist_t *nvroot, const char *parent_name)
 	char vdev_value[MAXPATHLEN];
 	char *s, *t;
 
-	char *vdev_type = (char *)"unknown";
+	const char *vdev_type = "unknown";
 	uint64_t vdev_id = UINT64_MAX;
-	char *vdev_path = NULL;
+	const char *vdev_path = NULL;
 	(void) nvlist_lookup_string(nvroot, ZPOOL_CONFIG_TYPE, &vdev_type);
 	(void) nvlist_lookup_uint64(nvroot, ZPOOL_CONFIG_ID, &vdev_id);
 	(void) nvlist_lookup_string(nvroot, ZPOOL_CONFIG_PATH, &vdev_path);

--- a/include/libnvpair.h
+++ b/include/libnvpair.h
@@ -42,9 +42,10 @@ extern "C" {
  * are all imported from <sys/nvpair.h> included above.
  */
 
-_LIBNVPAIR_H int nvpair_value_match(nvpair_t *, int, char *, char **);
-_LIBNVPAIR_H int nvpair_value_match_regex(nvpair_t *, int, char *, regex_t *,
-    char **);
+_LIBNVPAIR_H int nvpair_value_match(nvpair_t *, int, const char *,
+    const char **);
+_LIBNVPAIR_H int nvpair_value_match_regex(nvpair_t *, int, const char *,
+    regex_t *, const char **);
 
 _LIBNVPAIR_H void nvlist_print(FILE *, nvlist_t *);
 _LIBNVPAIR_H int nvlist_print_json(FILE *, nvlist_t *);
@@ -156,7 +157,7 @@ NVLIST_PRINTCTL_SVDECL(nvlist_prtctlop_uint32, uint32_t);
 NVLIST_PRINTCTL_SVDECL(nvlist_prtctlop_int64, int64_t);
 NVLIST_PRINTCTL_SVDECL(nvlist_prtctlop_uint64, uint64_t);
 NVLIST_PRINTCTL_SVDECL(nvlist_prtctlop_double, double);
-NVLIST_PRINTCTL_SVDECL(nvlist_prtctlop_string, char *);
+NVLIST_PRINTCTL_SVDECL(nvlist_prtctlop_string, const char *);
 NVLIST_PRINTCTL_SVDECL(nvlist_prtctlop_hrtime, hrtime_t);
 NVLIST_PRINTCTL_SVDECL(nvlist_prtctlop_nvlist, nvlist_t *);
 
@@ -185,7 +186,7 @@ NVLIST_PRINTCTL_AVDECL(nvlist_prtctlop_int32_array, int32_t *);
 NVLIST_PRINTCTL_AVDECL(nvlist_prtctlop_uint32_array, uint32_t *);
 NVLIST_PRINTCTL_AVDECL(nvlist_prtctlop_int64_array, int64_t *);
 NVLIST_PRINTCTL_AVDECL(nvlist_prtctlop_uint64_array, uint64_t *);
-NVLIST_PRINTCTL_AVDECL(nvlist_prtctlop_string_array, char **);
+NVLIST_PRINTCTL_AVDECL(nvlist_prtctlop_string_array, const char **);
 NVLIST_PRINTCTL_AVDECL(nvlist_prtctlop_nvlist_array, nvlist_t **);
 
 #undef	NVLIST_PRINTCTL_AVDECL	/* was just for "clarity" above */

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -533,7 +533,7 @@ _LIBZFS_H int zfs_prop_get_written(zfs_handle_t *zhp, const char *propname,
     char *propbuf, int proplen, boolean_t literal);
 _LIBZFS_H int zfs_prop_get_feature(zfs_handle_t *zhp, const char *propname,
     char *buf, size_t len);
-_LIBZFS_H uint64_t getprop_uint64(zfs_handle_t *, zfs_prop_t, char **);
+_LIBZFS_H uint64_t getprop_uint64(zfs_handle_t *, zfs_prop_t, const char **);
 _LIBZFS_H uint64_t zfs_prop_get_int(zfs_handle_t *, zfs_prop_t);
 _LIBZFS_H int zfs_prop_inherit(zfs_handle_t *, const char *, boolean_t);
 _LIBZFS_H const char *zfs_prop_values(zfs_prop_t);

--- a/include/os/linux/spl/rpc/xdr.h
+++ b/include/os/linux/spl/rpc/xdr.h
@@ -75,9 +75,6 @@ struct xdr_bytesrec {
 void xdrmem_create(XDR *xdrs, const caddr_t addr, const uint_t size,
     const enum xdr_op op);
 
-/* Currently not needed. If needed later, we'll add it to struct xdr_ops */
-#define	xdr_destroy(xdrs) ((void) 0)
-
 #define	xdr_control(xdrs, req, info) \
 	(xdrs)->x_ops->xdr_control((xdrs), (req), (info))
 

--- a/include/sys/dmu_recv.h
+++ b/include/sys/dmu_recv.h
@@ -79,8 +79,8 @@ typedef struct dmu_recv_cookie {
 	objlist_t *drc_ignore_objlist;
 } dmu_recv_cookie_t;
 
-int dmu_recv_begin(char *, char *, dmu_replay_record_t *,
-    boolean_t, boolean_t, boolean_t, nvlist_t *, nvlist_t *, char *,
+int dmu_recv_begin(const char *, const char *, dmu_replay_record_t *,
+    boolean_t, boolean_t, boolean_t, nvlist_t *, nvlist_t *, const char *,
     dmu_recv_cookie_t *, zfs_file_t *, offset_t *);
 int dmu_recv_stream(dmu_recv_cookie_t *, offset_t *);
 int dmu_recv_end(dmu_recv_cookie_t *, void *);

--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -76,7 +76,7 @@ typedef struct nvpair {
 	int16_t	nvp_reserve;	/* not used */
 	int32_t	nvp_value_elem;	/* number of elements for array types */
 	data_type_t nvp_type;	/* type of value */
-	/* name string */
+	char	nvp_name[];	/* name string */
 	/* aligned ptr array for string arrays */
 	/* aligned array of data for value */
 } nvpair_t;
@@ -109,7 +109,7 @@ typedef struct nvlist {
 #define	NV_ALIGN4(x)		(((x) + 3) & ~3)
 
 #define	NVP_SIZE(nvp)		((nvp)->nvp_size)
-#define	NVP_NAME(nvp)		((char *)(nvp) + sizeof (nvpair_t))
+#define	NVP_NAME(nvp)		((nvp)->nvp_name)
 #define	NVP_TYPE(nvp)		((nvp)->nvp_type)
 #define	NVP_NELEM(nvp)		((nvp)->nvp_value_elem)
 #define	NVP_VALUE(nvp)		((char *)(nvp) + NV_ALIGN(sizeof (nvpair_t) \

--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -232,7 +232,8 @@ _SYS_NVPAIR_H int nvlist_lookup_int64(const nvlist_t *, const char *,
     int64_t *);
 _SYS_NVPAIR_H int nvlist_lookup_uint64(const nvlist_t *, const char *,
     uint64_t *);
-_SYS_NVPAIR_H int nvlist_lookup_string(nvlist_t *, const char *, char **);
+_SYS_NVPAIR_H int nvlist_lookup_string(const nvlist_t *, const char *,
+    const char **);
 _SYS_NVPAIR_H int nvlist_lookup_nvlist(nvlist_t *, const char *, nvlist_t **);
 _SYS_NVPAIR_H int nvlist_lookup_boolean_array(nvlist_t *, const char *,
     boolean_t **, uint_t *);
@@ -267,14 +268,14 @@ _SYS_NVPAIR_H int nvlist_lookup_double(const nvlist_t *, const char *,
 
 _SYS_NVPAIR_H int nvlist_lookup_nvpair(nvlist_t *, const char *, nvpair_t **);
 _SYS_NVPAIR_H int nvlist_lookup_nvpair_embedded_index(nvlist_t *, const char *,
-    nvpair_t **, int *, char **);
+    nvpair_t **, int *, const char **);
 _SYS_NVPAIR_H boolean_t nvlist_exists(const nvlist_t *, const char *);
 _SYS_NVPAIR_H boolean_t nvlist_empty(const nvlist_t *);
 
 /* processing nvpair */
 _SYS_NVPAIR_H nvpair_t *nvlist_next_nvpair(nvlist_t *, const nvpair_t *);
 _SYS_NVPAIR_H nvpair_t *nvlist_prev_nvpair(nvlist_t *, const nvpair_t *);
-_SYS_NVPAIR_H char *nvpair_name(const nvpair_t *);
+_SYS_NVPAIR_H const char *nvpair_name(const nvpair_t *);
 _SYS_NVPAIR_H data_type_t nvpair_type(const nvpair_t *);
 _SYS_NVPAIR_H int nvpair_type_is_array(const nvpair_t *);
 _SYS_NVPAIR_H int nvpair_value_boolean_value(const nvpair_t *, boolean_t *);
@@ -287,7 +288,7 @@ _SYS_NVPAIR_H int nvpair_value_int32(const nvpair_t *, int32_t *);
 _SYS_NVPAIR_H int nvpair_value_uint32(const nvpair_t *, uint32_t *);
 _SYS_NVPAIR_H int nvpair_value_int64(const nvpair_t *, int64_t *);
 _SYS_NVPAIR_H int nvpair_value_uint64(const nvpair_t *, uint64_t *);
-_SYS_NVPAIR_H int nvpair_value_string(nvpair_t *, char **);
+_SYS_NVPAIR_H int nvpair_value_string(const nvpair_t *, const char **);
 _SYS_NVPAIR_H int nvpair_value_nvlist(nvpair_t *, nvlist_t **);
 _SYS_NVPAIR_H int nvpair_value_boolean_array(nvpair_t *, boolean_t **,
     uint_t *);
@@ -300,7 +301,8 @@ _SYS_NVPAIR_H int nvpair_value_int32_array(nvpair_t *, int32_t **, uint_t *);
 _SYS_NVPAIR_H int nvpair_value_uint32_array(nvpair_t *, uint32_t **, uint_t *);
 _SYS_NVPAIR_H int nvpair_value_int64_array(nvpair_t *, int64_t **, uint_t *);
 _SYS_NVPAIR_H int nvpair_value_uint64_array(nvpair_t *, uint64_t **, uint_t *);
-_SYS_NVPAIR_H int nvpair_value_string_array(nvpair_t *, char ***, uint_t *);
+_SYS_NVPAIR_H int nvpair_value_string_array(nvpair_t *, const char ***,
+    uint_t *);
 _SYS_NVPAIR_H int nvpair_value_nvlist_array(nvpair_t *, nvlist_t ***, uint_t *);
 _SYS_NVPAIR_H int nvpair_value_hrtime(nvpair_t *, hrtime_t *);
 #if !defined(_KERNEL) && !defined(_STANDALONE)
@@ -373,7 +375,8 @@ _SYS_NVPAIR_H uint8_t fnvlist_lookup_uint8(const nvlist_t *, const char *);
 _SYS_NVPAIR_H uint16_t fnvlist_lookup_uint16(const nvlist_t *, const char *);
 _SYS_NVPAIR_H uint32_t fnvlist_lookup_uint32(const nvlist_t *, const char *);
 _SYS_NVPAIR_H uint64_t fnvlist_lookup_uint64(const nvlist_t *, const char *);
-_SYS_NVPAIR_H char *fnvlist_lookup_string(nvlist_t *, const char *);
+_SYS_NVPAIR_H const char *fnvlist_lookup_string(const nvlist_t *,
+    const char *);
 _SYS_NVPAIR_H nvlist_t *fnvlist_lookup_nvlist(nvlist_t *, const char *);
 _SYS_NVPAIR_H boolean_t *fnvlist_lookup_boolean_array(nvlist_t *, const char *,
     uint_t *);
@@ -406,7 +409,7 @@ _SYS_NVPAIR_H uint8_t fnvpair_value_uint8(const nvpair_t *nvp);
 _SYS_NVPAIR_H uint16_t fnvpair_value_uint16(const nvpair_t *nvp);
 _SYS_NVPAIR_H uint32_t fnvpair_value_uint32(const nvpair_t *nvp);
 _SYS_NVPAIR_H uint64_t fnvpair_value_uint64(const nvpair_t *nvp);
-_SYS_NVPAIR_H char *fnvpair_value_string(nvpair_t *nvp);
+_SYS_NVPAIR_H const char *fnvpair_value_string(const nvpair_t *nvp);
 _SYS_NVPAIR_H nvlist_t *fnvpair_value_nvlist(nvpair_t *nvp);
 
 #ifdef	__cplusplus

--- a/lib/libnvpair/libnvpair.abi
+++ b/lib/libnvpair/libnvpair.abi
@@ -243,6 +243,9 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='160' id='664ac0b7'>
       <subrange length='20' type-id='7359adad' id='fdca39cf'/>
     </array-type-def>
+    <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='infinite' id='e84913bd'>
+      <subrange length='infinite' type-id='7359adad' id='031f2035'/>
+    </array-type-def>
     <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
     <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
     <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
@@ -320,6 +323,9 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
         <var-decl name='nvp_type' type-id='8d0687d2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvp_name' type-id='e84913bd' visibility='default'/>
       </data-member>
     </class-decl>
     <typedef-decl name='nvpair_t' type-id='1c34e459' id='57928edf'/>
@@ -698,7 +704,7 @@
     </class-decl>
     <class-decl name='__anonymous_struct__12' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7e'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='c0d0f877' visibility='default'/>
+        <var-decl name='op' type-id='bfc48fe4' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
@@ -802,7 +808,7 @@
     </class-decl>
     <class-decl name='__anonymous_struct__25' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f8b'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='de20bf07' visibility='default'/>
+        <var-decl name='op' type-id='337f4a72' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='arg' type-id='eaa32e2f' visibility='default'/>
@@ -858,11 +864,11 @@
     <pointer-type-def type-id='c19b74c3' size-in-bits='64' id='37e3bd22'/>
     <pointer-type-def type-id='37e3bd22' size-in-bits='64' id='03829398'/>
     <pointer-type-def type-id='a84c031d' size-in-bits='64' id='26a90f95'/>
-    <pointer-type-def type-id='26a90f95' size-in-bits='64' id='9b23c9ad'/>
-    <pointer-type-def type-id='9b23c9ad' size-in-bits='64' id='c0563f85'/>
     <qualified-type-def type-id='a84c031d' const='yes' id='9b45d938'/>
     <pointer-type-def type-id='9b45d938' size-in-bits='64' id='80f4b756'/>
     <qualified-type-def type-id='80f4b756' restrict='yes' id='9d26089a'/>
+    <pointer-type-def type-id='80f4b756' size-in-bits='64' id='7d3cd834'/>
+    <pointer-type-def type-id='7d3cd834' size-in-bits='64' id='44c8373a'/>
     <qualified-type-def type-id='57928edf' const='yes' id='642ee20f'/>
     <pointer-type-def type-id='642ee20f' size-in-bits='64' id='dace003f'/>
     <qualified-type-def type-id='aca3bac8' const='yes' id='2498fd78'/>
@@ -871,8 +877,8 @@
     <pointer-type-def type-id='a0eb0f08' size-in-bits='64' id='7408d286'/>
     <pointer-type-def type-id='cebdd548' size-in-bits='64' id='e379e62d'/>
     <pointer-type-def type-id='9f88f76e' size-in-bits='64' id='7ef0e988'/>
-    <pointer-type-def type-id='c5bb1a2b' size-in-bits='64' id='c0d0f877'/>
-    <pointer-type-def type-id='573fea1b' size-in-bits='64' id='de20bf07'/>
+    <pointer-type-def type-id='889f3b42' size-in-bits='64' id='bfc48fe4'/>
+    <pointer-type-def type-id='49055dd8' size-in-bits='64' id='337f4a72'/>
     <pointer-type-def type-id='70284cc6' size-in-bits='64' id='3be4d568'/>
     <pointer-type-def type-id='700c3bca' size-in-bits='64' id='6d994334'/>
     <pointer-type-def type-id='18ac1860' size-in-bits='64' id='506ab59a'/>
@@ -898,8 +904,8 @@
     <pointer-type-def type-id='3bd73b0c' size-in-bits='64' id='7e85a9b6'/>
     <pointer-type-def type-id='0d445e26' size-in-bits='64' id='330cc0d0'/>
     <pointer-type-def type-id='e4b89f30' size-in-bits='64' id='ed8aa8ba'/>
-    <pointer-type-def type-id='be7f4941' size-in-bits='64' id='2809de35'/>
-    <pointer-type-def type-id='fe5ae69d' size-in-bits='64' id='90d5edb9'/>
+    <pointer-type-def type-id='78e3bec8' size-in-bits='64' id='b38a1022'/>
+    <pointer-type-def type-id='a5193bb2' size-in-bits='64' id='6263eda4'/>
     <pointer-type-def type-id='2783af3c' size-in-bits='64' id='e44553b6'/>
     <pointer-type-def type-id='33c6e3d8' size-in-bits='64' id='1263777a'/>
     <pointer-type-def type-id='dadb9eca' size-in-bits='64' id='cbda43ac'/>
@@ -966,7 +972,7 @@
     </function-decl>
     <function-decl name='nvpair_name' mangled-name='nvpair_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_name'>
       <parameter type-id='dace003f'/>
-      <return type-id='26a90f95'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='nvpair_type' mangled-name='nvpair_type' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_type'>
       <parameter type-id='dace003f'/>
@@ -1027,8 +1033,8 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_string' mangled-name='nvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string'>
-      <parameter type-id='3fa542f0'/>
-      <parameter type-id='9b23c9ad'/>
+      <parameter type-id='dace003f'/>
+      <parameter type-id='7d3cd834'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_nvlist' mangled-name='nvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_nvlist'>
@@ -1098,7 +1104,7 @@
     </function-decl>
     <function-decl name='nvpair_value_string_array' mangled-name='nvpair_value_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_string_array'>
       <parameter type-id='3fa542f0'/>
-      <parameter type-id='c0563f85'/>
+      <parameter type-id='44c8373a'/>
       <parameter type-id='4dd26a40'/>
       <return type-id='95e97e5e'/>
     </function-decl>
@@ -1280,7 +1286,7 @@
     </function-decl>
     <function-decl name='nvlist_prtctlop_string' mangled-name='nvlist_prtctlop_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='2809de35' name='func'/>
+      <parameter type-id='b38a1022' name='func'/>
       <parameter type-id='eaa32e2f' name='private'/>
       <return type-id='48b5725f'/>
     </function-decl>
@@ -1358,7 +1364,7 @@
     </function-decl>
     <function-decl name='nvlist_prtctlop_string_array' mangled-name='nvlist_prtctlop_string_array' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_prtctlop_string_array'>
       <parameter type-id='b0c1ff8d' name='pctl'/>
-      <parameter type-id='90d5edb9' name='func'/>
+      <parameter type-id='6263eda4' name='func'/>
       <parameter type-id='eaa32e2f' name='private'/>
       <return type-id='48b5725f'/>
     </function-decl>
@@ -1393,16 +1399,16 @@
     <function-decl name='nvpair_value_match_regex' mangled-name='nvpair_value_match_regex' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match_regex'>
       <parameter type-id='3fa542f0' name='nvp'/>
       <parameter type-id='95e97e5e' name='ai'/>
-      <parameter type-id='26a90f95' name='value'/>
+      <parameter type-id='80f4b756' name='value'/>
       <parameter type-id='d33f11cb' name='value_regex'/>
-      <parameter type-id='9b23c9ad' name='ep'/>
+      <parameter type-id='7d3cd834' name='ep'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_match' mangled-name='nvpair_value_match' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match'>
       <parameter type-id='3fa542f0' name='nvp'/>
       <parameter type-id='95e97e5e' name='ai'/>
-      <parameter type-id='26a90f95' name='value'/>
-      <parameter type-id='9b23c9ad' name='ep'/>
+      <parameter type-id='80f4b756' name='value'/>
+      <parameter type-id='7d3cd834' name='ep'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-type size-in-bits='64' id='9f88f76e'>
@@ -1414,20 +1420,20 @@
       <parameter type-id='3502e3ff'/>
       <return type-id='95e97e5e'/>
     </function-type>
-    <function-type size-in-bits='64' id='c5bb1a2b'>
+    <function-type size-in-bits='64' id='889f3b42'>
       <parameter type-id='196db161'/>
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='5ce45b60'/>
       <parameter type-id='80f4b756'/>
-      <parameter type-id='26a90f95'/>
+      <parameter type-id='80f4b756'/>
       <return type-id='95e97e5e'/>
     </function-type>
-    <function-type size-in-bits='64' id='573fea1b'>
+    <function-type size-in-bits='64' id='49055dd8'>
       <parameter type-id='196db161'/>
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='5ce45b60'/>
       <parameter type-id='80f4b756'/>
-      <parameter type-id='9b23c9ad'/>
+      <parameter type-id='7d3cd834'/>
       <parameter type-id='3502e3ff'/>
       <return type-id='95e97e5e'/>
     </function-type>
@@ -1642,20 +1648,20 @@
       <parameter type-id='3502e3ff'/>
       <return type-id='95e97e5e'/>
     </function-type>
-    <function-type size-in-bits='64' id='be7f4941'>
+    <function-type size-in-bits='64' id='78e3bec8'>
       <parameter type-id='b0c1ff8d'/>
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='5ce45b60'/>
       <parameter type-id='80f4b756'/>
-      <parameter type-id='26a90f95'/>
+      <parameter type-id='80f4b756'/>
       <return type-id='95e97e5e'/>
     </function-type>
-    <function-type size-in-bits='64' id='fe5ae69d'>
+    <function-type size-in-bits='64' id='a5193bb2'>
       <parameter type-id='b0c1ff8d'/>
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='5ce45b60'/>
       <parameter type-id='80f4b756'/>
-      <parameter type-id='9b23c9ad'/>
+      <parameter type-id='7d3cd834'/>
       <parameter type-id='3502e3ff'/>
       <return type-id='95e97e5e'/>
     </function-type>
@@ -1930,8 +1936,8 @@
       <return type-id='9c313c2d'/>
     </function-decl>
     <function-decl name='fnvpair_value_string' mangled-name='fnvpair_value_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_string'>
-      <parameter type-id='3fa542f0'/>
-      <return type-id='26a90f95'/>
+      <parameter type-id='dace003f'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='fnvpair_value_nvlist' mangled-name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvpair_value_nvlist'>
       <parameter type-id='3fa542f0'/>
@@ -2327,9 +2333,9 @@
       <return type-id='9c313c2d'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_string' mangled-name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_string'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <return type-id='26a90f95'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_nvlist' mangled-name='fnvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fnvlist_lookup_nvlist'>
       <parameter type-id='5ce45b60' name='nvl'/>
@@ -2466,7 +2472,9 @@
     <typedef-decl name='u_quad_t' type-id='5f3d50a6' id='bd226ac0'/>
     <pointer-type-def type-id='bc407f0e' size-in-bits='64' id='17fd1621'/>
     <pointer-type-def type-id='755707df' size-in-bits='64' id='812c6697'/>
+    <pointer-type-def type-id='26a90f95' size-in-bits='64' id='9b23c9ad'/>
     <qualified-type-def type-id='9b23c9ad' restrict='yes' id='8c85230f'/>
+    <pointer-type-def type-id='9b23c9ad' size-in-bits='64' id='c0563f85'/>
     <qualified-type-def type-id='c19b74c3' const='yes' id='12373e33'/>
     <pointer-type-def type-id='12373e33' size-in-bits='64' id='c5f6c15b'/>
     <qualified-type-def type-id='80f4b756' const='yes' id='b99c00c9'/>
@@ -2925,9 +2933,9 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_string' mangled-name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_string'>
-      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='22cce67b' name='nvl'/>
       <parameter type-id='80f4b756' name='name'/>
-      <parameter type-id='9b23c9ad' name='val'/>
+      <parameter type-id='7d3cd834' name='val'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_nvlist' mangled-name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_lookup_nvlist'>
@@ -3043,7 +3051,7 @@
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='0b283d2e' name='ret'/>
       <parameter type-id='7292109c' name='ip'/>
-      <parameter type-id='9b23c9ad' name='ep'/>
+      <parameter type-id='7d3cd834' name='ep'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_exists' mangled-name='nvlist_exists' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_exists'>

--- a/lib/libnvpair/libnvpair.c
+++ b/lib/libnvpair/libnvpair.c
@@ -70,7 +70,7 @@ struct nvlist_printops {
 	DEFINEOP(print_int64, int64_t);
 	DEFINEOP(print_uint64, uint64_t);
 	DEFINEOP(print_double, double);
-	DEFINEOP(print_string, char *);
+	DEFINEOP(print_string, const char *);
 	DEFINEOP(print_hrtime, hrtime_t);
 	DEFINEOP(print_nvlist, nvlist_t *);
 	DEFINEARROP(print_boolean_array, boolean_t *);
@@ -83,7 +83,7 @@ struct nvlist_printops {
 	DEFINEARROP(print_uint32_array, uint32_t *);
 	DEFINEARROP(print_int64_array, int64_t *);
 	DEFINEARROP(print_uint64_array, uint64_t *);
-	DEFINEARROP(print_string_array, char **);
+	DEFINEARROP(print_string_array, const char **);
 	DEFINEARROP(print_nvlist_array, nvlist_t **);
 };
 
@@ -222,7 +222,7 @@ NVLIST_PRTFUNC(uint32, uint32_t, uint32_t, "0x%x")
 NVLIST_PRTFUNC(int64, int64_t, longlong_t, "%lld")
 NVLIST_PRTFUNC(uint64, uint64_t, u_longlong_t, "0x%llx")
 NVLIST_PRTFUNC(double, double, double, "0x%f")
-NVLIST_PRTFUNC(string, char *, char *, "%s")
+NVLIST_PRTFUNC(string, const char *, const char *, "%s")
 NVLIST_PRTFUNC(hrtime, hrtime_t, hrtime_t, "0x%llx")
 #if defined(__GNUC__) && !defined(__clang__) && \
 	defined(ZFS_UBSAN_ENABLED) && defined(HAVE_FORMAT_OVERFLOW)
@@ -266,7 +266,7 @@ NVLIST_ARRPRTFUNC(int32_array, int32_t, int32_t, "%d")
 NVLIST_ARRPRTFUNC(uint32_array, uint32_t, uint32_t, "0x%x")
 NVLIST_ARRPRTFUNC(int64_array, int64_t, longlong_t, "%lld")
 NVLIST_ARRPRTFUNC(uint64_array, uint64_t, u_longlong_t, "0x%llx")
-NVLIST_ARRPRTFUNC(string_array, char *, char *, "%s")
+NVLIST_ARRPRTFUNC(string_array, const char *, const char *, "%s")
 
 static int
 nvprint_nvlist(nvlist_prtctl_t pctl, void *private,
@@ -398,13 +398,13 @@ nvlist_prtctl_dofmt(nvlist_prtctl_t pctl, enum nvlist_prtctl_fmt which, ...)
 {
 	FILE *fp = pctl->nvprt_fp;
 	va_list ap;
-	char *name;
+	const char *name;
 
 	va_start(ap, which);
 
 	switch (which) {
 	case NVLIST_FMT_MEMBER_NAME:
-		name = va_arg(ap, char *);
+		name = va_arg(ap, const char *);
 		(void) fprintf(fp, pctl->nvprt_nmfmt, name);
 		break;
 
@@ -453,7 +453,7 @@ NVLIST_PRINTCTL_REPLACE(uint32, uint32_t)
 NVLIST_PRINTCTL_REPLACE(int64, int64_t)
 NVLIST_PRINTCTL_REPLACE(uint64, uint64_t)
 NVLIST_PRINTCTL_REPLACE(double, double)
-NVLIST_PRINTCTL_REPLACE(string, char *)
+NVLIST_PRINTCTL_REPLACE(string, const char *)
 NVLIST_PRINTCTL_REPLACE(hrtime, hrtime_t)
 NVLIST_PRINTCTL_REPLACE(nvlist, nvlist_t *)
 
@@ -477,7 +477,7 @@ NVLIST_PRINTCTL_AREPLACE(int32_array, int32_t *)
 NVLIST_PRINTCTL_AREPLACE(uint32_array, uint32_t *)
 NVLIST_PRINTCTL_AREPLACE(int64_array, int64_t *)
 NVLIST_PRINTCTL_AREPLACE(uint64_array, uint64_t *)
-NVLIST_PRINTCTL_AREPLACE(string_array, char **)
+NVLIST_PRINTCTL_AREPLACE(string_array, const char **)
 NVLIST_PRINTCTL_AREPLACE(nvlist_array, nvlist_t **)
 
 /*
@@ -580,7 +580,7 @@ static void
 nvlist_print_with_indent(nvlist_t *nvl, nvlist_prtctl_t pctl)
 {
 	FILE *fp = pctl->nvprt_fp;
-	char *name;
+	const char *name;
 	uint_t nelem;
 	nvpair_t *nvp;
 
@@ -670,7 +670,7 @@ nvlist_print_with_indent(nvlist_t *nvl, nvlist_prtctl_t pctl)
 			break;
 		}
 		case DATA_TYPE_STRING: {
-			char *val;
+			const char *val;
 			(void) nvpair_value_string(nvp, &val);
 			RENDER(pctl, string, nvl, name, val);
 			break;
@@ -736,7 +736,7 @@ nvlist_print_with_indent(nvlist_t *nvl, nvlist_prtctl_t pctl)
 			break;
 		}
 		case DATA_TYPE_STRING_ARRAY: {
-			char **val;
+			const char **val;
 			(void) nvpair_value_string_array(nvp, &val, &nelem);
 			ARENDER(pctl, string_array, nvl, name, val, nelem);
 			break;
@@ -866,7 +866,7 @@ dump_nvlist(nvlist_t *list, int indent)
 			break;
 
 		case DATA_TYPE_STRING:
-			NVP(elem, string, char *, char *, "'%s'");
+			NVP(elem, string, const char *, const char *, "'%s'");
 			break;
 
 		case DATA_TYPE_BYTE_ARRAY:
@@ -907,7 +907,8 @@ dump_nvlist(nvlist_t *list, int indent)
 			break;
 
 		case DATA_TYPE_STRING_ARRAY:
-			NVPA(elem, string_array, char *, char *, "'%s'");
+			NVPA(elem, string_array, const char *, const char *,
+			    "'%s'");
 			break;
 
 		case DATA_TYPE_NVLIST:
@@ -961,11 +962,11 @@ dump_nvlist(nvlist_t *list, int indent)
  */
 int
 nvpair_value_match_regex(nvpair_t *nvp, int ai,
-    char *value, regex_t *value_regex, char **ep)
+    const char *value, regex_t *value_regex, const char **ep)
 {
-	char	*evalue;
-	uint_t	a_len;
-	int	sr;
+	const char	*evalue;
+	uint_t		a_len;
+	int		sr;
 
 	if (ep)
 		*ep = NULL;
@@ -993,7 +994,7 @@ nvpair_value_match_regex(nvpair_t *nvp, int ai,
 	sr = EOF;
 	switch (nvpair_type(nvp)) {
 	case DATA_TYPE_STRING: {
-		char	*val;
+		const char *val;
 
 		/* check string value for match */
 		if (nvpair_value_string(nvp, &val) == 0) {
@@ -1009,7 +1010,7 @@ nvpair_value_match_regex(nvpair_t *nvp, int ai,
 		break;
 	}
 	case DATA_TYPE_STRING_ARRAY: {
-		char **val_array;
+		const char **val_array;
 
 		/* check indexed string value of array for match */
 		if ((nvpair_value_string_array(nvp, &val_array, &a_len) == 0) &&
@@ -1285,7 +1286,7 @@ nvpair_value_match_regex(nvpair_t *nvp, int ai,
 }
 
 int
-nvpair_value_match(nvpair_t *nvp, int ai, char *value, char **ep)
+nvpair_value_match(nvpair_t *nvp, int ai, const char *value, const char **ep)
 {
 	return (nvpair_value_match_regex(nvp, ai, value, NULL, ep));
 }

--- a/lib/libnvpair/libnvpair_json.c
+++ b/lib/libnvpair/libnvpair_json.c
@@ -134,7 +134,7 @@ nvlist_print_json(FILE *fp, nvlist_t *nvl)
 
 		switch (type) {
 		case DATA_TYPE_STRING: {
-			char *string = fnvpair_value_string(curr);
+			const char *string = fnvpair_value_string(curr);
 			if (nvlist_print_json_string(fp, string) == -1)
 				return (-1);
 			break;
@@ -220,7 +220,7 @@ nvlist_print_json(FILE *fp, nvlist_t *nvl)
 		}
 
 		case DATA_TYPE_STRING_ARRAY: {
-			char **val;
+			const char **val;
 			uint_t valsz, i;
 			VERIFY0(nvpair_value_string_array(curr, &val, &valsz));
 			FPRINTF(fp, "[");

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -2399,6 +2399,9 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='65536' id='163f6aa5'>
       <subrange length='8192' type-id='7359adad' id='c88f397d'/>
     </array-type-def>
+    <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='infinite' id='e84913bd'>
+      <subrange length='infinite' type-id='7359adad' id='031f2035'/>
+    </array-type-def>
     <array-type-def dimensions='1' type-id='9c313c2d' size-in-bits='128' id='c1c22e6c'>
       <subrange length='2' type-id='7359adad' id='52efc4ef'/>
     </array-type-def>
@@ -2455,6 +2458,9 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
         <var-decl name='nvp_type' type-id='8d0687d2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvp_name' type-id='e84913bd' visibility='default'/>
       </data-member>
     </class-decl>
     <typedef-decl name='nvpair_t' type-id='1c34e459' id='57928edf'/>
@@ -2745,7 +2751,7 @@
     </function-decl>
     <function-decl name='nvpair_name' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='dace003f'/>
-      <return type-id='26a90f95'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='3fa542f0'/>
@@ -3239,6 +3245,7 @@
     <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
     <qualified-type-def type-id='9b23c9ad' restrict='yes' id='8c85230f'/>
     <qualified-type-def type-id='80f4b756' restrict='yes' id='9d26089a'/>
+    <pointer-type-def type-id='80f4b756' size-in-bits='64' id='7d3cd834'/>
     <qualified-type-def type-id='aca3bac8' const='yes' id='2498fd78'/>
     <pointer-type-def type-id='2498fd78' size-in-bits='64' id='eed6c816'/>
     <qualified-type-def type-id='eed6c816' restrict='yes' id='a431a9da'/>
@@ -3351,9 +3358,9 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='5ce45b60'/>
+      <parameter type-id='22cce67b'/>
       <parameter type-id='80f4b756'/>
-      <parameter type-id='9b23c9ad'/>
+      <parameter type-id='7d3cd834'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
@@ -3803,7 +3810,6 @@
     <pointer-type-def type-id='fba6cb51' size-in-bits='64' id='32adbf30'/>
     <pointer-type-def type-id='f20fbd51' size-in-bits='64' id='a3681dea'/>
     <qualified-type-def type-id='26a90f95' restrict='yes' id='266fe297'/>
-    <pointer-type-def type-id='80f4b756' size-in-bits='64' id='7d3cd834'/>
     <qualified-type-def type-id='56fe4a37' const='yes' id='a75125ce'/>
     <pointer-type-def type-id='a75125ce' size-in-bits='64' id='48bea5ec'/>
     <qualified-type-def type-id='8afd6070' const='yes' id='1d853360'/>
@@ -4166,8 +4172,8 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvpair_value_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='3fa542f0'/>
-      <parameter type-id='9b23c9ad'/>
+      <parameter type-id='dace003f'/>
+      <parameter type-id='7d3cd834'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='fnvlist_free' visibility='default' binding='global' size-in-bits='64'>
@@ -4203,9 +4209,9 @@
       <return type-id='9c313c2d'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='5ce45b60'/>
+      <parameter type-id='22cce67b'/>
       <parameter type-id='80f4b756'/>
-      <return type-id='26a90f95'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='5ce45b60'/>
@@ -4418,7 +4424,7 @@
     <function-decl name='getprop_uint64' mangled-name='getprop_uint64' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='getprop_uint64'>
       <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='58603c44' name='prop'/>
-      <parameter type-id='9b23c9ad' name='source'/>
+      <parameter type-id='7d3cd834' name='source'/>
       <return type-id='9c313c2d'/>
     </function-decl>
     <function-decl name='zfs_prop_get_recvd' mangled-name='zfs_prop_get_recvd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_get_recvd'>
@@ -4688,7 +4694,7 @@
       <parameter type-id='95e97e5e'/>
       <parameter type-id='2e45de5d'/>
       <parameter type-id='5ce45b60'/>
-      <parameter type-id='9b23c9ad'/>
+      <parameter type-id='7d3cd834'/>
       <parameter type-id='5d6479ae'/>
       <parameter type-id='80f4b756'/>
       <return type-id='95e97e5e'/>
@@ -5993,8 +5999,8 @@
       <return type-id='9da381c4'/>
     </function-decl>
     <function-decl name='fnvpair_value_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='3fa542f0'/>
-      <return type-id='26a90f95'/>
+      <parameter type-id='dace003f'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='zfeature_is_supported' mangled-name='zfeature_is_supported' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfeature_is_supported'>
       <parameter type-id='80f4b756'/>
@@ -8140,8 +8146,8 @@
     <function-decl name='label_paths' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='5507783b'/>
       <parameter type-id='5ce45b60'/>
-      <parameter type-id='9b23c9ad'/>
-      <parameter type-id='9b23c9ad'/>
+      <parameter type-id='7d3cd834'/>
+      <parameter type-id='7d3cd834'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zutil_alloc' visibility='default' binding='global' size-in-bits='64'>

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -942,7 +942,7 @@ proplist_has_encryption_props(nvlist_t *props)
 {
 	int ret;
 	uint64_t intval;
-	char *strval;
+	const char *strval;
 
 	ret = nvlist_lookup_uint64(props,
 	    zfs_prop_to_name(ZFS_PROP_ENCRYPTION), &intval);
@@ -1007,7 +1007,7 @@ zfs_crypto_create(libzfs_handle_t *hdl, char *parent_name, nvlist_t *props,
 	char errbuf[ERRBUFLEN];
 	uint64_t crypt = ZIO_CRYPT_INHERIT, pcrypt = ZIO_CRYPT_INHERIT;
 	uint64_t keyformat = ZFS_KEYFORMAT_NONE;
-	char *keylocation = NULL;
+	const char *keylocation = NULL;
 	zfs_handle_t *pzhp = NULL;
 	uint8_t *wkeydata = NULL;
 	uint_t wkeylen = 0;
@@ -1595,7 +1595,7 @@ zfs_crypto_rewrap(zfs_handle_t *zhp, nvlist_t *raw_props, boolean_t inheritkey)
 	uint64_t crypt, pcrypt, keystatus, pkeystatus;
 	uint64_t keyformat = ZFS_KEYFORMAT_NONE;
 	zfs_handle_t *pzhp = NULL;
-	char *keylocation = NULL;
+	const char *keylocation = NULL;
 	char origin_name[MAXNAMELEN];
 	char prop_keylocation[MAXNAMELEN];
 	char parent_name[ZFS_MAX_DATASET_NAME_LEN];
@@ -1705,7 +1705,7 @@ zfs_crypto_rewrap(zfs_handle_t *zhp, nvlist_t *raw_props, boolean_t inheritkey)
 
 			/* default to prompt if no keylocation is specified */
 			if (keylocation == NULL) {
-				keylocation = (char *)"prompt";
+				keylocation = "prompt";
 				ret = nvlist_add_string(props,
 				    zfs_prop_to_name(ZFS_PROP_KEYLOCATION),
 				    keylocation);

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1029,7 +1029,7 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 {
 	nvpair_t *elem;
 	uint64_t intval;
-	char *strval;
+	const char *strval;
 	zfs_prop_t prop;
 	nvlist_t *ret;
 	int chosen_normal = -1;
@@ -2065,7 +2065,7 @@ error:
  * extract them appropriately.
  */
 uint64_t
-getprop_uint64(zfs_handle_t *zhp, zfs_prop_t prop, char **source)
+getprop_uint64(zfs_handle_t *zhp, zfs_prop_t prop, const char **source)
 {
 	nvlist_t *nv;
 	uint64_t value;
@@ -2079,14 +2079,14 @@ getprop_uint64(zfs_handle_t *zhp, zfs_prop_t prop, char **source)
 		verify(!zhp->zfs_props_table ||
 		    zhp->zfs_props_table[prop] == B_TRUE);
 		value = zfs_prop_default_numeric(prop);
-		*source = (char *)"";
+		*source = "";
 	}
 
 	return (value);
 }
 
 static const char *
-getprop_string(zfs_handle_t *zhp, zfs_prop_t prop, char **source)
+getprop_string(zfs_handle_t *zhp, zfs_prop_t prop, const char **source)
 {
 	nvlist_t *nv;
 	const char *value;
@@ -2100,7 +2100,7 @@ getprop_string(zfs_handle_t *zhp, zfs_prop_t prop, char **source)
 		verify(!zhp->zfs_props_table ||
 		    zhp->zfs_props_table[prop] == B_TRUE);
 		value = zfs_prop_default_string(prop);
-		*source = (char *)"";
+		*source = "";
 	}
 
 	return (value);
@@ -2138,7 +2138,7 @@ zfs_unset_recvd_props_mode(zfs_handle_t *zhp, uintptr_t *cookie)
  */
 static int
 get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
-    char **source, uint64_t *val)
+    const char **source, uint64_t *val)
 {
 	zfs_cmd_t zc = {"\0"};
 	nvlist_t *zplprops = NULL;
@@ -2370,7 +2370,7 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
  * Calculate the source type, given the raw source string.
  */
 static void
-get_source(zfs_handle_t *zhp, zprop_source_t *srctype, char *source,
+get_source(zfs_handle_t *zhp, zprop_source_t *srctype, const char *source,
     char *statbuf, size_t statlen)
 {
 	if (statbuf == NULL ||
@@ -2418,7 +2418,7 @@ zfs_prop_get_recvd(zfs_handle_t *zhp, const char *propname, char *propbuf,
 		zfs_unset_recvd_props_mode(zhp, &cookie);
 	} else {
 		nvlist_t *propval;
-		char *recvdval;
+		const char *recvdval;
 		if (nvlist_lookup_nvlist(zhp->zfs_recvd_props,
 		    propname, &propval) != 0)
 			return (-1);
@@ -2620,7 +2620,7 @@ zcp_check(zfs_handle_t *zhp, zfs_prop_t prop, uint64_t intval,
 				    (u_longlong_t)intval, (u_longlong_t)ans);
 			}
 		} else {
-			char *str_ans;
+			const char *str_ans;
 			error = nvlist_lookup_string(retnvl, "value", &str_ans);
 			if (error != 0) {
 				(void) fprintf(stderr, "%s: zcp check error: "
@@ -2652,7 +2652,7 @@ int
 zfs_prop_get(zfs_handle_t *zhp, zfs_prop_t prop, char *propbuf, size_t proplen,
     zprop_source_t *src, char *statbuf, size_t statlen, boolean_t literal)
 {
-	char *source = NULL;
+	const char *source = NULL;
 	uint64_t val;
 	const char *str;
 	const char *strval;
@@ -3053,7 +3053,7 @@ zfs_prop_get(zfs_handle_t *zhp, zfs_prop_t prop, char *propbuf, size_t proplen,
 uint64_t
 zfs_prop_get_int(zfs_handle_t *zhp, zfs_prop_t prop)
 {
-	char *source;
+	const char *source;
 	uint64_t val = 0;
 
 	(void) get_numeric_property(zhp, prop, NULL, &source, &val);
@@ -3077,7 +3077,7 @@ int
 zfs_prop_get_numeric(zfs_handle_t *zhp, zfs_prop_t prop, uint64_t *value,
     zprop_source_t *src, char *statbuf, size_t statlen)
 {
-	char *source;
+	const char *source;
 
 	/*
 	 * Check to see if this property applies to our object
@@ -4698,7 +4698,7 @@ zfs_expand_proplist(zfs_handle_t *zhp, zprop_list_t **plp, boolean_t received,
 	zprop_list_t **last, **start;
 	nvlist_t *userprops, *propval;
 	nvpair_t *elem;
-	char *strval;
+	const char *strval;
 	char buf[ZFS_MAXPROPLEN];
 
 	if (zprop_expand_list(hdl, plp, ZFS_TYPE_DATASET) != 0)
@@ -5484,7 +5484,7 @@ volsize_from_vdevs(zpool_handle_t *zhp, uint64_t nblocks, uint64_t blksize)
 	}
 
 	for (int v = 0; v < nvdevs; v++) {
-		char *type;
+		const char *type;
 		uint64_t nparity, ashift, asize, tsize;
 		uint64_t volsize;
 
@@ -5566,7 +5566,7 @@ zvol_volsize_to_reservation(zpool_handle_t *zph, uint64_t volsize,
 	uint64_t numdb;
 	uint64_t nblocks, volblocksize;
 	int ncopies;
-	char *strval;
+	const char *strval;
 
 	if (nvlist_lookup_string(props,
 	    zfs_prop_to_name(ZFS_PROP_COPIES), &strval) == 0)

--- a/lib/libzfs/libzfs_impl.h
+++ b/lib/libzfs/libzfs_impl.h
@@ -140,7 +140,7 @@ extern zfs_handle_t *make_dataset_handle_zc(libzfs_handle_t *, zfs_cmd_t *);
 extern zfs_handle_t *make_dataset_simple_handle_zc(zfs_handle_t *, zfs_cmd_t *);
 
 extern int zprop_parse_value(libzfs_handle_t *, nvpair_t *, int, zfs_type_t,
-    nvlist_t *, char **, uint64_t *, const char *);
+    nvlist_t *, const char **, uint64_t *, const char *);
 extern int zprop_expand_list(libzfs_handle_t *hdl, zprop_list_t **plp,
     zfs_type_t type);
 

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -280,7 +280,7 @@ zpool_in_use(libzfs_handle_t *hdl, int fd, pool_state_t *state, char **namestr,
     boolean_t *inuse)
 {
 	nvlist_t *config;
-	char *name = NULL;
+	const char *name = NULL;
 	boolean_t ret;
 	uint64_t guid = 0, vdev_guid;
 	zpool_handle_t *zhp;

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -224,7 +224,7 @@ zfs_iter_bookmarks(zfs_handle_t *zhp, int flags __maybe_unused,
 	for (pair = nvlist_next_nvpair(bmarks, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(bmarks, pair)) {
 		char name[ZFS_MAX_DATASET_NAME_LEN];
-		char *bmark_name;
+		const char *bmark_name;
 		nvlist_t *bmark_props;
 
 		bmark_name = nvpair_name(pair);

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -291,7 +291,7 @@ static int
 zfs_add_option(zfs_handle_t *zhp, char *options, int len,
     zfs_prop_t prop, const char *on, const char *off)
 {
-	char *source;
+	const char *source;
 	uint64_t value;
 
 	/* Skip adding duplicate default options */

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -459,9 +459,9 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 	nvpair_t *elem;
 	nvlist_t *retprops;
 	zpool_prop_t prop;
-	char *strval;
+	const char *strval;
 	uint64_t intval;
-	char *slash, *check;
+	const char *slash, *check;
 	struct stat64 statbuf;
 	zpool_handle_t *zhp;
 	char report[1024];
@@ -689,12 +689,12 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 				goto error;
 			}
 
-			*slash = '\0';
+			*(char *)slash = '\0';
 
 			if (strval[0] != '\0' &&
 			    (stat64(strval, &statbuf) != 0 ||
 			    !S_ISDIR(statbuf.st_mode))) {
-				*slash = '/';
+				*(char *)slash = '/';
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "'%s' is not a valid directory"),
 				    strval);
@@ -702,7 +702,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 				goto error;
 			}
 
-			*slash = '/';
+			*(char *)slash = '/';
 			break;
 
 		case ZPOOL_PROP_COMPATIBILITY:
@@ -932,7 +932,7 @@ vdev_expand_proplist(zpool_handle_t *zhp, const char *vdevname,
 {
 	zprop_list_t *entry;
 	char buf[ZFS_MAXPROPLEN];
-	char *strval = NULL;
+	const char *strval = NULL;
 	int err = 0;
 	nvpair_t *elem = NULL;
 	nvlist_t *vprops = NULL;
@@ -1290,7 +1290,7 @@ zpool_has_special_vdev(nvlist_t *nvroot)
 	if (nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN, &child,
 	    &children) == 0) {
 		for (uint_t c = 0; c < children; c++) {
-			char *bias;
+			const char *bias;
 
 			if (nvlist_lookup_string(child[c],
 			    ZPOOL_CONFIG_ALLOCATION_BIAS, &bias) == 0 &&
@@ -1314,7 +1314,7 @@ zpool_has_draid_vdev(nvlist_t *nvroot)
 	if (nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
 	    &child, &children) == 0) {
 		for (uint_t c = 0; c < children; c++) {
-			char *type;
+			const char *type;
 
 			if (nvlist_lookup_string(child[c],
 			    ZPOOL_CONFIG_TYPE, &type) == 0 &&
@@ -1394,7 +1394,7 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 
 	if (fsprops) {
 		uint64_t zoned;
-		char *zonestr;
+		const char *zonestr;
 
 		zoned = ((nvlist_lookup_string(fsprops,
 		    zfs_prop_to_name(ZFS_PROP_ZONED), &zonestr) == 0) &&
@@ -1987,7 +1987,7 @@ zpool_print_unsup_feat(nvlist_t *config)
 
 	for (nvpair_t *nvp = nvlist_next_nvpair(unsup_feat, NULL);
 	    nvp != NULL; nvp = nvlist_next_nvpair(unsup_feat, nvp)) {
-		char *desc = fnvpair_value_string(nvp);
+		const char *desc = fnvpair_value_string(nvp);
 		if (strlen(desc) > 0)
 			(void) printf("\t%s (%s)\n", nvpair_name(nvp), desc);
 		else
@@ -2011,7 +2011,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 	nvlist_t *nvinfo = NULL;
 	nvlist_t *missing = NULL;
 	const char *thename;
-	char *origname;
+	const char *origname;
 	int ret;
 	int error = 0;
 	char errbuf[ERRBUFLEN];
@@ -2239,7 +2239,7 @@ zpool_translate_vdev_guids(zpool_handle_t *zhp, nvlist_t *vds,
 	    elem = nvlist_next_nvpair(vds, elem)) {
 		boolean_t spare, cache;
 
-		char *vd_path = nvpair_name(elem);
+		const char *vd_path = nvpair_name(elem);
 		nvlist_t *tgt = zpool_find_vdev(zhp, vd_path, &spare, &cache,
 		    NULL);
 
@@ -2353,7 +2353,7 @@ list_errors:
 	for (elem = nvlist_next_nvpair(vd_errlist, NULL); elem != NULL;
 	    elem = nvlist_next_nvpair(vd_errlist, elem)) {
 		int64_t vd_error = xlate_init_err(fnvpair_value_int64(elem));
-		char *path;
+		const char *path;
 
 		if (nvlist_lookup_string(guids_to_paths, nvpair_name(elem),
 		    &path) != 0)
@@ -2451,7 +2451,7 @@ check_trim_errs(zpool_handle_t *zhp, trimflags_t *trim_flags,
 	for (elem = nvlist_next_nvpair(errlist, NULL);
 	    elem != NULL; elem = nvlist_next_nvpair(errlist, elem)) {
 		int64_t vd_error = xlate_trim_err(fnvpair_value_int64(elem));
-		char *path;
+		const char *path;
 
 		/*
 		 * If only the pool was specified, and it was not a secure
@@ -2634,7 +2634,7 @@ vdev_to_nvlist_iter(nvlist_t *nv, nvlist_t *search, boolean_t *avail_spare,
 	nvlist_t **child;
 	nvlist_t *ret;
 	uint64_t is_log;
-	char *srchkey;
+	const char *srchkey;
 	nvpair_t *pair = nvlist_next_nvpair(search, NULL);
 
 	/* Nothing to look for */
@@ -2656,7 +2656,7 @@ vdev_to_nvlist_iter(nvlist_t *nv, nvlist_t *search, boolean_t *avail_spare,
 		break;
 
 	case DATA_TYPE_STRING: {
-		char *srchval, *val;
+		const char *srchval, *val;
 
 		srchval = fnvpair_value_string(pair);
 		if (nvlist_lookup_string(nv, srchkey, &val) != 0)
@@ -2969,7 +2969,7 @@ zpool_vdev_online(zpool_handle_t *zhp, const char *path, int flags,
 		return (zfs_error(hdl, EZFS_ISSPARE, errbuf));
 
 #ifndef __FreeBSD__
-	char *pathname;
+	const char *pathname;
 	if ((flags & ZFS_ONLINE_EXPAND ||
 	    zpool_get_prop_int(zhp, ZPOOL_PROP_AUTOEXPAND, NULL)) &&
 	    nvlist_lookup_string(tgt, ZPOOL_CONFIG_PATH, &pathname) == 0) {
@@ -3181,7 +3181,8 @@ is_replacing_spare(nvlist_t *search, nvlist_t *tgt, int which)
 
 	if (nvlist_lookup_nvlist_array(search, ZPOOL_CONFIG_CHILDREN, &child,
 	    &children) == 0) {
-		char *type = fnvlist_lookup_string(search, ZPOOL_CONFIG_TYPE);
+		const char *type = fnvlist_lookup_string(search,
+		    ZPOOL_CONFIG_TYPE);
 		if ((strcmp(type, VDEV_TYPE_SPARE) == 0 ||
 		    strcmp(type, VDEV_TYPE_DRAID_SPARE) == 0) &&
 		    children == 2 && child[which] == tgt)
@@ -3484,7 +3485,8 @@ zpool_vdev_split(zpool_handle_t *zhp, char *newname, nvlist_t **newroot,
     nvlist_t *props, splitflags_t flags)
 {
 	zfs_cmd_t zc = {"\0"};
-	char errbuf[ERRBUFLEN], *bias;
+	char errbuf[ERRBUFLEN];
+	const char *bias;
 	nvlist_t *tree, *config, **child, **newchild, *newconfig = NULL;
 	nvlist_t **varray = NULL, *zc_props = NULL;
 	uint_t c, children, newchildren, lastlog = 0, vcount, found = 0;
@@ -3542,7 +3544,7 @@ zpool_vdev_split(zpool_handle_t *zhp, char *newname, nvlist_t **newroot,
 	for (c = 0; c < children; c++) {
 		uint64_t is_log = B_FALSE, is_hole = B_FALSE;
 		boolean_t is_special = B_FALSE, is_dedup = B_FALSE;
-		char *type;
+		const char *type;
 		nvlist_t **mchild, *vdev;
 		uint_t mchildren;
 		int entry;
@@ -4015,7 +4017,7 @@ char *
 zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
     int name_flags)
 {
-	char *type, *tpath;
+	const char *type, *tpath;
 	const char *path;
 	uint64_t value;
 	char buf[PATH_BUF_LEN];

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -694,6 +694,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			if (strval[0] != '\0' &&
 			    (stat64(strval, &statbuf) != 0 ||
 			    !S_ISDIR(statbuf.st_mode))) {
+				*slash = '/';
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "'%s' is not a valid directory"),
 				    strval);

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -119,7 +119,7 @@ dump_record(dmu_replay_record_t *drr, void *payload, size_t payload_len,
 typedef struct fsavl_node {
 	avl_node_t fn_node;
 	nvlist_t *fn_nvfs;
-	char *fn_snapname;
+	const char *fn_snapname;
 	uint64_t fn_guid;
 } fsavl_node_t;
 
@@ -137,7 +137,7 @@ fsavl_compare(const void *arg1, const void *arg2)
  * (optionally) name.
  */
 static nvlist_t *
-fsavl_find(avl_tree_t *avl, uint64_t snapguid, char **snapname)
+fsavl_find(avl_tree_t *avl, uint64_t snapguid, const char **snapname)
 {
 	fsavl_node_t fn_find;
 	fsavl_node_t *fn;
@@ -384,7 +384,7 @@ send_iterate_prop(zfs_handle_t *zhp, boolean_t received_only, nvlist_t *nv)
 
 	nvpair_t *elem = NULL;
 	while ((elem = nvlist_next_nvpair(props, elem)) != NULL) {
-		char *propname = nvpair_name(elem);
+		const char *propname = nvpair_name(elem);
 		zfs_prop_t prop = zfs_name_to_prop(propname);
 
 		if (!zfs_prop_user(propname)) {
@@ -412,7 +412,7 @@ send_iterate_prop(zfs_handle_t *zhp, boolean_t received_only, nvlist_t *nv)
 		if (isspacelimit && zhp->zfs_type == ZFS_TYPE_SNAPSHOT)
 			continue;
 
-		char *source;
+		const char *source;
 		if (nvlist_lookup_string(propnv, ZPROP_SOURCE, &source) == 0) {
 			if (strcmp(source, zhp->zfs_name) != 0 &&
 			    strcmp(source, ZPROP_SOURCE_VAL_RECVD) != 0)
@@ -428,7 +428,7 @@ send_iterate_prop(zfs_handle_t *zhp, boolean_t received_only, nvlist_t *nv)
 
 		if (zfs_prop_user(propname) ||
 		    zfs_prop_get_type(prop) == PROP_TYPE_STRING) {
-			char *value;
+			const char *value;
 			value = fnvlist_lookup_string(propnv, ZPROP_VALUE);
 			fnvlist_add_string(nv, propname, value);
 		} else {
@@ -1132,7 +1132,7 @@ dump_snapshot(zfs_handle_t *zhp, void *arg)
 
 	if (!sdd->doall && !isfromsnap && !istosnap) {
 		if (sdd->replicate) {
-			char *snapname;
+			const char *snapname;
 			nvlist_t *snapprops;
 			/*
 			 * Filter out all intermediate snapshots except origin
@@ -1372,7 +1372,7 @@ dump_filesystems(zfs_handle_t *rzhp, send_dump_data_t *sdd)
 		nvfs = fnvpair_value_nvlist(fspair);
 		(void) nvlist_lookup_uint64(nvfs, "origin", &origin_guid);
 		if (origin_guid != 0) {
-			char *snapname;
+			const char *snapname;
 			nvlist_t *origin_nv = fsavl_find(sdd->fsavl,
 			    origin_guid, &snapname);
 			if (origin_nv != NULL) {
@@ -1391,7 +1391,7 @@ again:
 	for (fspair = nvlist_next_nvpair(sdd->fss, NULL); fspair;
 	    fspair = nvlist_next_nvpair(sdd->fss, fspair)) {
 		nvlist_t *fslist, *parent_nv;
-		char *fsname;
+		const char *fsname;
 		zfs_handle_t *zhp;
 		int err;
 		uint64_t origin_guid = 0;
@@ -1757,8 +1757,8 @@ zfs_send_resume_impl_cb_impl(libzfs_handle_t *hdl, sendflags_t *flags,
     int outfd, nvlist_t *resume_nvl)
 {
 	char errbuf[ERRBUFLEN];
-	char *toname;
-	char *fromname = NULL;
+	const char *toname;
+	const char *fromname = NULL;
 	uint64_t resumeobj, resumeoff, toguid, fromguid, bytes;
 	zfs_handle_t *zhp;
 	int error = 0;
@@ -3254,7 +3254,7 @@ created_before(libzfs_handle_t *hdl, avl_tree_t *avl,
     uint64_t guid1, uint64_t guid2)
 {
 	nvlist_t *nvfs;
-	char *fsname = NULL, *snapname = NULL;
+	const char *fsname = NULL, *snapname = NULL;
 	char buf[ZFS_MAX_DATASET_NAME_LEN];
 	int rv;
 	zfs_handle_t *guid1hdl, *guid2hdl;
@@ -3320,7 +3320,7 @@ recv_fix_encryption_hierarchy(libzfs_handle_t *hdl, const char *top_zfs,
 		nvpair_t *snapel = NULL;
 		boolean_t is_encroot, is_clone, stream_encroot;
 		char *cp;
-		char *stream_keylocation = NULL;
+		const char *stream_keylocation = NULL;
 		char keylocation[MAXNAMELEN];
 		char fsname[ZFS_MAX_DATASET_NAME_LEN];
 
@@ -3440,12 +3440,12 @@ recv_incremental_replication(libzfs_handle_t *hdl, const char *tofs,
 	nvlist_t *local_nv, *deleted = NULL;
 	avl_tree_t *local_avl;
 	nvpair_t *fselem, *nextfselem;
-	char *fromsnap;
+	const char *fromsnap;
 	char newname[ZFS_MAX_DATASET_NAME_LEN];
 	char guidname[32];
 	int error;
 	boolean_t needagain, progress, recursive;
-	char *s1, *s2;
+	const char *s1, *s2;
 
 	fromsnap = fnvlist_lookup_string(stream_nv, "fromsnap");
 
@@ -3477,7 +3477,7 @@ again:
 		uint64_t originguid = 0;
 		uint64_t stream_originguid = 0;
 		uint64_t parent_fromsnap_guid, stream_parent_fromsnap_guid;
-		char *fsname, *stream_fsname;
+		const char *fsname, *stream_fsname;
 
 		nextfselem = nvlist_next_nvpair(local_nv, fselem);
 
@@ -3512,7 +3512,7 @@ again:
 			case 1: {
 				/* promote it! */
 				nvlist_t *origin_nvfs;
-				char *origin_fsname;
+				const char *origin_fsname;
 
 				origin_nvfs = fsavl_find(local_avl, originguid,
 				    NULL);
@@ -3543,7 +3543,7 @@ again:
 		for (snapelem = nvlist_next_nvpair(snaps, NULL);
 		    snapelem; snapelem = nextsnapelem) {
 			uint64_t thisguid;
-			char *stream_snapname;
+			const char *stream_snapname;
 			nvlist_t *found, *props;
 
 			nextsnapelem = nvlist_next_nvpair(snaps, snapelem);
@@ -3689,7 +3689,7 @@ again:
 			 * new fs.
 			 */
 			if (parent != NULL) {
-				char *pname;
+				const char *pname;
 
 				pname = fnvlist_lookup_string(parent, "name");
 				(void) snprintf(tryname, sizeof (tryname),
@@ -3740,8 +3740,8 @@ zfs_receive_package(libzfs_handle_t *hdl, int fd, const char *destname,
 {
 	nvlist_t *stream_nv = NULL;
 	avl_tree_t *stream_avl = NULL;
-	char *fromsnap = NULL;
-	char *sendsnap = NULL;
+	const char *fromsnap = NULL;
+	const char *sendsnap = NULL;
 	char *cp;
 	char tofs[ZFS_MAX_DATASET_NAME_LEN];
 	char sendfs[ZFS_MAX_DATASET_NAME_LEN];
@@ -4230,7 +4230,7 @@ zfs_setup_cmdline_props(libzfs_handle_t *hdl, zfs_type_t type,
 			 */
 			if (nvlist_exists(origprops, newname)) {
 				nvlist_t *attrs;
-				char *source = NULL;
+				const char *source = NULL;
 
 				attrs = fnvlist_lookup_nvlist(origprops,
 				    newname);
@@ -4354,7 +4354,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 	zprop_errflags_t prop_errflags;
 	nvlist_t *prop_errors = NULL;
 	boolean_t recursive;
-	char *snapname = NULL;
+	const char *snapname = NULL;
 	char destsnap[MAXPATHLEN * 2];
 	char origin[MAXNAMELEN] = {0};
 	char name[MAXPATHLEN];
@@ -4385,7 +4385,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 	boolean_t holds = flags->holds && !flags->skipholds;
 
 	if (stream_avl != NULL) {
-		char *keylocation = NULL;
+		const char *keylocation = NULL;
 		nvlist_t *lookup = NULL;
 		nvlist_t *fs = fsavl_find(stream_avl, drrb->drr_toguid,
 		    &snapname);
@@ -5503,7 +5503,7 @@ zfs_receive(libzfs_handle_t *hdl, const char *tosnap, nvlist_t *props,
 	char *top_zfs = NULL;
 	int err;
 	struct stat sb;
-	char *originsnap = NULL;
+	const char *originsnap = NULL;
 
 	/*
 	 * The only way fstat can fail is if we do not have a valid file

--- a/lib/libzfs/libzfs_status.c
+++ b/lib/libzfs/libzfs_status.c
@@ -168,7 +168,8 @@ find_vdev_problem(nvlist_t *vdev, int (*func)(vdev_stat_t *, uint_t),
 	 * later.
 	 */
 	if (ignore_replacing == B_TRUE) {
-		char *type = fnvlist_lookup_string(vdev, ZPOOL_CONFIG_TYPE);
+		const char *type = fnvlist_lookup_string(vdev,
+		    ZPOOL_CONFIG_TYPE);
 		if (strcmp(type, VDEV_TYPE_REPLACING) == 0)
 			return (B_FALSE);
 	}

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1595,13 +1595,13 @@ zfs_nicestrtonum(libzfs_handle_t *hdl, const char *value, uint64_t *num)
  */
 int
 zprop_parse_value(libzfs_handle_t *hdl, nvpair_t *elem, int prop,
-    zfs_type_t type, nvlist_t *ret, char **svalp, uint64_t *ivalp,
+    zfs_type_t type, nvlist_t *ret, const char **svalp, uint64_t *ivalp,
     const char *errbuf)
 {
 	data_type_t datatype = nvpair_type(elem);
 	zprop_type_t proptype;
 	const char *propname;
-	char *value;
+	const char *value;
 	boolean_t isnone = B_FALSE;
 	boolean_t isauto = B_FALSE;
 	int err = 0;

--- a/lib/libzfs/os/linux/libzfs_pool_os.c
+++ b/lib/libzfs/os/linux/libzfs_pool_os.c
@@ -96,7 +96,7 @@ zpool_relabel_disk(libzfs_handle_t *hdl, const char *path, const char *msg)
 static int
 read_efi_label(nvlist_t *config, diskaddr_t *sb)
 {
-	char *path;
+	const char *path;
 	int fd;
 	char diskname[MAXPATHLEN];
 	int err = -1;

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -1061,6 +1061,9 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='65536' id='163f6aa5'>
       <subrange length='8192' type-id='7359adad' id='c88f397d'/>
     </array-type-def>
+    <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='infinite' id='e84913bd'>
+      <subrange length='infinite' type-id='7359adad' id='031f2035'/>
+    </array-type-def>
     <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
     <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
     <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
@@ -1324,6 +1327,9 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
         <var-decl name='nvp_type' type-id='8d0687d2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='nvp_name' type-id='e84913bd' visibility='default'/>
       </data-member>
     </class-decl>
     <typedef-decl name='nvpair_t' type-id='1c34e459' id='57928edf'/>
@@ -2229,7 +2235,7 @@
     </function-decl>
     <function-decl name='nvpair_name' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='dace003f'/>
-      <return type-id='26a90f95'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='5ce45b60'/>
@@ -2317,9 +2323,9 @@
       <return type-id='9c313c2d'/>
     </function-decl>
     <function-decl name='fnvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='5ce45b60'/>
+      <parameter type-id='22cce67b'/>
       <parameter type-id='80f4b756'/>
-      <return type-id='26a90f95'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='libspl_assertf' mangled-name='libspl_assertf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libspl_assertf'>
       <parameter type-id='80f4b756'/>

--- a/lib/libzfsbootenv/libzfsbootenv.abi
+++ b/lib/libzfsbootenv/libzfsbootenv.abi
@@ -181,6 +181,7 @@
     <qualified-type-def type-id='a84c031d' const='yes' id='9b45d938'/>
     <pointer-type-def type-id='9b45d938' size-in-bits='64' id='80f4b756'/>
     <qualified-type-def type-id='80f4b756' restrict='yes' id='9d26089a'/>
+    <pointer-type-def type-id='80f4b756' size-in-bits='64' id='7d3cd834'/>
     <qualified-type-def type-id='8e8d4be3' const='yes' id='693c3853'/>
     <pointer-type-def type-id='693c3853' size-in-bits='64' id='22cce67b'/>
     <pointer-type-def type-id='95942d0c' size-in-bits='64' id='b0382bb3'/>
@@ -235,9 +236,9 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_string' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='5ce45b60'/>
+      <parameter type-id='22cce67b'/>
       <parameter type-id='80f4b756'/>
-      <parameter type-id='9b23c9ad'/>
+      <parameter type-id='7d3cd834'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_exists' visibility='default' binding='global' size-in-bits='64'>

--- a/lib/libzfsbootenv/lzbe_device.c
+++ b/lib/libzfsbootenv/lzbe_device.c
@@ -116,7 +116,7 @@ lzbe_get_boot_device(const char *pool, char **device)
 	libzfs_handle_t *hdl;
 	zpool_handle_t *zphdl;
 	nvlist_t *nv;
-	char *val;
+	const char *val;
 	int rv = -1;
 
 	if (pool == NULL || *pool == '\0' || device == NULL)
@@ -140,14 +140,13 @@ lzbe_get_boot_device(const char *pool, char **device)
 			 * we only do need dataset name.
 			 */
 			if (strncmp(val, "zfs:", 4) == 0) {
-				val += 4;
-				val = strdup(val);
-				if (val != NULL) {
-					size_t len = strlen(val);
+				char *tmp = strdup(val + 4);
+				if (tmp != NULL) {
+					size_t len = strlen(tmp);
 
-					if (val[len - 1] == ':')
-						val[len - 1] = '\0';
-					*device = val;
+					if (tmp[len - 1] == ':')
+						tmp[len - 1] = '\0';
+					*device = tmp;
 				} else {
 					rv = ENOMEM;
 				}

--- a/lib/libzpool/util.c
+++ b/lib/libzpool/util.c
@@ -65,7 +65,7 @@ show_vdev_stats(const char *desc, const char *ctype, nvlist_t *nv, int indent)
 
 	if (desc != NULL) {
 		const char *suffix = "";
-		char *bias = NULL;
+		const char *bias = NULL;
 		char bias_suffix[32];
 
 		(void) nvlist_lookup_uint64(nv, ZPOOL_CONFIG_IS_LOG, &is_log);
@@ -113,12 +113,13 @@ show_vdev_stats(const char *desc, const char *ctype, nvlist_t *nv, int indent)
 
 	for (c = 0; c < children; c++) {
 		nvlist_t *cnv = child[c];
-		char *cname = NULL, *tname;
+		const char *cname = NULL;
+		char *tname;
 		uint64_t np;
 		int len;
 		if (nvlist_lookup_string(cnv, ZPOOL_CONFIG_PATH, &cname) &&
 		    nvlist_lookup_string(cnv, ZPOOL_CONFIG_TYPE, &cname))
-			cname = (char *)"<unknown>";
+			cname = "<unknown>";
 		len = strlen(cname) + 2;
 		tname = umem_zalloc(len, UMEM_NOFAIL);
 		(void) strlcpy(tname, cname, len);
@@ -133,7 +134,7 @@ void
 show_pool_stats(spa_t *spa)
 {
 	nvlist_t *config, *nvroot;
-	char *name;
+	const char *name;
 
 	VERIFY(spa_get_stats(spa_name(spa), &config, NULL, 0) == 0);
 

--- a/lib/libzutil/os/linux/zutil_import_os.c
+++ b/lib/libzutil/os/linux/zutil_import_os.c
@@ -168,9 +168,9 @@ zpool_open_func(void *arg)
 	 * Add additional entries for paths described by this label.
 	 */
 	if (rn->rn_labelpaths) {
-		char *path = NULL;
-		char *devid = NULL;
-		char *env = NULL;
+		const char *path = NULL;
+		const char *devid = NULL;
+		const char *env = NULL;
 		rdsk_node_t *slice;
 		avl_index_t where;
 		int timeout;
@@ -769,7 +769,7 @@ no_dev:
  *    vdev_enc_sysfs_path: '/sys/class/enclosure/11:0:1:0/SLOT 4'
  */
 static void
-update_vdev_config_dev_sysfs_path(nvlist_t *nv, char *path)
+update_vdev_config_dev_sysfs_path(nvlist_t *nv, const char *path)
 {
 	char *upath, *spath;
 
@@ -795,7 +795,7 @@ sysfs_path_pool_vdev_iter_f(void *hdl_data, nvlist_t *nv, void *data)
 {
 	(void) hdl_data, (void) data;
 
-	char *path = NULL;
+	const char *path = NULL;
 	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &path) != 0)
 		return (1);
 
@@ -841,7 +841,7 @@ void
 update_vdev_config_dev_strs(nvlist_t *nv)
 {
 	vdev_dev_strs_t vds;
-	char *env, *type, *path;
+	const char *env, *type, *path;
 	uint64_t wholedisk = 0;
 
 	/*

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -1564,12 +1564,19 @@ discover_cached_paths(libpc_handle_t *hdl, nvlist_t *nv,
 	 * our directory cache.
 	 */
 	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &path) == 0) {
-		if ((dl = zfs_dirnamelen(path)) == -1)
+		int ret;
+		char c = '\0';
+		if ((dl = zfs_dirnamelen(path)) == -1) {
 			path = (char *)".";
-		else
+		} else {
+			c = path[dl];
 			path[dl] = '\0';
-		return (zpool_find_import_scan_dir(hdl, lock, cache,
-		    path, 0));
+		}
+		ret = zpool_find_import_scan_dir(hdl, lock, cache,
+		    path, 0);
+		if (c != '\0')
+			path[dl] = c;
+		return (ret);
 	}
 	return (0);
 }

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -233,7 +233,7 @@ fix_paths(libpc_handle_t *hdl, nvlist_t *nv, name_entry_t *names)
 	uint_t c, children;
 	uint64_t guid;
 	name_entry_t *ne, *best;
-	char *path;
+	const char *path;
 
 	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN,
 	    &child, &children) == 0) {
@@ -497,7 +497,7 @@ get_configs(libpc_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
 	uint_t i, nspares, nl2cache;
 	boolean_t config_seen;
 	uint64_t best_txg;
-	char *name, *hostname = NULL;
+	const char *name, *hostname = NULL;
 	uint64_t guid;
 	uint_t children = 0;
 	nvlist_t **child = NULL;
@@ -591,8 +591,8 @@ get_configs(libpc_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
 				 *	hostname (if available)
 				 */
 				uint64_t state, version;
-				char *comment = NULL;
-				char *compatibility = NULL;
+				const char *comment = NULL;
+				const char *compatibility = NULL;
 
 				version = fnvlist_lookup_uint64(tmp,
 				    ZPOOL_CONFIG_VERSION);
@@ -1161,12 +1161,12 @@ slice_cache_compare(const void *arg1, const void *arg2)
 
 static int
 label_paths_impl(libpc_handle_t *hdl, nvlist_t *nvroot, uint64_t pool_guid,
-    uint64_t vdev_guid, char **path, char **devid)
+    uint64_t vdev_guid, const char **path, const char **devid)
 {
 	nvlist_t **child;
 	uint_t c, children;
 	uint64_t guid;
-	char *val;
+	const char *val;
 	int error;
 
 	if (nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
@@ -1204,7 +1204,8 @@ label_paths_impl(libpc_handle_t *hdl, nvlist_t *nvroot, uint64_t pool_guid,
  * The returned pointers are only valid as long as label remains valid.
  */
 int
-label_paths(libpc_handle_t *hdl, nvlist_t *label, char **path, char **devid)
+label_paths(libpc_handle_t *hdl, nvlist_t *label, const char **path,
+    const char **devid)
 {
 	nvlist_t *nvroot;
 	uint64_t pool_guid;
@@ -1473,7 +1474,7 @@ zpool_find_import_impl(libpc_handle_t *hdl, importargs_t *iarg,
 			}
 
 			if (iarg->poolname != NULL && !aux) {
-				char *pname;
+				const char *pname;
 
 				matched = nvlist_lookup_string(config,
 				    ZPOOL_CONFIG_POOL_NAME, &pname) == 0 &&
@@ -1547,7 +1548,7 @@ static int
 discover_cached_paths(libpc_handle_t *hdl, nvlist_t *nv,
     avl_tree_t *cache, pthread_mutex_t *lock)
 {
-	char *path = NULL;
+	const char *path = NULL;
 	ssize_t dl;
 	uint_t children;
 	nvlist_t **child;
@@ -1567,15 +1568,17 @@ discover_cached_paths(libpc_handle_t *hdl, nvlist_t *nv,
 		int ret;
 		char c = '\0';
 		if ((dl = zfs_dirnamelen(path)) == -1) {
-			path = (char *)".";
+			path = ".";
 		} else {
 			c = path[dl];
-			path[dl] = '\0';
+			((char *)path)[dl] = '\0';
+
 		}
 		ret = zpool_find_import_scan_dir(hdl, lock, cache,
 		    path, 0);
 		if (c != '\0')
-			path[dl] = c;
+			((char *)path)[dl] = c;
+
 		return (ret);
 	}
 	return (0);
@@ -1595,7 +1598,7 @@ zpool_find_import_cached(libpc_handle_t *hdl, importargs_t *iarg)
 	nvlist_t *raw, *src, *dst;
 	nvlist_t *pools;
 	nvpair_t *elem;
-	char *name;
+	const char *name;
 	uint64_t this_guid;
 	boolean_t active;
 
@@ -1825,10 +1828,10 @@ zpool_search_import(libpc_handle_t *hdl, importargs_t *import)
 }
 
 static boolean_t
-pool_match(nvlist_t *cfg, char *tgt)
+pool_match(nvlist_t *cfg, const char *tgt)
 {
 	uint64_t v, guid = strtoull(tgt, NULL, 0);
-	char *s;
+	const char *s;
 
 	if (guid != 0) {
 		if (nvlist_lookup_uint64(cfg, ZPOOL_CONFIG_POOL_GUID, &v) == 0)
@@ -1913,7 +1916,7 @@ for_each_vdev_cb(void *zhp, nvlist_t *nv, pool_vdev_iter_f func,
 	uint_t c, children;
 	int ret = 0;
 	int i;
-	char *type;
+	const char *type;
 
 	const char *list[] = {
 	    ZPOOL_CONFIG_SPARES,

--- a/lib/libzutil/zutil_import.h
+++ b/lib/libzutil/zutil_import.h
@@ -33,8 +33,8 @@
 #define	IMPORT_ORDER_SCAN_OFFSET	10
 #define	IMPORT_ORDER_DEFAULT		100
 
-int label_paths(libpc_handle_t *hdl, nvlist_t *label, char **path,
-    char **devid);
+int label_paths(libpc_handle_t *hdl, nvlist_t *label, const char **path,
+    const char **devid);
 int zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
     avl_tree_t **slice_cache);
 

--- a/module/nvpair/fnvpair.c
+++ b/module/nvpair/fnvpair.c
@@ -402,10 +402,10 @@ fnvlist_lookup_uint64(const nvlist_t *nvl, const char *name)
 	return (rv);
 }
 
-char *
-fnvlist_lookup_string(nvlist_t *nvl, const char *name)
+const char *
+fnvlist_lookup_string(const nvlist_t *nvl, const char *name)
 {
-	char *rv;
+	const char *rv;
 	VERIFY0(nvlist_lookup_string(nvl, name, &rv));
 	return (rv);
 }
@@ -577,10 +577,10 @@ fnvpair_value_uint64(const nvpair_t *nvp)
 	return (rv);
 }
 
-char *
-fnvpair_value_string(nvpair_t *nvp)
+const char *
+fnvpair_value_string(const nvpair_t *nvp)
 {
-	char *rv;
+	const char *rv;
 	VERIFY0(nvpair_value_string(nvp, &rv));
 	return (rv);
 }

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -2057,8 +2057,11 @@ nvlist_lookup_nvpair_ei_sep(nvlist_t *nvl, const char *name, const char sep,
 				nvl = EMBEDDED_NVL(nvp);
 				break;
 			} else if (nvpair_type(nvp) == DATA_TYPE_NVLIST_ARRAY) {
-				(void) nvpair_value_nvlist_array(nvp,
-				    &nva, (uint_t *)&n);
+				if (nvpair_value_nvlist_array(nvp,
+				    &nva, (uint_t *)&n) != 0)
+					goto fail;
+				if (nva == NULL)
+					goto fail;
 				if ((n < 0) || (idx >= n))
 					goto fail;
 				nvl = nva[idx];

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -2808,7 +2808,7 @@ nvs_native_create(nvstream_t *nvs, nvs_native_t *native, char *buf,
 static void
 nvs_native_destroy(nvstream_t *nvs)
 {
-	(void) nvs;
+	nvs->nvs_private = NULL;
 }
 
 static int
@@ -3189,7 +3189,7 @@ nvs_xdr_destroy(nvstream_t *nvs)
 	switch (nvs->nvs_op) {
 	case NVS_OP_ENCODE:
 	case NVS_OP_DECODE:
-		xdr_destroy((XDR *)nvs->nvs_private);
+		nvs->nvs_private = NULL;
 		break;
 	default:
 		break;

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -473,7 +473,7 @@ nvt_remove_nvpair(nvlist_t *nvl, const nvpair_t *nvp)
 	}
 	i_nvp_t **tab = priv->nvp_hashtable;
 
-	char *name = NVP_NAME(nvp);
+	const char *name = NVP_NAME(nvp);
 	uint64_t hash = nvt_hash(name);
 	uint64_t index = hash & (priv->nvp_nbuckets - 1);
 
@@ -528,7 +528,7 @@ nvt_add_nvpair(nvlist_t *nvl, nvpair_t *nvp)
 	}
 	i_nvp_t **tab = priv->nvp_hashtable;
 
-	char *name = NVP_NAME(nvp);
+	const char *name = NVP_NAME(nvp);
 	uint64_t hash = nvt_hash(name);
 	uint64_t index = hash & (priv->nvp_nbuckets - 1);
 
@@ -1517,7 +1517,7 @@ nvlist_empty(const nvlist_t *nvl)
 	return (priv->nvp_list == NULL);
 }
 
-char *
+const char *
 nvpair_name(const nvpair_t *nvp)
 {
 	return (NVP_NAME(nvp));
@@ -1731,7 +1731,7 @@ nvlist_lookup_double(const nvlist_t *nvl, const char *name, double *val)
 #endif
 
 int
-nvlist_lookup_string(nvlist_t *nvl, const char *name, char **val)
+nvlist_lookup_string(const nvlist_t *nvl, const char *name, const char **val)
 {
 	return (nvlist_lookup_common(nvl, name, DATA_TYPE_STRING, NULL, val));
 }
@@ -1917,7 +1917,7 @@ nvlist_lookup_pairs(nvlist_t *nvl, int flag, ...)
  */
 static int
 nvlist_lookup_nvpair_ei_sep(nvlist_t *nvl, const char *name, const char sep,
-    nvpair_t **ret, int *ip, char **ep)
+    nvpair_t **ret, int *ip, const char **ep)
 {
 	nvpair_t	*nvp;
 	const char	*np;
@@ -2097,7 +2097,7 @@ nvlist_lookup_nvpair(nvlist_t *nvl, const char *name, nvpair_t **ret)
  * description.
  */
 int nvlist_lookup_nvpair_embedded_index(nvlist_t *nvl,
-    const char *name, nvpair_t **ret, int *ip, char **ep)
+    const char *name, nvpair_t **ret, int *ip, const char **ep)
 {
 	return (nvlist_lookup_nvpair_ei_sep(nvl, name, '.', ret, ip, ep));
 }
@@ -2192,7 +2192,7 @@ nvpair_value_double(const nvpair_t *nvp, double *val)
 #endif
 
 int
-nvpair_value_string(nvpair_t *nvp, char **val)
+nvpair_value_string(const nvpair_t *nvp, const char **val)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_STRING, NULL, val));
 }
@@ -2264,7 +2264,7 @@ nvpair_value_uint64_array(nvpair_t *nvp, uint64_t **val, uint_t *nelem)
 }
 
 int
-nvpair_value_string_array(nvpair_t *nvp, char ***val, uint_t *nelem)
+nvpair_value_string_array(nvpair_t *nvp, const char ***val, uint_t *nelem)
 {
 	return (nvpair_value_common(nvp, DATA_TYPE_STRING_ARRAY, nelem, val));
 }

--- a/module/os/freebsd/spl/spl_sysevent.c
+++ b/module/os/freebsd/spl/spl_sysevent.c
@@ -114,7 +114,7 @@ log_sysevent(nvlist_t *event)
 		}
 		case DATA_TYPE_STRING:
 		{
-			char *value;
+			const char *value;
 
 			(void) nvpair_value_string(elem, &value);
 			sbuf_printf(sb, " %s=%s", nvpair_name(elem), value);
@@ -180,7 +180,7 @@ log_sysevent(nvlist_t *event)
 		}
 		case DATA_TYPE_STRING_ARRAY:
 		{
-			char **strarr;
+			const char **strarr;
 			uint_t ii, nelem;
 
 			(void) nvpair_value_string_array(elem, &strarr, &nelem);

--- a/module/os/freebsd/zfs/zfs_znode.c
+++ b/module/os/freebsd/zfs/zfs_znode.c
@@ -1690,7 +1690,7 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	while ((elem = nvlist_next_nvpair(zplprops, elem)) != NULL) {
 		/* For the moment we expect all zpl props to be uint64_ts */
 		uint64_t val;
-		char *name;
+		const char *name;
 
 		ASSERT3S(nvpair_type(elem), ==, DATA_TYPE_UINT64);
 		val = fnvpair_value_uint64(elem);

--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -1866,7 +1866,7 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 	while ((elem = nvlist_next_nvpair(zplprops, elem)) != NULL) {
 		/* For the moment we expect all zpl props to be uint64_ts */
 		uint64_t val;
-		char *name;
+		const char *name;
 
 		ASSERT(nvpair_type(elem) == DATA_TYPE_UINT64);
 		VERIFY(nvpair_value_uint64(elem, &val) == 0);

--- a/module/zcommon/zfs_comutil.c
+++ b/module/zcommon/zfs_comutil.c
@@ -70,7 +70,7 @@ zfs_allocatable_devs(nvlist_t *nv)
 boolean_t
 zfs_special_devs(nvlist_t *nv, const char *type)
 {
-	char *bias;
+	const char *bias;
 	uint_t c;
 	nvlist_t **child;
 	uint_t children;
@@ -98,7 +98,7 @@ zpool_get_load_policy(nvlist_t *nvl, zpool_load_policy_t *zlpp)
 {
 	nvlist_t *policy;
 	nvpair_t *elem;
-	char *nm;
+	const char *nm;
 
 	/* Defaults */
 	zlpp->zlp_rewind = ZPOOL_NO_REWIND;

--- a/module/zcommon/zfs_deleg.c
+++ b/module/zcommon/zfs_deleg.c
@@ -102,9 +102,9 @@ zfs_deleg_canonicalize_perm(const char *perm)
 }
 
 static int
-zfs_validate_who(char *who)
+zfs_validate_who(const char *who)
 {
-	char *p;
+	const char *p;
 
 	if (who[2] != ZFS_DELEG_FIELD_SEP_CHR)
 		return (-1);

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -1217,10 +1217,11 @@ dmu_recv_resume_begin_sync(void *arg, dmu_tx_t *tx)
  * succeeds; otherwise we will leak the holds on the datasets.
  */
 int
-dmu_recv_begin(char *tofs, char *tosnap, dmu_replay_record_t *drr_begin,
-    boolean_t force, boolean_t heal, boolean_t resumable, nvlist_t *localprops,
-    nvlist_t *hidden_args, char *origin, dmu_recv_cookie_t *drc,
-    zfs_file_t *fp, offset_t *voffp)
+dmu_recv_begin(const char *tofs, const char *tosnap,
+    dmu_replay_record_t *drr_begin, boolean_t force, boolean_t heal,
+    boolean_t resumable, nvlist_t *localprops, nvlist_t *hidden_args,
+    const char *origin, dmu_recv_cookie_t *drc, zfs_file_t *fp,
+    offset_t *voffp)
 {
 	dmu_recv_begin_arg_t drba = { 0 };
 	int err;

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -160,14 +160,14 @@ dsl_bookmark_create_nvl_validate_pair(const char *bmark, const char *source)
 int
 dsl_bookmark_create_nvl_validate(nvlist_t *bmarks)
 {
-	char *first = NULL;
+	const char *first = NULL;
 	size_t first_len = 0;
 
 	for (nvpair_t *pair = nvlist_next_nvpair(bmarks, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(bmarks, pair)) {
 
-		char *bmark = nvpair_name(pair);
-		char *source;
+		const char *bmark = nvpair_name(pair);
+		const char *source;
 
 		/* list structure: values must be snapshots XOR bookmarks */
 		if (nvpair_value_string(pair, &source) != 0)
@@ -177,7 +177,7 @@ dsl_bookmark_create_nvl_validate(nvlist_t *bmarks)
 
 		/* same pool check */
 		if (first == NULL) {
-			char *cp = strpbrk(bmark, "/#");
+			const char *cp = strpbrk(bmark, "/#");
 			if (cp == NULL)
 				return (-1);
 			first = bmark;
@@ -305,11 +305,11 @@ dsl_bookmark_create_check(void *arg, dmu_tx_t *tx)
 
 	for (nvpair_t *pair = nvlist_next_nvpair(dbca->dbca_bmarks, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(dbca->dbca_bmarks, pair)) {
-		char *new = nvpair_name(pair);
+		const char *new = nvpair_name(pair);
 
 		int error = schema_err;
 		if (error == 0) {
-			char *source = fnvpair_value_string(pair);
+			const char *source = fnvpair_value_string(pair);
 			error = dsl_bookmark_create_check_impl(dp, new, source);
 			if (error != 0)
 				error = SET_ERROR(error);
@@ -589,8 +589,8 @@ dsl_bookmark_create_sync(void *arg, dmu_tx_t *tx)
 	for (nvpair_t *pair = nvlist_next_nvpair(dbca->dbca_bmarks, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(dbca->dbca_bmarks, pair)) {
 
-		char *new = nvpair_name(pair);
-		char *source = fnvpair_value_string(pair);
+		const char *new = nvpair_name(pair);
+		const char *source = fnvpair_value_string(pair);
 
 		if (strchr(source, '@') != NULL) {
 			dsl_bookmark_create_sync_impl_snap(new, source, tx,

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -143,7 +143,7 @@ dsl_crypto_params_create_nvlist(dcp_cmd_t cmd, nvlist_t *props,
 	dsl_wrapping_key_t *wkey = NULL;
 	uint8_t *wkeydata = NULL;
 	uint_t wkeydata_len = 0;
-	char *keylocation = NULL;
+	const char *keylocation = NULL;
 
 	dcp = kmem_zalloc(sizeof (dsl_crypto_params_t), KM_SLEEP);
 	dcp->cp_cmd = cmd;

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -1620,7 +1620,7 @@ dsl_dataset_snapshot_check(void *arg, dmu_tx_t *tx)
 		for (pair = nvlist_next_nvpair(cnt_track, NULL);
 		    pair != NULL; pair = nvlist_next_nvpair(cnt_track, pair)) {
 			int error = 0;
-			char *name;
+			const char *name;
 			uint64_t cnt = 0;
 			dsl_dataset_t *ds;
 
@@ -1652,7 +1652,7 @@ dsl_dataset_snapshot_check(void *arg, dmu_tx_t *tx)
 	    pair != NULL; pair = nvlist_next_nvpair(ddsa->ddsa_snaps, pair)) {
 		int error = 0;
 		dsl_dataset_t *ds;
-		char *name, *atp = NULL;
+		const char *name, *atp = NULL;
 		char dsname[ZFS_MAX_DATASET_NAME_LEN];
 
 		name = nvpair_name(pair);
@@ -1877,7 +1877,7 @@ dsl_dataset_snapshot_sync(void *arg, dmu_tx_t *tx)
 	for (pair = nvlist_next_nvpair(ddsa->ddsa_snaps, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(ddsa->ddsa_snaps, pair)) {
 		dsl_dataset_t *ds;
-		char *name, *atp;
+		const char *name, *atp;
 		char dsname[ZFS_MAX_DATASET_NAME_LEN];
 
 		name = nvpair_name(pair);
@@ -1906,7 +1906,7 @@ dsl_dataset_snapshot(nvlist_t *snaps, nvlist_t *props, nvlist_t *errors)
 	boolean_t needsuspend;
 	int error;
 	spa_t *spa;
-	char *firstname;
+	const char *firstname;
 	nvlist_t *suspended = NULL;
 
 	pair = nvlist_next_nvpair(snaps, NULL);
@@ -1925,8 +1925,8 @@ dsl_dataset_snapshot(nvlist_t *snaps, nvlist_t *props, nvlist_t *errors)
 		for (pair = nvlist_next_nvpair(snaps, NULL); pair != NULL;
 		    pair = nvlist_next_nvpair(snaps, pair)) {
 			char fsname[ZFS_MAX_DATASET_NAME_LEN];
-			char *snapname = nvpair_name(pair);
-			char *atp;
+			const char *snapname = nvpair_name(pair);
+			const char *atp;
 			void *cookie;
 
 			atp = strchr(snapname, '@');

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -658,7 +658,7 @@ dsl_destroy_snapshots_nvl(nvlist_t *snaps, boolean_t defer,
 	    zfs_lua_max_memlimit,
 	    fnvlist_lookup_nvpair(wrapper, ZCP_ARG_ARGLIST), result);
 	if (error != 0) {
-		char *errorstr = NULL;
+		const char *errorstr = NULL;
 		(void) nvlist_lookup_string(result, ZCP_RET_ERROR, &errorstr);
 		if (errorstr != NULL) {
 			zfs_dbgmsg("%s", errorstr);

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -956,7 +956,7 @@ dsl_props_set_check(void *arg, dmu_tx_t *tx)
 			return (SET_ERROR(ENAMETOOLONG));
 		}
 		if (nvpair_type(elem) == DATA_TYPE_STRING) {
-			char *valstr = fnvpair_value_string(elem);
+			const char *valstr = fnvpair_value_string(elem);
 			if (strlen(valstr) >= (version <
 			    SPA_VERSION_STMF_PROP ?
 			    ZAP_OLDMAXVALUELEN : ZAP_MAXVALUELEN)) {

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -115,7 +115,7 @@ dsl_dataset_user_hold_check(void *arg, dmu_tx_t *tx)
 	    pair != NULL; pair = nvlist_next_nvpair(dduha->dduha_holds, pair)) {
 		dsl_dataset_t *ds;
 		int error = 0;
-		char *htag, *name;
+		const char *htag, *name;
 
 		/* must be a snapshot */
 		name = nvpair_name(pair);
@@ -572,7 +572,7 @@ dsl_dataset_user_release_impl(nvlist_t *holds, nvlist_t *errlist,
 {
 	dsl_dataset_user_release_arg_t ddura;
 	nvpair_t *pair;
-	char *pool;
+	const char *pool;
 	int error;
 
 	pair = nvlist_next_nvpair(holds, NULL);

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -892,7 +892,7 @@ fm_fmri_hc_create(nvlist_t *fmri, int version, const nvlist_t *auth,
 	uint_t n;
 	int i, j;
 	va_list ap;
-	char *hcname, *hcid;
+	const char *hcname, *hcid;
 
 	if (!fm_fmri_hc_set_common(fmri, version, auth))
 		return;

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -550,7 +550,7 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 	elem = NULL;
 	while ((elem = nvlist_next_nvpair(props, elem)) != NULL) {
 		uint64_t intval;
-		char *strval, *slash, *check, *fname;
+		const char *strval, *slash, *check, *fname;
 		const char *propname = nvpair_name(elem);
 		zpool_prop_t prop = zpool_name_to_prop(propname);
 
@@ -752,7 +752,7 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 void
 spa_configfile_set(spa_t *spa, nvlist_t *nvp, boolean_t need_sync)
 {
-	char *cachefile;
+	const char *cachefile;
 	spa_config_dirent_t *dp;
 
 	if (nvlist_lookup_string(nvp, zpool_prop_to_name(ZPOOL_PROP_CACHEFILE),
@@ -3351,7 +3351,7 @@ static int
 spa_verify_host(spa_t *spa, nvlist_t *mos_config)
 {
 	uint64_t hostid;
-	char *hostname;
+	const char *hostname;
 	uint64_t myhostid = 0;
 
 	if (!spa_is_root(spa) && nvlist_lookup_uint64(mos_config,
@@ -3386,8 +3386,8 @@ spa_ld_parse_config(spa_t *spa, spa_import_type_t type)
 	int parse;
 	vdev_t *rvd;
 	uint64_t pool_guid;
-	char *comment;
-	char *compatibility;
+	const char *comment;
+	const char *compatibility;
 
 	/*
 	 * Versioning wasn't explicitly added to the label until later, so if
@@ -5797,7 +5797,7 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
     nvlist_t *zplprops, dsl_crypto_params_t *dcp)
 {
 	spa_t *spa;
-	char *altroot = NULL;
+	const char *altroot = NULL;
 	vdev_t *rvd;
 	dsl_pool_t *dp;
 	dmu_tx_t *tx;
@@ -5810,8 +5810,8 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	boolean_t has_encryption;
 	boolean_t has_allocclass;
 	spa_feature_t feat;
-	char *feat_name;
-	char *poolname;
+	const char *feat_name;
+	const char *poolname;
 	nvlist_t *nvl;
 
 	if (props == NULL ||
@@ -6110,7 +6110,7 @@ int
 spa_import(char *pool, nvlist_t *config, nvlist_t *props, uint64_t flags)
 {
 	spa_t *spa;
-	char *altroot = NULL;
+	const char *altroot = NULL;
 	spa_load_state_t state = SPA_LOAD_IMPORT;
 	zpool_load_policy_t policy;
 	spa_mode_t mode = spa_mode_global;
@@ -6290,7 +6290,7 @@ nvlist_t *
 spa_tryimport(nvlist_t *tryconfig)
 {
 	nvlist_t *config = NULL;
-	char *poolname, *cachefile;
+	const char *poolname, *cachefile;
 	spa_t *spa;
 	uint64_t state;
 	int error;
@@ -7563,7 +7563,7 @@ spa_vdev_split_mirror(spa_t *spa, const char *newname, nvlist_t *config,
 	uint_t c, children, lastlog;
 	nvlist_t **child, *nvl, *tmp;
 	dmu_tx_t *tx;
-	char *altroot = NULL;
+	const char *altroot = NULL;
 	vdev_t *rvd, **vml = NULL;			/* vdev modify list */
 	boolean_t activate_slog;
 
@@ -8783,7 +8783,7 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 
 	while ((elem = nvlist_next_nvpair(nvp, elem))) {
 		uint64_t intval;
-		char *strval, *fname;
+		const char *strval, *fname;
 		zpool_prop_t prop;
 		const char *propname;
 		zprop_type_t proptype;

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -245,7 +245,7 @@ spa_write_cachefile(spa_t *target, boolean_t removing, boolean_t postsysevent,
 {
 	spa_config_dirent_t *dp, *tdp;
 	nvlist_t *nvl;
-	char *pool_name;
+	const char *pool_name;
 	boolean_t ccw_failure;
 	int error = 0;
 
@@ -418,7 +418,7 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 	unsigned long hostid = 0;
 	boolean_t locked = B_FALSE;
 	uint64_t split_guid;
-	char *pool_name;
+	const char *pool_name;
 
 	if (vd == NULL) {
 		vd = rvd;

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -199,7 +199,7 @@ spa_history_log_notify(spa_t *spa, nvlist_t *nvl)
 {
 	nvlist_t *hist_nvl = fnvlist_alloc();
 	uint64_t uint64;
-	char *string;
+	const char *string;
 
 	if (nvlist_lookup_string(nvl, ZPOOL_HIST_CMD, &string) == 0)
 		fnvlist_add_string(hist_nvl, ZFS_EV_HIST_CMD, string);

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2307,7 +2307,7 @@ spa_import_progress_add(spa_t *spa)
 {
 	spa_history_list_t *shl = spa_import_progress_list;
 	spa_import_progress_t *sip;
-	char *poolname = NULL;
+	const char *poolname = NULL;
 
 	sip = kmem_zalloc(sizeof (spa_import_progress_t), KM_SLEEP);
 	sip->pool_guid = spa_guid(spa);

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -727,11 +727,11 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
     int alloctype)
 {
 	vdev_ops_t *ops;
-	char *type;
+	const char *type;
 	uint64_t guid = 0, islog;
 	vdev_t *vd;
 	vdev_indirect_config_t *vic;
-	char *tmp = NULL;
+	const char *tmp = NULL;
 	int rc;
 	vdev_alloc_bias_t alloc_bias = VDEV_BIAS_NONE;
 	boolean_t top_level = (parent && !parent->vdev_parent);
@@ -786,7 +786,7 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 		return (SET_ERROR(ENOTSUP));
 
 	if (top_level && alloctype == VDEV_ALLOC_ADD) {
-		char *bias;
+		const char *bias;
 
 		/*
 		 * If creating a top-level vdev, check for allocation
@@ -832,8 +832,8 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 	if (top_level && alloc_bias != VDEV_BIAS_NONE)
 		vd->vdev_alloc_bias = alloc_bias;
 
-	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &vd->vdev_path) == 0)
-		vd->vdev_path = spa_strdup(vd->vdev_path);
+	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &tmp) == 0)
+		vd->vdev_path = spa_strdup(tmp);
 
 	/*
 	 * ZPOOL_CONFIG_AUX_STATE = "external" means we previously forced a
@@ -847,18 +847,17 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 		vd->vdev_label_aux = VDEV_AUX_EXTERNAL;
 	}
 
-	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_DEVID, &vd->vdev_devid) == 0)
-		vd->vdev_devid = spa_strdup(vd->vdev_devid);
-	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PHYS_PATH,
-	    &vd->vdev_physpath) == 0)
-		vd->vdev_physpath = spa_strdup(vd->vdev_physpath);
+	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_DEVID, &tmp) == 0)
+		vd->vdev_devid = spa_strdup(tmp);
+	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PHYS_PATH, &tmp) == 0)
+		vd->vdev_physpath = spa_strdup(tmp);
 
 	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_VDEV_ENC_SYSFS_PATH,
-	    &vd->vdev_enc_sysfs_path) == 0)
-		vd->vdev_enc_sysfs_path = spa_strdup(vd->vdev_enc_sysfs_path);
+	    &tmp) == 0)
+		vd->vdev_enc_sysfs_path = spa_strdup(tmp);
 
-	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_FRU, &vd->vdev_fru) == 0)
-		vd->vdev_fru = spa_strdup(vd->vdev_fru);
+	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_FRU, &tmp) == 0)
+		vd->vdev_fru = spa_strdup(tmp);
 
 	/*
 	 * Set the whole_disk property.  If it's not specified, leave the value
@@ -989,7 +988,7 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 			    &vd->vdev_removed);
 
 			if (vd->vdev_faulted || vd->vdev_degraded) {
-				char *aux;
+				const char *aux;
 
 				vd->vdev_label_aux =
 				    VDEV_AUX_ERR_EXCEEDED;
@@ -5624,7 +5623,7 @@ vdev_replace_in_progress(vdev_t *vdev)
  * Add a (source=src, propname=propval) list to an nvlist.
  */
 static void
-vdev_prop_add_list(nvlist_t *nvl, const char *propname, char *strval,
+vdev_prop_add_list(nvlist_t *nvl, const char *propname, const char *strval,
     uint64_t intval, zprop_source_t src)
 {
 	nvlist_t *propval;
@@ -5664,7 +5663,7 @@ vdev_props_set_sync(void *arg, dmu_tx_t *tx)
 
 	while ((elem = nvlist_next_nvpair(nvprops, elem)) != NULL) {
 		uint64_t intval, objid = 0;
-		char *strval;
+		const char *strval;
 		vdev_prop_t prop;
 		const char *propname = nvpair_name(elem);
 		zprop_type_t proptype;
@@ -5760,10 +5759,10 @@ vdev_prop_set(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 		return (SET_ERROR(EINVAL));
 
 	while ((elem = nvlist_next_nvpair(nvprops, elem)) != NULL) {
-		char *propname = nvpair_name(elem);
+		const char *propname = nvpair_name(elem);
 		vdev_prop_t prop = vdev_name_to_prop(propname);
 		uint64_t intval = 0;
-		char *strval = NULL;
+		const char *strval = NULL;
 
 		if (prop == VDEV_PROP_USERPROP && !vdev_prop_user(propname)) {
 			error = EINVAL;

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -2720,7 +2720,7 @@ vdev_draid_spare_lookup(spa_t *spa, nvlist_t *nv, uint64_t *top_guidp,
 		return (SET_ERROR(ENOENT));
 	}
 
-	char *spare_name;
+	const char *spare_name;
 	error = nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &spare_name);
 	if (error != 0)
 		return (SET_ERROR(EINVAL));
@@ -2728,7 +2728,7 @@ vdev_draid_spare_lookup(spa_t *spa, nvlist_t *nv, uint64_t *top_guidp,
 	for (int i = 0; i < nspares; i++) {
 		nvlist_t *spare = spares[i];
 		uint64_t top_guid, spare_id;
-		char *type, *path;
+		const char *type, *path;
 
 		/* Skip non-distributed spares */
 		error = nvlist_lookup_string(spare, ZPOOL_CONFIG_TYPE, &type);

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -1359,6 +1359,7 @@ vdev_label_write_bootenv(vdev_t *vd, nvlist_t *env)
 	int error;
 	size_t nvsize;
 	char *nvbuf;
+	const char *tmp;
 
 	error = nvlist_size(env, &nvsize, NV_ENCODE_XDR);
 	if (error != 0)
@@ -1398,8 +1399,8 @@ vdev_label_write_bootenv(vdev_t *vd, nvlist_t *env)
 	bootenv->vbe_version = fnvlist_lookup_uint64(env, BOOTENV_VERSION);
 	switch (bootenv->vbe_version) {
 	case VB_RAW:
-		if (nvlist_lookup_string(env, GRUB_ENVMAP, &nvbuf) == 0) {
-			(void) strlcpy(bootenv->vbe_bootenv, nvbuf, nvsize);
+		if (nvlist_lookup_string(env, GRUB_ENVMAP, &tmp) == 0) {
+			(void) strlcpy(bootenv->vbe_bootenv, tmp, nvsize);
 		}
 		error = 0;
 		break;

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -2414,7 +2414,7 @@ spa_vdev_remove(spa_t *spa, uint64_t guid, boolean_t unspare)
 		 * in this pool.
 		 */
 		if (vd == NULL || unspare) {
-			char *type;
+			const char *type;
 			boolean_t draid_spare = B_FALSE;
 
 			if (nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE, &type)

--- a/module/zfs/zcp.c
+++ b/module/zfs/zcp.c
@@ -544,7 +544,7 @@ zcp_nvpair_value_to_lua(lua_State *state, nvpair_t *pair,
 		    fnvpair_value_nvlist(pair), errbuf, errbuf_len);
 		break;
 	case DATA_TYPE_STRING_ARRAY: {
-		char **strarr;
+		const char **strarr;
 		uint_t nelem;
 		(void) nvpair_value_string_array(pair, &strarr, &nelem);
 		lua_newtable(state);

--- a/module/zfs/zcp_get.c
+++ b/module/zfs/zcp_get.c
@@ -391,7 +391,7 @@ get_special_prop(lua_State *state, dsl_dataset_t *ds, const char *dsname,
 		dsl_dataset_crypt_stats(ds, nvl);
 		if (nvlist_lookup_nvlist(nvl, zfs_prop_to_name(zfs_prop),
 		    &propval) == 0) {
-			char *source;
+			const char *source;
 
 			(void) nvlist_lookup_uint64(propval, ZPROP_VALUE,
 			    &numval);

--- a/module/zfs/zcp_iter.c
+++ b/module/zfs/zcp_iter.c
@@ -333,7 +333,7 @@ zcp_user_props_list_gc(lua_State *state)
 static int
 zcp_user_props_iter(lua_State *state)
 {
-	char *source, *val;
+	const char *source, *val;
 	nvlist_t *nvprop;
 	nvlist_t **props = lua_touserdata(state, lua_upvalueindex(1));
 	nvpair_t *pair = lua_touserdata(state, lua_upvalueindex(2));

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -133,7 +133,7 @@ zfs_fuid_table_load(objset_t *os, uint64_t fuid_obj, avl_tree_t *idx_tree,
 
 		for (i = 0; i != count; i++) {
 			fuid_domain_t *domnode;
-			char *domain;
+			const char *domain;
 			uint64_t idx;
 
 			VERIFY(nvlist_lookup_string(fuidnvp[i], FUID_DOMAIN,

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -604,7 +604,7 @@ static int
 zfs_secpolicy_setprop(const char *dsname, zfs_prop_t prop, nvpair_t *propval,
     cred_t *cr)
 {
-	char *strval;
+	const char *strval;
 
 	/*
 	 * Check permissions for special properties.
@@ -935,7 +935,7 @@ zfs_secpolicy_snapshot(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 	for (pair = nvlist_next_nvpair(snaps, NULL); pair != NULL;
 	    pair = nvlist_next_nvpair(snaps, pair)) {
-		char *name = nvpair_name(pair);
+		char *name = (char *)nvpair_name(pair);
 		char *atp = strchr(name, '@');
 
 		if (atp == NULL) {
@@ -962,7 +962,7 @@ zfs_secpolicy_bookmark(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 	for (nvpair_t *pair = nvlist_next_nvpair(innvl, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(innvl, pair)) {
-		char *name = nvpair_name(pair);
+		char *name = (char *)nvpair_name(pair);
 		char *hashp = strchr(name, '#');
 
 		if (hashp == NULL) {
@@ -988,7 +988,7 @@ zfs_secpolicy_destroy_bookmarks(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 	for (pair = nvlist_next_nvpair(innvl, NULL); pair != NULL;
 	    pair = nextpair) {
-		char *name = nvpair_name(pair);
+		char *name = (char *)nvpair_name(pair);
 		char *hashp = strchr(name, '#');
 		nextpair = nvlist_next_nvpair(innvl, pair);
 
@@ -1036,9 +1036,9 @@ zfs_secpolicy_log_history(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 static int
 zfs_secpolicy_create_clone(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 {
-	char	parentname[ZFS_MAX_DATASET_NAME_LEN];
-	int	error;
-	char	*origin;
+	char		parentname[ZFS_MAX_DATASET_NAME_LEN];
+	int		error;
+	const char	*origin;
 
 	if ((error = zfs_get_parent(zc->zc_name, parentname,
 	    sizeof (parentname))) != 0)
@@ -1460,7 +1460,7 @@ zfs_ioc_pool_create(zfs_cmd_t *zc)
 		nvlist_t *nvl = NULL;
 		nvlist_t *hidden_args = NULL;
 		uint64_t version = SPA_VERSION;
-		char *tname;
+		const char *tname;
 
 		(void) nvlist_lookup_uint64(props,
 		    zpool_prop_to_name(ZPOOL_PROP_VERSION), &version);
@@ -3916,7 +3916,7 @@ static int
 zfs_ioc_channel_program(const char *poolname, nvlist_t *innvl,
     nvlist_t *outnvl)
 {
-	char *program;
+	const char *program;
 	uint64_t instrlimit, memlimit;
 	boolean_t sync_flag;
 	nvpair_t *nvarg = NULL;
@@ -4336,7 +4336,7 @@ zfs_ioc_rollback(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl)
 {
 	zfsvfs_t *zfsvfs;
 	zvol_state_handle_t *zv;
-	char *target = NULL;
+	const char *target = NULL;
 	int error;
 
 	(void) nvlist_lookup_string(innvl, "target", &target);
@@ -4412,7 +4412,7 @@ zfs_ioc_redact(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 {
 	(void) outnvl;
 	nvlist_t *redactnvl = NULL;
-	char *redactbook = NULL;
+	const char *redactbook = NULL;
 
 	if (nvlist_lookup_nvlist(innvl, "snapnv", &redactnvl) != 0)
 		return (SET_ERROR(EINVAL));
@@ -4808,10 +4808,10 @@ propval_equals(nvpair_t *p1, nvpair_t *p2)
 		return (B_FALSE);
 
 	if (nvpair_type(p1) == DATA_TYPE_STRING) {
-		char *valstr1, *valstr2;
+		const char *valstr1, *valstr2;
 
-		VERIFY(nvpair_value_string(p1, (char **)&valstr1) == 0);
-		VERIFY(nvpair_value_string(p2, (char **)&valstr2) == 0);
+		VERIFY(nvpair_value_string(p1, &valstr1) == 0);
+		VERIFY(nvpair_value_string(p2, &valstr2) == 0);
 		return (strcmp(valstr1, valstr2) == 0);
 	} else {
 		uint64_t intval1, intval2;
@@ -4932,9 +4932,9 @@ static boolean_t zfs_ioc_recv_inject_err;
  * encountered errors, if any. It's the callers responsibility to free.
  */
 static int
-zfs_ioc_recv_impl(char *tofs, char *tosnap, char *origin, nvlist_t *recvprops,
-    nvlist_t *localprops, nvlist_t *hidden_args, boolean_t force,
-    boolean_t heal, boolean_t resumable, int input_fd,
+zfs_ioc_recv_impl(char *tofs, char *tosnap, const char *origin,
+    nvlist_t *recvprops, nvlist_t *localprops, nvlist_t *hidden_args,
+    boolean_t force, boolean_t heal, boolean_t resumable, int input_fd,
     dmu_replay_record_t *begin_record, uint64_t *read_bytes,
     uint64_t *errflags, nvlist_t **errors)
 {
@@ -5280,7 +5280,7 @@ zfs_ioc_recv(zfs_cmd_t *zc)
 	nvlist_t *errors = NULL;
 	nvlist_t *recvdprops = NULL;
 	nvlist_t *localprops = NULL;
-	char *origin = NULL;
+	const char *origin = NULL;
 	char *tosnap;
 	char tofs[ZFS_MAX_DATASET_NAME_LEN];
 	int error = 0;
@@ -5382,8 +5382,8 @@ zfs_ioc_recv_new(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl)
 	nvlist_t *recvprops = NULL;
 	nvlist_t *localprops = NULL;
 	nvlist_t *hidden_args = NULL;
-	char *snapname;
-	char *origin = NULL;
+	const char *snapname;
+	const char *origin = NULL;
 	char *tosnap;
 	char tofs[ZFS_MAX_DATASET_NAME_LEN];
 	boolean_t force;
@@ -6232,7 +6232,7 @@ zfs_ioc_hold(const char *pool, nvlist_t *args, nvlist_t *errlist)
 	/* make sure the user didn't pass us any invalid (empty) tags */
 	for (pair = nvlist_next_nvpair(holds, NULL); pair != NULL;
 	    pair = nvlist_next_nvpair(holds, pair)) {
-		char *htag;
+		const char *htag;
 
 		error = nvpair_value_string(pair, &htag);
 		if (error != 0)
@@ -6452,7 +6452,7 @@ zfs_ioc_space_snaps(const char *lastsnap, nvlist_t *innvl, nvlist_t *outnvl)
 	int error;
 	dsl_pool_t *dp;
 	dsl_dataset_t *new, *old;
-	char *firstsnap;
+	const char *firstsnap;
 	uint64_t used, comp, uncomp;
 
 	firstsnap = fnvlist_lookup_string(innvl, "firstsnap");
@@ -6533,7 +6533,7 @@ zfs_ioc_send_new(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 	(void) outnvl;
 	int error;
 	offset_t off;
-	char *fromname = NULL;
+	const char *fromname = NULL;
 	int fd;
 	zfs_file_t *fp;
 	boolean_t largeblockok;
@@ -6543,7 +6543,7 @@ zfs_ioc_send_new(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 	boolean_t savedok;
 	uint64_t resumeobj = 0;
 	uint64_t resumeoff = 0;
-	char *redactbook = NULL;
+	const char *redactbook = NULL;
 
 	fd = fnvlist_lookup_int32(innvl, "fd");
 
@@ -6633,8 +6633,8 @@ zfs_ioc_send_space(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 	dsl_dataset_t *tosnap;
 	dsl_dataset_t *fromsnap = NULL;
 	int error;
-	char *fromname = NULL;
-	char *redactlist_book = NULL;
+	const char *fromname = NULL;
+	const char *redactlist_book = NULL;
 	boolean_t largeblockok;
 	boolean_t embedok;
 	boolean_t compressok;
@@ -7378,7 +7378,7 @@ zfs_check_input_nvpairs(nvlist_t *innvl, const zfs_ioc_vec_t *vec)
 	 */
 	for (nvpair_t *pair = nvlist_next_nvpair(innvl, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(innvl, pair)) {
-		char *name = nvpair_name(pair);
+		const char *name = nvpair_name(pair);
 		data_type_t type = nvpair_type(pair);
 		boolean_t identified = B_FALSE;
 

--- a/tests/zfs-tests/cmd/draid.c
+++ b/tests/zfs-tests/cmd/draid.c
@@ -1267,7 +1267,7 @@ draid_merge_impl(nvlist_t *allcfgs, const char *srcfilename, int *mergedp)
 		uint64_t nv_worst_ratio;
 		uint64_t allcfg_worst_ratio;
 		nvlist_t *cfg, *allcfg;
-		char *key;
+		const char *key;
 
 		switch (nvpair_type(elem)) {
 		case DATA_TYPE_NVLIST:

--- a/tests/zfs-tests/cmd/ereports.c
+++ b/tests/zfs-tests/cmd/ereports.c
@@ -62,7 +62,7 @@ static const char *const criteria_name[] = {
 static void
 print_ereport_line(nvlist_t *nvl)
 {
-	char *class;
+	const char *class;
 	int last = CRITERIA_NAMES_COUNT - 1;
 
 	/*
@@ -81,7 +81,7 @@ print_ereport_line(nvlist_t *nvl)
 		nvpair_t *nvp;
 		uint32_t i32 = 0;
 		uint64_t i64 = 0;
-		char *str = NULL;
+		const char *str = NULL;
 
 		if (nvlist_lookup_nvpair(nvl, criteria_name[i], &nvp) != 0) {
 			/* print a proxy for optional criteria */

--- a/tests/zfs-tests/cmd/nvlist_to_lua.c
+++ b/tests/zfs-tests/cmd/nvlist_to_lua.c
@@ -39,7 +39,7 @@ nvlist_equal(nvlist_t *nvla, nvlist_t *nvlb)
 	 */
 	for (nvpair_t *pair = nvlist_next_nvpair(nvla, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(nvla, pair)) {
-		char *key = nvpair_name(pair);
+		const char *key = nvpair_name(pair);
 
 		if (!nvlist_exists(nvlb, key))
 			return (B_FALSE);


### PR DESCRIPTION
### Motivation and Context
Both Coverity and Clang's static analyzer each had 3 complaints in the nvpair code. They were mostly false positives, with the exception of a possible NULL pointer dereference reported by Clang's static analyzer. The coverity reports had been marked as false positives, but upon reflection, I have decided to address them by using a C99 variable array member, much like we currently use elsewhere.

### Description
The individual commits have descriptions.

A patch constifying nvpair string functions is included to silence compiler complaints about dropping const that the compiler correctly began to make after the adoption of flexible array members. It touches far more than just `nvpair_name()` mostly because making certain things const required either making others const or adopting typecasts. With the exception of three instances in the ioctl code, we have chosen not to use typecasts.

### How Has This Been Tested?
A local build test has been done. The buildbot will do further testing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
