### PR TITLE
ZTS: Fix 'could not unmount datasets' on Alma 9

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -37,6 +37,12 @@
 . ${STF_SUITE}/include/math.shlib
 . ${STF_SUITE}/include/blkdev.shlib
 
+# On AlmaLinux 9 we will see $PWD = '.' instead of the full path.  This causes
+# some tests to fail.  Fix it up here.
+if [ "$PWD" = "." ] ; then
+	PWD="$(readlink -f $PWD)"
+fi
+
 #
 # Apply constrained path when available.  This is required since the
 # PATH may have been modified by sudo's secure_path behavior.


### PR DESCRIPTION
### Motivation and Context
Fix test failures on AlmaLinux 9

### Description
Many tests are failing on AlmaLinux 9 because ZTS could not destroy the pool in cleanup:

```
20:21:16.57 cannot unmount '/var/tmp/testdir': pool or dataset is busy
20:21:16.57 could not destroy 'testpool': could not unmount datasets

Tests with results other than PASS that are unexpected:
    FAIL cli_root/zfs_destroy/zfs_destroy_004_pos (expected PASS)
    FAIL cli_root/zfs_destroy/zfs_destroy_005_neg (expected PASS)
    FAIL cli_root/zfs_destroy/zfs_destroy_008_pos (expected PASS)
    FAIL cli_root/zfs_destroy/zfs_destroy_009_pos (expected PASS)
    FAIL cli_root/zfs_destroy/zfs_destroy_010_pos (expected PASS)
    FAIL cli_root/zfs_destroy/zfs_destroy_011_pos (expected PASS)
    FAIL cli_root/zfs_destroy/zfs_destroy_012_pos (expected PASS)
    FAIL cli_root/zfs_destroy/zfs_destroy_013_neg (expected PASS)
    FAIL cli_root/zfs_destroy/zfs_destroy_015_pos (expected PASS)
    FAIL cli_root/zfs_set/canmount_003_pos (expected PASS)
    FAIL cli_root/zfs_set/readonly_001_pos (expected PASS)
    FAIL cli_root/zfs_share/zfs_share_011_pos (expected PASS)
    FAIL cli_root/zfs_unmount/zfs_unmount_005_pos (expected PASS)
    FAIL cli_root/zpool_export/zpool_export_002_pos (expected PASS)
    FAIL io/io_uring (expected PASS)
    FAIL snapshot/snapshot_017_pos (expected PASS)
```

This was due to $PWD being set to '.' instead of the expected full path.  This patch sets $PWD to the full path.

### How Has This Been Tested?
Ran test suite locally.  Buildbot will test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
