### PR TITLE
Remove unused constant EdonR256_BLOCK_BITSIZE

### DIFF
--- a/include/sys/edonr.h
+++ b/include/sys/edonr.h
@@ -50,8 +50,6 @@ extern "C" {
 /* Specific algorithm definitions */
 #define	EdonR512_DIGEST_SIZE	64
 #define	EdonR512_BLOCK_SIZE	128
-
-#define	EdonR256_BLOCK_BITSIZE	512
 #define	EdonR512_BLOCK_BITSIZE	1024
 
 typedef struct {


### PR DESCRIPTION
### Motivation and Context

This request is just cosmetic. The constant isn't used any more - I had overseen it :(

### How Has This Been Tested?

The ci will test for us.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
