### PR TITLE
Revert "ZFS_IOC_COUNT_FILLED does unnecessary txg_wait_synced()"

### DIFF
--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1764,29 +1764,20 @@ dnode_try_claim(objset_t *os, uint64_t object, int slots)
 }
 
 /*
- * Checks if the dnode might contain any uncommitted changes to data blocks.
- * Dirty metadata (e.g. bonus buffer) does not count.
+ * Checks if the dnode contains any uncommitted dirty records.
  */
 boolean_t
 dnode_is_dirty(dnode_t *dn)
 {
 	mutex_enter(&dn->dn_mtx);
+
 	for (int i = 0; i < TXG_SIZE; i++) {
-		list_t *list = &dn->dn_dirty_records[i];
-		for (dbuf_dirty_record_t *dr = list_head(list);
-		    dr != NULL; dr = list_next(list, dr)) {
-			if (dr->dr_dbuf == NULL ||
-			    (dr->dr_dbuf->db_blkid != DMU_BONUS_BLKID &&
-			    dr->dr_dbuf->db_blkid != DMU_SPILL_BLKID)) {
-				mutex_exit(&dn->dn_mtx);
-				return (B_TRUE);
-			}
-		}
-		if (dn->dn_free_ranges[i] != NULL) {
+		if (multilist_link_active(&dn->dn_dirty_link[i])) {
 			mutex_exit(&dn->dn_mtx);
 			return (B_TRUE);
 		}
 	}
+
 	mutex_exit(&dn->dn_mtx);
 
 	return (B_FALSE);
@@ -2650,9 +2641,7 @@ dnode_next_offset(dnode_t *dn, int flags, uint64_t *offset,
 		rw_enter(&dn->dn_struct_rwlock, RW_READER);
 
 	if (dn->dn_phys->dn_nlevels == 0) {
-		if (!(flags & DNODE_FIND_HOLE)) {
-			error = SET_ERROR(ESRCH);
-		}
+		error = SET_ERROR(ESRCH);
 		goto out;
 	}
 


### PR DESCRIPTION
### Motivation and Context
This reverts commit 4b3133e671b958fa2c915a4faf57812820124a7b.

### Description
Users identified this commit as a possible source of data corruption: https://github.com/openzfs/zfs/issues/14753

### How Has This Been Tested?
Test build only

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
