### PR TITLE
run-zts test procfs/pool_state failed with uncorrectable I/O failure

### DIFF
--- a/tests/zfs-tests/tests/functional/procfs/pool_state.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/pool_state.ksh
@@ -141,7 +141,11 @@ remove_disk $SDISK
 # background since the command will hang when the pool gets suspended.  The
 # command will resume and exit after we restore the missing disk later on.
 zpool scrub $TESTPOOL2 &
-sleep 3		# Give the scrub some time to run before we check if it fails
+# Once we trigger the zpool scrub, all zpool/zfs command gets stuck for 180 seconds.
+# Post 180 seconds zpool/zfs commands gets start executing however few more seconds(10s)
+# it take to update the status.
+# hence sleeping for 200 seconds so that we get the correct status.
+sleep 200		# Give the scrub some time to run before we check if it fails
 
 log_must check_all $TESTPOOL2 "SUSPENDED"
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
This change is regarding `procfs/pool_state` zts test. 

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
`procfs/pool_state` functional test fails with Uncorrectable I/O Failure.

> SUCCESS: zpool online testpool-4aa935ff-0845 sdb
SUCCESS: zpool clear testpool-4aa935ff-0845
SUCCESS: modprobe scsi_debug dev_size_mb=256 add_host=1 num_tgts=1 max_luns=1 sector_size=512 physblk_exp=0
SUCCESS: [ ! -e /dev/kstat-state-realdisk ]
SUCCESS: zpool create testpool2 /dev/kstat-state-realdisk
SUCCESS: [ ! -e /var/tmp/kstat-state-realdisk.gz ]
SUCCESS: rm /dev/kstat-state-realdisk
SUCCESS: eval echo 'offline' > /sys/block/sde/device/state
SUCCESS: eval echo '1' > /sys/block/sde/device/delete
NOTE: Checking SUSPENDED = UNAVAIL = SUSPENDED = SUSPENDED
ERROR: check_all testpool2 SUSPENDED exited 1
~~ snip ~~
[ 7344.490274] WARNING: Pool 'testpool2' has encountered an uncorrectable I/O failure and has been suspended. 

Test creates a pool using single scsi_debug disk. And test tries to simulate the zpool SUSPENDED state. To achieve this it removed the scsi_debug disks and initiate the zpool scrub in background. It sleep for 3 seconds and make call to check the status of zpool at three difference places. 

> state1=$(zpool` status $pool | awk '/state: /{print $2}');
state2=$(zpool list -H -o health $pool)
state3=$(</proc/spl/kstat/zfs/$pool/state)

state1 commands gets stuck for 180 seconds and later we get the status in UNAVAIL state.

Once we trigger the zpool scrub, all zpool command gets stuck for 180 seconds. Post 180 seconds zpool commands gets start executing however few more seconds(roughly 10s) it take to update the status.

### Description
<!--- Describe your changes in detail -->
 Once we trigger the zpool scrub, all zpool/zfs command gets stuck for 180 seconds. Post 180 seconds zpool/zfs commands gets start executing however few more seconds(10s) it take to update the status. hence sleeping for 200 seconds so that we get the correct status.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
