### PR TITLE
Add all read-only compatible features to GRUB2 compatibility feature set

### DIFF
--- a/cmd/zpool/compatibility.d/grub2
+++ b/cmd/zpool/compatibility.d/grub2
@@ -1,6 +1,9 @@
 # Features which are supported by GRUB2
+allocation_classes
 async_destroy
+block_cloning
 bookmarks
+device_rebuild
 embedded_data
 empty_bpobj
 enabled_txg
@@ -8,5 +11,13 @@ extensible_dataset
 filesystem_limits
 hole_birth
 large_blocks
+livelist
+log_spacemap
 lz4_compress
+project_quota
+resilver_defer
 spacemap_histogram
+spacemap_v2
+userobj_accounting
+zilsaxattr
+zpool_checkpoint

--- a/man/man7/zpool-features.7
+++ b/man/man7/zpool-features.7
@@ -219,8 +219,11 @@ to the end of the line is ignored.
 .Bd -literal -compact -offset 4n
 .No example# Nm cat Pa /usr/share/zfs/compatibility.d/grub2
 # Features which are supported by GRUB2
+allocation_classes
 async_destroy
+block_cloning
 bookmarks
+device_rebuild
 embedded_data
 empty_bpobj
 enabled_txg
@@ -228,8 +231,16 @@ extensible_dataset
 filesystem_limits
 hole_birth
 large_blocks
+livelist
+log_spacemap
 lz4_compress
+project_quota
+resilver_defer
 spacemap_histogram
+spacemap_v2
+userobj_accounting
+zilsaxattr
+zpool_checkpoint
 
 .No example# Nm zpool Cm create Fl o Sy compatibility Ns = Ns Ar grub2 Ar bootpool Ar vdev
 .Ed


### PR DESCRIPTION
### Motivation and Context
Since GRUB2 opens pools in read-only mode, all read-only compatible features can be enabled.

### Description
Several read-only compatible features have been introduced since the GRUB2 compatibility file was created but the file wasn't updated.

I added all features from `zpool_feature_init()` in `module/zcommon/zfeature_common.c` where the
`ZFEATURE_FLAG_READONLY_COMPAT` flag is set.

This is my first PR here, so please excuse any mistakes I may have made.

### How Has This Been Tested?
I created a ZFS pool with `-o compatibility=grub2` used it as /boot and successfully booted from the pool using GRUB2. To make this easy and reproducible, I wrote a NixOS VM test, which I plan to upstream to Nixpkgs. I'll happily provide more details about this if requested.


### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).