### PR TITLE
fix some assign arc buf with brt clone and `O_TRUNC`

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2945,7 +2945,8 @@ dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx)
 	while (db->db_state == DB_READ || db->db_state == DB_FILL)
 		cv_wait(&db->db_changed, &db->db_mtx);
 
-	ASSERT(db->db_state == DB_CACHED || db->db_state == DB_UNCACHED);
+	ASSERT(db->db_state == DB_CACHED || db->db_state == DB_UNCACHED ||
+	    db->db_state == DB_NOFILL);
 
 	if (db->db_state == DB_CACHED &&
 	    zfs_refcount_count(&db->db_holds) - 1 > db->db_dirtycnt) {
@@ -2982,7 +2983,17 @@ dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx)
 			arc_buf_destroy(db->db_buf, db);
 		}
 		db->db_buf = NULL;
+	} else if (db->db_state == DB_NOFILL) {
+		/*
+		 * We will be completely replacing the cloned block.  In case
+		 * it was cloned in this transaction group, let's undirty the
+		 * pending clone and mark the block as uncached. This will be
+		 * as if the clone was never done.
+		 */
+		VERIFY(!dbuf_undirty(db, tx));
+		db->db_state = DB_UNCACHED;
 	}
+
 	ASSERT(db->db_buf == NULL);
 	dbuf_set_data(db, buf);
 	db->db_state = DB_FILL;

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -44,7 +44,8 @@ tests = ['block_cloning_copyfilerange', 'block_cloning_copyfilerange_partial',
     'block_cloning_copyfilerange_cross_dataset',
     'block_cloning_cross_enc_dataset',
     'block_cloning_copyfilerange_fallback_same_txg',
-    'block_cloning_replay', 'block_cloning_replay_encrypted']
+    'block_cloning_replay', 'block_cloning_replay_encrypted',
+    'block_cloning_ficlone_and_write']
 tags = ['functional', 'block_cloning']
 
 [tests/functional/chattr:Linux]

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -311,6 +311,8 @@ elif sys.platform.startswith('linux'):
             ['SKIP', cfr_cross_reason],
         'block_cloning/block_cloning_cross_enc_dataset':
             ['SKIP', cfr_cross_reason],
+        'block_cloning/block_cloning_ficlone_and_write':
+            ['SKIP', cfr_reason],
     })
 
 # Not all Github actions runners have scsi_debug module, so we may skip

--- a/tests/zfs-tests/cmd/clonefile.c
+++ b/tests/zfs-tests/cmd/clonefile.c
@@ -135,14 +135,23 @@ usage(void)
 {
 	printf(
 	    "usage:\n"
+	    "\n"
 	    "  FICLONE:\n"
 	    "    clonefile -c <src> <dst>\n"
+	    "    clonefile [opts] -c <src> <dst>\n"
 	    "  FICLONERANGE:\n"
 	    "    clonefile -r <src> <dst> <soff> <doff> <len>\n"
+	    "    clonefile [opts] -r <src> <dst> <soff> <doff> <len>\n"
 	    "  copy_file_range:\n"
 	    "    clonefile -f <src> <dst> <soff> <doff> <len>\n"
+	    "    clonefile [opts] -f <src> <dst> <soff> <doff> <len>\n"
 	    "  FIDEDUPERANGE:\n"
-	    "    clonefile -d <src> <dst> <soff> <doff> <len>\n");
+	    "    clonefile -d <src> <dst> <soff> <doff> <len>\n"
+	    "    clonefile [opts] -d <src> <dst> <soff> <doff> <len>\n"
+	    "\n"
+	    "  options:\n"
+	    "    -t  truncate dstfile (open with O_TRUNC)\n"
+	    "\n");
 	return (1);
 }
 
@@ -157,9 +166,10 @@ int
 main(int argc, char **argv)
 {
 	cf_mode_t mode = CF_MODE_NONE;
+	int dstflags = 0;
 
 	char c;
-	while ((c = getopt(argc, argv, "crfdq")) != -1) {
+	while ((c = getopt(argc, argv, "crfdqt")) != -1) {
 		switch (c) {
 			case 'c':
 				mode = CF_MODE_CLONE;
@@ -175,6 +185,9 @@ main(int argc, char **argv)
 				break;
 			case 'q':
 				quiet = 1;
+				break;
+			case 't':
+				dstflags = O_TRUNC;
 				break;
 		}
 	}
@@ -210,7 +223,7 @@ main(int argc, char **argv)
 		return (1);
 	}
 
-	int dfd = open(argv[optind+1], O_WRONLY|O_CREAT,
+	int dfd = open(argv[optind+1], O_WRONLY|O_CREAT|dstflags,
 	    S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
 	if (dfd < 0) {
 		fprintf(stderr, "open: %s: %s\n",

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -454,6 +454,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/block_cloning/block_cloning_cross_enc_dataset.ksh \
 	functional/block_cloning/block_cloning_replay.ksh \
 	functional/block_cloning/block_cloning_replay_encrypted.ksh \
+	functional/block_cloning/block_cloning_ficlone_and_write.ksh \
 	functional/bootfs/bootfs_001_pos.ksh \
 	functional/bootfs/bootfs_002_neg.ksh \
 	functional/bootfs/bootfs_003_pos.ksh \

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_ficlone_and_write.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_ficlone_and_write.ksh
@@ -1,0 +1,80 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023, Kay Pedersen <mail@mkwg.de>
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+  log_unsupported "copy_file_range not available before Linux 4.5"
+fi
+
+claim="O_TRUNC, writing and FICLONE to a large (>4G) file shouldn't fail"
+
+log_assert $claim
+
+NO_LOOP_BREAK=true
+
+function cleanup
+{
+    datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+function loop
+{
+    while $NO_LOOP_BREAK; do clonefile -c -t -q /$TESTPOOL/file /$TESTPOOL/clone; done
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $DISKS
+
+log_must dd if=/dev/urandom of=/$TESTPOOL/file bs=1M count=4000
+log_must sync_pool $TESTPOOL
+
+
+log_note "Copying entire file with FICLONE"
+
+log_must clonefile -c /$TESTPOOL/file /$TESTPOOL/clone
+log_must sync_pool $TESTPOOL
+
+log_must have_same_content /$TESTPOOL/file /$TESTPOOL/clone
+
+log_note "looping a clone"
+loop &
+
+log_must dd if=/dev/urandom of=/$TESTPOOL/clone bs=1M count=4000
+log_must dd if=/dev/urandom of=/$TESTPOOL/clone bs=1M count=4000
+
+NO_LOOP_BREAK=false
+
+# just to be sure all background jobs are killed.
+log_must kill $(jobs -p)
+
+log_must sync_pool $TESTPOOL
+
+log_pass $claim


### PR DESCRIPTION
This is definitely some strange bugs I found and I think I don't understand it fully. This is a draft for now.

this fixes some bugs when opening a file wiht O_TRUNC and writing to the same file at the same time with `dd` for example. O_TRUNC in the VFS calls set_attr and set_attr will figure out a trunc based on the O_TRUNC flag.
dmu_free_long_range_impl will free the data after that. If a reflink is and write is running at the same time it will fail with:
```
kernel:VERIFY(db->db_state == DB_CACHED || db->db_state == DB_UNCACHED) failed
kernel:PANIC at dbuf.c:2925:dbuf_assign_arcbuf()
```

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix, I don't think that this close a open Issue in the list. And I like `while true` loops.

### Description
<!--- Describe your changes in detail -->
How this can be reproduced:
```bash
zpool create -f tank /dev/sdb && zfs create tank/test
dd if=/dev/random of=/tank/test/test.img bs=4M count=1000 status=progress
zpool sync
while true; do clonefile -c /tank/test/test.img /tank/test/test.img2 && date; done
```
after that open a second shell and use:
```bash
dd if=/dev/random of=/tank/test/test.img2 bs=4M count=1000 status=progress
```

some bigger file are necessary to reproduce it.

`clonefile.c`: I will improve the path after we understand the bug fully and we are sure what happens here. Than I can provide a path with options and maybe some test as well.
@robn @behlendorf maybe you should check it out as well, because we got the reflink stuff off the ground together.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
By hand, left it for two hours running nothing happened. But maybe that was just luck?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
