### PR TITLE
Linux 6.5 compat: check BLK_OPEN_EXCL is defined

### DIFF
--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -85,7 +85,7 @@ static blk_mode_t
 #else
 static fmode_t
 #endif
-vdev_bdev_mode(spa_mode_t spa_mode)
+vdev_bdev_mode(spa_mode_t spa_mode, boolean_t exclusive)
 {
 #ifdef HAVE_BLK_MODE_T
 	blk_mode_t mode = 0;
@@ -95,6 +95,9 @@ vdev_bdev_mode(spa_mode_t spa_mode)
 
 	if (spa_mode & SPA_MODE_WRITE)
 		mode |= BLK_OPEN_WRITE;
+
+	if (exclusive)
+		mode |= BLK_OPEN_EXCL;
 #else
 	fmode_t mode = 0;
 
@@ -103,6 +106,9 @@ vdev_bdev_mode(spa_mode_t spa_mode)
 
 	if (spa_mode & SPA_MODE_WRITE)
 		mode |= FMODE_WRITE;
+
+	if (exclusive)
+		mode |= FMODE_EXCL;
 #endif
 
 	return (mode);
@@ -225,10 +231,10 @@ vdev_blkdev_get_by_path(const char *path, spa_mode_t mode, void *holder,
 {
 #ifdef HAVE_BLKDEV_GET_BY_PATH_4ARG
 	return (blkdev_get_by_path(path,
-	    vdev_bdev_mode(mode) | BLK_OPEN_EXCL, holder, hops));
+	    vdev_bdev_mode(mode, B_TRUE), holder, hops));
 #else
 	return (blkdev_get_by_path(path,
-	    vdev_bdev_mode(mode) | FMODE_EXCL, holder));
+	    vdev_bdev_mode(mode, B_TRUE), holder));
 #endif
 }
 
@@ -238,7 +244,7 @@ vdev_blkdev_put(struct block_device *bdev, spa_mode_t mode, void *holder)
 #ifdef HAVE_BLKDEV_PUT_HOLDER
 	return (blkdev_put(bdev, holder));
 #else
-	return (blkdev_put(bdev, vdev_bdev_mode(mode) | FMODE_EXCL));
+	return (blkdev_put(bdev, vdev_bdev_mode(mode, B_TRUE)));
 #endif
 }
 
@@ -248,9 +254,9 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 {
 	struct block_device *bdev;
 #ifdef HAVE_BLK_MODE_T
-	blk_mode_t mode = vdev_bdev_mode(spa_mode(v->vdev_spa));
+	blk_mode_t mode = vdev_bdev_mode(spa_mode(v->vdev_spa), B_FALSE);
 #else
-	fmode_t mode = vdev_bdev_mode(spa_mode(v->vdev_spa));
+	fmode_t mode = vdev_bdev_mode(spa_mode(v->vdev_spa), B_FALSE);
 #endif
 	hrtime_t timeout = MSEC2NSEC(zfs_vdev_open_timeout_ms);
 	vdev_disk_t *vd;


### PR DESCRIPTION
### Motivation and Context

See https://github.com/openzfs/zfs/pull/15099#issuecomment-1862766180

### Description

This is an alternate fix to #15688 which instead leverages an existing mechanism to check for the right flags.

### How Has This Been Tested?

Locally compiled.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
