### PR TITLE
Don't allow attach to a raidz child vdev

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7063,12 +7063,13 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 
 	if (!replacing) {
 		/*
-		 * For attach, the only allowable parent is a mirror or the root
-		 * vdev.
+		 * For attach, the only allowable parent is a mirror or
+		 * the root vdev. A raidz vdev can be attached to, but
+		 * you cannot attach to a raidz child.
 		 */
 		if (pvd->vdev_ops != &vdev_mirror_ops &&
-		    pvd->vdev_ops != &vdev_raidz_ops &&
-		    pvd->vdev_ops != &vdev_root_ops)
+		    pvd->vdev_ops != &vdev_root_ops &&
+		    !raidz)
 			return (spa_vdev_exit(spa, newrootvd, txg, ENOTSUP));
 
 		pvops = &vdev_mirror_ops;


### PR DESCRIPTION
### Motivation and Context
An automated test in FreeBSD encountered the case where an attach is attempted to a raidz child (#15536). This is not allowed and should fail but it now succeeds.

Regression from #15022.

### Description
One of the checks in `spa_vdev_attach()` was failing to detect this case. The parent vdev ops can be raidz in two different attach cases:

**Case 1** (attaching to raidz)
```
oldvd = pvd -> (raidz)
                / | \
               /  |  \
              /   |   \
            (c1) (c2) (c3)
```
**Case 2** (attaching to a child of raidz)
```
     pvd -> (raidz)
             / | \
            /  |  \
           /   |   \
oldvd -> (c1) (c2) (c3)
```
Changed the check to only accept case 1

### How Has This Been Tested?
ZTS functional/raidz
Ran reproducible test case from #15536 and it no longer happens

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
