### PR TITLE
[ubsan] Support varlen arrays at end of struct as [1] or []

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -231,6 +231,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS], [
 	ZFS_AC_CONFIG_ALWAYS_CPPCHECK
 	ZFS_AC_CONFIG_ALWAYS_SHELLCHECK
 	ZFS_AC_CONFIG_ALWAYS_PARALLEL
+	ZFS_AC_CONFIG_ALWAYS_CC_VARSIZE_ARRAY_IN_STRUCT
 ])
 
 AC_DEFUN([ZFS_AC_CONFIG], [
@@ -628,5 +629,31 @@ AC_DEFUN([ZFS_AC_PACKAGE], [
 		ZFS_AC_RPM
 		ZFS_AC_DPKG
 		ZFS_AC_ALIEN
+	])
+])
+
+dnl #
+dnl # Test whether C compiler supports variable-length array at the
+dnl # end of a struct definition, and if it needs a constant or not
+dnl # declaring a size
+dnl #
+AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_CC_VARSIZE_ARRAY_IN_STRUCT], [
+	AC_MSG_CHECKING(
+	    [if C compiler handles empty-index var-length array members])
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+		struct s {
+			int a;
+			int v[];
+		};
+
+		struct s test_array __attribute__((unused));
+	])], [
+		AC_MSG_RESULT([yes])
+		AC_DEFINE([VARLEN_ARRAY_IDX], [],
+		    [Index to use for variable-length array struct members])
+	], [
+		AC_MSG_RESULT([no])
+		AC_DEFINE([VARLEN_ARRAY_IDX], 1,
+		    [Index to use for variable-length array struct members])
 	])
 ])

--- a/include/os/linux/spl/sys/kmem_cache.h
+++ b/include/os/linux/spl/sys/kmem_cache.h
@@ -108,7 +108,8 @@ typedef struct spl_kmem_magazine {
 	uint32_t		skm_refill;	/* Batch refill size */
 	struct spl_kmem_cache	*skm_cache;	/* Owned by cache */
 	unsigned int		skm_cpu;	/* Owned by cpu */
-	void			*skm_objs[0];	/* Object pointers */
+	/* Object pointers */
+	void			*skm_objs[VARLEN_ARRAY_IDX];
 } spl_kmem_magazine_t;
 
 typedef struct spl_kmem_obj {

--- a/include/sys/sa_impl.h
+++ b/include/sys/sa_impl.h
@@ -177,8 +177,11 @@ typedef struct sa_hdr_phys {
 	 *
 	 */
 	uint16_t sa_layout_info;
-	uint16_t sa_lengths[1];	/* optional sizes for variable length attrs */
-	/* ... Data follows the lengths.  */
+	uint16_t sa_lengths[VARLEN_ARRAY_IDX];
+	/*
+	 * optional sizes for variable length attrs
+	 * ... Data follows the lengths.
+	 */
 } sa_hdr_phys_t;
 
 #define	SA_HDR_LAYOUT_NUM(hdr) BF32_GET(hdr->sa_layout_info, 0, 10)

--- a/include/sys/vdev_raidz_impl.h
+++ b/include/sys/vdev_raidz_impl.h
@@ -130,7 +130,8 @@ typedef struct raidz_row {
 	uint64_t rr_offset;		/* Logical offset for *_io_verify() */
 	uint64_t rr_size;		/* Physical size for *_io_verify() */
 #endif
-	raidz_col_t rr_col[0];		/* Flexible array of I/O columns */
+	/* Flexible array of I/O columns */
+	raidz_col_t rr_col[VARLEN_ARRAY_IDX];
 } raidz_row_t;
 
 typedef struct raidz_map {
@@ -139,7 +140,7 @@ typedef struct raidz_map {
 	int rm_nskip;			/* RAIDZ sectors skipped for padding */
 	int rm_skipstart;		/* Column index of padding start */
 	const raidz_impl_ops_t *rm_ops;	/* RAIDZ math operations */
-	raidz_row_t *rm_row[0];		/* flexible array of rows */
+	raidz_row_t *rm_row[VARLEN_ARRAY_IDX];	/* flexible array of rows */
 } raidz_map_t;
 
 

--- a/include/sys/zap_impl.h
+++ b/include/sys/zap_impl.h
@@ -61,7 +61,7 @@ typedef struct mzap_phys {
 	uint64_t mz_salt;
 	uint64_t mz_normflags;
 	uint64_t mz_pad[5];
-	mzap_ent_phys_t mz_chunk[1];
+	mzap_ent_phys_t mz_chunk[VARLEN_ARRAY_IDX];
 	/* actually variable size depending on block size */
 } mzap_phys_t;
 

--- a/include/sys/zap_leaf.h
+++ b/include/sys/zap_leaf.h
@@ -132,7 +132,7 @@ typedef struct zap_leaf_phys {
 	 * with the ZAP_LEAF_CHUNK() macro.
 	 */
 
-	uint16_t l_hash[1];
+	uint16_t l_hash[VARLEN_ARRAY_IDX];
 } zap_leaf_phys_t;
 
 typedef union zap_leaf_chunk {


### PR DESCRIPTION
### Motivation and Context
The `--enable-ubsan` configure feature complains when we index variable length arrays at the end of some structs because the arrays size is defined to be 1. Newer C compilers support declaring these as variable-sized using [] in the struct member type definition, which also quiets the `--enable-ubsan` complaint.

Reported in Issue #15145

### Description
Create a new `configure` test to detect support in the compiler for variable-length arrays as struct members declared with the `[]` (empty) subscript. If detected, `#define` a macro with an empty value. Otherwise, define that macro with a value of `1` (the existing behavior).

Change the following struct members to have their array size declared with the aforementioned CPP macro:
* `dk_gpt.efi_parts`
* `sa_hdr_phys.sa_lengths`
* `mzap_phys.mz_chunk`
* `zap_leaf_phys.l_hash`

### How Has This Been Tested?
Build tested.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
