### PR TITLE
setproctitle: fix ununitialised variable

### DIFF
--- a/lib/libzutil/os/linux/zutil_setproctitle.c
+++ b/lib/libzutil/os/linux/zutil_setproctitle.c
@@ -88,7 +88,7 @@ spt_copyenv(int envc, char *envp[])
 	char **envcopy;
 	char *eq;
 	int envsize;
-	int i, error;
+	int i, error = 0;
 
 	if (environ != envp)
 		return (0);


### PR DESCRIPTION
### Motivation and Context

@ryao kicked off a Coverity run, and it spat a few new things from the last six months.

### Description

Reported-by: Coverity (CID-1573333)

### How Has This Been Tested?

Compile checked only (but see #15580).

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
