### PR TITLE
Fix memory leak in zfs_setprocinit code

### DIFF
--- a/lib/libzutil/os/linux/zutil_setproctitle.c
+++ b/lib/libzutil/os/linux/zutil_setproctitle.c
@@ -82,25 +82,6 @@ spt_min(size_t a, size_t b)
 	return ((a < b) ? a : b);
 }
 
-/*
- * For discussion on the portability of the various methods, see
- * https://lists.freebsd.org/pipermail/freebsd-stable/2008-June/043136.html
- */
-static int
-spt_clearenv(void)
-{
-	char **tmp;
-
-	tmp = malloc(sizeof (*tmp));
-	if (tmp == NULL)
-		return (errno);
-
-	tmp[0] = NULL;
-	environ = tmp;
-
-	return (0);
-}
-
 static int
 spt_copyenv(int envc, char *envp[])
 {
@@ -124,12 +105,7 @@ spt_copyenv(int envc, char *envp[])
 		return (errno);
 	memcpy(envcopy, envp, envsize);
 
-	error = spt_clearenv();
-	if (error) {
-		environ = envp;
-		free(envcopy);
-		return (error);
-	}
+	environ = NULL;
 
 	for (i = 0; envcopy[i]; i++) {
 		eq = strchr(envcopy[i], '=');
@@ -142,6 +118,7 @@ spt_copyenv(int envc, char *envp[])
 		*eq = '=';
 
 		if (error) {
+			clearenv();
 			environ = envp;
 			free(envcopy);
 			return (error);


### PR DESCRIPTION
### Motivation and Context
When testing ZFS, we build with ASAN enabled. This allows us to check for bad memory accesses and leaks with low overhead. Unfortunately, there is a memory leak in almost every single userland zfs program that stems from our attempt to manipulate environment variables in the `setprocinit` code. In that code we are trying to create a full copy of the environment variables, which we do by clearing the environment variables and then adding each one to the list again. However, a cross-platform way to unset the current list of environment variables is not really offered. `clearenv` almost works, but it frees the old list, which we want to keep around. The comments in the existing code link to an old discussion on this subject, but it is about cross-platform supported ways to accomplish this. We don't need that; this code is Linux specific. All we need is an approach that most libcs will handle gracefully.

### Description
Instead of creating our own `environ` array and letting the `setenv` code manipulate it, we can set `environ` to NULL. I checked both musl and glibc, and both of them can handle a NULL environ without issues. Other platforms that want this code may need to change the behavior they've been using; the only one I know we might care about is OS X, but I'm not sure if they have a version of this code. @lundman Could you comment on that?

### How Has This Been Tested?
Ran the zfs test suite and various userland zfs programs with ASAN enabled without seeing the leak alert

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
