### PR TITLE
ZTS: Add Test Case for Block Cloning Replay

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -43,7 +43,8 @@ tests = ['block_cloning_copyfilerange', 'block_cloning_copyfilerange_partial',
     'block_cloning_disabled_ficlonerange',
     'block_cloning_copyfilerange_cross_dataset',
     'block_cloning_cross_enc_dataset',
-    'block_cloning_copyfilerange_fallback_same_txg']
+    'block_cloning_copyfilerange_fallback_same_txg',
+    'block_cloning_replay', 'block_cloning_replay_encrypted']
 tags = ['functional', 'block_cloning']
 
 [tests/functional/chattr:Linux]

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -301,6 +301,10 @@ elif sys.platform.startswith('linux'):
             ['SKIP', cfr_reason],
         'block_cloning/block_cloning_copyfilerange_fallback':
             ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_replay':
+            ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_replay_encrypted':
+            ['SKIP', cfr_reason],
         'block_cloning/block_cloning_copyfilerange_cross_dataset':
             ['SKIP', cfr_cross_reason],
         'block_cloning/block_cloning_copyfilerange_fallback_same_txg':
@@ -308,7 +312,6 @@ elif sys.platform.startswith('linux'):
         'block_cloning/block_cloning_cross_enc_dataset':
             ['SKIP', cfr_cross_reason],
     })
-
 
 # Not all Github actions runners have scsi_debug module, so we may skip
 #   some tests which use it.

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -452,6 +452,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/block_cloning/block_cloning_ficlonerange.ksh \
 	functional/block_cloning/block_cloning_ficlonerange_partial.ksh \
 	functional/block_cloning/block_cloning_cross_enc_dataset.ksh \
+	functional/block_cloning/block_cloning_replay.ksh \
+	functional/block_cloning/block_cloning_replay_encrypted.ksh \
 	functional/bootfs/bootfs_001_pos.ksh \
 	functional/bootfs/bootfs_002_neg.ksh \
 	functional/bootfs/bootfs_003_pos.ksh \

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning.kshlib
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning.kshlib
@@ -53,6 +53,6 @@ function get_same_blocks
 	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout.a
 	zdb $KEY -vvvvv $3 -O $4 | \
 	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout.b
-	echo $(sort $zdbout.a $zdbout.b | uniq -d | cut -f1 -d' ')
+	echo $(sort -n $zdbout.a $zdbout.b | uniq -d | cut -f1 -d' ')
 }
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay.ksh
@@ -1,0 +1,131 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+#
+# DESCRIPTION:
+#	Verify slogs are replayed correctly for cloned files. This
+#	test is ported from slog_replay tests for block cloning.
+#
+# STRATEGY:
+#	1. Create an empty file system (TESTFS)
+#	2. Create regular files and sync
+#	3. Freeze TESTFS
+#	4. Clone the file
+#	5. Unmount filesystem
+#	   <At this stage TESTFS is frozen, the intent log contains a
+#	   complete set of deltas to replay it>
+#	6. Remount TESTFS <which replays the intent log>
+#	7. Compare clone file with the original file
+#
+
+verify_runnable "global"
+
+if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+  log_unsupported "copy_file_range not available before Linux 4.5"
+fi
+
+export VDIR=$TEST_BASE_DIR/disk-bclone
+export VDEV="$VDIR/a $VDIR/b $VDIR/c"
+export LDEV="$VDIR/e $VDIR/f"
+log_must rm -rf $VDIR
+log_must mkdir -p $VDIR
+log_must truncate -s $MINVDEVSIZE $VDEV $LDEV
+
+claim="The slogs are replayed correctly for cloned files."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -rf $TESTDIR $VDIR $VDIR2
+}
+
+log_onexit cleanup
+
+#
+# 1. Create an empty file system (TESTFS)
+#
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $VDEV \
+	log mirror $LDEV
+log_must zfs create $TESTPOOL/$TESTFS
+
+#
+# 2. TX_WRITE: Create two files and sync txg
+#
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file1 \
+    oflag=sync bs=128k count=4
+log_must zfs set recordsize=16K $TESTPOOL/$TESTFS
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file2 \
+    oflag=sync bs=16K count=2048
+sync_pool $TESTPOOL
+
+#
+# 3. Checkpoint for ZIL Replay
+#
+log_must zpool freeze $TESTPOOL
+
+#
+# 4. TX_CLONE_RANGE: Clone the file
+#
+log_must clonefile -c /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
+log_must clonefile -c /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
+
+#
+# 5. Unmount filesystem and export the pool
+#
+# At this stage TESTFS is frozen, the intent log contains a complete set
+# of deltas to replay for clone files.
+#
+log_must zfs unmount /$TESTPOOL/$TESTFS
+
+log_note "Verify transactions to replay:"
+log_must zdb -iv $TESTPOOL/$TESTFS
+
+log_must zpool export $TESTPOOL
+
+#
+# 6. Remount TESTFS <which replays the intent log>
+#
+# Import the pool to unfreeze it and claim log blocks.  It has to be
+# `zpool import -f` because we can't write a frozen pool's labels!
+#
+log_must zpool import -f -d $VDIR $TESTPOOL
+
+#
+# 7. Compare clone file with the original file
+#
+log_must have_same_content /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
+log_must have_same_content /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
+
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file1 \
+	$TESTPOOL/$TESTFS clone1)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file2 \
+	$TESTPOOL/$TESTFS clone2)
+log_must [ "$blocks" = "$(seq -s " " 0 2047)" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay_encrypted.ksh
@@ -1,0 +1,133 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+#
+# DESCRIPTION:
+#	Verify slogs are replayed correctly for encrypted cloned files.
+#	This test is ported from slog_replay tests for block cloning.
+#
+# STRATEGY:
+#	1. Create an encrypted file system (TESTFS)
+#	2. Create regular files and sync
+#	3. Freeze TESTFS
+#	4. Clone the file
+#	5. Unmount filesystem
+#	   <At this stage TESTFS is frozen, the intent log contains a
+#	   complete set of deltas to replay it>
+#	6. Remount encrypted TESTFS <which replays the intent log>
+#	7. Compare clone file with the original file
+#
+
+verify_runnable "global"
+
+if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+  log_unsupported "copy_file_range not available before Linux 4.5"
+fi
+
+export VDIR=$TEST_BASE_DIR/disk-bclone
+export VDEV="$VDIR/a $VDIR/b $VDIR/c"
+export LDEV="$VDIR/e $VDIR/f"
+log_must rm -rf $VDIR
+log_must mkdir -p $VDIR
+log_must truncate -s $MINVDEVSIZE $VDEV $LDEV
+export PASSPHRASE="password"
+
+claim="The slogs are replayed correctly for encrypted cloned files."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -rf $TESTDIR $VDIR $VDIR2
+}
+
+log_onexit cleanup
+
+#
+# 1. Create an encrypted file system (TESTFS)
+#
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $VDEV \
+	log mirror $LDEV
+log_must eval "echo $PASSPHRASE | zfs create -o encryption=on" \
+	"-o keyformat=passphrase -o keylocation=prompt $TESTPOOL/$TESTFS"
+
+#
+# 2. TX_WRITE: Create two files and sync txg
+#
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file1 \
+    oflag=sync bs=128k count=4
+log_must zfs set recordsize=16K $TESTPOOL/$TESTFS
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file2 \
+    oflag=sync bs=16K count=2048
+sync_pool $TESTPOOL
+
+#
+# 3. Checkpoint for ZIL Replay
+#
+log_must zpool freeze $TESTPOOL
+
+#
+# 4. TX_CLONE_RANGE: Clone the file
+#
+log_must clonefile -c /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
+log_must clonefile -c /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
+
+#
+# 5. Unmount filesystem and export the pool
+#
+# At this stage TESTFS is frozen, the intent log contains a complete set
+# of deltas to replay for clone files.
+#
+log_must zfs unmount /$TESTPOOL/$TESTFS
+
+log_note "Verify transactions to replay:"
+log_must zdb -iv $TESTPOOL/$TESTFS
+
+log_must zpool export $TESTPOOL
+
+#
+# 6. Remount TESTFS <which replays the intent log>
+#
+# Import the pool to unfreeze it and claim log blocks.  It has to be
+# `zpool import -f` because we can't write a frozen pool's labels!
+#
+log_must eval "echo $PASSPHRASE | zpool import -l -f -d $VDIR $TESTPOOL"
+
+#
+# 7. Compare clone file with the original file
+#
+log_must have_same_content /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
+log_must have_same_content /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
+
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file1 \
+	$TESTPOOL/$TESTFS clone1 $PASSPHRASE)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file2 \
+	$TESTPOOL/$TESTFS clone2 $PASSPHRASE)
+log_must [ "$blocks" = "$(seq -s " " 0 2047)" ]
+
+log_pass $claim


### PR DESCRIPTION
This PR adds two tests (with and without encrypted datasets) when the cloned file is replayed through ZIL. `block_cloning_replay_encrypted` specfically validates the scenario that @amotin fixed under https://github.com/openzfs/zfs/commit/27d8c23c582056a23509a7b80844a1b6435750b0.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
