### PR TITLE
QAT: Fix uninitialized seed in QAT compression

### DIFF
--- a/module/os/linux/zfs/qat_compress.c
+++ b/module/os/linux/zfs/qat_compress.c
@@ -247,7 +247,7 @@ qat_compress_impl(qat_compress_dir_t dir, char *src, int src_len,
 	Cpa8U *buffer_meta_src = NULL;
 	Cpa8U *buffer_meta_dst = NULL;
 	Cpa32U buffer_meta_size = 0;
-	CpaDcRqResults dc_results;
+	CpaDcRqResults dc_results = {.checksum = 1};
 	CpaStatus status = CPA_STATUS_FAIL;
 	Cpa32U hdr_sz = 0;
 	Cpa32U compressed_sz;


### PR DESCRIPTION
### Motivation and Context
#14463

### Description
According to QAT example from intel, CpaDcRqResults have to be initialized with checksum=1 for adler32. Otherwise when error CPA_DC_OVERFLOW occurred, the next compression operation will continue on previously part-compressed data, and write invalid checksum data on disk. When ZFS decompress the compressed data, a invalid checksum will occurred and lead to issue #14463.

Reference doc: `330684-012-intel-qat-api-programmers-guide.pdf`
Code example from Intel: https://github.com/intel/qatlib/blob/ff155a0778320ce7cff532bfa96a65ad35aa75f7/quickassist/lookaside/access_layer/src/sample_code/functional/dc/stateless_multi_op_checksum_sample/cpa_dc_stateless_multi_op_checksum_sample.c#L319

### How Has This Been Tested?
#### Test platform
Xeon D-2177NT with three QAT device type c62x

#### Test version
- ZFS 2.0.3
- debian 11
- QAT driver v1.7.L.4.16.0-00017

#### Test setup
- `service qat start && modprobe zfs && service zfs-zed start`
- `zpool create testpool /dev/nvme0n1`
- `zfs set compression=gzip testpool`
- stress /testpool with fio

#### Test result
As shown in #14463, without this patch, data on disk will decompress failed and lead to kernel panic. With CpaDcRqResults  initialized with checksum=1, everything works fine.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
