### PR TITLE
spec: define _bashcompletiondir if undefined

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -19,6 +19,15 @@
 %endif
 %endif
 
+# Set the default _bashcompletiondir directory based on distribution.
+%if %{undefined _bashcompletiondir}
+%if 0%{?rhel}%{?fedora}%{?centos}%{?suse_version}%{?openEuler}
+%global _bashcompletiondir    /etc/bash_completion.d
+%else
+%global _bashcompletiondir    /usr/share/bash-completion
+%endif
+%endif
+
 # Set the default dracut directory based on distribution.
 %if %{undefined _dracutdir}
 %if 0%{?rhel}%{?fedora}%{?centos}%{?suse_version}%{?openEuler}


### PR DESCRIPTION
### Motivation and Context

Fix basic `rpmbuild --rebuild <srpm>` with source RPM.  

### Description

Always define _bashcompletiondir in the spec file to a reasonable value when it is undefined.  Required for `rpmbuild --rebuild <srpm>`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
