### PR TITLE
[2.1.2] Minor ZTS backports

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -282,6 +282,7 @@ elif sys.platform.startswith('linux'):
         'cli_root/zfs_rename/zfs_rename_002_pos': ['FAIL', known_reason],
         'cli_root/zpool_reopen/zpool_reopen_003_pos': ['FAIL', known_reason],
         'fault/auto_online_002_pos': ['FAIL', 11889],
+        'fault/auto_replace_001_pos': ['FAIL', 14851],
         'fault/auto_spare_002_pos': ['FAIL', 11889],
         'fault/auto_spare_multiple': ['FAIL', 11889],
         'fault/auto_spare_shared': ['FAIL', 11889],

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -210,6 +210,7 @@ elif sys.platform.startswith('linux'):
 # reasons listed above can be used.
 #
 maybe = {
+    'append/threadsappend_001_pos': ['FAIL', 6136],
     'chattr/setup': ['SKIP', exec_reason],
     'crtime/crtime_001_pos': ['SKIP', statx_reason],
     'cli_root/zdb/zdb_006_pos': ['FAIL', known_reason],
@@ -243,6 +244,7 @@ maybe = {
     'mmp/mmp_on_uberblocks': ['FAIL', known_reason],
     'pyzfs/pyzfs_unittest': ['SKIP', python_deps_reason],
     'pool_checkpoint/checkpoint_discard_busy': ['FAIL', '11946'],
+    'pam/setup': ['SKIP', "pamtester might be not available"],
     'projectquota/setup': ['SKIP', exec_reason],
     'removal/removal_condense_export': ['FAIL', known_reason],
     'reservation/reservation_008_pos': ['FAIL', '7741'],
@@ -252,14 +254,12 @@ maybe = {
     'snapshot/snapshot_010_pos': ['FAIL', '7961'],
     'snapused/snapused_004_pos': ['FAIL', '5513'],
     'tmpfile/setup': ['SKIP', tmpfile_reason],
-    'threadsappend/threadsappend_001_pos': ['FAIL', '6136'],
     'trim/setup': ['SKIP', trim_reason],
     'upgrade/upgrade_projectquota_001_pos': ['SKIP', project_id_reason],
     'user_namespace/setup': ['SKIP', user_ns_reason],
     'userquota/setup': ['SKIP', exec_reason],
-    'vdev_zaps/vdev_zaps_004_pos': ['FAIL', '6935'],
+    'vdev_zaps/vdev_zaps_004_pos': ['FAIL', known_reason],
     'zvol/zvol_ENOSPC/zvol_ENOSPC_001_pos': ['FAIL', '5848'],
-    'pam/setup': ['SKIP', "pamtester might be not available"],
 }
 
 if sys.platform.startswith('freebsd'):
@@ -281,7 +281,11 @@ elif sys.platform.startswith('linux'):
     maybe.update({
         'cli_root/zfs_rename/zfs_rename_002_pos': ['FAIL', known_reason],
         'cli_root/zpool_reopen/zpool_reopen_003_pos': ['FAIL', known_reason],
-        'fault/auto_spare_shared': ['FAIL', '11889'],
+        'fault/auto_online_002_pos': ['FAIL', 11889],
+        'fault/auto_spare_002_pos': ['FAIL', 11889],
+        'fault/auto_spare_multiple': ['FAIL', 11889],
+        'fault/auto_spare_shared': ['FAIL', 11889],
+        'fault/decompress_fault': ['FAIL', 11889],
         'io/io_uring': ['SKIP', 'io_uring support required'],
         'limits/filesystem_limit': ['SKIP', known_reason],
         'limits/snapshot_limit': ['SKIP', known_reason],

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -275,6 +275,7 @@ if sys.platform.startswith('freebsd'):
         'resilver/resilver_restart_001': ['FAIL', known_reason],
         'pool_checkpoint/checkpoint_big_rewind': ['FAIL', '12622'],
         'pool_checkpoint/checkpoint_indirect': ['FAIL', '12623'],
+        'snapshot/snapshot_002_pos': ['FAIL', '14831'],
     })
 elif sys.platform.startswith('linux'):
     maybe.update({


### PR DESCRIPTION
### Motivation and Context

Backport patches to annotate known ZTS issues.

### Description

339373eabb ZTS: Add auto_replace_001_pos to exceptions
09a7e40630 ZTS: Annotate additonal flaky test cases
4d64c57fa7 ZTS: add snapshot/snapshot_002_pos exception
c9cf9bd5e0 ZTS: send-c_volume is flaky
