### PR TITLE
rpm: Fix `make rpm` on Debian/Ubuntu

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -358,6 +358,9 @@ AC_DEFUN([ZFS_AC_RPM], [
 	AS_IF([test -n "$udevruledir" ], [
 		RPM_DEFINE_UTIL=${RPM_DEFINE_UTIL}' --define "_udevruledir $(udevruledir)"'
 	])
+	AS_IF([test -n "$bashcompletiondir" ], [
+		RPM_DEFINE_UTIL=${RPM_DEFINE_UTIL}' --define "_bashcompletiondir $(bashcompletiondir)"'
+	])
 	RPM_DEFINE_UTIL=${RPM_DEFINE_UTIL}' $(DEFINE_SYSTEMD)'
 	RPM_DEFINE_UTIL=${RPM_DEFINE_UTIL}' $(DEFINE_PYZFS)'
 	RPM_DEFINE_UTIL=${RPM_DEFINE_UTIL}' $(DEFINE_PAM)'

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -522,7 +522,7 @@ systemctl --system daemon-reload >/dev/null || true
 %config(noreplace) %{_sysconfdir}/%{name}/vdev_id.conf.*.example
 %attr(440, root, root) %config(noreplace) %{_sysconfdir}/sudoers.d/*
 
-%config(noreplace) %{_sysconfdir}/bash_completion.d/zfs
+%config(noreplace) %{_bashcompletiondir}/zfs
 
 %files -n libzpool5
 %{_libdir}/libzpool.so.*


### PR DESCRIPTION
The recent patch to change the bash completion install location based on the Distribution, ignored that it should still be possible to create RPMs on Debian derived systems. Additionally `make deb` itself creates RPMs and converts them via `alien`.

This patch adds the bashcompletiondir variable to the rpm defines and uses this for the location, where to get the bash completion file.

It still changes the location on Debian/Ubuntu systems in the final packages from /etc/bash_completion.d to
/usr/share/bash-completion/completions

Fixes: e69ade32e116e72d03068c03799924c3f1a15c95

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/openzfs/zfs/issues/15355
similar to https://github.com/openzfs/zfs/pull/15354/ 


### Description
<!--- Describe your changes in detail -->
the bashcompletiondir autoconf variable is passed to the rpm utilities and used as source-dir for the bash completion file.

This results in a difference of installation location for the completion on Debian/Ubuntu systems (as compared to
builds which don't contain e69ade32e116e72d03068c03799924c3f1a15c95):
without this patch and e69ade32e116e72d03068c03799924c3f1a15c95 it is installed in /etc/bash_completion.d
with both it ends up in /usr/share/bash-completion/completions/

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
running:
* `git clean -fdx; ./autogen.sh; ./configure; make rpm`  on a Fedora 38
* `git clean -fdx; ./autogen.sh; ./configure; make deb`  on a Debian 12
* `git clean -fdx; ./autogen.sh; ./configure; make native-deb`  on a Debian 12
and comparing the location of the completion file in the binary packages.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
