### PR TITLE
Document grub2 compatibility updates and test for all feature sets

### DIFF
--- a/cmd/zpool/compatibility.d/openzfsonosx-1.8.1
+++ b/cmd/zpool/compatibility.d/openzfsonosx-1.8.1
@@ -6,7 +6,6 @@ edonr
 embedded_data
 empty_bpobj
 enabled_txg
-encryption
 extensible_dataset
 filesystem_limits
 hole_birth

--- a/man/man7/zpool-features.7
+++ b/man/man7/zpool-features.7
@@ -219,8 +219,11 @@ to the end of the line is ignored.
 .Bd -literal -compact -offset 4n
 .No example# Nm cat Pa /usr/share/zfs/compatibility.d/grub2
 # Features which are supported by GRUB2
+allocation_classes
 async_destroy
+block_cloning
 bookmarks
+device_rebuild
 embedded_data
 empty_bpobj
 enabled_txg
@@ -229,8 +232,14 @@ filesystem_limits
 hole_birth
 large_blocks
 livelist
+log_spacemap
 lz4_compress
+project_quota
+resilver_defer
 spacemap_histogram
+spacemap_v2
+userobj_accounting
+zilsaxattr
 zpool_checkpoint
 
 .No example# Nm zpool Cm create Fl o Sy compatibility Ns = Ns Ar grub2 Ar bootpool Ar vdev

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_features_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_features_007_pos.ksh
@@ -34,6 +34,7 @@
 # STRATEGY:
 #	1. Create a pool with a known feature set.
 #	2. Verify only those features are active/enabled.
+#	3. Do this for all known feature sets
 #
 
 verify_runnable "global"
@@ -47,8 +48,11 @@ log_onexit cleanup
 
 log_assert "creates a pool with a specified feature set enabled"
 
-log_must zpool create -f -o compatibility=compat-2020 $TESTPOOL $DISKS
-check_feature_set $TESTPOOL compat-2020
-log_must zpool destroy -f $TESTPOOL
+for compat in "$ZPOOL_COMPAT_DIR"/*
+do
+	log_must zpool create -f -o compatibility="${compat##*/}" $TESTPOOL $DISKS
+	check_feature_set $TESTPOOL "${compat##*/}"
+	log_must zpool destroy -f $TESTPOOL
+done
 
 log_pass "creates a pool with a specified feature set enabled"


### PR DESCRIPTION
### Motivation and Context
grub2 compatibility list has been updated. `zpool-features.7` should be updated accordingly.

Adding a new feature to compatibility list also enables all its dependencies. It may potentially
enable any feature which is not present in compatibility list. We should test for all know feature
sets and make sure only those features are enabled that are present in compatibility list.

### Description
`zpool-features.7` is updated to reflect updates in grub2 compatibility list.

`zpool_create_features_007.ksh` tests for `compat-2020` feature set, that it only enables the
features that are listed in `compat-2020`. `zpool_create_features_007.ksh` is updated to test
for all known feature sets.

There was a fallout after updating the test, `openzfsonosx-1.8.1` lists `encryption` to be enabled,
`encryption` depends on `bookmark_v2` feature which is also enabled, but not listed in
`openzfsonosx-1.8.1` list. So, `encryption` has been removed from `openzfsonosx-1.8.1`.

### How Has This Been Tested?
A successful ZTS run after the updates.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
