### PR TITLE
Revert "Add colored output to zfs list"

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -3441,8 +3441,6 @@ print_header(list_cbdata_t *cb)
 	boolean_t first = B_TRUE;
 	boolean_t right_justify;
 
-	color_start(ANSI_BOLD);
-
 	for (; pl != NULL; pl = pl->pl_next) {
 		if (!first) {
 			(void) printf("  ");
@@ -3469,29 +3467,7 @@ print_header(list_cbdata_t *cb)
 			(void) printf("%-*s", (int)pl->pl_width, header);
 	}
 
-	color_end();
-
 	(void) printf("\n");
-}
-
-/*
- * Decides on the color that the avail value should be printed in.
- * > 80% used = yellow
- * > 90% used = red
- */
-static const char *
-zfs_list_avail_color(zfs_handle_t *zhp)
-{
-	uint64_t used = zfs_prop_get_int(zhp, ZFS_PROP_USED);
-	uint64_t avail = zfs_prop_get_int(zhp, ZFS_PROP_AVAILABLE);
-	int percentage = (int)((double)avail / MAX(avail + used, 1) * 100);
-
-	if (percentage > 20)
-		return (NULL);
-	else if (percentage > 10)
-		return (ANSI_YELLOW);
-	else
-		return (ANSI_RED);
 }
 
 /*
@@ -3556,9 +3532,6 @@ print_dataset(zfs_handle_t *zhp, list_cbdata_t *cb)
 			right_justify = B_FALSE;
 		}
 
-		if (pl->pl_prop == ZFS_PROP_AVAILABLE)
-			color_start(zfs_list_avail_color(zhp));
-
 		/*
 		 * If this is being called in scripted mode, or if this is the
 		 * last column and it is left-justified, don't include a width
@@ -3570,9 +3543,6 @@ print_dataset(zfs_handle_t *zhp, list_cbdata_t *cb)
 			(void) printf("%*s", (int)pl->pl_width, propstr);
 		else
 			(void) printf("%-*s", (int)pl->pl_width, propstr);
-
-		if (pl->pl_prop == ZFS_PROP_AVAILABLE)
-			color_end();
 	}
 
 	(void) putchar('\n');

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -740,8 +740,6 @@ command will be undone if the share is ever unshared (like via a reboot).
 .It Sy ZFS_COLOR
 Use ANSI color in
 .Nm zfs Cm diff
-and
-.Nm zfs Cm list
 output.
 .It Sy ZFS_MOUNT_HELPER
 Cause


### PR DESCRIPTION
This reverts commit 2bd0490fafe5ebb811dee9b0eb5d5c245c7a1cbf.

Running `zfs list -o avail rpool` will result in a core dump. This was introduced by `2bd0490fafe5ebb811dee9b0eb5d5c245c7a1cbf`. 

That change added the following function:

```
/*
  * Decides on the color that the avail value should be printed in.
  * > 80% used = yellow
  * > 90% used = red
  */
 static const char *
 zfs_list_avail_color(zfs_handle_t *zhp)
 {
         uint64_t used = zfs_prop_get_int(zhp, ZFS_PROP_USED);
         uint64_t avail = zfs_prop_get_int(zhp, ZFS_PROP_AVAILABLE);
         int percentage = (int)((double)avail / MAX(avail + used, 1) * 100);

         if (percentage > 20)
                 return (NULL);
         else if (percentage > 10)
                 return (ANSI_YELLOW);
         else
                 return (ANSI_RED);
 }
```

This function relies on both the `USED` and `AVAILABLE` properties but when you invoke the command as `zfs list -o avail` ZFS will prune the properties nvlist to include only the fields that were specified. As a result, only the `AVAILABLE` information will exist in the nvlist and when ZFS tries to get the `USED` information it will result this core dump:
```
#0  0x00007f61d529800b in raise () from /lib/x86_64-linux-gnu/libc.so.6
(gdb) bt
#0  0x00007f61d529800b in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f61d5277859 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f61d54beb1e in libspl_assertf (
    file=file@entry=0x7f61d550ccb1 "libzfs/libzfs_dataset.c",
    func=func@entry=0x7f61d550e670 <__FUNCTION__.20677> "getprop_uint64",
    line=line@entry=2081, format=format@entry=0x7f61d55118bb "%s")
    at libspl/assert.c:54
#3  0x00007f61d54c54ec in libspl_assert (
    buf=buf@entry=0x7f61d550d3f0 "!zhp->zfs_props_table || zhp->zfs_props_table[prop] == B_TRUE",
    func=func@entry=0x7f61d550e670 <__FUNCTION__.20677> "getprop_uint64",
    line=line@entry=2081, file=0x7f61d550ccb1 "libzfs/libzfs_dataset.c")
    at ../lib/libspl/include/assert.h:59
#4  0x00007f61d54c6beb in getprop_uint64 (zhp=zhp@entry=0x56016661a0f0,
    prop=prop@entry=ZFS_PROP_USED, source=source@entry=0x7ffc478c4288)
    at libzfs/libzfs_dataset.c:2081
#5  0x00007f61d54c7145 in get_numeric_property (zhp=0x56016661a0f0,
    prop=ZFS_PROP_USED, src=src@entry=0x0, source=source@entry=0x7ffc478c4288,
    val=val@entry=0x7ffc478c4290) at libzfs/libzfs_dataset.c:2333
#6  0x00007f61d54c72f2 in zfs_prop_get_int (zhp=<optimized out>,
    prop=<optimized out>) at libzfs/libzfs_dataset.c:3045
#7  0x00005601647837a4 in zfs_list_avail_color (zhp=0x56016661a0f0)
    at cmd/zfs/zfs_main.c:3485
--Type <RET> for more, q to quit, c to continue without paging--c
#8  0x0000560164786a0d in print_dataset (zhp=0x56016661a0f0, cb=0x7ffc478c54b0) at cmd/zfs/zfs_main.c:3560
#9  0x0000560164786bfc in list_callback (zhp=0x56016661a0f0, data=<optimized out>) at cmd/zfs/zfs_main.c:3595
#10 0x0000560164783109 in zfs_for_each (argc=<optimized out>, argv=0x560166621100, flags=<optimized out>, types=<optimized out>, sortcol=<optimized out>, proplist=<optimized out>, limit=0, callback=0x560164786bd0 <list_callback>, data=0x7ffc478c54b0) at cmd/zfs/zfs_iter.c:494
#11 0x0000560164788cc6 in zfs_do_list (argc=1, argv=0x560166621100) at cmd/zfs/zfs_main.c:3731
#12 0x000056016478237b in main (argc=5, argv=<optimized out>) at cmd/zfs/zfs_main.c:8796
```