### PR TITLE
ZTS: send_raw_ashift

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -173,6 +173,7 @@ if sys.platform.startswith('freebsd'):
         'link_count/link_count_001': ['SKIP', na_reason],
         'casenorm/mixed_create_failure': ['FAIL', 13215],
         'mmap/mmap_sync_001_pos': ['SKIP', na_reason],
+        'rsend/send_raw_ashift': ['SKIP', 14961],
     })
 elif sys.platform.startswith('linux'):
     known.update({

--- a/tests/zfs-tests/tests/functional/rsend/send_raw_ashift.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_raw_ashift.ksh
@@ -37,6 +37,10 @@ verify_runnable "both"
 
 log_assert "Verify raw sending to pools with greater ashift succeeds"
 
+if is_freebsd; then
+	log_unsupported "Runs too long on FreeBSD 14 (Issue #14961)"
+fi
+
 function cleanup
 {
 	rm -f $BACKDIR/fs@*


### PR DESCRIPTION
### Motivation and Context

http://build.zfsonlinux.org/builders/FreeBSD%20main%20amd64%20%28TEST%29/builds/5816/steps/shell_4/logs/summary

### Description

On FreeBSD 14 this test runs slowly in the CI environment and is killed by the 10 minute timeout.  Skip the test on FreeBSD until the slow down is resolved.

### How Has This Been Tested?

To be tested by the CI.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
