### PR TITLE
metaslab: tuneable to better control force ganging

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -15,7 +15,7 @@
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
 .\"
-.Dd January 10, 2023
+.Dd July 21, 2023
 .Dt ZFS 4
 .Os
 .
@@ -238,6 +238,11 @@ relative to the pool.
 .It Sy metaslab_force_ganging Ns = Ns Sy 16777217 Ns B Po 16 MiB + 1 B Pc Pq u64
 Make some blocks above a certain size be gang blocks.
 This option is used by the test suite to facilitate testing.
+.
+.It Sy metaslab_force_ganging_pct Ns = Ns Sy 3 Ns % Pq uint
+For blocks that could be forced to be a gang block (due to
+.Sy metaslab_force_ganging ) ,
+force this many of them to be gang blocks.
 .
 .It Sy zfs_ddt_zap_default_bs Ns = Ns Sy 15 Po 32 KiB Pc Pq int
 Default DDT ZAP data block size as a power of 2. Note that changing this after


### PR DESCRIPTION
### Motivation and Context

`metaslab_force_ganging` isn't enough to actually force ganging, because it still only forces 3% of the time. This adds `metaslab_force_ganging_pct` so we can configure how often to force ganging.

Sponsored-by: Klara, Inc.
Sponsored-by: Wasabi Technology, Inc.

### How Has This Been Tested?

Heavily as part of some other debugging work, but here's a simple standalone run:

```
# echo 32768 > /sys/module/zfs/parameters/metaslab_force_ganging
# echo 100 > /sys/module/zfs/parameters/metaslab_force_ganging_pct
# zpool create tank loop0

# dd if=/dev/random of=/tank/file bs=128K count=4
4+0 records in
4+0 records out
524288 bytes (524 kB, 512 KiB) copied, 0.0018605 s, 282 MB/s
# zpool sync
# grep 'trying ganging' /proc/spl/kstat/zfs/dbgmsg | wc -l
16
# zdb -b tank 2>/dev/null | grep ganged
  ganged count:                 8
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
