### PR TITLE
[2.2] Additional backports

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -5179,7 +5179,7 @@ dump_label(const char *dev)
 			if (nvlist_size(config, &size, NV_ENCODE_XDR) != 0)
 				size = buflen;
 
-			/* If the device is a cache device clear the header. */
+			/* If the device is a cache device read the header. */
 			if (!read_l2arc_header) {
 				if (nvlist_lookup_uint64(config,
 				    ZPOOL_CONFIG_POOL_STATE, &l2cache) == 0 &&

--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -617,6 +617,17 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		AC_MSG_RESULT([no])
 	fi
 	AC_SUBST(RPM_DEFINE_INITRAMFS)
+
+	AC_MSG_CHECKING([default bash completion directory])
+	case "$VENDOR" in
+		ubuntu)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
+		debian)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
+		freebsd)    bashcompletiondir=$sysconfdir/bash_completion.d;;
+		*)          bashcompletiondir=/etc/bash_completion.d   ;;
+	esac
+	AC_MSG_RESULT([$bashcompletiondir])
+	AC_SUBST(bashcompletiondir)
+
 ])
 
 dnl #

--- a/contrib/bash_completion.d/Makefile.am
+++ b/contrib/bash_completion.d/Makefile.am
@@ -1,5 +1,3 @@
-bashcompletiondir = $(sysconfdir)/bash_completion.d
-
 nodist_bashcompletion_DATA  = %D%/zfs
 SUBSTFILES                 += $(nodist_bashcompletion_DATA)
 

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: ZFS on Linux specific mailing list <zfs-discuss@list.zfsonlinux.org>
 Build-Depends: debhelper-compat (= 12),
                dh-python,
-               dkms (>> 2.1.1.2-5),
+               dh-sequence-dkms | dkms (>> 2.1.1.2-5),
                libaio-dev,
                libblkid-dev,
                libcurl4-openssl-dev,

--- a/contrib/debian/openzfs-zfsutils.install
+++ b/contrib/debian/openzfs-zfsutils.install
@@ -1,7 +1,6 @@
 etc/default/zfs
 etc/zfs/zfs-functions
 etc/zfs/zpool.d/
-etc/bash_completion.d/zfs
 lib/systemd/system-generators/
 lib/systemd/system-preset/
 lib/systemd/system/zfs-import-cache.service

--- a/contrib/debian/rules.in
+++ b/contrib/debian/rules.in
@@ -71,10 +71,6 @@ override_dh_auto_install:
 	@# Install the utilities.
 	$(MAKE) install DESTDIR='$(CURDIR)/debian/tmp'
 
-	# Use upstream's bash completion
-	install -D -t '$(CURDIR)/debian/tmp/usr/share/bash-completion/completions/' \
-		'$(CURDIR)/contrib/bash_completion.d/zfs'
-
 	# Move from bin_dir to /usr/sbin
 	# Remove suffix (.py) as per policy 10.4 - Scripts
 	# https://www.debian.org/doc/debian-policy/ch-files.html#s-scripts
@@ -136,7 +132,6 @@ override_dh_auto_install:
 
 	chmod a-x '$(CURDIR)/debian/tmp/etc/zfs/zfs-functions'
 	chmod a-x '$(CURDIR)/debian/tmp/etc/default/zfs'
-	chmod a-x '$(CURDIR)/debian/tmp/usr/share/bash-completion/completions/zfs'
 
 override_dh_python3:
 	dh_python3 -p openzfs-python3-pyzfs

--- a/include/os/linux/zfs/sys/trace_dbuf.h
+++ b/include/os/linux/zfs/sys/trace_dbuf.h
@@ -60,8 +60,12 @@
 
 #define	DBUF_TP_FAST_ASSIGN						\
 	if (db != NULL) {						\
-		__assign_str(os_spa,					\
-		spa_name(DB_DNODE(db)->dn_objset->os_spa));		\
+		if (POINTER_IS_VALID(DB_DNODE(db)->dn_objset)) {	\
+			__assign_str(os_spa,				\
+			spa_name(DB_DNODE(db)->dn_objset->os_spa));	\
+		} else {						\
+			__assign_str(os_spa, "NULL");			\
+		}							\
 									\
 		__entry->ds_object = db->db_objset->os_dsl_dataset ?	\
 		db->db_objset->os_dsl_dataset->ds_object : 0;		\

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -1138,6 +1138,16 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 		    POOL_STATE_L2CACHE) == 0);
 		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_GUID,
 		    vd->vdev_guid) == 0);
+
+		/*
+		 * This is merely to facilitate reporting the ashift of the
+		 * cache device through zdb. The actual retrieval of the
+		 * ashift (in vdev_alloc()) uses the nvlist
+		 * spa->spa_l2cache->sav_config (populated in
+		 * spa_ld_open_aux_vdevs()).
+		 */
+		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_ASHIFT,
+		    vd->vdev_ashift) == 0);
 	} else {
 		uint64_t txg = 0ULL;
 

--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -807,12 +807,12 @@ vdev_rebuild_thread(void *arg)
 
 		/*
 		 * Calculate the max number of in-flight bytes for top-level
-		 * vdev scanning operations (minimum 1MB, maximum 1/4 of
+		 * vdev scanning operations (minimum 1MB, maximum 1/2 of
 		 * arc_c_max shared by all top-level vdevs).  Limits for the
 		 * issuing phase are done per top-level vdev and are handled
 		 * separately.
 		 */
-		uint64_t limit = (arc_c_max / 4) / MAX(rvd->vdev_children, 1);
+		uint64_t limit = (arc_c_max / 2) / MAX(rvd->vdev_children, 1);
 		vr->vr_bytes_inflight_max = MIN(limit, MAX(1ULL << 20,
 		    zfs_rebuild_vdev_limit * vd->vdev_children));
 


### PR DESCRIPTION
### Motivation and Context

Backports for 2.2.

### Description

edbb2d16de Restrict short block cloning requests
29552a5ef4 Tweak rebuild in-flight hard limit

### How Has This Been Tested?

Backports from master.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
