### PR TITLE
Probe vdevs before marking removed

### DIFF
--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -445,14 +445,16 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 			return;
 
 		/* Remove the vdev since device is unplugged */
+		int remove_status = 0;
 		if (l2arc || (strcmp(class, "resource.fs.zfs.removed") == 0)) {
-			int status = zpool_vdev_remove_wanted(zhp, devname);
+			remove_status = zpool_vdev_remove_wanted(zhp, devname);
 			fmd_hdl_debug(hdl, "zpool_vdev_remove_wanted '%s'"
-			    ", ret:%d", devname, status);
+			    ", err:%d", devname, libzfs_errno(zhdl));
 		}
 
 		/* Replace the vdev with a spare if its not a l2arc */
-		if (!l2arc && (!fmd_prop_get_int32(hdl, "spare_on_remove") ||
+		if (!l2arc && !remove_status &&
+		    (!fmd_prop_get_int32(hdl, "spare_on_remove") ||
 		    replace_with_spare(hdl, zhp, vdev) == B_FALSE)) {
 			/* Could not handle with spare */
 			fmd_hdl_debug(hdl, "no spare for '%s'", devname);


### PR DESCRIPTION
### Motivation and Context

Issue #14859.  Better handle situations where a hotplug removal event was received but the ZED but the device should not be marked as REMOVED.  Setting a vdevs state as REMOVED does not consider pool redundancy extra care should be taken to avoid suspending the pool.

### Description

Before allowing the ZED to mark a vdev as REMOVED due to a hotplug event confirm that it is non-responsive with probe. Any device which can be successfully probed should be left ONLINE to prevent a healthy pool from being incorrectly SUSPENDED.  This may occur for at least the following two scenarios.

1) Drive expansion (`zpool online -e`) in VMware environments.   If, during the partition resize operation, a partition is removed and re-created then udev will send a removed event.

2) Re-scanning the namespaces of an NVMe device (`nvme ns-rescan`) may result in a udev remove and add event being delivered.

Finally, update the ZED to only kick in a spare when the removal was successful.

### How Has This Been Tested?

Lightly by simulating a hotplug event with `udevadm trigger -c remove <device>`.  When the removal event is received but the device is clearly still available EEXIST is correctly returned and the device is left ONLINE.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
