### PR TITLE
Miscellaneous FreeBSD compilation bugfixes

### DIFF
--- a/include/os/freebsd/spl/sys/simd_aarch64.h
+++ b/include/os/freebsd/spl/sys/simd_aarch64.h
@@ -45,6 +45,7 @@
 
 #include <sys/types.h>
 #include <machine/elf.h>
+#include <machine/md_var.h>
 
 #define	kfpu_allowed()		1
 #define	kfpu_initialize(tsk)	do {} while (0)

--- a/include/os/freebsd/spl/sys/simd_arm.h
+++ b/include/os/freebsd/spl/sys/simd_arm.h
@@ -44,6 +44,7 @@
 
 #include <sys/types.h>
 #include <machine/elf.h>
+#include <machine/md_var.h>
 
 #define	kfpu_allowed()		1
 #define	kfpu_initialize(tsk)	do {} while (0)

--- a/include/os/freebsd/spl/sys/simd_x86.h
+++ b/include/os/freebsd/spl/sys/simd_x86.h
@@ -45,6 +45,10 @@
 		fpu_kern_enter(curthread, NULL, FPU_KERN_NOCTX);\
 }
 
+#ifndef PCB_FPUNOSAVE
+#define	PCB_FPUNOSAVE	PCB_NPXNOSAVE
+#endif
+
 #define	kfpu_end()	{			\
 	if (__predict_false(curpcb->pcb_flags & PCB_FPUNOSAVE))	\
 		fpu_kern_leave(curthread, NULL);	\

--- a/include/os/freebsd/spl/sys/vnode.h
+++ b/include/os/freebsd/spl/sys/vnode.h
@@ -143,6 +143,10 @@ vn_flush_cached_data(vnode_t *vp, boolean_t sync)
 /*
  * Attributes of interest to the caller of setattr or getattr.
  */
+
+#undef AT_UID
+#undef AT_GID
+
 #define	AT_MODE		0x00002
 #define	AT_UID		0x00004
 #define	AT_GID		0x00008

--- a/module/icp/algs/blake3/blake3.c
+++ b/module/icp/algs/blake3/blake3.c
@@ -25,6 +25,7 @@
  * Copyright (c) 2021-2022 Tino Reichardt <milky-zfs@mcmilk.de>
  */
 
+#include <sys/simd.h>
 #include <sys/zfs_context.h>
 #include <sys/blake3.h>
 

--- a/module/icp/algs/blake3/blake3_generic.c
+++ b/module/icp/algs/blake3/blake3_generic.c
@@ -25,6 +25,7 @@
  * Copyright (c) 2021-2022 Tino Reichardt <milky-zfs@mcmilk.de>
  */
 
+#include <sys/simd.h>
 #include <sys/zfs_context.h>
 #include "blake3_impl.h"
 

--- a/module/icp/algs/blake3/blake3_impl.c
+++ b/module/icp/algs/blake3/blake3_impl.c
@@ -23,10 +23,10 @@
  * Copyright (c) 2021-2022 Tino Reichardt <milky-zfs@mcmilk.de>
  */
 
+#include <sys/simd.h>
 #include <sys/zfs_context.h>
 #include <sys/zfs_impl.h>
 #include <sys/blake3.h>
-#include <sys/simd.h>
 
 #include "blake3_impl.h"
 

--- a/module/icp/algs/sha2/sha256_impl.c
+++ b/module/icp/algs/sha2/sha256_impl.c
@@ -23,10 +23,10 @@
  * Copyright (c) 2022 Tino Reichardt <milky-zfs@mcmilk.de>
  */
 
+#include <sys/simd.h>
 #include <sys/zfs_context.h>
 #include <sys/zfs_impl.h>
 #include <sys/sha2.h>
-#include <sys/simd.h>
 
 #include <sha2/sha2_impl.h>
 #include <sys/asm_linkage.h>
@@ -118,7 +118,7 @@ const sha256_ops_t sha256_shani_impl = {
 };
 #endif
 
-#elif defined(__aarch64__) || defined(__arm__)
+#elif defined(__aarch64__) || (defined(__arm__) && __ARM_ARCH > 6)
 static boolean_t sha256_have_neon(void)
 {
 	return (kfpu_allowed() && zfs_neon_available());
@@ -192,7 +192,7 @@ static const sha256_ops_t *const sha256_impls[] = {
 #if defined(__x86_64) && defined(HAVE_SSE4_1)
 	&sha256_shani_impl,
 #endif
-#if defined(__aarch64__) || defined(__arm__)
+#if defined(__aarch64__) || (defined(__arm__) && __ARM_ARCH > 6)
 	&sha256_armv7_impl,
 	&sha256_neon_impl,
 	&sha256_armv8_impl,

--- a/module/icp/algs/sha2/sha512_impl.c
+++ b/module/icp/algs/sha2/sha512_impl.c
@@ -23,10 +23,10 @@
  * Copyright (c) 2022 Tino Reichardt <milky-zfs@mcmilk.de>
  */
 
+#include <sys/simd.h>
 #include <sys/zfs_context.h>
 #include <sys/zfs_impl.h>
 #include <sys/sha2.h>
-#include <sys/simd.h>
 
 #include <sha2/sha2_impl.h>
 #include <sys/asm_linkage.h>
@@ -108,7 +108,7 @@ const sha512_ops_t sha512_armv8_impl = {
 	.name = "armv8-ce"
 };
 
-#elif defined(__arm__)
+#elif defined(__arm__) && __ARM_ARCH > 6
 extern void zfs_sha512_block_armv7(uint64_t s[8], const void *, size_t);
 const sha512_ops_t sha512_armv7_impl = {
 	.is_supported = sha2_is_supported,
@@ -168,7 +168,7 @@ static const sha512_ops_t *const sha512_impls[] = {
 	&sha512_armv7_impl,
 	&sha512_armv8_impl,
 #endif
-#if defined(__arm__)
+#if defined(__arm__) && __ARM_ARCH > 6
 	&sha512_armv7_impl,
 	&sha512_neon_impl,
 #endif

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -29,12 +29,12 @@
 /* Portions Copyright 2007 Jeremy Teo */
 /* Portions Copyright 2010 Robert Milkowski */
 
-
 #include <sys/param.h>
 #include <sys/time.h>
 #include <sys/systm.h>
 #include <sys/sysmacros.h>
 #include <sys/resource.h>
+#include <security/mac/mac_framework.h>
 #include <sys/vfs.h>
 #include <sys/endian.h>
 #include <sys/vm.h>
@@ -85,7 +85,6 @@
 #include <sys/zfs_vnops.h>
 #include <sys/module.h>
 #include <sys/sysent.h>
-#include <security/mac/mac_framework.h>
 #include <sys/dmu_impl.h>
 #include <sys/brt.h>
 #include <sys/zfeature.h>
@@ -6241,6 +6240,7 @@ zfs_freebsd_copy_file_range(struct vop_copy_file_range_args *ap)
 	struct mount *mp;
 	struct uio io;
 	int error;
+	uint64_t len = *ap->a_lenp;
 
 	/*
 	 * TODO: If offset/length is not aligned to recordsize, use
@@ -6289,7 +6289,8 @@ zfs_freebsd_copy_file_range(struct vop_copy_file_range_args *ap)
 		goto unlock;
 
 	error = zfs_clone_range(VTOZ(invp), ap->a_inoffp, VTOZ(outvp),
-	    ap->a_outoffp, ap->a_lenp, ap->a_fsizetd->td_ucred);
+	    ap->a_outoffp, &len, ap->a_fsizetd->td_ucred);
+	*ap->a_lenp = (size_t)len;
 
 unlock:
 	if (invp != outvp)

--- a/module/zcommon/zfs_fletcher.c
+++ b/module/zcommon/zfs_fletcher.c
@@ -136,8 +136,8 @@
 #include <sys/types.h>
 #include <sys/sysmacros.h>
 #include <sys/byteorder.h>
-#include <sys/spa.h>
 #include <sys/simd.h>
+#include <sys/spa.h>
 #include <sys/zio_checksum.h>
 #include <sys/zfs_context.h>
 #include <zfs_fletcher.h>

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -30,6 +30,10 @@
 
 /* Portions Copyright 2010 Robert Milkowski */
 
+#if defined(_KERNEL)
+#include <sys/simd.h>
+#endif
+
 #include <sys/zio.h>
 #include <sys/spa.h>
 #include <sys/u8_textprep.h>
@@ -1036,8 +1040,6 @@ zfs_prop_align_right(zfs_prop_t prop)
 #endif
 
 #if defined(_KERNEL)
-
-#include <sys/simd.h>
 
 #if defined(HAVE_KERNEL_FPU_INTERNAL)
 uint8_t **zfs_kfpu_fpregs;

--- a/module/zfs/vdev_raidz_math.c
+++ b/module/zfs/vdev_raidz_math.c
@@ -22,6 +22,7 @@
  * Copyright (C) 2016 Gvozden Nešković. All rights reserved.
  */
 
+#include <sys/simd.h>
 #include <sys/zfs_context.h>
 #include <sys/types.h>
 #include <sys/zio.h>
@@ -29,7 +30,6 @@
 #include <sys/zfs_debug.h>
 #include <sys/vdev_raidz.h>
 #include <sys/vdev_raidz_impl.h>
-#include <sys/simd.h>
 
 /* Opaque implementation with NULL methods to represent original methods */
 static const raidz_impl_ops_t vdev_raidz_original_impl = {


### PR DESCRIPTION
### Motivation and Context
These changes are required to import latest OpenZFS changes into FreeBSD-base.

### Description

- Add missing machine/md_var.h to spl/sys/simd_aarch64.h and spl/sys/simd_arm.
- In spl/sys/simd_x86.h, PCB_FPUNOSAVE exists only on amd64, use PCB_NPXNOSAVE on i386
- In FreeBSD sys/elf_common.h redefines AT_UID and AT_GID on FreeBSD, we need a hack in vnode.h similar to Linux. sys/simd.h needs to be included early.
- In zfs_freebsd_copy_file_range() we pass a (size_t *)lenp to zfs_clone_range() that expects a (uint64_t *)
- Allow compiling armv6 world by limiting ARM macros in sha256_impl.c and sha512_impl.c to __ARM_ARCH > 6

### How Has This Been Tested?
make universe + running amd64 code
https://github.com/mmatuska/freebsd-src/tree/openzfs-431083f75

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
