### PR TITLE
ZTS: Update raidz_expand_005_pos.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/raidz/raidz_expand_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/raidz/raidz_expand_005_pos.ksh
@@ -113,7 +113,7 @@ function test_replace # <pool> <devices> <parity>
 	log_must zpool scrub -w $pool
 
 	log_must zpool status -v
-	log_must check_pool_status $pool "scan" "repaired 0B"
+	log_must check_pool_status $pool "scan" "with 0 errors"
 }
 
 log_must set_tunable32 EMBEDDED_SLOG_MIN_MS 99999


### PR DESCRIPTION
### Motivation and Context

https://build.openzfs.org/builders/CentOS%208%20x86_64%20%28TEST%29/builds/1495/steps/shell_4/logs/summary

### Description

Align the `raidz_expand_005_pos` test with the `raidz_expand_004_pos` test and only verify no errors were reported.  Allow scrub repair IO.

### How Has This Been Tested?

Will be verified by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
