### PR TITLE
[2.1.12] Refine special_small_blocks property validation

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1017,6 +1017,7 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 	nvlist_t *ret;
 	int chosen_normal = -1;
 	int chosen_utf = -1;
+	int set_maxbs = 0;
 
 	if (nvlist_alloc(&ret, NV_UNIQUE_NAME, 0) != 0) {
 		(void) no_memory(hdl);
@@ -1234,12 +1235,17 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
+			/* save the ZFS_PROP_RECORDSIZE during create op */
+			if (zpool_hdl == NULL && prop == ZFS_PROP_RECORDSIZE) {
+				set_maxbs = intval;
+			}
 			break;
 		}
 
 		case ZFS_PROP_SPECIAL_SMALL_BLOCKS:
 		{
-			int maxbs = SPA_OLD_MAXBLOCKSIZE;
+			int maxbs =
+			    set_maxbs == 0 ? SPA_OLD_MAXBLOCKSIZE : set_maxbs;
 			char buf[64];
 
 			if (zpool_hdl != NULL) {

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -37,7 +37,7 @@ tests = ['alloc_class_001_pos', 'alloc_class_002_neg', 'alloc_class_003_pos',
     'alloc_class_004_pos', 'alloc_class_005_pos', 'alloc_class_006_pos',
     'alloc_class_007_pos', 'alloc_class_008_pos', 'alloc_class_009_pos',
     'alloc_class_010_pos', 'alloc_class_011_neg', 'alloc_class_012_pos',
-    'alloc_class_013_pos']
+    'alloc_class_013_pos', 'alloc_class_014_neg', 'alloc_class_015_pos']
 tags = ['functional', 'alloc_class']
 
 [tests/functional/arc]

--- a/tests/zfs-tests/tests/functional/alloc_class/Makefile.am
+++ b/tests/zfs-tests/tests/functional/alloc_class/Makefile.am
@@ -14,7 +14,9 @@ dist_pkgdata_SCRIPTS = \
 	alloc_class_010_pos.ksh \
 	alloc_class_011_neg.ksh \
 	alloc_class_012_pos.ksh \
-	alloc_class_013_pos.ksh
+	alloc_class_013_pos.ksh \
+	alloc_class_014_neg.ksh \
+	alloc_class_015_pos.ksh
 
 dist_pkgdata_DATA = \
 	alloc_class.cfg \

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_014_neg.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_014_neg.ksh
@@ -1,0 +1,38 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+. $STF_SUITE/tests/functional/alloc_class/alloc_class.kshlib
+
+#
+# DESCRIPTION:
+#	Setting the special_small_blocks property greater than recordsize fails.
+#
+
+verify_runnable "global"
+
+claim="Setting the special_small_blocks property greater than recordsize fails"
+
+log_assert $claim
+log_onexit cleanup
+log_must disk_setup
+
+for size in 512 4096 32768 131072 524288 1048576
+do
+	let bigger=$size*2
+	log_mustnot zpool create -O recordsize=$size \
+		-O special_small_blocks=$bigger \
+		$TESTPOOL raidz $ZPOOL_DISKS special mirror \
+		$CLASS_DISK0 $CLASS_DISK1
+done
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_015_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_015_pos.ksh
@@ -1,0 +1,45 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+. $STF_SUITE/tests/functional/alloc_class/alloc_class.kshlib
+
+#
+# DESCRIPTION:
+# 	Can set special_small_blocks property less than or equal to recordsize.
+#
+
+verify_runnable "global"
+
+claim="Can set special_small_blocks property less than or equal to recordsize"
+
+log_assert $claim
+log_onexit cleanup
+log_must disk_setup
+
+for size in 8192 32768 131072 524288 1048576
+do
+	let smaller=$size/2
+	log_must zpool create -O recordsize=$size \
+		-O special_small_blocks=$smaller \
+		$TESTPOOL raidz $ZPOOL_DISKS special mirror \
+		$CLASS_DISK0 $CLASS_DISK1
+	log_must zpool destroy -f "$TESTPOOL"
+
+	log_must zpool create -O recordsize=$size \
+		-O special_small_blocks=$size \
+		$TESTPOOL raidz $ZPOOL_DISKS special mirror \
+		$CLASS_DISK0 $CLASS_DISK1
+	log_must zpool destroy -f "$TESTPOOL"
+done
+
+log_pass $claim


### PR DESCRIPTION
### Motivation and Context

Backport of #14811

### Description

When the special_small_blocks property is being set during a pool create it enforces a limit of 128KiB even if the pool's record size is larger.

If the recordsize property is being set during a pool create, then use that value instead of the default SPA_OLD_MAXBLOCKSIZE value.

