### PR TITLE
[2.2]  Add BTI landing pads to the AArch64 SHA2 assembly

### DIFF
--- a/module/icp/asm-aarch64/sha2/sha256-armv8.S
+++ b/module/icp/asm-aarch64/sha2/sha256-armv8.S
@@ -49,6 +49,7 @@
 .type	zfs_sha256_block_armv7,%function
 .align	6
 zfs_sha256_block_armv7:
+	hint	#34					// bti c
 	stp	x29,x30,[sp,#-128]!
 	add	x29,sp,#0
 
@@ -1015,6 +1016,7 @@ zfs_sha256_block_armv7:
 .type	zfs_sha256_block_armv8,%function
 .align	6
 zfs_sha256_block_armv8:
+	hint		#34				// bti c
 .Lv8_entry:
 	stp		x29,x30,[sp,#-16]!
 	add		x29,sp,#0
@@ -1155,6 +1157,7 @@ zfs_sha256_block_armv8:
 .type	zfs_sha256_block_neon,%function
 .align	4
 zfs_sha256_block_neon:
+	hint	#34					// bti c
 .Lneon_entry:
 	stp	x29, x30, [sp, #-16]!
 	mov	x29, sp

--- a/module/icp/asm-aarch64/sha2/sha512-armv8.S
+++ b/module/icp/asm-aarch64/sha2/sha512-armv8.S
@@ -73,6 +73,7 @@
 .type	zfs_sha512_block_armv7,%function
 .align	6
 zfs_sha512_block_armv7:
+	hint	#34					// bti c
 	stp	x29,x30,[sp,#-128]!
 	add	x29,sp,#0
 
@@ -1040,6 +1041,7 @@ zfs_sha512_block_armv7:
 .type	zfs_sha512_block_armv8,%function
 .align	6
 zfs_sha512_block_armv8:
+	hint		#34				// bti c
 .Lv8_entry:
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later
 	stp		x29,x30,[sp,#-16]!


### PR DESCRIPTION
### Motivation and Context

Backport for 2.2

### Description

The Arm Branch Target Identification (BTI) extension guards against branching to an unintended instruction.

To support BTI add the landing pad instructions to the SHA2 functions. These are from the hint space so are a nop on hardware that lacks BTI support or if BTI isn't enabled.

### How Has This Been Tested?

See original PR.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
