### PR TITLE
ZTS: zvol_misc_trim disable blk mq

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -277,6 +277,8 @@ elif sys.platform.startswith('linux'):
         'mmp/mmp_inactive_import': ['FAIL', known_reason],
         'zvol/zvol_misc/zvol_misc_snapdev': ['FAIL', 12621],
         'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', known_reason],
+        'zvol/zvol_misc/zvol_misc_fua': ['SKIP', 14872],
+        'zvol/zvol_misc/zvol_misc_trim': ['SKIP', 14872],
         'idmap_mount/idmap_mount_001': ['SKIP', idmap_reason],
         'idmap_mount/idmap_mount_002': ['SKIP', idmap_reason],
         'idmap_mount/idmap_mount_003': ['SKIP', idmap_reason],

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_fua.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_fua.ksh
@@ -45,6 +45,15 @@ fi
 
 if ! is_linux ; then
 	log_unsupported "Only linux supports dd with oflag=dsync for FUA writes"
+else
+	if [[ $(linux_version) -gt $(linux_version "6.2") ]]; then
+		log_unsupported "Disabled while issue #14872 is being worked"
+	fi
+
+	# Disabled for the CentOS 9 kernel
+	if [[ $(linux_version) -eq $(linux_version "5.14") ]]; then
+		log_unsupported "Disabled while issue #14872 is being worked"
+	fi
 fi
 
 typeset datafile1="$(mktemp zvol_misc_fua1.XXXXXX)"

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_trim.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_trim.ksh
@@ -44,6 +44,15 @@
 verify_runnable "global"
 
 if is_linux ; then
+	if [[ $(linux_version) -gt $(linux_version "6.2") ]]; then
+		log_unsupported "Disabled while issue #14872 is being worked"
+	fi
+
+	# Disabled for the CentOS 9 kernel
+	if [[ $(linux_version) -eq $(linux_version "5.14") ]]; then
+		log_unsupported "Disabled while issue #14872 is being worked"
+	fi
+
 	# We need '--force' here since the prior tests may leave a filesystem
 	# on the zvol, and blkdiscard will see that filesystem and print a
 	# warning unless you force it.
@@ -122,7 +131,6 @@ log_must zfs set compression=off $TESTPOOL/$TESTVOL
 
 # Remove old data from previous tests
 log_must $trimcmd $zvolpath
-
 
 set_blk_mq 1
 log_must_busy zpool export $TESTPOOL


### PR DESCRIPTION
### Motivation and Context

Narrow down the cause of the following CI failure:

http://build.zfsonlinux.org/builders/Fedora%2038%20x86_64%20%28TEST%29/builds/198/steps/shell_4/logs/console

### Description

Disable the block mq portion of zvol_misc_trim to determine if a change in 6.2 kernel and newer kernels is causing this ASSERT.

    VERIFY(zh->zh_claim_txg == 0) failed
    PANIC at zil.c:904:zil_create()

### How Has This Been Tested?

Relying on the CI to test this change.