### PR TITLE
Fixes for issues identified by recent Coverity defect reports

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -8942,12 +8942,12 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			}
 
 			/* normalize the property name */
-			propname = zpool_prop_to_name(prop);
-			proptype = zpool_prop_get_type(prop);
-			if (prop == ZPOOL_PROP_INVAL &&
-			    zfs_prop_user(elemname)) {
+			if (prop == ZPOOL_PROP_INVAL) {
 				propname = elemname;
 				proptype = PROP_TYPE_STRING;
+			} else {
+				propname = zpool_prop_to_name(prop);
+				proptype = zpool_prop_get_type(prop);
 			}
 
 			if (nvpair_type(elem) == DATA_TYPE_STRING) {

--- a/module/zfs/spa_errlog.c
+++ b/module/zfs/spa_errlog.c
@@ -683,7 +683,6 @@ spa_remove_healed_errors(spa_t *spa, avl_tree_t *s, avl_tree_t *l, dmu_tx_t *tx)
 	    &cookie)) != NULL) {
 		remove_error_from_list(spa, s, &se->se_bookmark);
 		remove_error_from_list(spa, l, &se->se_bookmark);
-		kmem_free(se, sizeof (spa_error_entry_t));
 
 		if (!spa_feature_is_enabled(spa, SPA_FEATURE_HEAD_ERRLOG)) {
 			bookmark_to_name(&se->se_bookmark, name, sizeof (name));
@@ -713,6 +712,7 @@ spa_remove_healed_errors(spa_t *spa, avl_tree_t *s, avl_tree_t *l, dmu_tx_t *tx)
 			}
 			zap_cursor_fini(&zc);
 		}
+		kmem_free(se, sizeof (spa_error_entry_t));
 	}
 }
 


### PR DESCRIPTION
### Motivation and Context
For some reason, Coverity's site is not showing the results of new scans, but its defect browser is showing them.

In the past week, Coverity has generated three new defect reports. One is a pre-existing undefined behavior bug that can cause systems to panic. Coverity began to detect it two instances of it after 8eae2d214cfa53862833eeeda9a5c1e9d5ded47d added enough context for Coverity to infer that a negative number could be used as an array index. The other is a use-after-free regression introduced by 6839ec6f1098c28ff7b772f1b31b832d05e6b567.

### Description
The undefined behavior bug can only be triggered on invalid properties. This could happen if a future userland tool attempts to set a property that we do not understand.

The use-after-free regression can happen on any machine that has been patched with 6839ec6f1098c28ff7b772f1b31b832d05e6b567 when removing healed errors from on-disk error logs. When the freed memory has been changed before it has been read, we will leak MOS objects. We could also potentially remove MOS objects that should not be removed.

### How Has This Been Tested?
The buildbot can test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
