### PR TITLE
Fix nfs_truncate_shares without /etc/exports.d

### DIFF
--- a/lib/libshare/os/linux/nfs.c
+++ b/lib/libshare/os/linux/nfs.c
@@ -47,6 +47,7 @@
 
 
 static boolean_t nfs_available(void);
+static boolean_t exports_available(void);
 
 typedef int (*nfs_shareopt_callback_t)(const char *opt, const char *value,
     void *cookie);
@@ -539,6 +540,8 @@ nfs_commit_shares(void)
 static void
 nfs_truncate_shares(void)
 {
+	if (!exports_available())
+		return;
 	nfs_reset_shares(ZFS_EXPORTS_LOCK, ZFS_EXPORTS_FILE);
 }
 
@@ -559,6 +562,21 @@ nfs_available(void)
 
 	if (!avail) {
 		if (access("/usr/sbin/exportfs", F_OK) != 0)
+			avail = -1;
+		else
+			avail = 1;
+	}
+
+	return (avail == 1);
+}
+
+static boolean_t
+exports_available(void)
+{
+	static int avail;
+
+	if (!avail) {
+		if (access(ZFS_EXPORTS_DIR, F_OK) != 0)
 			avail = -1;
 		else
 			avail = 1;


### PR DESCRIPTION
calling nfs_reset_shares on Linux prints a warning: 
`failed to lock /etc/exports.d/zfs.exports.lock: No such file or directory`
when /etc/exports.d does not exist. The directory gets created, when a filesystem is actually exported through nfs_toggle_share and nfs_init_share. The truncation of /etc/exports.d/zfs.exports happens unconditionally when calling `zfs mount -a` (via zfs_do_mount and share_mount in `cmd/zfs/zfs_main.c`).

Fixing the issue only in the Linux part, since the exports file on FreeBSD is in `/etc/zfs/`, which seems present on 2 FreeBSD systems I have access to (through `/etc/zfs/compatibility.d/`), while a Debian box does not have the directory even if `/usr/sbin/exportfs` is present through the `nfs-kernel-server` package.

The code for exports_available is copied from nfs_available above.

Fixes: ede037cda73675f42b1452187e8dd3438fafc220
("Make zfs-share service resilient to stale exports") 
Closes #15369

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
The commit adds a check for existence of `/etc/exports.d`, before trying to lock `/etc/exports.d/zfs.exports.lock`.
This prevents the printing of a warning message on `zfs mount -a` or `zfs share -a`

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/openzfs/zfs/issues/15369

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Compiled Proxmox utils and libs packages with the patch applied on top of ZFS-2.0.0 and verified that 
`zfs mount -a`  does not print the warning anymore

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
