### PR TITLE
zpool import -m also removing spare and cache when log device is missing

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6378,6 +6378,16 @@ spa_tryimport(nvlist_t *tryconfig)
 		spa->spa_config_source = SPA_CONFIG_SRC_SCAN;
 	}
 
+	/*
+	 * spa_import() relies on a pool config fetched by spa_try_import()
+	 * for spare/cache devices. Import flags are not passed to
+	 * spa_tryimport(), which makes it return early due to a missing log
+	 * device and missing retrieving the cache device and spare eventually.
+	 * Passing ZFS_IMPORT_MISSING_LOG to spa_tryimport() makes it fetch
+	 * the correct configuration regardless of the missing log device.
+	 */
+	spa->spa_import_flags |= ZFS_IMPORT_MISSING_LOG;
+
 	error = spa_load(spa, SPA_LOAD_TRYIMPORT, SPA_IMPORT_EXISTING);
 
 	/*

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -422,7 +422,7 @@ tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
     'import_cachefile_mirror_detached',
     'import_cachefile_paths_changed',
     'import_cachefile_shared_device',
-    'import_devices_missing',
+    'import_devices_missing', 'import_log_missing',
     'import_paths_changed',
     'import_rewind_config_changed',
     'import_rewind_device_replaced']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1056,6 +1056,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_import/import_cachefile_paths_changed.ksh \
 	functional/cli_root/zpool_import/import_cachefile_shared_device.ksh \
 	functional/cli_root/zpool_import/import_devices_missing.ksh \
+	functional/cli_root/zpool_import/import_log_missing.ksh \
 	functional/cli_root/zpool_import/import_paths_changed.ksh \
 	functional/cli_root/zpool_import/import_rewind_config_changed.ksh \
 	functional/cli_root/zpool_import/import_rewind_device_replaced.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/import_log_missing.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/import_log_missing.ksh
@@ -1,0 +1,75 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_import/zpool_import.kshlib
+
+#
+# DESCRIPTION:
+#	Import with missing log device should not remove spare/cache.
+#
+# STRATEGY:
+#	1. Create a pool.
+#	2. Add spare, cache and log devices to the pool.
+#	3. Export the pool.
+#	4. Remove the log device.
+#	5. Import the pool with -m flag.
+#	6. Verify that spare and cache are still present in the pool.
+#
+
+verify_runnable "global"
+
+log_onexit cleanup
+
+function test_missing_log
+{
+	typeset poolcreate="$1"
+	typeset cachevdev="$2"
+	typeset sparevdev="$3"
+	typeset logvdev="$4"
+	typeset missingvdev="$4"
+
+	log_note "$0: pool '$poolcreate', adding $cachevdev, $sparevdev," \
+		"$logvdev then moving away $missingvdev."
+
+	log_must zpool create $TESTPOOL1 $poolcreate
+
+	log_must zpool add $TESTPOOL1 cache $cachevdev spare $sparevdev \
+		log $logvdev
+
+	log_must_busy zpool export $TESTPOOL1
+
+	log_must mv $missingvdev $BACKUP_DEVICE_DIR
+
+	log_must zpool import -m -d $DEVICE_DIR $TESTPOOL1
+
+	CACHE_PRESENT=$(zpool status -v $TESTPOOL1 | grep $cachevdev)
+
+	SPARE_PRESENT=$(zpool status -v $TESTPOOL1 | grep $sparevdev)
+
+	if [ -z "$CACHE_PRESENT"] || [ -z "SPARE_PRESENT"]
+	then
+		log_fail "cache/spare vdev missing after importing with missing" \
+			"log device"
+	fi
+
+	# Cleanup
+	log_must zpool destroy $TESTPOOL1
+
+	log_note ""
+}
+
+log_must mkdir -p $BACKUP_DEVICE_DIR
+
+test_missing_log "$VDEV0" "$VDEV1" "$VDEV2" "$VDEV3"
+
+log_pass "zpool import succeeded with missing log device"


### PR DESCRIPTION
`spa_import()` relies on a pool config fetched by `spa_try_import()` for spare/cache devices. Import flags are not passed to `spa_tryimport()`, which makes it return early due to a missing log device and missing retrieving the cache device and spare eventually. Passing `ZFS_IMPORT_MISSING_LOG` to `spa_tryimport()` makes it fetch the correct configuration regardless of the missing log device.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### How Has This Been Tested?
- Create a zfs pool: `zpool create -f tank nvme0n1 cache nvme1n1 spare nvme2n1 log nvme3n1`
- Check pool status:
```
$ zpool status tank
	NAME        STATE     READ WRITE CKSUM
	tank        ONLINE       0     0     0
	  nvme0n1   ONLINE       0     0     0
	logs	
	  nvme3n1   ONLINE       0     0     0
	cache
	  nvme1n1   ONLINE       0     0     0
	spares
	  nvme2n1   AVAIL    
```
- Export the pool: `zpool export tank`
- Pull nvme3n1 drive, i.e., log device.
- Import the pool: `zpool import -m tank`
- Check the pool status again:
```
$ zpool status tank
	NAME                   STATE     READ WRITE CKSUM
	tank                   DEGRADED     0     0     0
	  nvme0n1              ONLINE       0     0     0
	logs	
	  1797033476626228610  UNAVAIL      0     0     0  was /dev/nvme3n1p1
```
- Expected pool status:
```
$ zpool status tank
	NAME                    STATE     READ WRITE CKSUM
	tank                    DEGRADED     0     0     0
	  nvme0n1               ONLINE       0     0     0
	logs	
	  15191547688177894754  UNAVAIL      0     0     0  was /dev/nvme3n1p1
	cache
	  nvme1n1               ONLINE       0     0     0
	spares
	  nvme2n1               AVAIL   
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
