### PR TITLE
Tweak rebuild in-flight hard limit

### DIFF
--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -807,12 +807,12 @@ vdev_rebuild_thread(void *arg)
 
 		/*
 		 * Calculate the max number of in-flight bytes for top-level
-		 * vdev scanning operations (minimum 1MB, maximum 1/4 of
+		 * vdev scanning operations (minimum 1MB, maximum 1/2 of
 		 * arc_c_max shared by all top-level vdevs).  Limits for the
 		 * issuing phase are done per top-level vdev and are handled
 		 * separately.
 		 */
-		uint64_t limit = (arc_c_max / 4) / MAX(rvd->vdev_children, 1);
+		uint64_t limit = (arc_c_max / 2) / MAX(rvd->vdev_children, 1);
 		vr->vr_bytes_inflight_max = MIN(limit, MAX(1ULL << 20,
 		    zfs_rebuild_vdev_limit * vd->vdev_children));
 


### PR DESCRIPTION
### Motivation and Context

Vendor testing shows we should be able to get a little more performance if we further relax the hard limit which we're hitting.

### Description

Allows `zfs_rebuild_vdev_limit` to be manually tuned to a larger value to get a little more performance on large systems.

### How Has This Been Tested?

Locally tested by comparing total rebuild times with various settings for `zfs_rebuild_vdev_limit`.  The default value remains unchanged.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
