### PR TITLE
Refactor `CONFIG_SPE` check on Linux/powerpc

### DIFF
--- a/include/os/linux/kernel/linux/simd_powerpc.h
+++ b/include/os/linux/kernel/linux/simd_powerpc.h
@@ -80,40 +80,32 @@
 #define	ENABLE_KERNEL_VSX
 #define	DISABLE_KERNEL_VSX
 #endif
-#ifdef CONFIG_SPE
-#define	kfpu_begin()				\
-	{					\
-		preempt_disable();		\
-		ENABLE_KERNEL_ALTIVEC		\
-		ENABLE_KERNEL_VSX		\
-		enable_kernel_spe();		\
-	}
-#define	kfpu_end()				\
-	{					\
-		disable_kernel_spe();		\
-		DISABLE_KERNEL_VSX		\
-		DISABLE_KERNEL_ALTIVEC		\
-		preempt_enable();		\
-	}
-#else /* CONFIG_SPE */
-#define	kfpu_begin()				\
-	{					\
-		preempt_disable();		\
-		ENABLE_KERNEL_ALTIVEC		\
-		ENABLE_KERNEL_VSX		\
-	}
-#define	kfpu_end()				\
-	{					\
-		DISABLE_KERNEL_VSX		\
-		DISABLE_KERNEL_ALTIVEC		\
-		preempt_enable();		\
-	}
+#ifdef	CONFIG_SPE
+#define	ENABLE_KERNEL_SPE	enable_kernel_spe();
+#define	DISABLE_KERNEL_SPE	disable_kernel_spe();
+#else
+#define	ENABLE_KERNEL_SPE
+#define	DISABLE_KERNEL_SPE
 #endif
+#define	kfpu_begin()				\
+	{					\
+		preempt_disable();		\
+		ENABLE_KERNEL_ALTIVEC		\
+		ENABLE_KERNEL_VSX		\
+		ENABLE_KERNEL_SPE		\
+	}
+#define	kfpu_end()				\
+	{					\
+		DISABLE_KERNEL_SPE		\
+		DISABLE_KERNEL_VSX		\
+		DISABLE_KERNEL_ALTIVEC		\
+		preempt_enable();		\
+	}
 #else
 /* seems that before 4.5 no-one bothered */
 #define	kfpu_begin()
 #define	kfpu_end()		preempt_enable()
-#endif
+#endif	/* Linux version >= 4.5 */
 
 #define	kfpu_init()		0
 #define	kfpu_fini()		((void) 0)

--- a/include/os/linux/kernel/linux/simd_powerpc.h
+++ b/include/os/linux/kernel/linux/simd_powerpc.h
@@ -67,15 +67,15 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
 #ifdef	CONFIG_ALTIVEC
-#define	ENABLE_KERNEL_ALTIVEC	enable_kernel_altivec()
-#define	DISABLE_KERNEL_ALTIVEC	disable_kernel_altivec()
+#define	ENABLE_KERNEL_ALTIVEC	enable_kernel_altivec();
+#define	DISABLE_KERNEL_ALTIVEC	disable_kernel_altivec();
 #else
 #define	ENABLE_KERNEL_ALTIVEC
 #define	DISABLE_KERNEL_ALTIVEC
 #endif
 #ifdef	CONFIG_VSX
-#define	ENABLE_KERNEL_VSX	enable_kernel_vsx()
-#define	DISABLE_KERNEL_VSX	disable_kernel_vsx()
+#define	ENABLE_KERNEL_VSX	enable_kernel_vsx();
+#define	DISABLE_KERNEL_VSX	disable_kernel_vsx();
 #else
 #define	ENABLE_KERNEL_VSX
 #define	DISABLE_KERNEL_VSX


### PR DESCRIPTION
### Motivation and Context
Commit 5401472 adds a check to call `enable_kernel_spe` and `disable_kernel_spe` only if `CONFIG_SPE` is defined. This introduces redundant implementations of `kfpu_begin()` and `kfpu_end()`.

### Description
Refactor this check in a way similar to what `CONFIG_ALTIVEC` and `CONFIG_VSX` are checked in #14591, in order to remove redundant codes.

### How Has This Been Tested?
Tested on my POWER7-based machine without `CONFIG_SPE`. May need more testings on machines with `CONFIG_SPE`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
