### PR TITLE
btree: Reduce opportunities for branch mispredictions in binary search

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -326,7 +326,7 @@ sublivelist_verify_func(void *args, dsl_deadlist_entry_t *dle)
 	int err;
 	struct sublivelist_verify *sv = args;
 
-	zfs_btree_create(&sv->sv_pair, sublivelist_block_refcnt_compare,
+	zfs_btree_create(&sv->sv_pair, sublivelist_block_refcnt_compare, NULL,
 	    sizeof (sublivelist_verify_block_refcnt_t));
 
 	err = bpobj_iterate_nofree(&dle->dle_bpobj, sublivelist_verify_blkptr,
@@ -390,7 +390,7 @@ sublivelist_verify_lightweight(void *args, dsl_deadlist_entry_t *dle)
 {
 	(void) args;
 	sublivelist_verify_t sv;
-	zfs_btree_create(&sv.sv_leftover, livelist_block_compare,
+	zfs_btree_create(&sv.sv_leftover, livelist_block_compare, NULL,
 	    sizeof (sublivelist_verify_block_t));
 	int err = sublivelist_verify_func(&sv, dle);
 	zfs_btree_clear(&sv.sv_leftover);
@@ -682,7 +682,7 @@ livelist_metaslab_validate(spa_t *spa)
 	(void) printf("Verifying deleted livelist entries\n");
 
 	sublivelist_verify_t sv;
-	zfs_btree_create(&sv.sv_leftover, livelist_block_compare,
+	zfs_btree_create(&sv.sv_leftover, livelist_block_compare, NULL,
 	    sizeof (sublivelist_verify_block_t));
 	iterate_deleted_livelists(spa, livelist_verify, &sv);
 
@@ -716,7 +716,7 @@ livelist_metaslab_validate(spa_t *spa)
 			mv.mv_start = m->ms_start;
 			mv.mv_end = m->ms_start + m->ms_size;
 			zfs_btree_create(&mv.mv_livelist_allocs,
-			    livelist_block_compare,
+			    livelist_block_compare, NULL,
 			    sizeof (sublivelist_verify_block_t));
 
 			mv_populate_livelist_allocs(&mv, &sv);

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -34,6 +34,20 @@ ifeq ($(CONFIG_KASAN),y)
 ZFS_MODULE_CFLAGS += -Wno-error=frame-larger-than=
 endif
 
+# Generated binary search code is particularly bad with this optimization.
+# Oddly, range_tree.c is not affected when unrolling is not done and dsl_scan.c
+# is not affected when unrolling is done.
+# Disable it until the following upstream issue is resolved:
+# https://github.com/llvm/llvm-project/issues/62790
+ifeq ($(CONFIG_X86),y)
+ifeq ($(CONFIG_CC_IS_CLANG),y)
+CFLAGS_zfs/dsl_scan.o += -mllvm -x86-cmov-converter=false
+CFLAGS_zfs/metaslab.o += -mllvm -x86-cmov-converter=false
+CFLAGS_zfs/range_tree.o += -mllvm -x86-cmov-converter=false
+CFLAGS_zfs/zap_micro.o += -mllvm -x86-cmov-converter=false
+endif
+endif
+
 ifneq ($(KBUILD_EXTMOD),)
 @CONFIG_QAT_TRUE@ZFS_MODULE_CFLAGS += -I@QAT_SRC@/include
 @CONFIG_QAT_TRUE@KBUILD_EXTRA_SYMBOLS += @QAT_SYMBOLS@

--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -400,6 +400,20 @@ beforeinstall:
 
 .include <bsd.kmod.mk>
 
+# Generated binary search code is particularly bad with this optimization.
+# Oddly, range_tree.c is not affected when unrolling is not done and dsl_scan.c
+# is not affected when unrolling is done.
+# Disable it until the following upstream issue is resolved:
+# https://github.com/llvm/llvm-project/issues/62790
+.if ${CC} == "clang"
+.if ${MACHINE_ARCH} == "i386" || ${MACHINE_ARCH} == "amd64"
+CFLAGS.dsl_scan.c= -mllvm -x86-cmov-converter=false
+CFLAGS.metaslab.c= -mllvm -x86-cmov-converter=false
+CFLAGS.range_tree.c= -mllvm -x86-cmov-converter=false
+CFLAGS.zap_micro.c= -mllvm -x86-cmov-converter=false
+.endif
+.endif
+
 CFLAGS.sysctl_os.c= -include ../zfs_config.h
 CFLAGS.xxhash.c+= -include ${SYSDIR}/sys/_null.h
 

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -4877,6 +4877,7 @@ scan_exec_io(dsl_pool_t *dp, const blkptr_t *bp, int zio_flags,
  * with single operation.  Plus it makes scrubs more sequential and reduces
  * chances that minor extent change move it within the B-tree.
  */
+__attribute__((always_inline)) inline
 static int
 ext_size_compare(const void *x, const void *y)
 {
@@ -4885,13 +4886,17 @@ ext_size_compare(const void *x, const void *y)
 	return (TREE_CMP(*a, *b));
 }
 
+ZFS_BTREE_FIND_IN_BUF_FUNC(ext_size_find_in_buf, uint64_t,
+    ext_size_compare)
+
 static void
 ext_size_create(range_tree_t *rt, void *arg)
 {
 	(void) rt;
 	zfs_btree_t *size_tree = arg;
 
-	zfs_btree_create(size_tree, ext_size_compare, sizeof (uint64_t));
+	zfs_btree_create(size_tree, ext_size_compare, ext_size_find_in_buf,
+	    sizeof (uint64_t));
 }
 
 static void

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -1342,6 +1342,7 @@ metaslab_group_allocatable(metaslab_group_t *mg, metaslab_group_t *rotor,
  * Comparison function for the private size-ordered tree using 32-bit
  * ranges. Tree is sorted by size, larger sizes at the end of the tree.
  */
+__attribute__((always_inline)) inline
 static int
 metaslab_rangesize32_compare(const void *x1, const void *x2)
 {
@@ -1352,16 +1353,15 @@ metaslab_rangesize32_compare(const void *x1, const void *x2)
 	uint64_t rs_size2 = r2->rs_end - r2->rs_start;
 
 	int cmp = TREE_CMP(rs_size1, rs_size2);
-	if (likely(cmp))
-		return (cmp);
 
-	return (TREE_CMP(r1->rs_start, r2->rs_start));
+	return (cmp + !cmp * TREE_CMP(r1->rs_start, r2->rs_start));
 }
 
 /*
  * Comparison function for the private size-ordered tree using 64-bit
  * ranges. Tree is sorted by size, larger sizes at the end of the tree.
  */
+__attribute__((always_inline)) inline
 static int
 metaslab_rangesize64_compare(const void *x1, const void *x2)
 {
@@ -1372,11 +1372,10 @@ metaslab_rangesize64_compare(const void *x1, const void *x2)
 	uint64_t rs_size2 = r2->rs_end - r2->rs_start;
 
 	int cmp = TREE_CMP(rs_size1, rs_size2);
-	if (likely(cmp))
-		return (cmp);
 
-	return (TREE_CMP(r1->rs_start, r2->rs_start));
+	return (cmp + !cmp * TREE_CMP(r1->rs_start, r2->rs_start));
 }
+
 typedef struct metaslab_rt_arg {
 	zfs_btree_t *mra_bt;
 	uint32_t mra_floor_shift;
@@ -1412,6 +1411,13 @@ metaslab_size_tree_full_load(range_tree_t *rt)
 	range_tree_walk(rt, metaslab_size_sorted_add, &arg);
 }
 
+
+ZFS_BTREE_FIND_IN_BUF_FUNC(metaslab_rt_find_rangesize32_in_buf,
+    range_seg32_t, metaslab_rangesize32_compare)
+
+ZFS_BTREE_FIND_IN_BUF_FUNC(metaslab_rt_find_rangesize64_in_buf,
+    range_seg64_t, metaslab_rangesize64_compare)
+
 /*
  * Create any block allocator specific components. The current allocators
  * rely on using both a size-ordered range_tree_t and an array of uint64_t's.
@@ -1424,19 +1430,22 @@ metaslab_rt_create(range_tree_t *rt, void *arg)
 
 	size_t size;
 	int (*compare) (const void *, const void *);
+	bt_find_in_buf_f bt_find;
 	switch (rt->rt_type) {
 	case RANGE_SEG32:
 		size = sizeof (range_seg32_t);
 		compare = metaslab_rangesize32_compare;
+		bt_find = metaslab_rt_find_rangesize32_in_buf;
 		break;
 	case RANGE_SEG64:
 		size = sizeof (range_seg64_t);
 		compare = metaslab_rangesize64_compare;
+		bt_find = metaslab_rt_find_rangesize64_in_buf;
 		break;
 	default:
 		panic("Invalid range seg type %d", rt->rt_type);
 	}
-	zfs_btree_create(size_tree, compare, size);
+	zfs_btree_create(size_tree, compare, bt_find, size);
 	mrap->mra_floor_shift = metaslab_by_size_min_shift;
 }
 

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -285,6 +285,7 @@ zap_byteswap(void *buf, size_t size)
 	}
 }
 
+__attribute__((always_inline)) inline
 static int
 mze_compare(const void *arg1, const void *arg2)
 {
@@ -294,6 +295,9 @@ mze_compare(const void *arg1, const void *arg2)
 	return (TREE_CMP((uint64_t)(mze1->mze_hash) << 32 | mze1->mze_cd,
 	    (uint64_t)(mze2->mze_hash) << 32 | mze2->mze_cd));
 }
+
+ZFS_BTREE_FIND_IN_BUF_FUNC(mze_find_in_buf, mzap_ent_t,
+    mze_compare)
 
 static void
 mze_insert(zap_t *zap, uint16_t chunkid, uint64_t hash)
@@ -461,7 +465,7 @@ mzap_open(objset_t *os, uint64_t obj, dmu_buf_t *db)
 		 * 62 entries before we have to add 2KB B-tree core node.
 		 */
 		zfs_btree_create_custom(&zap->zap_m.zap_tree, mze_compare,
-		    sizeof (mzap_ent_t), 512);
+		    mze_find_in_buf, sizeof (mzap_ent_t), 512);
 
 		zap_name_t *zn = zap_name_alloc(zap);
 		for (uint16_t i = 0; i < zap->zap_m.zap_num_chunks; i++) {

--- a/tests/zfs-tests/cmd/btree_test.c
+++ b/tests/zfs-tests/cmd/btree_test.c
@@ -501,7 +501,7 @@ main(int argc, char *argv[])
 	srandom(seed);
 
 	zfs_btree_init();
-	zfs_btree_create(&bt, zfs_btree_compare, sizeof (uint64_t));
+	zfs_btree_create(&bt, zfs_btree_compare, NULL, sizeof (uint64_t));
 
 	/*
 	 * This runs the named negative test. None of them should


### PR DESCRIPTION
### Motivation and Context
A conversation in IRC inspired me to read about different strategies for searching within the leaves of a b-tree. We currently do a binary search. However, linear search is a popular option (used by Rust for example), since it can be faster than binary search on small arrays due to cache effects. Various sources online suggest that the size of those arrays is in the range of 50 to 150 elements due to cache effects. Our b-tree leaves typically store 170 or more elements, so I assume linear search would be worse than binary search. However, while reading about this, I learned about a "branchless" binary search algorithm published by Knuth called Shar's algorithm (not to be confused with Shor's algorithm), which people find to be in the range of 2 to 3 times faster than regular binary search.

### Description
This implements shar's algorithm for binary search with comparator inlining. Consumers must opt into using the faster algorithm. At present, only B-Trees used inside kernel code have been modified to use the faster algorithm.

### How Has This Been Tested?
I wrote a small test program to convince myself that the proposed implementation is correct by comparing the output of the new implementation against the existing implementation by searching for every possible location relative to a 1024 value array:

```
#include <stdint.h>
#include <stdlib.h>
#include <stdio.h>

#define	BTREE_CORE_ELEMS	126
#define	BTREE_LEAF_SIZE		4096

typedef int boolean_t;

#define B_TRUE 1
#define B_FALSE 0

typedef struct zfs_btree_hdr {
	struct zfs_btree_core	*bth_parent;
	/*
	 * Set to -1 to indicate core nodes. Other values represent first
	 * valid element offset for leaf nodes.
	 */
	uint32_t		bth_first;
	/*
	 * For both leaf and core nodes, represents the number of elements in
	 * the node. For core nodes, they will have bth_count + 1 children.
	 */
	uint32_t		bth_count;
} zfs_btree_hdr_t;

typedef struct zfs_btree_core {
	zfs_btree_hdr_t	btc_hdr;
	zfs_btree_hdr_t	*btc_children[BTREE_CORE_ELEMS + 1];
	uint8_t		btc_elems[];
} zfs_btree_core_t;

typedef struct zfs_btree_leaf {
	zfs_btree_hdr_t	btl_hdr;
	uint8_t		btl_elems[];
} zfs_btree_leaf_t;

typedef struct zfs_btree_index {
	zfs_btree_hdr_t	*bti_node;
	uint32_t	bti_offset;
	/*
	 * True if the location is before the list offset, false if it's at
	 * the listed offset.
	 */
	boolean_t	bti_before;
} zfs_btree_index_t;

typedef struct btree {
	int (*bt_compar) (const void *, const void *);
	size_t			bt_elem_size;
	size_t			bt_leaf_size;
	uint32_t		bt_leaf_cap;
	int32_t			bt_height;
	uint64_t		bt_num_elems;
	uint64_t		bt_num_nodes;
	zfs_btree_hdr_t		*bt_root;
	zfs_btree_leaf_t	*bt_bulk; // non-null if bulk loading
} zfs_btree_t;

#define TREE_CMP(a, b) (((a) > (b)) - ((a) < (b)))

int comparator (const void *ap, const void *bp) {
	int a = *(int*)ap;
	int b = *(int*)bp;

	return (TREE_CMP(a, b));
}

/*
 * Find value in the array of elements provided. Uses a simple binary search.
 */
static void *
zfs_btree_find_in_buf(zfs_btree_t *tree, uint8_t *buf, uint32_t nelems,
    const void *value, zfs_btree_index_t *where)
{
	uint32_t max = nelems;
	uint32_t min = 0;
	while (max > min) {
		uint32_t idx = (min + max) / 2;
		uint8_t *cur = buf + idx * tree->bt_elem_size;
		int comp = tree->bt_compar(cur, value);
		if (comp < 0) {
			min = idx + 1;
		} else if (comp > 0) {
			max = idx;
		} else {
			where->bti_offset = idx;
			where->bti_before = B_FALSE;
			return (cur);
		}
	}

	where->bti_offset = max;
	where->bti_before = B_TRUE;
	return (NULL);
}

#define	ZFS_BTREE_FIND_IN_BUF_FUNC(NAME, T, COMP)			\
_Pragma("GCC diagnostic push")						\
_Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")			\
static void *								\
NAME(zfs_btree_t *tree, uint8_t *buf, uint32_t nelems,			\
    const void *value, zfs_btree_index_t *where)			\
{									\
	T *i = (T *)buf;						\
	(void) tree;							\
	_Pragma("GCC unroll 10")					\
	while (nelems > 1) {						\
		uint32_t half = nelems / 2;				\
		nelems -= half;						\
		i += (COMP(&i[half - 1], value) < 0) * half;		\
	}								\
									\
	int comp = COMP(i, value);					\
	where->bti_offset = (size_t)(i - (T *)buf) + (comp < 0);	\
	where->bti_before = (comp != 0);				\
									\
	if (comp == 0) {						\
		return (i);						\
	}								\
									\
	return (NULL);							\
}									\
_Pragma("GCC diagnostic pop")
ZFS_BTREE_FIND_IN_BUF_FUNC(zfs_btree_find_in_buf_new, uint32_t,  tree->bt_compar);

int main (void)
{
	union {
		uint8_t buf[BTREE_LEAF_SIZE];
		int arr[BTREE_LEAF_SIZE / sizeof (int)];
	} u;
	zfs_btree_t tree = {
		.bt_elem_size = sizeof (u.arr[0]),
		.bt_compar = comparator,
	};

	int size = 1024;

	for (int i = 0; i < size; i++)
		u.arr[i] = 2*i+1;

	for (int i = 0; i <= size*2+1; i++)
	{
		zfs_btree_index_t a, b;
		uint8_t *x, *y;
		x = zfs_btree_find_in_buf(&tree, &u.buf, size, &i, &a);
		y = zfs_btree_find_in_buf_new(&tree, &u.buf, size, &i, &b);
		if (a.bti_offset != b.bti_offset) {
			printf("Offsets do not match\n");
			return (1);
		}

		if (a.bti_before != b.bti_before) {
			printf("before does not match\n");
			return (1);
		}

		if (x != y) {
			printf("Return pointers do not match\n");
			return (1);
		}
	}

	printf("The two match\n");

	return (0);
}
```

On my machine, this reports that the two function's output matches and changing the array size from 1024 to 768 does not change that. This is consistent with the theory that the new function does not change what is returned from this function.

Some micro-benchmarks that I did on uncached arrays sized to match our B-Tree leaves suggest that this can improve binary search performance by up to 3.5 times when compiling with Clang 16 and up to 1.9 times when compiling with GCC 12.2:

https://github.com/openzfs/zfs/pull/14866#issuecomment-1554816701

Note that this has been updated to reflect the current state of the PR. An earlier version talked about an alternative binary search implementation, that micro-benchmarks later revealed to be slower than the current code.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
