### PR TITLE
[2.1.10] Fix for mountpoint=legacy

### DIFF
--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -341,11 +341,12 @@ mount_fs()
 				# isn't the root fs.
 				return 0
 			fi
-			# Last hail-mary: Hope 'rootmnt' is set!
-			mountpoint=""
+			# Don't use mount.zfs -o zfsutils for legacy mountpoint
 			if [ "$mountpoint" = "legacy" ]; then
 				ZFS_CMD="mount.zfs"
 			fi
+			# Last hail-mary: Hope 'rootmnt' is set!
+			mountpoint=""
 		else
 			mountpoint="$mountpoint1"
 		fi


### PR DESCRIPTION
### Motivation and Context

#14599, #14604

### Description

Fix for mountpoint=legacy
    
We need to clear mountpoint only after checking it.

### How Has This Been Tested?

See PR #14604.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)