### PR TITLE
RFC: Allow for different content in man pages based on OS

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -118,10 +118,28 @@ mancheck:
 
 
 if BUILD_LINUX
-# The manual pager in most Linux distros defaults to "BSD" when .Os is blank,
-# but leaving it blank makes things a lot easier on
-# FreeBSD when OpenZFS is vendored in the base system.
+# - The manual pager in most Linux distros defaults to "BSD" when .Os is blank,
+#   but leaving it blank makes things a lot easier on FreeBSD when OpenZFS is
+#   vendored in the base system.
+# - Remove non-Linux content from man pages
 INSTALL_DATA_HOOKS += man-install-data-hook
 man-install-data-hook:
-	cd $(DESTDIR)$(mandir) && $(SED) $(ac_inplace) 's/^\.Os$$/.Os OpenZFS/' $(subst %D%/,,$(dist_man_MANS) $(nodist_man_MANS))
+	cd $(DESTDIR)$(mandir) && \
+	$(SED) $(ac_inplace) 's/^\.Os$$/.Os OpenZFS/' \
+	    $(subst %D%/,,$(dist_man_MANS) $(nodist_man_MANS)) && \
+	$(SED) $(ac_inplace) \
+	    -e 's/^LINUX://' \
+	    -e '/^FREEBSD:/d' \
+	    $(subst %D%/,,$(dist_man_MANS) $(nodist_man_MANS))
+endif
+
+if BUILD_FREEBSD
+# - Remove non-FreeBSD content from man pages
+INSTALL_DATA_HOOKS += man-install-data-hook
+man-install-data-hook:
+	cd $(DESTDIR)$(mandir) && \
+	$(SED) $(ac_inplace) \
+	    -e 's/^FREEBSD://' \
+	    -e '/^LINUX:/d' \
+	    $(subst %D%/,,$(dist_man_MANS) $(nodist_man_MANS))
 endif

--- a/man/man7/zpoolprops.7
+++ b/man/man7/zpoolprops.7
@@ -275,7 +275,8 @@ This allows block device vdevs which support
 BLKDISCARD, such as SSDs, or file vdevs on which the underlying file system
 supports hole-punching, to reclaim unused blocks.
 The default value for this property is
-.Sy off .
+FREEBSD:.Sy on .
+LINUX:.Sy off .
 .Pp
 Automatic TRIM does not immediately reclaim blocks after a free.
 Instead, it will optimistically delay allowing smaller ranges to be aggregated


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Provide a way to add OS-specific content in man pages by adding the FREEBSD: and LINUX: prefixes, and extending the man pages install hook to parse those.

Currently only done for autotrim default value that differs between FreeBSD and Linux as a PoC (there are other examples where Linux-related text in man pages does not make sense on FreeBSD and generates user questions).

Done this way as at least mandoc used to render the man pages in FreeBSD does not support any in-page changes based on current OS (probably doable in groff?).

Related changes to FreeBSD in-base build of openzfs will be done separately if this is accepted.

P.S. the prefixes used here do not add any man page linter noise, but if there are better ideas, I'm looking forward to them.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
