### PR TITLE
module: small fixes for FreeBSD/aarch64

### DIFF
--- a/include/os/freebsd/spl/sys/simd_aarch64.h
+++ b/include/os/freebsd/spl/sys/simd_aarch64.h
@@ -44,13 +44,23 @@
 #define	_FREEBSD_SIMD_AARCH64_H
 
 #include <sys/types.h>
+#include <sys/ucontext.h>
 #include <machine/elf.h>
+#include <machine/fpu.h>
 #include <machine/md_var.h>
+#include <machine/pcb.h>
 
 #define	kfpu_allowed()		1
 #define	kfpu_initialize(tsk)	do {} while (0)
-#define	kfpu_begin()		do {} while (0)
-#define	kfpu_end()		do {} while (0)
+#define	kfpu_begin() do {						\
+	if (__predict_false(!is_fpu_kern_thread(0)))			\
+		fpu_kern_enter(curthread, NULL, FPU_KERN_NOCTX);	\
+} while (0)
+
+#define	kfpu_end() do {							\
+	if (__predict_false(curthread->td_pcb->pcb_fpflags & PCB_FP_NOSAVE)) \
+		fpu_kern_leave(curthread, NULL);			\
+} while (0)
 #define	kfpu_init()		(0)
 #define	kfpu_fini()		do {} while (0)
 

--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -507,6 +507,16 @@ CFLAGS.zstd_lazy.c+= ${__ZFS_ZSTD_AARCH64_FLAGS}
 CFLAGS.zstd_ldm.c+= ${__ZFS_ZSTD_AARCH64_FLAGS}
 CFLAGS.zstd_opt.c+= ${__ZFS_ZSTD_AARCH64_FLAGS}
 
+sha256-armv8.o: sha256-armv8.S
+	${CC} -c ${CFLAGS:N-mgeneral-regs-only} ${WERROR} ${.IMPSRC} \
+	     -o ${.TARGET}
+	${CTFCONVERT_CMD}
+
+sha512-armv8.o: sha512-armv8.S
+	${CC} -c ${CFLAGS:N-mgeneral-regs-only} ${WERROR} ${.IMPSRC} \
+	     -o ${.TARGET}
+	${CTFCONVERT_CMD}
+
 b3_aarch64_sse2.o: b3_aarch64_sse2.S
 	${CC} -c ${CFLAGS:N-mgeneral-regs-only} ${WERROR} ${.IMPSRC} \
 	     -o ${.TARGET}


### PR DESCRIPTION
### Motivation and Context
Following PR #13741, FreeBSD/aarch64 experiences a panic at boot as we try to use FPU instructions while doing the startup benchmarking.

### Description
The primary fix here is to add a proper implementation of kfpu_begin()/kfpu_end() for aarch64, which is implemented much like the x86 version -- fpu_kern(9) to wrap sections that want to do FPU things. I discovered two other issues in the openzfs build while I was forward porting these to the openzfs repo, I fixed one (need to remove -mgeneral-regs-only for sha256/sha512 .S files) and punted on the other one (non-trivial conflict between sys/elf_common.h and spl/sys/vnode.h. More details on the non-trivial conflict in the "resync" commit. (Edit to note: the one I punted on has since been fixed by PR #14674; verbiage about the conflict has been removed from commit messages)

### How Has This Been Tested?
Booted FreeBSD/aarch64 with changes applied. Another change was needed to stop clobbering x18 in the blake2 implementation; @mcmilk said he was working on a patch for this (I tested with a naive patch that "fixed" it but may not have done so properly).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
