### PR TITLE
Set timeout before creating pool in test

### DIFF
--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback_same_txg.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback_same_txg.ksh
@@ -48,9 +48,9 @@ function cleanup
 
 log_onexit cleanup
 
-log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $DISKS
-
 log_must set_tunable64 TXG_TIMEOUT 5000
+
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $DISKS
 
 log_must dd if=/dev/urandom of=/$TESTPOOL/file bs=128K count=4
 log_must clonefile -f /$TESTPOOL/file /$TESTPOOL/clone 0 0 524288


### PR DESCRIPTION
### Motivation and Context
Occasionally block_cloning_copyfilerange_fallback_same_txg fails because the clone happens in a later txg than the file creation. This can happen because the 5000 second timeout is set but we then immediately go on to the creation; there may still be a quick TXG in the pipeline that causes the clone to happen in a separate TXG.

### Description
We set the timeout before creating the pool; this is what it is done in the mmp tests, which make extensive use of the txg timeout tunable. That way, all txgs are guaranteed to be long ones.

### How Has This Been Tested?
ZTS runs, none of which have failed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
