### PR TITLE
Add compatibility symlinks for FreeBSD 12.{3,4} and 13.{0,1,2}

### DIFF
--- a/cmd/zpool/Makefile.am
+++ b/cmd/zpool/Makefile.am
@@ -169,6 +169,11 @@ zpoolcompatlinks = \
 	"freebsd-11.3		freebsd-12.0" \
 	"freebsd-11.3		freebsd-12.1" \
 	"freebsd-11.3		freebsd-12.2" \
+	"freebsd-11.3		freebsd-12.3" \
+	"freebsd-11.3		freebsd-12.4" \
+	"openzfs-2.1-freebsd	freebsd-13.0" \
+	"openzfs-2.1-freebsd	freebsd-13.1" \
+	"openzfs-2.1-freebsd	freebsd-13.2" \
 	"freebsd-11.3		freenas-11.3" \
 	"freenas-11.0		freenas-11.1" \
 	"openzfsonosx-1.9.3	openzfsonosx-1.9.4" \


### PR DESCRIPTION
Nothing major, just adding symlinks to match FreeBSD releases that have come since these files were last updated.

Would recommend backporting this commit to the 2.1 branch also.