### PR TITLE
Add mutex_enter_interruptible() for interruptible sleeping IOCTLs

### DIFF
--- a/include/os/freebsd/spl/sys/mutex.h
+++ b/include/os/freebsd/spl/sys/mutex.h
@@ -64,6 +64,7 @@ typedef enum {
 } while (0)
 #define	mutex_destroy(lock)	sx_destroy(lock)
 #define	mutex_enter(lock)	sx_xlock(lock)
+#define	mutex_enter_interruptible(lock)	sx_xlock_sig(lock)
 #define	mutex_enter_nested(lock, type)	sx_xlock(lock)
 #define	mutex_tryenter(lock)	sx_try_xlock(lock)
 #define	mutex_exit(lock)	sx_xunlock(lock)

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -837,7 +837,7 @@ extern kmutex_t spa_namespace_lock;
 
 extern void spa_write_cachefile(spa_t *, boolean_t, boolean_t, boolean_t);
 extern void spa_config_load(void);
-extern nvlist_t *spa_all_configs(uint64_t *);
+extern int spa_all_configs(uint64_t *generation, nvlist_t **pools);
 extern void spa_config_set(spa_t *spa, nvlist_t *config);
 extern nvlist_t *spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg,
     int getstats);

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -274,11 +274,13 @@ typedef struct kmutex {
 extern void mutex_init(kmutex_t *mp, char *name, int type, void *cookie);
 extern void mutex_destroy(kmutex_t *mp);
 extern void mutex_enter(kmutex_t *mp);
+extern int mutex_enter_check_return(kmutex_t *mp);
 extern void mutex_exit(kmutex_t *mp);
 extern int mutex_tryenter(kmutex_t *mp);
 
 #define	NESTED_SINGLE 1
 #define	mutex_enter_nested(mp, class) mutex_enter(mp)
+#define	mutex_enter_interruptible(mp) mutex_enter_check_return(mp)
 /*
  * RW locks
  */

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -206,6 +206,15 @@ mutex_enter(kmutex_t *mp)
 }
 
 int
+mutex_enter_check_return(kmutex_t *mp)
+{
+	int error = pthread_mutex_lock(&mp->m_lock);
+	if (error == 0)
+		mp->m_owner = pthread_self();
+	return (error);
+}
+
+int
 mutex_tryenter(kmutex_t *mp)
 {
 	int error = pthread_mutex_trylock(&mp->m_lock);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1582,8 +1582,9 @@ zfs_ioc_pool_configs(zfs_cmd_t *zc)
 	nvlist_t *configs;
 	int error;
 
-	if ((configs = spa_all_configs(&zc->zc_cookie)) == NULL)
-		return (SET_ERROR(EEXIST));
+	error = spa_all_configs(&zc->zc_cookie, &configs);
+	if (error)
+		return (error);
 
 	error = put_nvlist(zc, configs);
 


### PR DESCRIPTION
### Motivation and Context
This is to resolve a usability issue with running zpool status during a long-running zpool import. zpool status sleeps uninterruptibly on the mutex, so the sysadmin gets a unkillable hanging shell, which is a bad user experience. In our environment it's common for zpool import to take 5+ minutes, so we encounter this frequently. 

It's not just a problem for interactive use -- we use Pacemaker with the ZFS ocf resource agents, and these run zpool status periodically to perform health checks. Pacemaker continues to run these health checks while a pool is importing, and this can result in a very high number of hung zpool status tasks stuck in D state. This is mainly an annoyance as they clutter up ps output, etc., it isn't a performance issue, but being able to kill these processes would be nice.

There are further usability improvements possible here, for example, an option could be added to zpool status that makes it return immediately if it would block due to a concurrent zpool import. Possibly zpool import could set a flag and zpool status could check the flag before calling mutex_enter(). Mutex_tryenter() wouldn't work in this situation because it couldn't distinguish two concurrent status calls, for example. This is less crucial than making zpool status interruptible in my opinion, but just suggesting it as a further idea in case others like it.

There are other IOCTLs that zpool status calls (ZFS_IOC_POOL_STATS, ZFS_IOC_POOL_GET_PROPS) that should in principle be changed to use mutex_enter_interruptible(), since a zpool status could start and complete the first IOCTL (ZFS_IOC_POOL_CONFIGS), then a zpool import could start, then zpool status would sleep uninterruptibly. However, getting this first IOCTL converted should cover the 99% common case. If the response to this patch is positive I can submit a follow-up that converts the other 2 IOCTLs.

### Description
    Many long-running ZFS ioctls lock the spa_namespace_lock, forcing
    concurrent ioctls to sleep for the mutex. Previously, the only
    option is to call mutex_enter() which sleeps uninterruptibly. This
    is a usability issue for sysadmins, for example, if the admin runs
    `zpool status` while a slow `zpool import` is ongoing, the admin's
    shell will be locked in uninterruptible sleep for a long time.

    This patch resolves this admin usability issue by introducing
    mutex_enter_interruptible() which sleeps interruptibly while waiting
    to acquire a lock. It is implemented for both Linux and FreeBSD.

    The ZFS_IOC_POOL_CONFIGS ioctl, used by `zpool status`, is changed to
    use this new macro so that the command can be interrupted if it is
    issued during a concurrent `zpool import` (or other long-running
    operation).

### How Has This Been Tested?
Tested on Linux 6.5.0-rc6 and FreeBSD 13.2-RELEASE-p3.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
