### PR TITLE
Fix the ZFS checksum error histograms with larger record sizes

### DIFF
--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -790,7 +790,7 @@ update_histogram(uint64_t value_arg, uint8_t *hist, uint32_t *count)
 	/* We store the bits in big-endian (largest-first) order */
 	for (i = 0; i < 64; i++) {
 		if (value & (1ull << i)) {
-			hist[63 - i]++;
+			hist[63 - i] = MAX(hist[63 - i], hist[63 - i] + 1);
 			++bits;
 		}
 	}


### PR DESCRIPTION
My analysis in PR #14716 was incorrect.  Each histogram bucket contains the number of incorrect bits, by position in a 64-bit word, over the entire record.  8-bit buckets can overflow for record sizes above 2k. To forestall that, saturate each bucket at 255.  That should still get the point across: either all bits are equally wrong, or just a couple are.

Sponsored-by:	Axcient
Signed-off-by:	Alan Somers <asomers@gmail.com>

### Motivation and Context
After PR #14716, the bad_cleared_histogram and bad_set_histogram fields of an ereport.fs.zfs.checksum event could contain incorrect values for record sizes of 2kB and above, due to an integer overflow.

### Description
Rather than overflow, saturate the histogram buckets at 255.  That will still be sufficient for diagnostic purposes.

### How Has This Been Tested?
Tested on FreeBSD 14 using the zfsd_degrade_001_pos test case from FreeBSD's zfsd test suite.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).