### PR TITLE
dmu_buf_will_clone: fix race in transition back to NOFILL

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2715,15 +2715,23 @@ dmu_buf_will_clone(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	 * writes and clones into this block.
 	 */
 	mutex_enter(&db->db_mtx);
+	DBUF_VERIFY(db);
 	VERIFY(!dbuf_undirty(db, tx));
 	ASSERT0P(dbuf_find_dirty_eq(db, tx->tx_txg));
 	if (db->db_buf != NULL) {
 		arc_buf_destroy(db->db_buf, db);
 		db->db_buf = NULL;
+		dbuf_clear_data(db);
 	}
+
+	db->db_state = DB_NOFILL;
+	DTRACE_SET_STATE(db, "allocating NOFILL buffer for clone");
+
+	DBUF_VERIFY(db);
 	mutex_exit(&db->db_mtx);
 
-	dmu_buf_will_not_fill(db_fake, tx);
+	dbuf_noread(db);
+	(void) dbuf_dirty(db, tx);
 }
 
 void


### PR DESCRIPTION
### Motivation and Context

#15526 and the related unpleasantness of the week.

### Description

Previously, `dmu_buf_will_clone()` would roll back any dirty record, but would not clean out the modified data nor reset the state before releasing the lock. That leaves the last-written data in `db_data`, but the dbuf in the wrong state.

This is eventually corrected when the dbuf state is made `NOFILL`, and `dbuf_noread()` called (which clears out the old data), but at this point its too late, because the lock was already dropped with that invalid state.

Any caller acquiring the lock before the call into `dmu_buf_will_not_fill()` can find what appears to be a clean, readable buffer, and would take the wrong state from it: it should be getting the data from the cloned block, not from earlier (unwritten) dirty data.

Even after the state was switched to `NOFILL`, the old data was still not cleaned out until `dbuf_noread()`, which is another gap for a caller to take the lock and read the wrong data.

This commit fixes all this by properly cleaning up the previous state and then setting the new state before dropping the lock. The `DBUF_VERIFY()` calls confirm that the dbuf is in a valid state when the lock is down.

### Notes

How I got here is interesting. First, added `DBUF_VERIFY(db)` in `dmu_buf_will_clone()`, just after taking and just before releasing `db_mtx`.

Then ran:

```
dd if=/dev/random of=/tank/file bs=1M count=64 status=progress
zpool sync

while true ; do clonefile -t -c /tank/file /tank/clone ; done &
while true ; do dd if=/dev/random of=/tank/clone bs=4K count=16384 status=progress ; done &

wait
```

This immediatly blew up on the second `DBUF_VERIFY`, before releasing the lock. Examing the dbuf, it was in state `DB_CACHED` , no block pointer, no dirty records, but `db_data` set, so assertions tripped there.

And then I just kept following the breadcrumbs until arrived here, with `DBUF_VERIFY` passing.

Of course this is all assuming that `DBUF_VERIFY` is even correct for a clone write, but I think it is (as much as I can be sure of anything anymore).

### More notes

I am not sure if this is right. I wonder what happens if the dbuf is written to, then is cloned late while that write is being synced out. I don't know if this even makes sense but `dbuf_fix_old_data()` exists and it seems like this is not unlike the `!= NOFILL` case in `dbuf_dirty()`. But I'm very tired so.

Even if this is right, it isn't the whole story for #15526. There's a similar thing that can be tripped in 2.1 (pre block cloning). So even if you love this, don't assume its the whole game.

### How Has This Been Tested?

`block_cloning` tests pass, so at least clones still sorta work. `DBUF_VERIFY` is happy. My gut says its not worse, but this stuff is mad. Past performance is no guarantee of future results.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
