### PR TITLE
Do not persist user/group/project quota zap objects when unneeded

### DIFF
--- a/module/zfs/zfs_quota.c
+++ b/module/zfs/zfs_quota.c
@@ -347,18 +347,32 @@ zfs_set_userquota(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
 	if (*objp == 0) {
 		*objp = zap_create(zfsvfs->z_os, DMU_OT_USERGROUP_QUOTA,
 		    DMU_OT_NONE, 0, tx);
-		VERIFY(0 == zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
+		VERIFY0(zap_add(zfsvfs->z_os, MASTER_NODE_OBJ,
 		    zfs_userquota_prop_prefixes[type], 8, 1, objp, tx));
 	}
-	mutex_exit(&zfsvfs->z_lock);
 
 	if (quota == 0) {
 		err = zap_remove(zfsvfs->z_os, *objp, buf, tx);
 		if (err == ENOENT)
 			err = 0;
+		/*
+		 * If the quota contains no more entries after the entry
+		 * was removed, destroy the quota zap and remove the
+		 * reference from zfsvfs. This will save us unnecessary
+		 * zap_lookups for the quota during writes.
+		 */
+		uint64_t zap_nentries;
+		VERIFY0(zap_count(zfsvfs->z_os, *objp, &zap_nentries));
+		if (zap_nentries == 0) {
+			VERIFY0(zap_remove(zfsvfs->z_os, MASTER_NODE_OBJ,
+			    zfs_userquota_prop_prefixes[type], tx));
+			VERIFY0(zap_destroy(zfsvfs->z_os, *objp, tx));
+			*objp = 0;
+		}
 	} else {
 		err = zap_update(zfsvfs->z_os, *objp, buf, 8, 1, &quota, tx);
 	}
+	mutex_exit(&zfsvfs->z_lock);
 	ASSERT(err == 0);
 	if (fuid_dirtied)
 		zfs_fuid_sync(zfsvfs, tx);


### PR DESCRIPTION
### Motivation and Context

This change provides up to a ~300% performance improvement in the case where a user creates a zpool and adds a user/group/project quota, and then removes all  user/group/project quotas. In this case, today the write path will still do a zap_lookup on the quota object(s). Even when all quotas are deleted. 


### Description

In the zfs_id_over*quota functions, there is a short-circuit to skip the zap_lookup when the quota zap does not exist. If quotas are never used in a zpool, then the quota zap will never exist. But if user/group/project quotas are ever used, the zap objects will be created and will persist even if the quotas are deleted.

The quota zap_lookup in the write path can become a bottleneck for write-heavy small I/O workloads. Before this commit, it was not possible to remove this lookup without creating a new zpool.

During a write-heavy workload I was testing, I realized that these zap objects are a huge contributor to the total usage of zap_lookup:

```
[root@ip-198-19-76-37 ~]# bpftrace -e 'kprobe:zap_lookup { @[arg1] = count(); }'
Attaching 1 probe...
^C

@[130]: 264
@[1]: 343
@[2]: 390000
@[3]: 390000

[root@ip-198-19-76-37 ~]# zdb -d fsx/ 2:3
Dataset fsx [ZPL], ID 54, cr_txg 1, 204M, 25008 objects

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         2    1   128K    512      0     512    512  100.00  ZFS user/group/project quota
         3    1   128K    512      0     512    512  100.00  ZFS user/group/project quota
```

And a big contributor to CPU. In one of my workloads, ~90%  of CPU time is spent in zfs_id_overblockquota:

<img width="1199" alt="write_heavy_flame" src="https://user-images.githubusercontent.com/10247556/230084616-aa373d27-c4e2-4451-b7ec-ca1e25107db1.png">

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Created some user/group quotas and did some writes. Then verified that when I set my user/group quotas back to 0, the quota zap object is removed.

```
[root@ip-198-19-83-180 ~]# zdb -dd myds | grep project
        -1    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -2    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -3    1   128K    512      0     512    512  100.00  ZFS user/group/project used
         2    1   128K    512      0     512    512  100.00  ZFS user/group/project quota
         3    1   128K    512      0     512    512  100.00  ZFS user/group/project quota
[root@ip-198-19-83-180 ~]# zfs set userquota@0=0 myds
[root@ip-198-19-83-180 ~]# zfs set groupquota@0=0 myds
[root@ip-198-19-83-180 ~]# zdb -dd myds | grep project
        -1    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -2    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -3    1   128K    512      0     512    512  100.00  ZFS user/group/project used
```

A few test cases run with ior, comparing performance before/after this change when I added and then removed quotas on my file system:

* **No Quota Throughput**: throughput achieved on a server with zfs including this commit
* **Quota Throughput**: throughput achieved on a server with zfs 2.1.7
* **No Quota IOPS**: IOPS achieved on a server with zfs including this commit
* **Quota IOPS**: IOPS achieved on a server with zfs 2.1.7

![zfs_quota_write_zstd_6x](https://user-images.githubusercontent.com/10247556/230087100-0f954c9e-87db-498a-a004-4472131a3a3c.png)

![zfs_quota_write_zstd_7000x](https://user-images.githubusercontent.com/10247556/230087128-75b29a00-032b-4a0d-8547-7b7d0727ad52.png)

![zfs_quota_write_no_compression](https://user-images.githubusercontent.com/10247556/230087143-ee29ad36-3ad0-42d3-a6ca-20c673759ce1.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
