### PR TITLE
Fix Debian DKMS package so that module compilation succeeds

### DIFF
--- a/contrib/debian/rules.in
+++ b/contrib/debian/rules.in
@@ -7,8 +7,8 @@ NAME := $(shell awk '$$1 == "Name:" { print $$2; }' META)
 LINUX_MIN  := $(shell awk '/Linux-Minimum:/{print $$2}' META)
 LINUX_NEXT := $(shell awk -F'[ .]' '/Linux-Maximum:/{print $$2 "." $$3+1}' META)
 
-DKMSFILES := module include config zfs.release.in autogen.sh META AUTHORS \
-		COPYRIGHT LICENSE README.md
+DKMSFILES := module include config zfs.release.in autogen.sh copy-builtin META AUTHORS \
+		COPYRIGHT LICENSE README.md CODE_OF_CONDUCT.md NEWS NOTICE RELEASES.md
 
 ifndef KVERS
 KVERS=$(shell uname -r)


### PR DESCRIPTION
### Motivation and Context

As described in https://github.com/openzfs/zfs/issues/14887, following the generation of Debian packages with `make native-deb-utils`, the installation of `openzfs-zfs-dkms_2.1.99-1_all.deb` fails:
```
make[3]: Leaving directory '/usr/src/linux-headers-6.1.0-9-amd64'
make[2]: Leaving directory '/var/lib/dkms/zfs/2.1.99/build/module'
Making all in include
make[2]: Entering directory '/var/lib/dkms/zfs/2.1.99/build/include'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/var/lib/dkms/zfs/2.1.99/build/include'
make[2]: Entering directory '/var/lib/dkms/zfs/2.1.99/build'
make[2]: *** No rule to make target 'copy-builtin', needed by 'all-am'.  Stop.
make[2]: Leaving directory '/var/lib/dkms/zfs/2.1.99/build'
make[1]: *** [Makefile:984: all-recursive] Error 1
make[1]: Leaving directory '/var/lib/dkms/zfs/2.1.99/build'
make: *** [Makefile:888: all] Error 2
```

### Description

This MR changes slightly the definition of the Debian package so that all the necessary files are present in the generated package.

### How Has This Been Tested?

I have manually run `make native-deb-utils`, and then installed `openzfs-zfs-dkms_2.1.99-1_all.deb` in a Debian 12 environment.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
  - As discussed in https://github.com/openzfs/zfs/issues/14887, such a test would be to include the installation of the DKMS package in the CI workflow.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
