### PR TITLE
tests/zdb_encrypted: parse numbers a little more robustly

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_encrypted.ksh
@@ -55,8 +55,8 @@ log_must eval "echo $PASSPHRASE | zfs create -o mountpoint=$TESTDIR2" \
 
 echo 'my great encrypted text' > $file
 
-obj="$(ls -i $file | cut -d' ' -f1)"
-size="$(wc -c < $file)"
+typeset -i obj=$(ls -i $file | cut -d' ' -f1)
+typeset -i size=$(wc -c < $file)
 
 log_note "test file $file is objid $obj, size $size"
 


### PR DESCRIPTION
### Motivation and Context

`zdb_encrypted` fails on FreeBSD. #14791.

### Description

On FreeBSD, `wc` prints some leading spaces, while on Linux it does not. So we tell ksh to expect an integer, and it does the rest.

### How Has This Been Tested?

Hand-tested on Linux and FreeBSD.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
