### PR TITLE
linux: avoid splitting abd pages across bios

### DIFF
--- a/include/os/linux/kernel/linux/mod_compat.h
+++ b/include/os/linux/kernel/linux/mod_compat.h
@@ -68,6 +68,7 @@ enum scope_prefix_types {
 	zfs_trim,
 	zfs_txg,
 	zfs_vdev,
+	zfs_vdev_disk,
 	zfs_vdev_file,
 	zfs_vdev_mirror,
 	zfs_vnops,

--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -216,7 +216,6 @@ void abd_fini(void);
  */
 #if defined(__linux__) && defined(_KERNEL)
 unsigned int abd_bio_map_off(struct bio *, abd_t *, unsigned int, size_t);
-unsigned long abd_nr_pages_off(abd_t *, unsigned int, size_t);
 #endif
 
 #ifdef __cplusplus

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -1000,39 +1000,6 @@ abd_cache_reap_now(void)
 }
 
 #if defined(_KERNEL)
-/*
- * bio_nr_pages for ABD.
- * @off is the offset in @abd
- */
-unsigned long
-abd_nr_pages_off(abd_t *abd, unsigned int size, size_t off)
-{
-	unsigned long pos;
-
-	if (abd_is_gang(abd)) {
-		unsigned long count = 0;
-
-		for (abd_t *cabd = abd_gang_get_offset(abd, &off);
-		    cabd != NULL && size != 0;
-		    cabd = list_next(&ABD_GANG(abd).abd_gang_chain, cabd)) {
-			ASSERT3U(off, <, cabd->abd_size);
-			int mysize = MIN(size, cabd->abd_size - off);
-			count += abd_nr_pages_off(cabd, mysize, off);
-			size -= mysize;
-			off = 0;
-		}
-		return (count);
-	}
-
-	if (abd_is_linear(abd))
-		pos = (unsigned long)abd_to_buf(abd) + off;
-	else
-		pos = ABD_SCATTER(abd).abd_offset + off;
-
-	return (((pos + size + PAGESIZE - 1) >> PAGE_SHIFT) -
-	    (pos >> PAGE_SHIFT));
-}
-
 static unsigned int
 bio_map(struct bio *bio, void *buf_ptr, unsigned int bio_size)
 {


### PR DESCRIPTION
### Motivation and Context

In certain situations, its possible for OpenZFS to submit bios to the kernel that are misaligned, or can become misaligned after modification by the kernel. Some devices will reject misaligned bios, leading to IO errors being returned to OpenZFS:

```
Jul 11 17:55:17 A2-U40 kernel: sd 7:0:90:0: [sdcl] tag#8750 request not aligned to the logical block size
Jul 11 17:55:17 A2-U40 kernel: blk_update_request: I/O error, dev sdcl, sector 16416600664 op 0x1:(WRITE) flags 0x4700 phys_seg 128 prio class 0
Jul 11 17:55:17 A2-U40 kernel: sd 7:0:90:0: [sdcl] tag#8760 request not aligned to the logical block size
Jul 11 17:55:17 A2-U40 kernel: blk_update_request: I/O error, dev sdcl, sector 16416602503 op 0x1:(WRITE) flags 0x700 phys_seg 23 prio class 0
Jul 11 17:55:17 A2-U40 kernel: zio pool=pool-13395907298487379724 vdev=/dev/disk/by-id/wwn-0x5000cca28408a8ac-part1 error=5 type=2 offset=8405291151360 size=1032192 flags=40080c80
```

This came out of a complex situation at a customer site, involving:

* a write-heavy load, such that aggregation past 512K happened quite frequently
* a pool approaching 90% fragmentation, such that gang blocks were being produced (this is significant only insofar as gang blocks are backed by small memory allocations, which exacerbate the problem)

We found that reducing `zfs_vdev_aggregation_limit` down to ~500K was a sufficient workaround, which also gave us something to go on.

There’s a lot more detail in the commit messages, but the summary is that there are two factors:

* we frequently create bios that are too large for the underlying device, requiring the kernel to split them
* we quite often add single pages to bios in two segments, which taken together are aligned, but individually are not

If the kernel splits the bio right in the middle of the “pair” of segments for a full page, then the resulting bios are themselves misaligned, and will be rejected by some devices (notably, the SCSI driver).

The real solution to this issue is to never add less than a full page to a single bio segment, but to do that appears to require significant change in how the SPL memory allocator does its work and in how ABDs are constructed (I’ll describe some of my findings in a comments).

Instead, this PR works around the problem by better controlling the way the bio is created and filled, to ensure it never needs to be split.

Sponsored-by: Klara, Inc.
Sponsored-by: Wasabi Technology, Inc.

### Description

This PR ensures that a pair of segments representing a single page are never split by:

* ensuring that bios are sized correctly for the device they’re being submitted to such that they will never need to be split by the kernel
* ensuring that `abd_bio_map_off()` never ends a bio on the “left” side of a split. If both segments of a page can’t be included in the same bio, then stop and wait for the next bio

The commit messages have a lot more discussion of the details.

### How Has This Been Tested?

Reproducing this case is complicated, as we need to:

* generate lots of large IOs;
* composed of small allocations such that many of them are offset so they span more than one page;
* so as to raise the possibility that (a) a bio will be split (b) in between two halves of a “split page”;
* with the device driver or other stage below the block layer actually care about these misalignments and report on them.

The last one means the SCSI driver, unless there’s another I don’t know about.

The first three can be demonstrated by forcing all allocations to be gang blocks (note that gang blocks are not implicated; they’re just a convenient way to force a lot of small IO allocations).

```
echo 32768 > /sys/module/zfs/parameters/metaslab_force_ganging
echo 100 > /sys/module/zfs/parameters/metaslab_force_ganging_pct

zpool create -o ashift=12 -O recordsize=1M -O compression=off tank raidz1 sda sdb ...

fio --name=gang --directory=/tank --ioengine=pvsync2 --rw=randrw --nrfiles=32 --filesize=1-8M --bsrange=1k-4k --runtime=60 --time_based
```

Without this PR, this test should yield `request not aligned to the logical block size` errors almost immediately. With it, everything should be fine.

Earlier versions of these patches are currently in testing at the customer with additional warnings in place to notice any misaligned bios as they are submitted to the block layer. So far they have not reported anything under representative workloads, so I’m confident the approach is right. The question is just whether or not they’re sufficiently general to work everywhere.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).