### PR TITLE
FreeBSD: Fix file descriptor leak on pool import.

### DIFF
--- a/module/os/freebsd/zfs/zfs_file_os.c
+++ b/module/os/freebsd/zfs/zfs_file_os.c
@@ -50,26 +50,65 @@ int
 zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
 {
 	struct thread *td;
-	int rc, fd;
+	struct vnode *vp;
+	struct file *fp;
+	struct nameidata nd;
+	int error;
 
 	td = curthread;
 	pwd_ensure_dirs();
-	/* 12.x doesn't take a const char * */
-	rc = kern_openat(td, AT_FDCWD, __DECONST(char *, path),
-	    UIO_SYSSPACE, flags, mode);
-	if (rc)
-		return (SET_ERROR(rc));
-	fd = td->td_retval[0];
-	td->td_retval[0] = 0;
-	if (fget(curthread, fd, &cap_no_rights, fpp))
-		kern_close(td, fd);
+
+	KASSERT((flags & (O_EXEC | O_PATH)) == 0,
+	    ("invalid flags: 0x%x", flags));
+	KASSERT((flags & O_ACCMODE) != O_ACCMODE,
+	    ("invalid flags: 0x%x", flags));
+	flags = FFLAGS(flags);
+
+	error = falloc_noinstall(td, &fp);
+	if (error != 0) {
+		return (error);
+	}
+	fp->f_flag = flags & FMASK;
+
+#if __FreeBSD_version >= 1400043
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, path);
+#else
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, path, td);
+#endif
+	error = vn_open(&nd, &flags, mode, fp);
+	if (error != 0) {
+		falloc_abort(td, fp);
+		return (SET_ERROR(error));
+	}
+	NDFREE_PNBUF(&nd);
+	vp = nd.ni_vp;
+	fp->f_vnode = vp;
+	if (fp->f_ops == &badfileops) {
+		finit_vnode(fp, flags, NULL, &vnops);
+	}
+	VOP_UNLOCK(vp);
+	if (vp->v_type != VREG) {
+		zfs_file_close(fp);
+		return (SET_ERROR(EACCES));
+	}
+
+	if (flags & O_TRUNC) {
+		error = fo_truncate(fp, 0, td->td_ucred, td);
+		if (error != 0) {
+			zfs_file_close(fp);
+			return (SET_ERROR(error));
+		}
+	}
+
+	*fpp = fp;
+
 	return (0);
 }
 
 void
 zfs_file_close(zfs_file_t *fp)
 {
-	fo_close(fp, curthread);
+	fdrop(fp, curthread);
 }
 
 static int
@@ -260,7 +299,7 @@ zfs_file_get(int fd)
 void
 zfs_file_put(zfs_file_t *fp)
 {
-	fdrop(fp, curthread);
+	zfs_file_close(fp);
 }
 
 loff_t


### PR DESCRIPTION
While here, return the error we get from fgets() instead of pretending we succeeded.

Descriptor leak can be easily reproduced by doing:

	# zpool import tank
	# sysctl kern.openfiles
	# zpool export tank; zpool import tank
	# sysctl kern.openfiles

We were leaking four file descriptors on every import.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
The change corrects zfs_file_open()/zfs_file_close() functions to not leave open file descriptor on zfs_file_close().
If one does a lot of pool exports and imports, one can exhaust allowed number of open file descriptors in the system.

### Description
In order to close the file descriptor properly we need to also remember its number (and not only the file structure pointer).
This is why I had to create dedicated structure that can hold both: file descriptor number and a pointer to the file structure.

### How Has This Been Tested?
Running my bclone tests (which do a lot of pool imports and exports) failed, because of ENFILE (Too many open files in system). After applying the fix tests succeeded and descriptors don't leak.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
