### PR TITLE
port e78b7a7 tests: zts-report: issue numbers are numbers

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -164,8 +164,8 @@ summary = {
 # reasons listed above can be used.
 #
 known = {
-    'casenorm/mixed_none_lookup_ci': ['FAIL', '7633'],
-    'casenorm/mixed_formd_lookup_ci': ['FAIL', '7633'],
+    'casenorm/mixed_none_lookup_ci': ['FAIL', 7633],
+    'casenorm/mixed_formd_lookup_ci': ['FAIL', 7633],
     'cli_root/zfs_unshare/zfs_unshare_002_pos': ['SKIP', na_reason],
     'cli_root/zfs_unshare/zfs_unshare_006_pos': ['SKIP', na_reason],
     'cli_root/zpool_import/import_rewind_device_replaced':
@@ -175,7 +175,7 @@ known = {
     'privilege/setup': ['SKIP', na_reason],
     'refreserv/refreserv_004_pos': ['FAIL', known_reason],
     'rootpool/setup': ['SKIP', na_reason],
-    'rsend/rsend_008_pos': ['SKIP', '6066'],
+    'rsend/rsend_008_pos': ['SKIP', 6066],
     'vdev_zaps/vdev_zaps_007_pos': ['FAIL', known_reason],
 }
 
@@ -193,10 +193,10 @@ if sys.platform.startswith('freebsd'):
     })
 elif sys.platform.startswith('linux'):
     known.update({
-        'casenorm/mixed_formd_lookup': ['FAIL', '7633'],
-        'casenorm/mixed_formd_delete': ['FAIL', '7633'],
-        'casenorm/sensitive_formd_lookup': ['FAIL', '7633'],
-        'casenorm/sensitive_formd_delete': ['FAIL', '7633'],
+        'casenorm/mixed_formd_lookup': ['FAIL', 7633],
+        'casenorm/mixed_formd_delete': ['FAIL', 7633],
+        'casenorm/sensitive_formd_lookup': ['FAIL', 7633],
+        'casenorm/sensitive_formd_delete': ['FAIL', 7633],
         'removal/removal_with_zdb': ['SKIP', known_reason],
     })
 
@@ -220,49 +220,49 @@ maybe = {
     'cli_root/zfs_destroy/zfs_destroy_dev_removal_condense':
         ['FAIL', known_reason],
     'cli_root/zfs_get/zfs_get_004_pos': ['FAIL', known_reason],
-    'cli_root/zfs_get/zfs_get_009_pos': ['SKIP', '5479'],
+    'cli_root/zfs_get/zfs_get_009_pos': ['SKIP', 5479],
     'cli_root/zfs_rollback/zfs_rollback_001_pos': ['FAIL', known_reason],
     'cli_root/zfs_rollback/zfs_rollback_002_pos': ['FAIL', known_reason],
     'cli_root/zfs_share/setup': ['SKIP', share_reason],
     'cli_root/zfs_snapshot/zfs_snapshot_002_neg': ['FAIL', known_reason],
     'cli_root/zfs_unshare/setup': ['SKIP', share_reason],
     'cli_root/zpool_add/zpool_add_004_pos': ['FAIL', known_reason],
-    'cli_root/zpool_destroy/zpool_destroy_001_pos': ['SKIP', '6145'],
-    'cli_root/zpool_import/zpool_import_missing_003_pos': ['SKIP', '6839'],
+    'cli_root/zpool_destroy/zpool_destroy_001_pos': ['SKIP', 6145],
+    'cli_root/zpool_import/zpool_import_missing_003_pos': ['SKIP', 6839],
     'cli_root/zpool_initialize/zpool_initialize_import_export':
-        ['FAIL', '11948'],
+        ['FAIL', 11948],
     'cli_root/zpool_labelclear/zpool_labelclear_removed':
         ['FAIL', known_reason],
     'cli_root/zpool_trim/setup': ['SKIP', trim_reason],
-    'cli_root/zpool_upgrade/zpool_upgrade_004_pos': ['FAIL', '6141'],
+    'cli_root/zpool_upgrade/zpool_upgrade_004_pos': ['FAIL', 6141],
     'delegate/setup': ['SKIP', exec_reason],
     'fallocate/fallocate_punch-hole': ['SKIP', fspacectl_reason],
-    'history/history_004_pos': ['FAIL', '7026'],
-    'history/history_005_neg': ['FAIL', '6680'],
-    'history/history_006_neg': ['FAIL', '5657'],
+    'history/history_004_pos': ['FAIL', 7026],
+    'history/history_005_neg': ['FAIL', 6680],
+    'history/history_006_neg': ['FAIL', 5657],
     'history/history_008_pos': ['FAIL', known_reason],
     'history/history_010_pos': ['SKIP', exec_reason],
     'io/mmap': ['SKIP', fio_reason],
     'largest_pool/largest_pool_001_pos': ['FAIL', known_reason],
     'mmp/mmp_on_uberblocks': ['FAIL', known_reason],
     'pyzfs/pyzfs_unittest': ['SKIP', python_deps_reason],
-    'pool_checkpoint/checkpoint_discard_busy': ['FAIL', '11946'],
+    'pool_checkpoint/checkpoint_discard_busy': ['FAIL', 11946],
     'pam/setup': ['SKIP', "pamtester might be not available"],
     'projectquota/setup': ['SKIP', exec_reason],
     'removal/removal_condense_export': ['FAIL', known_reason],
-    'reservation/reservation_008_pos': ['FAIL', '7741'],
-    'reservation/reservation_018_pos': ['FAIL', '5642'],
+    'reservation/reservation_008_pos': ['FAIL', 7741],
+    'reservation/reservation_018_pos': ['FAIL', 5642],
     'snapshot/clone_001_pos': ['FAIL', known_reason],
-    'snapshot/snapshot_009_pos': ['FAIL', '7961'],
-    'snapshot/snapshot_010_pos': ['FAIL', '7961'],
-    'snapused/snapused_004_pos': ['FAIL', '5513'],
+    'snapshot/snapshot_009_pos': ['FAIL', 7961],
+    'snapshot/snapshot_010_pos': ['FAIL', 7961],
+    'snapused/snapused_004_pos': ['FAIL', 5513],
     'tmpfile/setup': ['SKIP', tmpfile_reason],
     'trim/setup': ['SKIP', trim_reason],
     'upgrade/upgrade_projectquota_001_pos': ['SKIP', project_id_reason],
     'user_namespace/setup': ['SKIP', user_ns_reason],
     'userquota/setup': ['SKIP', exec_reason],
     'vdev_zaps/vdev_zaps_004_pos': ['FAIL', known_reason],
-    'zvol/zvol_ENOSPC/zvol_ENOSPC_001_pos': ['FAIL', '5848'],
+    'zvol/zvol_ENOSPC/zvol_ENOSPC_001_pos': ['FAIL', 5848],
 }
 
 if sys.platform.startswith('freebsd'):
@@ -274,11 +274,11 @@ if sys.platform.startswith('freebsd'):
             ['FAIL', known_reason],
         'cli_root/zpool_import/zpool_import_012_pos': ['FAIL', known_reason],
         'delegate/zfs_allow_003_pos': ['FAIL', known_reason],
-        'inheritance/inherit_001_pos': ['FAIL', '11829'],
+        'inheritance/inherit_001_pos': ['FAIL', 11829],
         'resilver/resilver_restart_001': ['FAIL', known_reason],
-        'pool_checkpoint/checkpoint_big_rewind': ['FAIL', '12622'],
-        'pool_checkpoint/checkpoint_indirect': ['FAIL', '12623'],
-        'snapshot/snapshot_002_pos': ['FAIL', '14831'],
+        'pool_checkpoint/checkpoint_big_rewind': ['FAIL', 12622],
+        'pool_checkpoint/checkpoint_indirect': ['FAIL', 12623],
+        'snapshot/snapshot_002_pos': ['FAIL', 14831],
     })
 elif sys.platform.startswith('linux'):
     maybe.update({
@@ -296,7 +296,7 @@ elif sys.platform.startswith('linux'):
         'mmp/mmp_active_import': ['FAIL', known_reason],
         'mmp/mmp_exported_import': ['FAIL', known_reason],
         'mmp/mmp_inactive_import': ['FAIL', known_reason],
-        'zvol/zvol_misc/zvol_misc_snapdev': ['FAIL', '12621'],
+        'zvol/zvol_misc/zvol_misc_snapdev': ['FAIL', 12621],
         'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', known_reason],
     })
 
@@ -327,7 +327,7 @@ if os.environ.get('CI') == 'true':
     })
 
     maybe.update({
-        'events/events_002_pos': ['FAIL', '11546'],
+        'events/events_002_pos': ['FAIL', 11546],
     })
 elif sys.platform.startswith('linux'):
     maybe.update({
@@ -451,13 +451,13 @@ if __name__ == "__main__":
         if test in known:
             if known[test][1] == na_reason:
                 continue
-            elif known[test][1].isdigit():
-                expect = issue_url + known[test][1]
+            elif isinstance(known[test][1], int):
+                expect = f"{issue_url}{known[test][1]}"
             else:
                 expect = known[test][1]
         elif test in maybe:
-            if maybe[test][1].isdigit():
-                expect = issue_url + maybe[test][1]
+            if isinstance(maybe[test][1], int):
+                expect = f"{issue_url}{maybe[test][1]}"
             else:
                 expect = maybe[test][1]
         elif setup in known and known[setup][0] == "SKIP" and setup != test:


### PR DESCRIPTION
### Motivation and Context
e78b7a73feaa255dff8981da794b45702797c948 changed the convention in  `tests/test-runner/bin/zts-report.py.in` to express issue numbers with actual numbers, rather than strings.

New commits (e.g., 5b3b6e95c0f3aeea55932d91f469e8edd3c9cd0f) were then made using this convention, and then backported without reverting their convention (4e24df0e8151ea6323e682d50b39db70ada4c104).

This patch affirms the new convention, and avoids an exception during `zts-report.py ` execution.

### Description
This is a straightforward cherry-pick of e78b7a73feaa255dff8981da794b45702797c948 where all conflicts were ignored, and then all integer strings replaced (hopefully both my eyes and `/'[0-9` didn't miss any leftovers).

I don't know what the proper sign-off/reviewed-by convention is for a modified, joint commit like this.  I will change the message if anyone wants it different.

### How Has This Been Tested?
This is a test.  But more seriously, I think the exception in zts-report.py may be getting swallowed somewhere in the CI pipeline.  Later work might seek to address that.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. (**THIS IS A TEST**)
- [ ] I have run the ZFS Test Suite with this change applied. (**IN PROGRESS**)
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
