### PR TITLE
Fix zoneid when USER_NS is disabled

### DIFF
--- a/lib/libspl/os/linux/zone.c
+++ b/lib/libspl/os/linux/zone.c
@@ -42,20 +42,20 @@ getzoneid(void)
 	int c = snprintf(path, sizeof (path), "/proc/self/ns/user");
 	/* This API doesn't have any error checking... */
 	if (c < 0 || c >= sizeof (path))
-		return (0);
+		return (GLOBAL_ZONEID);
 
 	ssize_t r = readlink(path, buf, sizeof (buf) - 1);
 	if (r < 0)
-		return (0);
+		return (GLOBAL_ZONEID);
 
 	cp = strchr(buf, '[');
 	if (cp == NULL)
-		return (0);
+		return (GLOBAL_ZONEID);
 	cp++;
 
 	unsigned long n = strtoul(cp, NULL, 10);
 	if (n == ULONG_MAX && errno == ERANGE)
-		return (0);
+		return (GLOBAL_ZONEID);
 	zoneid_t z = (zoneid_t)n;
 
 	return (z);


### PR DESCRIPTION
getzoneid() should return GLOBAL_ZONEID instead of 0 when USER_NS is disabled.

### Motivation and Context
Fixes a Permission denied issue when creating or cloning a dataset when USER_NS is disabled as described in #15241.

### Description
getzoneid() on Linux now returns GLOBAL_ZONEID instead of 0 when USER_NS is disabled (or getzoneid fails otherwise).

### How Has This Been Tested?
This fixes the problem described in issue #15241 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
