### PR TITLE
Fix dkms installation of deb packages created with Alien.

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -24,6 +24,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 
 Requires:       dkms >= 2.2.0.3
+Requires(pre):  dkms >= 2.2.0.3
 Requires(post): dkms >= 2.2.0.3
 Requires(preun): dkms >= 2.2.0.3
 Requires:       gcc, make, perl, diffutils
@@ -68,9 +69,92 @@ fi
 %defattr(-,root,root)
 /usr/src/%{module}-%{version}
 
-%preun
-dkms remove -m %{module} -v %{version} --all
+%pre
+echo "Running pre installation script: $0. Parameters: $*"
+# We don't want any other versions lingering around in dkms.
+# Tests with 'dnf' showed that in case of reinstall, or upgrade
+#  the preun scriptlet removed the version we are trying to install.
+# Because of this, find all zfs dkms sources in /var/lib/dkms and
+#  remove them, if we find a matching version in dkms.
 
-%posttrans
-/usr/lib/dkms/common.postinst %{module} %{version}
+dkms_root=/var/lib/dkms
+if [ -d ${dkms_root}/%{module} ]; then
+    cd ${dkms_root}/%{module}
+    for x in [[:digit:]]*; do
+        [ -d "$x" ] || continue
+        otherver="$x"
+        opath="${dkms_root}/%{module}/${otherver}"
+        if [ "$otherver" != %{version} ]; then
+            # This is a workaround for a broken 'dkms status', we caused in a previous version.
+            # One day it might be not needed anymore, but it does not hurt to keep it.
+            if dkms status -m %{module} -v "$otherver" 2>&1 | grep "${opath}/source/dkms.conf does not exist"
+            then
+                echo "ERROR: dkms status is broken!" >&2
+                if [ -L "${opath}/source" -a ! -d "${opath}/source" ]
+                then
+                    echo "Trying to fix it by removing the symlink: ${opath}/source" >&2
+                    echo "You should manually remove ${opath}" >&2
+                    rm -f "${opath}/source" || echo "Removal failed!" >&2
+                fi
+            fi
+            if [ `dkms status -m %{module} -v "$otherver" | grep -c %{module}` -gt 0 ]; then
+                echo "Removing old %{module} dkms modules version $otherver from all kernels."
+                dkms remove -m %{module} -v "$otherver" --all ||:
+            fi
+        fi
+    done
+fi
+
+# Uninstall this version of zfs dkms modules before installation of the package.
+if [ `dkms status -m %{module} -v %{version} | grep -c %{module}` -gt 0 ]; then
+    echo "Removing %{module} dkms modules version %{version} from all kernels."
+    dkms remove -m %{module} -v %{version} --all ||:
+fi
+
+%post
+echo "Running post installation script: $0. Parameters: $*"
+# Add the module to dkms, as reccommended in the dkms man page.
+# This is generally rpm specfic.
+# But this also may help, if we have a broken 'dkms status'.
+# Because, if the sources are available and only the symlink pointing
+#  to them is missing, this will resolve the situation
+echo "Adding %{module} dkms modules version %{version} to dkms."
+dkms add -m %{module} -v %{version} %{!?not_rpm:--rpm_safe_upgrade} ||:
+
+# After installing the package, dkms install this zfs version for the current kernel.
+# Force the overwriting of old modules to avoid diff warnings in dkms status.
+# Or in case of a downgrade to overwrite newer versions.
+# Or if some other backed up versions have been restored before.
+echo "Installing %{module} dkms modules version %{version} for the current kernel."
+dkms install --force -m %{module} -v %{version} ||:
+
+%preun
+dkms_root="/var/lib/dkms/%{module}/%{version}"
+echo "Running pre uninstall script: $0. Parameters: $*"
+# In case of upgrade we do nothing. See above comment in pre hook.
+if [ "$1" = "1" -o "$1" = "upgrade" ] ; then
+    echo "This is an upgrade. Skipping pre uninstall action."
+    exit 0
+fi
+
+# Check if we uninstall the package. In that case remove the dkms modules.
+# '0' is the value for the first parameter for rpm packages.
+# 'remove' or 'purge' are the possible names for deb packages.
+if [ "$1" = "0" -o "$1" = "remove" -o "$1" = "purge" ] ; then
+    if [ `dkms status -m %{module} -v %{version} | grep -c %{module}` -gt 0 ]; then
+        echo "Removing %{module} dkms modules version %{version} from all kernels."
+        dkms remove -m %{module} -v %{version} --all %{!?not_rpm:--rpm_safe_upgrade} && exit 0
+    fi
+    # If removing the modules failed, it might be because of the broken 'dkms status'.
+    if dkms status -m %{module} -v %{version} 2>&1 | grep "${dkms_root}/source/dkms.conf does not exist"
+    then
+        echo "ERROR: dkms status is broken!" >&2
+        echo "You should manually remove ${dkms_root}" >&2
+        echo "WARNING: installed modules in /lib/modules/`uname -r`/extra could not be removed automatically!" >&2
+    fi
+else
+    echo "Script parameter $1 did not match any removal condition."
+fi
+
+exit 0
 


### PR DESCRIPTION
Alien does not honour the %posttrans hook.
So move the dkms uninstall/install scripts to the %pre/%post hooks in case of package install/upgrade.
In case of package removal, handle that in %preun.
Add removal of all old dkms modules.
Add checking for broken 'dkms status'. Handle that as good as possible and warn the user about it.
Also add more verbose messages about what we are doing.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is my first pull request ever. It's been a while since I used git and never before in a collaborating matter.
So please bear with me and I hope not to make too many mistakes.

I don't have any experience with building rpms and transforming them to deb packages.
But I dug myself through https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/ and https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html to get an idea of the things involved here.

Edit: Fixes: https://github.com/openzfs/zfs/issues/15328, https://github.com/openzfs/zfs/issues/15336 and https://github.com/openzfs/zfs/issues/15253.


### Description
<!--- Describe your changes in detail -->
In commit https://github.com/openzfs/zfs/pull/13182 the rpm scriptlet hook `%posttrans` was introduced.
But as it looks to me, Alien does not honour it, or there is no equivalent script hook for debian packages.
So to make sure the uninstall / install of the dkms modules happens in case of install/upgrade, I moved them to the %pre / %post hooks.
In case of package removal, handle that in %preun.
Also I added a check before running each command, to avoid a non zero exit status for the scripts.
Additionally I added verbose messages about what we are doing.

This change seems to ensure, that for each rpm hook a debian script is created by Alien.
Also I think it will always uninstall the dkms modules before installation of the new package and always will install the dkms modules after the new package has been installed.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
On my PC with Linux Mint 21.2, which is based on Ubuntu 22.04, I installed the zfs-dkms .deb file.
The dkms version used is 2.8.7.
In case of a fresh install, or an upgrade / re-install, everything went as expected.
Also the remove/purge actions yielded the expected result.

Edit: More tests were done. Descriptions in the replies below.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
