### PR TITLE
vdev: expose zfs_vdev_def_queue_depth as a module parameter

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1292,6 +1292,11 @@ as fuller devices will tend to be slower than empty devices.
 Also see
 .Sy zio_dva_throttle_enabled .
 .
+.It Sy zfs_vdev_def_queue_depth Ns = Ns Sy 32 Pq uint
+Default queue depth for each vdev IO allocator.
+Higher values allow for better coalescing of sequential writes before sending
+them to the disk, but can increase transaction commit times.
+.
 .It Sy zfs_vdev_failfast_mask Ns = Ns Sy 1 Pq uint
 Defines if the driver should retire on a given error type.
 The following options may be bitwise-ored together:

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -887,14 +887,6 @@ SYSCTL_UINT(_vfs_zfs, OID_AUTO, top_maxinflight,
 	" (LEGACY)");
 /* END CSTYLED */
 
-extern uint_t zfs_vdev_def_queue_depth;
-
-/* BEGIN CSTYLED */
-SYSCTL_UINT(_vfs_zfs_vdev, OID_AUTO, def_queue_depth,
-	CTLFLAG_RWTUN, &zfs_vdev_def_queue_depth, 0,
-	"Default queue depth for each allocator");
-/* END CSTYLED */
-
 /* zio.c */
 
 /* BEGIN CSTYLED */

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -1119,3 +1119,6 @@ ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, nia_delay, UINT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, queue_depth_pct, UINT, ZMOD_RW,
 	"Queue depth percentage for each top-level vdev");
+
+ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, def_queue_depth, UINT, ZMOD_RW,
+	"Default queue depth for each allocator");


### PR DESCRIPTION
### Motivation and Context

One of our customers needs to modify the `zfs_vdev_def_queue_depth` parameter, but it was not exposed to Linux.

### Description

Makes `zfs_vdev_def_queue_depth` a regular `ZFS_MODULE_PARAM`.

### How Has This Been Tested?

Compiled on Linux and FreeBSD correctly, confirmed that parameter is visible under `/sys/modules/zfs/parameters`.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
