### PR TITLE
Only provide execvpe(3) when needed

### DIFF
--- a/config/user.m4
+++ b/config/user.m4
@@ -31,7 +31,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER], [
 	ZFS_AC_CONFIG_USER_MAKEDEV_IN_MKDEV
 	ZFS_AC_CONFIG_USER_ZFSEXEC
 
-	AC_CHECK_FUNCS([issetugid mlockall strlcat strlcpy])
+	AC_CHECK_FUNCS([execvpe issetugid mlockall strlcat strlcpy])
 
 	AC_SUBST(RM)
 ])

--- a/lib/libspl/include/os/freebsd/sys/param.h
+++ b/lib/libspl/include/os/freebsd/sys/param.h
@@ -57,6 +57,8 @@
 extern size_t spl_pagesize(void);
 #define	PAGESIZE	(spl_pagesize())
 
+#ifndef HAVE_EXECVPE
 extern int execvpe(const char *name, char * const argv[], char * const envp[]);
+#endif
 
 #endif

--- a/lib/libzfs/os/freebsd/libzfs_compat.c
+++ b/lib/libzfs/os/freebsd/libzfs_compat.c
@@ -38,7 +38,8 @@
 #define	ZFS_KMOD	"openzfs"
 #endif
 
-
+#ifndef HAVE_EXECVPE
+/* FreeBSD prior to 15 lacks execvpe */
 static int
 execvPe(const char *name, const char *path, char * const *argv,
     char * const *envp)
@@ -192,6 +193,7 @@ execvpe(const char *name, char * const argv[], char * const envp[])
 
 	return (execvPe(name, path, argv, envp));
 }
+#endif /* !HAVE_EXECVPE */
 
 static __thread char errbuf[ERRBUFLEN];
 


### PR DESCRIPTION
Check for the existence of execvpe(3) and only provide the FreeBSD compat version if required.

### Motivation and Context
OpenZFS currently unconditionally defines execvpe in the SPL on FreeBSD. I'd like to add it (actually just expose it) on FreeBSD.

### Description
Enable an autoconf check for execvpe and check for HAVE_EXECVPE before declared if defining it.

Technically it's a library ABI change on FreeBSD, but probably not in a way that matters?

### How Has This Been Tested?
Trivial and it compiles. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
