### PR TITLE
Extend import_progress kstat with a notes field

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -971,6 +971,10 @@ extern int spa_import_progress_set_max_txg(uint64_t pool_guid,
     uint64_t max_txg);
 extern int spa_import_progress_set_state(uint64_t pool_guid,
     spa_load_state_t spa_load_state);
+extern void spa_import_progress_set_notes(spa_t *spa,
+    const char *fmt, ...) __printflike(2, 3);
+extern void spa_import_progress_set_notes_nolog(spa_t *spa,
+    const char *fmt, ...) __printflike(2, 3);
 
 /* Pool configuration locks */
 extern int spa_config_tryenter(spa_t *spa, int locks, const void *tag,

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3109,6 +3109,7 @@ spa_load(spa_t *spa, spa_load_state_t state, spa_import_type_t type)
 	spa->spa_load_state = state;
 	(void) spa_import_progress_set_state(spa_guid(spa),
 	    spa_load_state(spa));
+	spa_import_progress_set_notes(spa, "spa_load()");
 
 	gethrestime(&spa->spa_loaded_ts);
 	error = spa_load_impl(spa, type, &ereport);
@@ -3337,7 +3338,7 @@ spa_activity_check(spa_t *spa, uberblock_t *ub, nvlist_t *config)
 	uint64_t mmp_config = ub->ub_mmp_config;
 	uint16_t mmp_seq = MMP_SEQ_VALID(ub) ? MMP_SEQ(ub) : 0;
 	uint64_t import_delay;
-	hrtime_t import_expire;
+	hrtime_t import_expire, now;
 	nvlist_t *mmp_label = NULL;
 	vdev_t *rvd = spa->spa_root_vdev;
 	kcondvar_t cv;
@@ -3375,7 +3376,17 @@ spa_activity_check(spa_t *spa, uberblock_t *ub, nvlist_t *config)
 
 	import_expire = gethrtime() + import_delay;
 
-	while (gethrtime() < import_expire) {
+	spa_import_progress_set_notes(spa, "Checking MMP activity, waiting "
+	    "%llu ms", (u_longlong_t)NSEC2MSEC(import_delay));
+
+	int interations = 0;
+	while ((now = gethrtime()) < import_expire) {
+		if (interations++ % 30 == 0) {
+			spa_import_progress_set_notes(spa, "Checking MMP "
+			    "activity, %llu ms remaining",
+			    (u_longlong_t)NSEC2MSEC(import_expire - now));
+		}
+
 		(void) spa_import_progress_set_mmp_check(spa_guid(spa),
 		    NSEC2SEC(import_expire - gethrtime()));
 
@@ -4995,6 +5006,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	/*
 	 * Retrieve the checkpoint txg if the pool has a checkpoint.
 	 */
+	spa_import_progress_set_notes(spa, "Loading checkpoint txg");
 	error = spa_ld_read_checkpoint_txg(spa);
 	if (error != 0)
 		return (error);
@@ -5007,6 +5019,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	 * initiated. Otherwise we could be reading from indirect vdevs before
 	 * we have loaded their mappings.
 	 */
+	spa_import_progress_set_notes(spa, "Loading indirect vdev metadata");
 	error = spa_ld_open_indirect_vdev_metadata(spa);
 	if (error != 0)
 		return (error);
@@ -5015,6 +5028,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	 * Retrieve the full list of active features from the MOS and check if
 	 * they are all supported.
 	 */
+	spa_import_progress_set_notes(spa, "Checking feature flags");
 	error = spa_ld_check_features(spa, &missing_feat_write);
 	if (error != 0)
 		return (error);
@@ -5023,6 +5037,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	 * Load several special directories from the MOS needed by the dsl_pool
 	 * layer.
 	 */
+	spa_import_progress_set_notes(spa, "Loading special MOS directories");
 	error = spa_ld_load_special_directories(spa);
 	if (error != 0)
 		return (error);
@@ -5030,6 +5045,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	/*
 	 * Retrieve pool properties from the MOS.
 	 */
+	spa_import_progress_set_notes(spa, "Loading properties");
 	error = spa_ld_get_props(spa);
 	if (error != 0)
 		return (error);
@@ -5038,6 +5054,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	 * Retrieve the list of auxiliary devices - cache devices and spares -
 	 * and open them.
 	 */
+	spa_import_progress_set_notes(spa, "Loading AUX vdevs");
 	error = spa_ld_open_aux_vdevs(spa, type);
 	if (error != 0)
 		return (error);
@@ -5046,14 +5063,17 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	 * Load the metadata for all vdevs. Also check if unopenable devices
 	 * should be autoreplaced.
 	 */
+	spa_import_progress_set_notes(spa, "Loading vdev metadata");
 	error = spa_ld_load_vdev_metadata(spa);
 	if (error != 0)
 		return (error);
 
+	spa_import_progress_set_notes(spa, "Loading dedup tables");
 	error = spa_ld_load_dedup_tables(spa);
 	if (error != 0)
 		return (error);
 
+	spa_import_progress_set_notes(spa, "Loading BRT");
 	error = spa_ld_load_brt(spa);
 	if (error != 0)
 		return (error);
@@ -5062,6 +5082,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	 * Verify the logs now to make sure we don't have any unexpected errors
 	 * when we claim log blocks later.
 	 */
+	spa_import_progress_set_notes(spa, "Verifying Log Devices");
 	error = spa_ld_verify_logs(spa, type, ereport);
 	if (error != 0)
 		return (error);
@@ -5083,6 +5104,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	 * state. When performing an extreme rewind, we verify the whole pool,
 	 * which can take a very long time.
 	 */
+	spa_import_progress_set_notes(spa, "Verifying pool data");
 	error = spa_ld_verify_pool_data(spa);
 	if (error != 0)
 		return (error);
@@ -5092,6 +5114,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	 * we write anything to the pool because we'd need to update the space
 	 * accounting using the deflated sizes.
 	 */
+	spa_import_progress_set_notes(spa, "Calculating deflated space");
 	spa_update_dspace(spa);
 
 	/*
@@ -5099,6 +5122,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 	 * pool. If we are importing the pool in read-write mode, a few
 	 * additional steps must be performed to finish the import.
 	 */
+	spa_import_progress_set_notes(spa, "Starting import");
 	if (spa_writeable(spa) && (spa->spa_load_state == SPA_LOAD_RECOVER ||
 	    spa->spa_load_max_txg == UINT64_MAX)) {
 		uint64_t config_cache_txg = spa->spa_config_txg;
@@ -5122,6 +5146,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 			    (u_longlong_t)spa->spa_uberblock.ub_checkpoint_txg);
 		}
 
+		spa_import_progress_set_notes(spa, "Claiming ZIL blocks");
 		/*
 		 * Traverse the ZIL and claim all blocks.
 		 */
@@ -5141,6 +5166,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 		 * will have been set for us by ZIL traversal operations
 		 * performed above.
 		 */
+		spa_import_progress_set_notes(spa, "Syncing ZIL claims");
 		txg_wait_synced(spa->spa_dsl_pool, spa->spa_claim_max_txg);
 
 		/*
@@ -5148,6 +5174,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 		 * next sync, we would update the config stored in vdev labels
 		 * and the cachefile (by default /etc/zfs/zpool.cache).
 		 */
+		spa_import_progress_set_notes(spa, "Updating configs");
 		spa_ld_check_for_config_update(spa, config_cache_txg,
 		    update_config_cache);
 
@@ -5156,6 +5183,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 		 * Then check all DTLs to see if anything needs resilvering.
 		 * The resilver will be deferred if a rebuild was started.
 		 */
+		spa_import_progress_set_notes(spa, "Starting resilvers");
 		if (vdev_rebuild_active(spa->spa_root_vdev)) {
 			vdev_rebuild_restart(spa);
 		} else if (!dsl_scan_resilvering(spa->spa_dsl_pool) &&
@@ -5169,6 +5197,8 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 		 */
 		spa_history_log_version(spa, "open", NULL);
 
+		spa_import_progress_set_notes(spa,
+		    "Restarting device removals");
 		spa_restart_removal(spa);
 		spa_spawn_aux_threads(spa);
 
@@ -5181,19 +5211,26 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 		 * auxiliary threads above (from which the livelist
 		 * deletion zthr is part of).
 		 */
+		spa_import_progress_set_notes(spa,
+		    "Cleaning up inconsistent objsets");
 		(void) dmu_objset_find(spa_name(spa),
 		    dsl_destroy_inconsistent, NULL, DS_FIND_CHILDREN);
 
 		/*
 		 * Clean up any stale temporary dataset userrefs.
 		 */
+		spa_import_progress_set_notes(spa,
+		    "Cleaning up temporary userrefs");
 		dsl_pool_clean_tmp_userrefs(spa->spa_dsl_pool);
 
 		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
+		spa_import_progress_set_notes(spa, "Restarting initialize");
 		vdev_initialize_restart(spa->spa_root_vdev);
+		spa_import_progress_set_notes(spa, "Restarting TRIM");
 		vdev_trim_restart(spa->spa_root_vdev);
 		vdev_autotrim_restart(spa);
 		spa_config_exit(spa, SCL_CONFIG, FTAG);
+		spa_import_progress_set_notes(spa, "Finished importing");
 	}
 
 	spa_import_progress_remove(spa_guid(spa));

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -425,7 +425,8 @@ tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
     'import_devices_missing', 'import_log_missing',
     'import_paths_changed',
     'import_rewind_config_changed',
-    'import_rewind_device_replaced']
+    'import_rewind_device_replaced',
+    'zpool_import_status']
 tags = ['functional', 'cli_root', 'zpool_import']
 timeout = 1200
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_status.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_status.ksh
@@ -1,0 +1,132 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2023 Klara, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_import/zpool_import.cfg
+
+#
+# DESCRIPTION:
+# 	During a pool import, the 'import_progress' kstat contains details
+# 	on the import progress.
+#
+# STRATEGY:
+#	1. Create test pool with several devices
+#	2. Generate some ZIL records and spacemap logs
+#	3. Export the pool
+#	4. Import the pool in the background and monitor the kstat content
+#	5. Check the zfs debug messages for import progress
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must set_tunable64 KEEP_LOG_SPACEMAPS_AT_EXPORT 0
+	log_must set_tunable64 METASLAB_DEBUG_LOAD 0
+
+	destroy_pool $TESTPOOL1
+}
+
+log_assert "During a pool import, the 'import_progress' kstat contains " \
+	"notes on the progress"
+
+log_onexit cleanup
+
+log_must zpool create $TESTPOOL1 $VDEV0 $VDEV1 $VDEV2
+typeset guid=$(zpool get -H -o value guid $TESTPOOL1)
+
+log_must zfs create -o recordsize=8k $TESTPOOL1/fs
+#
+# This dd command works around an issue where ZIL records aren't created
+# after freezing the pool unless a ZIL header already exists. Create a file
+# synchronously to force ZFS to write one out.
+#
+log_must dd if=/dev/zero of=/$TESTPOOL1/fs/sync conv=fsync bs=1 count=1
+
+#
+# Overwrite some blocks to populate spacemap logs
+#
+log_must dd if=/dev/urandom of=/$TESTPOOL1/fs/00 bs=1M count=200
+sync_all_pools
+log_must dd if=/dev/urandom of=/$TESTPOOL1/fs/00 bs=1M count=200
+sync_all_pools
+
+#
+# Freeze the pool to retain intent log records
+#
+log_must zpool freeze $TESTPOOL1
+
+# fill_fs [destdir] [dirnum] [filenum] [bytes] [num_writes] [data]
+log_must fill_fs /$TESTPOOL1/fs 1 2000 100 1024 R
+
+log_must zpool list -v $TESTPOOL1
+
+#
+# Unmount filesystem and export the pool
+#
+# At this stage the zfs intent log contains
+# a set of records to replay.
+#
+log_must zfs unmount /$TESTPOOL1/fs
+
+log_must set_tunable64 KEEP_LOG_SPACEMAPS_AT_EXPORT 1
+log_must zpool export $TESTPOOL1
+
+log_must set_tunable64 METASLAB_DEBUG_LOAD 1
+log_note "Starting zpool import in background at" $(date +'%H:%M:%S')
+zpool import -d $DEVICE_DIR -f $guid &
+pid=$!
+
+#
+# capture progress until import is finished
+#
+log_note waiting for pid $pid to exit
+kstat import_progress
+while [[ -d /proc/"$pid" ]]; do
+	line=$(kstat import_progress | grep -v pool_guid)
+	if [[ -n $line ]]; then
+		echo $line
+	fi
+	if [[ -f /$TESTPOOL1/fs/00 ]]; then
+		break;
+	fi
+	sleep 0.0001
+done
+log_note "zpool import completed at" $(date +'%H:%M:%S')
+
+entries=$(kstat dbgmsg | grep "spa_import_progress_set_notes_impl(): 'testpool1'" | wc -l)
+log_note "found $entries progress notes in dbgmsg"
+log_must test $entries -gt 20
+
+log_must zpool status $TESTPOOL1
+
+log_pass "During a pool import, the 'import_progress' kstat contains " \
+	"notes on the progress"


### PR DESCRIPTION
### Motivation and Context
As reported and observed in other issues, the time for an unclean pool import can take a long time. It would be nice to be able to observe where the time is being spent for imports that are taking a long time to complete.

### Description
This change adds more details to the existing `import_progress` kstat in the form of import progress notes.

This information is also logged to the zfs debug messages.

Sponsored-By: OpenDrives Inc.
Sponsored-By: Klara Inc.

Here's an example of output from the zfs debug messages:
```
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Starting import
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' using uberblock with txg=33
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Loading checkpoint txg
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Loading indirect vdev metadata
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Checking feature flags
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Loading special MOS directories
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Loading properties
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Loading AUX vdevs
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Loading vdev metadata
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 0 of 18 log space maps in 0 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 1 of 18 log space maps in 0 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 2 of 18 log space maps in 0 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 3 of 18 log space maps in 0 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 4 of 18 log space maps in 0 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 5 of 18 log space maps in 0 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 6 of 18 log space maps in 0 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 7 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 8 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 9 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 10 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 11 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 12 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 13 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 14 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 15 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 16 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 17 of 18 log space maps in 1 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' read 18 log space maps (18 total blocks - blksz = 131072 bytes) in 2 ms
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Loading dedup tables
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Loading BRT
1700151770   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Verifying Log Devices
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Verifying pool data
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Calculating deflated space
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Starting import
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Claiming ZIL blocks
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Syncing ZIL claims
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Updating configs
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Starting resilvers
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Restarting device removals
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Cleaning up inconsistent objsets
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Cleaning up temporary uerrefs
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Restarting Initialize
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Restarting TRIM
1700151771   spa_misc.c:2306:spa_import_progress_set_notes(): 'testpool1' Finished importing
```

### How Has This Been Tested?
Added a new ZTS test, `zpool_import_status`, to verify the kstat and zfs dbgmsg outputs.
Also ran `ztest` and performed some manual pool import testing

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
