### PR TITLE
CI: Move perl script to dist_noinst_DATA

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -9,7 +9,6 @@ dist_noinst_SCRIPTS = \
 	%D%/man-dates.sh \
 	%D%/mancheck.sh \
 	%D%/paxcheck.sh \
-	%D%/update_authors.pl \
 	%D%/zfs-tests-color.sh
 
 scripts_scripts = \
@@ -30,6 +29,7 @@ endif
 dist_noinst_DATA += \
 	%D%/cstyle.pl \
 	%D%/enum-extract.pl \
+	%D%/update_authors.pl \
 	%D%/zfs2zol-patch.sed \
 	%D%/zol2zfs-patch.sed
 


### PR DESCRIPTION
### Motivation and Context

Fix my mistake from 000cfca0689a988a5a0973245b9a90529e4778fb which added the script to the wrong place in the makefile.

### Description

Everything listed in dist_noinst_SCRIPTS is assumed to be a shell scrip, this generates a shellcheck SC1071 error since perl is not supported.  Move update_authors.pl to dist_noinst_DATA with the other perl scripts.

### How Has This Been Tested?

To be verified by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
