### PR TITLE
Don't do a readonly check for vdev user properties

### DIFF
--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -483,8 +483,8 @@ vdev_prop_user(const char *name)
 }
 
 /*
- * Given a pool property ID, returns the corresponding name.
- * Assuming the pool property ID is valid.
+ * Given a vdev property ID, returns the corresponding name.
+ * Assuming the vdev property ID is valid.
  */
 const char *
 vdev_prop_to_name(vdev_prop_t prop)
@@ -501,6 +501,9 @@ vdev_prop_get_type(vdev_prop_t prop)
 boolean_t
 vdev_prop_readonly(vdev_prop_t prop)
 {
+	if (prop == VDEV_PROP_USERPROP)
+		return (B_FALSE);
+
 	return (vdev_prop_table[prop].pd_attr == PROP_READONLY);
 }
 


### PR DESCRIPTION
These should be always writable, more so we did the check with negative index (VDEV_PROP_USERPROP is defined the same as VDEV_PROP_INVAL, which is -1).

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change allows setting user properties on vdevs (again? don't know if it worked previously or not).

### Description
<!--- Describe your changes in detail -->
Check if property is VDEV_PROP_USERPROP, if yes, skip readonly check.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
