### PR TITLE
FreeBSD: Implement taskq_init_ent()

### DIFF
--- a/include/os/freebsd/spl/sys/taskq.h
+++ b/include/os/freebsd/spl/sys/taskq.h
@@ -81,7 +81,6 @@ typedef struct taskq_ent {
 
 #define	TASKQID_INVALID		((taskqid_t)0)
 
-#define	taskq_init_ent(x)
 extern taskq_t *system_taskq;
 /* Global dynamic task queue for long delay */
 extern taskq_t *system_delay_taskq;
@@ -92,6 +91,7 @@ extern taskqid_t taskq_dispatch_delay(taskq_t *, task_func_t, void *,
 extern void taskq_dispatch_ent(taskq_t *, task_func_t, void *, uint_t,
     taskq_ent_t *);
 extern int taskq_empty_ent(taskq_ent_t *);
+extern void taskq_init_ent(taskq_ent_t *);
 taskq_t	*taskq_create(const char *, int, pri_t, int, int, uint_t);
 taskq_t	*taskq_create_instance(const char *, int, int, pri_t, int, int, uint_t);
 taskq_t	*taskq_create_proc(const char *, int, pri_t, int, int,

--- a/module/os/freebsd/spl/spl_taskq.c
+++ b/module/os/freebsd/spl/spl_taskq.c
@@ -398,19 +398,31 @@ void
 taskq_dispatch_ent(taskq_t *tq, task_func_t func, void *arg, uint32_t flags,
     taskq_ent_t *task)
 {
-	int prio;
-
 	/*
 	 * If TQ_FRONT is given, we want higher priority for this task, so it
 	 * can go at the front of the queue.
 	 */
-	prio = !!(flags & TQ_FRONT);
-	task->tqent_id = 0;
+	task->tqent_task.ta_priority = !!(flags & TQ_FRONT);
 	task->tqent_func = func;
 	task->tqent_arg = arg;
-
-	TASK_INIT(&task->tqent_task, prio, taskq_run_ent, task);
 	taskqueue_enqueue(tq->tq_queue, &task->tqent_task);
+}
+
+void
+taskq_init_ent(taskq_ent_t *task)
+{
+	TASK_INIT(&task->tqent_task, 0, taskq_run_ent, task);
+	task->tqent_func = NULL;
+	task->tqent_arg = NULL;
+	task->tqent_id = 0;
+	task->tqent_type = NORMAL_TASK;
+	task->tqent_rc = 0;
+}
+
+int
+taskq_empty_ent(taskq_ent_t *task)
+{
+	return (task->tqent_task.ta_pending == 0);
 }
 
 void
@@ -438,10 +450,4 @@ void
 taskq_wait_outstanding(taskq_t *tq, taskqid_t id __unused)
 {
 	taskqueue_drain_all(tq->tq_queue);
-}
-
-int
-taskq_empty_ent(taskq_ent_t *t)
-{
-	return (t->tqent_task.ta_pending == 0);
 }


### PR DESCRIPTION
Previously taskq_init_ent() was an empty macro, while actual init was done by taskq_dispatch_ent().  It could be slightly faster in case taskq never enqueued. But without it taskq_empty_ent() relied on the structure being zeroed by somebody else, that is not good.

As a side effect this allows the same task to be queued several times, that is normal on FreeBSD, that may or may not get useful here also one day.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
