### PR TITLE
PAM: various improvements

### DIFF
--- a/contrib/pam_zfs_key/pam_zfs_key.c
+++ b/contrib/pam_zfs_key/pam_zfs_key.c
@@ -437,7 +437,7 @@ typedef struct {
 	char *dsname;
 	uid_t uid;
 	const char *username;
-	int unmount_and_unload;
+	boolean_t unmount_and_unload;
 } zfs_key_config_t;
 
 static int
@@ -471,7 +471,7 @@ zfs_key_config_load(pam_handle_t *pamh, zfs_key_config_t *config,
 	}
 	config->uid = entry->pw_uid;
 	config->username = name;
-	config->unmount_and_unload = 1;
+	config->unmount_and_unload = B_TRUE;
 	config->dsname = NULL;
 	config->homedir = NULL;
 	for (int c = 0; c < argc; c++) {
@@ -482,7 +482,7 @@ zfs_key_config_load(pam_handle_t *pamh, zfs_key_config_t *config,
 			free(config->runstatedir);
 			config->runstatedir = strdup(argv[c] + 12);
 		} else if (strcmp(argv[c], "nounmount") == 0) {
-			config->unmount_and_unload = 0;
+			config->unmount_and_unload = B_FALSE;
 		} else if (strcmp(argv[c], "prop_mountpoint") == 0) {
 			if (config->homedir == NULL)
 				config->homedir = strdup(entry->pw_dir);

--- a/contrib/pam_zfs_key/pam_zfs_key.c
+++ b/contrib/pam_zfs_key/pam_zfs_key.c
@@ -386,7 +386,7 @@ decrypt_mount(pam_handle_t *pamh, const char *ds_name,
 	int ret = lzc_load_key(ds_name, noop, (uint8_t *)key->value,
 	    WRAPPING_KEY_LEN);
 	pw_free(key);
-	if (ret) {
+	if (ret && ret != EEXIST) {
 		pam_syslog(pamh, LOG_ERR, "load_key failed: %d", ret);
 		zfs_close(ds);
 		return (-1);

--- a/tests/runfiles/freebsd.run
+++ b/tests/runfiles/freebsd.run
@@ -25,3 +25,8 @@ tags = ['functional']
 [tests/functional/cli_root/zfs_jail:FreeBSD]
 tests = ['zfs_jail_001_pos']
 tags = ['functional', 'cli_root', 'zfs_jail']
+
+[tests/functional/pam:FreeBSD]
+tests = ['pam_basic', 'pam_change_unmounted', 'pam_nounmount', 'pam_recursive',
+    'pam_short_password']
+tags = ['functional', 'pam']

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -140,7 +140,7 @@ tests = ['umount_unlinked_drain']
 tags = ['functional', 'mount']
 
 [tests/functional/pam:Linux]
-tests = ['pam_basic', 'pam_nounmount', 'pam_short_password']
+tests = ['pam_basic', 'pam_nounmount', 'pam_recursive', 'pam_short_password']
 tags = ['functional', 'pam']
 
 [tests/functional/procfs:Linux]

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -140,7 +140,8 @@ tests = ['umount_unlinked_drain']
 tags = ['functional', 'mount']
 
 [tests/functional/pam:Linux]
-tests = ['pam_basic', 'pam_nounmount', 'pam_recursive', 'pam_short_password']
+tests = ['pam_basic', 'pam_change_unmounted', 'pam_nounmount', 'pam_recursive',
+    'pam_short_password']
 tags = ['functional', 'pam']
 
 [tests/functional/procfs:Linux]

--- a/tests/zfs-tests/tests/functional/pam/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/pam/cleanup.ksh
@@ -25,5 +25,6 @@
 rmconfig
 destroy_pool $TESTPOOL
 del_user ${username}
+del_user ${username}rec
 del_group pamtestgroup
 log_must rm -rf "$runstatedir" $TESTDIRS

--- a/tests/zfs-tests/tests/functional/pam/pam_recursive.ksh
+++ b/tests/zfs-tests/tests/functional/pam/pam_recursive.ksh
@@ -1,0 +1,72 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/tests/functional/pam/utilities.kshlib
+
+if [ -n "$ASAN_OPTIONS" ]; then
+	export LD_PRELOAD=$(ldd "$(command -v zfs)" | awk '/libasan\.so/ {print $3}')
+fi
+
+username="${username}rec"
+
+# Set up a deeper hierarchy, a mountpoint that doesn't interfere with other tests,
+# and a user which references that mountpoint
+log_must zfs create "$TESTPOOL/pampam"
+log_must zfs create -o mountpoint="$TESTDIR/rec" "$TESTPOOL/pampam/pam"
+echo "recurpass" | zfs create -o encryption=aes-256-gcm -o keyformat=passphrase \
+	-o keylocation=prompt "$TESTPOOL/pampam/pam/${username}"
+log_must zfs unmount "$TESTPOOL/pampam/pam/${username}"
+log_must zfs unload-key "$TESTPOOL/pampam/pam/${username}"
+log_must add_user pamtestgroup ${username} "$TESTDIR/rec"
+
+function keystatus {
+	log_must [ "$(get_prop keystatus "$TESTPOOL/pampam/pam/${username}")" = "$1" ]
+}
+
+log_mustnot ismounted "$TESTPOOL/pampam/pam/${username}"
+keystatus unavailable
+
+function test_session {
+	echo "recurpass" | pamtester ${pamservice} ${username} open_session
+	references 1
+	log_must ismounted "$TESTPOOL/pampam/pam/${username}"
+	keystatus available
+
+	log_must pamtester ${pamservice} ${username} close_session
+	references 0
+	log_mustnot ismounted "$TESTPOOL/pampam/pam/${username}"
+	keystatus unavailable
+}
+
+genconfig "homes=$TESTPOOL/pampam/pam prop_mountpoint runstatedir=${runstatedir}"
+test_session
+
+genconfig "homes=$TESTPOOL/pampam recursive_homes prop_mountpoint runstatedir=${runstatedir}"
+test_session
+
+genconfig "homes=$TESTPOOL recursive_homes prop_mountpoint runstatedir=${runstatedir}"
+test_session
+
+genconfig "homes=* recursive_homes prop_mountpoint runstatedir=${runstatedir}"
+test_session
+
+log_pass "done."


### PR DESCRIPTION
Continuing from #14789… @felixdoerre

### Motivation and Context

- *PAM: add 'recursive_homes' flag to use with 'prop_mountpoint'* – I really need to not have the limitation of having all homes under one directory, that limitation doesn't really make sense with `prop_mountpoint` IMO.
- *PAM: support password changes even when not mounted* – had this patch around for a while, not the most important for me personally anymore but thought it might still be useful for others, because it makes sense that the `passwd` command shouldn't require a user to be logged in for an admin to change their password.
- *PAM: add 'forceunmount' flag* – honestly mostly because the unmount was always failing after exiting a simple FreeBSD's `login` session (though e.g. not a `su -l` one) heh.
- *PAM: do not fail to mount if the key's already loaded* – well, motivated entirely by the mount failing after such an unmount failure, but one could imagine a variety of other situations where this could happen.
- *PAM: add 'uid_min' and 'uid_max' options for changing the uid range* – the inability to have root have a pam_zfs_key'ed home due to the `uid >= 1000` check was bothering me, so I've decided to convert that check into a configurable one.

### Description

A variety of PAM module changes. Submitting as one PR to avoid having a bunch of barely-different CI runs, and they're not that complex anyway. If only some commits are acceptable, I can remove the others. Bikeshedding on option names also definitely welcome :)

### How Has This Been Tested?

~~"Works for me"…~~ Actually now added tests for password change when unmounted and for recursive search.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
