### PR TITLE
checkstyle: fix action failures

### DIFF
--- a/cmd/zed/zed.d/statechange-slot_off.sh
+++ b/cmd/zed/zed.d/statechange-slot_off.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC3014,SC2154,SC2086,SC2034
 #
 # Turn off disk's enclosure slot if it becomes FAULTED.
 #

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -110,9 +110,9 @@ Removes ZFS label information from the specified
 .It Xo
 .Xr zpool-attach 8 Ns / Ns Xr zpool-detach 8
 .Xc
-Converts a non-redundant disk into a mirror, or increases the redundancy level of an existing mirror
-.Ns (
-.Cm attach Ns ), or performs the inverse operation (
+Converts a non-redundant disk into a mirror, or increases
+the redundancy level of an existing mirror
+.Cm ( attach Ns ), or performs the inverse operation (
 .Cm detach Ns ).
 .It Xo
 .Xr zpool-add 8 Ns / Ns Xr zpool-remove 8
@@ -265,7 +265,7 @@ While not recommended, a pool based on files can be useful for experimental
 purposes.
 .Dl # Nm zpool Cm create Ar tank Pa /path/to/file/a /path/to/file/b
 .
-.Ss Example 5 : No Making a non-mirrored ZFS Storage Pool mirrored.
+.Ss Example 5 : No Making a non-mirrored ZFS Storage Pool mirrored
 The following command converts an existing single device
 .Ar sda
 into a mirror by attaching a second device to it,


### PR DESCRIPTION
Errors Silenced (other zed scripts did the same) - shellcheck:
```
cmd/zed/zed.d/statechange-slot_off.sh:26:7: warning: ZED_ZEDLET_DIR is referenced but not assigned. [SC2154]
make: *** [Makefile:7085: shellcheck-here-cmd^zed^zed.d^statechange-slot_off.sh] Error 1
make: *** Waiting for unfinished jobs....
cmd/zed/zed.d/statechange-slot_off.sh:34:7: warning: ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT is referenced but not assigned. [SC2154]
cmd/zed/zed.d/statechange-slot_off.sh:38:7: warning: ZEVENT_VDEV_STATE_STR is referenced but not assigned. [SC2154]
cmd/zed/zed.d/statechange-slot_off.sh:42:12: warning: ZEVENT_VDEV_ENC_SYSFS_PATH is referenced but not assigned. [SC2154]
cmd/zed/zed.d/statechange-slot_off.sh:48:1: warning: i appears unused. Verify use (or export if used externally). [SC2034]
cmd/zed/zed.d/statechange-slot_off.sh:51:2: warning: j appears unused. Verify use (or export if used externally). [SC2034]
cmd/zed/zed.d/statechange-slot_off.sh:52:15: note: Double quote to prevent globbing and word splitting. [SC2086]
cmd/zed/zed.d/statechange-slot_off.sh:52:58: warning: In POSIX sh, == in place of = is undefined. [SC3014]
cmd/zed/zed.d/statechange-slot_off.sh:59:13: note: Double quote to prevent globbing and word splitting. [SC2086]
cmd/zed/zed.d/statechange-slot_off.sh:63:64: warning: ZEVENT_VDEV_PATH is referenced but not assigned. [SC2154]
```

Errors Fixed - mancheck:
```
mandoc: ./man/man8/zpool.8:113:100: STYLE: input text line longer than 80 bytes: Converts a non-redun...
mandoc: ./man/man8/zpool.8:114:2: WARNING: skipping no-space macro
mandoc: ./man/man8/zpool.8:268:67: STYLE: no blank before trailing delimiter: No Making a non-mirrored ZFS Storage Pool mirrored.
make: *** [Makefile:7239: mancheck] Error 1
```