### PR TITLE
zed: update zed.d/statechange-slot_off.sh

### DIFF
--- a/cmd/zed/zed.d/Makefile.am
+++ b/cmd/zed/zed.d/Makefile.am
@@ -16,6 +16,7 @@ dist_zedexec_SCRIPTS = \
 	%D%/scrub_finish-notify.sh \
 	%D%/statechange-led.sh \
 	%D%/statechange-notify.sh \
+	%D%/statechange-slot_off.sh \
 	%D%/trim_finish-notify.sh \
 	%D%/vdev_attach-led.sh \
 	%D%/vdev_clear-led.sh
@@ -35,6 +36,7 @@ zedconfdefaults = \
 	scrub_finish-notify.sh \
 	statechange-led.sh \
 	statechange-notify.sh \
+	statechange-slot_off.sh \
 	vdev_attach-led.sh \
 	vdev_clear-led.sh
 

--- a/cmd/zed/zed.d/statechange-slot_off.sh
+++ b/cmd/zed/zed.d/statechange-slot_off.sh
@@ -43,15 +43,17 @@ if [ ! -f "$ZEVENT_VDEV_ENC_SYSFS_PATH/power_status" ] ; then
 	exit 4
 fi
 
-echo "off" | tee "$ZEVENT_VDEV_ENC_SYSFS_PATH/power_status"
-
-# Wait for sysfs for report that the slot is off.  It can take ~400ms on some
-# enclosures.
+# Turn off the slot and wait for sysfs to report that the slot is off.
+# It can take ~400ms on some enclosures and multiple retries may be needed.
 for i in $(seq 1 20) ; do
-	if [ "$(cat $ZEVENT_VDEV_ENC_SYSFS_PATH/power_status)" == "off" ] ; then
-		break
-	fi
-	sleep 0.1
+	echo "off" | tee "$ZEVENT_VDEV_ENC_SYSFS_PATH/power_status"
+
+	for j in $(seq 1 5) ; do
+		if [ "$(cat $ZEVENT_VDEV_ENC_SYSFS_PATH/power_status)" == "off" ] ; then
+			break 2
+		fi
+		sleep 0.1
+	done
 done
 
 if [ "$(cat $ZEVENT_VDEV_ENC_SYSFS_PATH/power_status)" != "off" ] ; then


### PR DESCRIPTION
### Motivation and Context

Follow up for 15200.

### Description

The statechange-slot_off.sh zedlet which was added in #15200 needed to be installed so it's included by the packages.

Additional testing has also shown that multiple retries are often needed for the script to operate reliably.

### How Has This Been Tested?

Local rpm-utils package build.  Repeatedly using `zpool offline -f` to fault a drive and observing wait times and retries required.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
