### PR TITLE
Fix the FreeBSD userspace build

### DIFF
--- a/cmd/zpool/os/freebsd/zpool_vdev_os.c
+++ b/cmd/zpool/os/freebsd/zpool_vdev_os.c
@@ -128,6 +128,9 @@ check_file(const char *file, boolean_t force, boolean_t isspare)
 int
 zpool_power_current_state(zpool_handle_t *zhp, char *vdev)
 {
+
+	(void) zhp;
+	(void) vdev;
 	/* Enclosure slot power not supported on FreeBSD yet */
 	return (-1);
 }
@@ -135,6 +138,10 @@ zpool_power_current_state(zpool_handle_t *zhp, char *vdev)
 int
 zpool_power(zpool_handle_t *zhp, char *vdev, boolean_t turn_on)
 {
+
+	(void) zhp;
+	(void) vdev;
+	(void) turn_on;
 	/* Enclosure slot power not supported on FreeBSD yet */
 	return (ENOTSUP);
 }

--- a/lib/libzutil/os/freebsd/zutil_import_os.c
+++ b/lib/libzutil/os/freebsd/zutil_import_os.c
@@ -263,3 +263,11 @@ update_vdevs_config_dev_sysfs_path(nvlist_t *config)
 {
 	(void) config;
 }
+
+int
+zpool_disk_wait(const char *path)
+{
+
+	(void) path;
+	return (ENOTSUP);
+}


### PR DESCRIPTION
Fix a couple of build breaks I hit when building zfs locally on FreeBSD.

### Motivation and Context
OpenZFS should build on FreeBSD.

### Description
Address a warning about unused parameters, and add a stub implementation of `zpool_disk_wait()`.

### How Has This Been Tested?
Build testing only.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
