### PR TITLE
[2.2] compact: workaround for GPL-only symbols on riscv from Linux 6.2

### DIFF
--- a/config/kernel-flush_dcache_page.m4
+++ b/config/kernel-flush_dcache_page.m4
@@ -1,7 +1,8 @@
 dnl #
 dnl # Starting from Linux 5.13, flush_dcache_page() becomes an inline
-dnl # function and may indirectly referencing GPL-only cpu_feature_keys on
-dnl # powerpc
+dnl # function and may indirectly referencing GPL-only symbols:
+dnl # on powerpc: cpu_feature_keys
+dnl # on riscv: PageHuge (added from 6.2)
 dnl #
 
 dnl #

--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -168,6 +168,9 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_SRC], [
 			ZFS_AC_KERNEL_SRC_CPU_HAS_FEATURE
 			ZFS_AC_KERNEL_SRC_FLUSH_DCACHE_PAGE
 			;;
+		riscv*)
+			ZFS_AC_KERNEL_SRC_FLUSH_DCACHE_PAGE
+			;;
 	esac
 
 	AC_MSG_CHECKING([for available kernel interfaces])
@@ -308,6 +311,9 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_RESULT], [
 	case "$host_cpu" in
 		powerpc*)
 			ZFS_AC_KERNEL_CPU_HAS_FEATURE
+			ZFS_AC_KERNEL_FLUSH_DCACHE_PAGE
+			;;
+		riscv*)
 			ZFS_AC_KERNEL_FLUSH_DCACHE_PAGE
 			;;
 	esac

--- a/include/os/linux/kernel/linux/dcache_compat.h
+++ b/include/os/linux/kernel/linux/dcache_compat.h
@@ -42,14 +42,25 @@
 /*
  * Starting from Linux 5.13, flush_dcache_page() becomes an inline function
  * and under some configurations, may indirectly referencing GPL-only
- * cpu_feature_keys on powerpc. Override this function when it is detected
- * being GPL-only.
+ * symbols, e.g., cpu_feature_keys on powerpc and PageHuge on riscv.
+ * Override this function when it is detected being GPL-only.
  */
 #if defined __powerpc__ && defined HAVE_FLUSH_DCACHE_PAGE_GPL_ONLY
 #include <linux/simd_powerpc.h>
 #define	flush_dcache_page(page)	do {					\
 		if (!cpu_has_feature(CPU_FTR_COHERENT_ICACHE) &&	\
 		    test_bit(PG_dcache_clean, &(page)->flags))		\
+			clear_bit(PG_dcache_clean, &(page)->flags);	\
+	} while (0)
+#endif
+/*
+ * For riscv implementation, the use of PageHuge can be safely removed.
+ * Because it handles pages allocated by HugeTLB, while flush_dcache_page
+ * in zfs module is only called on kernel pages.
+ */
+#if defined __riscv && defined HAVE_FLUSH_DCACHE_PAGE_GPL_ONLY
+#define	flush_dcache_page(page)	do {					\
+		if (test_bit(PG_dcache_clean, &(page)->flags))		\
 			clear_bit(PG_dcache_clean, &(page)->flags);	\
 	} while (0)
 #endif


### PR DESCRIPTION
### Motivation and Context

#14974  and #15627

### Description

Since Linux 6.2, the implementation of flush_dcache_page on riscv references GPL-only symbol `PageHuge`, breaking the build of zfs.

This patch uses existing mechanism to override flush_dcache_page, removing the call to `PageHuge`. According to comments in kernel, it is only used to do some check against HugeTLB pages, which only exist in userspace. ZFS uses flush_dcache_page only on kernel pages, thus this patch will not introduce any behaviour change.

### How Has This Been Tested?

Clean cherry pick from master.
