### PR TITLE
Fix l2arc_apply_transforms ztest crash

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -9111,7 +9111,7 @@ l2arc_apply_transforms(spa_t *spa, arc_buf_hdr_t *hdr, uint64_t asize,
 		}
 		ASSERT3U(psize, <=, HDR_GET_PSIZE(hdr));
 		if (psize < asize)
-			memset((char *)tmp + psize, 0, asize - psize);
+			memset((char *)tmp + psize, 0, bufsize - psize);
 		psize = HDR_GET_PSIZE(hdr);
 		abd_return_buf_copy(cabd, tmp, bufsize);
 		to_write = cabd;

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -9092,15 +9092,16 @@ l2arc_apply_transforms(spa_t *spa, arc_buf_hdr_t *hdr, uint64_t asize,
 		 * write things before deciding to fail compression in nearly
 		 * every case.)
 		 */
-		cabd = abd_alloc_for_io(size, ismd);
-		tmp = abd_borrow_buf(cabd, size);
+		uint64_t bufsize = MAX(size, asize);
+		cabd = abd_alloc_for_io(bufsize, ismd);
+		tmp = abd_borrow_buf(cabd, bufsize);
 
 		psize = zio_compress_data(compress, to_write, &tmp, size,
 		    hdr->b_complevel);
 
 		if (psize >= asize) {
 			psize = HDR_GET_PSIZE(hdr);
-			abd_return_buf_copy(cabd, tmp, size);
+			abd_return_buf_copy(cabd, tmp, bufsize);
 			HDR_SET_COMPRESS(hdr, ZIO_COMPRESS_OFF);
 			to_write = cabd;
 			abd_copy(to_write, hdr->b_l1hdr.b_pabd, psize);
@@ -9112,7 +9113,7 @@ l2arc_apply_transforms(spa_t *spa, arc_buf_hdr_t *hdr, uint64_t asize,
 		if (psize < asize)
 			memset((char *)tmp + psize, 0, asize - psize);
 		psize = HDR_GET_PSIZE(hdr);
-		abd_return_buf_copy(cabd, tmp, size);
+		abd_return_buf_copy(cabd, tmp, bufsize);
 		to_write = cabd;
 	}
 


### PR DESCRIPTION
### Motivation and Context
We have a crash ocurring pretty regularly in zloop that indicates corruption in the buffer allocated by `l2arc_apply_transforms`. This issue is documented in #15177.

### Description
In #13375 we modified the allocation size of the buffer that we use to apply l2arc transforms to be the size of the arc hdr we're using, rather than the allocation size that will be in place on the disk, because sometimes the hdr size is larger. Unfortunately, sometimes the allocation size is larger, which means that we overflow the buffer in that case. This change modifies the allocation to be the max of the two values.

### How Has This Been Tested?
Two hours of zloop runs with asan, and the issue did not recur. Previously it reliably occurred within 30 minutes. I'm not sure of the easiest way to test to make sure that the original issue is still fixed; @rincebrain is there a test in the test suite that covers it? If not I can try to do some manual testing of the early abort logic.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
