### PR TITLE
zed: Allow autoreplace and fault LEDs for removed vdevs

### DIFF
--- a/cmd/zed/agents/zfs_mod.c
+++ b/cmd/zed/agents/zfs_mod.c
@@ -372,6 +372,7 @@ zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 	/* Only autoreplace bad disks */
 	if ((vs->vs_state != VDEV_STATE_DEGRADED) &&
 	    (vs->vs_state != VDEV_STATE_FAULTED) &&
+	    (vs->vs_state != VDEV_STATE_REMOVED) &&
 	    (vs->vs_state != VDEV_STATE_CANT_OPEN)) {
 		zed_log_msg(LOG_INFO, "  not autoreplacing since disk isn't in "
 		    "a bad state (currently %llu)", vs->vs_state);

--- a/cmd/zed/zed.d/statechange-led.sh
+++ b/cmd/zed/zed.d/statechange-led.sh
@@ -121,7 +121,7 @@ state_to_val()
 {
 	state="$1"
 	case "$state" in
-		FAULTED|DEGRADED|UNAVAIL)
+		FAULTED|DEGRADED|UNAVAIL|REMOVED)
 			echo 1
 			;;
 		ONLINE)


### PR DESCRIPTION
### Motivation and Context
Have ZED treat REMOVED drives correctly

### Description
Allow zed to autoreplace vdevs marked as REMOVED.  Also update `statechange-led.sh` zedlet to toggle fault LEDs for REMOVED vdevs.

### How Has This Been Tested?
Tested manually by powering off an NVMe drive in a pool and saw it REMOVED.  With this change, the fault LED for the drive went on.  Then I exported the pool, wiped the NVMe drive, imported the pool, and then powered on the NVMe drive again to simulate an autoreplace with a blank disk.  Saw the NVMe drive correctly get autoreplaced into the pool and the fault LED was cleared.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
