### PR TITLE
Fix: add git repo checkout to testing workflows

### DIFF
--- a/.github/workflows/zfs-linux-tests.yml
+++ b/.github/workflows/zfs-linux-tests.yml
@@ -13,6 +13,9 @@ jobs:
   zloop:
     runs-on: ubuntu-${{ inputs.os }}
     steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/download-artifact@v3
       with:
         name: modules-${{ inputs.os }}
@@ -50,6 +53,9 @@ jobs:
   sanity:
     runs-on: ubuntu-${{ inputs.os }}
     steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/download-artifact@v3
       with:
         name: modules-${{ inputs.os }}
@@ -83,6 +89,9 @@ jobs:
       matrix:
         tests: [ part1, part2, part3, part4 ]
     steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/download-artifact@v3
       with:
         name: modules-${{ inputs.os }}


### PR DESCRIPTION

### Motivation and Context

When the github runner images change, there are some hours (days?) with different action runner [image versions](https://github.com/actions/runner-images#available-images).
I implemented check for this ... but this code path does not work, because the repo has not been checked out :(

This fix just checks out the repo.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
