### PR TITLE
[2.2] readmmap.c: fix building with MUSL libc

### DIFF
--- a/tests/zfs-tests/cmd/readmmap.c
+++ b/tests/zfs-tests/cmd/readmmap.c
@@ -44,6 +44,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <sys/mman.h>
+#include <sys/types.h>
 #include <time.h>
 
 int


### PR DESCRIPTION
### Motivation and Context

Backport of #15130 for MUSL libc. 

### Description

glibc includes sys/types.h from stdlib.h. This is not the case for MUSL, so explicitly include it. Fixes usage of uint_t.

### How Has This Been Tested?

Tested by original PR author.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
