### PR TITLE
Add '-u' - nomount flag for zfs set

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -532,6 +532,7 @@ _LIBZFS_H nvlist_t *zfs_valid_proplist(libzfs_handle_t *, zfs_type_t,
 _LIBZFS_H const char *zfs_prop_to_name(zfs_prop_t);
 _LIBZFS_H int zfs_prop_set(zfs_handle_t *, const char *, const char *);
 _LIBZFS_H int zfs_prop_set_list(zfs_handle_t *, nvlist_t *);
+_LIBZFS_H int zfs_prop_set_list_flags(zfs_handle_t *, nvlist_t *, int);
 _LIBZFS_H int zfs_prop_get(zfs_handle_t *, zfs_prop_t, char *, size_t,
     zprop_source_t *, char *, size_t, boolean_t);
 _LIBZFS_H int zfs_prop_get_recvd(zfs_handle_t *, const char *, char *, size_t,
@@ -653,6 +654,13 @@ typedef struct zprop_get_cbdata {
 	zfs_type_t cb_type;
 	vdev_cbdata_t cb_vdevs;
 } zprop_get_cbdata_t;
+
+#define	ZFS_SET_NOMOUNT		1
+
+typedef struct zprop_set_cbdata {
+	int cb_flags;
+	nvlist_t *cb_proplist;
+} zprop_set_cbdata_t;
 
 _LIBZFS_H void zprop_print_one_property(const char *, zprop_get_cbdata_t *,
     const char *, const char *, zprop_source_t, const char *,

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -396,6 +396,7 @@
     <elf-symbol name='zfs_prop_readonly' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_prop_set' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_prop_set_list' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_prop_set_list_flags' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_prop_setonce' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_prop_string_to_index' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_prop_to_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -4426,6 +4427,12 @@
     <function-decl name='zfs_prop_set_list' mangled-name='zfs_prop_set_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list'>
       <parameter type-id='9200a744' name='zhp'/>
       <parameter type-id='5ce45b60' name='props'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_prop_set_list_flags' mangled-name='zfs_prop_set_list_flags' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_set_list_flags'>
+      <parameter type-id='9200a744' name='zhp'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <parameter type-id='95e97e5e' name='flags'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_prop_inherit' mangled-name='zfs_prop_inherit' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_inherit'>

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1248,10 +1248,18 @@ Otherwise, they are automatically remounted in the new location if the property
 was previously
 .Sy legacy
 or
-.Sy none ,
-or if they were mounted before the property was changed.
+.Sy none .
 In addition, any shared file systems are unshared and shared in the new
 location.
+.Pp
+When the
+.Sy mountpoint
+property is set with
+.Nm zfs Cm set Fl u
+, the
+.Sy mountpoint
+property is updated but dataset is not mounted or unmounted and remains
+as it was before.
 .It Sy nbmand Ns = Ns Sy on Ns | Ns Sy off
 Controls whether the file system should be mounted with
 .Sy nbmand
@@ -1656,6 +1664,13 @@ by default.
 This means that any additional access control
 (disallow specific user specific access etc) must be done on the underlying file
 system.
+.Pp
+When the
+.Sy sharesmb
+property is updated with
+.Nm zfs Cm set Fl u
+, the property is set to desired value, but the operation to share, reshare
+or unshare the the dataset is not performed.
 .It Sy sharenfs Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Ar opts
 Controls whether the file system is shared via NFS, and what options are to be
 used.
@@ -1699,6 +1714,13 @@ or if they were shared before the property was changed.
 If the new property is
 .Sy off ,
 the file systems are unshared.
+.Pp
+When the
+.Sy sharenfs
+property is updated with
+.Nm zfs Cm set Fl u
+, the property is set to desired value, but the operation to share, reshare
+or unshare the the dataset is not performed.
 .It Sy logbias Ns = Ns Sy latency Ns | Ns Sy throughput
 Provide a hint to ZFS about handling of synchronous requests in this dataset.
 If

--- a/man/man8/zfs-set.8
+++ b/man/man8/zfs-set.8
@@ -39,6 +39,7 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm set
+.Op Fl u
 .Ar property Ns = Ns Ar value Oo Ar property Ns = Ns Ar value Oc Ns …
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns …
 .Nm zfs
@@ -60,6 +61,7 @@
 .It Xo
 .Nm zfs
 .Cm set
+.Op Fl u
 .Ar property Ns = Ns Ar value Oo Ar property Ns = Ns Ar value Oc Ns …
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns …
 .Xc
@@ -79,6 +81,11 @@ For more information, see the
 .Em User Properties
 section of
 .Xr zfsprops 7 .
+.Bl -tag -width "-u"
+.It Fl u
+Update mountpoint, sharenfs, sharesmb property but do not mount or share the
+dataset.
+.El
 .It Xo
 .Nm zfs
 .Cm get

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -281,7 +281,7 @@ tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
     'user_property_004_pos', 'version_001_neg', 'zfs_set_001_neg',
     'zfs_set_002_neg', 'zfs_set_003_neg', 'property_alias_001_pos',
     'mountpoint_003_pos', 'ro_props_001_pos', 'zfs_set_keylocation',
-    'zfs_set_feature_activation']
+    'zfs_set_feature_activation', 'zfs_set_nomount']
 tags = ['functional', 'cli_root', 'zfs_set']
 
 [tests/functional/cli_root/zfs_share]

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -212,7 +212,7 @@ tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
     'user_property_001_pos', 'user_property_003_neg', 'readonly_001_pos',
     'user_property_004_pos', 'version_001_neg',
     'zfs_set_003_neg', 'property_alias_001_pos',
-    'zfs_set_keylocation', 'zfs_set_feature_activation']
+    'zfs_set_keylocation', 'zfs_set_feature_activation', 'zfs_set_nomount']
 tags = ['functional', 'cli_root', 'zfs_set']
 
 [tests/functional/cli_root/zfs_snapshot]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -870,6 +870,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_set/zfs_set_003_neg.ksh \
 	functional/cli_root/zfs_set/zfs_set_feature_activation.ksh \
 	functional/cli_root/zfs_set/zfs_set_keylocation.ksh \
+	functional/cli_root/zfs_set/zfs_set_nomount.ksh \
 	functional/cli_root/zfs_share/cleanup.ksh \
 	functional/cli_root/zfs_share/setup.ksh \
 	functional/cli_root/zfs_share/zfs_share_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_nomount.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_nomount.ksh
@@ -1,0 +1,103 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by iXsystems, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
+
+#
+# DESCRIPTION:
+# 'zfs set -u' should update the mountpoint, sharenfs and sharesmb
+# properties without mounting and sharing the dataset. Validate the
+# bevaior while dataset is mounted and unmounted.
+#
+# STRATEGY:
+# 1. Confirm dataset is currently mounted
+# 2. Update the mountpoint with -u flag
+# 3. Confirm mountpoint property is updated with new value
+# 4. Confirm dataset is still mounted at previous mountpoint
+# 5. Unmount the dataset
+# 6. Confirm dataset is unmounted
+# 7. Mount the dataset
+# 8. Confirm dataset is mounted at new mountpoint, that was set with -u flag.
+# 9. Update and mount the dataset at previous mountpoint.
+# 10. Unmount the dataset
+# 11. Update mountpoint property with zfs set -u
+# 12. Confirm dataset is not mounted
+# 13. Update sharenfs property with zfs set -u
+# 14. Confirm dataset is not mounted
+# 15. Update sharesmb property with zfs set -u
+# 16. Confirm dataset is not mounted
+# 17. Mount the dataset and confirm dataset is mounted at new mountpoint
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zfs set sharenfs=off $TESTPOOL/$TESTFS
+	if is_linux; then
+		log_must zfs set sharesmb=off $TESTPOOL/$TESTFS
+	fi
+	rm -r $newmpt
+}
+
+log_assert "'zfs set -u' sets the mountpoint and share properties without " \
+	"mounting the dataset"
+log_onexit cleanup
+
+oldmpt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+newmpt=$TEST_BASE_DIR/abc
+
+# Test while dataset is mounted
+log_must ismounted $TESTPOOL/$TESTFS
+log_must zfs set -u mountpoint=$newmpt $TESTPOOL/$TESTFS
+log_must check_user_prop $TESTPOOL/$TESTFS mountpoint $newmpt
+log_must eval "[[ "$(mount | grep $TESTPOOL/$TESTFS | awk '{print $3}')" == $oldmpt ]]"
+log_must zfs unmount $TESTPOOL/$TESTFS
+log_mustnot ismounted $TESTPOOL/$TESTFS
+log_must zfs mount $TESTPOOL/$TESTFS
+log_must eval "[[ "$(mount | grep $TESTPOOL/$TESTFS | awk '{print $3}')" == $newmpt ]]"
+
+# Test while dataset is unmounted
+log_must zfs set mountpoint=$oldmpt $TESTPOOL/$TESTFS
+log_must ismounted $TESTPOOL/$TESTFS
+log_must zfs unmount $TESTPOOL/$TESTFS
+log_must zfs set -u mountpoint=$newmpt $TESTPOOL/$TESTFS
+log_mustnot ismounted $TESTPOOL/$TESTFS
+log_must zfs set -u sharenfs=on $TESTPOOL/$TESTFS
+log_mustnot ismounted $TESTPOOL/$TESTFS
+if is_linux; then
+	log_must zfs set -u sharesmb=on $TESTPOOL/$TESTFS
+	log_mustnot ismounted $TESTPOOL/$TESTFS
+fi
+log_must zfs mount $TESTPOOL/$TESTFS
+log_must check_user_prop $TESTPOOL/$TESTFS mountpoint $newmpt
+log_must eval "[[ "$(mount | grep $TESTPOOL/$TESTFS | awk '{print $3}')" == $newmpt ]]"
+
+log_must zfs set mountpoint=$oldmpt $TESTPOOL/$TESTFS
+log_must ismounted $TESTPOOL/$TESTFS
+
+log_pass "'zfs set -u' functions correctly"


### PR DESCRIPTION


### Motivation and Context
#15240 updates the behavior for mountpoint property such that, whenever mountpoint
property is updated, it attempts to mount and share the dataset. To provide the user
with option to keep the dataset unmounted and still update the mountpoint without
mounting or sharing the dataset, '-u' flag can be used.

### Description
This commit adds '-u' flag for zfs set operation. With this flag, mountpoint, sharenfs
and sharesmb properties can be updated without actually mounting or sharing
the dataset.

If any of mountpoint, sharenfs or sharesmb properties are updated with '-u' flag,
the property is set to desired value but the operation to (re/un)mount and/or
(re/un)share the dataset is not performed and dataset remains as it was before.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).