### PR TITLE
Add a delay to tearing down threads on Linux.

### DIFF
--- a/include/os/linux/spl/sys/taskq.h
+++ b/include/os/linux/spl/sys/taskq.h
@@ -104,6 +104,7 @@ typedef struct taskq {
 	/* list node for the cpu hotplug callback */
 	struct hlist_node	tq_hp_cb_node;
 	boolean_t		tq_hp_support;
+	unsigned long		lastshouldstop; /* when to purge dynamic */
 } taskq_t;
 
 typedef struct taskq_ent {

--- a/man/man4/spl.4
+++ b/man/man4/spl.4
@@ -193,4 +193,19 @@ The proc file will walk the lists with lock held,
 reading it could cause a lock-up if the list grow too large
 without limiting the output.
 "(truncated)" will be shown if the list is larger than the limit.
+.
+.It Sy spl_taskq_thread_timeout_ms Ns = Ns Sy 10000 Pq uint
+(Linux-only)
+How long a taskq has to have had no work before we tear it down.
+Previously, we would tear down a dynamic taskq worker as soon
+as we noticed it had no work, but it was observed that this led
+to a lot of churn in tearing down things we then immediately
+spawned anew.
+In practice, it seems any nonzero value will remove the vast
+majority of this churn, while the nontrivially larger value
+was chosen to help filter out the little remaining churn on
+a mostly idle system.
+Setting this value to
+.Sy 0
+will revert to the previous behavior.
 .El


### PR DESCRIPTION
(n.b. this is a patch I've been running locally for almost 2 years and just forgot to ever upstream until I was forward-porting my local changes and deleting ones that were no longer needed, much like #14462.)

(I'm not sure if people will like this, or not, but I've found it useful for avoiding my nominally idle system saying it was spending a lot of its remaining not-idle time doing this...)

It's been observed that in certain workloads (zvol-related being one obvious case, though I've had trouble reproducing this in isolation on a testbed...), ZFS with dynamic_taskq enabled will end up spending a large amount of time spinning up taskqs only to tear them down again almost immediately, then spin them up again...

I noticed this when I looked at what my mostly-idle system was doing and wondered how on earth taskq creation/destroy was a bunch of time in `perf top`...

So I added a configurable delay to avoid it tearing down tasks the first time it notices them idle, rather than requiring a fixed number of tasks, and the total number of threads at steady state went up, but the amount of time being burned just tearing down/turning up new ones almost vanished.

(Basically any delay above 0 will moot most of this, but a delay longer than a couple ms does reduce the churn slightly more going from 1000/sec to 20/sec to almost 0/sec...)

### Motivation and Context
I've not tried running down which threads are wastefully spawning, as I'd basically need to flood printk to get it, since spl can't use dbgmsg...

[I think you can spot when I turn this mitigation from on to off on this graph of activity](https://www.dropbox.com/s/q4atfvgf3k1p3en/fork%20me%20up.png?dl=0) (yes, I know it says forks, but I promise, it includes kernel task churn...)

### Description
Adds a field for tracking when we noticed a taskq was idle, and then we check it the next time we look for idle things, and if the delta is larger than the tunable, we actually tear it down. (A value of 0 reverts to the old behavior.)

### How Has This Been Tested?
I've been running this since at least November 2021 without explosions and with much less time burnt just spawning things.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
