### PR TITLE
xattr dataset prop: change defaults to sa

### DIFF
--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1961,14 +1961,13 @@ enabled for virus scanning to occur.
 The default value is
 .Sy off .
 This property is not used by OpenZFS.
-.It Sy xattr Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy sa
+.It Sy xattr Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy dir Ns | Ns Sy sa
 Controls whether extended attributes are enabled for this file system.
 Two styles of extended attributes are supported: either directory-based
 or system-attribute-based.
 .Pp
-The default value of
-.Sy on
-enables directory-based extended attributes.
+Directory-based extended attributes can be enabled by setting the value to
+.Sy dir .
 This style of extended attribute imposes no practical limit
 on either the size or number of attributes which can be set on a file.
 Although under Linux the
@@ -1981,7 +1980,10 @@ This is the most compatible
 style of extended attribute and is supported by all ZFS implementations.
 .Pp
 System-attribute-based xattrs can be enabled by setting the value to
-.Sy sa .
+.Sy sa
+(default and equal to
+.Sy on
+) .
 The key advantage of this type of xattr is improved performance.
 Storing extended attributes as system attributes
 significantly decreases the amount of disk I/O required.

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -164,7 +164,7 @@ zfsvfs_parse_option(char *option, int token, substring_t *args, vfs_t *vfsp)
 		vfsp->vfs_do_xattr = B_TRUE;
 		break;
 	case TOKEN_XATTR:
-		vfsp->vfs_xattr = ZFS_XATTR_DIR;
+		vfsp->vfs_xattr = ZFS_XATTR_SA;
 		vfsp->vfs_do_xattr = B_TRUE;
 		break;
 	case TOKEN_NOXATTR:

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -361,7 +361,7 @@ zfs_prop_init(void)
 
 	static const zprop_index_t xattr_table[] = {
 		{ "off",	ZFS_XATTR_OFF },
-		{ "on",		ZFS_XATTR_DIR },
+		{ "on",		ZFS_XATTR_SA },
 		{ "sa",		ZFS_XATTR_SA },
 		{ "dir",	ZFS_XATTR_DIR },
 		{ NULL }
@@ -474,7 +474,7 @@ zfs_prop_init(void)
 	zprop_register_index(ZFS_PROP_LOGBIAS, "logbias", ZFS_LOGBIAS_LATENCY,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
 	    "latency | throughput", "LOGBIAS", logbias_table, sfeatures);
-	zprop_register_index(ZFS_PROP_XATTR, "xattr", ZFS_XATTR_DIR,
+	zprop_register_index(ZFS_PROP_XATTR, "xattr", ZFS_XATTR_SA,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT,
 	    "on | off | dir | sa", "XATTR", xattr_table, sfeatures);
 	zprop_register_index(ZFS_PROP_DNODESIZE, "dnodesize",

--- a/tests/zfs-tests/tests/functional/projectquota/projectid_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectid_003_pos.ksh
@@ -59,7 +59,7 @@ log_onexit cleanup
 
 log_assert "Check changing project ID with directory-based extended attributes"
 
-log_must zfs set xattr=on $QFS
+log_must zfs set xattr=dir $QFS
 
 log_must touch $PRJGUARD
 log_must chattr -p $PRJID1 $PRJGUARD
@@ -76,6 +76,6 @@ sync_pool
 typeset prj_aft=$(project_obj_count $QFS $PRJID1)
 
 [[ $prj_aft -ge $((prj_bef + 5)) ]] ||
-	log_fail "new value ($prj_aft) is NOT 5 largr than old one ($prj_bef)"
+	log_fail "new value ($prj_aft) is NOT 5 larger than old one ($prj_bef)"
 
 log_pass "Changing project ID with directory-based extended attributes pass"

--- a/tests/zfs-tests/tests/functional/xattr/xattr_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_001_pos.ksh
@@ -52,7 +52,7 @@ function cleanup {
 	fi
 }
 
-set -A args "on" "sa"
+set -A args "dir" "sa"
 
 log_assert "Create/read/write/append of xattrs works"
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/xattr/xattr_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_002_neg.ksh
@@ -46,7 +46,7 @@ function cleanup {
 
 }
 
-set -A args "on" "sa"
+set -A args "dir" "sa"
 
 log_assert "A read of a non-existent xattr fails"
 log_onexit cleanup


### PR DESCRIPTION
I'll push this PR as proposal for better defaults, but will set it as draft until manual testing.
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Let's have optimal default settings.

### Description
<!--- Describe your changes in detail -->
It's the main recommendation to set xattr=sa
even in man pages, so let's set it by default.

xattr=sa don't use feature flag, so in the worst
case we'll have non-readable xattrs by other
non-openzfs platforms.

Non-overridden default `xattr` prop of existing pools
will automatically use `sa` after this commit too.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
CI's tests looks good, I'll check compatibility with existing pools later.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
