### PR TITLE
Ensure we call fput when cloning fails due to different devices.

### DIFF
--- a/module/os/linux/zfs/zpl_file_range.c
+++ b/module/os/linux/zfs/zpl_file_range.c
@@ -202,8 +202,10 @@ zpl_ioctl_ficlone(struct file *dst_file, void *arg)
 	if (src_file == NULL)
 		return (-EBADF);
 
-	if (dst_file->f_op != src_file->f_op)
+	if (dst_file->f_op != src_file->f_op) {
+		fput(src_file);
 		return (-EXDEV);
+	}
 
 	size_t len = i_size_read(file_inode(src_file));
 
@@ -237,8 +239,10 @@ zpl_ioctl_ficlonerange(struct file *dst_file, void __user *arg)
 	if (src_file == NULL)
 		return (-EBADF);
 
-	if (dst_file->f_op != src_file->f_op)
+	if (dst_file->f_op != src_file->f_op) {
+		fput(src_file);
 		return (-EXDEV);
+	}
 
 	size_t len = fcr.fcr_src_length;
 	if (len == 0)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context

Right now, zpl_ioctl_ficlone and zpl_ioctl_ficlonerange do not call
put on the src fd if the source and destination are on two different
devices. This leaves the source file held open in this case.

### Description

<!--- Describe your changes in detail -->

The change calls fput when the files are on different devices before returning
an error.

### How Has This Been Tested?

Calling these ioctls with cross-device files in a loop before and after
and watching the open file count.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

It is not obvious to me how to add a user space test for this, but i'm open to ideas :)
