### PR TITLE
contrib/bash_completion.d: fix error spew from __zfs_match_snapshot() [2.1.13]

### DIFF
--- a/contrib/bash_completion.d/zfs.in
+++ b/contrib/bash_completion.d/zfs.in
@@ -69,7 +69,7 @@ __zfs_match_snapshot()
     else
         if [ "$cur" != "" ] && __zfs_list_datasets "$cur" &> /dev/null
         then
-            $__ZFS_CMD list -H -o name -s name -t filesystem -r "$cur" | tail -n +2
+            $__ZFS_CMD list -H -o name -s name -t filesystem,volume -r "$cur" | tail -n +2
             # We output the base dataset name even though we might be
             # completing a command that can only take a snapshot, because it
             # prevents bash from considering the completion finished when it


### PR DESCRIPTION
Backport of #12820 (clean cherry-pick).

I just hit
```
$ zfs snapshot filling/store/nabijaczleweli/vm-zootcannot open 'filling/store/nabijaczleweli/vm-zoot': operation not applicable to datasets of this te

filling/store/nabijaczleweli/vm-zoot   filling/store/nabijaczleweli/vm-zoot@
$ zfs snapshot filling/store/nabijaczleweli/vm-zoot@
filling/store/nabijaczleweli/vm-zoot@2023-06-11-pre-bookworm  filling/store/nabijaczleweli/vm-zoot@clean-grub-on-zfs
```
on bookworm. Turns out I already fixed this two years! It just never got backported. Well, here it is.