### PR TITLE
fix(mount): do not truncate shares not zfs mount

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7234,7 +7234,8 @@ share_mount(int op, int argc, char **argv)
 		pthread_mutex_init(&share_mount_state.sm_lock, NULL);
 
 		/* For a 'zfs share -a' operation start with a clean slate. */
-		zfs_truncate_shares(NULL);
+		if (op == OP_SHARE)
+			zfs_truncate_shares(NULL);
 
 		/*
 		 * libshare isn't mt-safe, so only do the operation in parallel

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -287,7 +287,8 @@ tags = ['functional', 'cli_root', 'zfs_set']
 [tests/functional/cli_root/zfs_share]
 tests = ['zfs_share_001_pos', 'zfs_share_002_pos', 'zfs_share_003_pos',
     'zfs_share_004_pos', 'zfs_share_006_pos', 'zfs_share_008_neg',
-    'zfs_share_010_neg', 'zfs_share_011_pos', 'zfs_share_concurrent_shares']
+    'zfs_share_010_neg', 'zfs_share_011_pos', 'zfs_share_concurrent_shares',
+    'zfs_share_after_mount']
 tags = ['functional', 'cli_root', 'zfs_share']
 
 [tests/functional/cli_root/zfs_snapshot]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -890,6 +890,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_share/zfs_share_012_pos.ksh \
 	functional/cli_root/zfs_share/zfs_share_013_pos.ksh \
 	functional/cli_root/zfs_share/zfs_share_concurrent_shares.ksh \
+	functional/cli_root/zfs_share/zfs_share_after_mount.ksh \
 	functional/cli_root/zfs_snapshot/cleanup.ksh \
 	functional/cli_root/zfs_snapshot/setup.ksh \
 	functional/cli_root/zfs_snapshot/zfs_snapshot_001_neg.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_after_mount.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_after_mount.ksh
@@ -1,0 +1,62 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Proxmox. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+# DESCRIPTION:
+# Verify that nfs shares persist after zfs mount -a
+#
+# STRATEGY:
+# 1. Verify that the filesystem is not shared.
+# 2. Enable the 'sharenfs' property
+# 3. Verify filesystem is shared
+# 4. Invoke 'zfs mount -a'
+# 5. Verify filesystem is still shared
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must zfs set sharenfs=off $TESTPOOL/$TESTFS
+	is_shared $TESTPOOL/$TESTFS && \
+		log_must unshare_fs $TESTPOOL/$TESTFS
+	log_must zfs share -a
+}
+
+
+log_onexit cleanup
+
+cleanup
+
+log_must zfs set sharenfs="on" $TESTPOOL/$TESTFS
+log_must is_shared $TESTPOOL/$TESTFS
+log_must is_exported $TESTPOOL/$TESTFS
+
+log_must zfs mount -a
+log_must is_shared $TESTPOOL/$TESTFS
+log_must is_exported $TESTPOOL/$TESTFS
+
+log_pass "Verify that nfs shares persist after zfs mount -a"


### PR DESCRIPTION
### Motivation and Context

When running `zfs share -a` resetting the exports.d/zfs.exports makes sense to get a clean state.
Truncating was also called with `zfs mount -a` which would not populate the file again.

This was introduced with https://github.com/openzfs/zfs/commit/ede037cda73675f42b1452187e8dd3438fafc220
Fixes: https://github.com/openzfs/zfs/issues/15607


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

only calling truncate with `zfs share -a`

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

tested with running `zfs mount -a` and compared with the behavior of ZFS 2.1

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
