### PR TITLE
Fix kmodtool for packaging mainline Linux

### DIFF
--- a/scripts/kmodtool
+++ b/scripts/kmodtool
@@ -333,7 +333,22 @@ print_customrpmtemplate ()
 {
 	for kernel in ${1}
 	do
-		if [[ -e "${buildroot}/usr/src/kernels/${kernel}" ]] ; then
+		if [[ -e "${prefix}/lib/modules/${kernel}/build/Makefile" ]]; then
+			# likely a user-build-kernel with available buildfiles
+			# fixme: we should check if uname from Makefile is the same as ${kernel}
+
+			kernel_versions="${kernel_versions}${kernel}___${prefix}/lib/modules/${kernel}/build/ "
+			print_rpmtemplate_per_kmodpkg --custom "${kernel}"
+
+			# create development package
+			if [[ -n "${devel}" ]]; then
+				# create devel package including common headers
+				print_rpmtemplate_kmoddevelpkg --custom "${kernel}"
+
+				# create devel package
+				print_rpmtemplate_per_kmoddevelpkg --custom "${kernel}"
+			fi
+		elif [[ -e "${buildroot}/usr/src/kernels/${kernel}" ]]; then
 			# this looks like a Fedora/RH kernel -- print a normal template (which includes the proper BR) and be happy :)
 			kernel_versions="${kernel_versions}${kernel}___${buildroot}%{_usrsrc}/kernels/${kernel} "
 
@@ -348,21 +363,6 @@ print_customrpmtemplate ()
 
 				# create devel package
 				print_rpmtemplate_per_kmoddevelpkg --redhat ${kernel} ${kernel##${kernel_verrelarch}}
-			fi
-		elif [[ -e "${prefix}/lib/modules/${kernel}/build/Makefile" ]]; then
-			# likely a user-build-kernel with available buildfiles
-			# fixme: we should check if uname from Makefile is the same as ${kernel}
-
-			kernel_versions="${kernel_versions}${kernel}___${prefix}/lib/modules/${kernel}/build/ "
-			print_rpmtemplate_per_kmodpkg --custom "${kernel}"
-
-			# create development package
-			if [[ -n "${devel}" ]]; then
-				# create devel package including common headers
-				print_rpmtemplate_kmoddevelpkg --custom "${kernel}"
-
-				# create devel package
-				print_rpmtemplate_per_kmoddevelpkg --custom "${kernel}"
 			fi
 		else
 			error_out 2 "Don't know how to handle ${kernel} -- ${prefix}/lib/modules/${kernel}/build/Makefile not found"


### PR DESCRIPTION
### Motivation and Context
I built a kernel.org 5.15.94 using Clang for some work on a Lustre patch (https://review.whamcloud.com/c/fs/lustre-release/+/50063). I needed to build the openZFS kernel modules as well. The build failed because kmodtool was incorrectly identifying my kernel as a RHEL/CentOS one.

### Description
Changing the order of the checks in kmodtool allows the kernel to be identified correctly. The custom kernel has the Makefile under `/lib/modules/${kernel}/build`, whereas the RHEL distributed kernel does not.

### How Has This Been Tested?
The kmod package builds on both my default system and the system with the custom kernel. I ran this though shellcheck and it didn't return any errors. The change isn't POSIX, but kmodtool is using bash in the shebang anyway.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
