### PR TITLE
Fix "out of memory" error

### DIFF
--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -291,10 +291,8 @@ zpool_in_use(libzfs_handle_t *hdl, int fd, pool_state_t *state, char **namestr,
 
 	*inuse = B_FALSE;
 
-	if (zpool_read_label(fd, &config, NULL) != 0) {
-		(void) no_memory(hdl);
+	if (zpool_read_label(fd, &config, NULL) != 0)
 		return (-1);
-	}
 
 	if (config == NULL)
 		return (0);

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -1056,9 +1056,20 @@ zpool_read_label(int fd, nvlist_t **config, int *num_labels)
 				case EINVAL:
 					break;
 				case EINPROGRESS:
-					// This shouldn't be possible to
-					// encounter, die if we do.
+					/*
+					 * This shouldn't be possible to
+					 * encounter, die if we do.
+					 */
 					ASSERT(B_FALSE);
+					zfs_fallthrough;
+				case EREMOTEIO:
+					/*
+					 * May be returned by an NVMe device
+					 * which is visible in /dev/ but due
+					 * to a low-level format change, or
+					 * other error, needs to be rescanned.
+					 * Try the slow method.
+					 */
 					zfs_fallthrough;
 				case EOPNOTSUPP:
 				case ENOSYS:


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/issues/13538#issuecomment-1837552799.  We're being a bit to aggressive about aborting immediately in `zpool_in_use()` when the label can't be read.  It turns out we can safely relax this.  In fact, it's not unlikely that on `zpool create` a scsi rescan will be triggered when partitioning the device which will resolve the issue.
 
### Description

Drop the no_memory() call from zpool_in_use() when reading the label fails and instead return the error to the caller.  This prevents a misleading "internal error: out of memory" error when the label can't be read.  This will result in is_spare() returning B_FALSE instead of aborting, which is already safely handled.

Furthermore, on Linux it's possible for EREMOTEIO to returned by an NVMe device if the device has been low-level formatted and not rescanned.  In this case we want to fallback to the legacy scanning method and read any of the labels we can.

### How Has This Been Tested?

Locally commented out the `no_memory()` call on a system with an NVMe device returning EREMOTEIO.  During `zpool create` a rescan was correctly triggered when the device was repartitioned resolving the issue.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
