### PR TITLE
ZTS: zvol_misc_trim retry busy export

### DIFF
--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_trim.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_trim.ksh
@@ -125,12 +125,12 @@ log_must $trimcmd $zvolpath
 
 
 set_blk_mq 1
-log_must zpool export $TESTPOOL
+log_must_busy zpool export $TESTPOOL
 log_must zpool import $TESTPOOL
 do_test
 
 set_blk_mq 0
-log_must zpool export $TESTPOOL
+log_must_busy zpool export $TESTPOOL
 log_must zpool import $TESTPOOL
 do_test
 


### PR DESCRIPTION
### Motivation and Context

CI failures such as:

http://build.zfsonlinux.org/builders/Fedora%2037%20x86_64%20%28TEST%29/builds/124/steps/shell_4/logs/summary

```
Test: /usr/share/zfs/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_trim (run as root) [00:00] [FAIL]
03:52:08.75 /etc/sudoers:89:24: invalid operator "+=" for "exempt_group"
03:52:08.81 ASSERTION: Verify that a ZFS volume can be TRIMed
03:52:08.82 SUCCESS: zfs set compression=off testpool/testvol
03:52:08.85 SUCCESS: blkdiscard --force /dev/zvol/testpool/testvol
03:52:08.85 0
03:52:08.85 SUCCESS: set_tunable32 VOL_USE_BLK_MQ 1
03:52:08.88 cannot export 'testpool': pool is busy
03:52:08.88 ERROR: zpool export testpool exited 1
03:52:08.88 NOTE: Performing test-fail callback (/usr/share/zfs/zfs-tests/callbacks/zfs_dbgmsg.ksh)
```

### Description

Retry the export if the pool is busy due to an open zvol. Observed in the CI on Fedora 37.

This change does not attempt to resolve the 'invalid operator "+=" for "exempt_group"' error.

### How Has This Been Tested?

The same retry when busy helper has been used elsewhere in the test suite.  I'm relying on the CI to verify this fix.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
