### PR TITLE
Implement FIDUPERANGE for Linux.

### DIFF
--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -184,20 +184,30 @@ zpl_dir_emit_dots(struct file *file, zpl_dir_context_t *ctx)
 }
 #endif /* HAVE_VFS_ITERATE */
 
-
+typedef struct zfs_locked_range zfs_locked_range_t;
 /* zpl_file_range.c */
 
 /* handlers for file_operations of the same name */
-extern ssize_t zpl_copy_file_range(struct file *src_file, loff_t src_off,
-    struct file *dst_file, loff_t dst_off, size_t len, unsigned int flags);
-extern loff_t zpl_remap_file_range(struct file *src_file, loff_t src_off,
-    struct file *dst_file, loff_t dst_off, loff_t len, unsigned int flags);
-extern int zpl_clone_file_range(struct file *src_file, loff_t src_off,
-    struct file *dst_file, loff_t dst_off, uint64_t len);
-extern int zpl_dedupe_file_range(struct file *src_file, loff_t src_off,
-    struct file *dst_file, loff_t dst_off, uint64_t len);
-extern int zpl_dedupe_file_compare(struct file *src_file, loff_t src_off,
-	struct file *dst_file, loff_t dst_off, uint64_t len, bool *is_same);
+extern ssize_t
+zpl_copy_file_range(struct file *src_file, loff_t src_off,
+		    struct file *dst_file, loff_t dst_off, size_t len,
+		    unsigned int flags);
+extern loff_t
+zpl_remap_file_range(struct file *src_file, loff_t src_off,
+		     struct file *dst_file, loff_t dst_off, loff_t len,
+		     unsigned int flags);
+extern int
+zpl_clone_file_range(struct file *src_file, loff_t src_off,
+		     struct file *dst_file, loff_t dst_off, uint64_t len);
+extern int
+zpl_dedupe_file_range(struct file *src_file, loff_t src_off,
+		      struct file *dst_file, loff_t dst_off, uint64_t len);
+extern int
+zpl_dedupe_file_compare_locked(struct file *src_file, loff_t src_off,
+			       struct file *dst_file, loff_t dst_off,
+			       uint64_t len, bool *is_same,
+			       zfs_locked_range_t *src_zlr,
+			       zfs_locked_range_t *dst_zlr);
 
 /* compat for FICLONE/FICLONERANGE/FIDEDUPERANGE ioctls */
 typedef struct {

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -190,24 +190,22 @@ typedef struct zfs_locked_range zfs_locked_range_t;
 /* handlers for file_operations of the same name */
 extern ssize_t
 zpl_copy_file_range(struct file *src_file, loff_t src_off,
-		    struct file *dst_file, loff_t dst_off, size_t len,
+    struct file *dst_file, loff_t dst_off, size_t len,
 		    unsigned int flags);
 extern loff_t
 zpl_remap_file_range(struct file *src_file, loff_t src_off,
-		     struct file *dst_file, loff_t dst_off, loff_t len,
-		     unsigned int flags);
+    struct file *dst_file, loff_t dst_off, loff_t len,
+    unsigned int flags);
 extern int
 zpl_clone_file_range(struct file *src_file, loff_t src_off,
-		     struct file *dst_file, loff_t dst_off, uint64_t len);
+    struct file *dst_file, loff_t dst_off, uint64_t len);
 extern int
 zpl_dedupe_file_range(struct file *src_file, loff_t src_off,
-		      struct file *dst_file, loff_t dst_off, uint64_t len);
+    struct file *dst_file, loff_t dst_off, uint64_t len);
 extern int
 zpl_dedupe_file_compare_locked(struct file *src_file, loff_t src_off,
-			       struct file *dst_file, loff_t dst_off,
-			       uint64_t len, bool *is_same,
-			       zfs_locked_range_t *src_zlr,
-			       zfs_locked_range_t *dst_zlr);
+    struct file *dst_file, loff_t dst_off, uint64_t len, bool *is_same,
+    zfs_locked_range_t *src_zlr, zfs_locked_range_t *dst_zlr);
 
 /* compat for FICLONE/FICLONERANGE/FIDEDUPERANGE ioctls */
 typedef struct {

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -196,6 +196,8 @@ extern int zpl_clone_file_range(struct file *src_file, loff_t src_off,
     struct file *dst_file, loff_t dst_off, uint64_t len);
 extern int zpl_dedupe_file_range(struct file *src_file, loff_t src_off,
     struct file *dst_file, loff_t dst_off, uint64_t len);
+extern int zpl_dedupe_file_compare(struct file *src_file, loff_t src_off,
+	struct file *dst_file, loff_t dst_off, uint64_t len, bool *is_same);
 
 /* compat for FICLONE/FICLONERANGE/FIDEDUPERANGE ioctls */
 typedef struct {

--- a/include/sys/zfs_vnops.h
+++ b/include/sys/zfs_vnops.h
@@ -25,14 +25,19 @@
 #ifndef	_SYS_FS_ZFS_VNOPS_H
 #define	_SYS_FS_ZFS_VNOPS_H
 #include <sys/zfs_vnops_os.h>
+typedef struct zfs_locked_range zfs_locked_range_t;
 
 extern int zfs_fsync(znode_t *, int, cred_t *);
 extern int zfs_read(znode_t *, zfs_uio_t *, int, cred_t *);
+extern int zfs_read_locked(znode_t *, zfs_uio_t *, int, cred_t *,
+    zfs_locked_range_t *);
 extern int zfs_write(znode_t *, zfs_uio_t *, int, cred_t *);
 extern int zfs_holey(znode_t *, ulong_t, loff_t *);
 extern int zfs_access(znode_t *, int, int, cred_t *);
 extern int zfs_clone_range(znode_t *, uint64_t *, znode_t *, uint64_t *,
     uint64_t *, cred_t *);
+extern int zfs_clone_range_locked(znode_t *, uint64_t *, znode_t *, uint64_t *,
+    uint64_t *, cred_t *, zfs_locked_range_t *, zfs_locked_range_t *);
 extern int zfs_clone_range_replay(znode_t *, uint64_t, uint64_t, uint64_t,
     const blkptr_t *, size_t);
 

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -354,7 +354,7 @@ out:
  */
 int
 zfs_read_locked(struct znode *zp, zfs_uio_t *uio, int ioflag, cred_t *cr,
-				zfs_locked_range_t *zrl)
+    zfs_locked_range_t *zrl)
 {
 	(void) cr;
 	int error = 0;
@@ -362,7 +362,7 @@ zfs_read_locked(struct znode *zp, zfs_uio_t *uio, int ioflag, cred_t *cr,
 
 	/* The range is verified below */
 	if (!zrl) {
-		return -EINVAL;
+		return (-EINVAL);
 	}
 
 	zfsvfs_t *zfsvfs = ZTOZSB(zp);
@@ -412,11 +412,12 @@ zfs_read_locked(struct znode *zp, zfs_uio_t *uio, int ioflag, cred_t *cr,
 		zil_commit(zfsvfs->z_log, zp->z_id);
 
 	/*
-	 * Ensure the lock covers the range. 
+	 * Ensure the lock covers the range.
 	 */
 	if (zrl->lr_offset > zfs_uio_offset(uio) ||
-	    (zfs_uio_offset(uio) + zfs_uio_resid(uio)) > (zrl->lr_offset + zrl->lr_length)) {
-		return -EINVAL;
+	    (zfs_uio_offset(uio) + zfs_uio_resid(uio)) >
+		    (zrl->lr_offset + zrl->lr_length)) {
+		return (-EINVAL);
 	}
 	/*
 	 * If we are reading past end-of-file we can skip
@@ -1550,10 +1551,10 @@ unlock:
 /*
  * This function is exactly the same as zfs_clone_range, except
  * it is called with the range locks already held.
- * 
+ *
  * It verifies that we hold locks for the src/dest clone range.
  * It performs no unlocking of the locks.
- * 
+ *
  * On success, the function return the number of bytes copied in *lenp.
  * Note, it doesn't return how much bytes are left to be copied.
  * On errors which are caused by any file system limitations or
@@ -1563,8 +1564,8 @@ unlock:
  */
 int
 zfs_clone_range_locked(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
-    uint64_t *outoffp, uint64_t *lenp, cred_t *cr,
-	zfs_locked_range_t *src_zlr, zfs_locked_range_t *dst_zlr)
+    uint64_t *outoffp, uint64_t *lenp, cred_t *cr, zfs_locked_range_t *src_zlr,
+    zfs_locked_range_t *dst_zlr)
 {
 	zfsvfs_t	*inzfsvfs, *outzfsvfs;
 	objset_t	*inos, *outos;
@@ -1686,15 +1687,15 @@ zfs_clone_range_locked(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	 * Verify locks
 	 */
 	if (!src_zlr || !dst_zlr || dst_zlr->lr_type != RL_WRITER) {
-		return -EINVAL;
+		return (-EINVAL);
 	}
 	if (src_zlr->lr_offset > inoff ||
 	    (inoff + len) > (src_zlr->lr_offset + src_zlr->lr_length)) {
-		return -EINVAL;
+		return (-EINVAL);
 	}
 	if (dst_zlr->lr_offset > outoff ||
 	    (outoff + len) > (dst_zlr->lr_offset + dst_zlr->lr_length)) {
-		return -EINVAL;
+		return (-EINVAL);
 	}
 
 	inblksz = inzp->z_blksz;


### PR DESCRIPTION
This resolves issue #11065 by implementing FIDUPERANGE on Linux.

It is a draft because i need a little help from someone a little more familiar with ZFS code to
see if there is a better way to do the locking. (once it's all ready, i'll close this PR and create one with 
the proper template).

FIDUPERANGE takes a src file, offset, length, and then an array of places to duplicate the range into.
The result status is per-destination.

For this, the correct locking (or at least one version) looks like this (IMHO, of course :P):

for each destination to duplicate a range into:
A. read lock the src range/offset
B. write lock the dst range/offset
C. compare the src and dest ranges to ensure they are the same.
D. if same, clone src into dst
E. release write lock.
F. release read lock.

Because the results are per-destination, it's actually okay if the src file changes after F but before the next iteration - we will simply report that the ranges for remaining destination are no longer the same when we compare them, and not remap.

Here are the immediate issues:

1. zfs_read (which i use to read and compare the files) wants to hold the read lock during C above. That is not possible since we have it write locked and they are not recursive locks. It's not obvious to me if zfs_read is the wrong thing to use here, or if i should create a zfs_read_already_locked that takes the locks, verifies they are right for the range, and proceeds without further locking.

2. zpl_clone_file_range has the same issue (it wants to write lock the destination).

Note: We could hold the read lock for all iterations of the loop, and avoid re-reading the src range for each destination.
I have not bothered to explore this tradeoff.

