### PR TITLE
initramfs: allow user-defined unlocking mechanism

### DIFF
--- a/contrib/initramfs/README.md
+++ b/contrib/initramfs/README.md
@@ -82,3 +82,23 @@ To use this feature:
    in that case, use RSA (2048-bit or more) instead.
 3. Rebuild the initramfs with your keys: `update-initramfs -u`
 4. During the system boot, login via SSH and run: `zfsunlock`
+
+### Unlocking a ZFS encrypted root via alternate means
+
+You may supply your own unlocking mechanism, if you have another use case. 
+Examples:
+
+* retrieve a key from the TPM (clevis, tpm2-tools)
+* retrieve a key over the network (Hashicorp Vault)
+
+(These use cases are not supported or endorsed by the project.)
+
+To supply your own mechanism:
+
+1. Create `/etc/zfs/zfs-load-key-user` and define the `load_key_user` function,
+ which will be called with `$1` set to the value of `encryptionroot`
+  * `load_key_user` is expected to call `zfs load-key` or achieve the same 
+effect. 
+  * Key status will be checked after the function returns. If successful, 
+  `decrypt_fs` will return immediately.
+2. Rebuild the initramfs

--- a/contrib/initramfs/hooks/zfs.in
+++ b/contrib/initramfs/hooks/zfs.in
@@ -41,6 +41,7 @@ copy_file cache  "@sysconfdir@/zfs/zpool.cache"
 copy_file config "@initconfdir@/zfs"
 copy_file config "@sysconfdir@/zfs/zfs-functions"
 copy_file config "@sysconfdir@/zfs/vdev_id.conf"
+[ -f "@sysconfdir@/zfs/zfs-load-key-user" ] && copy_file config "@sysconfdir@/zfs/zfs-load-key-user"
 copy_file rule   "@udevruledir@/60-zvol.rules"
 copy_file rule   "@udevruledir@/69-vdev.rules"
 

--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -420,6 +420,16 @@ decrypt_fs()
 			# Continue only if the key needs to be loaded
 			[ "$KEYSTATUS" = "unavailable" ] || return 0
 
+			# Use user-provided key loading function if available
+			if [ -f "/etc/zfs/zfs-load-key-user" ]; then
+				. /etc/zfs/zfs-load-key-user
+				load_key_user "${ENCRYPTIONROOT}"
+				# Don't trust user function, check key status
+				KEYSTATUS="$(get_fs_value "${ENCRYPTIONROOT}" keystatus)"	
+				# Exit if user function was successful
+				[ "$KEYSTATUS" = "unavailable" ] || return 0
+			fi
+			
 			# Do not prompt if key is stored noninteractively,
 			if ! [ "${KEYLOCATION}" = "prompt" ]; then
 				$ZFS load-key "${ENCRYPTIONROOT}"


### PR DESCRIPTION
Closes #13757
The user may provide a `load_key_user` function
in `/etc/zfs/zfs-load-key-user`, which will be called to load the decryption key if available.
There is no effect if `zfs-load-key-user` is not present
