### PR TITLE
zdb: fix printf() length for uint64_t devid

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2126,14 +2126,14 @@ dump_brt(spa_t *spa)
 			continue;
 
 		if (!brtvd->bv_initiated) {
-			printf("BRT: vdev %lu: empty\n", vdevid);
+			printf("BRT: vdev %" PRIu64 ": empty\n", vdevid);
 			continue;
 		}
 
 		zdb_nicenum(brtvd->bv_totalcount, count, sizeof (count));
 		zdb_nicebytes(brtvd->bv_usedspace, used, sizeof (used));
 		zdb_nicebytes(brtvd->bv_savedspace, saved, sizeof (saved));
-		printf("BRT: vdev %lu: refcnt %s; used %s; saved %s\n",
+		printf("BRT: vdev %" PRIu64 ": refcnt %s; used %s; saved %s\n",
 		    vdevid, count, used, saved);
 	}
 
@@ -2156,7 +2156,7 @@ dump_brt(spa_t *spa)
 			uint64_t offset = *(uint64_t *)za.za_name;
 			uint64_t refcnt = za.za_first_integer;
 
-			snprintf(dva, sizeof (dva), "%lu:%llx", vdevid,
+			snprintf(dva, sizeof (dva), "%" PRIu64 ":%llx", vdevid,
 			    (u_longlong_t)offset);
 			printf("%-16s %-10llu\n", dva, (u_longlong_t)refcnt);
 		}


### PR DESCRIPTION
Signed-off-by:	Martin Matuska <mm@FreeBSD.org>

### Motivation and Context
Fixes compilation errors on 32-bit platforms.

### Description
The devid uint64_t variable should be represented as PRIu64

### How Has This Been Tested?
Compiled on 32-bit platforms.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
