### PR TITLE
systemd: Use non-absolute paths in Exec* lines

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -15,7 +15,7 @@ ConditionPathIsDirectory=/sys/module/zfs
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=-@initconfdir@/zfs
-ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN $ZPOOL_IMPORT_OPTS
+ExecStart=zpool import -c @sysconfdir@/zfs/zpool.cache -aN $ZPOOL_IMPORT_OPTS
 
 [Install]
 WantedBy=zfs-import.target

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -14,7 +14,7 @@ ConditionPathIsDirectory=/sys/module/zfs
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=-@initconfdir@/zfs
-ExecStart=@sbindir@/zpool import -aN -o cachefile=none $ZPOOL_IMPORT_OPTS
+ExecStart=zpool import -aN -o cachefile=none $ZPOOL_IMPORT_OPTS
 
 [Install]
 WantedBy=zfs-import.target

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -12,7 +12,7 @@ ConditionPathIsDirectory=/sys/module/zfs
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=-@initconfdir@/zfs
-ExecStart=@sbindir@/zfs mount -a
+ExecStart=zfs mount -a
 
 [Install]
 WantedBy=zfs.target

--- a/etc/systemd/system/zfs-scrub@.service.in
+++ b/etc/systemd/system/zfs-scrub@.service.in
@@ -8,8 +8,8 @@ ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
 EnvironmentFile=-@initconfdir@/zfs
-ExecStart=/bin/sh -c '\
-if @sbindir@/zpool status %i | grep -q "scrub in progress"; then\
-exec @sbindir@/zpool wait -t scrub %i;\
-else exec @sbindir@/zpool scrub -w %i; fi'
-ExecStop=-/bin/sh -c '@sbindir@/zpool scrub -p %i 2>/dev/null || true'
+ExecStart=sh -c '\
+if zpool status %i | grep -q "scrub in progress"; then\
+exec zpool wait -t scrub %i;\
+else exec zpool scrub -w %i; fi'
+ExecStop=-sh -c 'zpool scrub -p %i 2>/dev/null || true'

--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -14,7 +14,7 @@ ConditionPathIsDirectory=/sys/module/zfs
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=-@initconfdir@/zfs
-ExecStart=@sbindir@/zfs share -a
+ExecStart=zfs share -a
 
 [Install]
 WantedBy=zfs.target

--- a/etc/systemd/system/zfs-trim@.service.in
+++ b/etc/systemd/system/zfs-trim@.service.in
@@ -8,8 +8,8 @@ ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
 EnvironmentFile=-@initconfdir@/zfs
-ExecStart=/bin/sh -c '\
-if @sbindir@/zpool status %i | grep -q "(trimming)"; then\
-exec @sbindir@/zpool wait -t trim %i;\
-else exec @sbindir@/zpool trim -w %i; fi'
-ExecStop=-/bin/sh -c '@sbindir@/zpool trim -s %i 2>/dev/null || true'
+ExecStart=sh -c '\
+if zpool status %i | grep -q "(trimming)"; then\
+exec zpool wait -t trim %i;\
+else exec zpool trim -w %i; fi'
+ExecStop=-sh -c 'zpool trim -s %i 2>/dev/null || true'

--- a/etc/systemd/system/zfs-volume-wait.service.in
+++ b/etc/systemd/system/zfs-volume-wait.service.in
@@ -9,7 +9,7 @@ ConditionPathIsDirectory=/sys/module/zfs
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=-@initconfdir@/zfs
-ExecStart=@bindir@/zvol_wait
+ExecStart=zvol_wait
 
 [Install]
 WantedBy=zfs-volumes.target

--- a/etc/systemd/system/zfs-zed.service.in
+++ b/etc/systemd/system/zfs-zed.service.in
@@ -5,7 +5,7 @@ ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
 EnvironmentFile=-@initconfdir@/zfs
-ExecStart=@sbindir@/zed -F
+ExecStart=zed -F
 Restart=always
 
 [Install]


### PR DESCRIPTION
Since systemd v239, Exec* binaries are resolved from PATH when they are not-absolute. Switch to this by default for ease of downstream maintainance. Many downstream distributions move individual binaries to locations that existing compile-time configurations cannot accomodate.

### Motivation and Context
Note distributions do move some of the commands between bin, sbin, usr/bin, usr/sbin in a way that config options cannot accomodate and thus require patching (and rebasing) on every release. WIth this change, this becomes unnecessary as each distro can ship the binaries in the locations that suits them best with systemd units just working without needing to be patched up.

### Description
Use non-absolute paths in Exec* lines of all systemd units.

### How Has This Been Tested?
Integrated into downstream distro packaging & is now being upstreamed.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
