### PR TITLE
spa: Fix FreeBSD sysctl handlers

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1392,7 +1392,7 @@ spa_taskq_param_set(zio_type_t t, char *cfg)
 }
 
 static int
-spa_taskq_param_get(zio_type_t t, char *buf)
+spa_taskq_param_get(zio_type_t t, char *buf, boolean_t add_newline)
 {
 	int pos = 0;
 
@@ -1410,7 +1410,8 @@ spa_taskq_param_get(zio_type_t t, char *buf)
 		sep = " ";
 	}
 
-	buf[pos++] = '\n';
+	if (add_newline)
+		buf[pos++] = '\n';
 	buf[pos] = '\0';
 
 	return (pos);
@@ -1428,7 +1429,7 @@ spa_taskq_read_param_set(const char *val, zfs_kernel_param_t *kp)
 static int
 spa_taskq_read_param_get(char *buf, zfs_kernel_param_t *kp)
 {
-	return (spa_taskq_param_get(ZIO_TYPE_READ, buf));
+	return (spa_taskq_param_get(ZIO_TYPE_READ, buf, TRUE));
 }
 
 static int
@@ -1442,7 +1443,7 @@ spa_taskq_write_param_set(const char *val, zfs_kernel_param_t *kp)
 static int
 spa_taskq_write_param_get(char *buf, zfs_kernel_param_t *kp)
 {
-	return (spa_taskq_param_get(ZIO_TYPE_WRITE, buf));
+	return (spa_taskq_param_get(ZIO_TYPE_WRITE, buf, TRUE));
 }
 #else
 /*
@@ -1457,7 +1458,7 @@ spa_taskq_read_param(ZFS_MODULE_PARAM_ARGS)
 	char buf[SPA_TASKQ_PARAM_MAX];
 	int err;
 
-	(void) spa_taskq_param_get(ZIO_TYPE_READ, buf);
+	(void) spa_taskq_param_get(ZIO_TYPE_READ, buf, FALSE);
 	err = sysctl_handle_string(oidp, buf, sizeof (buf), req);
 	if (err || req->newptr == NULL)
 		return (err);
@@ -1470,7 +1471,7 @@ spa_taskq_write_param(ZFS_MODULE_PARAM_ARGS)
 	char buf[SPA_TASKQ_PARAM_MAX];
 	int err;
 
-	(void) spa_taskq_param_get(ZIO_TYPE_WRITE, buf);
+	(void) spa_taskq_param_get(ZIO_TYPE_WRITE, buf, FALSE);
 	err = sysctl_handle_string(oidp, buf, sizeof (buf), req);
 	if (err || req->newptr == NULL)
 		return (err);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1445,8 +1445,6 @@ spa_taskq_write_param_get(char *buf, zfs_kernel_param_t *kp)
 	return (spa_taskq_param_get(ZIO_TYPE_WRITE, buf));
 }
 #else
-#include <sys/sbuf.h>
-
 /*
  * On FreeBSD load-time parameters can be set up before malloc() is available,
  * so we have to do all the parsing work on the stack.
@@ -1457,19 +1455,11 @@ static int
 spa_taskq_read_param(ZFS_MODULE_PARAM_ARGS)
 {
 	char buf[SPA_TASKQ_PARAM_MAX];
-	int err = 0;
+	int err;
 
-	if (req->newptr == NULL) {
-		int len = spa_taskq_param_get(ZIO_TYPE_READ, buf);
-		struct sbuf *s = sbuf_new_for_sysctl(NULL, NULL, len+1, req);
-		sbuf_cpy(s, buf);
-		err = sbuf_finish(s);
-		sbuf_delete(s);
-		return (err);
-	}
-
+	(void) spa_taskq_param_get(ZIO_TYPE_READ, buf);
 	err = sysctl_handle_string(oidp, buf, sizeof (buf), req);
-	if (err)
+	if (err || req->newptr == NULL)
 		return (err);
 	return (spa_taskq_param_set(ZIO_TYPE_READ, buf));
 }
@@ -1478,19 +1468,11 @@ static int
 spa_taskq_write_param(ZFS_MODULE_PARAM_ARGS)
 {
 	char buf[SPA_TASKQ_PARAM_MAX];
-	int err = 0;
+	int err;
 
-	if (req->newptr == NULL) {
-		int len = spa_taskq_param_get(ZIO_TYPE_WRITE, buf);
-		struct sbuf *s = sbuf_new_for_sysctl(NULL, NULL, len+1, req);
-		sbuf_cpy(s, buf);
-		err = sbuf_finish(s);
-		sbuf_delete(s);
-		return (err);
-	}
-
+	(void) spa_taskq_param_get(ZIO_TYPE_WRITE, buf);
 	err = sysctl_handle_string(oidp, buf, sizeof (buf), req);
-	if (err)
+	if (err || req->newptr == NULL)
 		return (err);
 	return (spa_taskq_param_set(ZIO_TYPE_WRITE, buf));
 }


### PR DESCRIPTION
The change fixes a misuse of FreeBSD's sbuf API which triggers an assertion failure in debug kernels.

### Motivation and Context
The patch fixes the panic reported here: https://lists.freebsd.org/archives/freebsd-fs/2023-December/002943.html

### Description
We can allocate the sbuf on the stack and use the buffer that we want to return instead of allocating a copy. This is simpler and more efficient, and avoids the bug.

### How Has This Been Tested?
I reproduced the panic and verified that it is gone after this patch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
