### PR TITLE
Fix compilation on early arm architectures

### DIFF
--- a/module/icp/asm-arm/sha2/sha256-armv7.S
+++ b/module/icp/asm-arm/sha2/sha256-armv7.S
@@ -21,8 +21,11 @@
 
 #if defined(__arm__)
 
-#define	__ARM_ARCH__      7
-#define	__ARM_MAX_ARCH__  7
+#ifndef __ARM_ARCH
+# define __ARM_ARCH__	7
+#else
+# define __ARM_ARCH__	__ARM_ARCH
+#endif
 
 #if defined(__thumb2__)
 .syntax unified

--- a/module/icp/asm-arm/sha2/sha256-armv7.S
+++ b/module/icp/asm-arm/sha2/sha256-armv7.S
@@ -1849,7 +1849,11 @@ zfs_sha256_block_neon:
 	stmdb	sp!,{r4-r12,lr}
 
 	sub	r11,sp,#16*4+16
+#if __ARM_ARCH__ >=7
 	adr	r14,K256
+#else
+	ldr	r14,=K256
+#endif
 	bic	r11,r11,#15		@ align for 128-bit stores
 	mov	r12,sp
 	mov	sp,r11			@ alloca

--- a/module/icp/asm-arm/sha2/sha512-armv7.S
+++ b/module/icp/asm-arm/sha2/sha512-armv7.S
@@ -21,8 +21,11 @@
 
 #if defined(__arm__)
 
-#define	__ARM_ARCH__      7
-#define	__ARM_MAX_ARCH__  7
+#ifndef __ARM_ARCH
+# define __ARM_ARCH__	7
+#else
+# define __ARM_ARCH__	__ARM_ARCH
+#endif
 
 #ifndef __KERNEL__
 # define VFP_ABI_PUSH	vstmdb	sp!,{d8-d15}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently OpenZFS won't build on early arm architectures (see debian port on [`armel`](https://buildd.debian.org/status/fetch.php?pkg=zfs-linux&arch=armel&ver=2.2.1-1%7Eexp1&stamp=1700646459&raw=0)).

Some errors are generated when compiling `module/icp/asm-arm/sha2/sha256-armv7.S` and `module/icp/asm-arm/sha2/sha512-armv7.S`:

```text
module/icp/asm-arm/sha2/sha256-armv7.S: Assembler messages:
module/icp/asm-arm/sha2/sha256-armv7.S:92: Error: selected processor does not support `rev r2,r2' in ARM mode
module/icp/asm-arm/sha2/sha256-armv7.S:150: Error: selected processor does not support `rev r2,r2' in ARM mode
module/icp/asm-arm/sha2/sha256-armv7.S:208: Error: selected processor does not support `rev r2,r2' in ARM mode
module/icp/asm-arm/sha2/sha256-armv7.S:266: Error: selected processor does not support `rev r2,r2' in ARM mode
...

module/icp/asm-arm/sha2/sha512-armv7.S: Assembler messages:
module/icp/asm-arm/sha2/sha512-armv7.S:168: Error: selected processor does not support `rev r3,r3' in ARM mode
module/icp/asm-arm/sha2/sha512-armv7.S:169: Error: selected processor does not support `rev r4,r4' in ARM mode
```

But the code actually has compiler guards to provide support for early arm architectures: https://github.com/openzfs/zfs/blob/a94860a6dee1c07bb96ee36dafcba40b804560cc/module/icp/asm-arm/sha2/sha256-armv7.S#L83-L108

Also, another error would be thrown when `__ARM_ARCH__` macro is correctly set with early arms:

```shell
$ arm-linux-gnueabihf-gcc -march=armv6 -msoft-float -c sha256-armv7.S -o sha256-armv7.o
sha256-armv7.S: Assembler messages:
sha256-armv7.S:1853: Error: invalid constant (ffffffffffffefa0) after fixup
```

This is caused by `adr` instruction on L1849: https://github.com/openzfs/zfs/blob/a94860a6dee1c07bb96ee36dafcba40b804560cc/module/icp/asm-arm/sha2/sha256-armv7.S#L1845-L1853

On early ISAs, `adr` could not load an address (`K256`) that is too far away from PC.

### Description
<!--- Describe your changes in detail -->

1. Use `__ARM_ARCH` that would be set by compiler (both GCC and Clang) when possible, so that these files compile with early architectures such as `armv5te` and `armv6`.
2. Replace `adr` with `ldr` on early architectures.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
The code now compiles on `armv5te` and `armv6`. Since I have made no functionality change and it is taken from OpenSSL, I suppose no further test is needed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
