### PR TITLE
Update the kstat dataset_name when renaming a zvol

### DIFF
--- a/include/sys/dataset_kstats.h
+++ b/include/sys/dataset_kstats.h
@@ -71,6 +71,7 @@ typedef struct dataset_kstats {
 
 int dataset_kstats_create(dataset_kstats_t *, objset_t *);
 void dataset_kstats_destroy(dataset_kstats_t *);
+void dataset_kstats_rename(dataset_kstats_t *dk, const char *);
 
 void dataset_kstats_update_write_kstats(dataset_kstats_t *, int64_t);
 void dataset_kstats_update_read_kstats(dataset_kstats_t *, int64_t);

--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -1319,6 +1319,7 @@ zvol_os_rename_minor(zvol_state_t *zv, const char *newname)
 		}
 	}
 	strlcpy(zv->zv_name, newname, sizeof (zv->zv_name));
+	dataset_kstats_rename(&zv->zv_kstat, newname);
 }
 
 /*

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -1528,6 +1528,8 @@ zvol_os_rename_minor(zvol_state_t *zv, const char *newname)
 	 */
 	set_disk_ro(zv->zv_zso->zvo_disk, !readonly);
 	set_disk_ro(zv->zv_zso->zvo_disk, readonly);
+
+	dataset_kstats_rename(&zv->zv_kstat, newname);
 }
 
 void

--- a/module/zfs/dataset_kstats.c
+++ b/module/zfs/dataset_kstats.c
@@ -199,6 +199,19 @@ dataset_kstats_destroy(dataset_kstats_t *dk)
 }
 
 void
+dataset_kstats_rename(dataset_kstats_t *dk, const char *name)
+{
+	dataset_kstat_values_t *dkv = dk->dk_kstats->ks_data;
+	char *ds_name;
+
+	ds_name = KSTAT_NAMED_STR_PTR(&dkv->dkv_ds_name);
+	ASSERT3S(ds_name, !=, NULL);
+	ASSERT3S(KSTAT_NAMED_STR_BUFLEN(&dkv->dkv_ds_name), ==,
+	    ZFS_MAX_DATASET_NAME_LEN);
+	(void) strlcpy(ds_name, name, ZFS_MAX_DATASET_NAME_LEN);
+}
+
+void
 dataset_kstats_update_write_kstats(dataset_kstats_t *dk,
     int64_t nwritten)
 {

--- a/module/zfs/dataset_kstats.c
+++ b/module/zfs/dataset_kstats.c
@@ -206,9 +206,8 @@ dataset_kstats_rename(dataset_kstats_t *dk, const char *name)
 
 	ds_name = KSTAT_NAMED_STR_PTR(&dkv->dkv_ds_name);
 	ASSERT3S(ds_name, !=, NULL);
-	ASSERT3S(KSTAT_NAMED_STR_BUFLEN(&dkv->dkv_ds_name), ==,
-	    ZFS_MAX_DATASET_NAME_LEN);
-	(void) strlcpy(ds_name, name, ZFS_MAX_DATASET_NAME_LEN);
+	(void) strlcpy(ds_name, name,
+	    KSTAT_NAMED_STR_BUFLEN(&dkv->dkv_ds_name));
 }
 
 void


### PR DESCRIPTION
Closes		#15482 (for FreeBSD only)
Sponsored-by:	Axcient
Signed-off-by:	Alan Somers <asomers@gmail.com>

### Motivation and Context
Fixes #15482 .  It updates the kstat's dataset_name field when renaming a zvol.

### Description
Add a `dataset_kstats_rename` function, and call it during `zvol_os_rename_minor` on FreeBSD.  Fixing the bug on Linux is left for future work.

### How Has This Been Tested?

Manually tested with the Steps to Reproduce given in the linked issue

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
