### PR TITLE
Use __attribute__((malloc)) on memory allocation functions

### DIFF
--- a/include/os/freebsd/spl/sys/kmem.h
+++ b/include/os/freebsd/spl/sys/kmem.h
@@ -75,7 +75,7 @@ typedef struct kmem_cache {
 extern uint64_t spl_kmem_cache_inuse(kmem_cache_t *cache);
 extern uint64_t spl_kmem_cache_entry_size(kmem_cache_t *cache);
 
-__attribute__((alloc_size(1)))
+__attribute__((malloc, alloc_size(1)))
 void *zfs_kmem_alloc(size_t size, int kmflags);
 void zfs_kmem_free(void *buf, size_t size);
 uint64_t kmem_size(void);
@@ -83,6 +83,7 @@ kmem_cache_t *kmem_cache_create(const char *name, size_t bufsize, size_t align,
     int (*constructor)(void *, void *, int), void (*destructor)(void *, void *),
     void (*reclaim)(void *) __unused, void *private, vmem_t *vmp, int cflags);
 void kmem_cache_destroy(kmem_cache_t *cache);
+__attribute__((malloc))
 void *kmem_cache_alloc(kmem_cache_t *cache, int flags);
 void kmem_cache_free(kmem_cache_t *cache, void *buf);
 boolean_t kmem_cache_reap_active(void);

--- a/include/os/linux/spl/sys/kmem.h
+++ b/include/os/linux/spl/sys/kmem.h
@@ -31,10 +31,10 @@
 #include <linux/vmalloc.h>
 
 extern int kmem_debugging(void);
-extern char *kmem_vasprintf(const char *fmt, va_list ap)
-    __attribute__((format(printf, 1, 0)));
-extern char *kmem_asprintf(const char *fmt, ...)
-    __attribute__((format(printf, 1, 2)));
+__attribute__((format(printf, 1, 0)))
+extern char *kmem_vasprintf(const char *fmt, va_list ap);
+__attribute__((format(printf, 1, 2)))
+extern char *kmem_asprintf(const char *fmt, ...);
 extern char *kmem_strdup(const char *str);
 extern void kmem_strfree(char *str);
 
@@ -186,10 +186,10 @@ extern unsigned int spl_kmem_alloc_max;
 #define	kmem_free(ptr, sz)	spl_kmem_free((ptr), (sz))
 #define	kmem_cache_reap_active	spl_kmem_cache_reap_active
 
-extern void *spl_kmem_alloc(size_t sz, int fl, const char *func, int line)
-    __attribute__((alloc_size(1)));
-extern void *spl_kmem_zalloc(size_t sz, int fl, const char *func, int line)
-    __attribute__((alloc_size(1)));
+__attribute__((malloc, alloc_size(1)))
+extern void *spl_kmem_alloc(size_t sz, int fl, const char *func, int line);
+__attribute__((malloc, alloc_size(1)))
+extern void *spl_kmem_zalloc(size_t sz, int fl, const char *func, int line);
 extern void spl_kmem_free(const void *ptr, size_t sz);
 
 /*

--- a/include/os/linux/spl/sys/vmem.h
+++ b/include/os/linux/spl/sys/vmem.h
@@ -91,8 +91,10 @@ typedef struct vmem { } vmem_t;
 #define	vmem_zalloc(sz, fl)	spl_vmem_zalloc((sz), (fl), __func__, __LINE__)
 #define	vmem_free(ptr, sz)	spl_vmem_free((ptr), (sz))
 
-extern void *spl_vmem_alloc(size_t sz, int fl, const char *func, int line);
-extern void *spl_vmem_zalloc(size_t sz, int fl, const char *func, int line);
+extern void *spl_vmem_alloc(size_t sz, int fl, const char *func, int line)
+    __attribute__((malloc, alloc_size(1)));
+extern void *spl_vmem_zalloc(size_t sz, int fl, const char *func, int line)
+    __attribute__((malloc, alloc_size(1)));
 extern void spl_vmem_free(const void *ptr, size_t sz);
 
 int spl_vmem_init(void);

--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -86,10 +86,15 @@ extern int zfs_abd_scatter_enabled;
  * Allocations and deallocations
  */
 
+__attribute__((malloc))
 abd_t *abd_alloc(size_t, boolean_t);
+__attribute__((malloc))
 abd_t *abd_alloc_linear(size_t, boolean_t);
+__attribute__((malloc))
 abd_t *abd_alloc_gang(void);
+__attribute__((malloc))
 abd_t *abd_alloc_for_io(size_t, boolean_t);
+__attribute__((malloc))
 abd_t *abd_alloc_sametype(abd_t *, size_t);
 boolean_t abd_size_alloc_linear(size_t);
 void abd_gang_add(abd_t *, abd_t *, boolean_t);

--- a/lib/libspl/include/umem.h
+++ b/lib/libspl/include/umem.h
@@ -83,7 +83,7 @@ const char *_umem_debug_init(void);
 const char *_umem_options_init(void);
 const char *_umem_logging_init(void);
 
-__attribute__((alloc_size(1)))
+__attribute__((malloc, alloc_size(1)))
 static inline void *
 umem_alloc(size_t size, int flags)
 {
@@ -96,7 +96,7 @@ umem_alloc(size_t size, int flags)
 	return (ptr);
 }
 
-__attribute__((alloc_size(1)))
+__attribute__((malloc, alloc_size(1)))
 static inline void *
 umem_alloc_aligned(size_t size, size_t align, int flags)
 {
@@ -118,7 +118,7 @@ umem_alloc_aligned(size_t size, size_t align, int flags)
 	return (ptr);
 }
 
-__attribute__((alloc_size(1)))
+__attribute__((malloc, alloc_size(1)))
 static inline void *
 umem_zalloc(size_t size, int flags)
 {
@@ -188,6 +188,7 @@ umem_cache_destroy(umem_cache_t *cp)
 	umem_free(cp, sizeof (umem_cache_t));
 }
 
+__attribute__((malloc))
 static inline void *
 umem_cache_alloc(umem_cache_t *cp, int flags)
 {


### PR DESCRIPTION
### Motivation and Context
It occurred to me that we could make our binary code slightly faster and more compact if we explicitly informed the C compiler that pointers from memory allocation functions are not able to alias other pointers.

### Description
This informs the C compiler that pointers returned from these functions do not alias other functions, which allows it to do better code optimization and should make the compiled code smaller.

Note that we had been inconsistently using function attributes in our headers, by placing them before the start of a function prototype declaration in some places or after the end in other places. I took the opportunity to make things somewhat more consistent by placing them at the end unless the the function is an inline function, in which case, we place them at the beginning. This strikes me as more readable than placing them wherever as we had previously done.

References:
https://stackoverflow.com/a/53654773
https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-malloc-function-attribute https://clang.llvm.org/docs/AttributeReference.html#malloc

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
