### PR TITLE
avoid variable-length-array syntax that trip up strict-bound UBSAN

### DIFF
--- a/include/sys/efi_partition.h
+++ b/include/sys/efi_partition.h
@@ -324,7 +324,7 @@ typedef struct dk_gpt {
 	uint_t		efi_reserved1;	/* future use - set to zero */
 	diskaddr_t	efi_altern_lba;	/* lba of alternate GPT header */
 	uint_t		efi_reserved[12]; /* future use - set to zero */
-	struct dk_part	efi_parts[1];	/* array of partitions */
+	struct dk_part	efi_parts[];	/* array of partitions */
 } dk_gpt_t;
 
 /* possible values for "efi_flags" */

--- a/include/sys/sa_impl.h
+++ b/include/sys/sa_impl.h
@@ -177,7 +177,7 @@ typedef struct sa_hdr_phys {
 	 *
 	 */
 	uint16_t sa_layout_info;
-	uint16_t sa_lengths[1];	/* optional sizes for variable length attrs */
+	uint16_t sa_lengths[];	/* optional sizes for variable length attrs */
 	/* ... Data follows the lengths.  */
 } sa_hdr_phys_t;
 
@@ -265,7 +265,7 @@ struct sa_handle {
 
 #define	SA_HDR_SIZE_MATCH_LAYOUT(hdr, tb) \
 	(SA_HDR_SIZE(hdr) == (sizeof (sa_hdr_phys_t) + \
-	(tb->lot_var_sizes > 1 ? P2ROUNDUP((tb->lot_var_sizes - 1) * \
+	(tb->lot_var_sizes > 1 ? P2ROUNDUP(tb->lot_var_sizes * \
 	sizeof (uint16_t), 8) : 0)))
 
 int sa_add_impl(sa_handle_t *, sa_attr_type_t,

--- a/include/sys/zap_impl.h
+++ b/include/sys/zap_impl.h
@@ -61,7 +61,7 @@ typedef struct mzap_phys {
 	uint64_t mz_salt;
 	uint64_t mz_normflags;
 	uint64_t mz_pad[5];
-	mzap_ent_phys_t mz_chunk[1];
+	mzap_ent_phys_t mz_chunk[];
 	/* actually variable size depending on block size */
 } mzap_phys_t;
 

--- a/include/sys/zap_leaf.h
+++ b/include/sys/zap_leaf.h
@@ -132,7 +132,7 @@ typedef struct zap_leaf_phys {
 	 * with the ZAP_LEAF_CHUNK() macro.
 	 */
 
-	uint16_t l_hash[1];
+	uint16_t l_hash[];
 } zap_leaf_phys_t;
 
 typedef union zap_leaf_chunk {

--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -370,7 +370,7 @@ efi_alloc_and_init(int fd, uint32_t nparts, struct dk_gpt **vtoc)
 	}
 
 	length = sizeof (struct dk_gpt) +
-	    sizeof (struct dk_part) * (nparts - 1);
+	    sizeof (struct dk_part) * nparts;
 
 	vptr = calloc(1, length);
 	if (vptr == NULL)
@@ -410,7 +410,7 @@ efi_alloc_and_read(int fd, struct dk_gpt **vtoc)
 	/* figure out the number of entries that would fit into 16K */
 	nparts = EFI_MIN_ARRAY_SIZE / sizeof (efi_gpe_t);
 	length = (int) sizeof (struct dk_gpt) +
-	    (int) sizeof (struct dk_part) * (nparts - 1);
+	    (int) sizeof (struct dk_part) * nparts;
 	vptr = calloc(1, length);
 
 	if (vptr == NULL)
@@ -422,7 +422,7 @@ efi_alloc_and_read(int fd, struct dk_gpt **vtoc)
 	if ((rval == VT_EINVAL) && vptr->efi_nparts > nparts) {
 		void *tmp;
 		length = (int) sizeof (struct dk_gpt) +
-		    (int) sizeof (struct dk_part) * (vptr->efi_nparts - 1);
+		    (int) sizeof (struct dk_part) * vptr->efi_nparts;
 		if ((tmp = realloc(vptr, length)) == NULL) {
 			/* cppcheck-suppress doubleFree */
 			free(vptr);


### PR DESCRIPTION
### Motivation and Context
This fixes https://github.com/openzfs/zfs/issues/15145 i.e., a stricter bound checking when UBSAN is enabled for Linux since 6.5.

Disabling UBSAN is not really an option for us, and the "modern" (C99) VLA syntax is so widely used, that using it makes IMO the code a tiny bit more readable as a side effect.

### Description
Use the more common C99 syntax to declare variable length arrays, while older ones, where a (fake) array length of one was declared, works too in C, it's making it impossible to distinguish an out-of-bound access for a variable array access.

### How Has This Been Tested?
I have built ZFS 2.2 with this patch for the 6.5 kernel, then I
- booted in setups that used 6.2 kernel and ZFS 2.1.13 as root filesystem
- did many ZFS syncs between that setup and an older still using ZFS 2.1.13, in both directions. 
- general usage of ZFS volumes/datasets for e.g., FS mounts for containers or directly for virtual machines
- ran the ZFS Test Suite
 
In https://github.com/openzfs/zfs/issues/15145#issuecomment-1740315246 it's mentioned that there could be some potential regression due to change in size that the structs report through the `sizeof` operator, I tried to check the changed structs usage in-depth, and commented on them in the commit message, but as I'm not that familiar with the code base I might have missed some things.

If anybody knows better tests to ensure compatibility w.r.t. the structs touched I'd be glad to hear them, and try to execute/implement them.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
