### PR TITLE
systemd: define zfs-share to be PartOf zfs-mount

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7234,7 +7234,8 @@ share_mount(int op, int argc, char **argv)
 		pthread_mutex_init(&share_mount_state.sm_lock, NULL);
 
 		/* For a 'zfs share -a' operation start with a clean slate. */
-		zfs_truncate_shares(NULL);
+		if (op == OP_SHARE)
+			zfs_truncate_shares(NULL);
 
 		/*
 		 * libshare isn't mt-safe, so only do the operation in parallel


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Since ZFS 2.2
NFS shares configured via sharenfs disappear after restarting zfs-mount.service and on boot in some configurations.

### Description
forces zfs-share to restart with zfs-mount by configured the PartOf property in systemd unit

### How Has This Been Tested?
Verified `systemctl restart zfs-mount` 
