### PR TITLE
zvol: Temporally disable blk-mq

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2317,63 +2317,6 @@ If
 .Sy zvol_threads
 to the number of CPUs present or 32 (whichever is greater).
 .
-.It Sy zvol_blk_mq_threads Ns = Ns Sy 0 Pq uint
-The number of threads per zvol to use for queuing IO requests.
-This parameter will only appear if your kernel supports
-.Li blk-mq
-and is only read and assigned to a zvol at zvol load time.
-If
-.Sy 0
-(the default) then internally set
-.Sy zvol_blk_mq_threads
-to the number of CPUs present.
-.
-.It Sy zvol_use_blk_mq Ns = Ns Sy 0 Ns | Ns 1 Pq uint
-Set to
-.Sy 1
-to use the
-.Li blk-mq
-API for zvols.
-Set to
-.Sy 0
-(the default) to use the legacy zvol APIs.
-This setting can give better or worse zvol performance depending on
-the workload.
-This parameter will only appear if your kernel supports
-.Li blk-mq
-and is only read and assigned to a zvol at zvol load time.
-.
-.It Sy zvol_blk_mq_blocks_per_thread Ns = Ns Sy 8 Pq uint
-If
-.Sy zvol_use_blk_mq
-is enabled, then process this number of
-.Sy volblocksize Ns -sized blocks per zvol thread.
-This tunable can be use to favor better performance for zvol reads (lower
-values) or writes (higher values).
-If set to
-.Sy 0 ,
-then the zvol layer will process the maximum number of blocks
-per thread that it can.
-This parameter will only appear if your kernel supports
-.Li blk-mq
-and is only applied at each zvol's load time.
-.
-.It Sy zvol_blk_mq_queue_depth Ns = Ns Sy 0 Pq uint
-The queue_depth value for the zvol
-.Li blk-mq
-interface.
-This parameter will only appear if your kernel supports
-.Li blk-mq
-and is only applied at each zvol's load time.
-If
-.Sy 0
-(the default) then use the kernel's default queue depth.
-Values are clamped to the kernel's
-.Dv BLKDEV_MIN_RQ
-and
-.Dv BLKDEV_MAX_RQ Ns / Ns Dv BLKDEV_DEFAULT_RQ
-limits.
-.
 .It Sy zvol_volmode Ns = Ns Sy 1 Pq uint
 Defines zvol block devices behaviour when
 .Sy volmode Ns = Ns Sy default :

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -1626,18 +1626,6 @@ MODULE_PARM_DESC(zvol_prefetch_bytes, "Prefetch N bytes at zvol start+end");
 module_param(zvol_volmode, uint, 0644);
 MODULE_PARM_DESC(zvol_volmode, "Default volmode property value");
 
-#ifdef HAVE_BLK_MQ
-module_param(zvol_blk_mq_queue_depth, uint, 0644);
-MODULE_PARM_DESC(zvol_blk_mq_queue_depth, "Default blk-mq queue depth");
-
-module_param(zvol_use_blk_mq, uint, 0644);
-MODULE_PARM_DESC(zvol_use_blk_mq, "Use the blk-mq API for zvols");
-
-module_param(zvol_blk_mq_blocks_per_thread, uint, 0644);
-MODULE_PARM_DESC(zvol_blk_mq_blocks_per_thread,
-    "Process volblocksize blocks per thread");
-#endif
-
 #ifndef HAVE_BLKDEV_GET_ERESTARTSYS
 module_param(zvol_open_timeout_ms, uint, 0644);
 MODULE_PARM_DESC(zvol_open_timeout_ms, "Timeout for ZVOL open retries");

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -89,7 +89,7 @@ VDEV_VALIDATE_SKIP		vdev.validate_skip		vdev_validate_skip
 VOL_INHIBIT_DEV			UNSUPPORTED			zvol_inhibit_dev
 VOL_MODE			vol.mode			zvol_volmode
 VOL_RECURSIVE			vol.recursive			UNSUPPORTED
-VOL_USE_BLK_MQ			UNSUPPORTED			zvol_use_blk_mq
+VOL_USE_BLK_MQ			UNSUPPORTED			UNSUPPORTED
 XATTR_COMPAT			xattr_compat			zfs_xattr_compat
 ZEVENT_LEN_MAX			zevent.len_max			zfs_zevent_len_max
 ZEVENT_RETAIN_MAX		zevent.retain_max		zfs_zevent_retain_max


### PR DESCRIPTION

### Motivation and Context
Do not allow blk-mq to be enabled on zvols

### Description
There was a report of zvol data loss (#15351) after enabling blk-mq on a zvol backed with 16k physical block sized disks.  Out of an abundance of caution, do not allow the user to enable blk-mq until we can look into the issue.

Note that blk-mq was never enabled by default on zvols.  It was always opt-in via the zvol_use_blk_mq module parameter.

### How Has This Been Tested?
Test built

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
