### PR TITLE
Use `zfs_spa_pause_sync` to stay on same txg

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -246,7 +246,7 @@ uint64_t	zfs_max_missing_tvds_scan = 0;
 /*
  * Debugging aid that pauses spa_sync() towards the end.
  */
-static const boolean_t	zfs_pause_spa_sync = B_FALSE;
+static boolean_t zfs_pause_spa_sync = B_FALSE;
 
 /*
  * Variables to indicate the livelist condense zthr func should wait at certain
@@ -10181,3 +10181,6 @@ ZFS_MODULE_PARAM(zfs_livelist_condense, zfs_livelist_condense_, new_alloc, INT,
 	"Whether extra ALLOC blkptrs were added to a livelist entry while it "
 	"was being condensed");
 /* END CSTYLED */
+
+ZFS_MODULE_PARAM(zfs, zfs_, pause_spa_sync, INT, ZMOD_RW,
+	"Set to pause sync thread; clear to resume (debug use only)");

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -61,6 +61,7 @@ MULTIHOST_HISTORY		multihost.history		zfs_multihost_history
 MULTIHOST_IMPORT_INTERVALS	multihost.import_intervals	zfs_multihost_import_intervals
 MULTIHOST_INTERVAL		multihost.interval		zfs_multihost_interval
 OVERRIDE_ESTIMATE_RECORDSIZE	send.override_estimate_recordsize	zfs_override_estimate_recordsize
+PAUSE_SPA_SYNC			pause_spa_sync			zfs_pause_spa_sync
 PREFETCH_DISABLE		prefetch.disable		zfs_prefetch_disable
 REBUILD_SCRUB_ENABLED		rebuild_scrub_enabled		zfs_rebuild_scrub_enabled
 REMOVAL_SUSPEND_PROGRESS	removal_suspend_progress	zfs_removal_suspend_progress

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback_same_txg.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback_same_txg.ksh
@@ -44,6 +44,7 @@ function cleanup
 {
 	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
 	set_tunable64 TXG_TIMEOUT $timeout
+	set_tunable64 PAUSE_SPA_SYNC 0
 }
 
 log_onexit cleanup
@@ -52,8 +53,10 @@ log_must set_tunable64 TXG_TIMEOUT 5000
 
 log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $DISKS
 
+log_must set_tunable64 PAUSE_SPA_SYNC 1
 log_must dd if=/dev/urandom of=/$TESTPOOL/file bs=128K count=4
 log_must clonefile -f /$TESTPOOL/file /$TESTPOOL/clone 0 0 524288
+log_must set_tunable64 PAUSE_SPA_SYNC 0
 
 log_must sync_pool $TESTPOOL
 


### PR DESCRIPTION
### Motivation and Context

See #15349.

### Description

Trying @behlendorf's [suggestion](https://github.com/openzfs/zfs/pull/15349#issuecomment-1747728178) to forcibly stop the txg advancing to make sure both write and clone happen on the same txg. Since `zfs_spa_pause_sync` wasn't exposed (or I didn't know how to use it), this PR lifts it up to be a module parameter.

### How Has This Been Tested?

I did a quick test to see that it passes locally, but the full test run here is the real point!

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
