### PR TITLE
Linux 6.6 compat: fix uninitialized timespec for LLVM

### DIFF
--- a/config/kernel-inode-times.m4
+++ b/config/kernel-inode-times.m4
@@ -50,6 +50,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_TIMES], [
 		struct timespec64 ts;
 
 		memset(&ip, 0, sizeof(ip));
+		memset(&ts, 0, sizeof(ts));
 		inode_set_ctime_to_ts(&ip, ts);
 	])
 ])


### PR DESCRIPTION
Commit fe9d409e9088 ("Linux 6.6 compat: use inode_get/set_ctime*(...)") adds compatibility with Linux v6.6 but people using the LLVM toolchain for their kernels encounter kabi check failure due to uninitialized `ts`:

```
/var/lib/dkms/zfs/2.2.1/build/build/inode_set_ctime_to_ts/inode_set_ctime_to_ts.c:79:30: error: variable 'ts' is uninitialized when used here [-Werror,-Wuninitialized]
   79 |                 inode_set_ctime_to_ts(&ip, ts);
      |                                            ^~
/var/lib/dkms/zfs/2.2.1/build/build/inode_set_ctime_to_ts/inode_set_ctime_to_ts.c:76:3: note: variable 'ts' is declared here
   76 |                 struct timespec64 ts;
      |                 ^
```

Similar incident was fixed with commit 3e5d41d807b0 ("config/kernel-inode-times: initialize timespec").

Follow it and initialize `ts`.

Fixes: fe9d409e9088 ("Linux 6.6 compat: use inode_get/set_ctime*(...)")

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Using the latest OpenZFS with Linux v6.6 built with LLVM 17 toolchain breaks autoconf and therefore the kernel module build.

### Description
<!--- Describe your changes in detail -->

Similar issue was handled before. This commit follows the previous commit's patch and initializes `struct timespec64 ts` for LLVM compiler.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Build-tested with Linux v6.6 using the LLVM 17 toolchain and checked ZFS module loads and behaves correctly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
