### PR TITLE
Linux 6.3 compat: Fix memcpy "detected field-spanning write" error

### DIFF
--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -120,6 +120,10 @@ extern "C" {
 #define	DN_MAX_LEVELS	(DIV_ROUND_UP(DN_MAX_OFFSET_SHIFT - SPA_MINBLOCKSHIFT, \
 	DN_MIN_INDBLKSHIFT - SPA_BLKPTRSHIFT) + 1)
 
+/*
+ * Use the flexible array instead of the fixed length one dn_bonus
+ * to address memcpy/memmove fortify error
+ */
 #define	DN_BONUS(dnp)	((void*)((dnp)->dn_bonus_flexible + \
 	(((dnp)->dn_nblkptr - 1) * sizeof (blkptr_t))))
 #define	DN_MAX_BONUS_LEN(dnp) \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Signed-off-by: Youzhong Yang <yyang@mathworks.com>

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The following errors were observed when running zfs test suite:

```
[ 1667.309351] memcpy: detected field-spanning write (size 3904) of single field "((void*)((dn->dn_phys)->dn_bonus + (((dn->dn_phys)->dn_nblkptr - 1) * sizeof (blkptr_t))))" at /tmp/zfs-build-root-YvJzdwOd/BUILD/zfs-kmod-2.1.99/_kmod_build_6.3.0-0.rc5.20230405git76f598ba7d8e.44.fc39.x86_64/../zfs-2.1.99/module/zfs/dbuf.c:4112 (size 320)
```

```
[ 1667.357445] memcpy: detected field-spanning write (size 3904) of single field "((void*)((&ddnp[i])->dn_bonus + (((&ddnp[i])->dn_nblkptr - 1) * sizeof (blkptr_t))))" at /tmp/zfs-build-root-YvJzdwOd/BUILD/zfs-kmod-2.1.99/_kmod_build_6.3.0-0.rc5.20230405git76f598ba7d8e.44.fc39.x86_64/../zfs-2.1.99/module/os/linux/zfs/zio_crypt.c:902 (size 320)
```

The fortified memcpy() and memmove() starting from Linux kernel 6.1+ will generate the above warning message when copying bonus data of more than 320 bytes into the dnode_phys_t.

The error could be reproduced by /usr/share/zfs/zfs-tests.sh -T zfs_diff.

### Description
<!--- Describe your changes in detail -->
Add a new union member of flexible array to dnode_phys_t and use it in the macro so we can silence the memcpy() fortify error.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
