### PR TITLE
[2.2] Additional backports for 2.2

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1775,8 +1775,9 @@ zio_write_compress(zio_t *zio)
 			compress = ZIO_COMPRESS_OFF;
 
 		/* Make sure someone doesn't change their mind on overwrites */
-		ASSERT(BP_IS_EMBEDDED(bp) || MIN(zp->zp_copies + BP_IS_GANG(bp),
-		    spa_max_replication(spa)) == BP_GET_NDVAS(bp));
+		ASSERT(BP_IS_EMBEDDED(bp) || BP_IS_GANG(bp) ||
+		    MIN(zp->zp_copies, spa_max_replication(spa))
+		    == BP_GET_NDVAS(bp));
 	}
 
 	/* If it's a compressed write that is not raw, compress the buffer. */

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning.kshlib
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning.kshlib
@@ -34,13 +34,21 @@ function have_same_content
 	log_must [ "$hash1" = "$hash2" ]
 }
 
-function unique_blocks
+#
+# get_same_blocks dataset1 path/to/file1 dataset2 path/to/file2
+#
+# Returns a space-separated list of the indexes (starting at 0) of the L0
+# blocks that are shared between both files (by first DVA and checksum).
+# Assumes that the two files have the same content, use have_same_content to
+# confirm that.
+#
+function get_same_blocks
 {
 	typeset zdbout=${TMPDIR:-$TEST_BASE_DIR}/zdbout.$$
 	zdb -vvvvv $1 -O $2 | \
-	    awk '/ L0 / { print ++l " " $3 " " $7 }' > $zdbout.a
+	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout.a
 	zdb -vvvvv $3 -O $4 | \
-	    awk '/ L0 / { print ++l " " $3 " " $7 }' > $zdbout.b
+	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout.b
 	echo $(sort $zdbout.a $zdbout.b | uniq -d | cut -f1 -d' ')
 }
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange.ksh
@@ -54,7 +54,7 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
 
-typeset blocks=$(unique_blocks $TESTPOOL file1 $TESTPOOL file2)
-log_must [ "$blocks" = "1 2 3 4" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "0 1 2 3" ]
 
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_cross_dataset.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_cross_dataset.ksh
@@ -58,8 +58,8 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/$TESTFS1/file1 /$TESTPOOL/$TESTFS2/file2
 
-typeset blocks=$(unique_blocks \
+typeset blocks=$(get_same_blocks \
   $TESTPOOL/$TESTFS1 file1 $TESTPOOL/$TESTFS2 file2)
-log_must [ "$blocks" = "1 2 3 4" ]
+log_must [ "$blocks" = "0 1 2 3" ]
 
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback.ksh
@@ -58,8 +58,8 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file /$TESTPOOL/clone
 
-typeset blocks=$(unique_blocks $TESTPOOL file $TESTPOOL clone)
-log_must [ "$blocks" = "1 2 3 4" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file $TESTPOOL clone)
+log_must [ "$blocks" = "0 1 2 3" ]
 
 
 log_note "Copying within a block with copy_file_range"
@@ -69,8 +69,8 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file /$TESTPOOL/clone
 
-typeset blocks=$(unique_blocks $TESTPOOL file $TESTPOOL clone)
-log_must [ "$blocks" = "2 3 4" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file $TESTPOOL clone)
+log_must [ "$blocks" = "1 2 3" ]
 
 
 log_note "Copying across a block with copy_file_range"
@@ -80,7 +80,7 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file /$TESTPOOL/clone
 
-typeset blocks=$(unique_blocks $TESTPOOL file $TESTPOOL clone)
-log_must [ "$blocks" = "2" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file $TESTPOOL clone)
+log_must [ "$blocks" = "1" ]
 
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback_same_txg.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback_same_txg.ksh
@@ -59,7 +59,7 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file /$TESTPOOL/clone
 
-typeset blocks=$(unique_blocks $TESTPOOL file $TESTPOOL clone)
+typeset blocks=$(get_same_blocks $TESTPOOL file $TESTPOOL clone)
 log_must [ "$blocks" = "" ]
 
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_partial.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_partial.ksh
@@ -54,7 +54,7 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
 
-typeset blocks=$(unique_blocks $TESTPOOL file1 $TESTPOOL file2)
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
 log_must [ "$blocks" = "" ]
 
 log_must clonefile -f /$TESTPOOL/file1 /$TESTPOOL/file2 131072 131072 262144
@@ -62,7 +62,7 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
 
-typeset blocks=$(unique_blocks $TESTPOOL file1 $TESTPOOL file2)
-log_must [ "$blocks" = "2 3" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "1 2" ]
 
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_disabled_copyfilerange.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_disabled_copyfilerange.ksh
@@ -54,7 +54,7 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
 
-typeset blocks=$(unique_blocks $TESTPOOL file1 $TESTPOOL file2)
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
 log_must [ "$blocks" = "" ]
 
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_ficlone.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_ficlone.ksh
@@ -50,7 +50,7 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
 
-typeset blocks=$(unique_blocks $TESTPOOL file1 $TESTPOOL file2)
-log_must [ "$blocks" = "1 2 3 4" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "0 1 2 3" ]
 
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_ficlonerange.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_ficlonerange.ksh
@@ -50,7 +50,7 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
 
-typeset blocks=$(unique_blocks $TESTPOOL file1 $TESTPOOL file2)
-log_must [ "$blocks" = "1 2 3 4" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "0 1 2 3" ]
 
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_ficlonerange_partial.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_ficlonerange_partial.ksh
@@ -50,7 +50,7 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
 
-typeset blocks=$(unique_blocks $TESTPOOL file1 $TESTPOOL file2)
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
 log_must [ "$blocks" = "" ]
 
 log_must clonefile -r /$TESTPOOL/file1 /$TESTPOOL/file2 131072 131072 262144
@@ -58,7 +58,7 @@ log_must sync_pool $TESTPOOL
 
 log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
 
-typeset blocks=$(unique_blocks $TESTPOOL file1 $TESTPOOL file2)
-log_must [ "$blocks" = "2 3" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "1 2" ]
 
 log_pass $claim


### PR DESCRIPTION
### Motivation and Context

Backports for 2.2.

### Description

804414aad2 tests/block_cloning: rename and document get_same_blocks helper
ed39d668ea Update outdated assertion from zio_write_compress

### How Has This Been Tested?

Cherry picked from master.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
