### PR TITLE
[2.2] zfs_setattr: fix atime update

### DIFF
--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -2435,9 +2435,8 @@ top:
 
 	if ((mask & ATTR_ATIME) || zp->z_atime_dirty) {
 		zp->z_atime_dirty = B_FALSE;
-		inode_timespec_t tmp_atime;
+		inode_timespec_t tmp_atime = zpl_inode_get_atime(ip);
 		ZFS_TIME_ENCODE(&tmp_atime, atime);
-		zpl_inode_set_atime_to_ts(ZTOI(zp), tmp_atime);
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_ATIME(zfsvfs), NULL,
 		    &atime, sizeof (atime));
 	}

--- a/tests/zfs-tests/cmd/ctime.c
+++ b/tests/zfs-tests/cmd/ctime.c
@@ -362,12 +362,20 @@ main(void)
 			return (1);
 		}
 
-		if (t1 == t2) {
-			(void) fprintf(stderr, "%s: t1(%ld) == t2(%ld)\n",
+
+		/*
+		 * Ideally, time change would be exactly two seconds, but allow
+		 * a little slack in case of scheduling delays or similar.
+		 */
+		long delta = (long)t2 - (long)t1;
+		if (delta < 2 || delta > 4) {
+			(void) fprintf(stderr,
+			    "%s: BAD time change: t1(%ld), t2(%ld)\n",
 			    timetest_table[i].name, (long)t1, (long)t2);
 			return (1);
 		} else {
-			(void) fprintf(stderr, "%s: t1(%ld) != t2(%ld)\n",
+			(void) fprintf(stderr,
+			    "%s: good time change: t1(%ld), t2(%ld)\n",
 			    timetest_table[i].name, (long)t1, (long)t2);
 		}
 	}


### PR DESCRIPTION
### Description

In 3c13601a1 I messed up and changed this bit of code to set the inode atime to an uninitialised value, when actually it was just supposed to loading the atime from the inode to be stored in the SA. This changes it to what it should have been.

(backport #15773)

### How Has This Been Tested?

Compile and sanity test against 5.10.x:

```
$ touch /tank/file
$ stat -c%x /tank/file
2024-01-14 03:06:50.926824089 +0000
```

The bug and fix are simple, so I'm assuming tests would show the same results as #15573.

[update]: existing ctime/mtime/atime modification test has been updated to check the update makes sense, not just that it was updated.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
