### PR TITLE
config/zfs-build.m4: add Gentoo's bash-completion path

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -626,6 +626,7 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		ubuntu)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
 		debian)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
 		freebsd)    bashcompletiondir=$sysconfdir/bash_completion.d;;
+		gentoo)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
 		*)          bashcompletiondir=/etc/bash_completion.d   ;;
 	esac
 	AC_MSG_RESULT([$bashcompletiondir])


### PR DESCRIPTION
### Motivation and Context

e69ade32e116e72d03068c03799924c3f1a15c95 started installing to `/etc/bash-completion.d` for unrecognised distros which installed to the wrong path on Gentoo.

### Description

Add Gentoo to the list of known distros and the corresponding correct path.

### How Has This Been Tested?

Tested on Gentoo and bash completions are now installed to the correct location.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
