### PR TITLE
Fix occasional rsend test crashes

### DIFF
--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -650,10 +650,12 @@ send_worker(void *arg)
 	unsigned int bufsiz = max_pipe_buffer(ctx->from);
 	ssize_t rd;
 
-	while ((rd = splice(ctx->from, NULL, ctx->to, NULL, bufsiz,
-	    SPLICE_F_MOVE | SPLICE_F_MORE)) > 0)
-		;
-
+	for (;;) {
+		rd = splice(ctx->from, NULL, ctx->to, NULL, bufsiz,
+		    SPLICE_F_MOVE | SPLICE_F_MORE);
+		if ((rd == -1 && errno != EINTR) || rd == 0)
+			break;
+	}
 	int err = (rd == -1) ? errno : 0;
 	close(ctx->from);
 	return ((void *)(uintptr_t)err);


### PR DESCRIPTION
### Motivation and Context
We have occasional crashes in the rsend tests. Debugging revealed that this is because the `send_worker` thread is getting `EINTR` from `splice()`. This happens when a non-fatal signal is received during the syscall. We should retry the syscall, rather than exiting failure.

### Description
Tweak the loop to only break if the splice is finished or we receive a non-EINTR error.

### How Has This Been Tested?
Ran the rsend tests in a loop for 24 hours without issues. Usually the issue reproduced in less than that time.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
