### PR TITLE
Add all read-only compatible zpool features to grub2 compatibility

### DIFF
--- a/cmd/zpool/compatibility.d/grub2
+++ b/cmd/zpool/compatibility.d/grub2
@@ -1,6 +1,9 @@
 # Features which are supported by GRUB2
+allocation_classes
 async_destroy
+block_cloning
 bookmarks
+device_rebuild
 embedded_data
 empty_bpobj
 enabled_txg
@@ -9,6 +12,13 @@ filesystem_limits
 hole_birth
 large_blocks
 livelist
+log_spacemap
 lz4_compress
+obsolete_counts
+project_quota
+resilver_defer
 spacemap_histogram
+spacemap_v2
+userobj_accounting
+zilsaxattr
 zpool_checkpoint


### PR DESCRIPTION
### Motivation and Context
GRUB opens the boot-pool in read-only mode, but not all read-only compatible zpool
features are listed in grub2 compatibility file.

### Description
GRUB opens the boot pool in read-only mode. All read-only compatible features for zpool
can be enabled and added to grub2 compatibility, as GRUB does not open the boot-pool
for write.

### How Has This Been Tested?
Tested by creating a boot-pool with all read-only compatible zpool features enabled and
booting from the boot-pool.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
