### PR TITLE
zfs-kmod.spec: preserve signature in linux kmod built by make rpm-kmod

### DIFF
--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -150,6 +150,30 @@ for kernel_version in %{?kernel_versions}; do
 done
 
 
+# Module signing (modsign)
+#
+# This must be run _after_ find-debuginfo.sh runs, otherwise that will strip
+# the signature off of the modules.
+# (Based on Fedora's kernel.spec workaround)
+%define __modsign_install_post \
+    sign_pem="%{ksrc}/certs/signing_key.pem"; \
+    sign_x509="%{ksrc}/certs/signing_key.x509"; \
+    if [ -f "${sign_x509}" ]\
+    then \
+        echo "Signing kernel modules ..."; \
+        for kmod in $(find ${RPM_BUILD_ROOT}%{kmodinstdir_prefix}/*/extra/ -name \*.ko); do \
+            %{ksrc}/scripts/sign-file sha256 ${sign_pem} ${sign_x509} ${kmod}; \
+        done \
+    fi \
+%{nil}
+
+# hack to ensure signing happens after find-debuginfo.sh runs
+%define __spec_install_post \
+    %{?__debug_package:%{__debug_install_post}}\
+    %{__arch_install_post}\
+    %{__os_install_post}\
+    %{__modsign_install_post}
+
 %install
 rm -rf ${RPM_BUILD_ROOT}
 

--- a/rpm/redhat/zfs-kmod.spec.in
+++ b/rpm/redhat/zfs-kmod.spec.in
@@ -72,6 +72,30 @@ fi
         %{?kernel_llvm}
 make %{?_smp_mflags}
 
+# Module signing (modsign)
+#
+# This must be run _after_ find-debuginfo.sh runs, otherwise that will strip
+# the signature off of the modules.
+# (Based on Fedora's kernel.spec workaround)
+%define __modsign_install_post \
+        sign_pem="%{ksrc}/certs/signing_key.pem"; \
+        sign_x509="%{ksrc}/certs/signing_key.x509"; \
+        if [ -f "${sign_x509}" ]\
+        then \
+            echo "Signing kernel modules ..."; \
+            for kmod in $(find %{buildroot}/lib/modules/%{kverrel}/extra/ -name \*.ko); do \
+                    %{ksrc}/scripts/sign-file sha256 ${sign_pem} ${sign_x509} ${kmod}; \
+            done \
+        fi \
+%{nil}
+
+# hack to ensure signing happens after find-debuginfo.sh runs
+%define __spec_install_post \
+        %{?__debug_package:%{__debug_install_post}}\
+        %{__arch_install_post}\
+        %{__os_install_post}\
+        %{__modsign_install_post}
+
 %install
 make install \
         DESTDIR=${RPM_BUILD_ROOT} \


### PR DESCRIPTION
### Motivation and Context
When the linux kernel source tree is configured with a signing key and certificate, kmods are automatically signed. So, if properly configured, one would expect the existing zfs `make rpm-kmod` to result in rpms which contain signed spl.ko and zfs.ko kmods. However, because of a known issue with the rpm build process, when rpmbuild strips debug symbols from binaries, it also strips signatures. 
This PR corrects that issue, ensuring that signing occurs after the debug symbols and signatures are stripped, thus providing rpms with signed kmods.

### Description
This is an rpm spec, packaging-only change. It provides rpm spec macros to sign the zfs and spl kmods as the final step after the %install scriptlet. This is needed since the find-debuginfo.sh script strips out debug symbols plus signatures.

Kernel module signing only occurs when the required files are present as typically required in the linux source tree:
- certs/signing_key.pem
- certs/signing_key.x509

This method for overriding the default __spec_install_post macro is inspired by (and largely copied from) the Fedora kernel.spec.

### How Has This Been Tested?
This has been tested in both Fedora 39 and AlmaLinux 9 x86_64 container image environments. 

With all typical build requirements for linux kernel, zfs, and rpm per [the docs](https://openzfs.github.io/openzfs-docs/Developer%20Resources/Custom%20Packages.html#kmod), `make rpm-kmod` was executed with and without the expected signing_key pair. 

As expected, when the signing_key was present, the resulting `kmod-zfs-VERSION.rpm` contained kmods with a signature:
```
bash-5.2# modinfo zfs.ko|grep sign
signer:         Default Company Ltd
signature:      11:F7:64:99:0F:8D:FD:DC:92:DC:59:5B:E9:BE:FC:D4:E1:04:00:27:
bash-5.2# 
```
Also as expected, when the signing_key was absent, no signature was found on the kmods in the resulting rpm:
```
bash-5.2# modinfo zfs.ko|grep sign
bash-5.2# 
```

In the Fedora test, I have also loaded the signed kmod into the kernel and used it.

Note: by default `./configure` in the above case uses the `generic` rpm spec.

On AlmaLinux 9, the same test was performed using `./configure --with-spec=redhat` in order to test the build of a kABI tracking kmod.

The same, expected results were found.


Since this is a rpm packaging-only change, this should not effect any other code area.
 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
