### PR TITLE
Fix cloning into already dirty dbufs.

### DIFF
--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -382,6 +382,7 @@ void dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx);
 dbuf_dirty_record_t *dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx);
 dbuf_dirty_record_t *dbuf_dirty_lightweight(dnode_t *dn, uint64_t blkid,
     dmu_tx_t *tx);
+boolean_t dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx);
 arc_buf_t *dbuf_loan_arcbuf(dmu_buf_impl_t *db);
 void dmu_buf_write_embedded(dmu_buf_t *dbuf, void *data,
     bp_embedded_type_t etype, enum zio_compress comp,

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -175,7 +175,6 @@ struct {
 		continue;						\
 }
 
-static boolean_t dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx);
 static void dbuf_write(dbuf_dirty_record_t *dr, arc_buf_t *data, dmu_tx_t *tx);
 static void dbuf_sync_leaf_verify_bonus_dnode(dbuf_dirty_record_t *dr);
 static int dbuf_read_verify_dnode_crypt(dmu_buf_impl_t *db, uint32_t flags);
@@ -2518,7 +2517,7 @@ dbuf_undirty_bonus(dbuf_dirty_record_t *dr)
  * Undirty a buffer in the transaction group referenced by the given
  * transaction.  Return whether this evicted the dbuf.
  */
-static boolean_t
+boolean_t
 dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 {
 	uint64_t txg = tx->tx_txg;

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2190,7 +2190,8 @@ dmu_read_l0_bps(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 	for (int i = 0; i < numbufs; i++) {
 		dbuf = dbp[i];
 		db = (dmu_buf_impl_t *)dbuf;
-		bp = db->db_blkptr;
+
+		mutex_enter(&db->db_mtx);
 
 		/*
 		 * If the block is not on the disk yet, it has no BP assigned.
@@ -2212,10 +2213,16 @@ dmu_read_l0_bps(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 				 * The block was modified in the same
 				 * transaction group.
 				 */
+				mutex_exit(&db->db_mtx);
 				error = SET_ERROR(EAGAIN);
 				goto out;
 			}
+		} else {
+			bp = db->db_blkptr;
 		}
+
+		mutex_exit(&db->db_mtx);
+
 		if (bp == NULL) {
 			/*
 			 * The block was created in this transaction group,
@@ -2273,19 +2280,22 @@ dmu_brt_clone(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 		ASSERT(db->db_blkid != DMU_BONUS_BLKID);
 		ASSERT(BP_IS_HOLE(bp) || dbuf->db_size == BP_GET_LSIZE(bp));
 
-		if (db->db_state == DB_UNCACHED) {
-			/*
-			 * XXX-PJD: If the dbuf is already cached, calling
-			 * dmu_buf_will_not_fill() will panic on assertion
-			 * (db->db_buf == NULL) in dbuf_clear_data(),
-			 * which is called from dbuf_noread() in DB_NOFILL
-			 * case. I'm not 100% sure this is the right thing
-			 * to do, but it seems to work.
-			 */
-			dmu_buf_will_not_fill(dbuf, tx);
+		mutex_enter(&db->db_mtx);
+		VERIFY(!dbuf_undirty(db, tx));
+		ASSERT(list_head(&db->db_dirty_records) == NULL);
+		mutex_exit(&db->db_mtx);
+
+		if (db->db_buf != NULL) {
+			arc_buf_destroy(db->db_buf, db);
+			db->db_buf = NULL;
 		}
 
+		dmu_buf_will_not_fill(dbuf, tx);
+
+		mutex_enter(&db->db_mtx);
+
 		dr = list_head(&db->db_dirty_records);
+		VERIFY(dr != NULL);
 		ASSERT3U(dr->dr_txg, ==, tx->tx_txg);
 		dl = &dr->dt.dl;
 		dl->dr_overridden_by = *bp;
@@ -2300,6 +2310,8 @@ dmu_brt_clone(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 			dl->dr_overridden_by.blk_phys_birth =
 			    BP_PHYSICAL_BIRTH(bp);
 		}
+
+		mutex_exit(&db->db_mtx);
 
 		/*
 		 * When data in embedded into BP there is no need to create

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2281,14 +2281,15 @@ dmu_brt_clone(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 		ASSERT(BP_IS_HOLE(bp) || dbuf->db_size == BP_GET_LSIZE(bp));
 
 		mutex_enter(&db->db_mtx);
+
 		VERIFY(!dbuf_undirty(db, tx));
 		ASSERT(list_head(&db->db_dirty_records) == NULL);
-		mutex_exit(&db->db_mtx);
-
 		if (db->db_buf != NULL) {
 			arc_buf_destroy(db->db_buf, db);
 			db->db_buf = NULL;
 		}
+
+		mutex_exit(&db->db_mtx);
 
 		dmu_buf_will_not_fill(dbuf, tx);
 


### PR DESCRIPTION
Undirty the dbuf and destroy its buffer when cloning into it.

Reported by:	Richard Yao
Reported by:	Benjamin Coddington
Coverity ID:	CID-1535375

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes a panic when cloning to a file that was written to in the same transaction group.

### Description
<!--- Describe your changes in detail -->
When the dbuf we are trying to clone into was dirtied by writing into it in the same transaction group before cloning into it we will panic. We need to first undirty the dbuf and destroy its buffer.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
