### PR TITLE
[2.1.12] ZTS: Add zpool_resilver_concurrent exception

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -183,6 +183,8 @@ if sys.platform.startswith('freebsd'):
     known.update({
         'cli_root/zfs_receive/receive-o-x_props_override':
             ['FAIL', known_reason],
+        'cli_root/zpool_resilver/zpool_resilver_concurrent':
+            ['SKIP', na_reason],
         'cli_root/zpool_wait/zpool_wait_trim_basic': ['SKIP', trim_reason],
         'cli_root/zpool_wait/zpool_wait_trim_cancel': ['SKIP', trim_reason],
         'cli_root/zpool_wait/zpool_wait_trim_flag': ['SKIP', trim_reason],


### PR DESCRIPTION
### Motivation and Context

Backport of #14904

### Description

The zpool_resilver_concurrent test case requires the ZED which is not used on FreeBSD.  Add this test to the known list of skipped tested for FreeBSD.