### PR TITLE
Work around Raspberry Pi kernel packaging oddities

### DIFF
--- a/contrib/debian/control.modules.in
+++ b/contrib/debian/control.modules.in
@@ -5,7 +5,7 @@ Maintainer: ZFS on Linux specific mailing list <zfs-discuss@list.zfsonlinux.org>
 Build-Depends: debhelper-compat (= 10),
                dkms (>> 2.1.1.2-5),
                libtool,
-               linux-headers-_KVERS_
+               linux-headers-_KVERS_ | raspberrypi-kernel-headers
 Standards-Version: 4.3.0
 Homepage: http://www.openzfs.org/
 Vcs-Git: https://github.com/openzfs/zfs.git
@@ -14,7 +14,7 @@ Vcs-Browser: https://github.com/openzfs/zfs
 Package: openzfs-zfs-modules-_KVERS_
 Architecture: _ARCH_
 Provides: openzfs-zfs-modules
-Depends: linux-image-_KVERS_
+Depends: linux-image-_KVERS_ | raspberrypi-kernel
 Recommends: openzfsutils
 Replaces: zfs-modules-_KVERS_
 Conflicts: zfs-modules-_KVERS_


### PR DESCRIPTION
On Debian and Ubuntu and friends, you get something like "linux-image-$(uname -r)" and "linux-headers-$(uname -r)" you can put a Depends on.

On Raspberry Pi OS, you get "raspberrypi-kernel" and "raspberrypi-kernel-headers", with version numbers like 20230411-1.

There is not, as far as I can tell, a reasonable way to map that to a kernel version short of reaching out and digging around in the changelogs or Makefile, so just special-case it so the packages don't fail to install at install time. They still might not work if the versions don't match, but I don't see a way to do anything about that...

### Motivation and Context
Someone reported that trying to build the native-deb packages on the artist formerly known as Raspbian broke at install time, and it turned out to be from an unmeetable dependency on linux-image-$(uname -r).

### Description
Just add a special case for Raspbian to not check the exact version built against, otherwise this can never work.

It still might not work, but since using Raspbian you can't have multiple kernel packages installed at a time, this seems like the best you're going to get, unless you just add a hard dependency on the exact version and break on, say, 20221104-2...

### How Has This Been Tested?
It built for the person originally reporting the problem.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
