### PR TITLE
spa_history: verify history objects are on list

### DIFF
--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2225,6 +2225,7 @@ spa_import_progress_truncate(spa_history_list_t *shl, unsigned int size)
 	spa_import_progress_t *sip;
 	while (shl->size > size) {
 		sip = list_remove_head(&shl->procfs_list.pl_list);
+		VERIFY(sip);
 		if (sip->pool_name)
 			spa_strfree(sip->pool_name);
 		if (sip->spa_load_notes)

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -616,6 +616,7 @@ spa_mmp_history_truncate(spa_history_list_t *shl, unsigned int size)
 	spa_mmp_history_t *smh;
 	while (shl->size > size) {
 		smh = list_remove_head(&shl->procfs_list.pl_list);
+		VERIFY(smh);
 		if (smh->vdev_path)
 			kmem_strfree(smh->vdev_path);
 		kmem_free(smh, sizeof (spa_mmp_history_t));


### PR DESCRIPTION
### Motivation and Context

@ryao kicked off a Coverity run, and it spat a few new things from the last six months.

### Description

If there's no item on the list then we get a null deref and crash anyway, so there's no actual change here.

This shouldn't happen anyway because we won't try if the history size is 0, so this is protecting against future accounting bugs.

Reported-by: Coverity (CID-1573322)
Reported-by: Coverity (CID-1573331)

### How Has This Been Tested?

Compile checked only (but see #15580).

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
