### PR TITLE
Unbreak FreeBSD world build after 3bd4df384

### DIFF
--- a/include/os/freebsd/spl/sys/taskq.h
+++ b/include/os/freebsd/spl/sys/taskq.h
@@ -120,6 +120,7 @@ void	taskq_resume(taskq_t *);
 #endif /* _KERNEL */
 
 #ifdef _STANDALONE
+typedef void taskq_t;
 typedef int taskq_ent_t;
 #define	taskq_init_ent(x)
 #endif /* _STANDALONE */


### PR DESCRIPTION
### Motivation and Context
The commit 3bd4df384 has broken the FreeBSD world build.

### Description
 Since 3bd4df384  the type taskq_t must be defined in when _STANDALONE is defined.

### How Has This Been Tested?
FreeBSD main

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).