### PR TITLE
[2.1.12] ZTS: threadsappend_001_pos

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -212,7 +212,7 @@ elif sys.platform.startswith('linux'):
 # reasons listed above can be used.
 #
 maybe = {
-    'append/threadsappend_001_pos': ['FAIL', 6136],
+    'threadsappend/threadsappend_001_pos': ['FAIL', 6136],
     'chattr/setup': ['SKIP', exec_reason],
     'crtime/crtime_001_pos': ['SKIP', statx_reason],
     'cli_root/zdb/zdb_006_pos': ['FAIL', known_reason],


### PR DESCRIPTION
### Motivation and Context

Resolve expected failures which were not annotated correctly by the `zts-report.py.in` script.

### Description

Correct exception path used in zts-report.py.in.

The path was changed by f567d67fdae5819ec25048a8b5d648fc14e6defe which has not been backported.  

### How Has This Been Tested?

Will be verified by the CI.
