### PR TITLE
Fix Uberblock Label and Path Handling Issues related to AUX vdevs

### DIFF
--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -278,6 +278,7 @@ struct spa {
 
 	spa_aux_vdev_t	spa_spares;		/* hot spares */
 	spa_aux_vdev_t	spa_l2cache;		/* L2ARC cache devices */
+	boolean_t	spa_aux_sync_uber;	/* need to sync aux uber */
 	nvlist_t	*spa_label_features;	/* Features for reading MOS */
 	uint64_t	spa_config_object;	/* MOS object for pool config */
 	uint64_t	spa_config_generation;	/* config generation number */

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -1210,13 +1210,26 @@ label_paths(libpc_handle_t *hdl, nvlist_t *label, const char **path,
 	nvlist_t *nvroot;
 	uint64_t pool_guid;
 	uint64_t vdev_guid;
+	uint64_t state;
 
 	*path = NULL;
 	*devid = NULL;
+	if (nvlist_lookup_uint64(label, ZPOOL_CONFIG_GUID, &vdev_guid) != 0)
+		return (ENOENT);
+
+	/*
+	 * In case of spare or l2cache, we directly return path/devid from the
+	 * label.
+	 */
+	if (!(nvlist_lookup_uint64(label, ZPOOL_CONFIG_POOL_STATE, &state)) &&
+	    (state == POOL_STATE_SPARE || state == POOL_STATE_L2CACHE)) {
+		(void) nvlist_lookup_string(label, ZPOOL_CONFIG_PATH, path);
+		(void) nvlist_lookup_string(label, ZPOOL_CONFIG_DEVID, devid);
+		return (0);
+	}
 
 	if (nvlist_lookup_nvlist(label, ZPOOL_CONFIG_VDEV_TREE, &nvroot) ||
-	    nvlist_lookup_uint64(label, ZPOOL_CONFIG_POOL_GUID, &pool_guid) ||
-	    nvlist_lookup_uint64(label, ZPOOL_CONFIG_GUID, &vdev_guid))
+	    nvlist_lookup_uint64(label, ZPOOL_CONFIG_POOL_GUID, &pool_guid))
 		return (ENOENT);
 
 	return (label_paths_impl(hdl, nvroot, pool_guid, vdev_guid, path,

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -1031,6 +1031,10 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 	int error;
 	uint64_t spare_guid = 0, l2cache_guid = 0;
 	int flags = ZIO_FLAG_CONFIG_WRITER | ZIO_FLAG_CANFAIL;
+	boolean_t reason_spare = (reason == VDEV_LABEL_SPARE || (reason ==
+	    VDEV_LABEL_REMOVE && vd->vdev_isspare));
+	boolean_t reason_l2cache = (reason == VDEV_LABEL_L2CACHE || (reason ==
+	    VDEV_LABEL_REMOVE && vd->vdev_isl2cache));
 
 	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
 
@@ -1116,34 +1120,20 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 	 * really part of an active pool just yet.  The labels will
 	 * be written again with a meaningful txg by spa_sync().
 	 */
-	if (reason == VDEV_LABEL_SPARE ||
-	    (reason == VDEV_LABEL_REMOVE && vd->vdev_isspare)) {
+	if (reason_spare || reason_l2cache) {
 		/*
-		 * For inactive hot spares, we generate a special label that
-		 * identifies as a mutually shared hot spare.  We write the
-		 * label if we are adding a hot spare, or if we are removing an
-		 * active hot spare (in which case we want to revert the
-		 * labels).
+		 * For inactive hot spares and level 2 ARC devices, we generate
+		 * a special label that identifies as a mutually shared hot
+		 * spare or l2cache device. We write the label in case of
+		 * addition or removal of hot spare or l2cache vdev (in which
+		 * case we want to revert the labels).
 		 */
 		VERIFY(nvlist_alloc(&label, NV_UNIQUE_NAME, KM_SLEEP) == 0);
 
 		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_VERSION,
 		    spa_version(spa)) == 0);
 		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_POOL_STATE,
-		    POOL_STATE_SPARE) == 0);
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_GUID,
-		    vd->vdev_guid) == 0);
-	} else if (reason == VDEV_LABEL_L2CACHE ||
-	    (reason == VDEV_LABEL_REMOVE && vd->vdev_isl2cache)) {
-		/*
-		 * For level 2 ARC devices, add a special label.
-		 */
-		VERIFY(nvlist_alloc(&label, NV_UNIQUE_NAME, KM_SLEEP) == 0);
-
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_VERSION,
-		    spa_version(spa)) == 0);
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_POOL_STATE,
-		    POOL_STATE_L2CACHE) == 0);
+		    reason_spare ? POOL_STATE_SPARE : POOL_STATE_L2CACHE) == 0);
 		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_GUID,
 		    vd->vdev_guid) == 0);
 
@@ -1154,8 +1144,26 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 		 * spa->spa_l2cache->sav_config (populated in
 		 * spa_ld_open_aux_vdevs()).
 		 */
-		VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_ASHIFT,
-		    vd->vdev_ashift) == 0);
+		if (reason_l2cache) {
+			VERIFY(nvlist_add_uint64(label, ZPOOL_CONFIG_ASHIFT,
+			    vd->vdev_ashift) == 0);
+		}
+
+		/*
+		 * Add path information to help find it during pool import
+		 */
+		if (vd->vdev_path != NULL) {
+			VERIFY(nvlist_add_string(label, ZPOOL_CONFIG_PATH,
+			    vd->vdev_path) == 0);
+		}
+		if (vd->vdev_devid != NULL) {
+			VERIFY(nvlist_add_string(label, ZPOOL_CONFIG_DEVID,
+			    vd->vdev_devid) == 0);
+		}
+		if (vd->vdev_physpath != NULL) {
+			VERIFY(nvlist_add_string(label, ZPOOL_CONFIG_PHYS_PATH,
+			    vd->vdev_physpath) == 0);
+		}
 
 		/*
 		 * When spare or l2cache (aux) vdev is added during pool


### PR DESCRIPTION
This PR addresses three similar issues for AUX vdevs:
* Ensure uberblock label always dumped: When spare or l2cache (aux) vdev is added during pool creation, spa->spa_uberblock is not dumped until that point. Subsequently, the aux label is never synchronized after its initial creation, resulting in the uberblock label remaining undumped. The uberblock is crucial for lib_blkid in identifying the ZFS partition type. To address this issue, we now ensure sync of the uberblock label once if it's not dumped initially.
* Extend aux label to add path information: Pool import logic uses vdev paths, so it makes sense to add path information on AUX vdev as well.
* Add path handling for aux vdevs in label_path: If the AUX vdev is added using UUID, importing the pool falls back AUX vdev to open it with disk name instead of UUID due to the absence of path information for AUX vdevs previously. Since AUX label now have path information, this PR adds path handling for it in `label_path`.

### How Has This Been Tested?

1. **Uberblock label issue (Used by libblkid to identify zfs partition type)**

Before this patch
```
# zpool create tank sdb spare sdc
# dd if=/dev/sdc1 bs=256K count=1 | hexdump -C -v | grep "0c b1 ba"
# udevadm info /dev/sdc1 | grep zfs_member
```

After this patch:
```
# zpool create tank sdb spare sdc
# dd if=/dev/sdc1 bs=256K count=1 | hexdump -C -v | grep "0c b1 ba"
00021000  0c b1 ba 00 00 00 00 00  88 13 00 00 00 00 00 00  |................|
# udevadm info /dev/sdc1 | grep zfs_member
E: ID_FS_TYPE=zfs_member
```

2. **Extended AUX label**

Before the patch
```
# zdb -l /dev/sdc1
------------------------------------
LABEL 0 
------------------------------------
    version: 5000
    state: 3
    guid: 15986349143942038035
    labels = 0 1 2 3 
```
After the patch:
```
# zdb -l /dev/sdc1
------------------------------------
LABEL 0 
------------------------------------
    version: 5000
    state: 3
    guid: 15986349143942038035
    path: '/dev/sdc1'
    devid: 'scsi-0QEMU_QEMU_HARDDISK_drive4-part1'
    phys_path: 'pci-0000:00:05.0-scsi-0:0:1:1'
    labels = 0 1 2 3 
```

3. **Issue with AUX UUID during pool import**

Before the patch:
```
# zpool create tank 59768b84-1aea-b649-82f8-e837a54be4ff
# zpool add tank spare 2e0105d0-f092-1f43-bb14-52d1e858116f
# zpool status
  pool: tank
 state: ONLINE
config:
	NAME                                    STATE     READ WRITE CKSUM
	tank                                    ONLINE       0     0     0
	  59768b84-1aea-b649-82f8-e837a54be4ff  ONLINE       0     0     0
	spares
	  2e0105d0-f092-1f43-bb14-52d1e858116f  AVAIL   
# zpool export tank
# zpool import tank
# zpool status
  pool: tank
 state: ONLINE
config:
	NAME                                    STATE     READ WRITE CKSUM
	tank                                    ONLINE       0     0     0
	  59768b84-1aea-b649-82f8-e837a54be4ff  ONLINE       0     0     0
	spares
	  sdc  AVAIL   
```
After the patch:
```
# zpool create tank 59768b84-1aea-b649-82f8-e837a54be4ff
# zpool add tank spare 2e0105d0-f092-1f43-bb14-52d1e858116f
# zpool status
  pool: tank
 state: ONLINE
config:
	NAME                                    STATE     READ WRITE CKSUM
	tank                                    ONLINE       0     0     0
	  59768b84-1aea-b649-82f8-e837a54be4ff  ONLINE       0     0     0
	spares
	  2e0105d0-f092-1f43-bb14-52d1e858116f  AVAIL   
# zpool export tank
# zpool import tank
# zpool status
  pool: tank
 state: ONLINE
config:
	NAME                                    STATE     READ WRITE CKSUM
	tank                                    ONLINE       0     0     0
	  59768b84-1aea-b649-82f8-e837a54be4ff  ONLINE       0     0     0
	spares
	  2e0105d0-f092-1f43-bb14-52d1e858116f  AVAIL   
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
