### PR TITLE
improve tests and update man page for healing recv

### DIFF
--- a/man/man8/zfs-receive.8
+++ b/man/man8/zfs-receive.8
@@ -29,7 +29,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd April 26, 2022
+.Dd March 12, 2023
 .Dt ZFS-RECEIVE 8
 .Os
 .
@@ -56,8 +56,7 @@
 .Cm receive
 .Fl A
 .Ar filesystem Ns | Ns Ar volume
-.
-.Nm
+.Nm zfs
 .Cm receive
 .Fl c
 .Op Fl vn
@@ -406,15 +405,15 @@ deleting its saved partially received state.
 .Op Fl vn
 .Ar filesystem Ns | Ns Ar snapshot
 .Xc
-Attempt to correct data corruption in the specified dataset,
+Attempt to repair data corruption in the specified dataset,
 by using the provided stream as the source of healthy data.
 This method of healing can only heal data blocks present in the stream.
 Metadata can not be healed by corrective receive.
-Running a scrub is recommended post-healing to ensure all corruption was
-healed.
+Running a scrub is recommended post-healing to ensure all data corruption was
+repaired.
 .Pp
-It's important to consider why corruption has happened in the first place
-since if you have slowly failing hardware periodically healing the data
+It's important to consider why corruption has happened in the first place.
+If you have slowly failing hardware - periodically repairing the data
 is not going to save you from data loss later on when the hardware fails
 completely.
 .El

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -242,7 +242,7 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_raw', 'zfs_receive_raw_incremental', 'zfs_receive_-e',
     'zfs_receive_raw_-d', 'zfs_receive_from_zstd', 'zfs_receive_new_props',
     'zfs_receive_-wR-encrypted-mix', 'zfs_receive_corrective',
-    'zfs_receive_compressed_corrective']
+    'zfs_receive_compressed_corrective', 'zfs_receive_large_block_corrective']
 tags = ['functional', 'cli_root', 'zfs_receive']
 
 [tests/functional/cli_root/zfs_rename]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -774,6 +774,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_receive/zfs_receive_-wR-encrypted-mix.ksh \
 	functional/cli_root/zfs_receive/zfs_receive_corrective.ksh \
 	functional/cli_root/zfs_receive/zfs_receive_compressed_corrective.ksh \
+	functional/cli_root/zfs_receive/zfs_receive_large_block_corrective.ksh \
 	functional/cli_root/zfs_rename/cleanup.ksh \
 	functional/cli_root/zfs_rename/setup.ksh \
 	functional/cli_root/zfs_rename/zfs_rename_001_pos.ksh \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a follow-up to https://github.com/openzfs/zfs/pull/9372. It does not change any functionality just tests and documentation.



<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing documentation problems and adding more testing.

### Description
<!--- Describe your changes in detail -->
The commit has 3 parts and I could break it up into separate commits if that's more desirable:
1) Fix the manpage. See https://openzfs.github.io/openzfs-docs/man/8/zfs-receive.8.html for the current state. The "SYNOPSIS" section is incorrectly formatted for `receive -c`.
I also took this opportunity to reword some parts and fix a run-on sentence in the manpage.
2) Add large block testing for corrective recv. This adds a new test that makes sure blocks generated using `zfs send -L/--large-block` large-block send flag are able to be used for healing.
3) Since https://github.com/openzfs/zfs/issues/13675 is fixed the `zfs_receive_corrective.ksh` test no longer sets `-o feature@head_errlog=disabled` on pool creation so that it can also test for regressions related to head_errlog feature.
Note that the `zfs_receive_compressed_corrective.ksh` and `zfs_receive_large_block_corrective.ksh` tests are still creating pools with `-o feature@head_errlog=disabled`.

### How Has This Been Tested?
I've run the corrective recv tests locally and have made sure (with `zstream dump`) that send files created during the large block test do indeed have fewer DRR_WRITE records in them.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Testing (a change to or addition of tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
