### PR TITLE
Drop lying to the compiler in the fletcher4 code

### DIFF
--- a/include/zfs_fletcher.h
+++ b/include/zfs_fletcher.h
@@ -76,19 +76,19 @@ typedef struct zfs_fletcher_superscalar {
 } zfs_fletcher_superscalar_t;
 
 typedef struct zfs_fletcher_sse {
-	uint64_t v[2] __attribute__((aligned(16)));
+	uint64_t v[2];
 } zfs_fletcher_sse_t;
 
 typedef struct zfs_fletcher_avx {
-	uint64_t v[4] __attribute__((aligned(32)));
+	uint64_t v[4];
 } zfs_fletcher_avx_t;
 
 typedef struct zfs_fletcher_avx512 {
-	uint64_t v[8] __attribute__((aligned(64)));
+	uint64_t v[8];
 } zfs_fletcher_avx512_t;
 
 typedef struct zfs_fletcher_aarch64_neon {
-	uint64_t v[2] __attribute__((aligned(16)));
+	uint64_t v[2];
 } zfs_fletcher_aarch64_neon_t;
 
 
@@ -160,21 +160,5 @@ _ZFS_FLETCHER_H const fletcher_4_ops_t fletcher_4_aarch64_neon_ops;
 #ifdef	__cplusplus
 }
 #endif
-
-#if	defined(ZFS_UBSAN_ENABLED)
-#if	defined(__has_attribute)
-#if	__has_attribute(no_sanitize_undefined)
-#define	ZFS_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize_undefined))
-#elif	__has_attribute(no_sanitize)
-#define	ZFS_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))
-#else
-#error	"Compiler has to support attribute "
-	"`no_sanitize_undefined` or `no_sanitize(\"undefined\")`"
-	"when compiling with UBSan enabled"
-#endif	/* __has_attribute(no_sanitize_undefined) */
-#endif	/* defined(__has_attribute) */
-#else
-#define	ZFS_NO_SANITIZE_UNDEFINED
-#endif	/* defined(ZFS_UBSAN_ENABLED) */
 
 #endif	/* _ZFS_FLETCHER_H */

--- a/module/zcommon/zfs_fletcher.c
+++ b/module/zcommon/zfs_fletcher.c
@@ -301,21 +301,18 @@ fletcher_2_byteswap(const void *buf, uint64_t size,
 	(void) fletcher_2_incremental_byteswap((void *) buf, size, zcp);
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_scalar_init(fletcher_4_ctx_t *ctx)
 {
 	ZIO_SET_CHECKSUM(&ctx->scalar, 0, 0, 0, 0);
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_scalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
 	memcpy(zcp, &ctx->scalar, sizeof (zio_cksum_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_scalar_native(fletcher_4_ctx_t *ctx, const void *buf,
     uint64_t size)
@@ -339,7 +336,6 @@ fletcher_4_scalar_native(fletcher_4_ctx_t *ctx, const void *buf,
 	ZIO_SET_CHECKSUM(&ctx->scalar, a, b, c, d);
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_scalar_byteswap(fletcher_4_ctx_t *ctx, const void *buf,
     uint64_t size)

--- a/module/zcommon/zfs_fletcher_aarch64_neon.c
+++ b/module/zcommon/zfs_fletcher_aarch64_neon.c
@@ -48,14 +48,12 @@
 #include <sys/string.h>
 #include <zfs_fletcher.h>
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_aarch64_neon_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->aarch64_neon, 0, 4 * sizeof (zfs_fletcher_aarch64_neon_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_aarch64_neon_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {

--- a/module/zcommon/zfs_fletcher_avx512.c
+++ b/module/zcommon/zfs_fletcher_avx512.c
@@ -35,14 +35,12 @@
 #define	__asm __asm__ __volatile__
 #endif
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_avx512f_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->avx512, 0, 4 * sizeof (zfs_fletcher_avx512_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_avx512f_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {

--- a/module/zcommon/zfs_fletcher_intel.c
+++ b/module/zcommon/zfs_fletcher_intel.c
@@ -47,14 +47,12 @@
 #include <sys/simd.h>
 #include <zfs_fletcher.h>
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_avx2_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->avx, 0, 4 * sizeof (zfs_fletcher_avx_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_avx2_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {

--- a/module/zcommon/zfs_fletcher_sse.c
+++ b/module/zcommon/zfs_fletcher_sse.c
@@ -49,14 +49,12 @@
 #include <sys/byteorder.h>
 #include <zfs_fletcher.h>
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_sse2_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->sse, 0, 4 * sizeof (zfs_fletcher_sse_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_sse2_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {

--- a/module/zcommon/zfs_fletcher_superscalar.c
+++ b/module/zcommon/zfs_fletcher_superscalar.c
@@ -47,14 +47,12 @@
 #include <sys/string.h>
 #include <zfs_fletcher.h>
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->superscalar, 0, 4 * sizeof (zfs_fletcher_superscalar_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
@@ -70,7 +68,6 @@ fletcher_4_superscalar_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 	ZIO_SET_CHECKSUM(zcp, A, B, C, D);
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar_native(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
@@ -110,7 +107,6 @@ fletcher_4_superscalar_native(fletcher_4_ctx_t *ctx,
 	ctx->superscalar[3].v[1] = d2;
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar_byteswap(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)

--- a/module/zcommon/zfs_fletcher_superscalar4.c
+++ b/module/zcommon/zfs_fletcher_superscalar4.c
@@ -47,14 +47,12 @@
 #include <sys/string.h>
 #include <zfs_fletcher.h>
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar4_init(fletcher_4_ctx_t *ctx)
 {
 	memset(ctx->superscalar, 0, 4 * sizeof (zfs_fletcher_superscalar_t));
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar4_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 {
@@ -84,7 +82,6 @@ fletcher_4_superscalar4_fini(fletcher_4_ctx_t *ctx, zio_cksum_t *zcp)
 	ZIO_SET_CHECKSUM(zcp, A, B, C, D);
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar4_native(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)
@@ -150,7 +147,6 @@ fletcher_4_superscalar4_native(fletcher_4_ctx_t *ctx,
 	ctx->superscalar[3].v[3] = d4;
 }
 
-ZFS_NO_SANITIZE_UNDEFINED
 static void
 fletcher_4_superscalar4_byteswap(fletcher_4_ctx_t *ctx,
     const void *buf, uint64_t size)


### PR DESCRIPTION
### Motivation and Context
This is probably the uncontroversial part of #13631, which fixes a real problem people are having.

There's still things to improve in our code after this is merged, but it should stop the breakage that people have reported, where we lie about a type always being aligned and then pass in stack objects with no alignment requirement and hope for the best.

Of course, our SIMD code was written with unaligned accesses, so it doesn't care if we drop this...but some auto-vectorized code that gcc emits sure does, since we told it it can assume they're aligned.


### Description
Drop the forced alignment claims that are inaccurate on the fletcher_4_ctx_t, and drop the compiler annotations that tell UBSan not to look too closely at our code as a result of our lies.

It shouldn't tank performance, either, since we already were lying sometimes about the objects being aligned...

### How Has This Been Tested?
Isn't that what CI is for? ;)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
