### PR TITLE
Scrubbing range of txg

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -288,7 +288,8 @@ typedef struct trimflags {
 /*
  * Functions to manipulate pool and vdev state
  */
-_LIBZFS_H int zpool_scan(zpool_handle_t *, pool_scan_func_t, pool_scrub_cmd_t);
+_LIBZFS_H int zpool_scan(zpool_handle_t *, pool_scan_func_t, pool_scrub_cmd_t,
+    uint64_t, uint64_t);
 _LIBZFS_H int zpool_initialize(zpool_handle_t *, pool_initialize_func_t,
     nvlist_t *);
 _LIBZFS_H int zpool_initialize_wait(zpool_handle_t *, pool_initialize_func_t,

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -379,6 +379,7 @@ typedef struct dmu_buf {
 #define	DMU_POOL_CREATION_VERSION	"creation_version"
 #define	DMU_POOL_SCAN			"scan"
 #define	DMU_POOL_ERRORSCRUB		"error_scrub"
+#define	DMU_POOL_LAST_SCRUBBED_TXG	"last_scrubbed_txg"
 #define	DMU_POOL_FREE_BPOBJ		"free_bpobj"
 #define	DMU_POOL_BPTREE_OBJ		"bptree_obj"
 #define	DMU_POOL_EMPTY_BPOBJ		"empty_bpobj"

--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -188,7 +188,8 @@ void dsl_scan_setup_sync(void *, dmu_tx_t *);
 void dsl_scan_fini(struct dsl_pool *dp);
 void dsl_scan_sync(struct dsl_pool *, dmu_tx_t *);
 int dsl_scan_cancel(struct dsl_pool *);
-int dsl_scan(struct dsl_pool *, pool_scan_func_t);
+int dsl_scan(struct dsl_pool *, pool_scan_func_t, uint64_t starttxg,
+    uint64_t txgend);
 void dsl_scan_assess_vdev(struct dsl_pool *dp, vdev_t *vd);
 boolean_t dsl_scan_scrubbing(const struct dsl_pool *dp);
 boolean_t dsl_errorscrubbing(const struct dsl_pool *dp);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -256,6 +256,7 @@ typedef enum {
 	ZPOOL_PROP_BCLONEUSED,
 	ZPOOL_PROP_BCLONESAVED,
 	ZPOOL_PROP_BCLONERATIO,
+	ZPOOL_PROP_LAST_SCRUBBED_TXG,
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
@@ -1046,6 +1047,7 @@ typedef enum pool_scan_func {
 typedef enum pool_scrub_cmd {
 	POOL_SCRUB_NORMAL = 0,
 	POOL_SCRUB_PAUSE,
+	POOL_SCRUB_FROM_LAST_TXG,
 	POOL_SCRUB_FLAGS_END
 } pool_scrub_cmd_t;
 

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1051,6 +1051,7 @@ extern uint64_t spa_get_deadman_failmode(spa_t *spa);
 extern void spa_set_deadman_failmode(spa_t *spa, const char *failmode);
 extern boolean_t spa_suspended(spa_t *spa);
 extern uint64_t spa_bootfs(spa_t *spa);
+extern uint64_t spa_get_last_scrubbed_txg(spa_t *spa);
 extern uint64_t spa_delegation(spa_t *spa);
 extern objset_t *spa_meta_objset(spa_t *spa);
 extern space_map_t *spa_syncing_log_sm(spa_t *spa);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -816,6 +816,8 @@ extern void spa_l2cache_drop(spa_t *spa);
 
 /* scanning */
 extern int spa_scan(spa_t *spa, pool_scan_func_t func);
+extern int spa_scan_range(spa_t *spa, pool_scan_func_t func, uint64_t txgstart,
+    uint64_t txgend);
 extern int spa_scan_stop(spa_t *spa);
 extern int spa_scrub_pause_resume(spa_t *spa, pool_scrub_cmd_t flag);
 

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -296,6 +296,7 @@ struct spa {
 	uint64_t	spa_scan_pass_scrub_spent_paused; /* total paused */
 	uint64_t	spa_scan_pass_exam;	/* examined bytes per pass */
 	uint64_t	spa_scan_pass_issued;	/* issued bytes per pass */
+	uint64_t	spa_scrubbed_last_txg;	/* last txg scrubbed */
 
 	/* error scrub pause time in milliseconds */
 	uint64_t	spa_scan_pass_errorscrub_pause;

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -1251,41 +1251,15 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libtpool/thread_pool.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='8901473c' size-in-bits='576' id='f5da478b'>
-      <subrange length='1' type-id='7359adad' id='52f813b4'/>
-    </array-type-def>
     <array-type-def dimensions='1' type-id='49ef3ffd' size-in-bits='1024' id='a14403f5'>
       <subrange length='16' type-id='7359adad' id='848d0938'/>
     </array-type-def>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='384' id='36d7f119'>
       <subrange length='48' type-id='7359adad' id='8f6d2a81'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='bd54fe1a' size-in-bits='512' id='5d4efd44'>
-      <subrange length='8' type-id='7359adad' id='56e0c0b1'/>
-    </array-type-def>
     <array-type-def dimensions='1' type-id='f0981eeb' size-in-bits='64' id='0d532ec1'>
       <subrange length='2' type-id='7359adad' id='52efc4ef'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='eaa32e2f' size-in-bits='256' id='209ef23f'>
-      <subrange length='4' type-id='7359adad' id='16fe7105'/>
-    </array-type-def>
-    <class-decl name='__cancel_jmp_buf_tag' size-in-bits='576' is-struct='yes' visibility='default' id='8901473c'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__cancel_jmp_buf' type-id='379a1ab7' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='__mask_was_saved' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__pthread_unwind_buf_t' size-in-bits='832' is-struct='yes' naming-typedef-id='4423cf7f' visibility='default' id='a0abc656'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__cancel_jmp_buf' type-id='f5da478b' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='__pad' type-id='209ef23f' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__pthread_unwind_buf_t' type-id='a0abc656' id='4423cf7f'/>
     <union-decl name='__atomic_wide_counter' size-in-bits='64' naming-typedef-id='f3b40860' visibility='default' id='613ce450'>
       <data-member access='public'>
         <var-decl name='__value64' type-id='3a47d82b' visibility='default'/>
@@ -1331,7 +1305,6 @@
       </data-member>
     </union-decl>
     <typedef-decl name='pthread_cond_t' type-id='cbb12c12' id='62fab762'/>
-    <typedef-decl name='__jmp_buf' type-id='5d4efd44' id='379a1ab7'/>
     <class-decl name='__pthread_cond_s' size-in-bits='384' is-struct='yes' visibility='default' id='c987b47c'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__wseq' type-id='f3b40860' visibility='default'/>
@@ -1381,13 +1354,6 @@
         <var-decl name='tpa_tid' type-id='4051f5e7' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='8901473c' size-in-bits='64' id='eb91b7ea'/>
-    <pointer-type-def type-id='4423cf7f' size-in-bits='64' id='ba7c727c'/>
-    <pointer-type-def type-id='b9c97942' size-in-bits='64' id='bbf06c47'/>
-    <qualified-type-def type-id='bbf06c47' restrict='yes' id='65e6ec45'/>
-    <qualified-type-def type-id='b9c97942' const='yes' id='191f6b72'/>
-    <pointer-type-def type-id='191f6b72' size-in-bits='64' id='e475fb88'/>
-    <qualified-type-def type-id='e475fb88' restrict='yes' id='5a8729d0'/>
     <qualified-type-def type-id='8037c762' const='yes' id='f50ea9b2'/>
     <pointer-type-def type-id='f50ea9b2' size-in-bits='64' id='5e14fa48'/>
     <qualified-type-def type-id='836265dd' const='yes' id='7d24c58d'/>
@@ -1515,15 +1481,7 @@
       <parameter type-id='7292109c'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='__pthread_register_cancel' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='ba7c727c'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
     <function-decl name='__pthread_unregister_cancel' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='ba7c727c'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
-    <function-decl name='__pthread_unwind_next' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='ba7c727c'/>
       <return type-id='48b5725f'/>
     </function-decl>
@@ -1554,12 +1512,6 @@
     <function-decl name='__sysconf' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
       <return type-id='bd54fe1a'/>
-    </function-decl>
-    <function-decl name='pthread_sigmask' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='5a8729d0'/>
-      <parameter type-id='65e6ec45'/>
-      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='tpool_abandon' mangled-name='tpool_abandon' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='tpool_abandon'>
       <parameter type-id='9cf59a50' name='tpool'/>
@@ -2929,7 +2881,8 @@
       <enumerator name='ZPOOL_PROP_BCLONEUSED' value='33'/>
       <enumerator name='ZPOOL_PROP_BCLONESAVED' value='34'/>
       <enumerator name='ZPOOL_PROP_BCLONERATIO' value='35'/>
-      <enumerator name='ZPOOL_NUM_PROPS' value='36'/>
+      <enumerator name='ZPOOL_PROP_LAST_SCRUBBED_TXG' value='36'/>
+      <enumerator name='ZPOOL_NUM_PROPS' value='37'/>
     </enum-decl>
     <typedef-decl name='zpool_prop_t' type-id='af1ba157' id='5d0c23fb'/>
     <typedef-decl name='regoff_t' type-id='95e97e5e' id='54a2a2a8'/>
@@ -5725,7 +5678,8 @@
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='POOL_SCRUB_NORMAL' value='0'/>
       <enumerator name='POOL_SCRUB_PAUSE' value='1'/>
-      <enumerator name='POOL_SCRUB_FLAGS_END' value='2'/>
+      <enumerator name='POOL_SCRUB_FROM_LAST_TXG' value='2'/>
+      <enumerator name='POOL_SCRUB_FLAGS_END' value='3'/>
     </enum-decl>
     <typedef-decl name='pool_scrub_cmd_t' type-id='a1474cbd' id='b51cf3c2'/>
     <enum-decl name='zpool_errata' id='d9abbf54'>
@@ -5754,6 +5708,112 @@
       <enumerator name='POOL_TRIM_FUNCS' value='3'/>
     </enum-decl>
     <typedef-decl name='pool_trim_func_t' type-id='54ed608a' id='b1146b8d'/>
+    <enum-decl name='zfs_ioc' id='12033f13'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='ZFS_IOC_FIRST' value='23040'/>
+      <enumerator name='ZFS_IOC' value='23040'/>
+      <enumerator name='ZFS_IOC_POOL_CREATE' value='23040'/>
+      <enumerator name='ZFS_IOC_POOL_DESTROY' value='23041'/>
+      <enumerator name='ZFS_IOC_POOL_IMPORT' value='23042'/>
+      <enumerator name='ZFS_IOC_POOL_EXPORT' value='23043'/>
+      <enumerator name='ZFS_IOC_POOL_CONFIGS' value='23044'/>
+      <enumerator name='ZFS_IOC_POOL_STATS' value='23045'/>
+      <enumerator name='ZFS_IOC_POOL_TRYIMPORT' value='23046'/>
+      <enumerator name='ZFS_IOC_POOL_SCAN' value='23047'/>
+      <enumerator name='ZFS_IOC_POOL_FREEZE' value='23048'/>
+      <enumerator name='ZFS_IOC_POOL_UPGRADE' value='23049'/>
+      <enumerator name='ZFS_IOC_POOL_GET_HISTORY' value='23050'/>
+      <enumerator name='ZFS_IOC_VDEV_ADD' value='23051'/>
+      <enumerator name='ZFS_IOC_VDEV_REMOVE' value='23052'/>
+      <enumerator name='ZFS_IOC_VDEV_SET_STATE' value='23053'/>
+      <enumerator name='ZFS_IOC_VDEV_ATTACH' value='23054'/>
+      <enumerator name='ZFS_IOC_VDEV_DETACH' value='23055'/>
+      <enumerator name='ZFS_IOC_VDEV_SETPATH' value='23056'/>
+      <enumerator name='ZFS_IOC_VDEV_SETFRU' value='23057'/>
+      <enumerator name='ZFS_IOC_OBJSET_STATS' value='23058'/>
+      <enumerator name='ZFS_IOC_OBJSET_ZPLPROPS' value='23059'/>
+      <enumerator name='ZFS_IOC_DATASET_LIST_NEXT' value='23060'/>
+      <enumerator name='ZFS_IOC_SNAPSHOT_LIST_NEXT' value='23061'/>
+      <enumerator name='ZFS_IOC_SET_PROP' value='23062'/>
+      <enumerator name='ZFS_IOC_CREATE' value='23063'/>
+      <enumerator name='ZFS_IOC_DESTROY' value='23064'/>
+      <enumerator name='ZFS_IOC_ROLLBACK' value='23065'/>
+      <enumerator name='ZFS_IOC_RENAME' value='23066'/>
+      <enumerator name='ZFS_IOC_RECV' value='23067'/>
+      <enumerator name='ZFS_IOC_SEND' value='23068'/>
+      <enumerator name='ZFS_IOC_INJECT_FAULT' value='23069'/>
+      <enumerator name='ZFS_IOC_CLEAR_FAULT' value='23070'/>
+      <enumerator name='ZFS_IOC_INJECT_LIST_NEXT' value='23071'/>
+      <enumerator name='ZFS_IOC_ERROR_LOG' value='23072'/>
+      <enumerator name='ZFS_IOC_CLEAR' value='23073'/>
+      <enumerator name='ZFS_IOC_PROMOTE' value='23074'/>
+      <enumerator name='ZFS_IOC_SNAPSHOT' value='23075'/>
+      <enumerator name='ZFS_IOC_DSOBJ_TO_DSNAME' value='23076'/>
+      <enumerator name='ZFS_IOC_OBJ_TO_PATH' value='23077'/>
+      <enumerator name='ZFS_IOC_POOL_SET_PROPS' value='23078'/>
+      <enumerator name='ZFS_IOC_POOL_GET_PROPS' value='23079'/>
+      <enumerator name='ZFS_IOC_SET_FSACL' value='23080'/>
+      <enumerator name='ZFS_IOC_GET_FSACL' value='23081'/>
+      <enumerator name='ZFS_IOC_SHARE' value='23082'/>
+      <enumerator name='ZFS_IOC_INHERIT_PROP' value='23083'/>
+      <enumerator name='ZFS_IOC_SMB_ACL' value='23084'/>
+      <enumerator name='ZFS_IOC_USERSPACE_ONE' value='23085'/>
+      <enumerator name='ZFS_IOC_USERSPACE_MANY' value='23086'/>
+      <enumerator name='ZFS_IOC_USERSPACE_UPGRADE' value='23087'/>
+      <enumerator name='ZFS_IOC_HOLD' value='23088'/>
+      <enumerator name='ZFS_IOC_RELEASE' value='23089'/>
+      <enumerator name='ZFS_IOC_GET_HOLDS' value='23090'/>
+      <enumerator name='ZFS_IOC_OBJSET_RECVD_PROPS' value='23091'/>
+      <enumerator name='ZFS_IOC_VDEV_SPLIT' value='23092'/>
+      <enumerator name='ZFS_IOC_NEXT_OBJ' value='23093'/>
+      <enumerator name='ZFS_IOC_DIFF' value='23094'/>
+      <enumerator name='ZFS_IOC_TMP_SNAPSHOT' value='23095'/>
+      <enumerator name='ZFS_IOC_OBJ_TO_STATS' value='23096'/>
+      <enumerator name='ZFS_IOC_SPACE_WRITTEN' value='23097'/>
+      <enumerator name='ZFS_IOC_SPACE_SNAPS' value='23098'/>
+      <enumerator name='ZFS_IOC_DESTROY_SNAPS' value='23099'/>
+      <enumerator name='ZFS_IOC_POOL_REGUID' value='23100'/>
+      <enumerator name='ZFS_IOC_POOL_REOPEN' value='23101'/>
+      <enumerator name='ZFS_IOC_SEND_PROGRESS' value='23102'/>
+      <enumerator name='ZFS_IOC_LOG_HISTORY' value='23103'/>
+      <enumerator name='ZFS_IOC_SEND_NEW' value='23104'/>
+      <enumerator name='ZFS_IOC_SEND_SPACE' value='23105'/>
+      <enumerator name='ZFS_IOC_CLONE' value='23106'/>
+      <enumerator name='ZFS_IOC_BOOKMARK' value='23107'/>
+      <enumerator name='ZFS_IOC_GET_BOOKMARKS' value='23108'/>
+      <enumerator name='ZFS_IOC_DESTROY_BOOKMARKS' value='23109'/>
+      <enumerator name='ZFS_IOC_RECV_NEW' value='23110'/>
+      <enumerator name='ZFS_IOC_POOL_SYNC' value='23111'/>
+      <enumerator name='ZFS_IOC_CHANNEL_PROGRAM' value='23112'/>
+      <enumerator name='ZFS_IOC_LOAD_KEY' value='23113'/>
+      <enumerator name='ZFS_IOC_UNLOAD_KEY' value='23114'/>
+      <enumerator name='ZFS_IOC_CHANGE_KEY' value='23115'/>
+      <enumerator name='ZFS_IOC_REMAP' value='23116'/>
+      <enumerator name='ZFS_IOC_POOL_CHECKPOINT' value='23117'/>
+      <enumerator name='ZFS_IOC_POOL_DISCARD_CHECKPOINT' value='23118'/>
+      <enumerator name='ZFS_IOC_POOL_INITIALIZE' value='23119'/>
+      <enumerator name='ZFS_IOC_POOL_TRIM' value='23120'/>
+      <enumerator name='ZFS_IOC_REDACT' value='23121'/>
+      <enumerator name='ZFS_IOC_GET_BOOKMARK_PROPS' value='23122'/>
+      <enumerator name='ZFS_IOC_WAIT' value='23123'/>
+      <enumerator name='ZFS_IOC_WAIT_FS' value='23124'/>
+      <enumerator name='ZFS_IOC_VDEV_GET_PROPS' value='23125'/>
+      <enumerator name='ZFS_IOC_VDEV_SET_PROPS' value='23126'/>
+      <enumerator name='ZFS_IOC_POOL_SCRUB' value='23127'/>
+      <enumerator name='ZFS_IOC_PLATFORM' value='23168'/>
+      <enumerator name='ZFS_IOC_EVENTS_NEXT' value='23169'/>
+      <enumerator name='ZFS_IOC_EVENTS_CLEAR' value='23170'/>
+      <enumerator name='ZFS_IOC_EVENTS_SEEK' value='23171'/>
+      <enumerator name='ZFS_IOC_NEXTBOOT' value='23172'/>
+      <enumerator name='ZFS_IOC_JAIL' value='23173'/>
+      <enumerator name='ZFS_IOC_USERNS_ATTACH' value='23173'/>
+      <enumerator name='ZFS_IOC_UNJAIL' value='23174'/>
+      <enumerator name='ZFS_IOC_USERNS_DETACH' value='23174'/>
+      <enumerator name='ZFS_IOC_SET_BOOTENV' value='23175'/>
+      <enumerator name='ZFS_IOC_GET_BOOTENV' value='23176'/>
+      <enumerator name='ZFS_IOC_LAST' value='23177'/>
+    </enum-decl>
+    <typedef-decl name='zfs_ioc_t' type-id='12033f13' id='5b35941c'/>
     <enum-decl name='zpool_wait_activity_t' naming-typedef-id='73446457' id='849338e3'>
       <underlying-type type-id='9cac1fee'/>
       <enumerator name='ZPOOL_WAIT_CKPT_DISCARD' value='0'/>
@@ -5922,6 +5982,13 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='lzc_set_vdev_prop' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='80f4b756'/>
+      <parameter type-id='5ce45b60'/>
+      <parameter type-id='857bb57e'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_scrub' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='5b35941c'/>
       <parameter type-id='80f4b756'/>
       <parameter type-id='5ce45b60'/>
       <parameter type-id='857bb57e'/>
@@ -6291,6 +6358,8 @@
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='7313fbe2' name='func'/>
       <parameter type-id='b51cf3c2' name='cmd'/>
+      <parameter type-id='9c313c2d' name='txgstart'/>
+      <parameter type-id='9c313c2d' name='txgend'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zpool_find_vdev_by_physpath' mangled-name='zpool_find_vdev_by_physpath' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev_by_physpath'>
@@ -6542,6 +6611,15 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libzfs/libzfs_sendrecv.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='8901473c' size-in-bits='576' id='f5da478b'>
+      <subrange length='1' type-id='7359adad' id='52f813b4'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='95e97e5e' size-in-bits='384' id='73b82f0f'>
+      <subrange length='12' type-id='7359adad' id='84827bdc'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='bd54fe1a' size-in-bits='512' id='5d4efd44'>
+      <subrange length='8' type-id='7359adad' id='56e0c0b1'/>
+    </array-type-def>
     <array-type-def dimensions='1' type-id='9c313c2d' size-in-bits='2176' id='8c2bcad1'>
       <subrange length='34' type-id='7359adad' id='6a6a7e00'/>
     </array-type-def>
@@ -6562,6 +6640,9 @@
     </array-type-def>
     <array-type-def dimensions='1' type-id='b96825af' size-in-bits='64' id='13339fda'>
       <subrange length='8' type-id='7359adad' id='56e0c0b1'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='eaa32e2f' size-in-bits='256' id='209ef23f'>
+      <subrange length='4' type-id='7359adad' id='16fe7105'/>
     </array-type-def>
     <class-decl name='sendflags' size-in-bits='576' is-struct='yes' visibility='default' id='f6aa15be'>
       <data-member access='public' layout-offset-in-bits='0'>
@@ -7109,25 +7190,103 @@
         <var-decl name='drr_checksum' type-id='39730d0b' visibility='default'/>
       </data-member>
     </class-decl>
+    <class-decl name='__cancel_jmp_buf_tag' size-in-bits='576' is-struct='yes' visibility='default' id='8901473c'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__cancel_jmp_buf' type-id='379a1ab7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='__mask_was_saved' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_unwind_buf_t' size-in-bits='832' is-struct='yes' naming-typedef-id='4423cf7f' visibility='default' id='a0abc656'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__cancel_jmp_buf' type-id='f5da478b' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='__pad' type-id='209ef23f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pthread_unwind_buf_t' type-id='a0abc656' id='4423cf7f'/>
+    <typedef-decl name='__jmp_buf' type-id='5d4efd44' id='379a1ab7'/>
     <typedef-decl name='__clockid_t' type-id='95e97e5e' id='08f9a87a'/>
+    <typedef-decl name='__timer_t' type-id='eaa32e2f' id='df209b60'/>
     <typedef-decl name='clockid_t' type-id='08f9a87a' id='a1c3b834'/>
+    <class-decl name='sigevent' size-in-bits='512' is-struct='yes' visibility='default' id='519bc206'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='sigev_value' type-id='eabacd01' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='sigev_signo' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='sigev_notify' type-id='95e97e5e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_sigev_un' type-id='ac5ab599' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='384' is-anonymous='yes' visibility='default' id='ac5ab599'>
+      <data-member access='public'>
+        <var-decl name='_pad' type-id='73b82f0f' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='_tid' type-id='3629bad8' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='_sigev_thread' type-id='e7f43f7b' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7b'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_function' type-id='5f147c28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_attribute' type-id='7347a39e' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='itimerspec' size-in-bits='256' is-struct='yes' visibility='default' id='acbdbcc6'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='it_interval' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='it_value' type-id='a9c79a1f' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='timer_t' type-id='df209b60' id='b07ae406'/>
     <typedef-decl name='Byte' type-id='002ac4a6' id='efb9ba06'/>
     <typedef-decl name='uLong' type-id='7359adad' id='5bbcce85'/>
     <typedef-decl name='Bytef' type-id='efb9ba06' id='c1606520'/>
     <typedef-decl name='uLongf' type-id='5bbcce85' id='4d39af59'/>
     <pointer-type-def type-id='c1606520' size-in-bits='64' id='4c667223'/>
+    <pointer-type-def type-id='8901473c' size-in-bits='64' id='eb91b7ea'/>
+    <pointer-type-def type-id='4423cf7f' size-in-bits='64' id='ba7c727c'/>
+    <pointer-type-def type-id='b9c97942' size-in-bits='64' id='bbf06c47'/>
+    <qualified-type-def type-id='bbf06c47' restrict='yes' id='65e6ec45'/>
     <qualified-type-def type-id='c1606520' const='yes' id='a6124a50'/>
     <pointer-type-def type-id='a6124a50' size-in-bits='64' id='e8cb3e0e'/>
+    <qualified-type-def type-id='b9c97942' const='yes' id='191f6b72'/>
+    <pointer-type-def type-id='191f6b72' size-in-bits='64' id='e475fb88'/>
+    <qualified-type-def type-id='e475fb88' restrict='yes' id='5a8729d0'/>
     <qualified-type-def type-id='781a52d7' const='yes' id='413ab2b8'/>
     <pointer-type-def type-id='413ab2b8' size-in-bits='64' id='41671bd6'/>
+    <qualified-type-def type-id='acbdbcc6' const='yes' id='4ba62af7'/>
+    <pointer-type-def type-id='4ba62af7' size-in-bits='64' id='f39579e7'/>
+    <qualified-type-def type-id='f39579e7' restrict='yes' id='9b23e165'/>
     <pointer-type-def type-id='c70fa2e8' size-in-bits='64' id='2e711a2a'/>
     <pointer-type-def type-id='3ff5601b' size-in-bits='64' id='4aafb922'/>
+    <pointer-type-def type-id='acbdbcc6' size-in-bits='64' id='116842ac'/>
+    <qualified-type-def type-id='116842ac' restrict='yes' id='3d3c4cf4'/>
     <pointer-type-def type-id='9e59d1d4' size-in-bits='64' id='4ea84b4f'/>
     <pointer-type-def type-id='945467e6' size-in-bits='64' id='8def7735'/>
+    <pointer-type-def type-id='519bc206' size-in-bits='64' id='ef2f159c'/>
+    <qualified-type-def type-id='ef2f159c' restrict='yes' id='de0eb5a4'/>
     <pointer-type-def type-id='3d3ffb69' size-in-bits='64' id='72a26210'/>
     <pointer-type-def type-id='c9d12d66' size-in-bits='64' id='b2eb2c3f'/>
+    <pointer-type-def type-id='b07ae406' size-in-bits='64' id='36e89359'/>
+    <qualified-type-def type-id='36e89359' restrict='yes' id='de98c2bb'/>
     <pointer-type-def type-id='a9c79a1f' size-in-bits='64' id='3d83ba87'/>
     <pointer-type-def type-id='4d39af59' size-in-bits='64' id='60db3356'/>
+    <pointer-type-def type-id='f1abb096' size-in-bits='64' id='5f147c28'/>
     <pointer-type-def type-id='39730d0b' size-in-bits='64' id='c24fc2ee'/>
     <function-decl name='nvlist_print' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='822cd80b'/>
@@ -7288,6 +7447,23 @@
       <parameter type-id='eaa32e2f'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='pthread_exit' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='eaa32e2f'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='__pthread_register_cancel' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='ba7c727c'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='__pthread_unwind_next' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='ba7c727c'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='sigaddset' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='9e80f729'/>
+      <parameter type-id='95e97e5e'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='perror' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='80f4b756'/>
       <return type-id='48b5725f'/>
@@ -7306,15 +7482,37 @@
       <parameter type-id='3d83ba87'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='timer_create' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='a1c3b834'/>
+      <parameter type-id='de0eb5a4'/>
+      <parameter type-id='de98c2bb'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='timer_delete' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='b07ae406'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='timer_settime' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='b07ae406'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='9b23e165'/>
+      <parameter type-id='3d3c4cf4'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='write' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='b59d7dce'/>
       <return type-id='79a0948f'/>
     </function-decl>
-    <function-decl name='sleep' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='f0981eeb'/>
-      <return type-id='f0981eeb'/>
+    <function-decl name='pause' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='pthread_sigmask' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='5a8729d0'/>
+      <parameter type-id='65e6ec45'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='uncompress' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='4c667223'/>
@@ -7392,6 +7590,10 @@
       <parameter type-id='9200a744'/>
       <parameter type-id='eaa32e2f'/>
       <return type-id='c19b74c3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='f1abb096'>
+      <parameter type-id='eabacd01'/>
+      <return type-id='48b5725f'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libzfs/libzfs_status.c' language='LANG_C99'>
@@ -8067,14 +8269,6 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libzfs/os/linux/libzfs_util_os.c' language='LANG_C99'>
-    <class-decl name='itimerspec' size-in-bits='256' is-struct='yes' visibility='default' id='acbdbcc6'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='it_interval' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='it_value' type-id='a9c79a1f' visibility='default'/>
-      </data-member>
-    </class-decl>
     <typedef-decl name='nfds_t' type-id='7359adad' id='555eef66'/>
     <class-decl name='pollfd' size-in-bits='64' is-struct='yes' visibility='default' id='b440e872'>
       <data-member access='public' layout-offset-in-bits='0'>
@@ -8087,9 +8281,6 @@
         <var-decl name='revents' type-id='a2185560' visibility='default'/>
       </data-member>
     </class-decl>
-    <qualified-type-def type-id='acbdbcc6' const='yes' id='4ba62af7'/>
-    <pointer-type-def type-id='4ba62af7' size-in-bits='64' id='f39579e7'/>
-    <pointer-type-def type-id='acbdbcc6' size-in-bits='64' id='116842ac'/>
     <pointer-type-def type-id='b440e872' size-in-bits='64' id='3ac36db0'/>
     <function-decl name='access' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='80f4b756'/>
@@ -8365,9 +8556,6 @@
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='256' id='16dc656a'>
       <subrange length='32' type-id='7359adad' id='ae5bde82'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='95e97e5e' size-in-bits='384' id='73b82f0f'>
-      <subrange length='12' type-id='7359adad' id='84827bdc'/>
-    </array-type-def>
     <class-decl name='importargs' size-in-bits='448' is-struct='yes' visibility='default' id='7ac83801'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='path' type-id='9b23c9ad' visibility='default'/>
@@ -8460,39 +8648,6 @@
         <var-decl name='__glibc_reserved' type-id='16dc656a' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='sigevent' size-in-bits='512' is-struct='yes' visibility='default' id='519bc206'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='sigev_value' type-id='eabacd01' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='sigev_signo' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='sigev_notify' type-id='95e97e5e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_sigev_un' type-id='ac5ab599' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' id='ac5ab599'>
-      <data-member access='public'>
-        <var-decl name='_pad' type-id='73b82f0f' visibility='default'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='_tid' type-id='3629bad8' visibility='default'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='_sigev_thread' type-id='e7f43f7b' visibility='default'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7b'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_function' type-id='5f147c28' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_attribute' type-id='7347a39e' visibility='default'/>
-      </data-member>
-    </class-decl>
     <pointer-type-def type-id='e4957c49' size-in-bits='64' id='924bbc81'/>
     <qualified-type-def type-id='924bbc81' const='yes' id='5499dcde'/>
     <pointer-type-def type-id='5499dcde' size-in-bits='64' id='2236d41c'/>
@@ -8503,9 +8658,6 @@
     <pointer-type-def type-id='7a842a6b' size-in-bits='64' id='07ee4a58'/>
     <pointer-type-def type-id='8a70a786' size-in-bits='64' id='5507783b'/>
     <pointer-type-def type-id='b1e62775' size-in-bits='64' id='f095e320'/>
-    <pointer-type-def type-id='519bc206' size-in-bits='64' id='ef2f159c'/>
-    <qualified-type-def type-id='ef2f159c' restrict='yes' id='de0eb5a4'/>
-    <pointer-type-def type-id='f1abb096' size-in-bits='64' id='5f147c28'/>
     <qualified-type-def type-id='48b5725f' volatile='yes' id='b0b3cbf9'/>
     <pointer-type-def type-id='b0b3cbf9' size-in-bits='64' id='fe09dd29'/>
     <function-decl name='update_vdev_config_dev_strs' mangled-name='update_vdev_config_dev_strs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='update_vdev_config_dev_strs'>
@@ -8559,10 +8711,6 @@
       <parameter type-id='eaa32e2f'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-type size-in-bits='64' id='f1abb096'>
-      <parameter type-id='eabacd01'/>
-      <return type-id='48b5725f'/>
-    </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libzutil/zutil_nicenum.c' language='LANG_C99'>
     <type-decl name='long double' size-in-bits='128' id='e095c704'/>
@@ -8707,8 +8855,8 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='module/zcommon/zfeature_common.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='83f29ca2' size-in-bits='17920' id='dd432c71'>
-      <subrange length='40' type-id='7359adad' id='ae4a9561'/>
+    <array-type-def dimensions='1' type-id='83f29ca2' size-in-bits='17920' id='fd3c7989'>
+      <subrange length='40' type-id='7359adad' id='8f80b239'/>
     </array-type-def>
     <enum-decl name='zfeature_flags' id='6db816a4'>
       <underlying-type type-id='9cac1fee'/>
@@ -8785,7 +8933,7 @@
     <pointer-type-def type-id='611586a1' size-in-bits='64' id='2e243169'/>
     <qualified-type-def type-id='eaa32e2f' const='yes' id='83be723c'/>
     <pointer-type-def type-id='83be723c' size-in-bits='64' id='7acd98a2'/>
-    <var-decl name='spa_feature_table' type-id='dd432c71' mangled-name='spa_feature_table' visibility='default' elf-symbol-id='spa_feature_table'/>
+    <var-decl name='spa_feature_table' type-id='fd3c7989' mangled-name='spa_feature_table' visibility='default' elf-symbol-id='spa_feature_table'/>
     <var-decl name='zfeature_checks_disable' type-id='c19b74c3' mangled-name='zfeature_checks_disable' visibility='default' elf-symbol-id='zfeature_checks_disable'/>
     <function-decl name='opendir' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='80f4b756'/>

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -341,6 +341,7 @@ zpool_get_prop(zpool_handle_t *zhp, zpool_prop_t prop, char *buf,
 		case ZPOOL_PROP_MAXDNODESIZE:
 		case ZPOOL_PROP_BCLONESAVED:
 		case ZPOOL_PROP_BCLONEUSED:
+		case ZPOOL_PROP_LAST_SCRUBBED_TXG:
 			if (literal)
 				(void) snprintf(buf, len, "%llu",
 				    (u_longlong_t)intval);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2646,7 +2646,8 @@ out:
  * Scan the pool.
  */
 int
-zpool_scan(zpool_handle_t *zhp, pool_scan_func_t func, pool_scrub_cmd_t cmd)
+zpool_scan(zpool_handle_t *zhp, pool_scan_func_t func, pool_scrub_cmd_t cmd,
+    uint64_t txgstart, uint64_t txgend)
 {
 	char errbuf[ERRBUFLEN];
 	int err;
@@ -2655,6 +2656,8 @@ zpool_scan(zpool_handle_t *zhp, pool_scan_func_t func, pool_scrub_cmd_t cmd)
 	nvlist_t *args = fnvlist_alloc();
 	fnvlist_add_uint64(args, "scan_type", (uint64_t)func);
 	fnvlist_add_uint64(args, "scan_command", (uint64_t)cmd);
+	fnvlist_add_uint64(args, "scan_txgstart", txgstart);
+	fnvlist_add_uint64(args, "scan_txgend", txgend);
 
 	err = lzc_scrub(ZFS_IOC_POOL_SCRUB, zhp->zpool_name, args, NULL);
 	fnvlist_free(args);

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -1360,7 +1360,9 @@
       <enumerator name='ZFS_IOC_EVENTS_SEEK' value='23171'/>
       <enumerator name='ZFS_IOC_NEXTBOOT' value='23172'/>
       <enumerator name='ZFS_IOC_JAIL' value='23173'/>
+      <enumerator name='ZFS_IOC_USERNS_ATTACH' value='23173'/>
       <enumerator name='ZFS_IOC_UNJAIL' value='23174'/>
+      <enumerator name='ZFS_IOC_USERNS_DETACH' value='23174'/>
       <enumerator name='ZFS_IOC_SET_BOOTENV' value='23175'/>
       <enumerator name='ZFS_IOC_GET_BOOTENV' value='23176'/>
       <enumerator name='ZFS_IOC_LAST' value='23177'/>
@@ -2537,6 +2539,13 @@
     </function-decl>
     <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_fini'>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='lzc_scrub' mangled-name='lzc_scrub' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_scrub'>
+      <parameter type-id='5b35941c' name='ioc'/>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='5ce45b60' name='source'/>
+      <parameter type-id='857bb57e' name='resultp'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='lzc_create' mangled-name='lzc_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_create'>
       <parameter type-id='80f4b756' name='fsname'/>

--- a/man/man7/zpoolprops.7
+++ b/man/man7/zpoolprops.7
@@ -28,7 +28,7 @@
 .\" Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
 .\" Copyright (c) 2023, Klara Inc.
 .\"
-.Dd April 18, 2023
+.Dd August 30, 2023
 .Dt ZPOOLPROPS 7
 .Os
 .
@@ -129,6 +129,14 @@ A unique identifier for the pool.
 The current health of the pool.
 Health can be one of
 .Sy ONLINE , DEGRADED , FAULTED , OFFLINE, REMOVED , UNAVAIL .
+.It Sy last_scrubbed_txg
+Indicates the transaction group (TXG) up to which the most recent scrub
+operation has checked and repaired the dataset.
+This provides insight into the data integrity status of their pool at
+a specific point in time.
+The
+.Xr zpool-scrub 8
+might be used to utilize this property.
 .It Sy leaked
 Space not released while
 .Sy freeing

--- a/man/man8/zpool-scrub.8
+++ b/man/man8/zpool-scrub.8
@@ -39,6 +39,7 @@
 .Op Fl s Ns | Ns Fl p
 .Op Fl w
 .Op Fl e
+.Op Fl C
 .Op Fl T Ar txg
 .Op Fl E Ar txg
 .Ar pool Ns …
@@ -116,6 +117,10 @@ The pool must have been scrubbed at least once with the
 feature enabled to use this option.
 Error scrubbing cannot be run simultaneously with regular scrubbing or
 resilvering, nor can it be run when a regular scrub is paused.
+.It Fl C
+Continue scrub from last saved txg (see zpool
+.Sy last_scrubbed_txg
+property).
 .It Fl T
 Specify the txg to use for a start point of scrub.
 .It Fl E

--- a/man/man8/zpool-scrub.8
+++ b/man/man8/zpool-scrub.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd June 22, 2023
+.Dd August 21, 2023
 .Dt ZPOOL-SCRUB 8
 .Os
 .
@@ -39,6 +39,8 @@
 .Op Fl s Ns | Ns Fl p
 .Op Fl w
 .Op Fl e
+.Op Fl T Ar txg
+.Op Fl E Ar txg
 .Ar pool Ns …
 .
 .Sh DESCRIPTION
@@ -114,6 +116,10 @@ The pool must have been scrubbed at least once with the
 feature enabled to use this option.
 Error scrubbing cannot be run simultaneously with regular scrubbing or
 resilvering, nor can it be run when a regular scrub is paused.
+.It Fl T
+Specify the txg to use for a start point of scrub.
+.It Fl E
+Specify the txg to use for a end point of scrub.
 .El
 .Sh EXAMPLES
 .Ss Example 1

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -125,6 +125,9 @@ zpool_prop_init(void)
 	zprop_register_number(ZPOOL_PROP_BCLONERATIO, "bcloneratio", 0,
 	    PROP_READONLY, ZFS_TYPE_POOL, "<1.00x or higher if cloned>",
 	    "BCLONE_RATIO", B_FALSE, sfeatures);
+	zprop_register_number(ZPOOL_PROP_LAST_SCRUBBED_TXG,
+	    "last_scrubbed_txg", 0, PROP_READONLY, ZFS_TYPE_POOL, "<txg>",
+	    "LAST_SCRUBBED_TXG", B_FALSE, sfeatures);
 
 	/* default number properties */
 	zprop_register_number(ZPOOL_PROP_VERSION, "version", SPA_VERSION,

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -228,6 +228,9 @@ static int zfs_resilver_disable_defer = B_FALSE;
 	((scn)->scn_phys.scn_func == POOL_SCAN_SCRUB || \
 	(scn)->scn_phys.scn_func == POOL_SCAN_RESILVER)
 
+#define	DSL_SCAN_IS_SCRUB(scn)		\
+	((scn)->scn_phys.scn_func == POOL_SCAN_SCRUB)
+
 /*
  * Enable/disable the processing of the free_bpobj object.
  */
@@ -1127,15 +1130,24 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 
 	spa_notify_waiters(spa);
 
-	if (dsl_scan_restarting(scn, tx))
+	if (dsl_scan_restarting(scn, tx)) {
 		spa_history_log_internal(spa, "scan aborted, restarting", tx,
 		    "errors=%llu", (u_longlong_t)spa_approx_errlog_size(spa));
-	else if (!complete)
+	} else if (!complete) {
 		spa_history_log_internal(spa, "scan cancelled", tx,
 		    "errors=%llu", (u_longlong_t)spa_approx_errlog_size(spa));
-	else
+	} else {
 		spa_history_log_internal(spa, "scan done", tx,
 		    "errors=%llu", (u_longlong_t)spa_approx_errlog_size(spa));
+		if (DSL_SCAN_IS_SCRUB(scn)) {
+			VERIFY0(zap_update(dp->dp_meta_objset,
+			    DMU_POOL_DIRECTORY_OBJECT,
+			    DMU_POOL_LAST_SCRUBBED_TXG,
+			    sizeof (uint64_t), 1,
+			    &scn->scn_phys.scn_max_txg, tx));
+			spa->spa_scrubbed_last_txg = scn->scn_phys.scn_max_txg;
+		}
+	}
 
 	if (DSL_SCAN_IS_SCRUB_RESILVER(scn)) {
 		spa->spa_scrub_active = B_FALSE;

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -844,18 +844,24 @@ dsl_scan_setup_check(void *arg, dmu_tx_t *tx)
 	return (0);
 }
 
+typedef struct {
+	pool_scan_func_t func;
+	uint64_t	 txgstart;
+	uint64_t	 txgend;
+} setup_sync_arg_t;
+
 void
 dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 {
-	(void) arg;
+	setup_sync_arg_t *setup_sync_arg = (setup_sync_arg_t *)arg;
 	dsl_scan_t *scn = dmu_tx_pool(tx)->dp_scan;
-	pool_scan_func_t *funcp = arg;
 	dmu_object_type_t ot = 0;
 	dsl_pool_t *dp = scn->scn_dp;
 	spa_t *spa = dp->dp_spa;
 
 	ASSERT(!dsl_scan_is_running(scn));
-	ASSERT(*funcp > POOL_SCAN_NONE && *funcp < POOL_SCAN_FUNCS);
+	ASSERT(setup_sync_arg->func > POOL_SCAN_NONE &&
+	    setup_sync_arg->func < POOL_SCAN_FUNCS);
 	memset(&scn->scn_phys, 0, sizeof (scn->scn_phys));
 
 	/*
@@ -865,10 +871,14 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 	memset(&scn->errorscrub_phys, 0, sizeof (scn->errorscrub_phys));
 	dsl_errorscrub_sync_state(scn, tx);
 
-	scn->scn_phys.scn_func = *funcp;
+	scn->scn_phys.scn_func = setup_sync_arg->func;
 	scn->scn_phys.scn_state = DSS_SCANNING;
-	scn->scn_phys.scn_min_txg = 0;
-	scn->scn_phys.scn_max_txg = tx->tx_txg;
+	scn->scn_phys.scn_min_txg = setup_sync_arg->txgstart;
+	if (setup_sync_arg->txgend == 0) {
+		scn->scn_phys.scn_max_txg = tx->tx_txg;
+	} else {
+		scn->scn_phys.scn_max_txg = setup_sync_arg->txgend;
+	}
 	scn->scn_phys.scn_ddt_class_max = DDT_CLASSES - 1; /* the entire DDT */
 	scn->scn_phys.scn_start_time = gethrestime_sec();
 	scn->scn_phys.scn_errors = 0;
@@ -953,7 +963,7 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 
 	spa_history_log_internal(spa, "scan setup", tx,
 	    "func=%u mintxg=%llu maxtxg=%llu",
-	    *funcp, (u_longlong_t)scn->scn_phys.scn_min_txg,
+	    setup_sync_arg->func, (u_longlong_t)scn->scn_phys.scn_min_txg,
 	    (u_longlong_t)scn->scn_phys.scn_max_txg);
 }
 
@@ -963,10 +973,16 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
  * error scrub.
  */
 int
-dsl_scan(dsl_pool_t *dp, pool_scan_func_t func)
+dsl_scan(dsl_pool_t *dp, pool_scan_func_t func, uint64_t txgstart,
+    uint64_t txgend)
 {
 	spa_t *spa = dp->dp_spa;
 	dsl_scan_t *scn = dp->dp_scan;
+	setup_sync_arg_t setup_sync_arg;
+
+	if (func != POOL_SCAN_SCRUB && (txgstart != 0 || txgend != 0)) {
+		return (EINVAL);
+	}
 
 	/*
 	 * Purge all vdev caches and probe all devices.  We do this here
@@ -1017,8 +1033,13 @@ dsl_scan(dsl_pool_t *dp, pool_scan_func_t func)
 		return (SET_ERROR(err));
 	}
 
+	setup_sync_arg.func = func;
+	setup_sync_arg.txgstart = txgstart;
+	setup_sync_arg.txgend = txgend;
+
 	return (dsl_sync_task(spa_name(spa), dsl_scan_setup_check,
-	    dsl_scan_setup_sync, &func, 0, ZFS_SPACE_CHECK_EXTRA_RESERVED));
+	    dsl_scan_setup_sync, &setup_sync_arg, 0,
+	    ZFS_SPACE_CHECK_EXTRA_RESERVED));
 }
 
 static void
@@ -4282,13 +4303,16 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 	 */
 	if (dsl_scan_restarting(scn, tx) ||
 	    (spa->spa_resilver_deferred && zfs_resilver_disable_defer)) {
-		pool_scan_func_t func = POOL_SCAN_SCRUB;
+		setup_sync_arg_t setup_sync_arg = {
+			.func = POOL_SCAN_SCRUB,
+		};
 		dsl_scan_done(scn, B_FALSE, tx);
 		if (vdev_resilver_needed(spa->spa_root_vdev, NULL, NULL))
-			func = POOL_SCAN_RESILVER;
+			setup_sync_arg.func = POOL_SCAN_RESILVER;
 		zfs_dbgmsg("restarting scan func=%u on %s txg=%llu",
-		    func, dp->dp_spa->spa_name, (longlong_t)tx->tx_txg);
-		dsl_scan_setup_sync(&func, tx);
+		    setup_sync_arg.func, dp->dp_spa->spa_name,
+		    (longlong_t)tx->tx_txg);
+		dsl_scan_setup_sync(&setup_sync_arg, tx);
 	}
 
 	/*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -366,6 +366,9 @@ spa_prop_get_config(spa_t *spa, nvlist_t **nvp)
 		spa_prop_add_list(*nvp, ZPOOL_PROP_BCLONERATIO, NULL,
 		    brt_get_ratio(spa), src);
 
+		spa_prop_add_list(*nvp, ZPOOL_PROP_LAST_SCRUBBED_TXG, NULL,
+		    spa_get_last_scrubbed_txg(spa), src);
+
 		spa_prop_add_list(*nvp, ZPOOL_PROP_HEALTH, NULL,
 		    rvd->vdev_state, src);
 
@@ -4237,6 +4240,12 @@ spa_ld_get_props(spa_t *spa)
 
 	error = spa_dir_prop(spa, DMU_POOL_ERRLOG_SCRUB,
 	    &spa->spa_errlog_scrub, B_FALSE);
+	if (error != 0 && error != ENOENT)
+		return (spa_vdev_err(rvd, VDEV_AUX_CORRUPT_DATA, EIO));
+
+	/* Load the last scrubbed txg. */
+	error = spa_dir_prop(spa, DMU_POOL_LAST_SCRUBBED_TXG,
+	    &spa->spa_scrubbed_last_txg, B_FALSE);
 	if (error != 0 && error != ENOENT)
 		return (spa_vdev_err(rvd, VDEV_AUX_CORRUPT_DATA, EIO));
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2548,6 +2548,12 @@ spa_mode(spa_t *spa)
 }
 
 uint64_t
+spa_get_last_scrubbed_txg(spa_t *spa)
+{
+	return (spa->spa_scrubbed_last_txg);
+}
+
+uint64_t
 spa_bootfs(spa_t *spa)
 {
 	return (spa->spa_bootfs);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1729,6 +1729,11 @@ zfs_ioc_pool_scrub(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 		if (scan_txgstart != 0 || scan_txgend != 0)
 			return (SET_ERROR(EINVAL));
 		error = spa_scan_stop(spa);
+	} else if (scan_cmd == POOL_SCRUB_FROM_LAST_TXG) {
+		if (scan_txgstart != 0)
+			return (SET_ERROR(EINVAL));
+		error = spa_scan_range(spa, scan_type,
+		    spa_get_last_scrubbed_txg(spa), scan_txgend);
 	} else {
 		error = spa_scan_range(spa, scan_type, scan_txgstart,
 		    scan_txgend);

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1169,6 +1169,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_scrub/zpool_scrub_multiple_copies.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_offline_device.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_print_repairing.ksh \
+	functional/cli_root/zpool_scrub/zpool_scrub_txg_continue_from_last.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_txg_end.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_txg_start.ksh \
 	functional/cli_root/zpool_scrub/zpool_error_scrub_001_pos.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1169,6 +1169,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_scrub/zpool_scrub_multiple_copies.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_offline_device.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_print_repairing.ksh \
+	functional/cli_root/zpool_scrub/zpool_scrub_txg_end.ksh \
+	functional/cli_root/zpool_scrub/zpool_scrub_txg_start.ksh \
 	functional/cli_root/zpool_scrub/zpool_error_scrub_001_pos.ksh \
 	functional/cli_root/zpool_scrub/zpool_error_scrub_002_pos.ksh \
 	functional/cli_root/zpool_scrub/zpool_error_scrub_003_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_txg_continue_from_last.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_txg_continue_from_last.ksh
@@ -1,0 +1,104 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+# Copyright (c) 2023, Klara Inc.
+#
+# This software was developed by
+# Mariusz Zaborski <mariusz.zaborski@klarasystems.com>
+# under sponsorship from Wasabi Technology, Inc.  and Klara Inc.
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+. $STF_SUITE/tests/functional/cli_root/zpool_import/zpool_import.kshlib
+
+#
+# DESCRIPTION:
+#	Verify scrub -C
+#
+# STRATEGY:
+#      1. Create a pool and create one file.
+#      2. Verify that the last_txg_scrub is 0.
+#      3. Run scrub.
+#      4. Verify that the last_txg_scrub is set.
+#      5. Create second file.
+#      6. Invalidate both files.
+#      7. Run scrub only from last point.
+#      8. Verify that only one file, that was created with newer txg,
+#         was detected.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must zinject -c all
+	log_must rm -f $mntpnt/f1
+	log_must rm -f $mntpnt/f2
+}
+
+log_onexit cleanup
+
+log_assert "Verify scrub -C."
+
+# Create one file.
+mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+
+log_must file_write -b 1048576 -c 10 -o create -d 0 -f $mntpnt/f1
+log_must sync_pool $TESTPOOL true
+f1txg=$(get_last_txg_synced $TESTPOOL)
+
+# Verify that last_scrubbed_txg isn't set.
+zpoollasttxg=$(zpool get -H -o value last_scrubbed_txg $TESTPOOL)
+log_must [ $zpoollasttxg -eq 0 ]
+
+# Run scrub.
+log_must zpool scrub -w $TESTPOOL
+
+# Verify that last_scrubbed_txg is set.
+zpoollasttxg=$(zpool get -H -o value last_scrubbed_txg $TESTPOOL)
+log_must [ $zpoollasttxg -ne 0 ]
+
+# Create second file.
+log_must file_write -b 1048576 -c 10 -o create -d 0 -f $mntpnt/f2
+log_must sync_pool $TESTPOOL true
+f2txg=$(get_last_txg_synced $TESTPOOL)
+
+# Make sure that the sync txg are different.
+log_must [ $f1txg -ne $f2txg ]
+
+# Insert faults.
+log_must zinject -a -t data -e io -T read $mntpnt/f1
+log_must zinject -a -t data -e io -T read $mntpnt/f2
+
+# Run scrub from last saved point.
+log_must zpool scrub -w -C $TESTPOOL
+
+# Verify that only newer file was detected.
+log_mustnot eval "zpool status -v $TESTPOOL | grep '$mntpnt/f1'"
+log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f2'"
+
+# Verify that both files are corrupted.
+log_must zpool scrub -w $TESTPOOL
+log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f1'"
+log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f2'"
+
+log_pass "Verified scrub -C show expected status."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_txg_end.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_txg_end.ksh
@@ -1,0 +1,88 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+# Copyright (c) 2023, Klara Inc.
+#
+# This software was developed by
+# Mariusz Zaborski <mariusz.zaborski@klarasystems.com>
+# under sponsorship from Wasabi Technology, Inc.  and Klara Inc.
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+. $STF_SUITE/tests/functional/cli_root/zpool_import/zpool_import.kshlib
+
+#
+# DESCRIPTION:
+#	Verify scrub -E <txg>
+#
+# STRATEGY:
+#      1. Create a pool and create two files.
+#      2. Corrupt the two files directly on the disks.
+#      3. Run a scrub with a txg that is between the birth time of
+#         the first file and birth time of the second file.
+#      4. Check that only the first file was reported as corrupted.
+#      5. Perform a full scrub.
+#      6. Check that both files were reported as corrupted.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must zinject -c all
+	log_must rm -f $mntpnt/f1
+	log_must rm -f $mntpnt/f2
+}
+
+log_onexit cleanup
+
+log_assert "Verify scrub -E."
+
+# Create two files and save a last txg.
+mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+
+log_must file_write -b 1048576 -c 10 -o create -d 0 -f $mntpnt/f1
+log_must sync_pool $TESTPOOL true
+f1txg=$(get_last_txg_synced $TESTPOOL)
+
+log_must file_write -b 1048576 -c 10 -o create -d 0 -f $mntpnt/f2
+log_must sync_pool $TESTPOOL true
+f2txg=$(get_last_txg_synced $TESTPOOL)
+
+# Make sure that the sync txg are different.
+log_must [ $f1txg -ne $f2txg ]
+
+# Insert faults.
+log_must zinject -a -t data -e io -T read $mntpnt/f1
+log_must zinject -a -t data -e io -T read $mntpnt/f2
+
+# Verify that only first file was detected.
+log_must zpool scrub -w -E "${f1txg}" $TESTPOOL
+log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f1'"
+log_mustnot eval "zpool status -v $TESTPOOL | grep '$mntpnt/f2'"
+
+# Verify that both files are corrupted.
+log_must zpool scrub -w $TESTPOOL
+log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f1'"
+log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f2'"
+
+log_pass "Verified scrub -E show expected status."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_txg_start.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_txg_start.ksh
@@ -1,0 +1,88 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+# Copyright (c) 2023, Klara Inc.
+#
+# This software was developed by
+# Mariusz Zaborski <mariusz.zaborski@klarasystems.com>
+# under sponsorship from Wasabi Technology, Inc.  and Klara Inc.
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+. $STF_SUITE/tests/functional/cli_root/zpool_import/zpool_import.kshlib
+
+#
+# DESCRIPTION:
+#	Verify scrub -T <txg>
+#
+# STRATEGY:
+#      1. Create a pool and create two files.
+#      2. Corrupt the two files directly on the disks.
+#      3. Run a scrub with a txg that is between the birth time of
+#         the first file and birth time of the second file.
+#      4. Check that only the second file was reported as corrupted.
+#      5. Perform a full scrub.
+#      6. Check that both files were reported as corrupted.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must zinject -c all
+	log_must rm -f $mntpnt/f1
+	log_must rm -f $mntpnt/f2
+}
+
+log_onexit cleanup
+
+log_assert "Verify scrub -T."
+
+# Create two files and save a last txg.
+mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+
+log_must file_write -b 1048576 -c 10 -o create -d 0 -f $mntpnt/f1
+log_must sync_pool $TESTPOOL true
+f1txg=$(get_last_txg_synced $TESTPOOL)
+
+log_must file_write -b 1048576 -c 10 -o create -d 0 -f $mntpnt/f2
+log_must sync_pool $TESTPOOL true
+f2txg=$(get_last_txg_synced $TESTPOOL)
+
+# Make sure that the sync txg are different.
+log_must [ $f1txg -ne $f2txg ]
+
+# Insert faults.
+log_must zinject -a -t data -e io -T read $mntpnt/f1
+log_must zinject -a -t data -e io -T read $mntpnt/f2
+
+# Verify that only second file was detected.
+log_must zpool scrub -w -T "${f1txg}" $TESTPOOL
+log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f2'"
+log_mustnot eval "zpool status -v $TESTPOOL | grep '$mntpnt/f1'"
+
+# Verify that both files are corrupted.
+log_must zpool scrub -w $TESTPOOL
+log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f1'"
+log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f2'"
+
+log_pass "Verified scrub -T show expected status."


### PR DESCRIPTION
### Motivation and Context

Sometimes it is useful to only scrub a particular range of `txg`. Some users might want to scrub only new data because they would like to know if the new write wasn't corrupted. Some users would like to scrub only historical data to know that they weren't corrupted. Providing users with a more granularly scrub can allow them to detect potential issues, via scrubbing more often smaller pieces of data.

### Description
Currently, we allow users only to scrub known errors or do a full scrub. After this change, the user will be able to point out which `txg` he would like to scrub (single, or range). Additionally for users who would like to scrub only new data, a new `zpool property` was introduced, that stores last scrubbed txg, so users can run scrub only from the last saved point.
We use a `scn_max_txg` and `scn_min_txg` which are already built into scrub, to accomplish taht.

### How Has This Been Tested?
New tests were added.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
