### PR TITLE
arc_summary: "ARC prefetch metadata accesses:" appears twice in the output.

### DIFF
--- a/cmd/arc_summary
+++ b/cmd/arc_summary
@@ -711,7 +711,7 @@ def section_archits(kstats_dict):
     pd_total = int(arc_stats['prefetch_data_hits']) +\
         int(arc_stats['prefetch_data_iohits']) +\
         int(arc_stats['prefetch_data_misses'])
-    prt_2('ARC prefetch metadata accesses:', f_perc(pd_total, all_accesses),
+    prt_2('ARC prefetch data accesses:', f_perc(pd_total, all_accesses),
           f_hits(pd_total))
     pd_todo = (('Prefetch data hits:', arc_stats['prefetch_data_hits']),
                ('Prefetch data I/O hits:', arc_stats['prefetch_data_iohits']),


### PR DESCRIPTION
"ARC prefetch metadata accesses:" appears twice in the output.
The first occurence should be "ARC prefetch data accesses:"

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #15426 
### Description
Changed the title of the section in cmd/arc_summary

### How Has This Been Tested?
tested locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
