### PR TITLE
Packaging: Auto-generate changelog during configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@
 modules.order
 Makefile
 Makefile.in
+changelog
 *.patch
 *.orig
 *.tmp

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,7 @@ ZFS_AC_DEBUG_INVARIANTS
 
 AC_CONFIG_FILES([
 	contrib/debian/rules
+	contrib/debian/changelog
 	Makefile
 	include/Makefile
 	lib/libzfs/libzfs.pc

--- a/contrib/debian/changelog.in
+++ b/contrib/debian/changelog.in
@@ -1,3 +1,9 @@
+openzfs-linux (@VERSION@-1) unstable; urgency=low
+
+  * OpenZFS @VERSION@ is tagged.
+
+ -- Umer Saleem <usaleem@ixsystems.com>  Wed, 15 Nov 2023 15:00:00 +0500
+
 openzfs-linux (2.2.99-1) unstable; urgency=low
 
   * OpenZFS 2.2 is tagged.


### PR DESCRIPTION
### Motivation and Context
With new releases and version updates, `contrib/debian/changelog` needs to be updated with a new changelog entry, this adds an extra step for release process.

### Description
Auto-generate changelog based off on `@VERSION@` during configure, so that it is not needed to be update with new releases / version updates.

### How Has This Been Tested?
Created native Debian packages after the update. Confirmed they are generated with same version, as before (2.2.99 for master branch).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
