### PR TITLE
zdb: Fix zdb '-O|-r' options with -e/exported zpool

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -9091,22 +9091,6 @@ main(int argc, char **argv)
 	if (dump_opt['l'])
 		return (dump_label(argv[0]));
 
-	if (dump_opt['O']) {
-		if (argc != 2)
-			usage();
-		dump_opt['v'] = verbose + 3;
-		return (dump_path(argv[0], argv[1], NULL));
-	}
-	if (dump_opt['r']) {
-		target_is_spa = B_FALSE;
-		if (argc != 3)
-			usage();
-		dump_opt['v'] = verbose;
-		error = dump_path(argv[0], argv[1], &object);
-		if (error != 0)
-			fatal("internal error: %s", strerror(error));
-	}
-
 	if (dump_opt['X'] || dump_opt['F'])
 		rewind = ZPOOL_DO_REWIND |
 		    (dump_opt['X'] ? ZPOOL_EXTREME_REWIND : 0);
@@ -9205,6 +9189,29 @@ main(int argc, char **argv)
 	if (searchdirs != NULL) {
 		umem_free(searchdirs, nsearch * sizeof (char *));
 		searchdirs = NULL;
+	}
+
+	/*
+	 * We need to make sure to process -O option or call
+	 * dump_path after the -e option has been processed,
+	 * which imports the pool to the namespace if it's
+	 * not in the cachefile.
+	 */
+	if (dump_opt['O']) {
+		if (argc != 2)
+			usage();
+		dump_opt['v'] = verbose + 3;
+		return (dump_path(argv[0], argv[1], NULL));
+	}
+
+	if (dump_opt['r']) {
+		target_is_spa = B_FALSE;
+		if (argc != 3)
+			usage();
+		dump_opt['v'] = verbose;
+		error = dump_path(argv[0], argv[1], &object);
+		if (error != 0)
+			fatal("internal error: %s", strerror(error));
 	}
 
 	/*


### PR DESCRIPTION
### Motivation and Context
Signed-off-by: Akash B [akash-b@hpe.com](mailto:akash-b@hpe.com)
For a given zpool used by lustre (dataset) which consists of many files and directories, where we were not able to use `zdb -O` option to get the objectid for the path which was reported by `zpool status -v` and was failing with below errors. The zpools are generally created with `cachefile=none` option, so `zdb -e` +option is generally used to debug.
```
-snip-of-zpool-status-
errors: Permanent errors have been detected in the following files:

        pool-mds65/mdt65:/oi.9/0x200000009:0x0:0x0
-snip-

# zdb -e pool-mds65/mdt65 -O oi.9/0x200000009:0x0:0x0
failed to hold dataset 'pool-mds65/mdt65': No such file or directory

# zdb -e -p . pool-oss0/ost0 -O file1
failed to hold dataset 'pool-oss0/ost0': No such file or directory

# zdb -e -p . pool-oss0/ost0 -O file1 -vvv
failed to hold dataset 'pool-oss0/ost0': No such file or directory

# zdb -e pool-oss0/ost0 -r file1 /tmp/filecopy1 -p.
failed to hold dataset 'pool-oss0/ost0': No such file or directory
zdb: internal error: No such file or directory
```

### Description
zdb with '-e' or exported zpool doesn't work along with '-O' and '-r' options as we process them before '-e' has been processed.

Below errors are seen:
```
~> zdb -e pool-mds65/mdt65 -O oi.9/0x200000009:0x0:0x0 
failed to hold dataset 'pool-mds65/mdt65': No such file or directory

~> zdb -e pool-oss0/ost0 -r file1 /tmp/filecopy1 -p. 
failed to hold dataset 'pool-oss0/ost0': No such file or directory
zdb: internal error: No such file or directory
```
We need to make sure to process '-O|-r' options after the '-e' option has been processed, which imports the pool to the namespace if it's not in the cachefile.

Issue reproduced with:
```
# truncate -s 1G file1 file2 file3 file4 file5 file6 file7 file8 file9 file10 file11 file12 file13 file14 file15
# pwd
/root/test/files
# zpool create -f -o cachefile=none -o failmode=panic -O canmount=off pool-oss0 draid2:11d:2s /root/test/files/file1 /root/test/files/file2 /root/test/files/file3 /root/test/files/file4 /root/test/files/file5 /root/test/files/file6 /root/test/files/file7 /root/test/files/file8 /root/test/files/file9 /root/test/files/file10 /root/test/files/file11 /root/test/files/file12 /root/test/files/file13 /root/test/files/file14 /root/test/files/file15
# zfs create -o mountpoint=/mnt/ost0 pool-oss0/ost0
# zfs set recordsize=4M pool-oss0/ost0
# touch /mnt/ost0/file1
# zpool sync -f pool-oss0
# zpool export -f -a
# 
# zdb -e -p . pool-oss0/ost0 -O file1 -vvv
failed to hold dataset 'pool-oss0/ost0': No such file or directory
# zdb -e -p. pool-oss0/ost0 -r file1 /tmp/filecopy1
failed to hold dataset 'pool-oss0/ost0': No such file or directory
zdb: internal error: No such file or directory
#
# zdb -dddddd pool-oss0/ost0 -e -p. 2 | grep path
        path    /file1
```
with the fix applied:
```
# zdb -e -p . pool-oss0/ost0 -O file1 -vvv

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         2    1   128K    512      0     512    512    0.00  ZFS plain file (K=inherit) (Z=inherit=lz4)
                                               176   bonus  System attributes
        dnode flags: USERUSED_ACCOUNTED USEROBJUSED_ACCOUNTED
        dnode maxblkid: 0
        uid     0
        gid     0
        atime   Thu Nov 16 06:23:50 2023
        mtime   Thu Nov 16 06:23:50 2023
        ctime   Thu Nov 16 06:23:50 2023
        crtime  Thu Nov 16 06:23:50 2023
        gen     16
        mode    100644
        size    0
        parent  34
        links   1
        pflags  840800000004
Indirect blocks:

# zdb -e -p. pool-oss0/ost0 -r file1 /tmp/filecopy1
Copying object 2 to file /tmp/filecopy1
Object 2 is 0 bytes
```

### How Has This Been Tested?
Tested locally in KVM and server along with lustre.
ZTS.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
