### PR TITLE
dmu_buf_will_clone: change assertion to fix 32-bit compiler warning

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2701,7 +2701,7 @@ dmu_buf_will_clone(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	 */
 	mutex_enter(&db->db_mtx);
 	VERIFY(!dbuf_undirty(db, tx));
-	ASSERT0(dbuf_find_dirty_eq(db, tx->tx_txg));
+	ASSERT3P(dbuf_find_dirty_eq(db, tx->tx_txg), ==, NULL);
 	if (db->db_buf != NULL) {
 		arc_buf_destroy(db->db_buf, db);
 		db->db_buf = NULL;


### PR DESCRIPTION
Building `module/zfs/dbuf.c` for 32-bit targets can result in a warning:

    In file included from /workspace/src/sys/contrib/openzfs/include/sys/zfs_context.h:97,
                     from /workspace/src/sys/contrib/openzfs/module/zfs/dbuf.c:32:
    /workspace/src/sys/contrib/openzfs/module/zfs/dbuf.c: In function 'dmu_buf_will_clone':
    /workspace/src/sys/contrib/openzfs/lib/libspl/include/assert.h:116:33: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
      116 |         const uint64_t __left = (uint64_t)(LEFT);                       \
          |                                 ^
    /workspace/src/sys/contrib/openzfs/lib/libspl/include/assert.h:148:25: note: in expansion of macro 'VERIFY0'
      148 | #define ASSERT0         VERIFY0
          |                         ^~~~~~~
    /workspace/src/sys/contrib/openzfs/module/zfs/dbuf.c:2704:9: note: in expansion of macro 'ASSERT0'
     2704 |         ASSERT0(dbuf_find_dirty_eq(db, tx->tx_txg));
          |         ^~~~~~~

This is because `dbuf_find_dirty_eq()` returns a pointer, which if pointers are 32-bit results in a warning about the cast to `uint64_t`.

Instead, use the regular `ASSERT()` macro, and compare the return value with `NULL`, which should work regardless of the target's bitness.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
