### PR TITLE
Make sure all necessary RPM path macros are defined

### DIFF
--- a/config/rpm.am
+++ b/config/rpm.am
@@ -83,6 +83,11 @@ srpm-common:
 		rpm-local || exit 1; \
 	LANG=C $(RPMBUILD) \
 		--define "_tmppath $$rpmbuild/TMP" \
+		--define "_builddir $$rpmbuild/BUILD" \
+		--define "_rpmdir $$rpmbuild/RPMS" \
+		--define "_srcrpmdir $$rpmbuild/SRPMS" \
+		--define "_specdir $$rpmbuild/SPECS" \
+		--define "_sourcedir $$rpmbuild/SOURCES" \
 		--define "_topdir $$rpmbuild" \
 		$(def) -bs $$rpmbuild/SPECS/$$rpmspec || exit 1; \
 	cp $$rpmbuild/SRPMS/$$rpmpkg . || exit 1; \
@@ -99,6 +104,11 @@ rpm-common:
 		rpm-local || exit 1; \
 	LANG=C ${RPMBUILD} \
 		--define "_tmppath $$rpmbuild/TMP" \
+		--define "_builddir $$rpmbuild/BUILD" \
+		--define "_rpmdir $$rpmbuild/RPMS" \
+		--define "_srcrpmdir $$rpmbuild/SRPMS" \
+		--define "_specdir $$rpmbuild/SPECS" \
+		--define "_sourcedir $$rpmbuild/SOURCES" \
 		--define "_topdir $$rpmbuild" \
 		$(def) --rebuild $$rpmpkg || exit 1; \
 	cp $$rpmbuild/RPMS/*/* . || exit 1; \


### PR DESCRIPTION
### Motivation and Context

When building (s)rpm files through the Makefile, a directory structure is created in /tmp to hold the various files.

In case the user running the command has overridden some of the RPM path settings through their user profile (for example in `~/.rpmmacros`), these paths do not line up with the configuration, and the build fails.

Make sure all paths used are properly defined.

### How Has This Been Tested?
1) As a user, create a `~/.rpmmacros` file with the following content (as an example):
```
%_topdir                %(echo $HOME)/rpmbuild
%_tmppath               %{_topdir}/TEMP
%_builddir              %{_tmppath}/BUILD

%_rpmtopdir             %{_topdir}/RPM/%{name}
%_sourcedir             %{_rpmtopdir}
%_specdir               %{_rpmtopdir}
%_rpmdir                %{_topdir}/RPMS
%_srcrpmdir             %{_topdir}/RPMS
%_rpmfilename           %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm
```
2) Without this patch applied, do a `./autogen.sh ; ./configure ; make -j1 srpm` run
3) Observe it will fail with errors about failing to find some files
4) Apply the patch
5) Repeat step 2)
6) Observe that the build succeeds

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
