### PR TITLE
RFC: Add an upper limit on the 12.5% savings requirement

### DIFF
--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -145,8 +145,16 @@ zio_compress_data(enum zio_compress c, abd_t *src, void **dst, size_t s_len,
 	if (c == ZIO_COMPRESS_EMPTY)
 		return (s_len);
 
-	/* Compress at least 12.5% */
-	d_len = s_len - (s_len >> 3);
+	/*
+	 * Compress at least 12.5%...
+	 * ...upper bounded by 16k, since above 128k, the savings requirements
+	 * start to become the limiting factor.
+	 */
+	
+	if (s_len > SPA_OLD_MAXBLOCKSIZE)
+		d_len = s_len - (SPA_OLD_MAXBLOCKSIZE >> 3);
+	else
+		d_len = s_len - (s_len >> 3);
 
 	complevel = ci->ci_level;
 


### PR DESCRIPTION
### Motivation and Context
We've previously discussed removing the 12.5% threshold entirely, and I think there's still some reasons that's a bad idea. I've got a PR that's more involved to get better stats on that being true or not, that's not done yet, but for now, upper bounding the 12.5% threshold seemed like a reasonable starting point for avoiding people needing to save 2M to compress 16M blocks.

### Description
Upper bounds the "saves at least 12.5%" check to "saves at least MIN(16k, 12.5% of source size)".

I've not benchmarked this yet, or even tested it compiles, I wanted to propose it and get people's thoughts on the idea, while I go fire off a round or five of benchmarks. (I'll be adding stats for how often this behavior triggers versus the old behavior to track useful data before benchmarking.)

### How Has This Been Tested?
Not even slightly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
