### PR TITLE
FreeBSD: taskq: Remove unused declaration

### DIFF
--- a/module/os/freebsd/spl/spl_taskq.c
+++ b/module/os/freebsd/spl/spl_taskq.c
@@ -64,8 +64,6 @@ taskq_t *dynamic_taskq = NULL;
 
 proc_t *system_proc;
 
-extern int uma_align_cache;
-
 static MALLOC_DEFINE(M_TASKQ, "taskq", "taskq structures");
 
 static LIST_HEAD(tqenthashhead, taskq_ent) *tqenthashtbl;


### PR DESCRIPTION
Variable 'uma_align_cache' has not been used since commit "FreeBSD: Use a hash table for taskqid lookups" (3933305ea).  Moreover, it is soon going to become private to FreeBSD's UMA in 15.0-CURRENT (main), 14.0-STABLE (stable/14) and 13.2-STABLE (stable/13).  Should accessing this information become necessary again, one will have to use the new accessors for recent versions.