### PR TITLE
CI: add FreeBSD build with Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+  ARCH: amd64
+
+build_task:
+  matrix:
+    freebsd_instance:
+      image_family: freebsd-12-4
+    freebsd_instance:
+      image_family: freebsd-13-2
+    freebsd_instance:
+      image_family: freebsd-14-0-snap
+  prepare_script:
+    - pkg install -y autoconf automake libtool gettext-runtime gmake ksh93 py39-packaging py39-cffi py39-sysctl
+  configure_script:
+    - env MAKE=gmake ./autogen.sh
+    - env MAKE=gmake ./configure --with-config="user" --with-python=3.9
+  build_script:
+    - gmake -j `sysctl -n kern.smp.cpus`
+  install_script:
+    - gmake install

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 !udev/**
 
 !.editorconfig
+!.cirrus.yml
 !.gitignore
 !.gitmodules
 !AUTHORS
@@ -59,7 +60,6 @@
 !RELEASES.md
 !TEST
 !zfs.release.in
-
 
 #
 # Normal rules


### PR DESCRIPTION
### Motivation and Context
As a first step for automatic FreeBSD testing add a build and install for FreeBSD versions 12.4, 13.2 and 14-snapshot using Cirrus CI. As next steps we can extend it to run the ZFS test suite.

### Description
Add .cirrus.yml to the project and non-exclude it in .gitignore
The GitHub project needs to install the Cirrus CI GitHub app.

### How Has This Been Tested?
Cirrus CI build on GitHub mmatuska/zfs

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).