### PR TITLE
dracut: support mountpoint=legacy for root dataset

### DIFF
--- a/contrib/dracut/90zfs/zfs-env-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-env-bootfs.service.in
@@ -12,11 +12,12 @@ ExecStart=/bin/sh -c '                                                          
     decode_root_args || exit 0;                                                                \
     [ "$root" = "zfs:AUTO" ] && root="$(@sbindir@/zpool list -H -o bootfs | grep -m1 -vFx -)"; \
     rootflags="$(getarg rootflags=)";                                                          \
-    case ",$rootflags," in                                                                     \
-        *,zfsutil,*) ;;                                                                        \
-        ,,) rootflags=zfsutil ;;                                                               \
-        *)  rootflags="zfsutil,$rootflags" ;;                                                  \
-    esac;                                                                                      \
+    [ "$(@sbindir@/zfs get -H -o value mountpoint "$root")" = legacy ] ||                      \
+        case ",$rootflags," in                                                                 \
+            *,zfsutil,*) ;;                                                                    \
+            ,,) rootflags=zfsutil ;;                                                           \
+            *)  rootflags="zfsutil,$rootflags" ;;                                              \
+        esac;                                                                                  \
     exec systemctl set-environment BOOTFS="$root" BOOTFSFLAGS="$rootflags"'
 
 [Install]


### PR DESCRIPTION
Support mountpoint=legacy for the root dataset in the dracut zfs support scripts.

mountpoint=/ or mountpoint=/sysroot also works.

Change zfs-env-bootfs.service to add zfsutil to BOOTFSFLAGS only for non-legacy root datasets, using the support function determine_rootflags() added to zfs-lib.sh.

### Motivation and Context
This allows using the dracut kernel commandline option `root=ZFS=pool/dataset` for datasets that have `mountpoint=legacy` set.

This is documented as already working, but it looks like once the root mount was switched to use the generator stuff it broke.

### How Has This Been Tested?
I made the changes in my `/usr/lib/dracut/modules.d/90zfs` and reran dracut on my system, testing booting the root dataset with mountpoint being `/`, `/sysroot` and `legacy`.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)