### PR TITLE
WIP: ZIL: Remove big memory copies from zl_issuer_lock.

### DIFF
--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -93,6 +93,8 @@ abd_t *abd_alloc_for_io(size_t, boolean_t);
 abd_t *abd_alloc_sametype(abd_t *, size_t);
 boolean_t abd_size_alloc_linear(size_t);
 void abd_gang_add(abd_t *, abd_t *, boolean_t);
+void abd_gang_add_buf(abd_t *, void *, size_t);
+void abd_gang_add_zeros(abd_t *, size_t);
 void abd_free(abd_t *);
 abd_t *abd_get_offset(abd_t *, size_t);
 abd_t *abd_get_offset_size(abd_t *, size_t, size_t);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -570,7 +570,7 @@ int dmu_buf_hold(objset_t *os, uint64_t object, uint64_t offset,
     const void *tag, dmu_buf_t **, int flags);
 int dmu_buf_hold_array(objset_t *os, uint64_t object, uint64_t offset,
     uint64_t length, int read, const void *tag, int *numbufsp,
-    dmu_buf_t ***dbpp);
+    dmu_buf_t ***dbpp, uint32_t flags);
 int dmu_buf_hold_by_dnode(dnode_t *dn, uint64_t offset,
     const void *tag, dmu_buf_t **dbp, int flags);
 int dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset,
@@ -1047,8 +1047,11 @@ typedef struct zgd {
 	struct lwb	*zgd_lwb;
 	struct blkptr	*zgd_bp;
 	dmu_buf_t	*zgd_db;
+	dmu_buf_t	**zgd_dbp;
+	int		zgd_dbn;
 	struct zfs_locked_range *zgd_lr;
 	void		*zgd_private;
+	struct zgd	*zgd_next;
 } zgd_t;
 
 typedef void dmu_sync_cb_t(zgd_t *arg, int error);

--- a/include/sys/zfs_vnops.h
+++ b/include/sys/zfs_vnops.h
@@ -55,5 +55,6 @@ extern void update_pages(znode_t *, int64_t, int, objset_t *);
 extern void zfs_zrele_async(znode_t *zp);
 
 extern zil_get_data_t zfs_get_data;
+extern zil_done_data_t zfs_done_data;
 
 #endif

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -535,8 +535,9 @@ typedef int zil_parse_blk_func_t(zilog_t *zilog, const blkptr_t *bp, void *arg,
 typedef int zil_parse_lr_func_t(zilog_t *zilog, const lr_t *lr, void *arg,
     uint64_t txg);
 typedef int zil_replay_func_t(void *arg1, void *arg2, boolean_t byteswap);
-typedef int zil_get_data_t(void *arg, uint64_t arg2, lr_write_t *lr, char *dbuf,
-    struct lwb *lwb, zio_t *zio);
+typedef int zil_get_data_t(void *arg, uint64_t arg2, lr_write_t *lr,
+    struct lwb *lwb, boolean_t usegang);
+typedef void zil_done_data_t(struct lwb *lwb);
 
 extern int zil_parse(zilog_t *zilog, zil_parse_blk_func_t *parse_blk_func,
     zil_parse_lr_func_t *parse_lr_func, void *arg, uint64_t txg,
@@ -549,7 +550,7 @@ extern zilog_t	*zil_alloc(objset_t *os, zil_header_t *zh_phys);
 extern void	zil_free(zilog_t *zilog);
 
 extern zilog_t	*zil_open(objset_t *os, zil_get_data_t *get_data,
-    zil_sums_t *zil_sums);
+    zil_done_data_t *done_data, zil_sums_t *zil_sums);
 extern void	zil_close(zilog_t *zilog);
 
 extern boolean_t zil_replay(objset_t *os, void *arg,
@@ -578,6 +579,7 @@ extern void	zil_clean(zilog_t *zilog, uint64_t synced_txg);
 extern int	zil_suspend(const char *osname, void **cookiep);
 extern void	zil_resume(void *cookie);
 
+extern void	zil_lwb_add_buf(struct lwb *lwb);
 extern void	zil_lwb_add_block(struct lwb *lwb, const blkptr_t *bp);
 extern void	zil_lwb_add_txg(struct lwb *lwb, uint64_t txg);
 extern int	zil_bp_tree_add(zilog_t *zilog, const blkptr_t *bp);

--- a/include/sys/zil_impl.h
+++ b/include/sys/zil_impl.h
@@ -90,13 +90,17 @@ typedef enum {
  */
 typedef struct lwb {
 	zilog_t		*lwb_zilog;	/* back pointer to log struct */
+	void		*lwb_private;	/* private storage for get_data() */
 	blkptr_t	lwb_blk;	/* on disk address of this log blk */
 	boolean_t	lwb_fastwrite;	/* is blk marked for fastwrite? */
 	boolean_t	lwb_slog;	/* lwb_blk is on SLOG device */
-	int		lwb_nused;	/* # used bytes in buffer */
+	int		lwb_bused;	/* # used bytes in buffer */
+	int		lwb_badded;	/* # buffer bytes added to block */
+	int		lwb_nused;	/* # used bytes in block */
 	int		lwb_sz;		/* size of block and buffer */
 	lwb_state_t	lwb_state;	/* the state of this lwb */
 	char		*lwb_buf;	/* log write buffer */
+	abd_t		*lwb_abd;	/* Gang ABD passed to write ZIO */
 	zio_t		*lwb_write_zio;	/* zio for the lwb buffer */
 	zio_t		*lwb_root_zio;	/* root zio for lwb write and flushes */
 	uint64_t	lwb_issued_txg;	/* the txg when the write is issued */
@@ -176,6 +180,7 @@ struct zilog {
 	const zil_header_t *zl_header;	/* log header buffer */
 	objset_t	*zl_os;		/* object set we're logging */
 	zil_get_data_t	*zl_get_data;	/* callback to get object content */
+	zil_done_data_t	*zl_done_data;	/* callback to release object content */
 	lwb_t		*zl_last_lwb_opened; /* most recent lwb opened */
 	hrtime_t	zl_last_lwb_latency; /* zio latency of last lwb done */
 	uint64_t	zl_lr_seq;	/* on-disk log record sequence number */

--- a/include/sys/zvol_impl.h
+++ b/include/sys/zvol_impl.h
@@ -84,8 +84,8 @@ void zvol_log_truncate(zvol_state_t *zv, dmu_tx_t *tx, uint64_t off,
     uint64_t len, boolean_t sync);
 void zvol_log_write(zvol_state_t *zv, dmu_tx_t *tx, uint64_t offset,
     uint64_t size, int sync);
-int zvol_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
-    struct lwb *lwb, zio_t *zio);
+zil_get_data_t zvol_get_data;
+zil_done_data_t zvol_done_data;
 int zvol_init_impl(void);
 void zvol_fini_impl(void);
 void zvol_wait_close(zvol_state_t *zv);

--- a/module/os/freebsd/zfs/dmu_os.c
+++ b/module/os/freebsd/zfs/dmu_os.c
@@ -91,7 +91,7 @@ dmu_write_pages(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 		return (0);
 
 	err = dmu_buf_hold_array(os, object, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp);
+	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH);
 	if (err)
 		return (err);
 
@@ -154,7 +154,8 @@ dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
 	ASSERT3S(last_size, <=, PAGE_SIZE);
 
 	err = dmu_buf_hold_array(os, object, IDX_TO_OFF(ma[0]->pindex),
-	    IDX_TO_OFF(count - 1) + last_size, TRUE, FTAG, &numbufs, &dbp);
+	    IDX_TO_OFF(count - 1) + last_size, TRUE, FTAG, &numbufs, &dbp,
+	    DMU_READ_PREFETCH);
 	if (err != 0)
 		return (err);
 

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -1058,7 +1058,7 @@ zfsvfs_setup(zfsvfs_t *zfsvfs, boolean_t mounting)
 		if (error)
 			return (error);
 		zfsvfs->z_log = zil_open(zfsvfs->z_os, zfs_get_data,
-		    &zfsvfs->z_kstat.dk_zil_sums);
+		    zfs_done_data, &zfsvfs->z_kstat.dk_zil_sums);
 
 		/*
 		 * During replay we remove the read only flag to
@@ -1132,7 +1132,7 @@ zfsvfs_setup(zfsvfs_t *zfsvfs, boolean_t mounting)
 	} else {
 		ASSERT3P(zfsvfs->z_kstat.dk_kstats, !=, NULL);
 		zfsvfs->z_log = zil_open(zfsvfs->z_os, zfs_get_data,
-		    &zfsvfs->z_kstat.dk_zil_sums);
+		    zfs_done_data, &zfsvfs->z_kstat.dk_zil_sums);
 	}
 
 	/*

--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -1248,7 +1248,8 @@ zvol_ensure_zilog(zvol_state_t *zv)
 		}
 		if (zv->zv_zilog == NULL) {
 			zv->zv_zilog = zil_open(zv->zv_objset,
-			    zvol_get_data, &zv->zv_kstat.dk_zil_sums);
+			    zvol_get_data, zvol_done_data,
+			    &zv->zv_kstat.dk_zil_sums);
 			zv->zv_flags |= ZVOL_WRITTEN_TO;
 			/* replay / destroy done in zvol_os_create_minor() */
 			VERIFY0(zv->zv_zilog->zl_header->zh_flags &
@@ -1491,7 +1492,8 @@ zvol_os_create_minor(const char *name)
 	if (error)
 		goto out_dmu_objset_disown;
 	ASSERT3P(zv->zv_zilog, ==, NULL);
-	zv->zv_zilog = zil_open(os, zvol_get_data, &zv->zv_kstat.dk_zil_sums);
+	zv->zv_zilog = zil_open(os, zvol_get_data, zvol_done_data,
+	    &zv->zv_kstat.dk_zil_sums);
 	if (spa_writeable(dmu_objset_spa(os))) {
 		if (zil_replay_disable)
 			replayed_zil = zil_destroy(zv->zv_zilog, B_FALSE);

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -860,7 +860,7 @@ zfsvfs_setup(zfsvfs_t *zfsvfs, boolean_t mounting)
 		if (error)
 			return (error);
 		zfsvfs->z_log = zil_open(zfsvfs->z_os, zfs_get_data,
-		    &zfsvfs->z_kstat.dk_zil_sums);
+		    zfs_done_data, &zfsvfs->z_kstat.dk_zil_sums);
 
 		/*
 		 * During replay we remove the read only flag to
@@ -927,7 +927,7 @@ zfsvfs_setup(zfsvfs_t *zfsvfs, boolean_t mounting)
 	} else {
 		ASSERT3P(zfsvfs->z_kstat.dk_kstats, !=, NULL);
 		zfsvfs->z_log = zil_open(zfsvfs->z_os, zfs_get_data,
-		    &zfsvfs->z_kstat.dk_zil_sums);
+		    zfs_done_data, &zfsvfs->z_kstat.dk_zil_sums);
 	}
 
 	/*

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -557,7 +557,8 @@ zvol_request_impl(zvol_state_t *zv, struct bio *bio, struct request *rq,
 			rw_enter(&zv->zv_suspend_lock, RW_WRITER);
 			if (zv->zv_zilog == NULL) {
 				zv->zv_zilog = zil_open(zv->zv_objset,
-				    zvol_get_data, &zv->zv_kstat.dk_zil_sums);
+				    zvol_get_data, zvol_done_data,
+				    &zv->zv_kstat.dk_zil_sums);
 				zv->zv_flags |= ZVOL_WRITTEN_TO;
 				/* replay / destroy done in zvol_create_minor */
 				VERIFY0((zv->zv_zilog->zl_header->zh_flags &
@@ -1417,7 +1418,8 @@ zvol_os_create_minor(const char *name)
 	if (error)
 		goto out_dmu_objset_disown;
 	ASSERT3P(zv->zv_zilog, ==, NULL);
-	zv->zv_zilog = zil_open(os, zvol_get_data, &zv->zv_kstat.dk_zil_sums);
+	zv->zv_zilog = zil_open(os, zvol_get_data, zvol_done_data,
+	    &zv->zv_kstat.dk_zil_sums);
 	if (spa_writeable(dmu_objset_spa(os))) {
 		if (zil_replay_disable)
 			replayed_zil = zil_destroy(zv->zv_zilog, B_FALSE);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -638,7 +638,7 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 int
 dmu_buf_hold_array(objset_t *os, uint64_t object, uint64_t offset,
     uint64_t length, int read, const void *tag, int *numbufsp,
-    dmu_buf_t ***dbpp)
+    dmu_buf_t ***dbpp, uint32_t flags)
 {
 	dnode_t *dn;
 	int err;
@@ -648,7 +648,7 @@ dmu_buf_hold_array(objset_t *os, uint64_t object, uint64_t offset,
 		return (err);
 
 	err = dmu_buf_hold_array_by_dnode(dn, offset, length, read, tag,
-	    numbufsp, dbpp, DMU_READ_PREFETCH);
+	    numbufsp, dbpp, flags);
 
 	dnode_rele(dn, FTAG);
 
@@ -1137,7 +1137,7 @@ dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 		return;
 
 	VERIFY0(dmu_buf_hold_array(os, object, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp));
+	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH));
 	dmu_write_impl(dbp, numbufs, offset, size, buf, tx);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
@@ -1172,7 +1172,7 @@ dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 		return;
 
 	VERIFY(0 == dmu_buf_hold_array(os, object, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp));
+	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH));
 
 	for (i = 0; i < numbufs; i++) {
 		dmu_buf_t *db = dbp[i];
@@ -1209,7 +1209,7 @@ dmu_redact(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	dmu_buf_t **dbp;
 
 	VERIFY0(dmu_buf_hold_array(os, object, offset, size, FALSE, FTAG,
-	    &numbufs, &dbp));
+	    &numbufs, &dbp, DMU_READ_PREFETCH));
 	for (i = 0; i < numbufs; i++)
 		dmu_buf_redact(dbp[i], tx);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
@@ -2181,7 +2181,7 @@ dmu_read_l0_bps(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 	int error, numbufs;
 
 	error = dmu_buf_hold_array(os, object, offset, length, FALSE, FTAG,
-	    &numbufs, &dbp);
+	    &numbufs, &dbp, DMU_READ_PREFETCH);
 	if (error != 0) {
 		if (error == ESRCH) {
 			error = SET_ERROR(ENXIO);
@@ -2272,7 +2272,7 @@ dmu_brt_clone(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 	spa = os->os_spa;
 
 	VERIFY0(dmu_buf_hold_array(os, object, offset, length, FALSE, FTAG,
-	    &numbufs, &dbp));
+	    &numbufs, &dbp, DMU_READ_PREFETCH));
 	ASSERT3U(nbps, ==, numbufs);
 
 	for (int i = 0; i < numbufs; i++) {


### PR DESCRIPTION
Before this change ZIL code composed its log blocks in linear memory buffers by copying individual transactions and their data before issuing writes.  All of those operations were done while holding zl_issuer_lock, that created huge lock contention on multi-threaded workloads with large write traffic to the same dataset/zvol.

This change utilizes Gang ABDs to concatenate large log records or data chunks, skipping memory copies. Depending on vdev capabilities memory copy may not be needed at all, or at very least it will be done later in I/O pipeline without holding any locks.

Non-write and WR_INDIRECT itx's should be handled same as before. WR_COPIED itx's already have their data embedded and just added to the Gang ABD instead of copying.  WR_NEED_COPY itx's, depending on size, can either do dmu_read*() same as before to copy the data, or take a hold on the buffers with dmu_buf_hold_array*() and add them to the Gang ABD.  In the last case the buffers remain held and the range read-locked until the LWB write completes and the Gang ABD is destroyed.

### How Has This Been Tested?
Tests of VMware vMotion to ZVOL-backed iSCSI target with sync=always and NVDIMM SLOG show throughput increase from 1.8GB/s with 30% CPU usage before to 2.6GB/s with 20% CPU usage after.  The lock contention is still visible in profiler, but reduced by several times.  The memory copy is still visible on FreeBSD, but in I/O pipeline inside vdev_geom, since none of ZIL structures are page-aligned.  On Linux I suspect it may work even better, depending on hardware support for arbitrary scatter/gather, but I haven't tested it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
