### PR TITLE
Linux: Fix build warnings from LLVM/Clang 15.0.7

### DIFF
--- a/include/os/linux/zfs/sys/trace_zil.h
+++ b/include/os/linux/zfs/sys/trace_zil.h
@@ -152,6 +152,9 @@
  *     zilog_t *, ...,
  *     itx_t *, ...);
  */
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wordered-compare-function-pointers"
 /* BEGIN CSTYLED */
 DECLARE_EVENT_CLASS(zfs_zil_process_itx_class,
 	TP_PROTO(zilog_t *zilog, itx_t *itx),
@@ -169,6 +172,7 @@ DECLARE_EVENT_CLASS(zfs_zil_process_itx_class,
 	    ZILOG_TP_PRINTK_ARGS, ITX_TP_PRINTK_ARGS)
 );
 /* END CSTYLED */
+#pragma clang diagnostic pop
 
 #define	DEFINE_ZIL_PROCESS_ITX_EVENT(name) \
 DEFINE_EVENT(zfs_zil_process_itx_class, name, \

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -2466,8 +2466,7 @@ zfs_zaccess_trivial(znode_t *zp, uint32_t *working_mode, cred_t *cr,
 
 #if (defined(HAVE_IOPS_PERMISSION_USERNS) || \
 	defined(HAVE_IOPS_PERMISSION_IDMAP))
-	if (mnt_ns)
-		err = generic_permission(mnt_ns, ZTOI(zp), mask);
+	err = generic_permission(mnt_ns, ZTOI(zp), mask);
 #else
 	err = generic_permission(ZTOI(zp), mask);
 #endif


### PR DESCRIPTION
### Motivation and Context
I recently needed to build a recent kernel on a Ubuntu 18.04 system with sanitizers that required a much more recent compiler than those included with Ubuntu 18.04. The first modern compiler that I got working on it was LLVM/Clang 15.0.7, so I built both the kernel and ZFS with it, only to discover that -Werror causes build failures because of issues that go uncaught because almost nobody builds the Linux kernel modules with LLVM/Clang.

This was done by Klara Systems and sponsored by Wasabi Technology, Inc.

### Description
The individual patches have descriptions.

### How Has This Been Tested?
Here are some rough instructions describing how I tested this.

I first installed pkgsrc:

```
cd $HOME
CVS_RSH=ssh cvs -danoncvs@anoncvs.NetBSD.org:/cvsroot checkout -P pkgsrc
cd pkgsrc/bootstrap
./bootstrap --prefer-pkgsrc yes --make-jobs $(nproc)
PATH="/usr/pkg/bin:$PATH"
MANPATH="/usr/pkg/man:$MANPATH"
cd ../lang/clang
sudo bmake install clean
```

I then built Linux roughly this way:

```
cd $HOME
git clone https://gitlab.com/linux-kernel/stable.git linux
cd linux
git checkout v6.3-rc6
cp /boot/config-5.3.0-26-generic .config
make CC=clang HOSTCC=clang -j$(nproc) olddefconfig
make CC=clang HOSTCC=clang -j$(nproc)
sudo make CC=clang HOSTCC=clang -j$(nproc) modules_install
```

For ZFS, I had a local branch that I rebased on master, but the commands to do the same with master are roughly this:

```
cd $HOME
git clone https://github.com/openzfs/zfs.git
cd zfs
git clean -xdf
./autogen.sh
CC=clang KERNEL_CC=clang ./configure --enable-debug --enable-debuginfo --with-config=all --with-linux="${HOME}/linux" --with-linux-obj="${HOME}/linux"
make -j$(nproc)
```

The make command will fail without these patches.

I needed to install new firmware for the newer kernel's NIC driver:

```
cd $HOME
git clone git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
sudo cp linux-firmware/bnx2x/*7.13.21* linux-firmware/bnx2x/*7.13.15* /lib/firmware/bnx2x/
```

There is a debian bug for that:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1006500

There is a weird bug in the kernel's block device driver for the controller that has the drive with the rootfs where it requires the partitions to be reprobed when kexec booting (it affects older kernels, although I have yet to confirm it also affects the latest), so I installed dracut and modified it to reprobe all devices:

```
sudo -i
apt install dracut
mkdir /usr/lib/dracut/modules.d/70fix-boot
cat > /usr/lib/dracut/modules.d/70fix-boot/fix-boot.sh << END
#!/bin/sh

. /lib/dracut-lib.sh

modprobe mpt3sas
modprobe smartpqi

sleep 1

for i in /dev/sd[a-z] /dev/sd[a-z][a-z]; do
        blockdev --rereadpt "\${i}"
done;
END

cat > /usr/lib/dracut/modules.d/70fix-boot/module-setup.sh << END
#!/bin/bash

check() {
        return 0
}

# called by dracut
installkernel() {
    :
}

# called by dracut
install() {
    inst_hook pre-udev 10 "\$moddir/fix-boot.sh"
    inst /sbin/blockdev
}
END
chmod u+x /usr/lib/dracut/modules.d/70fix-boot/*
exit
```

Then I kexec booted into the new kernel after building an initramfs archive:

```
sudo dracut --early-microcode --force ${HOME}/initrd.img-6.3.0-rc6 6.3.0-rc6

sudo -i kexec --type="bzImage" -l ${HOME}/linux/arch/x86/boot/bzImage --initrd=${HOME}/initrd.img-6.3.0-rc6 --command-line="$(cat /proc/cmdline)" --console-vga --real-mode --noefi

sudo -i systemctl kexec
```

After reconnecting to the machine over SSH, I was able to load the kernel modules:

```
ssh ...
cd zfs
sudo ./scripts/zfs.sh -v -r
```

Then I simply imported the pool and ran a workload on it. Everything worked.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
