### PR TITLE
BRT: Limit brt_vdev_dump() to only one vdev

### DIFF
--- a/module/zfs/brt.c
+++ b/module/zfs/brt.c
@@ -344,7 +344,7 @@ brt_vdev_entcount_get(const brt_vdev_t *brtvd, uint64_t idx)
 
 	ASSERT3U(idx, <, brtvd->bv_size);
 
-	if (brtvd->bv_need_byteswap) {
+	if (unlikely(brtvd->bv_need_byteswap)) {
 		return (BSWAP_16(brtvd->bv_entcount[idx]));
 	} else {
 		return (brtvd->bv_entcount[idx]);
@@ -357,7 +357,7 @@ brt_vdev_entcount_set(brt_vdev_t *brtvd, uint64_t idx, uint16_t entcnt)
 
 	ASSERT3U(idx, <, brtvd->bv_size);
 
-	if (brtvd->bv_need_byteswap) {
+	if (unlikely(brtvd->bv_need_byteswap)) {
 		brtvd->bv_entcount[idx] = BSWAP_16(entcnt);
 	} else {
 		brtvd->bv_entcount[idx] = entcnt;
@@ -392,55 +392,39 @@ brt_vdev_entcount_dec(brt_vdev_t *brtvd, uint64_t idx)
 
 #ifdef ZFS_DEBUG
 static void
-brt_vdev_dump(brt_t *brt)
+brt_vdev_dump(brt_vdev_t *brtvd)
 {
-	brt_vdev_t *brtvd;
-	uint64_t vdevid;
+	uint64_t idx;
 
-	if ((zfs_flags & ZFS_DEBUG_BRT) == 0) {
-		return;
-	}
-
-	if (brt->brt_nvdevs == 0) {
-		zfs_dbgmsg("BRT empty");
-		return;
-	}
-
-	zfs_dbgmsg("BRT vdev dump:");
-	for (vdevid = 0; vdevid < brt->brt_nvdevs; vdevid++) {
-		uint64_t idx;
-
-		brtvd = &brt->brt_vdevs[vdevid];
-		zfs_dbgmsg("  vdevid=%llu/%llu meta_dirty=%d entcount_dirty=%d "
-		    "size=%llu totalcount=%llu nblocks=%llu bitmapsize=%zu\n",
-		    (u_longlong_t)vdevid, (u_longlong_t)brtvd->bv_vdevid,
-		    brtvd->bv_meta_dirty, brtvd->bv_entcount_dirty,
-		    (u_longlong_t)brtvd->bv_size,
-		    (u_longlong_t)brtvd->bv_totalcount,
-		    (u_longlong_t)brtvd->bv_nblocks,
-		    (size_t)BT_SIZEOFMAP(brtvd->bv_nblocks));
-		if (brtvd->bv_totalcount > 0) {
-			zfs_dbgmsg("    entcounts:");
-			for (idx = 0; idx < brtvd->bv_size; idx++) {
-				if (brt_vdev_entcount_get(brtvd, idx) > 0) {
-					zfs_dbgmsg("      [%04llu] %hu",
-					    (u_longlong_t)idx,
-					    brt_vdev_entcount_get(brtvd, idx));
-				}
+	zfs_dbgmsg("  BRT vdevid=%llu meta_dirty=%d entcount_dirty=%d "
+	    "size=%llu totalcount=%llu nblocks=%llu bitmapsize=%zu\n",
+	    (u_longlong_t)brtvd->bv_vdevid,
+	    brtvd->bv_meta_dirty, brtvd->bv_entcount_dirty,
+	    (u_longlong_t)brtvd->bv_size,
+	    (u_longlong_t)brtvd->bv_totalcount,
+	    (u_longlong_t)brtvd->bv_nblocks,
+	    (size_t)BT_SIZEOFMAP(brtvd->bv_nblocks));
+	if (brtvd->bv_totalcount > 0) {
+		zfs_dbgmsg("    entcounts:");
+		for (idx = 0; idx < brtvd->bv_size; idx++) {
+			uint16_t entcnt = brt_vdev_entcount_get(brtvd, idx);
+			if (entcnt > 0) {
+				zfs_dbgmsg("      [%04llu] %hu",
+				    (u_longlong_t)idx, entcnt);
 			}
 		}
-		if (brtvd->bv_entcount_dirty) {
-			char *bitmap;
+	}
+	if (brtvd->bv_entcount_dirty) {
+		char *bitmap;
 
-			bitmap = kmem_alloc(brtvd->bv_nblocks + 1, KM_SLEEP);
-			for (idx = 0; idx < brtvd->bv_nblocks; idx++) {
-				bitmap[idx] =
-				    BT_TEST(brtvd->bv_bitmap, idx) ? 'x' : '.';
-			}
-			bitmap[idx] = '\0';
-			zfs_dbgmsg("    bitmap: %s", bitmap);
-			kmem_free(bitmap, brtvd->bv_nblocks + 1);
+		bitmap = kmem_alloc(brtvd->bv_nblocks + 1, KM_SLEEP);
+		for (idx = 0; idx < brtvd->bv_nblocks; idx++) {
+			bitmap[idx] =
+			    BT_TEST(brtvd->bv_bitmap, idx) ? 'x' : '.';
 		}
+		bitmap[idx] = '\0';
+		zfs_dbgmsg("    dirty: %s", bitmap);
+		kmem_free(bitmap, brtvd->bv_nblocks + 1);
 	}
 }
 #endif
@@ -769,7 +753,8 @@ brt_vdev_addref(brt_t *brt, brt_vdev_t *brtvd, const brt_entry_t *bre,
 	BT_SET(brtvd->bv_bitmap, idx);
 
 #ifdef ZFS_DEBUG
-	brt_vdev_dump(brt);
+	if (zfs_flags & ZFS_DEBUG_BRT)
+		brt_vdev_dump(brtvd);
 #endif
 }
 
@@ -805,7 +790,8 @@ brt_vdev_decref(brt_t *brt, brt_vdev_t *brtvd, const brt_entry_t *bre,
 	BT_SET(brtvd->bv_bitmap, idx);
 
 #ifdef ZFS_DEBUG
-	brt_vdev_dump(brt);
+	if (zfs_flags & ZFS_DEBUG_BRT)
+		brt_vdev_dump(brtvd);
 #endif
 }
 


### PR DESCRIPTION
Without this patch on pool of 60 vdevs with ZFS_DEBUG enabled clone takes much more time than copy, while heavily trashing dbgmsg for no good reason, repeatedly dumping all vdevs BRTs again and again, even unmodified ones, for each cloned/freed block.

I am generally not sure this dumping is not excessive, but decided to keep it for now, just restricting its scope to more reasonable.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
