### PR TITLE
[2.2] freebsd: spa taskq config fixes

### DIFF
--- a/include/os/freebsd/spl/sys/mod_os.h
+++ b/include/os/freebsd/spl/sys/mod_os.h
@@ -91,6 +91,12 @@
 #define	param_set_max_auto_ashift_args(var) \
     CTLTYPE_UINT, NULL, 0, param_set_max_auto_ashift, "IU"
 
+#define	spa_taskq_read_param_set_args(var) \
+    CTLTYPE_STRING, NULL, 0, spa_taskq_read_param, "A"
+
+#define	spa_taskq_write_param_set_args(var) \
+    CTLTYPE_STRING, NULL, 0, spa_taskq_write_param, "A"
+
 #define	fletcher_4_param_set_args(var) \
     CTLTYPE_STRING, NULL, 0, fletcher_4_param, "A"
 

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1398,8 +1398,6 @@ spa_taskq_write_param_get(char *buf, zfs_kernel_param_t *kp)
 	return (spa_taskq_param_get(ZIO_TYPE_WRITE, buf));
 }
 #else
-#include <sys/sbuf.h>
-
 /*
  * On FreeBSD load-time parameters can be set up before malloc() is available,
  * so we have to do all the parsing work on the stack.
@@ -1410,19 +1408,11 @@ static int
 spa_taskq_read_param(ZFS_MODULE_PARAM_ARGS)
 {
 	char buf[SPA_TASKQ_PARAM_MAX];
-	int err = 0;
+	int err;
 
-	if (req->newptr == NULL) {
-		int len = spa_taskq_param_get(ZIO_TYPE_READ, buf);
-		struct sbuf *s = sbuf_new_for_sysctl(NULL, NULL, len+1, req);
-		sbuf_cpy(s, buf);
-		err = sbuf_finish(s);
-		sbuf_delete(s);
-		return (err);
-	}
-
+	(void) spa_taskq_param_get(ZIO_TYPE_READ, buf);
 	err = sysctl_handle_string(oidp, buf, sizeof (buf), req);
-	if (err)
+	if (err || req->newptr == NULL)
 		return (err);
 	return (spa_taskq_param_set(ZIO_TYPE_READ, buf));
 }
@@ -1431,19 +1421,11 @@ static int
 spa_taskq_write_param(ZFS_MODULE_PARAM_ARGS)
 {
 	char buf[SPA_TASKQ_PARAM_MAX];
-	int err = 0;
+	int err;
 
-	if (req->newptr == NULL) {
-		int len = spa_taskq_param_get(ZIO_TYPE_WRITE, buf);
-		struct sbuf *s = sbuf_new_for_sysctl(NULL, NULL, len+1, req);
-		sbuf_cpy(s, buf);
-		err = sbuf_finish(s);
-		sbuf_delete(s);
-		return (err);
-	}
-
+	(void) spa_taskq_param_get(ZIO_TYPE_WRITE, buf);
 	err = sysctl_handle_string(oidp, buf, sizeof (buf), req);
-	if (err)
+	if (err || req->newptr == NULL)
 		return (err);
 	return (spa_taskq_param_set(ZIO_TYPE_WRITE, buf));
 }

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1345,7 +1345,7 @@ spa_taskq_param_set(zio_type_t t, char *cfg)
 }
 
 static int
-spa_taskq_param_get(zio_type_t t, char *buf)
+spa_taskq_param_get(zio_type_t t, char *buf, boolean_t add_newline)
 {
 	int pos = 0;
 
@@ -1363,7 +1363,8 @@ spa_taskq_param_get(zio_type_t t, char *buf)
 		sep = " ";
 	}
 
-	buf[pos++] = '\n';
+	if (add_newline)
+		buf[pos++] = '\n';
 	buf[pos] = '\0';
 
 	return (pos);
@@ -1381,7 +1382,7 @@ spa_taskq_read_param_set(const char *val, zfs_kernel_param_t *kp)
 static int
 spa_taskq_read_param_get(char *buf, zfs_kernel_param_t *kp)
 {
-	return (spa_taskq_param_get(ZIO_TYPE_READ, buf));
+	return (spa_taskq_param_get(ZIO_TYPE_READ, buf, TRUE));
 }
 
 static int
@@ -1395,7 +1396,7 @@ spa_taskq_write_param_set(const char *val, zfs_kernel_param_t *kp)
 static int
 spa_taskq_write_param_get(char *buf, zfs_kernel_param_t *kp)
 {
-	return (spa_taskq_param_get(ZIO_TYPE_WRITE, buf));
+	return (spa_taskq_param_get(ZIO_TYPE_WRITE, buf, TRUE));
 }
 #else
 /*
@@ -1410,7 +1411,7 @@ spa_taskq_read_param(ZFS_MODULE_PARAM_ARGS)
 	char buf[SPA_TASKQ_PARAM_MAX];
 	int err;
 
-	(void) spa_taskq_param_get(ZIO_TYPE_READ, buf);
+	(void) spa_taskq_param_get(ZIO_TYPE_READ, buf, FALSE);
 	err = sysctl_handle_string(oidp, buf, sizeof (buf), req);
 	if (err || req->newptr == NULL)
 		return (err);
@@ -1423,7 +1424,7 @@ spa_taskq_write_param(ZFS_MODULE_PARAM_ARGS)
 	char buf[SPA_TASKQ_PARAM_MAX];
 	int err;
 
-	(void) spa_taskq_param_get(ZIO_TYPE_WRITE, buf);
+	(void) spa_taskq_param_get(ZIO_TYPE_WRITE, buf, FALSE);
 	err = sysctl_handle_string(oidp, buf, sizeof (buf), req);
 	if (err || req->newptr == NULL)
 		return (err);


### PR DESCRIPTION
### Motivation and Context

#15753 reports `zfs-2.2.3-staging` doesn't compile. I screwed up backporting #15675 in #15695 and missed one change.

Closes #15753.

### Description

Adds the missing change. Also backports #15719, which is approved and I was planning to backport as soon as it landed.

### How Has This Been Tested?

Compile checked on Linux and FreeBSD.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
