### PR TITLE
module/icp/asm-arm/sha2: enable non-SIMD asm kernels on armv5/6

### DIFF
--- a/module/icp/algs/sha2/sha256_impl.c
+++ b/module/icp/algs/sha2/sha256_impl.c
@@ -118,7 +118,15 @@ const sha256_ops_t sha256_shani_impl = {
 };
 #endif
 
-#elif defined(__aarch64__) || (defined(__arm__) && __ARM_ARCH > 6)
+#elif defined(__aarch64__) || defined(__arm__)
+extern void zfs_sha256_block_armv7(uint32_t s[8], const void *, size_t);
+const sha256_ops_t sha256_armv7_impl = {
+	.is_supported = sha2_is_supported,
+	.transform = zfs_sha256_block_armv7,
+	.name = "armv7"
+};
+
+#if __ARM_ARCH > 6
 static boolean_t sha256_have_neon(void)
 {
 	return (kfpu_allowed() && zfs_neon_available());
@@ -128,13 +136,6 @@ static boolean_t sha256_have_armv8ce(void)
 {
 	return (kfpu_allowed() && zfs_sha256_available());
 }
-
-extern void zfs_sha256_block_armv7(uint32_t s[8], const void *, size_t);
-const sha256_ops_t sha256_armv7_impl = {
-	.is_supported = sha2_is_supported,
-	.transform = zfs_sha256_block_armv7,
-	.name = "armv7"
-};
 
 TF(zfs_sha256_block_neon, tf_sha256_neon);
 const sha256_ops_t sha256_neon_impl = {
@@ -149,6 +150,7 @@ const sha256_ops_t sha256_armv8_impl = {
 	.transform = tf_sha256_armv8ce,
 	.name = "armv8-ce"
 };
+#endif
 
 #elif defined(__PPC64__)
 static boolean_t sha256_have_isa207(void)
@@ -192,10 +194,12 @@ static const sha256_ops_t *const sha256_impls[] = {
 #if defined(__x86_64) && defined(HAVE_SSE4_1)
 	&sha256_shani_impl,
 #endif
-#if defined(__aarch64__) || (defined(__arm__) && __ARM_ARCH > 6)
+#if defined(__aarch64__) || defined(__arm__)
 	&sha256_armv7_impl,
+#if __ARM_ARCH > 6
 	&sha256_neon_impl,
 	&sha256_armv8_impl,
+#endif
 #endif
 #if defined(__PPC64__)
 	&sha256_ppc_impl,

--- a/module/icp/algs/sha2/sha512_impl.c
+++ b/module/icp/algs/sha2/sha512_impl.c
@@ -88,7 +88,7 @@ const sha512_ops_t sha512_avx2_impl = {
 };
 #endif
 
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(__arm__)
 extern void zfs_sha512_block_armv7(uint64_t s[8], const void *, size_t);
 const sha512_ops_t sha512_armv7_impl = {
 	.is_supported = sha2_is_supported,
@@ -96,6 +96,7 @@ const sha512_ops_t sha512_armv7_impl = {
 	.name = "armv7"
 };
 
+#if defined(__aarch64__)
 static boolean_t sha512_have_armv8ce(void)
 {
 	return (kfpu_allowed() && zfs_sha512_available());
@@ -107,15 +108,9 @@ const sha512_ops_t sha512_armv8_impl = {
 	.transform = tf_sha512_armv8ce,
 	.name = "armv8-ce"
 };
+#endif
 
-#elif defined(__arm__) && __ARM_ARCH > 6
-extern void zfs_sha512_block_armv7(uint64_t s[8], const void *, size_t);
-const sha512_ops_t sha512_armv7_impl = {
-	.is_supported = sha2_is_supported,
-	.transform = zfs_sha512_block_armv7,
-	.name = "armv7"
-};
-
+#if defined(__arm__) && __ARM_ARCH > 6
 static boolean_t sha512_have_neon(void)
 {
 	return (kfpu_allowed() && zfs_neon_available());
@@ -127,6 +122,7 @@ const sha512_ops_t sha512_neon_impl = {
 	.transform = tf_sha512_neon,
 	.name = "neon"
 };
+#endif
 
 #elif defined(__PPC64__)
 TF(zfs_sha512_ppc, tf_sha512_ppc);
@@ -164,13 +160,14 @@ static const sha512_ops_t *const sha512_impls[] = {
 #if defined(__x86_64) && defined(HAVE_AVX2)
 	&sha512_avx2_impl,
 #endif
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__arm__)
 	&sha512_armv7_impl,
+#if defined(__aarch64__)
 	&sha512_armv8_impl,
 #endif
 #if defined(__arm__) && __ARM_ARCH > 6
-	&sha512_armv7_impl,
 	&sha512_neon_impl,
+#endif
 #endif
 #if defined(__PPC64__)
 	&sha512_ppc_impl,

--- a/module/icp/asm-arm/sha2/sha256-armv7.S
+++ b/module/icp/asm-arm/sha2/sha256-armv7.S
@@ -1837,6 +1837,7 @@ zfs_sha256_block_armv7:
 #endif
 .size	zfs_sha256_block_armv7,.-zfs_sha256_block_armv7
 
+#if __ARM_ARCH__ >= 7
 .arch	armv7-a
 .fpu	neon
 
@@ -1849,11 +1850,7 @@ zfs_sha256_block_neon:
 	stmdb	sp!,{r4-r12,lr}
 
 	sub	r11,sp,#16*4+16
-#if __ARM_ARCH__ >=7
 	adr	r14,K256
-#else
-	ldr	r14,=K256
-#endif
 	bic	r11,r11,#15		@ align for 128-bit stores
 	mov	r12,sp
 	mov	sp,r11			@ alloca
@@ -2773,4 +2770,5 @@ zfs_sha256_block_armv8:
 	bx	lr		@ bx lr
 .size	zfs_sha256_block_armv8,.-zfs_sha256_block_armv8
 
-#endif
+#endif // #if __ARM_ARCH__ >= 7
+#endif // #if defined(__arm__)

--- a/module/icp/asm-arm/sha2/sha512-armv7.S
+++ b/module/icp/asm-arm/sha2/sha512-armv7.S
@@ -493,6 +493,7 @@ zfs_sha512_block_armv7:
 #endif
 .size	zfs_sha512_block_armv7,.-zfs_sha512_block_armv7
 
+#if __ARM_ARCH__ >= 7
 .arch	armv7-a
 .fpu	neon
 
@@ -1822,4 +1823,5 @@ zfs_sha512_block_neon:
 	VFP_ABI_POP
 	bx	lr				@ .word	0xe12fff1e
 .size	zfs_sha512_block_neon,.-zfs_sha512_block_neon
-#endif
+#endif // #if __ARM_ARCH__ >= 7
+#endif // #if defined(__arm__)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

My merged pull request #15557 fixes compilation of sha2 kernels on arm v5/6.

However, the compiler guards only allow `sha256/512_armv7_impl` to be used when `__ARM_ARCH > 6`. Therefore old arm architectures cannot leverage the well-written asm kernels `zfs_sha256/512_block_armv7` (from openssl project) and always fall back to the generic C implementation. This might lead to unnecessary performance degradation.

These kernels are actually named [`armv4`](https://github.com/openssl/openssl/blob/master/crypto/sha/asm/sha256-armv4.pl) from the openssl side. So I believe it has been guaranteed to work on old arm arches.

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

This patch enables these ASM kernels on all arm architectures. Some compiler guards are adjusted accordingly to avoid the unnecessary compilation of SIMD (e.g., neon, armv8ce) kernels on old architectures.

See also: https://github.com/openzfs/zfs/commit/4c5fec01a48acc184614ab8735e6954961990235

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

I have tested compilation on `armv5te` / `armv6` architectures. No behavior changes are made to other architectures.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
