### PR TITLE
Autotrim High Load Average Fix

### DIFF
--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -196,7 +196,8 @@ vdev_autotrim_wait_kick(vdev_t *vd, int num_of_kick)
 	for (int i = 0; i < num_of_kick; i++) {
 		if (vd->vdev_autotrim_exit_wanted)
 			break;
-		cv_wait(&vd->vdev_autotrim_kick_cv, &vd->vdev_autotrim_lock);
+		cv_wait_idle(&vd->vdev_autotrim_kick_cv,
+		    &vd->vdev_autotrim_lock);
 	}
 	boolean_t exit_wanted = vd->vdev_autotrim_exit_wanted;
 	mutex_exit(&vd->vdev_autotrim_lock);


### PR DESCRIPTION
Switch from cv_wait() to cv_wait_idle() inside vdev_autotrim_wait_kick(), which should mitigate the high load average while waiting.


### Motivation and Context
Attempt to fix the issue #15453 


### How Has This Been Tested?
Not tested. Need help from the community to test if this fixes the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
