### PR TITLE
Intel QAT 1.7 compatibility

### DIFF
--- a/module/os/linux/zfs/qat_compress.c
+++ b/module/os/linux/zfs/qat_compress.c
@@ -193,9 +193,9 @@ qat_dc_init(void)
 		sd.huffType = CPA_DC_HT_FULL_DYNAMIC;
 		sd.sessDirection = CPA_DC_DIR_COMBINED;
 		sd.sessState = CPA_DC_STATELESS;
-		#if (CPA_DC_API_VERSION_NUM_MAJOR == 1 && CPA_DC_API_VERSION_NUM_MINOR < 6)
+#if (CPA_DC_API_VERSION_NUM_MAJOR == 1 && CPA_DC_API_VERSION_NUM_MINOR < 6)
 		sd.deflateWindowSize = 7;
-		#endif
+#endif
 		sd.checksum = CPA_DC_ADLER32;
 		status = cpaDcGetSessionSize(dc_inst_handles[i],
 		    &sd, &sess_size, &ctx_size);

--- a/module/os/linux/zfs/qat_compress.c
+++ b/module/os/linux/zfs/qat_compress.c
@@ -193,7 +193,9 @@ qat_dc_init(void)
 		sd.huffType = CPA_DC_HT_FULL_DYNAMIC;
 		sd.sessDirection = CPA_DC_DIR_COMBINED;
 		sd.sessState = CPA_DC_STATELESS;
+		#if (CPA_DC_API_VERSION_NUM_MAJOR == 1 && CPA_DC_API_VERSION_NUM_MINOR < 6)
 		sd.deflateWindowSize = 7;
+		#endif
 		sd.checksum = CPA_DC_ADLER32;
 		status = cpaDcGetSessionSize(dc_inst_handles[i],
 		    &sd, &sess_size, &ctx_size);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

Compilation currently fails with QAT support using the latest 1.x HW version driver from intel.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Based on the intel QAT samples which are bundled in the 1.x drivers, this is the preferred approach since api version 1.6

see https://www.intel.de/content/www/de/de/download/19734/intel-quickassist-technology-driver-for-linux-hw-version-1-x.html?

### Description
Added a preprocessor #if/#endif like in the intel samples

### How Has This Been Tested?
Not yet, but it compiles

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
