### PR TITLE
Adding new read-only compatible zpool features to compatibility.d/grub2

### DIFF
--- a/cmd/zpool/compatibility.d/grub2
+++ b/cmd/zpool/compatibility.d/grub2
@@ -8,5 +8,7 @@ extensible_dataset
 filesystem_limits
 hole_birth
 large_blocks
+livelist
 lz4_compress
 spacemap_histogram
+zpool_checkpoint

--- a/man/man7/zpool-features.7
+++ b/man/man7/zpool-features.7
@@ -228,8 +228,10 @@ extensible_dataset
 filesystem_limits
 hole_birth
 large_blocks
+livelist
 lz4_compress
 spacemap_histogram
+zpool_checkpoint
 
 .No example# Nm zpool Cm create Fl o Sy compatibility Ns = Ns Ar grub2 Ar bootpool Ar vdev
 .Ed


### PR DESCRIPTION
### Motivation and Context

GRUB2 is compatible with all "read-only compatible" features, so it is safe to add new features of this type to the grub2 compatibility list. We generally want to include all compatible features, to minimize the differences between grub2-compatible pools and no-compatibility pools.

### Description

Adding new properties `livelist` and `zpool_checkpoint` to `compatibility.d/grub2` accordingly.

Also adding them to the man page which references this file as an example, for consistency.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Signed-off-by: Colm Buckley <colm@tuatha.org>