### PR TITLE
[2.1] compat: add check for kernel_neon_* availability

### DIFF
--- a/config/kernel-fpu.m4
+++ b/config/kernel-fpu.m4
@@ -91,6 +91,13 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_FPU], [
 		__kernel_fpu_end();
 	], [], [ZFS_META_LICENSE])
 
+	ZFS_LINUX_TEST_SRC([kernel_neon], [
+		#include <asm/neon.h>
+	], [
+		kernel_neon_begin();
+		kernel_neon_end();
+	], [], [ZFS_META_LICENSE])
+
 	ZFS_LINUX_TEST_SRC([fpu_internal], [
 		#if defined(__x86_64) || defined(__x86_64__) || \
 		    defined(__i386) || defined(__i386__)
@@ -186,18 +193,28 @@ AC_DEFUN([ZFS_AC_KERNEL_FPU], [
 			AC_DEFINE(KERNEL_EXPORTS_X86_FPU, 1,
 			    [kernel exports FPU functions])
 		],[
-			ZFS_LINUX_TEST_RESULT([fpu_internal], [
-				AC_MSG_RESULT(internal)
-				AC_DEFINE(HAVE_KERNEL_FPU_INTERNAL, 1,
-				    [kernel fpu internal])
+			dnl #
+			dnl # ARM neon symbols (only on arm and arm64)
+			dnl # could be GPL-only on arm64 after Linux 6.2
+			dnl #
+			ZFS_LINUX_TEST_RESULT([kernel_neon_license],[
+				AC_MSG_RESULT(kernel_neon_*)
+				AC_DEFINE(HAVE_KERNEL_NEON, 1,
+				    [kernel has kernel_neon_* functions])
 			],[
-				ZFS_LINUX_TEST_RESULT([fpu_xsave_internal], [
-				    AC_MSG_RESULT(internal with internal XSAVE)
-				    AC_DEFINE(HAVE_KERNEL_FPU_XSAVE_INTERNAL, 1,
-					[kernel fpu and XSAVE internal])
-			    ],[
-				AC_MSG_RESULT(unavailable)
-			    ])
+				ZFS_LINUX_TEST_RESULT([fpu_internal], [
+					AC_MSG_RESULT(internal)
+					AC_DEFINE(HAVE_KERNEL_FPU_INTERNAL, 1,
+						[kernel fpu internal])
+				],[
+					ZFS_LINUX_TEST_RESULT([fpu_xsave_internal], [
+						AC_MSG_RESULT(internal with internal XSAVE)
+						AC_DEFINE(HAVE_KERNEL_FPU_XSAVE_INTERNAL, 1,
+						[kernel fpu and XSAVE internal])
+					],[
+					AC_MSG_RESULT(unavailable)
+					])
+				])
 			])
 		])
 	])

--- a/include/os/linux/kernel/linux/simd_aarch64.h
+++ b/include/os/linux/kernel/linux/simd_aarch64.h
@@ -43,9 +43,15 @@
 #include <sys/types.h>
 #include <asm/neon.h>
 
+#if (defined(HAVE_KERNEL_NEON) && defined(CONFIG_KERNEL_MODE_NEON))
 #define	kfpu_allowed()		1
 #define	kfpu_begin()		kernel_neon_begin()
 #define	kfpu_end()		kernel_neon_end()
+#else
+#define	kfpu_allowed()		0
+#define	kfpu_begin()		do {} while (0)
+#define	kfpu_end()		do {} while (0)
+#endif
 #define	kfpu_init()		0
 #define	kfpu_fini()		((void) 0)
 


### PR DESCRIPTION
This patch backports the change from #15711 (to ZFS 2.2.x) because some OS vendors have back-ported this change from Linux 6.2+ to their older kernels.

The original patch addressed these issues:

1. Linux 6.2+ on arm64 has exported them with `EXPORT_SYMBOL_GPL`, so license compatibility must be checked before use.
2. On both arm and arm64, the definitions of these symbols are guarded by `CONFIG_KERNEL_MODE_NEON`, but their declarations are still present. Checking in configuration phase only leads to MODPOST errors (undefined references).

### How Has This Been Tested?

Our CI system is building RPMs for this large matrix and this patch is applied on all ZFS 2.1 builds irrespective of the other things in the matrix:

* architecture: `aarch64`, `x86_64`
* ZFS version: `2.1`, `2.2`
* ZFS variant/flavor: `dkms`, `kabi`
* Enterprise Linux version: `8`, `9` (specifically we use Rocky Linux)

The problem resolved by this PR only came up on EL9 aarch64, because EL9 backported the patch from Linux 6.2 in the latest version. I have successfully built and installed all of the packages this matrix creates, but due to CI using Docker, I have _not_ yet had the opportunity to load the actual kernel modules. I assume that the project's build bot does do this, but if not, I plan on rolling this out in the next week or so and can check it then.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
