### PR TITLE
Fix checkstyle warning

### DIFF
--- a/module/os/freebsd/zfs/zfs_ctldir.c
+++ b/module/os/freebsd/zfs/zfs_ctldir.c
@@ -686,7 +686,7 @@ zfsctl_root_readdir(struct vop_readdir_args *ap)
 	 * The check below facilitates the idiom of repeating calls until the
 	 * count to return is 0.
 	 */
-	if (zfs_uio_offset(&uio) == 3 * sizeof(entry)) {
+	if (zfs_uio_offset(&uio) == 3 * sizeof (entry)) {
 		return (0);
 	}
 


### PR DESCRIPTION
### Motivation and Context

Keep the code clean.

### Description

Resolve a checkstyle warning  I accidentally overlooked when merging e37a89d5d0ba07da09998de6701a6c0ec43903b7.

### How Has This Been Tested?

`make checkstyle`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
