### PR TITLE
spl: cmn_err_once() should be usable in brace-less if else statements

### DIFF
--- a/include/os/freebsd/spl/sys/cmn_err.h
+++ b/include/os/freebsd/spl/sys/cmn_err.h
@@ -75,36 +75,36 @@ extern void panic(const char *, ...)
     __attribute__((format(printf, 1, 2), __noreturn__));
 
 #define	cmn_err_once(ce, ...)				\
-{							\
+do {							\
 	static volatile uint32_t printed = 0;		\
 	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
 		cmn_err(ce, __VA_ARGS__);		\
 	}						\
-}
+} while (0)
 
 #define	vcmn_err_once(ce, fmt, ap)			\
-{							\
+do {							\
 	static volatile uint32_t printed = 0;		\
 	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
 		vcmn_err(ce, fmt, ap);			\
 	}						\
-}
+} while (0)
 
 #define	zcmn_err_once(zone, ce, ...)			\
-{							\
+do {							\
 	static volatile uint32_t printed = 0;		\
 	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
 		zcmn_err(zone, ce, __VA_ARGS__);	\
 	}						\
-}
+} while (0)
 
 #define	vzcmn_err_once(zone, ce, fmt, ap)		\
-{							\
+do {							\
 	static volatile uint32_t printed = 0;		\
 	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
 		vzcmn_err(zone, ce, fmt, ap);		\
 	}						\
-}
+} while (0)
 
 #endif /* !_ASM */
 

--- a/include/os/linux/spl/sys/cmn_err.h
+++ b/include/os/linux/spl/sys/cmn_err.h
@@ -47,19 +47,19 @@ extern void vpanic(const char *, va_list)
 #define	fm_panic	panic
 
 #define	cmn_err_once(ce, ...)				\
-{							\
+do {							\
 	static volatile uint32_t printed = 0;		\
 	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
 		cmn_err(ce, __VA_ARGS__);		\
 	}						\
-}
+} while (0)
 
 #define	vcmn_err_once(ce, fmt, ap)			\
-{							\
+do {							\
 	static volatile uint32_t printed = 0;		\
 	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
 		vcmn_err(ce, fmt, ap);			\
 	}						\
-}
+} while (0)
 
 #endif /* SPL_CMN_ERR_H */

--- a/lib/libspl/include/sys/cmn_err.h
+++ b/lib/libspl/include/sys/cmn_err.h
@@ -30,35 +30,35 @@
 #include <atomic.h>
 
 #define	cmn_err_once(ce, ...)				\
-{							\
+do {							\
 	static volatile uint32_t printed = 0;		\
 	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
 		cmn_err(ce, __VA_ARGS__);		\
 	}						\
-}
+} while (0)
 
 #define	vcmn_err_once(ce, fmt, ap)			\
-{							\
+do {							\
 	static volatile uint32_t printed = 0;		\
 	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
 		vcmn_err(ce, fmt, ap);			\
 	}						\
-}
+} while (0)
 
 #define	zcmn_err_once(zone, ce, ...)			\
-{							\
+do {							\
 	static volatile uint32_t printed = 0;		\
 	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
 		zcmn_err(zone, ce, __VA_ARGS__);	\
 	}						\
-}
+} while (0)
 
 #define	vzcmn_err_once(zone, ce, fmt, ap)		\
-{							\
+do {							\
 	static volatile uint32_t printed = 0;		\
 	if (atomic_cas_32(&printed, 0, 1) == 0) {	\
 		vzcmn_err(zone, ce, fmt, ap);		\
 	}						\
-}
+} while (0)
 
 #endif


### PR DESCRIPTION
### Motivation and Context

Commit 11913870 (#14567) added cmn_err_once() by #define'ing a compound statement but failed to consider usage in a single statement brace-less if else.

Follow-up for #14567

### Description

Fix the problem by using the common "do {} while (0)" construct.

### How Has This Been Tested?

Builds.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
