### PR TITLE
Failed to build on Debian Sid PowerPC using GCC 12.2

### DIFF
--- a/lib/libspl/include/sys/simd.h
+++ b/lib/libspl/include/sys/simd.h
@@ -31,7 +31,7 @@
 #include <sys/types.h>
 
 /* including <sys/auxv.h> clashes with AT_UID and others */
-#if defined(__arm__) || defined(__aarch64__) || defined(powerpc)
+#if defined(__arm__) || defined(__aarch64__) || defined(__powerpc__)
 #if defined(__FreeBSD__)
 #define	AT_HWCAP	25
 #define	AT_HWCAP2	26


### PR DESCRIPTION
### Motivation and Context

build log:
```
In file included from ../module/zcommon/zfs_fletcher.c:140:
../lib/libspl/include/sys/simd.h: In function 'zfs_altivec_available':
../lib/libspl/include/sys/simd.h:566:31: warning: implicit declaration of function 'getauxval' [-Wimplicit-function-declaration]
../lib/libspl/include/sys/simd.h:566:41: error: 'AT_HWCAP' undeclared (first use in this function)
../lib/libspl/include/sys/simd.h:566:41: note: each undeclared identifier is reported only once for each function it appears in
../lib/libspl/include/sys/simd.h: In function 'zfs_vsx_available':
../lib/libspl/include/sys/simd.h:573:41: error: 'AT_HWCAP' undeclared (first use in this function)../lib/libspl/include/sys/simd.h: In function 'zfs_isa207_available':
../lib/libspl/include/sys/simd.h:580:41: error: 'AT_HWCAP' undeclared (first use in this function)
../lib/libspl/include/sys/simd.h:581:42: error: 'AT_HWCAP2' undeclared (first use in this function)
make: *** [Makefile:9252: module/zcommon/libzfs_la-zfs_fletcher.lo] Error 1
```

gcc version:
```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/powerpc64-linux-gnu/12/lto-wrapper
Target: powerpc64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 12.2.0-14' --with-bugurl=file:///usr/share/doc/gcc-12/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++ --prefix=/usr --with-gcc-major-version-only --program-suffix=-12 --program-prefix=powerpc64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libquadmath --disable-libquadmath-support --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --with-libphobos-druntime-only=yes --enable-objc-gc=auto --enable-secureplt --disable-softfloat --enable-targets=powerpc64-linux,powerpc-linux --enable-multiarch --disable-werror --with-long-double-128 --enable-multilib --enable-checking=release --build=powerpc64-linux-gnu --host=powerpc64-linux-gnu --target=powerpc64-linux-gnu
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.2.0 (Debian 12.2.0-14)
```

### Description

File `lib/libspl/include/sys/simd.h` uses macro `powerpc` to detect the target architecture, but the macro didn't get predefined by GCC 12.2 installed from Debian. It should use `__powerpc__` instead.

I can only produce this issue with Debian's GCC packages, GCC that I built from source did predefine `powerpc`:
```
$ gcc-13-20230226 -E -dM -x c /dev/null | grep "^#define powerpc"
#define powerpc 1
$ gcc-9.4 -E -dM -x c /dev/null | grep "^#define powerpc"
#define powerpc 1
```

So I guess it was triggered by a GCC configuration difference.

### How Has This Been Tested?
It builds with Debian's GCC 12.2 after the change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
