### PR TITLE
Fix ZED auto-replace for VDEVs using by-id paths

### DIFF
--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 /*
- * Default wait time for a device name to be created.
+ * Default wait time in milliseconds for a device name to be created.
  */
 #define	DISK_LABEL_WAIT		(30 * 1000)  /* 30 seconds */
 

--- a/lib/libzutil/os/linux/zutil_import_os.c
+++ b/lib/libzutil/os/linux/zutil_import_os.c
@@ -582,9 +582,8 @@ zfs_device_get_physical(struct udev_device *dev, char *bufptr, size_t buflen)
  * Wait up to timeout_ms for udev to set up the device node.  The device is
  * considered ready when libudev determines it has been initialized, all of
  * the device links have been verified to exist, and it has been allowed to
- * settle.  At this point the device the device can be accessed reliably.
- * Depending on the complexity of the udev rules this process could take
- * several seconds.
+ * settle.  At this point the device can be accessed reliably. Depending on
+ * the complexity of the udev rules this process could take several seconds.
  */
 int
 zpool_label_disk_wait(const char *path, int timeout_ms)

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -115,10 +115,10 @@ tags = ['functional', 'fallocate']
 
 [tests/functional/fault:Linux]
 tests = ['auto_offline_001_pos', 'auto_online_001_pos', 'auto_online_002_pos',
-    'auto_replace_001_pos', 'auto_spare_001_pos', 'auto_spare_002_pos',
-    'auto_spare_multiple', 'auto_spare_ashift', 'auto_spare_shared',
-    'decrypt_fault', 'decompress_fault', 'scrub_after_resilver',
-    'zpool_status_-s']
+    'auto_replace_001_pos', 'auto_replace_002_pos', 'auto_spare_001_pos',
+    'auto_spare_002_pos', 'auto_spare_multiple', 'auto_spare_ashift',
+    'auto_spare_shared', 'decrypt_fault', 'decompress_fault',
+    'scrub_after_resilver', 'zpool_status_-s']
 tags = ['functional', 'fault']
 
 [tests/functional/features/large_dnode:Linux]

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -329,6 +329,7 @@ if os.environ.get('CI') == 'true':
         'fault/auto_online_001_pos': ['SKIP', ci_reason],
         'fault/auto_online_002_pos': ['SKIP', ci_reason],
         'fault/auto_replace_001_pos': ['SKIP', ci_reason],
+        'fault/auto_replace_002_pos': ['SKIP', ci_reason],
         'fault/auto_spare_ashift': ['SKIP', ci_reason],
         'fault/auto_spare_shared': ['SKIP', ci_reason],
         'procfs/pool_state': ['SKIP', ci_reason],

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -130,12 +130,14 @@ export SYSTEM_FILES_LINUX='attr
     chattr
     exportfs
     fallocate
+    flock
     free
     getfattr
     groupadd
     groupdel
     groupmod
     hostid
+    logger
     losetup
     lsattr
     lsblk
@@ -145,21 +147,20 @@ export SYSTEM_FILES_LINUX='attr
     md5sum
     mkswap
     modprobe
+    mountpoint
     mpstat
     nsenter
     parted
     perf
     setfattr
+    setpriv
     sha256sum
     udevadm
     unshare
     useradd
     userdel
     usermod
-    setpriv
-    mountpoint
-    flock
-    logger'
+    wipefs'
 
 export ZFS_FILES='zdb
     zfs

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1890,7 +1890,7 @@ function check_vdev_state # pool disk state{online,offline,unavail,removed}
 	typeset disk=${2#*$DEV_DSKDIR/}
 	typeset state=$3
 
-	cur_state=$(zpool get state -H -o value $pool $disk)
+	cur_state=$(get_device_state $pool $disk)
 
 	[ $state = $cur_state ]
 }

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1890,7 +1890,7 @@ function check_vdev_state # pool disk state{online,offline,unavail,removed}
 	typeset disk=${2#*$DEV_DSKDIR/}
 	typeset state=$3
 
-	cur_state=$(get_device_state $pool $disk)
+	cur_state=$(zpool get state -H -o value $pool $disk)
 
 	[ $state = $cur_state ]
 }

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1426,6 +1426,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/fault/auto_online_001_pos.ksh \
 	functional/fault/auto_online_002_pos.ksh \
 	functional/fault/auto_replace_001_pos.ksh \
+	functional/fault/auto_replace_002_pos.ksh \
 	functional/fault/auto_spare_001_pos.ksh \
 	functional/fault/auto_spare_002_pos.ksh \
 	functional/fault/auto_spare_ashift.ksh \

--- a/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
@@ -91,7 +91,7 @@ log_must zpool export $TESTPOOL
 # Record the partition UUID for later comparison
 part_uuid=$(udevadm info --query=property --property=ID_PART_TABLE_UUID \
     --value /dev/disk/by-id/$SD_DEVICE_ID)
-log_note original disk GPT uuid ${part_uuid}
+[[ -z "$part_uuid" ]] || log_note original disk GPT uuid ${part_uuid}
 
 #
 # Wipe and offline the disk
@@ -123,11 +123,18 @@ log_must wait_replacing $TESTPOOL 60
 # Validate auto-replace was successful
 log_must check_state $TESTPOOL "" "ONLINE"
 
+#
 # Confirm the partition UUID changed so we know the new disk was relabeled
-new_uuid=$(udevadm info --query=property --property=ID_PART_TABLE_UUID \
-    --value /dev/disk/by-id/$SD_DEVICE_ID)
-log_note new disk GPT uuid ${new_uuid}
-[[ "$part_uuid" = "$new_uuid" ]] && \
-    log_fail "The new disk was not relabeled as expected"
+#
+# Note: some older versions of udevadm don't support "--property" option so
+# we'll # skip this test when it is not supported
+#
+if [ ! -z "$part_uuid" ]; then
+	new_uuid=$(udevadm info --query=property --property=ID_PART_TABLE_UUID \
+	    --value /dev/disk/by-id/$SD_DEVICE_ID)
+	log_note new disk GPT uuid ${new_uuid}
+	[[ "$part_uuid" = "$new_uuid" ]] && \
+	    log_fail "The new disk was not relabeled as expected"
+fi
 
 log_pass "Auto-replace test successful"

--- a/tests/zfs-tests/tests/functional/fault/auto_replace_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_replace_002_pos.ksh
@@ -21,6 +21,7 @@
 #
 #
 # Copyright (c) 2017 by Intel Corporation. All rights reserved.
+# Copyright (c) 2023 by Klara, Inc. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -29,6 +30,7 @@
 #
 # DESCRIPTION:
 # Testing Fault Management Agent ZED Logic - Automated Auto-Replace Test.
+# Verifys that auto-replace works with by-id paths.
 #
 # STRATEGY:
 # 1. Update /etc/zfs/vdev_id.conf with scsidebug alias for a persistent path.
@@ -37,12 +39,11 @@
 # 3. Export the pool
 # 4. Wipe and offline the scsi_debug disk
 # 5. Import the pool with missing disk
-# 6. Re-online the wiped scsi_debug disk
+# 6. Re-online the wiped scsi_debug disk with a new serial number
 # 7. Verify ZED detects the new blank disk and replaces the missing vdev
 # 8. Verify that the scsi_debug disk was re-partitioned
 #
-# Creates a raidz1 zpool using persistent /dev/disk/by-vdev path names
-# (ie not /dev/sdc)
+# Creates a raidz1 zpool using persistent /dev/disk/by-id path names
 #
 # Auto-replace is opt in, and matches by phys_path.
 #
@@ -61,7 +62,36 @@ function cleanup
 	unload_scsi_debug
 }
 
-log_assert "Testing automated auto-replace FMA test"
+#
+# Wait until a vdev transitions to its replacement vdev
+#
+# Return 0 when vdev reaches expected state, 1 on timeout.
+#
+# Note: index +2 is to skip over root and raidz-0 vdevs
+#
+function wait_vdev_online # pool index oldguid timeout
+{
+	typeset pool=$1
+	typeset -i index=$2+2
+	typeset guid=$3
+	typeset timeout=${4:-60}
+	typeset -i i=0
+
+	while [[ $i -lt $timeout ]]; do
+		vdev_guids=( $(zpool get -H -o value guid $pool all-vdevs) )
+
+		if [ "${vdev_guids[$index]}" != "${guid}" ]; then
+			log_note "new vdev[$((index-2))]: ${vdev_guids[$index]}, replacing ${guid}"
+			return 0
+		fi
+
+		i=$((i+1))
+		sleep 1
+	done
+
+	return 1
+}
+log_assert "automated auto-replace with by-id paths"
 log_onexit cleanup
 
 load_scsi_debug $SDSIZE $SDHOSTS $SDTGTS $SDLUNS '512b'
@@ -78,7 +108,10 @@ SD_DEVICE=$(udevadm info -q all -n $DEV_DSKDIR/$SD | \
 [ -z $SD_DEVICE ] && log_fail "vdev rule was not registered properly"
 
 log_must zpool events -c
-log_must zpool create -f $TESTPOOL raidz1 $SD_DEVICE $DISK1 $DISK2 $DISK3
+log_must zpool create -f $TESTPOOL raidz1 $SD_DEVICE_ID $DISK1 $DISK2 $DISK3
+
+vdev_guid=$(zpool get guid -H -o value $TESTPOOL $SD_DEVICE_ID)
+log_note original vdev guid ${vdev_guid}
 
 # Auto-replace is opt-in so need to set property
 log_must zpool set autoreplace=on $TESTPOOL
@@ -113,12 +146,31 @@ log_must zpool import $TESTPOOL
 log_must check_state $TESTPOOL "" "DEGRADED"
 block_device_wait
 
-# Online an empty disk in the same physical location
+#
+# Online an empty disk in the same physical location, with a different by-id
+# symlink. We use vpd_use_hostno to make sure the underlying serial number
+# changes for the new disk which in turn gives us a different by-id path.
+#
+# The original names were something like:
+# 	/dev/disk/by-id/scsi-SLinux_scsi_debug_16000-part1
+# 	/dev/disk/by-id/wwn-0x33333330000007d0-part1
+#
+# This new inserted disk, will have different links like:
+# 	/dev/disk/by-id/scsi-SLinux_scsi_debug_2000-part1
+# 	/dev/disk/by-id/wwn-0x0x3333333000003e80 -part1
+#
+echo '0' > /sys/bus/pseudo/drivers/scsi_debug/vpd_use_hostno
+
 insert_disk $SD $SD_HOST
 
+# make sure the physical path points to the same scsi-debug device
+SD_DEVICE_ID=$(get_persistent_disk_name $SD)
+echo "alias scsidebug /dev/disk/by-id/$SD_DEVICE_ID" >>$VDEVID_CONF
+block_device_wait
+
 # Wait for the new disk to be online and replaced
-log_must wait_vdev_state $TESTPOOL "scsidebug" "ONLINE" 60
-log_must wait_replacing $TESTPOOL 60
+log_must wait_vdev_online $TESTPOOL 0 $vdev_guid 45
+log_must wait_replacing $TESTPOOL 45
 
 # Validate auto-replace was successful
 log_must check_state $TESTPOOL "" "ONLINE"
@@ -130,4 +182,4 @@ log_note new disk GPT uuid ${new_uuid}
 [[ "$part_uuid" = "$new_uuid" ]] && \
     log_fail "The new disk was not relabeled as expected"
 
-log_pass "Auto-replace test successful"
+log_pass "automated auto-replace with by-id paths"


### PR DESCRIPTION
### Motivation and Context
The ZFS auto-replace mechanism will detect a blank disk inserted for a degraded/faulted VDEV and automatically partition the disk and issue a VDEV replacement.

There are two different `/dev/disk/by-xxx` paths involved, a `by-id` and a `by-vdev`.
In the 'by-vdev' case, the path is both a persistent and physical path.
In the 'by-id' case, the path is persistent and also a unique path.
During an auto-replace, the newly partition disk will have a different 'by-id' name, however the 'by-vdev' name will not change.

A regression in the distant past, changed the ZED auto-replace code such that it is attempting to use the old 'by-id' name during the replacement but that name no longer exists in the 'by-id' namespace. This causes the auto-replace operation to fail.

Note that since the 'by-vdev' names don't change, it's perfectly fine to use the previous VDEV path when dev paths are 'by-vdev'.
### Description
The change is simple -- restore the original code so that the VDEV path is updated when using by-id paths.
The more challenging part was to devise a second ZTS test, that would test auto-replace for 'by-id' and help prevent a future regression.

With that new test, we can now do an A|B test with , and without, the fix to confirm that auto-replace for by-id paths works. The existing auto-replace test, `functional/fault/auto_replace_001_pos`, will confirm that we didn't break auto-replace for 'by-vdev' paths.

In the original `functional/fault/auto_replace_001_pos test`, the disk wipe (using `dd`) was not effective in removing the partitioning since the kernel was never informed of the wipe.
- Added a call to `wipefs(8)` so that the kernel is informed and ZED will re-partition the device.
- Added a validation step that the repartitioning occurred by confirming that the GPT partition UUID changes

Sponsored-By: OpenDrives Inc.
Sponsored-By: Klara Inc.
### How Has This Been Tested?
ZTS  `functional/fault` tests
Audit ZED logging from the tests to confirm that ZED auto-replace was functioning as expected.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
