### PR TITLE
[2.2] Linux 6.7 compat

### DIFF
--- a/config/kernel-current-time.m4
+++ b/config/kernel-current-time.m4
@@ -2,12 +2,15 @@ dnl #
 dnl # 4.9, current_time() added
 dnl # 4.18, return type changed from timespec to timespec64
 dnl #
+dnl # Note that we don't care about the return type in this check. If we have
+dnl # to implement a fallback, we'll know we're <4.9, which was timespec.
+dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_CURRENT_TIME], [
 	ZFS_LINUX_TEST_SRC([current_time], [
 		#include <linux/fs.h>
 	], [
 		struct inode ip __attribute__ ((unused));
-		ip.i_atime = current_time(&ip);
+		(void) current_time(&ip);
 	])
 ])
 

--- a/config/kernel-inode-times.m4
+++ b/config/kernel-inode-times.m4
@@ -52,6 +52,48 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_TIMES], [
 		memset(&ip, 0, sizeof(ip));
 		inode_set_ctime_to_ts(&ip, ts);
 	])
+
+	dnl #
+	dnl # 6.7 API change
+	dnl # i_atime/i_mtime no longer directly accessible, must use
+	dnl # inode_get_mtime(ip), inode_set_mtime*(ip) to
+	dnl # read/write.
+	dnl #
+	ZFS_LINUX_TEST_SRC([inode_get_atime], [
+		#include <linux/fs.h>
+	],[
+		struct inode ip;
+
+		memset(&ip, 0, sizeof(ip));
+		inode_get_atime(&ip);
+	])
+	ZFS_LINUX_TEST_SRC([inode_get_mtime], [
+		#include <linux/fs.h>
+	],[
+		struct inode ip;
+
+		memset(&ip, 0, sizeof(ip));
+		inode_get_mtime(&ip);
+	])
+
+	ZFS_LINUX_TEST_SRC([inode_set_atime_to_ts], [
+		#include <linux/fs.h>
+	],[
+		struct inode ip;
+		struct timespec64 ts = {0};
+
+		memset(&ip, 0, sizeof(ip));
+		inode_set_atime_to_ts(&ip, ts);
+	])
+	ZFS_LINUX_TEST_SRC([inode_set_mtime_to_ts], [
+		#include <linux/fs.h>
+	],[
+		struct inode ip;
+		struct timespec64 ts = {0};
+
+		memset(&ip, 0, sizeof(ip));
+		inode_set_mtime_to_ts(&ip, ts);
+	])
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_INODE_TIMES], [
@@ -87,6 +129,42 @@ AC_DEFUN([ZFS_AC_KERNEL_INODE_TIMES], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_INODE_SET_CTIME_TO_TS, 1,
 		    [inode_set_ctime_to_ts() exists in linux/fs.h])
+	],[
+		AC_MSG_RESULT(no)
+	])
+
+	AC_MSG_CHECKING([whether inode_get_atime() exists])
+	ZFS_LINUX_TEST_RESULT([inode_get_atime], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_INODE_GET_ATIME, 1,
+		    [inode_get_atime() exists in linux/fs.h])
+	],[
+		AC_MSG_RESULT(no)
+	])
+
+	AC_MSG_CHECKING([whether inode_set_atime_to_ts() exists])
+	ZFS_LINUX_TEST_RESULT([inode_set_atime_to_ts], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_INODE_SET_ATIME_TO_TS, 1,
+		    [inode_set_atime_to_ts() exists in linux/fs.h])
+	],[
+		AC_MSG_RESULT(no)
+	])
+
+	AC_MSG_CHECKING([whether inode_get_mtime() exists])
+	ZFS_LINUX_TEST_RESULT([inode_get_mtime], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_INODE_GET_MTIME, 1,
+		    [inode_get_mtime() exists in linux/fs.h])
+	],[
+		AC_MSG_RESULT(no)
+	])
+
+	AC_MSG_CHECKING([whether inode_set_mtime_to_ts() exists])
+	ZFS_LINUX_TEST_RESULT([inode_set_mtime_to_ts], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_INODE_SET_MTIME_TO_TS, 1,
+		    [inode_set_mtime_to_ts() exists in linux/fs.h])
 	],[
 		AC_MSG_RESULT(no)
 	])

--- a/config/kernel-shrink.m4
+++ b/config/kernel-shrink.m4
@@ -128,6 +128,25 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_SHRINKER_CALLBACK], [
 	])
 ])
 
+dnl #
+dnl # 6.7 API change
+dnl # register_shrinker has been replaced by shrinker_register.
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_SHRINKER_REGISTER], [
+	ZFS_LINUX_TEST_SRC([shrinker_register], [
+		#include <linux/shrinker.h>
+		unsigned long shrinker_cb(struct shrinker *shrink,
+		    struct shrink_control *sc) { return 0; }
+	],[
+		struct shrinker cache_shrinker = {
+			.count_objects = shrinker_cb,
+			.scan_objects = shrinker_cb,
+			.seeks = DEFAULT_SEEKS,
+		};
+		shrinker_register(&cache_shrinker);
+	])
+])
+
 AC_DEFUN([ZFS_AC_KERNEL_SHRINKER_CALLBACK],[
 	dnl #
 	dnl # 6.0 API change
@@ -165,14 +184,36 @@ AC_DEFUN([ZFS_AC_KERNEL_SHRINKER_CALLBACK],[
 			dnl # cs->shrink() is logically split in to
 			dnl # cs->count_objects() and cs->scan_objects()
 			dnl #
-			AC_MSG_CHECKING([if cs->count_objects callback exists])
+			AC_MSG_CHECKING(
+			    [whether cs->count_objects callback exists])
 			ZFS_LINUX_TEST_RESULT(
-				[shrinker_cb_shrink_control_split],[
-					AC_MSG_RESULT(yes)
-					AC_DEFINE(HAVE_SPLIT_SHRINKER_CALLBACK, 1,
-						[cs->count_objects exists])
+			    [shrinker_cb_shrink_control_split],[
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_SPLIT_SHRINKER_CALLBACK, 1,
+				    [cs->count_objects exists])
 			],[
+				AC_MSG_RESULT(no)
+
+				AC_MSG_CHECKING(
+				    [whether shrinker_register exists])
+				ZFS_LINUX_TEST_RESULT([shrinker_register], [
+					AC_MSG_RESULT(yes)
+					AC_DEFINE(HAVE_SHRINKER_REGISTER, 1,
+					    [shrinker_register exists])
+
+					dnl # We assume that the split shrinker
+					dnl # callback exists if
+					dnl # shrinker_register() exists,
+					dnl # because the latter is a much more
+					dnl # recent addition, and the macro
+					dnl # test for shrinker_register() only
+					dnl # works if the callback is split
+					AC_DEFINE(HAVE_SPLIT_SHRINKER_CALLBACK,
+					    1, [cs->count_objects exists])
+				],[
+					AC_MSG_RESULT(no)
 					ZFS_LINUX_TEST_ERROR([shrinker])
+				])
 			])
 		])
 	])
@@ -211,6 +252,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_SHRINKER], [
 	ZFS_AC_KERNEL_SRC_SHRINKER_CALLBACK
 	ZFS_AC_KERNEL_SRC_SHRINK_CONTROL_STRUCT
 	ZFS_AC_KERNEL_SRC_REGISTER_SHRINKER_VARARG
+	ZFS_AC_KERNEL_SRC_SHRINKER_REGISTER
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_SHRINKER], [

--- a/config/kernel-shrink.m4
+++ b/config/kernel-shrink.m4
@@ -19,12 +19,44 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_SUPER_BLOCK_S_SHRINK], [
 	],[])
 ])
 
+dnl #
+dnl # 6.7 API change
+dnl # s_shrink is now a pointer.
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_SUPER_BLOCK_S_SHRINK_PTR], [
+	ZFS_LINUX_TEST_SRC([super_block_s_shrink_ptr], [
+		#include <linux/fs.h>
+		unsigned long shrinker_cb(struct shrinker *shrink,
+		    struct shrink_control *sc) { return 0; }
+		static struct shrinker shrinker = {
+			.count_objects = shrinker_cb,
+			.scan_objects = shrinker_cb,
+			.seeks = DEFAULT_SEEKS,
+		};
+		static const struct super_block
+		    sb __attribute__ ((unused)) = {
+			.s_shrink = &shrinker,
+		};
+	],[])
+])
+
 AC_DEFUN([ZFS_AC_KERNEL_SUPER_BLOCK_S_SHRINK], [
 	AC_MSG_CHECKING([whether super_block has s_shrink])
 	ZFS_LINUX_TEST_RESULT([super_block_s_shrink], [
 		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_SUPER_BLOCK_S_SHRINK, 1,
+			[have super_block s_shrink])
 	],[
-		ZFS_LINUX_TEST_ERROR([sb->s_shrink()])
+		AC_MSG_RESULT(no)
+		AC_MSG_CHECKING([whether super_block has s_shrink pointer])
+		ZFS_LINUX_TEST_RESULT([super_block_s_shrink_ptr], [
+			AC_MSG_RESULT(yes)
+			AC_DEFINE(HAVE_SUPER_BLOCK_S_SHRINK_PTR, 1,
+				[have super_block s_shrink pointer])
+		],[
+			AC_MSG_RESULT(no)
+			ZFS_LINUX_TEST_ERROR([sb->s_shrink()])
+		])
 	])
 ])
 
@@ -174,6 +206,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SHRINK_CONTROL_STRUCT], [
 
 AC_DEFUN([ZFS_AC_KERNEL_SRC_SHRINKER], [
 	ZFS_AC_KERNEL_SRC_SUPER_BLOCK_S_SHRINK
+	ZFS_AC_KERNEL_SRC_SUPER_BLOCK_S_SHRINK_PTR
 	ZFS_AC_KERNEL_SRC_SHRINK_CONTROL_HAS_NID
 	ZFS_AC_KERNEL_SRC_SHRINKER_CALLBACK
 	ZFS_AC_KERNEL_SRC_SHRINK_CONTROL_STRUCT

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -273,5 +273,25 @@ extern long zpl_ioctl_fideduperange(struct file *filp, void *arg);
 #else
 #define	zpl_inode_set_ctime_to_ts(ip, ts)	(ip->i_ctime = ts)
 #endif
+#ifdef HAVE_INODE_GET_ATIME
+#define	zpl_inode_get_atime(ip)	inode_get_atime(ip)
+#else
+#define	zpl_inode_get_atime(ip)	(ip->i_atime)
+#endif
+#ifdef HAVE_INODE_SET_ATIME_TO_TS
+#define	zpl_inode_set_atime_to_ts(ip, ts)	inode_set_atime_to_ts(ip, ts)
+#else
+#define	zpl_inode_set_atime_to_ts(ip, ts)	(ip->i_atime = ts)
+#endif
+#ifdef HAVE_INODE_GET_MTIME
+#define	zpl_inode_get_mtime(ip)	inode_get_mtime(ip)
+#else
+#define	zpl_inode_get_mtime(ip)	(ip->i_mtime)
+#endif
+#ifdef HAVE_INODE_SET_MTIME_TO_TS
+#define	zpl_inode_set_mtime_to_ts(ip, ts)	inode_set_mtime_to_ts(ip, ts)
+#else
+#define	zpl_inode_set_mtime_to_ts(ip, ts)	(ip->i_mtime = ts)
+#endif
 
 #endif	/* _SYS_ZPL_H */

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -79,6 +79,7 @@ SPL_OBJS := \
 	spl-kstat.o \
 	spl-proc.o \
 	spl-procfs-list.o \
+	spl-shrinker.o \
 	spl-taskq.o \
 	spl-thread.o \
 	spl-trace.o \

--- a/module/os/linux/spl/spl-shrinker.c
+++ b/module/os/linux/spl/spl-shrinker.c
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
+ *  UCRL-CODE-235197
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Solaris Porting Layer (SPL) Shrinker Implementation.
+ */
+
+#include <sys/kmem.h>
+#include <sys/shrinker.h>
+
+#ifdef HAVE_SINGLE_SHRINKER_CALLBACK
+/* 3.0-3.11: single shrink() callback, which we wrap to carry both functions */
+struct spl_shrinker_wrap {
+	struct shrinker shrinker;
+	spl_shrinker_cb countfunc;
+	spl_shrinker_cb scanfunc;
+};
+
+static int
+spl_shrinker_single_cb(struct shrinker *shrinker, struct shrink_control *sc)
+{
+	struct spl_shrinker_wrap *sw = (struct spl_shrinker_wrap *)shrinker;
+
+	if (sc->nr_to_scan != 0)
+		(void) sw->scanfunc(&sw->shrinker, sc);
+	return (sw->countfunc(&sw->shrinker, sc));
+}
+#endif
+
+struct shrinker *
+spl_register_shrinker(const char *name, spl_shrinker_cb countfunc,
+    spl_shrinker_cb scanfunc, int seek_cost)
+{
+	struct shrinker *shrinker;
+
+	/* allocate shrinker */
+#if defined(HAVE_SHRINKER_REGISTER)
+	/* 6.7: kernel will allocate the shrinker for us */
+	shrinker = shrinker_alloc(0, name);
+#elif defined(HAVE_SPLIT_SHRINKER_CALLBACK)
+	/* 3.12-6.6: we allocate the shrinker  */
+	shrinker = kmem_zalloc(sizeof (struct shrinker), KM_SLEEP);
+#elif defined(HAVE_SINGLE_SHRINKER_CALLBACK)
+	/* 3.0-3.11: allocate a wrapper */
+	struct spl_shrinker_wrap *sw =
+	    kmem_zalloc(sizeof (struct spl_shrinker_wrap), KM_SLEEP);
+	shrinker = &sw->shrinker;
+#else
+	/* 2.x-2.6.22, or a newer shrinker API has been introduced. */
+#error "Unknown shrinker API"
+#endif
+
+	if (shrinker == NULL)
+		return (NULL);
+
+	/* set callbacks */
+#ifdef HAVE_SINGLE_SHRINKER_CALLBACK
+	sw->countfunc = countfunc;
+	sw->scanfunc = scanfunc;
+	shrinker->shrink = spl_shrinker_single_cb;
+#else
+	shrinker->count_objects = countfunc;
+	shrinker->scan_objects = scanfunc;
+#endif
+
+	/* set params */
+	shrinker->seeks = seek_cost;
+
+	/* register with kernel */
+#if defined(HAVE_SHRINKER_REGISTER)
+	shrinker_register(shrinker);
+#elif defined(HAVE_REGISTER_SHRINKER_VARARG)
+	register_shrinker(shrinker, name);
+#else
+	register_shrinker(shrinker);
+#endif
+
+	return (shrinker);
+}
+EXPORT_SYMBOL(spl_register_shrinker);
+
+void
+spl_unregister_shrinker(struct shrinker *shrinker)
+{
+#if defined(HAVE_SHRINKER_REGISTER)
+	shrinker_free(shrinker);
+#elif defined(HAVE_SPLIT_SHRINKER_CALLBACK)
+	unregister_shrinker(shrinker);
+	kmem_free(shrinker, sizeof (struct shrinker));
+#elif defined(HAVE_SINGLE_SHRINKER_CALLBACK)
+	unregister_shrinker(shrinker);
+	kmem_free(shrinker, sizeof (struct spl_shrinker_wrap));
+#else
+#error "Unknown shrinker API"
+#endif
+}
+EXPORT_SYMBOL(spl_unregister_shrinker);

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -520,8 +520,8 @@ zfsctl_inode_alloc(zfsvfs_t *zfsvfs, uint64_t id,
 	ip->i_uid = SUID_TO_KUID(0);
 	ip->i_gid = SGID_TO_KGID(0);
 	ip->i_blkbits = SPA_MINBLOCKSHIFT;
-	ip->i_atime = now;
-	ip->i_mtime = now;
+	zpl_inode_set_atime_to_ts(ip, now);
+	zpl_inode_set_mtime_to_ts(ip, now);
 	zpl_inode_set_ctime_to_ts(ip, now);
 	ip->i_fop = fops;
 	ip->i_op = ops;

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1240,12 +1240,18 @@ zfs_prune_aliases(zfsvfs_t *zfsvfs, unsigned long nr_to_scan)
  * and inode caches.  This can occur when the ARC needs to free meta data
  * blocks but can't because they are all pinned by entries in these caches.
  */
+#if defined(HAVE_SUPER_BLOCK_S_SHRINK)
+#define	S_SHRINK(sb)	(&(sb)->s_shrink)
+#elif defined(HAVE_SUPER_BLOCK_S_SHRINK_PTR)
+#define	S_SHRINK(sb)	((sb)->s_shrink)
+#endif
+
 int
 zfs_prune(struct super_block *sb, unsigned long nr_to_scan, int *objects)
 {
 	zfsvfs_t *zfsvfs = sb->s_fs_info;
 	int error = 0;
-	struct shrinker *shrinker = &sb->s_shrink;
+	struct shrinker *shrinker = S_SHRINK(sb);
 	struct shrink_control sc = {
 		.nr_to_scan = nr_to_scan,
 		.gfp_mask = GFP_KERNEL,
@@ -1257,7 +1263,7 @@ zfs_prune(struct super_block *sb, unsigned long nr_to_scan, int *objects)
 #if defined(HAVE_SPLIT_SHRINKER_CALLBACK) && \
 	defined(SHRINK_CONTROL_HAS_NID) && \
 	defined(SHRINKER_NUMA_AWARE)
-	if (sb->s_shrink.flags & SHRINKER_NUMA_AWARE) {
+	if (shrinker->flags & SHRINKER_NUMA_AWARE) {
 		*objects = 0;
 		for_each_online_node(sc.nid) {
 			*objects += (*shrinker->scan_objects)(shrinker, &sc);

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -2435,15 +2435,17 @@ top:
 
 	if ((mask & ATTR_ATIME) || zp->z_atime_dirty) {
 		zp->z_atime_dirty = B_FALSE;
-		ZFS_TIME_ENCODE(&ip->i_atime, atime);
+		inode_timespec_t tmp_atime;
+		ZFS_TIME_ENCODE(&tmp_atime, atime);
+		zpl_inode_set_atime_to_ts(ZTOI(zp), tmp_atime);
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_ATIME(zfsvfs), NULL,
 		    &atime, sizeof (atime));
 	}
 
 	if (mask & (ATTR_MTIME | ATTR_SIZE)) {
 		ZFS_TIME_ENCODE(&vap->va_mtime, mtime);
-		ZTOI(zp)->i_mtime = zpl_inode_timestamp_truncate(
-		    vap->va_mtime, ZTOI(zp));
+		zpl_inode_set_mtime_to_ts(ZTOI(zp),
+		    zpl_inode_timestamp_truncate(vap->va_mtime, ZTOI(zp)));
 
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(zfsvfs), NULL,
 		    mtime, sizeof (mtime));
@@ -3657,7 +3659,7 @@ zfs_putpage(struct inode *ip, struct page *pp, struct writeback_control *wbc,
 	caddr_t		va;
 	int		err = 0;
 	uint64_t	mtime[2], ctime[2];
-	inode_timespec_t tmp_ctime;
+	inode_timespec_t tmp_ts;
 	sa_bulk_attr_t	bulk[3];
 	int		cnt = 0;
 	struct address_space *mapping;
@@ -3821,9 +3823,10 @@ zfs_putpage(struct inode *ip, struct page *pp, struct writeback_control *wbc,
 	    &zp->z_pflags, 8);
 
 	/* Preserve the mtime and ctime provided by the inode */
-	ZFS_TIME_ENCODE(&ip->i_mtime, mtime);
-	tmp_ctime = zpl_inode_get_ctime(ip);
-	ZFS_TIME_ENCODE(&tmp_ctime, ctime);
+	tmp_ts = zpl_inode_get_mtime(ip);
+	ZFS_TIME_ENCODE(&tmp_ts, mtime);
+	tmp_ts = zpl_inode_get_ctime(ip);
+	ZFS_TIME_ENCODE(&tmp_ts, ctime);
 	zp->z_atime_dirty = B_FALSE;
 	zp->z_seq++;
 
@@ -3873,7 +3876,7 @@ zfs_dirty_inode(struct inode *ip, int flags)
 	zfsvfs_t	*zfsvfs = ITOZSB(ip);
 	dmu_tx_t	*tx;
 	uint64_t	mode, atime[2], mtime[2], ctime[2];
-	inode_timespec_t tmp_ctime;
+	inode_timespec_t tmp_ts;
 	sa_bulk_attr_t	bulk[4];
 	int		error = 0;
 	int		cnt = 0;
@@ -3918,10 +3921,12 @@ zfs_dirty_inode(struct inode *ip, int flags)
 	SA_ADD_BULK_ATTR(bulk, cnt, SA_ZPL_CTIME(zfsvfs), NULL, &ctime, 16);
 
 	/* Preserve the mode, mtime and ctime provided by the inode */
-	ZFS_TIME_ENCODE(&ip->i_atime, atime);
-	ZFS_TIME_ENCODE(&ip->i_mtime, mtime);
-	tmp_ctime = zpl_inode_get_ctime(ip);
-	ZFS_TIME_ENCODE(&tmp_ctime, ctime);
+	tmp_ts = zpl_inode_get_atime(ip);
+	ZFS_TIME_ENCODE(&tmp_ts, atime);
+	tmp_ts = zpl_inode_get_mtime(ip);
+	ZFS_TIME_ENCODE(&tmp_ts, mtime);
+	tmp_ts = zpl_inode_get_ctime(ip);
+	ZFS_TIME_ENCODE(&tmp_ts, ctime);
 	mode = ip->i_mode;
 
 	zp->z_mode = mode;
@@ -3964,7 +3969,9 @@ zfs_inactive(struct inode *ip)
 		if (error) {
 			dmu_tx_abort(tx);
 		} else {
-			ZFS_TIME_ENCODE(&ip->i_atime, atime);
+			inode_timespec_t tmp_atime;
+			tmp_atime = zpl_inode_get_atime(ip);
+			ZFS_TIME_ENCODE(&tmp_atime, atime);
 			mutex_enter(&zp->z_lock);
 			(void) sa_update(zp->z_sa_hdl, SA_ZPL_ATIME(zfsvfs),
 			    (void *)&atime, sizeof (atime), tx);

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -526,7 +526,8 @@ zpl_setattr(struct dentry *dentry, struct iattr *ia)
 	vap->va_ctime = ia->ia_ctime;
 
 	if (vap->va_mask & ATTR_ATIME)
-		ip->i_atime = zpl_inode_timestamp_truncate(ia->ia_atime, ip);
+		zpl_inode_set_atime_to_ts(ip,
+		    zpl_inode_timestamp_truncate(ia->ia_atime, ip));
 
 	cookie = spl_fstrans_mark();
 #ifdef HAVE_USERNS_IOPS_SETATTR


### PR DESCRIPTION
### Motivation and Context

Backport #15681 to 2.2.

Upcoming Linux 6.7 release will change a couple of interfaces. Adapt or die!

### Description

Adjusts for three changes:
- `i_atime` and `i_mtime` in `struct inode` are no longer directly accessible, but must use accessor functions
- `s_shrink` in `struct super_block` is now a pointer rather than an embedded struct
- The "shrinker" (ie inode reclaim) API has changed, such that the kernel now allocates shrinkers dynamically rather than allowing a static shrinker to be registered.

### How Has This Been Tested?

This version compiled checked against 6.7-rc6 and 5.10.170. Assuming its fine elsewhere based on testing in #15681.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
