### PR TITLE
initramfs: source user/vendor scripts from /etc/zfs/initramfs-tools-load-key{,.d/*}

### DIFF
--- a/contrib/initramfs/hooks/zfs.in
+++ b/contrib/initramfs/hooks/zfs.in
@@ -41,6 +41,9 @@ copy_file cache  "@sysconfdir@/zfs/zpool.cache"
 copy_file config "@initconfdir@/zfs"
 copy_file config "@sysconfdir@/zfs/zfs-functions"
 copy_file config "@sysconfdir@/zfs/vdev_id.conf"
+for f in "@sysconfdir@/zfs/initramfs-tools-load-key" "@sysconfdir@/zfs/initramfs-tools-load-key.d/"*; do
+	copy_file config "$f"
+done
 copy_file rule   "@udevruledir@/60-zvol.rules"
 copy_file rule   "@udevruledir@/69-vdev.rules"
 

--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -420,6 +420,16 @@ decrypt_fs()
 			# Continue only if the key needs to be loaded
 			[ "$KEYSTATUS" = "unavailable" ] || return 0
 
+			# Try extensions first
+			for f in "/etc/zfs/initramfs-tools-load-key" "/etc/zfs/initramfs-tools-load-key.d/"*; do
+				[ -r "$f" ] || continue
+				(. "$f") && {
+					# Successful return and actually-loaded key: we're done
+					KEYSTATUS="$(get_fs_value "${ENCRYPTIONROOT}" keystatus)"
+					[ "$KEYSTATUS" = "unavailable" ] || return 0
+				}
+			done
+
 			# Do not prompt if key is stored noninteractively,
 			if ! [ "${KEYLOCATION}" = "prompt" ]; then
 				$ZFS load-key "${ENCRYPTIONROOT}"


### PR DESCRIPTION
### Motivation and Context
By dropping in a file in a directory (for packages) or by making a file (for local administrators), custom key loading methods may be provided for the rootfs and necessities.

Supersedes #14704, see https://github.com/openzfs/zfs/pull/14704#issuecomment-1502493723

### Description
For a
```
Adding config /etc/zfs/initramfs-tools-load-key
Adding config /etc/zfs/initramfs-tools-load-key.d/console
```
where the first is unhelpful and the second just logs stuff we get:
```
[    4.134300] Buffer I/O error on dev fd0, logical block 0, async page read
done.
done.
+ echo zoot2-zoot
zoot2-zoot
+ echo prompt
prompt
+ echo /sbin/zfs
/sbin/zfs
+ echo /sbin/zpool
/sbin/zpool
+ KEYLOCATION=file:///init
+ b2sum /init
/init: /etc/zfs/initramfs-tools-load-key: line 9: b2sum: not found
+ key=
+ return
console
Enter passphrase for 'zoot2-zoot':
Begin: Mounting 'zoot2-zoot' on '/root//' ... done.
+ echo zoot2-zoot/etc
zoot2-zoot/etc
+ echo prompt
prompt
+ echo /sbin/zfs
/sbin/zfs
+ echo /sbin/zpool
/sbin/zpool
+ KEYLOCATION=file:///init
+ b2sum /init
/init: /etc/zfs/initramfs-tools-load-key: line 9: b2sum: not found
+ key=
+ return
console
Enter passphrase for 'zoot2-zoot/etc':
```

and when the first loads both keys:
```

[    3.922498] Buffer I/O error on dev fd0, logical block 0, async page read
done.
done.
+ echo zoot2-zoot
zoot2-zoot
+ echo prompt
prompt
+ echo /sbin/zfs
/sbin/zfs
+ echo /sbin/zpool
/sbin/zpool
+ key=dupanina
+ printf '%s\n'+  dupanina
/sbin/zfs load-key -L prompt zoot2-zoot
Begin: Mounting 'zoot2-zoot' on '/root//' ... done.
+ echo zoot2-zoot/etc
zoot2-zoot/etc
+ echo prompt
prompt
+ echo /sbin/zfs
/sbin/zfs
+ echo /sbin/zpool
/sbin/zpool
+ key=dupanina
+ printf '%s\n' dupanina
+ /sbin/zfs load-key -L prompt zoot2-zoot/etc
Key load error: Incorrect key provided for 'zoot2-zoot/etc'.
+ key=dupanina2
+ printf '%s\n' dupanina2
+ /sbin/zfs load-key -L prompt zoot2-zoot/etc
Begin: Mounting 'zoot2-zoot/etc' on '/root//etc' ... done.
Begin: Mounting 'zoot2-zoot/home' on '/root//home' ... done.
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
