### PR TITLE
Silence a handful of Coverity warnings

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3132,7 +3132,7 @@ zfs_force_import_required(nvlist_t *config)
 	 * local hostid.
 	 */
 	if (nvlist_lookup_uint64(nvinfo, ZPOOL_CONFIG_HOSTID, &hostid) != 0)
-		nvlist_lookup_uint64(config, ZPOOL_CONFIG_HOSTID, &hostid);
+		hostid = fnvlist_lookup_uint64(config, ZPOOL_CONFIG_HOSTID);
 
 	if (state != POOL_STATE_EXPORTED && hostid != get_system_hostid())
 		return (B_TRUE);

--- a/lib/libzutil/os/linux/zutil_setproctitle.c
+++ b/lib/libzutil/os/linux/zutil_setproctitle.c
@@ -88,7 +88,7 @@ spt_copyenv(int envc, char *envp[])
 	char **envcopy;
 	char *eq;
 	int envsize;
-	int i, error;
+	int i, error = 0;
 
 	if (environ != envp)
 		return (0);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6069,7 +6069,7 @@ arc_prune_task(void *ptr)
 	if (func != NULL)
 		func(ap->p_adjust, ap->p_private);
 
-	zfs_refcount_remove(&ap->p_refcnt, func);
+	(void) zfs_refcount_remove(&ap->p_refcnt, func);
 }
 
 /*
@@ -6098,7 +6098,7 @@ arc_prune_async(uint64_t adjust)
 		ap->p_adjust = adjust;
 		if (taskq_dispatch(arc_prune_taskq, arc_prune_task,
 		    ap, TQ_SLEEP) == TASKQID_INVALID) {
-			zfs_refcount_remove(&ap->p_refcnt, ap->p_pfunc);
+			(void) zfs_refcount_remove(&ap->p_refcnt, ap->p_pfunc);
 			continue;
 		}
 		ARCSTAT_BUMP(arcstat_prune);
@@ -7720,7 +7720,7 @@ arc_fini(void)
 
 	mutex_enter(&arc_prune_mtx);
 	while ((p = list_remove_head(&arc_prune_list)) != NULL) {
-		zfs_refcount_remove(&p->p_refcnt, &arc_prune_list);
+		(void) zfs_refcount_remove(&p->p_refcnt, &arc_prune_list);
 		zfs_refcount_destroy(&p->p_refcnt);
 		kmem_free(p, sizeof (*p));
 	}
@@ -8301,7 +8301,8 @@ top:
 			ARCSTAT_BUMPDOWN(arcstat_l2_log_blk_count);
 			zfs_refcount_remove_many(&dev->l2ad_lb_asize, asize,
 			    lb_ptr_buf);
-			zfs_refcount_remove(&dev->l2ad_lb_count, lb_ptr_buf);
+			(void) zfs_refcount_remove(&dev->l2ad_lb_count,
+			    lb_ptr_buf);
 			kmem_free(lb_ptr_buf->lb_ptr,
 			    sizeof (l2arc_log_blkptr_t));
 			kmem_free(lb_ptr_buf, sizeof (l2arc_lb_ptr_buf_t));
@@ -8772,7 +8773,8 @@ retry:
 			ARCSTAT_BUMPDOWN(arcstat_l2_log_blk_count);
 			zfs_refcount_remove_many(&dev->l2ad_lb_asize, asize,
 			    lb_ptr_buf);
-			zfs_refcount_remove(&dev->l2ad_lb_count, lb_ptr_buf);
+			(void) zfs_refcount_remove(&dev->l2ad_lb_count,
+			    lb_ptr_buf);
 			list_remove(&dev->l2ad_lbptr_list, lb_ptr_buf);
 			kmem_free(lb_ptr_buf->lb_ptr,
 			    sizeof (l2arc_log_blkptr_t));

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2221,6 +2221,7 @@ spa_import_progress_truncate(spa_history_list_t *shl, unsigned int size)
 	spa_import_progress_t *sip;
 	while (shl->size > size) {
 		sip = list_remove_head(&shl->procfs_list.pl_list);
+		VERIFY(sip);
 		if (sip->pool_name)
 			spa_strfree(sip->pool_name);
 		kmem_free(sip, sizeof (spa_import_progress_t));

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -616,6 +616,7 @@ spa_mmp_history_truncate(spa_history_list_t *shl, unsigned int size)
 	spa_mmp_history_t *smh;
 	while (shl->size > size) {
 		smh = list_remove_head(&shl->procfs_list.pl_list);
+		VERIFY(smh);
 		if (smh->vdev_path)
 			kmem_strfree(smh->vdev_path);
 		kmem_free(smh, sizeof (spa_mmp_history_t));


### PR DESCRIPTION
### Motivation and Context

@ryao kicked off a Coverity run, and it spat a few new things from the last six months. Here's some minor updates for the low-hanging fruit.

### Description

See commit messages.

### How Has This Been Tested?

Compile checked only.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
