### PR TITLE
Add 'zpool status -e' flag to see unhealthy vdevs

### DIFF
--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -36,7 +36,7 @@
 .Sh SYNOPSIS
 .Nm zpool
 .Cm status
-.Op Fl DigLpPstvx
+.Op Fl DeigLpPstvx
 .Op Fl T Sy u Ns | Ns Sy d
 .Op Fl c Op Ar SCRIPT1 Ns Oo , Ns Ar SCRIPT2 Oc Ns …
 .Oo Ar pool Oc Ns …
@@ -69,6 +69,8 @@ See the
 option of
 .Nm zpool Cm iostat
 for complete details.
+.It Fl e
+Only show unhealthy vdevs (not-ONLINE or with errors).
 .It Fl i
 Display vdev initialization status.
 .It Fl g

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -536,7 +536,8 @@ tags = ['functional', 'cli_root', 'zpool_split']
 tests = ['zpool_status_001_pos', 'zpool_status_002_pos',
     'zpool_status_003_pos', 'zpool_status_004_pos',
     'zpool_status_005_pos', 'zpool_status_006_pos',
-    'zpool_status_007_pos', 'zpool_status_features_001_pos']
+    'zpool_status_007_pos', 'zpool_status_008_pos',
+    'zpool_status_features_001_pos']
 tags = ['functional', 'cli_root', 'zpool_status']
 
 [tests/functional/cli_root/zpool_sync]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1239,6 +1239,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_status/zpool_status_005_pos.ksh \
 	functional/cli_root/zpool_status/zpool_status_006_pos.ksh \
 	functional/cli_root/zpool_status/zpool_status_007_pos.ksh \
+	functional/cli_root/zpool_status/zpool_status_008_pos.ksh \
 	functional/cli_root/zpool_status/zpool_status_features_001_pos.ksh \
 	functional/cli_root/zpool_sync/cleanup.ksh \
 	functional/cli_root/zpool_sync/setup.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_002_pos.ksh
@@ -51,7 +51,7 @@ else
 fi
 
 set -A args "" "-x" "-v" "-x $testpool" "-v $testpool" "-xv $testpool" \
-	"-vx $testpool"
+	"-vx $testpool" "-e $testpool" "-es $testpool"
 
 log_assert "Executing 'zpool status' with correct options succeeds"
 
@@ -63,5 +63,7 @@ while [[ $i -lt ${#args[*]} ]]; do
 
 	(( i = i + 1 ))
 done
+
+cleanup 
 
 log_pass "'zpool status' with correct options succeeded"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_003_pos.ksh
@@ -37,6 +37,7 @@
 # 3. Read the file
 # 4. Take a snapshot and make a clone
 # 5. Verify we see "snapshot, clone and filesystem" output in 'zpool status -v'
+#      and 'zpool status -ev'
 
 function cleanup
 {
@@ -68,6 +69,7 @@ log_must zpool status -v $TESTPOOL2
 log_must eval "zpool status -v | grep '$TESTPOOL2@snap:/10m_file'"
 log_must eval "zpool status -v | grep '$TESTPOOL2/clone/10m_file'"
 log_must eval "zpool status -v | grep '$TESTPOOL2/10m_file'"
+log_must eval "zpool status -ev | grep '$TESTPOOL2/10m_file'"
 log_mustnot eval "zpool status -v | grep '$TESTFS1'"
 
 log_pass "'zpool status -v' outputs affected filesystem, snapshot & clone"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_008_pos.ksh
@@ -1,0 +1,104 @@
+#!/bin/ksh -p
+
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2024 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify 'zpool status -e' only shows unhealthy devices.
+#
+# STRATEGY:
+# 1. Create zpool
+# 2. Force DEGRADE, FAULT, or inject slow IOs for vdevs
+# 3. Verify vdevs are reported correctly with -e and -s
+# 4. Verify parents are reported as DEGRADED
+# 5. Verify healthy children are not reported
+#
+
+function cleanup
+{
+	log_must set_tunable64 ZIO_SLOW_IO_MS $OLD_SLOW_IO
+	zinject -c all
+	poolexists $TESTPOOL2 && destroy_pool $TESTPOOL2
+	log_must rm -f $all_vdevs
+}
+
+log_assert "Verify 'zpool status -e'"
+
+log_onexit cleanup
+
+all_vdevs=$(echo $TESTDIR/vdev{1..6})
+log_must mkdir -p $TESTDIR
+log_must truncate -s $MINVDEVSIZE $all_vdevs
+
+OLD_SLOW_IO=$(get_tunable ZIO_SLOW_IO_MS)
+
+for raid_type in "draid2:3d:6c:1s" "raidz2"; do
+
+	log_must zpool create -f $TESTPOOL2 $raid_type $all_vdevs
+
+	# Check DEGRADED vdevs are shown.
+	log_must check_vdev_state $TESTPOOL2 $TESTDIR/vdev4 "ONLINE"
+	log_must zinject -d $TESTDIR/vdev4 -A degrade $TESTPOOL2
+	log_must eval "zpool status -e $TESTPOOL2 | grep $TESTDIR/vdev4 | grep DEGRADED"
+
+	# Check FAULTED vdevs are shown.
+	log_must check_vdev_state $TESTPOOL2 $TESTDIR/vdev5 "ONLINE"
+	log_must zinject -d $TESTDIR/vdev5 -A fault $TESTPOOL2
+	log_must eval "zpool status -e $TESTPOOL2 | grep $TESTDIR/vdev5 | grep FAULTED"
+
+	# Check no ONLINE vdevs are shown
+	log_mustnot eval "zpool status -e $TESTPOOL2 | grep ONLINE"
+
+	# Check no ONLINE slow vdevs are show.  Then mark IOs greater than
+	# 10ms slow, delay IOs 20ms to vdev6, check slow IOs.
+	log_must check_vdev_state $TESTPOOL2 $TESTDIR/vdev6 "ONLINE"
+	log_mustnot eval "zpool status -es $TESTPOOL2 | grep ONLINE"
+
+	log_must set_tunable64 ZIO_SLOW_IO_MS 10
+	log_must zinject -d $TESTDIR/vdev6 -D20:100 $TESTPOOL2
+	log_must mkfile 1048576 /$TESTPOOL2/testfile
+	sync_pool $TESTPOOL2
+	log_must set_tunable64 ZIO_SLOW_IO_MS $OLD_SLOW_IO
+
+	# Check vdev6 slow IOs are only shown when requested with -s.
+	log_mustnot eval "zpool status -e $TESTPOOL2 | grep $TESTDIR/vdev6 | grep ONLINE"
+	log_must eval "zpool status -es $TESTPOOL2 | grep $TESTDIR/vdev6 | grep ONLINE"
+
+	# Pool level and top-vdev level status must be DEGRADED.
+	log_must eval "zpool status -e $TESTPOOL2 | grep $TESTPOOL2 | grep DEGRADED"
+	log_must eval "zpool status -e $TESTPOOL2 | grep $raid_type | grep DEGRADED"
+
+	# Check that healthy vdevs[1-3] aren't shown with -e.
+	log_must check_vdev_state $TESTPOOL2 $TESTDIR/vdev1 "ONLINE"
+	log_must check_vdev_state $TESTPOOL2 $TESTDIR/vdev2 "ONLINE"
+	log_must check_vdev_state $TESTPOOL2 $TESTDIR/vdev3 "ONLINE"
+	log_mustnot eval "zpool status -es $TESTPOOL2 | grep $TESTDIR/vdev1 | grep ONLINE"
+	log_mustnot eval "zpool status -es $TESTPOOL2 | grep $TESTDIR/vdev2 | grep ONLINE"
+	log_mustnot eval "zpool status -es $TESTPOOL2 | grep $TESTDIR/vdev3 | grep ONLINE"
+
+	log_must zinject -c all
+	log_must zpool status -es $TESTPOOL2
+
+	zpool destroy $TESTPOOL2
+done
+
+log_pass "Verify zpool status -e shows only unhealthy vdevs"


### PR DESCRIPTION
### Motivation and Context
When very large pools are present, it can be laborious to find reasons for why a pool is degraded and/or where an unhealthy vdev is. 

### Description
This option filters out vdevs that are ONLINE and with no errors to make it easier to see where the issues are. Root and parents of unhealthy vdevs will always be printed.

### How Has This Been Tested?
Sample vdev listings with '-e' option
- Single large pool 
```
[root@iron5:~]# zpool list
	NAME    SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
	iron5   582T  89.7M   582T        -         -     0%     0%  1.00x    ONLINE  -
[root@iron5:~]# zpool status | wc -l
	97
```
- All vdevs healthy 
```
[root@iron5:zfs2.2]# ./zpool status -e 
  pool: iron5 
 state: ONLINE 
  scan: scrub repaired 0B in 00:00:01 with 0 errors on Thu Jan 11 14:40:45 2024 
config:

	NAME        STATE     READ WRITE CKSUM
	iron5       ONLINE       0     0     0

errors: No known data errors
```
- ZFS errors 
```
[root@iron5:zfs2.2]# ./zpool status -e 
  pool: iron5 
 state: ONLINE 
status: One or more devices has experienced an error resulting in data corruption.  Applications may be affected. action: Restore the file in question if possible.  Otherwise restore the entire pool from backup. see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-8A 
  scan: scrub repaired 24K in 00:00:01 with 1 errors on Thu Jan 11 14:41:27 2024 
config:

	NAME        STATE     READ WRITE CKSUM
	iron5       ONLINE       0     0     0
	  raidz2-5  ONLINE       1     0     0
	    L23     ONLINE       1     0     0
	    L24     ONLINE       1     0     0
	    L37     ONLINE       1     0     0

errors: 1 data errors, use '-v' for a list
```
- Vdev faulted 
```
[root@iron5:zfs2.2]# ./zpool status -e 
   pool: iron5 state: DEGRADED 
status: One or more devices are faulted in response to persistent errors. Sufficient replicas exist for the pool to continue functioning in a degraded state. action: Replace the faulted device, or use 'zpool clear' to mark the device repaired. 
  scan: scrub repaired 0B in 00:00:00 with 0 errors on Thu Jan 11 14:39:42 2024 
config:

	NAME        STATE     READ WRITE CKSUM
	iron5       DEGRADED     0     0     0
	  raidz2-6  DEGRADED     0     0     0
	    L67     FAULTED      0     0     0  too many errors

errors: No known data errors
```
- Vdev missing 
```
[root@iron5:zfs2.2]# ./zpool status -e 
  pool: iron5 
 state: DEGRADED 
status: One or more devices could not be used because the label is missing or invalid.  Sufficient replicas exist for the pool to continue functioning in a degraded state. action: Replace the device using 'zpool replace'. see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-4J 
  scan: scrub repaired 0B in 00:00:01 with 0 errors on Thu Jan 11 14:42:30 2024 
config:

	NAME        STATE     READ WRITE CKSUM
	iron5       DEGRADED     0     0     0
	  raidz2-6  DEGRADED     0     0     0
	    L67     UNAVAIL      3     1     0
```


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ X] I have updated the documentation accordingly.
- [ X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Signed-off-by: Cameron Harr <harr1@llnl.gov>