### PR TITLE
zed: fix typo in variable ZED_POWER_OFF_ENCLO*US*RE_SLOT_ON_FAULT

### DIFF
--- a/cmd/zed/zed.d/statechange-slot_off.sh
+++ b/cmd/zed/zed.d/statechange-slot_off.sh
@@ -5,7 +5,7 @@
 #
 # Bad SCSI disks can often "disappear and reappear" causing all sorts of chaos
 # as they flip between FAULTED and ONLINE.  If
-# ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT is set in zed.rc, and the disk gets
+# ZED_POWER_OFF_ENCLOSURE_SLOT_ON_FAULT is set in zed.rc, and the disk gets
 # FAULTED, then power down the slot via sysfs:
 #
 # /sys/class/enclosure/<enclosure>/<slot>/power_status
@@ -19,7 +19,7 @@
 # Exit codes:
 #   0: slot successfully powered off
 #   1: enclosure not available
-#   2: ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT disabled
+#   2: ZED_POWER_OFF_ENCLOSURE_SLOT_ON_FAULT disabled
 #   3: vdev was not FAULTED
 #   4: The enclosure sysfs path passed from ZFS does not exist
 #   5: Enclosure slot didn't actually turn off after we told it to
@@ -32,7 +32,7 @@ if [ ! -d /sys/class/enclosure ] ; then
 	exit 1
 fi
 
-if [ "${ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT}" != "1" ] ; then
+if [ "${ZED_POWER_OFF_ENCLOSURE_SLOT_ON_FAULT}" != "1" ] ; then
 	exit 2
 fi
 

--- a/cmd/zed/zed.d/zed.rc
+++ b/cmd/zed/zed.d/zed.rc
@@ -146,7 +146,7 @@ ZED_SYSLOG_SUBCLASS_EXCLUDE="history_event"
 # Power off the drive's slot in the enclosure if it becomes FAULTED.  This can
 # help silence misbehaving drives.  This assumes your drive enclosure fully
 # supports slot power control via sysfs.
-#ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT=1
+#ZED_POWER_OFF_ENCLOSURE_SLOT_ON_FAULT=1
 
 ##
 # Ntfy topic


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There's a typo in the name of the variable to enable a zedlet.

Fixes 11fbcacf37d1a66c7a40bb8920c70ce9a87270ea
("zed: Add zedlet to power off slot when drive is faulted")

### Description
<!--- Describe your changes in detail -->

Replace ENCLO_US_RE with ENCLO_SU_RE in the name of the variable.

Mechanical change:

`$ sed -i 's/ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT/ZED_POWER_OFF_ENCLOSURE_SLOT_ON_FAULT/g' cmd/zed/zed.d/zed.rc cmd/zed/zed.d/statechange-slot_off.sh`

Note this changes the user-visible string in zed.rc, thus might break current users with the wrong string, but it's ~2 months since zfs-2.2.0 tag is out, thus should not be widespread yet.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Before:
```
   $ grep -r ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT
    cmd/zed/zed.d/zed.rc:#ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT=1
    cmd/zed/zed.d/statechange-slot_off.sh:# ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT is set in zed.rc, and the disk gets
    cmd/zed/zed.d/statechange-slot_off.sh:#   2: ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT disabled
    cmd/zed/zed.d/statechange-slot_off.sh:if [ "${ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT}" != "1" ] ; then
```

After:
```
    $ grep -r ZED_POWER_OFF_ENCLOUSRE_SLOT_ON_FAULT
    $
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).