### PR TITLE
[2.1.13] zfs-dkms rpm: simplify scriptlets, fix uninstall

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -68,46 +68,9 @@ fi
 %defattr(-,root,root)
 /usr/src/%{module}-%{version}
 
-%post
-for POSTINST in /usr/lib/dkms/common.postinst; do
-    if [ -f $POSTINST ]; then
-        $POSTINST %{module} %{version}
-        exit $?
-    fi
-    echo "WARNING: $POSTINST does not exist."
-done
-echo -e "ERROR: DKMS version is too old and %{module} was not"
-echo -e "built with legacy DKMS support."
-echo -e "You must either rebuild %{module} with legacy postinst"
-echo -e "support or upgrade DKMS to a more current version."
-exit 1
-
 %preun
-# Are we doing an upgrade?
-if [ "$1" = "1" -o "$1" = "upgrade" ] ; then
-	# Yes we are.  Are we upgrading to a new ZFS version?
-	NEWEST_VER=$(dkms status zfs | tr -d , | sort -r -V | awk '/installed/{print $2; exit}')
-	if [ "$NEWEST_VER" != "%{version}" ] ; then
-		# Yes, it's a new ZFS version.  We'll uninstall the old module
-		# later on in this script.
-		true
-	else
-		# No, it's probably an upgrade of the same ZFS version
-		# to a new distro (zfs-dkms-0.7.12.fc28->zfs-dkms-0.7.12.fc29).
-		# Don't remove our modules, since the rebuild for the new
-		# distro will automatically delete the old modules.
-		exit 0
-	fi
-fi
+dkms remove -m %{module} -v %{version} --all
 
-# If we're here then we're doing an uninstall (not upgrade).
-CONFIG_H="/var/lib/dkms/%{module}/%{version}/*/*/%{module}_config.h"
-SPEC_META_ALIAS="@PACKAGE@-@VERSION@-@RELEASE@"
-DKMS_META_ALIAS=`cat $CONFIG_H 2>/dev/null |
-    awk -F'"' '/META_ALIAS\s+"/ { print $2; exit 0 }'`
-if [ "$SPEC_META_ALIAS" = "$DKMS_META_ALIAS" ]; then
-    echo -e
-    echo -e "Uninstall of %{module} module ($SPEC_META_ALIAS) beginning:"
-    dkms remove -m %{module} -v %{version} --all %{!?not_rpm:--rpm_safe_upgrade}
-fi
-exit 0
+%posttrans
+/usr/lib/dkms/common.postinst %{module} %{version}
+


### PR DESCRIPTION
### Motivation and Context
Backport of 063c83a

### Description
Cherry-pick of 063c83a from https://github.com/openzfs/zfs/pull/13182.  No modifications needed.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
