### PR TITLE
Add VERIFY0P() and ASSERT0P() macros

### DIFF
--- a/include/os/freebsd/spl/sys/debug.h
+++ b/include/os/freebsd/spl/sys/debug.h
@@ -39,12 +39,14 @@
  * ASSERT3U()	- Assert unsigned X OP Y is true, if not panic.
  * ASSERT3P()	- Assert pointer X OP Y is true, if not panic.
  * ASSERT0()	- Assert value is zero, if not panic.
+ * ASSERT0P()	- Assert pointer is null, if not panic.
  * VERIFY()	- Verify X is true, if not panic.
  * VERIFY3B()	- Verify boolean X OP Y is true, if not panic.
  * VERIFY3S()	- Verify signed X OP Y is true, if not panic.
  * VERIFY3U()	- Verify unsigned X OP Y is true, if not panic.
  * VERIFY3P()	- Verify pointer X OP Y is true, if not panic.
  * VERIFY0()	- Verify value is zero, if not panic.
+ * VERIFY0P()	- Verify pointer is null, if not panic.
  */
 
 #ifndef _SPL_DEBUG_H
@@ -135,6 +137,15 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    (long long)_verify0_right);				\
 	} while (0)
 
+#define	VERIFY0P(RIGHT)	do {						\
+		const uintptr_t _verify0_right = (uintptr_t)(RIGHT);	\
+		if (unlikely(!(0 == _verify0_right)))			\
+		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
+		    "VERIFY0P(" #RIGHT ") "				\
+		    "failed (NULL == %p)\n",				\
+		    (void *)_verify0_right);				\
+	} while (0)
+
 /*
  * Debugging disabled (--disable-debug)
  */
@@ -150,6 +161,7 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #define	ASSERT3P(x, y, z)						\
 	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
 #define	ASSERT0(x)		((void) sizeof ((uintptr_t)(x)))
+#define	ASSERT0P(x)		((void) sizeof ((uintptr_t)(x)))
 #define	IMPLY(A, B)							\
 	((void) sizeof ((uintptr_t)(A)), (void) sizeof ((uintptr_t)(B)))
 #define	EQUIV(A, B)		\
@@ -165,6 +177,7 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #define	ASSERT3U	VERIFY3U
 #define	ASSERT3P	VERIFY3P
 #define	ASSERT0		VERIFY0
+#define	ASSERT0P	VERIFY0P
 #define	ASSERT		VERIFY
 #define	IMPLY(A, B) \
 	((void)(likely((!(A)) || (B)) ||				\

--- a/include/os/freebsd/spl/sys/debug.h
+++ b/include/os/freebsd/spl/sys/debug.h
@@ -89,8 +89,8 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%d " #OP " %d)\n",				\
-		    (boolean_t)(_verify3_left),				\
-		    (boolean_t)(_verify3_right));			\
+		    (boolean_t)_verify3_left,				\
+		    (boolean_t)_verify3_right);				\
 	} while (0)
 
 #define	VERIFY3S(LEFT, OP, RIGHT)	do {				\
@@ -100,8 +100,8 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%lld " #OP " %lld)\n",			\
-		    (long long) (_verify3_left),			\
-		    (long long) (_verify3_right));			\
+		    (long long)_verify3_left,				\
+		    (long long)_verify3_right);				\
 	} while (0)
 
 #define	VERIFY3U(LEFT, OP, RIGHT)	do {				\
@@ -111,8 +111,8 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%llu " #OP " %llu)\n",			\
-		    (unsigned long long) (_verify3_left),		\
-		    (unsigned long long) (_verify3_right));		\
+		    (unsigned long long)_verify3_left,			\
+		    (unsigned long long)_verify3_right);		\
 	} while (0)
 
 #define	VERIFY3P(LEFT, OP, RIGHT)	do {				\
@@ -121,19 +121,18 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		if (unlikely(!(_verify3_left OP _verify3_right)))	\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
-		    "failed (%px " #OP " %px)\n",			\
-		    (void *) (_verify3_left),				\
-		    (void *) (_verify3_right));				\
+		    "failed (%p " #OP " %p)\n",				\
+		    (void *)_verify3_left,				\
+		    (void *)_verify3_right);				\
 	} while (0)
 
 #define	VERIFY0(RIGHT)	do {						\
-		const int64_t _verify3_left = (int64_t)(0);		\
-		const int64_t _verify3_right = (int64_t)(RIGHT);	\
-		if (unlikely(!(_verify3_left == _verify3_right)))	\
+		const int64_t _verify0_right = (int64_t)(RIGHT);	\
+		if (unlikely(!(0 == _verify0_right)))			\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
-		    "VERIFY0(0 == " #RIGHT ") "				\
+		    "VERIFY0(" #RIGHT ") "				\
 		    "failed (0 == %lld)\n",				\
-		    (long long) (_verify3_right));			\
+		    (long long)_verify0_right);				\
 	} while (0)
 
 /*

--- a/include/os/linux/spl/sys/debug.h
+++ b/include/os/linux/spl/sys/debug.h
@@ -34,12 +34,14 @@
  * ASSERT3U()	- Assert unsigned X OP Y is true, if not panic.
  * ASSERT3P()	- Assert pointer X OP Y is true, if not panic.
  * ASSERT0()	- Assert value is zero, if not panic.
+ * ASSERT0P()	- Assert pointer is null, if not panic.
  * VERIFY()	- Verify X is true, if not panic.
  * VERIFY3B()	- Verify boolean X OP Y is true, if not panic.
  * VERIFY3S()	- Verify signed X OP Y is true, if not panic.
  * VERIFY3U()	- Verify unsigned X OP Y is true, if not panic.
  * VERIFY3P()	- Verify pointer X OP Y is true, if not panic.
  * VERIFY0()	- Verify value is zero, if not panic.
+ * VERIFY0P()	- Verify pointer is null, if not panic.
  */
 
 #ifndef _SPL_DEBUG_H
@@ -139,6 +141,15 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    (long long)_verify0_right);				\
 	} while (0)
 
+#define	VERIFY0P(RIGHT)	do {						\
+		const uintptr_t _verify0_right = (uintptr_t)(RIGHT);	\
+		if (unlikely(!(0 == _verify0_right)))			\
+		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
+		    "VERIFY0P(" #RIGHT ") "				\
+		    "failed (NULL == %px)\n",				\
+		    (void *)_verify0_right);				\
+	} while (0)
+
 #define	VERIFY_IMPLY(A, B) \
 	((void)(likely((!(A)) || (B)) ||				\
 	    spl_assert("(" #A ") implies (" #B ")",			\
@@ -164,6 +175,7 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #define	ASSERT3P(x, y, z)						\
 	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
 #define	ASSERT0(x)		((void) sizeof ((uintptr_t)(x)))
+#define	ASSERT0P(x)		((void) sizeof ((uintptr_t)(x)))
 #define	IMPLY(A, B)							\
 	((void) sizeof ((uintptr_t)(A)), (void) sizeof ((uintptr_t)(B)))
 #define	EQUIV(A, B)		\
@@ -179,6 +191,7 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #define	ASSERT3U	VERIFY3U
 #define	ASSERT3P	VERIFY3P
 #define	ASSERT0		VERIFY0
+#define	ASSERT0P	VERIFY0P
 #define	ASSERT		VERIFY
 #define	IMPLY		VERIFY_IMPLY
 #define	EQUIV		VERIFY_EQUIV

--- a/include/os/linux/spl/sys/debug.h
+++ b/include/os/linux/spl/sys/debug.h
@@ -93,8 +93,8 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%d " #OP " %d)\n",				\
-		    (boolean_t)(_verify3_left),				\
-		    (boolean_t)(_verify3_right));			\
+		    (boolean_t)_verify3_left,				\
+		    (boolean_t)_verify3_right);				\
 	} while (0)
 
 #define	VERIFY3S(LEFT, OP, RIGHT)	do {				\
@@ -104,8 +104,8 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%lld " #OP " %lld)\n",			\
-		    (long long)(_verify3_left),				\
-		    (long long)(_verify3_right));			\
+		    (long long)_verify3_left,				\
+		    (long long)_verify3_right);				\
 	} while (0)
 
 #define	VERIFY3U(LEFT, OP, RIGHT)	do {				\
@@ -115,8 +115,8 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%llu " #OP " %llu)\n",			\
-		    (unsigned long long)(_verify3_left),		\
-		    (unsigned long long)(_verify3_right));		\
+		    (unsigned long long)_verify3_left,			\
+		    (unsigned long long)_verify3_right);		\
 	} while (0)
 
 #define	VERIFY3P(LEFT, OP, RIGHT)	do {				\
@@ -126,18 +126,17 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%px " #OP " %px)\n",			\
-		    (void *) (_verify3_left),				\
-		    (void *) (_verify3_right));				\
+		    (void *)_verify3_left,				\
+		    (void *)_verify3_right);				\
 	} while (0)
 
 #define	VERIFY0(RIGHT)	do {						\
-		const int64_t _verify3_left = (int64_t)(0);		\
-		const int64_t _verify3_right = (int64_t)(RIGHT);	\
-		if (unlikely(!(_verify3_left == _verify3_right)))	\
+		const int64_t _verify0_right = (int64_t)(RIGHT);	\
+		if (unlikely(!(0 == _verify0_right)))			\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
-		    "VERIFY0(0 == " #RIGHT ") "				\
+		    "VERIFY0(" #RIGHT ") "				\
 		    "failed (0 == %lld)\n",				\
-		    (long long) (_verify3_right));			\
+		    (long long)_verify0_right);				\
 	} while (0)
 
 #define	VERIFY_IMPLY(A, B) \

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -120,6 +120,15 @@ do {									\
 		    (u_longlong_t)__left);				\
 } while (0)
 
+#define	VERIFY0P(LEFT)							\
+do {									\
+	const uintptr_t __left = (uintptr_t)(LEFT);			\
+	if (!(__left == 0))						\
+		libspl_assertf(__FILE__, __FUNCTION__, __LINE__,	\
+		    "%s == 0 (%p == 0)", #LEFT,				\
+		    (void *)__left);					\
+} while (0)
+
 #ifdef assert
 #undef assert
 #endif
@@ -134,6 +143,7 @@ do {									\
 #define	ASSERT3P(x, y, z)						\
 	((void) sizeof ((uintptr_t)(x)), (void) sizeof ((uintptr_t)(z)))
 #define	ASSERT0(x)		((void) sizeof ((uintptr_t)(x)))
+#define	ASSERT0P(x)		((void) sizeof ((uintptr_t)(x)))
 #define	ASSERT(x)		((void) sizeof ((uintptr_t)(x)))
 #define	assert(x)		((void) sizeof ((uintptr_t)(x)))
 #define	IMPLY(A, B)							\
@@ -146,6 +156,7 @@ do {									\
 #define	ASSERT3U	VERIFY3U
 #define	ASSERT3P	VERIFY3P
 #define	ASSERT0		VERIFY0
+#define	ASSERT0P	VERIFY0P
 #define	ASSERT		VERIFY
 #define	assert		VERIFY
 #define	IMPLY(A, B) \

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -107,8 +107,8 @@ do {									\
 	const uintptr_t __right = (uintptr_t)(RIGHT);			\
 	if (!(__left OP __right))					\
 		libspl_assertf(__FILE__, __FUNCTION__, __LINE__,	\
-		    "%s %s %s (0x%llx %s 0x%llx)", #LEFT, #OP, #RIGHT,	\
-		    (u_longlong_t)__left, #OP, (u_longlong_t)__right);	\
+		    "%s %s %s (%p %s %p)", #LEFT, #OP, #RIGHT,		\
+		    (void *)__left, #OP, (void *)__right);		\
 } while (0)
 
 #define	VERIFY0(LEFT)							\

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2701,7 +2701,7 @@ dmu_buf_will_clone(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	 */
 	mutex_enter(&db->db_mtx);
 	VERIFY(!dbuf_undirty(db, tx));
-	ASSERT3P(dbuf_find_dirty_eq(db, tx->tx_txg), ==, NULL);
+	ASSERT0P(dbuf_find_dirty_eq(db, tx->tx_txg));
 	if (db->db_buf != NULL) {
 		arc_buf_destroy(db->db_buf, db);
 		db->db_buf = NULL;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As pointed out in #15224, `ASSERT0()` cannot be safely used to check a pointer.

### Description
<!--- Describe your changes in detail -->
This pull request adds `VERIFY0P()` and `ASSERT0P()` macros which can safely be used to verify that a pointer is null. It also addresses some code quality issues in the existing `VERIFY*()` macros.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
The patch has been tested in a FreeBSD 15 tree.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
