### PR TITLE
Distribute zfs-[un]jail.8 on FreeBSD and zfs-[un]zone.8 on Linux. Make zoned/jailed zfsprops(7) make more sense.

### DIFF
--- a/contrib/debian/openzfs-zfsutils.install
+++ b/contrib/debian/openzfs-zfsutils.install
@@ -59,7 +59,6 @@ usr/share/man/man8/zfs-get.8
 usr/share/man/man8/zfs-groupspace.8
 usr/share/man/man8/zfs-hold.8
 usr/share/man/man8/zfs-inherit.8
-usr/share/man/man8/zfs-jail.8
 usr/share/man/man8/zfs-list.8
 usr/share/man/man8/zfs-load-key.8
 usr/share/man/man8/zfs-mount-generator.8
@@ -79,7 +78,6 @@ usr/share/man/man8/zfs-set.8
 usr/share/man/man8/zfs-share.8
 usr/share/man/man8/zfs-snapshot.8
 usr/share/man/man8/zfs-unallow.8
-usr/share/man/man8/zfs-unjail.8
 usr/share/man/man8/zfs-unload-key.8
 usr/share/man/man8/zfs-unmount.8
 usr/share/man/man8/zfs-unzone.8

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -38,7 +38,6 @@ dist_man_MANS = \
 	%D%/man8/zfs-groupspace.8 \
 	%D%/man8/zfs-hold.8 \
 	%D%/man8/zfs-inherit.8 \
-	%D%/man8/zfs-jail.8 \
 	%D%/man8/zfs-list.8 \
 	%D%/man8/zfs-load-key.8 \
 	%D%/man8/zfs-mount.8 \
@@ -57,14 +56,11 @@ dist_man_MANS = \
 	%D%/man8/zfs-share.8 \
 	%D%/man8/zfs-snapshot.8 \
 	%D%/man8/zfs-unallow.8 \
-	%D%/man8/zfs-unjail.8 \
 	%D%/man8/zfs-unload-key.8 \
 	%D%/man8/zfs-unmount.8 \
-	%D%/man8/zfs-unzone.8 \
 	%D%/man8/zfs-upgrade.8 \
 	%D%/man8/zfs-userspace.8 \
 	%D%/man8/zfs-wait.8 \
-	%D%/man8/zfs-zone.8 \
 	%D%/man8/zfs_ids_to_path.8 \
 	%D%/man8/zgenhostid.8 \
 	%D%/man8/zinject.8 \
@@ -103,6 +99,18 @@ dist_man_MANS = \
 	%D%/man8/zstream.8 \
 	%D%/man8/zstreamdump.8 \
 	%D%/man8/zpool_influxdb.8
+
+if BUILD_FREEBSD
+dist_man_MANS += \
+	%D%/man8/zfs-jail.8 \
+	%D%/man8/zfs-unjail.8
+endif
+
+if BUILD_LINUX
+dist_man_MANS += \
+	%D%/man8/zfs-unzone.8 \
+	%D%/man8/zfs-zone.8
+endif
 
 nodist_man_MANS = \
 	%D%/man8/zed.8 \

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -38,7 +38,7 @@
 .\" Copyright (c) 2019, Kjeld Schouten-Lebbing
 .\" Copyright (c) 2022 Hewlett Packard Enterprise Development LP.
 .\"
-.Dd April 18, 2023
+.Dd August 8, 2023
 .Dt ZFSPROPS 7
 .Os
 .
@@ -1916,13 +1916,15 @@ See
 for more information.
 Jails are a
 .Fx
-feature and are not relevant on other platforms.
-The default value is
-.Sy off .
-.It Sy zoned Ns = Ns Sy on Ns | Ns Sy off
+feature and this property is not available on other platforms.
+.It Sy zoned Ns = Ns Sy off Ns | Ns Sy on
 Controls whether the dataset is managed from a non-global zone or namespace.
-The default value is
-.Sy off .
+See
+.Xr zfs-zone 8
+for more information.
+Zoning is a
+Linux
+feature and this property is not available on other platforms.
 .El
 .Pp
 The following three properties cannot be changed after the file system is


### PR DESCRIPTION
### Motivation and Context
If I have zfs-jail(8) on my system then why don't I have zfs jail. If the documentation says I should be able to see jailed then why can't I.

### Description
Put zfs-jail and zfs-zoned in if-freebsd/if-linux. Describe jailed/zoned as "only *available* on freebsd/linux". Also clean up the description because my god.

### How Has This Been Tested?
eyeball. ill look at the CI builds to see the file lists

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. – none apply
- [ ] I have run the ZFS Test Suite with this change applied. – CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
