### PR TITLE
freebsd: fix bootstrapping tools under Linux/musl

### DIFF
--- a/lib/libspl/include/os/freebsd/sys/stat.h
+++ b/lib/libspl/include/os/freebsd/sys/stat.h
@@ -76,8 +76,12 @@ fstat64_blk(int fd, struct stat64 *st)
 /*
  * Only Intel-based Macs have a separate stat64; Arm-based Macs are like
  * FreeBSD and have a full 64-bit stat from the start.
+ *
+ * On Linux, musl libc is full 64-bit too and has deprecated its own version
+ * of these defines since version 1.2.4.
  */
-#if defined(__APPLE__) && !(defined(__i386__) || defined(__x86_64__))
+#if (defined(__APPLE__) && !(defined(__i386__) || defined(__x86_64__))) || \
+	(defined(__linux__) && !defined(__GLIBC__))
 #define	stat64	stat
 #define	fstat64	fstat
 #endif


### PR DESCRIPTION

### Motivation and Context

musl libc has deprecated LFS64 aliases, so bootstrapping FreeBSD tools under musl distros has been failing with stat64 errors.

### Description

Apply the aliases under non-glibc Linux to fix this problem.

### How Has This Been Tested?

This is part of my work on making FreeBSD build under Chimera Linux; it builds :)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).