### PR TITLE
Linux 6.5 compat: spl: properly unregister sysctl entries

### DIFF
--- a/module/os/linux/spl/spl-proc.c
+++ b/module/os/linux/spl/spl-proc.c
@@ -47,6 +47,10 @@ static unsigned long table_min = 0;
 static unsigned long table_max = ~0;
 
 static struct ctl_table_header *spl_header = NULL;
+#ifndef HAVE_REGISTER_SYSCTL_TABLE
+static struct ctl_table_header *spl_kmem = NULL;
+static struct ctl_table_header *spl_kstat = NULL;
+#endif
 static struct proc_dir_entry *proc_spl = NULL;
 static struct proc_dir_entry *proc_spl_kmem = NULL;
 static struct proc_dir_entry *proc_spl_kmem_slab = NULL;
@@ -668,6 +672,16 @@ static void spl_proc_cleanup(void)
 	remove_proc_entry("taskq", proc_spl);
 	remove_proc_entry("spl", NULL);
 
+#ifndef HAVE_REGISTER_SYSCTL_TABLE
+	if (spl_kstat) {
+		unregister_sysctl_table(spl_kstat);
+		spl_kstat = NULL;
+	}
+	if (spl_kmem) {
+		unregister_sysctl_table(spl_kmem);
+		spl_kmem = NULL;
+	}
+#endif
 	if (spl_header) {
 		unregister_sysctl_table(spl_header);
 		spl_header = NULL;
@@ -688,12 +702,13 @@ spl_proc_init(void)
 	if (spl_header == NULL)
 		return (-EUNATCH);
 
-	if (register_sysctl("kernel/spl/kmem", spl_kmem_table) == NULL) {
+	spl_kmem = register_sysctl("kernel/spl/kmem", spl_kmem_table);
+	if (spl_kmem == NULL) {
 		rc = -EUNATCH;
 		goto out;
 	}
-
-	if (register_sysctl("kernel/spl/kstat", spl_kstat_table) == NULL) {
+	spl_kstat = register_sysctl("kernel/spl/kstat", spl_kstat_table);
+	if (spl_kstat == NULL) {
 		rc = -EUNATCH;
 		goto out;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

spl fails to properly unload the registered sysctl entries when register_ssyctl_table() is not available in the kernel  (>= 6.5).

Corresponding tracking bug in Ubuntu: https://bugs.launchpad.net/bugs/2034510

### Description
<!--- Describe your changes in detail -->

When register_sysctl_table() is unavailable we fail to properly unregister sysctl entries under "kernel/spl".

This leads to errors like the following when spl is unloaded/reloaded, making impossible to properly reload the spl module:

 [  746.995704] sysctl duplicate entry: /kernel/spl/kmem/slab_kvmem_total

Fix by cleaning up all the sub-entries inside "kernel/spl" when the spl module is unloaded.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

```
modprobe -r zfs
modprobe -r spl
modprobe zfs
```

When the problem happens spl fails to load and we can see the following line in dmesg:

```
 [  746.995704] sysctl duplicate entry: /kernel/spl/kmem/slab_kvmem_total
```

<!--- Include details of your testing environment, and the tests you ran to -->

Test has been reproduced in a local VM running the latest 6.5 upstream kernel.

<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
