### PR TITLE
Make abd_raidz_gen_iterate() pass an initialized pointer to the callback

### DIFF
--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -1025,7 +1025,7 @@ abd_raidz_gen_iterate(abd_t **cabds, abd_t *dabd, size_t off,
 	size_t len, dlen;
 	struct abd_iter caiters[3];
 	struct abd_iter daiter;
-	void *caddrs[3];
+	void *caddrs[3], *daddr;
 	unsigned long flags __maybe_unused = 0;
 	abd_t *c_cabds[3];
 	abd_t *c_dabd = NULL;
@@ -1057,10 +1057,13 @@ abd_raidz_gen_iterate(abd_t **cabds, abd_t *dabd, size_t off,
 		if (dsize > 0) {
 			IMPLY(abd_is_gang(dabd), c_dabd != NULL);
 			abd_iter_map(&daiter);
+			daddr = daiter.iter_mapaddr;
 			len = MIN(daiter.iter_mapsize, len);
 			dlen = len;
-		} else
+		} else {
+			daddr = NULL;
 			dlen = 0;
+		}
 
 		/* must be progressive */
 		ASSERT3U(len, >, 0);
@@ -1070,7 +1073,7 @@ abd_raidz_gen_iterate(abd_t **cabds, abd_t *dabd, size_t off,
 		 */
 		ASSERT3U(((uint64_t)len & 511ULL), ==, 0);
 
-		func_raidz_gen(caddrs, daiter.iter_mapaddr, len, dlen);
+		func_raidz_gen(caddrs, daddr, len, dlen);
 
 		for (i = parity-1; i >= 0; i--) {
 			abd_iter_unmap(&caiters[i]);


### PR DESCRIPTION
Address a sanitizer warning about a use of an uninitialized variable.

### Motivation and Context
It addresses a KMSAN report that occurs when loading zfs.ko on FreeBSD:

```
#18 0xffffffff83219419 in panic (fmt=0xffffffff85468abb "MSan: Uninitialized %s memory in %s, offset %zu/%zu, addr %p, from %s+%#lx")                                                                                                                                                                                [63/1897]
    at /root/freebsd/sys/kern/kern_shutdown.c:894                                                                                                                                                                                                                                                                             
#19 0xffffffff833fca16 in kmsan_report_hook (addr=0xfffffe001fd71d50, orig=<optimized out>, size=8, off=0, hook=0xffffffff87b5aa1f "raidz d1")
    at /root/freebsd/sys/kern/subr_msan.c:197                                                                                                                  
#20 0xffffffff833dc0f5 in kmsan_shadow_check (addr=<optimized out>, size=<optimized out>, hook=<optimized out>) at /root/freebsd/sys/kern/subr_msan.c:380
#21 0xffffffff876084e4 in raidz_syn_pq_abd (tc=<optimized out>, dc=0xa34206c, tsize=16384, dsize=0)  
    at /root/freebsd/sys/contrib/openzfs/module/zfs/vdev_raidz_math_impl.h:865                                                                                 
#22 0xffffffff8707ecad in abd_raidz_gen_iterate (cabds=cabds@entry=0xfffffe001fd72090, dabd=dabd@entry=0x0, off=off@entry=0, csize=<optimized out>, 
    csize@entry=16384, dsize=dsize@entry=0, parity=parity@entry=2, func_raidz_gen=0xffffffff876081d0 <raidz_syn_pq_abd>)                         
    at /root/freebsd/sys/contrib/openzfs/module/zfs/abd.c:1073                                                                                                 
#23 0xffffffff87602191 in raidz_reconstruct_pq_impl (rr=<optimized out>, tgtidx=<optimized out>)
    at /root/freebsd/sys/contrib/openzfs/module/zfs/vdev_raidz_math_impl.h:992
#24 scalar_rec_pq (rrp=rrp@entry=0xfffffe002f32d000, tgtidx=tgtidx@entry=0xfffffe001fd72334)
    at /root/freebsd/sys/contrib/openzfs/module/zfs/vdev_raidz_math_scalar.c:250
#25 0xffffffff875fa158 in vdev_raidz_math_reconstruct (rm=rm@entry=0xfffffe001f929f60, rr=rr@entry=0xfffffe002f32d000, 
    parity_valid=parity_valid@entry=0xfffffe001fd72360, dt=dt@entry=0xfffffe001fd72334, nbaddata=nbaddata@entry=2)
    at /root/freebsd/sys/contrib/openzfs/module/zfs/vdev_raidz_math.c:268
#26 0xffffffff875e0e49 in vdev_raidz_reconstruct_row (rm=rm@entry=0xfffffe001f929f60, rr=rr@entry=0xfffffe002f32d000, 
    t=t@entry=0xffffffff87c1acf4 <benchmark_rec_impl.rec_tgt+36>, nt=nt@entry=3) at /root/freebsd/sys/contrib/openzfs/module/zfs/vdev_raidz.c:1457
#27 0xffffffff875e08df in vdev_raidz_reconstruct (rm=rm@entry=0xfffffe001f929f60, t=t@entry=0xffffffff87c1acf4 <benchmark_rec_impl.rec_tgt+36>, 
    nt=nt@entry=3) at /root/freebsd/sys/contrib/openzfs/module/zfs/vdev_raidz.c:2198
#28 0xffffffff875fb8da in benchmark_rec_impl (rm=0xfffffe001f929f60, fn=3) at /root/freebsd/sys/contrib/openzfs/module/zfs/vdev_raidz_math.c:385
#29 benchmark_raidz_impl (bench_rm=0xfffffe001f929f60, fn=3, bench_fn=<optimized out>) at /root/freebsd/sys/contrib/openzfs/module/zfs/vdev_raidz_math.c:412
```

### Description
abd_raidz_gen_iterate() has a degenerate case wherein it'll pass an uninitialized pointer to a callback. The change causes it to pass NULL instead.

### How Has This Been Tested?
Verified that the KMSAN report no longer arises when loading zfs.ko.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
