### PR TITLE
Add ZED tunable for disk label wait during auto-replace

### DIFF
--- a/cmd/zed/agents/zfs_agents.c
+++ b/cmd/zed/agents/zfs_agents.c
@@ -388,13 +388,13 @@ zfs_agent_consumer_thread(void *arg)
 }
 
 void
-zfs_agent_init(libzfs_handle_t *zfs_hdl)
+zfs_agent_init(libzfs_handle_t *zfs_hdl, const char *zedlet_dir)
 {
 	fmd_hdl_t *hdl;
 
 	g_zfs_hdl = zfs_hdl;
 
-	if (zfs_slm_init() != 0)
+	if (zfs_slm_init(zedlet_dir) != 0)
 		zed_log_die("Failed to initialize zfs slm");
 	zed_log_msg(LOG_INFO, "Add Agent: init");
 

--- a/cmd/zed/agents/zfs_agents.h
+++ b/cmd/zed/agents/zfs_agents.h
@@ -28,14 +28,14 @@ extern "C" {
 /*
  * Agent abstraction presented to ZED
  */
-extern void zfs_agent_init(libzfs_handle_t *);
+extern void zfs_agent_init(libzfs_handle_t *, const char *);
 extern void zfs_agent_fini(void);
 extern void zfs_agent_post_event(const char *, const char *, nvlist_t *);
 
 /*
  * ZFS Sysevent Linkable Module (SLM)
  */
-extern int zfs_slm_init(void);
+extern int zfs_slm_init(const char *);
 extern void zfs_slm_fini(void);
 extern void zfs_slm_event(const char *, const char *, nvlist_t *);
 

--- a/cmd/zed/zed.d/zed.rc
+++ b/cmd/zed/zed.d/zed.rc
@@ -147,3 +147,11 @@ ZED_SYSLOG_SUBCLASS_EXCLUDE="history_event"
 # help silence misbehaving drives.  This assumes your drive enclosure fully
 # supports slot power control via sysfs.
 #ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT=1
+
+# During auto-replace of vdev device, the device is labeled
+# asynchronously on Linux. Use ZED_DISK_LABEL_WAIT_TIME to
+# change how long to wait for the partitioned device symlinks
+# to show up before giving up. The time is in milliseconds and
+# defaults to 3000 if not specified here.
+#
+#ZED_DISK_LABEL_WAIT_TIME=3000

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -64,7 +64,7 @@ zed_event_init(struct zed_conf *zcp)
 		    ZFS_DEV, strerror(errno));
 	}
 
-	zfs_agent_init(zcp->zfs_hdl);
+	zfs_agent_init(zcp->zfs_hdl, zcp->zedlet_dir);
 
 	if (zed_disk_event_init() != 0) {
 		if (zcp->do_idle)

--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 /*
- * Default wait time for a device name to be created.
+ * Default wait time in milliseconds for a device name to be created.
  */
 #define	DISK_LABEL_WAIT		(30 * 1000)  /* 30 seconds */
 

--- a/lib/libzutil/os/linux/zutil_import_os.c
+++ b/lib/libzutil/os/linux/zutil_import_os.c
@@ -582,9 +582,8 @@ zfs_device_get_physical(struct udev_device *dev, char *bufptr, size_t buflen)
  * Wait up to timeout_ms for udev to set up the device node.  The device is
  * considered ready when libudev determines it has been initialized, all of
  * the device links have been verified to exist, and it has been allowed to
- * settle.  At this point the device the device can be accessed reliably.
- * Depending on the complexity of the udev rules this process could take
- * several seconds.
+ * settle.  At this point the device can be accessed reliably. Depending on
+ * the complexity of the udev rules this process could take several seconds.
  */
 int
 zpool_label_disk_wait(const char *path, int timeout_ms)


### PR DESCRIPTION
### Motivation and Context
During an auto-replace of a VDEV device, the device is labeled asynchronously in ZED and it waits until the partition link appears before proceeding with the zpool_vdev_attach(). 

We have seen cases where ZED doesn't wait long enough for the partition link to appear and so the auto-replace fails. Below is the ZED log message observed:
```
zed[3752]: zfs_mod: expected replacement disk /dev/disk/by-id/scsi-35000c500a5713fa4-part1 is missing
```
Note that during a `zpool create` or `zpool add` it waits up to 30 seconds when calling `zpool_label_disk_wait()`.

### Description
Added a new ZED configuration tunable, `ZED_DISK_LABEL_WAIT_TIME` which can override the previously hard-coded value of 3000 ms.

Also re-worded the log message when the timeout is reached before the link appears:
```
zfs_mod: after labeling replacement disk, the expected disk partition link '/dev/disk/by-id/scsi-35000c500a5713fa4-part1' is missing after waiting 3000 ms
```
Sponsored-By: OpenDrives Inc.
Sponsored-By: Klara Inc.

### How Has This Been Tested?
Tested manually and with ZTS `functional/fault/auto_replace_001_pos`

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
