### PR TITLE
contrib: dracut: fix race with root=zfs:dset when necessities required

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -81,6 +81,9 @@ install() {
 		inst_simple "${moddir}/zfs-env-bootfs.service" "${systemdsystemunitdir}/zfs-env-bootfs.service"
 		systemctl -q --root "${initdir}" add-wants zfs-import.target zfs-env-bootfs.service
 
+		inst_simple "${moddir}/zfs-nonroot-necessities.service" "${systemdsystemunitdir}/zfs-nonroot-necessities.service"
+		systemctl -q --root "${initdir}" add-requires initrd-root-fs.target zfs-nonroot-necessities.service
+
 		# Add user-provided unit overrides:
 		# - /etc/systemd/system/${_service}
 		# - /etc/systemd/system/${_service}.d/overrides.conf

--- a/contrib/dracut/90zfs/zfs-env-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-env-bootfs.service.in
@@ -1,6 +1,5 @@
 [Unit]
-Description=Set BOOTFS environment for dracut
-Documentation=man:zpool(8)
+Description=Set BOOTFS and BOOTFSFLAGS environment variables for dracut
 DefaultDependencies=no
 After=zfs-import-cache.service
 After=zfs-import-scan.service
@@ -8,7 +7,17 @@ Before=zfs-import.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "exec systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | grep -m1 -vFx -)"
+ExecStart=/bin/sh -c '                                                                         \
+    . /lib/dracut-zfs-lib.sh;                                                                  \
+    decode_root_args || exit 0;                                                                \
+    [ "$root" = "zfs:AUTO" ] && root="$(@sbindir@/zpool list -H -o bootfs | grep -m1 -vFx -)"; \
+    rootflags="$(getarg rootflags=)";                                                          \
+    case ",$rootflags," in                                                                     \
+        *,zfsutil,*) ;;                                                                        \
+        ,,) rootflags=zfsutil ;;                                                               \
+        *)  rootflags="zfsutil,$rootflags" ;;                                                  \
+    esac;                                                                                      \
+    exec systemctl set-environment BOOTFS="$root" BOOTFSFLAGS="$rootflags"'
 
 [Install]
 WantedBy=zfs-import.target

--- a/contrib/dracut/90zfs/zfs-generator.sh.in
+++ b/contrib/dracut/90zfs/zfs-generator.sh.in
@@ -14,80 +14,23 @@ GENERATOR_DIR="$1"
 . /lib/dracut-zfs-lib.sh
 decode_root_args || exit 0
 
-[ -z "${rootflags}" ] && rootflags=$(getarg rootflags=)
-case ",${rootflags}," in
-	*,zfsutil,*) ;;
-	,,)	rootflags=zfsutil ;;
-	*)	rootflags="zfsutil,${rootflags}" ;;
-esac
-
 [ -n "$debug" ] && echo "zfs-generator: writing extension for sysroot.mount to $GENERATOR_DIR/sysroot.mount.d/zfs-enhancement.conf" >> /dev/kmsg
 
 
-mkdir -p "$GENERATOR_DIR"/sysroot.mount.d "$GENERATOR_DIR"/initrd-root-fs.target.requires "$GENERATOR_DIR"/dracut-pre-mount.service.d
+mkdir -p "$GENERATOR_DIR"/sysroot.mount.d "$GENERATOR_DIR"/dracut-pre-mount.service.d
+
 {
     echo "[Unit]"
     echo "Before=initrd-root-fs.target"
     echo "After=zfs-import.target"
     echo
     echo "[Mount]"
-    if [ "${root}" = "zfs:AUTO" ]; then
-      echo "PassEnvironment=BOOTFS"
-      echo 'What=${BOOTFS}'
-    else
-      echo "What=${root}"
-    fi
+    echo "PassEnvironment=BOOTFS BOOTFSFLAGS"
+    echo 'What=${BOOTFS}'
     echo "Type=zfs"
-    echo "Options=${rootflags}"
+    echo 'Options=${BOOTFSFLAGS}'
 } > "$GENERATOR_DIR"/sysroot.mount.d/zfs-enhancement.conf
 ln -fs ../sysroot.mount "$GENERATOR_DIR"/initrd-root-fs.target.requires/sysroot.mount
-
-
-if [ "${root}" = "zfs:AUTO" ]; then
-  {
-      echo "[Unit]"
-      echo "Before=initrd-root-fs.target"
-      echo "After=sysroot.mount"
-      echo "DefaultDependencies=no"
-      echo
-      echo "[Service]"
-      echo "Type=oneshot"
-      echo "PassEnvironment=BOOTFS"
-      echo "ExecStart=/bin/sh -c '" '                                        \
-        . /lib/dracut-zfs-lib.sh;                                            \
-        _zfs_nonroot_necessities_cb() {                                      \
-            zfs mount | grep -m1 -q "^$1 " && return 0;                      \
-            echo "Mounting $1 on /sysroot$2";                                \
-            mount -o zfsutil -t zfs "$1" "/sysroot$2";                       \
-        };                                                                   \
-        for_relevant_root_children "${BOOTFS}" _zfs_nonroot_necessities_cb;' \
-      "'"
-  } > "$GENERATOR_DIR"/zfs-nonroot-necessities.service
-  ln -fs ../zfs-nonroot-necessities.service "$GENERATOR_DIR"/initrd-root-fs.target.requires/zfs-nonroot-necessities.service
-else
-  # We can solve this statically at generation time, so do!
-  _zfs_generator_cb() {
-      dset="${1}"
-      mpnt="${2}"
-      unit="$(systemd-escape --suffix=mount -p "/sysroot${mpnt}")"
-
-      {
-          echo "[Unit]"
-          echo "Before=initrd-root-fs.target"
-          echo "After=sysroot.mount"
-          echo
-          echo "[Mount]"
-          echo "Where=/sysroot${mpnt}"
-          echo "What=${dset}"
-          echo "Type=zfs"
-          echo "Options=zfsutil"
-      } > "$GENERATOR_DIR/${unit}"
-      ln -fs ../"${unit}" "$GENERATOR_DIR"/initrd-root-fs.target.requires/"${unit}"
-  }
-
-  for_relevant_root_children "${root}" _zfs_generator_cb
-fi
-
 
 {
     echo "[Unit]"

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -39,7 +39,7 @@ mount_dataset() {
 
 # for_relevant_root_children DATASET EXEC
 #   Runs "EXEC dataset mountpoint" for all children of DATASET that are needed for system bringup
-#   Used by zfs-generator.sh and friends, too!
+#   Used by zfs-nonroot-necessities.service and friends, too!
 for_relevant_root_children() {
     dataset="${1}"
     exec="${2}"

--- a/contrib/dracut/90zfs/zfs-nonroot-necessities.service.in
+++ b/contrib/dracut/90zfs/zfs-nonroot-necessities.service.in
@@ -1,0 +1,20 @@
+[Unit]
+Before=initrd-root-fs.target
+After=sysroot.mount
+DefaultDependencies=no
+ConditionEnvironment=BOOTFS
+
+[Service]
+Type=oneshot
+PassEnvironment=BOOTFS
+ExecStart=/bin/sh -c '                                                \
+    . /lib/dracut-zfs-lib.sh;                                         \
+    _zfs_nonroot_necessities_cb() {                                   \
+        @sbindir@/zfs mount | grep -m1 -q "^$1 " && return 0;         \
+        echo "Mounting $1 on /sysroot$2";                             \
+        mount -o zfsutil -t zfs "$1" "/sysroot$2";                    \
+    };                                                                \
+    for_relevant_root_children "${BOOTFS}" _zfs_nonroot_necessities_cb'
+
+[Install]
+RequiredBy=initrd-root-fs.target

--- a/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-rollback-bootfs.service.in
@@ -5,8 +5,9 @@ After=zfs-import.target dracut-pre-mount.service zfs-snapshot-bootfs.service
 Before=dracut-mount.service
 DefaultDependencies=no
 ConditionKernelCommandLine=bootfs.rollback
+ConditionEnvironment=BOOTFS
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPNAME="$(getarg bootfs.rollback)"; exec @sbindir@/zfs rollback -Rf "$root@${SNAPNAME:-%v}"'
+ExecStart=/bin/sh -c '. /lib/dracut-lib.sh; SNAPNAME="$(getarg bootfs.rollback)"; exec @sbindir@/zfs rollback -Rf "$BOOTFS@${SNAPNAME:-%v}"'
 RemainAfterExit=yes

--- a/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-snapshot-bootfs.service.in
@@ -5,8 +5,9 @@ After=zfs-import.target dracut-pre-mount.service
 Before=dracut-mount.service
 DefaultDependencies=no
 ConditionKernelCommandLine=bootfs.snapshot
+ConditionEnvironment=BOOTFS
 
 [Service]
 Type=oneshot
-ExecStart=-/bin/sh -c '. /lib/dracut-zfs-lib.sh; decode_root_args || exit; [ "$root" = "zfs:AUTO" ] && root="$BOOTFS"; SNAPNAME="$(getarg bootfs.snapshot)"; exec @sbindir@/zfs snapshot "$root@${SNAPNAME:-%v}"'
+ExecStart=-/bin/sh -c '. /lib/dracut-lib.sh; SNAPNAME="$(getarg bootfs.snapshot)"; exec @sbindir@/zfs snapshot "$BOOTFS@${SNAPNAME:-%v}"'
 RemainAfterExit=yes

--- a/contrib/dracut/Makefile.am
+++ b/contrib/dracut/Makefile.am
@@ -16,6 +16,7 @@ pkgdracut_90_SCRIPTS = \
 
 pkgdracut_90_DATA = \
 	%D%/90zfs/zfs-env-bootfs.service \
+	%D%/90zfs/zfs-nonroot-necessities.service \
 	%D%/90zfs/zfs-rollback-bootfs.service \
 	%D%/90zfs/zfs-snapshot-bootfs.service
 

--- a/man/man7/dracut.zfs.7
+++ b/man/man7/dracut.zfs.7
@@ -1,6 +1,6 @@
 .\" SPDX-License-Identifier: 0BSD
 .\"
-.Dd April 4, 2022
+.Dd March 28, 2023
 .Dt DRACUT.ZFS 7
 .Os
 .
@@ -28,13 +28,13 @@ zfs-import-scan.service \(da                       \(da           | zfs-import-c
                  zfs-import.target \(-> dracut-pre-mount.service
                         |          \(ua            |
                         | dracut-zfs-generator  |
-                        |  ____________________/|
+                        | _____________________/|
                         |/                      \(da
-                        |                   sysroot.mount \(<-\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em dracut-zfs-generator
-                        |                       |                                        \(da   |
-                        |                       \(da            sysroot-{usr,etc,lib,&c.}.mount |
-                        |             initrd-root-fs.target \(<-\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em or                 \(da
-                        |                       |              zfs-nonroot-necessities.service
+                        |                   sysroot.mount \(<-\(em\(em\(em dracut-zfs-generator
+                        |                       |
+                        |                       \(da
+                        |             initrd-root-fs.target \(<-\(em zfs-nonroot-necessities.service
+                        |                       |                                 |
                         |                       \(da                                 |
                         \(da             dracut-mount.service                        |
        zfs-snapshot-bootfs.service              |                                 |
@@ -42,7 +42,7 @@ zfs-import-scan.service \(da                       \(da           | zfs-import-c
                         \(da                       …                                 |
        zfs-rollback-bootfs.service              |                                 |
                         |                       \(da                                 |
-                        |               sysroot-usr.mount \(<-\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em/
+                        |          /sysroot/{usr,etc,lib,&c.} \(<-\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em\(em/
                         |                       |
                         |                       \(da
                         |                initrd-fs.target


### PR DESCRIPTION
### Motivation and Context
See commit message; in short, from the [reporter's journal](https://gist.github.com/griwes/6c28a134bee98c014b40603d3f056b62):
```
Mar 28 18:21:12 localhost zfs-generator: writing extension for sysroot.mount to /run/systemd/generator/sysroot.mount.d/zfs-enhancement.conf
Mar 28 18:21:12 localhost zfs-generator: finished
```
but (note the timestamp)
``` 
Mar 28 18:21:13 localhost systemd[1]: zfs-import.target changed dead -> active
Mar 28 18:21:13 localhost systemd[1]: zfs-import.target: Job 53 zfs-import.target/start finished, result=done
Mar 28 18:21:13 localhost systemd[1]: Reached target zfs-import.target - ZFS pool import target.
```
which can only work when a systemd generator loses a race to pool import, which it does in a VM but probably not on most hardware.

The diff looks big but only because the `if [ "${root}" = "zfs:AUTO" ]; then` branch moved to a separate file (and is unchanged there), rootflags parsing moved in with zfs-env-bootfs (also unchanged), and `[ "$root" = "zfs:AUTO" ] &&` moved in from zfs-snapshot/rollback-bootfs to zfs-env-bootfs.

The actual new code changes is the new spelling of `zfs-enhancement.conf`, `decode_root_args || exit 0` in z-e-b, and `ConditionEnvironment=`s.

### How Has This Been Tested?
Works with root=zfs:AUTO, root=zfs:dset, and root=/dev/vdb (on ext4)<!--; original reporter also confirms this fixed it for them-->.

Found, tested, and proofed on ZFS 2.1.[279] installations; 2.1.10 backport in #14691.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. — CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).