### PR TITLE
Pack our DDT ZAPs a bit denser.

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -239,6 +239,16 @@ relative to the pool.
 Make some blocks above a certain size be gang blocks.
 This option is used by the test suite to facilitate testing.
 .
+.It Sy zfs_ddt_zap_default_bs Ns = Ns Sy 15 Po 32 KiB Pc Pq int
+Default DDT ZAP data block size as a power of 2. Note that changing this after
+creating a DDT on the pool will not affect existing DDTs, only newly created
+ones.
+.
+.It Sy zfs_ddt_zap_default_ibs Ns = Ns Sy 15 Po 32 KiB Pc Pq int
+Default DDT ZAP indirect block size as a power of 2. Note that changing this
+after creating a DDT on the pool will not affect existing DDTs, only newly
+created ones.
+.
 .It Sy zfs_default_bs Ns = Ns Sy 9 Po 512 B Pc Pq int
 Default dnode block size as a power of 2.
 .

--- a/module/zfs/ddt_zap.c
+++ b/module/zfs/ddt_zap.c
@@ -31,8 +31,8 @@
 #include <sys/zap.h>
 #include <sys/dmu_tx.h>
 
-static const int ddt_zap_leaf_blockshift = 12;
-static const int ddt_zap_indirect_blockshift = 12;
+static unsigned int ddt_zap_default_bs = 15;
+static unsigned int ddt_zap_default_ibs = 15;
 
 static int
 ddt_zap_create(objset_t *os, uint64_t *objectp, dmu_tx_t *tx, boolean_t prehash)
@@ -43,7 +43,7 @@ ddt_zap_create(objset_t *os, uint64_t *objectp, dmu_tx_t *tx, boolean_t prehash)
 		flags |= ZAP_FLAG_PRE_HASHED_KEY;
 
 	*objectp = zap_create_flags(os, 0, flags, DMU_OT_DDT_ZAP,
-	    ddt_zap_leaf_blockshift, ddt_zap_indirect_blockshift,
+	    ddt_zap_default_bs, ddt_zap_default_ibs,
 	    DMU_OT_NONE, 0, tx);
 
 	return (*objectp == 0 ? SET_ERROR(ENOTSUP) : 0);
@@ -166,3 +166,10 @@ const ddt_ops_t ddt_zap_ops = {
 	ddt_zap_walk,
 	ddt_zap_count,
 };
+
+/* BEGIN CSTYLED */
+ZFS_MODULE_PARAM(zfs_dedup, , ddt_zap_default_bs, UINT, ZMOD_RW,
+	"DDT ZAP leaf blockshift");
+ZFS_MODULE_PARAM(zfs_dedup, , ddt_zap_default_ibs, UINT, ZMOD_RW,
+	"DDT ZAP indirect blockshift");
+/* END CSTYLED */


### PR DESCRIPTION
The DDT is really inefficient on 4k and up vdevs, because it always allocates 4k blocks, for leaf and non, and while compression could save us somewhat at ashift 9, that stops being true.

### Motivation and Context
Here's  the output of `zpool status -D` on two pools, one with leaf+indirect blockshift 12, and one with 17, with two copies of one send stream and one copy of another as inputs:

The DDT is really inefficient on 4k and up vdevs, because it always allocates 4k blocks, for leaf and non, and while compression could save us somewhat at ashift 9, that stops being true.

### Motivation and Context
Here's  the output of `zpool status -D` on two pools, ashift 12, one with leaf+indirect blockshift 12, and one with 17, with two copies of one send stream and one copy of another as inputs:

```
  pool: oldddt
 state: ONLINE
config:

        NAME        STATE     READ WRITE CKSUM
        oldddt      ONLINE       0     0     0
          nvme1n1   ONLINE       0     0     0

errors: No known data errors

 dedup: DDT entries 2748780, size 767B on disk, 247B in core

bucket              allocated                       referenced
______   ______________________________   ______________________________
refcnt   blocks   LSIZE   PSIZE   DSIZE   blocks   LSIZE   PSIZE   DSIZE
------   ------   -----   -----   -----   ------   -----   -----   -----
     1     310K   37.8G   36.6G   36.6G     310K   37.8G   36.6G   36.6G
     2    1.86M   27.9G   13.4G   14.0G    3.72M   55.9G   26.9G   28.0G
     4     467K   8.53G   5.70G   5.83G    1.87M   35.4G   23.8G   24.3G
     8    1.75K   83.8M   52.6M   53.2M    14.8K    738M    439M    443M
    16       80     10M    332K    332K    1.65K    211M   6.80M   6.80M
    32       27   3.38M    108K    108K    1.18K    151M   4.73M   4.73M
    64       18   2.25M     72K     72K    1.62K    208M   6.49M   6.49M
   128        1    128K      4K      4K      128     16M    512K    512K
   512        1    128K      4K      4K     1013    127M   3.96M   3.96M
 Total    2.62M   74.3G   55.8G   56.5G    5.91M    130G   87.8G   89.5G

     6    24K     24K     72K     12K    1.00     0.00      L3 DDT ZAP algorithm
   165   660K    660K   1.93M     12K    1.00     0.00      L2 DDT ZAP algorithm
 5.11K  20.4M   20.4M   61.3M     12K    1.00     0.06      L1 DDT ZAP algorithm
  163K   653M    653M   1.91G     12K    1.00     2.03      L0 DDT ZAP algorithm
  169K   674M    674M   1.97G     12K    1.00     2.09  DDT ZAP algorithm
     2    32K      8K     24K     12K    4.00     0.00  DDT statistics

  pool: newddt
 state: ONLINE
config:

        NAME        STATE     READ WRITE CKSUM
        newddt      ONLINE       0     0     0
          nvme2n1   ONLINE       0     0     0

errors: No known data errors

 dedup: DDT entries 2748780, size 273B on disk, 195B in core

bucket              allocated                       referenced
______   ______________________________   ______________________________
refcnt   blocks   LSIZE   PSIZE   DSIZE   blocks   LSIZE   PSIZE   DSIZE
------   ------   -----   -----   -----   ------   -----   -----   -----
     1     310K   37.8G   36.6G   36.6G     310K   37.8G   36.6G   36.6G
     2    1.86M   27.9G   13.4G   14.0G    3.72M   55.9G   26.9G   28.0G
     4     467K   8.53G   5.70G   5.83G    1.87M   35.4G   23.8G   24.3G
     8    1.75K   83.8M   52.6M   53.2M    14.8K    738M    439M    443M
    16       80     10M    332K    332K    1.65K    211M   6.80M   6.80M
    32       27   3.38M    108K    108K    1.18K    151M   4.73M   4.73M
    64       18   2.25M     72K     72K    1.62K    208M   6.49M   6.49M
   128        1    128K      4K      4K      128     16M    512K    512K
   512        1    128K      4K      4K     1013    127M   3.96M   3.96M
 Total    2.62M   74.3G   55.8G   56.5G    5.91M    130G   87.8G   89.5G

     6   768K    232K    696K    116K    3.31     0.00      L1 DDT ZAP algorithm
 4.01K   513M    239M    718M    179K    2.15     0.75      L0 DDT ZAP algorithm
 4.02K   514M    239M    718M    179K    2.15     0.75  DDT ZAP algorithm
     2    32K      8K     24K     12K    4.00     0.00  DDT statistics

```

And in case you think just changing indirect will be a big win for this, here's indirect 17 leaf 12:

```
  pool: oldnewddt
 state: ONLINE
config:

        NAME        STATE     READ WRITE CKSUM
        oldnewddt   ONLINE       0     0     0
          nvme2n1   ONLINE       0     0     0

errors: No known data errors

 dedup: DDT entries 2748780, size 758B on disk, 249B in core

bucket              allocated                       referenced
______   ______________________________   ______________________________
refcnt   blocks   LSIZE   PSIZE   DSIZE   blocks   LSIZE   PSIZE   DSIZE
------   ------   -----   -----   -----   ------   -----   -----   -----
     1     310K   37.8G   36.6G   36.6G     310K   37.8G   36.6G   36.6G
     2    1.86M   27.9G   13.4G   14.0G    3.72M   55.9G   26.9G   28.0G
     4     467K   8.53G   5.70G   5.83G    1.87M   35.4G   23.8G   24.3G
     8    1.75K   83.8M   52.6M   53.2M    14.8K    738M    439M    443M
    16       80     10M    332K    332K    1.65K    211M   6.80M   6.80M
    32       27   3.38M    108K    108K    1.18K    151M   4.73M   4.73M
    64       18   2.25M     72K     72K    1.62K    208M   6.49M   6.49M
   128        1    128K      4K      4K      128     16M    512K    512K
   512        1    128K      4K      4K     1013    127M   3.96M   3.96M
 Total    2.62M   74.3G   55.8G   56.5G    5.91M    130G   87.8G   89.5G

     2   256K     16K     48K     24K   16.00     0.00      L2 DDT ZAP algorithm
   165  20.6M   8.31M   24.9M    155K    2.48     0.03      L1 DDT ZAP algorithm
  164K   655M    655M   1.92G     12K    1.00     2.03      L0 DDT ZAP algorithm
  164K   675M    663M   1.94G   12.1K    1.02     2.06  DDT ZAP algorithm
     2    32K      8K     24K     12K    4.00     0.00  DDT statistics
```


### Description
Kick both the indirect and leaf blockshift up to 128k. Also add tunables so people can adjust this if they need to, though obviously it's not going to rewrite old ZAPs.

I think just upping the leaf a lot would be almost all of the gain here, but upping indirect to at least compress a little seems reasonable to me....

...but I figured I'd propose the most drastic option short of large_blocks and we could start the discussion of where to agree on.

### How Has This Been Tested?
Tests?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
