### PR TITLE
Debug auto_replace_001_pos failures

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1951,6 +1951,7 @@ function check_pool_status # pool token keyword <verbose>
 #	is_pool_removing - to check if the pool removing is a vdev
 #	is_pool_removed - to check if the pool remove is completed
 #	is_pool_discarding - to check if the pool checkpoint is being discarded
+#	is_pool_replacing - to check if the pool is performing a replacement
 #
 function is_pool_resilvering #pool <verbose>
 {
@@ -1996,6 +1997,10 @@ function is_pool_removed #pool
 function is_pool_discarding #pool
 {
 	check_pool_status "$1" "checkpoint" "discarding"
+}
+function is_pool_replacing #pool
+{
+	zpool status "$1" | grep -qE 'replacing-[0-9]+'
 }
 
 function wait_for_degraded
@@ -2983,12 +2988,15 @@ function wait_freeing #pool
 # Wait for every device replace operation to complete
 #
 # $1 pool name
+# $2 timeout
 #
-function wait_replacing #pool
+function wait_replacing #pool timeout
 {
+	typeset timeout=${2:-300}
 	typeset pool=${1:-$TESTPOOL}
-	while zpool status $pool | grep -qE 'replacing-[0-9]+'; do
-		log_must sleep 1
+	for (( timer = 0; timer < $timeout; timer++ )); do
+		is_pool_replacing $pool || break;
+		sleep 1;
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
@@ -54,6 +54,7 @@ fi
 
 function cleanup
 {
+	zpool status $TESTPOOL
 	destroy_pool $TESTPOOL
 	sed -i '/alias scsidebug/d' $VDEVID_CONF
 	unload_scsi_debug
@@ -99,8 +100,8 @@ block_device_wait
 insert_disk $SD $SD_HOST
 
 # Wait for the new disk to be online and replaced
-log_must wait_vdev_state $TESTPOOL "scsidebug" "ONLINE" $MAXTIMEOUT
-log_must wait_replacing $TESTPOOL
+log_must wait_vdev_state $TESTPOOL "scsidebug" "ONLINE" 60
+log_must wait_replacing $TESTPOOL 60
 
 # Validate auto-replace was successful
 log_must check_state $TESTPOOL "" "ONLINE"


### PR DESCRIPTION
### Motivation and Context

Failures on Fedora 37 CI builder like this:

http://build.zfsonlinux.org/builders/Fedora%2037%20x86_64%20%28TEST%29/builds/268/steps/shell_4/logs/summary

### Description

Reduced the timeout to 60 seconds which should be more than sufficient and allow the test to be marked as FAILED rather than KILLED.  Also dump the pool status on cleanup.

### How Has This Been Tested?

Relying on the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [  ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
