### PR TITLE
ZTS: Fix verify_fs_mount in delegate_common.kshlib

### DIFF
--- a/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
+++ b/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
@@ -861,7 +861,7 @@ function verify_fs_mount
 	fi
 
 	if ! ismounted $fs ; then
-		log_must zfs set mountpoint=$newmntpt $fs
+		log_must zfs set -u mountpoint=$newmntpt $fs
 		log_must rm -rf $newmntpt
 		log_must mkdir $newmntpt
 
@@ -878,7 +878,7 @@ function verify_fs_mount
 		fi
 		log_must zfs umount $fs
 		log_must rm -rf $newmntpt
-		log_must zfs set mountpoint=$mntpt $fs
+		log_must zfs set -u mountpoint=$mntpt $fs
 	fi
 
 	return 0


### PR DESCRIPTION
### Motivation and Context
`verify_fs_mount` in `delegate_common.kshlib` expects the dataset to remain unmounted after updating the mountpoint property.  `zfs_allow_010_pos` test case fails because of this.

### Description
This commit updates `verify_fs_mount` and uses `nomount` parameter for zfs set to update the mountpoint property without mounting the dataset.

This fixes the `zfs_allow_010_pos` test case, which was failing on FreeBSD after the behavior update in setting the mountpoint property.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
