### PR TITLE
Introduce two types of root ZIOs

### DIFF
--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -547,6 +547,8 @@ extern zio_t *zio_null(zio_t *pio, spa_t *spa, vdev_t *vd,
 
 extern zio_t *zio_root(spa_t *spa,
     zio_done_func_t *done, void *priv, zio_flag_t flags);
+extern zio_t *zio_root_done(spa_t *spa,
+    zio_done_func_t *done, void *priv, zio_flag_t flags);
 
 extern void zio_destroy(zio_t *zio);
 

--- a/include/sys/zio_impl.h
+++ b/include/sys/zio_impl.h
@@ -159,7 +159,7 @@ enum zio_stage {
 	ZIO_STAGE_DONE			= 1 << 25	/* RWFCI */
 };
 
-#define	ZIO_ROOT_PIPELINE			\
+#define	ZIO_DONE_PIPELINE			\
 	ZIO_STAGE_DONE
 
 #define	ZIO_INTERLOCK_STAGES			\

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3548,7 +3548,7 @@ spa_ld_parse_config(spa_t *spa, spa_import_type_t type)
 	spa->spa_async_zio_root = kmem_alloc(max_ncpus * sizeof (void *),
 	    KM_SLEEP);
 	for (int i = 0; i < max_ncpus; i++) {
-		spa->spa_async_zio_root[i] = zio_root(spa, NULL, NULL,
+		spa->spa_async_zio_root[i] = zio_root_done(spa, NULL, NULL,
 		    ZIO_FLAG_CANFAIL | ZIO_FLAG_SPECULATIVE |
 		    ZIO_FLAG_GODFATHER);
 	}
@@ -6016,7 +6016,7 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	spa->spa_async_zio_root = kmem_alloc(max_ncpus * sizeof (void *),
 	    KM_SLEEP);
 	for (int i = 0; i < max_ncpus; i++) {
-		spa->spa_async_zio_root[i] = zio_root(spa, NULL, NULL,
+		spa->spa_async_zio_root[i] = zio_root_done(spa, NULL, NULL,
 		    ZIO_FLAG_CANFAIL | ZIO_FLAG_SPECULATIVE |
 		    ZIO_FLAG_GODFATHER);
 	}

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1787,7 +1787,7 @@ zil_lwb_write_issue(zilog_t *zilog, lwb_t *lwb)
 		zil_lwb_commit(zilog, lwb, itx);
 	lwb->lwb_nused = lwb->lwb_nfilled;
 
-	lwb->lwb_root_zio = zio_root(spa, zil_lwb_flush_vdevs_done, lwb,
+	lwb->lwb_root_zio = zio_root_done(spa, zil_lwb_flush_vdevs_done, lwb,
 	    ZIO_FLAG_CANFAIL);
 
 	/*


### PR DESCRIPTION
The zio_root() interface was recently changed to remove the READY stage in the pipeline. There might be workloads that rely on zio_root() calling the READY pipeline phase.

This change addresses that by re-introducing the original functionality of zio_root() and introduce a new interface, zio_root_done(), which is used in the performance critical paths of the ZIL.

