### PR TITLE
Install bashcompletion file in appropriate location

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -617,6 +617,17 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		AC_MSG_RESULT([no])
 	fi
 	AC_SUBST(RPM_DEFINE_INITRAMFS)
+
+	AC_MSG_CHECKING([default bash completion directory])
+	case "$VENDOR" in
+		ubuntu)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
+		debian)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
+		freebsd)    bashcompletiondir=$sysconfdir/bash_completion.d;;
+		*)          bashcompletiondir=/etc/bash_completion.d   ;;
+	esac
+	AC_MSG_RESULT([$bashcompletiondir])
+	AC_SUBST(bashcompletiondir)
+
 ])
 
 dnl #

--- a/contrib/bash_completion.d/Makefile.am
+++ b/contrib/bash_completion.d/Makefile.am
@@ -1,5 +1,3 @@
-bashcompletiondir = $(sysconfdir)/bash_completion.d
-
 nodist_bashcompletion_DATA  = %D%/zfs
 SUBSTFILES                 += $(nodist_bashcompletion_DATA)
 

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: ZFS on Linux specific mailing list <zfs-discuss@list.zfsonlinux.org>
 Build-Depends: debhelper-compat (= 12),
                dh-python,
-               dkms (>> 2.1.1.2-5),
+               dh-sequence-dkms | dkms (>> 2.1.1.2-5),
                libaio-dev,
                libblkid-dev,
                libcurl4-openssl-dev,

--- a/contrib/debian/openzfs-zfsutils.install
+++ b/contrib/debian/openzfs-zfsutils.install
@@ -1,7 +1,6 @@
 etc/default/zfs
 etc/zfs/zfs-functions
 etc/zfs/zpool.d/
-etc/bash_completion.d/zfs
 lib/systemd/system-generators/
 lib/systemd/system-preset/
 lib/systemd/system/zfs-import-cache.service

--- a/contrib/debian/rules.in
+++ b/contrib/debian/rules.in
@@ -71,10 +71,6 @@ override_dh_auto_install:
 	@# Install the utilities.
 	$(MAKE) install DESTDIR='$(CURDIR)/debian/tmp'
 
-	# Use upstream's bash completion
-	install -D -t '$(CURDIR)/debian/tmp/usr/share/bash-completion/completions/' \
-		'$(CURDIR)/contrib/bash_completion.d/zfs'
-
 	# Move from bin_dir to /usr/sbin
 	# Remove suffix (.py) as per policy 10.4 - Scripts
 	# https://www.debian.org/doc/debian-policy/ch-files.html#s-scripts
@@ -136,7 +132,6 @@ override_dh_auto_install:
 
 	chmod a-x '$(CURDIR)/debian/tmp/etc/zfs/zfs-functions'
 	chmod a-x '$(CURDIR)/debian/tmp/etc/default/zfs'
-	chmod a-x '$(CURDIR)/debian/tmp/usr/share/bash-completion/completions/zfs'
 
 override_dh_python3:
 	dh_python3 -p openzfs-python3-pyzfs


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
This patchset is the result of trying to build Debian Packages for 2.2.0-rc4 for Proxmox[0]
The changes in debian/contrib were only targeted at the fix (I did not try to install the resulting packages)

[0] https://git.proxmox.com/?p=zfsonlinux.git;a=tree
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Somewhere between zfs-2.1.12 and zfs-2.2.0-rc4 a change caused the bash completion to
actually get installed to DESTDIR - I assume 612b8dff5bc3d827efb864a199a62bda1a419254
introduced it.
Instead of working around the different location used in Debian based distributions (/usr/share/bash-completion/completions/, instead of /etc/bash_completion.d) in debian/rules [1] , setting the path during ./configure seems preferable) 

[1] https://github.com/openzfs/zfs/blob/4647353c8b2b5ca506da45bb9b01e1f3ef521847/contrib/debian/rules.in#L75
 (similar workaround can be found in Debian upstream and Proxmox rules files)

### Description
<!--- Describe your changes in detail -->
commit 1/3 sets the bashcompletiondir variable based on the vendor, inspired by similar settings for initdir and initconfdir
commit 2/3 is a small update to contrib/debian/control, in order to make building packages work on Debian Bookworm (the dkms package is virtual and should be replaced by dh-sequence-dkms)
commit 3/3 adapts contrib/debian/rules to not move the bashcompletion file around anymore

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
on Debian 12 I ran:
git clean -fdx; ./autogen.sh; ./configure --with-config=user; cp -a contrib/debian .; dpkg-buildpackage -b -uc -us
(the --with-config=user was a shorter way instead of providing the custom kernel-header location in Proxmox VE)
on Fedora 38:
git clean -fdx; ./autogen.sh ; ./configure  ; make rpm
and verifying that the bash completion file was installed in the correct location

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
