### PR TITLE
[2.2] add missing brt tests and fix cloning into mmaped and cached file

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1355,6 +1355,10 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 			break;
 		}
 
+		if (zn_has_cached_data(outzp, outoff, outoff + size - 1)) {
+			update_pages(outzp, outoff, size, outos);
+		}
+
 		zfs_clear_setid_bits_if_necessary(outzfsvfs, outzp, cr,
 		    &clear_setid_bits_txg, tx);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,6 +16,7 @@ dist_scripts_test_runner_include_DATA = \
 
 scripts_runfilesdir = $(datadir)/$(PACKAGE)/runfiles
 dist_scripts_runfiles_DATA = \
+	%D%/runfiles/bclone.run \
 	%D%/runfiles/common.run \
 	%D%/runfiles/freebsd.run \
 	%D%/runfiles/linux.run \

--- a/tests/runfiles/bclone.run
+++ b/tests/runfiles/bclone.run
@@ -1,0 +1,46 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# This run file contains all of the common functional tests.  When
+# adding a new test consider also adding it to the sanity.run file
+# if the new test runs to completion in only a few seconds.
+#
+# Approximate run time: 5 hours
+#
+
+[DEFAULT]
+pre = setup
+quiet = False
+pre_user = root
+user = root
+timeout = 28800
+post_user = root
+post = cleanup
+failsafe_user = root
+failsafe = callbacks/zfs_failsafe
+outputdir = /var/tmp/test_results
+tags = ['bclone']
+
+[tests/functional/bclone]
+tests = ['bclone_crossfs_corner_cases',
+    'bclone_crossfs_data',
+    'bclone_crossfs_embedded',
+    'bclone_crossfs_hole',
+    'bclone_diffprops_all',
+    'bclone_diffprops_checksum',
+    'bclone_diffprops_compress',
+    'bclone_diffprops_copies',
+    'bclone_diffprops_recordsize',
+    'bclone_prop_sync',
+    'bclone_samefs_corner_cases',
+    'bclone_samefs_data',
+    'bclone_samefs_embedded',
+    'bclone_samefs_hole']
+tags = ['bclone']

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -53,6 +53,24 @@ tags = ['functional', 'arc']
 tests = ['atime_001_pos', 'atime_002_neg', 'root_atime_off', 'root_atime_on']
 tags = ['functional', 'atime']
 
+[tests/functional/bclone]
+tests = ['bclone_crossfs_corner_cases_limited',
+    'bclone_crossfs_data',
+    'bclone_crossfs_embedded',
+    'bclone_crossfs_hole',
+    'bclone_diffprops_all',
+    'bclone_diffprops_checksum',
+    'bclone_diffprops_compress',
+    'bclone_diffprops_copies',
+    'bclone_diffprops_recordsize',
+    'bclone_prop_sync',
+    'bclone_samefs_corner_cases_limited',
+    'bclone_samefs_data',
+    'bclone_samefs_embedded',
+    'bclone_samefs_hole']
+tags = ['functional', 'bclone']
+timeout = 7200
+
 [tests/functional/bootfs]
 tests = ['bootfs_001_pos', 'bootfs_002_neg', 'bootfs_003_pos',
     'bootfs_004_neg', 'bootfs_005_neg', 'bootfs_006_pos', 'bootfs_007_pos',

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -79,7 +79,7 @@ tests = ['block_cloning_copyfilerange', 'block_cloning_copyfilerange_partial',
     'block_cloning_cross_enc_dataset',
     'block_cloning_copyfilerange_fallback_same_txg',
     'block_cloning_replay', 'block_cloning_replay_encrypted',
-    'block_cloning_lwb_buffer_overflow']
+    'block_cloning_lwb_buffer_overflow', 'block_cloning_clone_mmap_write']
 tags = ['functional', 'block_cloning']
 
 [tests/functional/bootfs]

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -72,7 +72,9 @@ tags = ['functional', 'bclone']
 timeout = 7200
 
 [tests/functional/block_cloning]
-tests = ['block_cloning_copyfilerange', 'block_cloning_copyfilerange_partial',
+tests = ['block_cloning_clone_mmap_cached',
+    'block_cloning_copyfilerange',
+    'block_cloning_copyfilerange_partial',
     'block_cloning_copyfilerange_fallback',
     'block_cloning_disabled_copyfilerange',
     'block_cloning_copyfilerange_cross_dataset',

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -71,6 +71,17 @@ tests = ['bclone_crossfs_corner_cases_limited',
 tags = ['functional', 'bclone']
 timeout = 7200
 
+[tests/functional/block_cloning]
+tests = ['block_cloning_copyfilerange', 'block_cloning_copyfilerange_partial',
+    'block_cloning_copyfilerange_fallback',
+    'block_cloning_disabled_copyfilerange',
+    'block_cloning_copyfilerange_cross_dataset',
+    'block_cloning_cross_enc_dataset',
+    'block_cloning_copyfilerange_fallback_same_txg',
+    'block_cloning_replay', 'block_cloning_replay_encrypted',
+    'block_cloning_lwb_buffer_overflow']
+tags = ['functional', 'block_cloning']
+
 [tests/functional/bootfs]
 tests = ['bootfs_001_pos', 'bootfs_002_neg', 'bootfs_003_pos',
     'bootfs_004_neg', 'bootfs_005_neg', 'bootfs_006_pos', 'bootfs_007_pos',

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -35,17 +35,9 @@ tests = ['atime_003_pos', 'root_relatime_on']
 tags = ['functional', 'atime']
 
 [tests/functional/block_cloning:Linux]
-tests = ['block_cloning_copyfilerange', 'block_cloning_copyfilerange_partial',
-    'block_cloning_copyfilerange_fallback',
-    'block_cloning_ficlone', 'block_cloning_ficlonerange',
-    'block_cloning_ficlonerange_partial',
-    'block_cloning_disabled_copyfilerange', 'block_cloning_disabled_ficlone',
-    'block_cloning_disabled_ficlonerange',
-    'block_cloning_copyfilerange_cross_dataset',
-    'block_cloning_cross_enc_dataset',
-    'block_cloning_copyfilerange_fallback_same_txg',
-    'block_cloning_replay', 'block_cloning_replay_encrypted',
-    'block_cloning_lwb_buffer_overflow']
+tests = ['block_cloning_ficlone', 'block_cloning_ficlonerange',
+    'block_cloning_ficlonerange_partial', 'block_cloning_disabled_ficlone',
+    'block_cloning_disabled_ficlonerange']
 tags = ['functional', 'block_cloning']
 
 [tests/functional/chattr:Linux]

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -43,7 +43,8 @@ tests = ['block_cloning_copyfilerange', 'block_cloning_copyfilerange_partial',
     'block_cloning_disabled_ficlonerange',
     'block_cloning_copyfilerange_cross_dataset',
     'block_cloning_cross_enc_dataset',
-    'block_cloning_copyfilerange_fallback_same_txg']
+    'block_cloning_copyfilerange_fallback_same_txg',
+    'block_cloning_replay', 'block_cloning_replay_encrypted']
 tags = ['functional', 'block_cloning']
 
 [tests/functional/chattr:Linux]

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -44,7 +44,8 @@ tests = ['block_cloning_copyfilerange', 'block_cloning_copyfilerange_partial',
     'block_cloning_copyfilerange_cross_dataset',
     'block_cloning_cross_enc_dataset',
     'block_cloning_copyfilerange_fallback_same_txg',
-    'block_cloning_replay', 'block_cloning_replay_encrypted']
+    'block_cloning_replay', 'block_cloning_replay_encrypted',
+    'block_cloning_lwb_buffer_overflow']
 tags = ['functional', 'block_cloning']
 
 [tests/functional/chattr:Linux]

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -263,13 +263,50 @@ if sys.platform.startswith('freebsd'):
         'cli_root/zpool_import/zpool_import_012_pos': ['FAIL', known_reason],
         'delegate/zfs_allow_003_pos': ['FAIL', known_reason],
         'inheritance/inherit_001_pos': ['FAIL', 11829],
-        'resilver/resilver_restart_001': ['FAIL', known_reason],
         'pool_checkpoint/checkpoint_big_rewind': ['FAIL', 12622],
         'pool_checkpoint/checkpoint_indirect': ['FAIL', 12623],
+        'resilver/resilver_restart_001': ['FAIL', known_reason],
         'snapshot/snapshot_002_pos': ['FAIL', '14831'],
     })
 elif sys.platform.startswith('linux'):
     maybe.update({
+        'bclone/bclone_crossfs_corner_cases': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_crossfs_corner_cases_limited':
+            ['SKIP', cfr_cross_reason],
+        'bclone/bclone_crossfs_data': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_crossfs_embedded': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_crossfs_hole': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_diffprops_all': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_diffprops_checksum': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_diffprops_compress': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_diffprops_copies': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_diffprops_recordsize': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_prop_sync': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_samefs_corner_cases': ['SKIP', cfr_reason],
+        'bclone/bclone_samefs_corner_cases_limited': ['SKIP', cfr_reason],
+        'bclone/bclone_samefs_data': ['SKIP', cfr_reason],
+        'bclone/bclone_samefs_embedded': ['SKIP', cfr_reason],
+        'bclone/bclone_samefs_hole': ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_copyfilerange':
+            ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_copyfilerange_cross_dataset':
+            ['SKIP', cfr_cross_reason],
+        'block_cloning/block_cloning_copyfilerange_fallback':
+            ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_copyfilerange_fallback_same_txg':
+            ['SKIP', cfr_cross_reason],
+        'block_cloning/block_cloning_copyfilerange_partial':
+            ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_cross_enc_dataset':
+            ['SKIP', cfr_cross_reason],
+        'block_cloning/block_cloning_disabled_copyfilerange':
+            ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_lwb_buffer_overflow':
+            ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_replay':
+            ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_replay_encrypted':
+            ['SKIP', cfr_reason],
         'cli_root/zfs_rename/zfs_rename_002_pos': ['FAIL', known_reason],
         'cli_root/zpool_reopen/zpool_reopen_003_pos': ['FAIL', known_reason],
         'fault/auto_online_002_pos': ['FAIL', 11889],
@@ -278,41 +315,21 @@ elif sys.platform.startswith('linux'):
         'fault/auto_spare_multiple': ['FAIL', 11889],
         'fault/auto_spare_shared': ['FAIL', 11889],
         'fault/decompress_fault': ['FAIL', 11889],
+        'idmap_mount/idmap_mount_001': ['SKIP', idmap_reason],
+        'idmap_mount/idmap_mount_002': ['SKIP', idmap_reason],
+        'idmap_mount/idmap_mount_003': ['SKIP', idmap_reason],
+        'idmap_mount/idmap_mount_004': ['SKIP', idmap_reason],
+        'idmap_mount/idmap_mount_005': ['SKIP', idmap_reason],
         'io/io_uring': ['SKIP', 'io_uring support required'],
         'limits/filesystem_limit': ['SKIP', known_reason],
         'limits/snapshot_limit': ['SKIP', known_reason],
         'mmp/mmp_active_import': ['FAIL', known_reason],
         'mmp/mmp_exported_import': ['FAIL', known_reason],
         'mmp/mmp_inactive_import': ['FAIL', known_reason],
-        'zvol/zvol_misc/zvol_misc_snapdev': ['FAIL', 12621],
-        'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', known_reason],
         'zvol/zvol_misc/zvol_misc_fua': ['SKIP', 14872],
+        'zvol/zvol_misc/zvol_misc_snapdev': ['FAIL', 12621],
         'zvol/zvol_misc/zvol_misc_trim': ['SKIP', 14872],
-        'idmap_mount/idmap_mount_001': ['SKIP', idmap_reason],
-        'idmap_mount/idmap_mount_002': ['SKIP', idmap_reason],
-        'idmap_mount/idmap_mount_003': ['SKIP', idmap_reason],
-        'idmap_mount/idmap_mount_004': ['SKIP', idmap_reason],
-        'idmap_mount/idmap_mount_005': ['SKIP', idmap_reason],
-        'block_cloning/block_cloning_disabled_copyfilerange':
-            ['SKIP', cfr_reason],
-        'block_cloning/block_cloning_copyfilerange':
-            ['SKIP', cfr_reason],
-        'block_cloning/block_cloning_copyfilerange_partial':
-            ['SKIP', cfr_reason],
-        'block_cloning/block_cloning_copyfilerange_fallback':
-            ['SKIP', cfr_reason],
-        'block_cloning/block_cloning_replay':
-            ['SKIP', cfr_reason],
-        'block_cloning/block_cloning_replay_encrypted':
-            ['SKIP', cfr_reason],
-        'block_cloning/block_cloning_lwb_buffer_overflow':
-            ['SKIP', cfr_reason],
-        'block_cloning/block_cloning_copyfilerange_cross_dataset':
-            ['SKIP', cfr_cross_reason],
-        'block_cloning/block_cloning_copyfilerange_fallback_same_txg':
-            ['SKIP', cfr_cross_reason],
-        'block_cloning/block_cloning_cross_enc_dataset':
-            ['SKIP', cfr_cross_reason],
+        'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', known_reason],
     })
 
 # Not all Github actions runners have scsi_debug module, so we may skip

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -305,6 +305,8 @@ elif sys.platform.startswith('linux'):
             ['SKIP', cfr_reason],
         'block_cloning/block_cloning_replay_encrypted':
             ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_lwb_buffer_overflow':
+            ['SKIP', cfr_reason],
         'block_cloning/block_cloning_copyfilerange_cross_dataset':
             ['SKIP', cfr_cross_reason],
         'block_cloning/block_cloning_copyfilerange_fallback_same_txg':

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -301,6 +301,10 @@ elif sys.platform.startswith('linux'):
             ['SKIP', cfr_reason],
         'block_cloning/block_cloning_copyfilerange_fallback':
             ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_replay':
+            ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_replay_encrypted':
+            ['SKIP', cfr_reason],
         'block_cloning/block_cloning_copyfilerange_cross_dataset':
             ['SKIP', cfr_cross_reason],
         'block_cloning/block_cloning_copyfilerange_fallback_same_txg':
@@ -308,7 +312,6 @@ elif sys.platform.startswith('linux'):
         'block_cloning/block_cloning_cross_enc_dataset':
             ['SKIP', cfr_cross_reason],
     })
-
 
 # Not all Github actions runners have scsi_debug module, so we may skip
 #   some tests which use it.

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -287,6 +287,7 @@ elif sys.platform.startswith('linux'):
         'bclone/bclone_samefs_data': ['SKIP', cfr_reason],
         'bclone/bclone_samefs_embedded': ['SKIP', cfr_reason],
         'bclone/bclone_samefs_hole': ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_clone_mmap_cached': ['SKIP', cfr_reason],
         'block_cloning/block_cloning_clone_mmap_write':
             ['SKIP', cfr_reason],
         'block_cloning/block_cloning_copyfilerange':

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -287,6 +287,8 @@ elif sys.platform.startswith('linux'):
         'bclone/bclone_samefs_data': ['SKIP', cfr_reason],
         'bclone/bclone_samefs_embedded': ['SKIP', cfr_reason],
         'bclone/bclone_samefs_hole': ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_clone_mmap_write':
+            ['SKIP', cfr_reason],
         'block_cloning/block_cloning_copyfilerange':
             ['SKIP', cfr_reason],
         'block_cloning/block_cloning_copyfilerange_cross_dataset':

--- a/tests/zfs-tests/cmd/.gitignore
+++ b/tests/zfs-tests/cmd/.gitignore
@@ -2,6 +2,7 @@
 /btree_test
 /chg_usr_exec
 /clonefile
+/clone_mmap_cached
 /clone_mmap_write
 /devname2devid
 /dir_rd_update

--- a/tests/zfs-tests/cmd/.gitignore
+++ b/tests/zfs-tests/cmd/.gitignore
@@ -2,6 +2,7 @@
 /btree_test
 /chg_usr_exec
 /clonefile
+/clone_mmap_write
 /devname2devid
 /dir_rd_update
 /draid

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -2,6 +2,7 @@ scripts_zfs_tests_bindir = $(datadir)/$(PACKAGE)/zfs-tests/bin
 
 
 scripts_zfs_tests_bin_PROGRAMS  = %D%/chg_usr_exec
+scripts_zfs_tests_bin_PROGRAMS += %D%/clonefile
 scripts_zfs_tests_bin_PROGRAMS += %D%/cp_files
 scripts_zfs_tests_bin_PROGRAMS += %D%/ctime
 scripts_zfs_tests_bin_PROGRAMS += %D%/dir_rd_update
@@ -119,7 +120,6 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/renameat2
 scripts_zfs_tests_bin_PROGRAMS += %D%/xattrtest
 scripts_zfs_tests_bin_PROGRAMS += %D%/zed_fd_spill-zedlet
 scripts_zfs_tests_bin_PROGRAMS += %D%/idmap_util
-scripts_zfs_tests_bin_PROGRAMS += %D%/clonefile
 
 %C%_idmap_util_LDADD = libspl.la
 

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -3,6 +3,7 @@ scripts_zfs_tests_bindir = $(datadir)/$(PACKAGE)/zfs-tests/bin
 
 scripts_zfs_tests_bin_PROGRAMS  = %D%/chg_usr_exec
 scripts_zfs_tests_bin_PROGRAMS += %D%/clonefile
+scripts_zfs_tests_bin_PROGRAMS += %D%/clone_mmap_write
 scripts_zfs_tests_bin_PROGRAMS += %D%/cp_files
 scripts_zfs_tests_bin_PROGRAMS += %D%/ctime
 scripts_zfs_tests_bin_PROGRAMS += %D%/dir_rd_update

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -3,6 +3,7 @@ scripts_zfs_tests_bindir = $(datadir)/$(PACKAGE)/zfs-tests/bin
 
 scripts_zfs_tests_bin_PROGRAMS  = %D%/chg_usr_exec
 scripts_zfs_tests_bin_PROGRAMS += %D%/clonefile
+scripts_zfs_tests_bin_PROGRAMS += %D%/clone_mmap_cached
 scripts_zfs_tests_bin_PROGRAMS += %D%/clone_mmap_write
 scripts_zfs_tests_bin_PROGRAMS += %D%/cp_files
 scripts_zfs_tests_bin_PROGRAMS += %D%/ctime

--- a/tests/zfs-tests/cmd/clone_mmap_cached.c
+++ b/tests/zfs-tests/cmd/clone_mmap_cached.c
@@ -1,0 +1,146 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2024 by Pawel Jakub Dawidek
+ */
+
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifdef __FreeBSD__
+#define	loff_t	off_t
+#endif
+
+ssize_t
+copy_file_range(int, loff_t *, int, loff_t *, size_t, unsigned int)
+    __attribute__((weak));
+
+static void *
+mmap_file(int fd, size_t size)
+{
+	void *p;
+
+	p = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+	if (p == MAP_FAILED) {
+		(void) fprintf(stderr, "mmap failed: %s\n", strerror(errno));
+		exit(2);
+	}
+
+	return (p);
+}
+
+static void
+usage(const char *progname)
+{
+
+	/*
+	 * -i cache input before copy_file_range(2).
+	 * -o cache input before copy_file_range(2).
+	 */
+	(void) fprintf(stderr, "usage: %s [-io] <input> <output>\n", progname);
+	exit(3);
+}
+
+int
+main(int argc, char *argv[])
+{
+	int dfd, sfd;
+	size_t dsize, ssize;
+	void *dmem, *smem, *ptr;
+	off_t doff, soff;
+	struct stat sb;
+	bool cache_input, cache_output;
+	const char *progname;
+	int c;
+
+	progname = argv[0];
+	cache_input = cache_output = false;
+
+	while ((c = getopt(argc, argv, "io")) != -1) {
+		switch (c) {
+		case 'i':
+			cache_input = true;
+			break;
+		case 'o':
+			cache_output = true;
+			break;
+		default:
+			usage(progname);
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (argc != 2) {
+		usage(progname);
+	}
+
+	sfd = open(argv[0], O_RDONLY);
+	if (fstat(sfd, &sb) == -1) {
+		(void) fprintf(stderr, "fstat failed: %s\n", strerror(errno));
+		exit(2);
+	}
+	ssize = sb.st_size;
+	smem = mmap_file(sfd, ssize);
+
+	dfd = open(argv[1], O_RDWR);
+	if (fstat(dfd, &sb) == -1) {
+		(void) fprintf(stderr, "fstat failed: %s\n", strerror(errno));
+		exit(2);
+	}
+	dsize = sb.st_size;
+	dmem = mmap_file(dfd, dsize);
+
+	/*
+	 * Hopefully it won't be compiled out.
+	 */
+	if (cache_input) {
+		ptr = malloc(ssize);
+		assert(ptr != NULL);
+		memcpy(ptr, smem, ssize);
+		free(ptr);
+	}
+	if (cache_output) {
+		ptr = malloc(ssize);
+		assert(ptr != NULL);
+		memcpy(ptr, dmem, dsize);
+		free(ptr);
+	}
+
+	soff = doff = 0;
+	if (copy_file_range(sfd, &soff, dfd, &doff, ssize, 0) < 0) {
+		(void) fprintf(stderr, "copy_file_range failed: %s\n",
+		    strerror(errno));
+		exit(2);
+	}
+
+	exit(memcmp(smem, dmem, ssize) == 0 ? 0 : 1);
+}

--- a/tests/zfs-tests/cmd/clone_mmap_write.c
+++ b/tests/zfs-tests/cmd/clone_mmap_write.c
@@ -1,0 +1,123 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * This program clones the file, mmap it, and writes from the map into
+ * file. This scenario triggers a panic on Linux in dbuf_redirty(),
+ * which is fixed under PR#15656. On FreeBSD, the same test causes data
+ * corruption, which is fixed by PR#15665.
+ *
+ * It would be good to test for this scenario in ZTS. This program and
+ * issue was initially produced by @robn.
+ */
+#ifndef _GNU_SOURCE
+#define	_GNU_SOURCE
+#endif
+
+#include <fcntl.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+#ifdef __FreeBSD__
+#define	loff_t	off_t
+#endif
+
+ssize_t
+copy_file_range(int, loff_t *, int, loff_t *, size_t, unsigned int)
+    __attribute__((weak));
+
+static int
+open_file(const char *source)
+{
+	int fd;
+	if ((fd = open(source, O_RDWR | O_APPEND)) < 0) {
+		(void) fprintf(stderr, "Error opening %s\n", source);
+		exit(1);
+	}
+	sync();
+	return (fd);
+}
+
+static int
+clone_file(int sfd, long long size, const char *dest)
+{
+	int dfd;
+
+	if ((dfd = open(dest, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR)) < 0) {
+		(void) fprintf(stderr, "Error opening %s\n", dest);
+		exit(1);
+	}
+
+	if (copy_file_range(sfd, 0, dfd, 0, size, 0) < 0) {
+		(void) fprintf(stderr, "copy_file_range failed\n");
+		exit(1);
+	}
+
+	return (dfd);
+}
+
+static void *
+map_file(int fd, long long size)
+{
+	void *p = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+	if (p == MAP_FAILED) {
+		(void) fprintf(stderr, "mmap failed\n");
+		exit(1);
+	}
+
+	return (p);
+}
+
+static void
+map_write(void *p, int fd)
+{
+	if (pwrite(fd, p, 1024*128, 0) < 0) {
+		(void) fprintf(stderr, "write failed\n");
+		exit(1);
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	int sfd, dfd;
+	void *p;
+	struct stat sb;
+	if (argc != 3) {
+		(void) printf("usage: %s <input source file> "
+		    "<clone destination file>\n", argv[0]);
+		exit(1);
+	}
+	sfd = open_file(argv[1]);
+	if (fstat(sfd, &sb) == -1) {
+		(void) fprintf(stderr, "fstat failed\n");
+		exit(1);
+	}
+	dfd = clone_file(sfd, sb.st_size, argv[2]);
+	p = map_file(dfd, sb.st_size);
+	map_write(p, dfd);
+	return (0);
+}

--- a/tests/zfs-tests/cmd/clonefile.c
+++ b/tests/zfs-tests/cmd/clonefile.c
@@ -162,7 +162,7 @@ main(int argc, char **argv)
 {
 	cf_mode_t mode = CF_MODE_NONE;
 
-	char c;
+	int c;
 	while ((c = getopt(argc, argv, "crfdq")) != -1) {
 		switch (c) {
 			case 'c':

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -98,7 +98,8 @@ export SYSTEM_FILES_COMMON='awk
     uname
     uniq
     vmstat
-    wc'
+    wc
+    xargs'
 
 export SYSTEM_FILES_FREEBSD='chflags
     compress

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -185,6 +185,7 @@ export ZFSTEST_FILES='badsend
     btree_test
     chg_usr_exec
     clonefile
+    clone_mmap_write
     devname2devid
     dir_rd_update
     draid

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -185,6 +185,7 @@ export ZFSTEST_FILES='badsend
     btree_test
     chg_usr_exec
     clonefile
+    clone_mmap_cached
     clone_mmap_write
     devname2devid
     dir_rd_update

--- a/tests/zfs-tests/include/math.shlib
+++ b/tests/zfs-tests/include/math.shlib
@@ -123,10 +123,21 @@ function verify_ne # <a> <b> <type>
 #
 # $1 lower bound
 # $2 upper bound
+# [$3 how many]
 function random_int_between
 {
 	typeset -i min=$1
 	typeset -i max=$2
+	typeset -i count
+	typeset -i i
 
-	echo $(( (RANDOM % (max - min + 1)) + min ))
+	if [[ -z "$3" ]]; then
+		count=1
+	else
+		count=$3
+	fi
+
+	for (( i = 0; i < $count; i++ )); do
+		echo $(( (RANDOM % (max - min + 1)) + min ))
+	done
 }

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -90,6 +90,9 @@ nobase_dist_datadir_zfs_tests_tests_DATA += \
 	functional/alloc_class/alloc_class.kshlib \
 	functional/atime/atime.cfg \
 	functional/atime/atime_common.kshlib \
+	functional/bclone/bclone.cfg \
+	functional/bclone/bclone_common.kshlib \
+	functional/bclone/bclone_corner_cases.kshlib \
 	functional/block_cloning/block_cloning.kshlib \
 	functional/cache/cache.cfg \
 	functional/cache/cache.kshlib \
@@ -438,6 +441,24 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/atime/root_atime_on.ksh \
 	functional/atime/root_relatime_on.ksh \
 	functional/atime/setup.ksh \
+	functional/bclone/bclone_crossfs_corner_cases.ksh \
+	functional/bclone/bclone_crossfs_corner_cases_limited.ksh \
+	functional/bclone/bclone_crossfs_data.ksh \
+	functional/bclone/bclone_crossfs_embedded.ksh \
+	functional/bclone/bclone_crossfs_hole.ksh \
+	functional/bclone/bclone_diffprops_all.ksh \
+	functional/bclone/bclone_diffprops_checksum.ksh \
+	functional/bclone/bclone_diffprops_compress.ksh \
+	functional/bclone/bclone_diffprops_copies.ksh \
+	functional/bclone/bclone_diffprops_recordsize.ksh \
+	functional/bclone/bclone_prop_sync.ksh \
+	functional/bclone/bclone_samefs_corner_cases.ksh \
+	functional/bclone/bclone_samefs_corner_cases_limited.ksh \
+	functional/bclone/bclone_samefs_data.ksh \
+	functional/bclone/bclone_samefs_embedded.ksh \
+	functional/bclone/bclone_samefs_hole.ksh \
+	functional/bclone/cleanup.ksh \
+	functional/bclone/setup.ksh \
 	functional/block_cloning/cleanup.ksh \
 	functional/block_cloning/setup.ksh \
 	functional/block_cloning/block_cloning_copyfilerange_cross_dataset.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -454,6 +454,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/block_cloning/block_cloning_cross_enc_dataset.ksh \
 	functional/block_cloning/block_cloning_replay.ksh \
 	functional/block_cloning/block_cloning_replay_encrypted.ksh \
+	functional/block_cloning/block_cloning_lwb_buffer_overflow.ksh \
 	functional/bootfs/bootfs_001_pos.ksh \
 	functional/bootfs/bootfs_002_neg.ksh \
 	functional/bootfs/bootfs_003_pos.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -452,6 +452,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/block_cloning/block_cloning_ficlonerange.ksh \
 	functional/block_cloning/block_cloning_ficlonerange_partial.ksh \
 	functional/block_cloning/block_cloning_cross_enc_dataset.ksh \
+	functional/block_cloning/block_cloning_replay.ksh \
+	functional/block_cloning/block_cloning_replay_encrypted.ksh \
 	functional/bootfs/bootfs_001_pos.ksh \
 	functional/bootfs/bootfs_002_neg.ksh \
 	functional/bootfs/bootfs_003_pos.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -461,6 +461,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/bclone/setup.ksh \
 	functional/block_cloning/cleanup.ksh \
 	functional/block_cloning/setup.ksh \
+	functional/block_cloning/block_cloning_clone_mmap_cached.ksh \
 	functional/block_cloning/block_cloning_clone_mmap_write.ksh \
 	functional/block_cloning/block_cloning_copyfilerange_cross_dataset.ksh \
 	functional/block_cloning/block_cloning_copyfilerange_fallback.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -461,6 +461,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/bclone/setup.ksh \
 	functional/block_cloning/cleanup.ksh \
 	functional/block_cloning/setup.ksh \
+	functional/block_cloning/block_cloning_clone_mmap_write.ksh \
 	functional/block_cloning/block_cloning_copyfilerange_cross_dataset.ksh \
 	functional/block_cloning/block_cloning_copyfilerange_fallback.ksh \
 	functional/block_cloning/block_cloning_copyfilerange_fallback_same_txg.ksh \

--- a/tests/zfs-tests/tests/functional/bclone/TODO
+++ b/tests/zfs-tests/tests/functional/bclone/TODO
@@ -1,0 +1,4 @@
+- If dedup enabled, block_cloning uses dedup.
+- check when block cloning doesn't suppose to work
+- check block cloning between two different pools
+- block cloning from a snapshot

--- a/tests/zfs-tests/tests/functional/bclone/bclone.cfg
+++ b/tests/zfs-tests/tests/functional/bclone/bclone.cfg
@@ -1,0 +1,32 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+# TODO: We should calculate that based on ashift.
+export MINBLOCKSIZE=512
+
+export TESTSRCFS="$TESTPOOL/$TESTFS/src"
+export TESTDSTFS="$TESTPOOL/$TESTFS/dst"
+export TESTSRCDIR="$TESTDIR/src"
+export TESTDSTDIR="$TESTDIR/dst"

--- a/tests/zfs-tests/tests/functional/bclone/bclone_common.kshlib
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_common.kshlib
@@ -1,0 +1,280 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/tests/functional/bclone/bclone.cfg
+
+export RECORDSIZE=$(zfs get -Hp -o value recordsize $TESTPOOL/$TESTFS)
+
+MINBLKSIZE1=512
+MINBLKSIZE2=1024
+
+function verify_block_cloning
+{
+	if is_linux && [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+		log_unsupported "copy_file_range not available before Linux 4.5"
+	fi
+}
+
+function verify_crossfs_block_cloning
+{
+	if is_linux && [[ $(linux_version) -lt $(linux_version "5.3") ]]; then
+		log_unsupported "copy_file_range can't copy cross-filesystem before Linux 5.3"
+	fi
+}
+
+# Unused.
+function size_to_dsize
+{
+    typeset -r size=$1
+    typeset -r dir=$2
+
+    typeset -r dataset=$(df $dir | tail -1 | awk '{print $1}')
+    typeset -r recordsize=$(get_prop recordsize $dataset)
+    typeset -r copies=$(get_prop copies $dataset)
+    typeset dsize
+
+    if [[ $size -le $recordsize ]]; then
+        dsize=$(( ((size - 1) / MINBLOCKSIZE + 1) * MINBLOCKSIZE ))
+    else
+        dsize=$(( ((size - 1) / recordsize + 1) * recordsize ))
+    fi
+    dsize=$((dsize*copies))
+
+    echo $dsize
+}
+
+function test_file_integrity
+{
+    typeset -r original_checksum=$1
+    typeset -r clone=$2
+    typeset -r filesize=$3
+
+    typeset -r clone_checksum=$(sha256digest $clone)
+
+    if [[ $original_checksum != $clone_checksum ]]; then
+        log_fail "Clone $clone is corrupted with file size $filesize"
+    fi
+}
+
+function verify_pool_prop_eq
+{
+    typeset -r prop=$1
+    typeset -r expected=$2
+
+    typeset -r value=$(get_pool_prop $prop $TESTPOOL)
+    if [[ $value != $expected ]]; then
+        log_fail "Pool property $prop is incorrect: expected $expected, got $value"
+    fi
+}
+
+function verify_pool_props
+{
+    typeset -r dsize=$1
+    typeset -r ratio=$2
+
+    if [[ $dsize -eq 0 ]]; then
+        verify_pool_prop_eq bcloneused 0
+        verify_pool_prop_eq bclonesaved 0
+        verify_pool_prop_eq bcloneratio 1.00
+    else
+        if [[ $ratio -eq 1 ]]; then
+            verify_pool_prop_eq bcloneused 0
+        else
+            verify_pool_prop_eq bcloneused $dsize
+        fi
+        verify_pool_prop_eq bclonesaved $((dsize*(ratio-1)))
+        verify_pool_prop_eq bcloneratio "${ratio}.00"
+    fi
+}
+
+# Function to test file copying and integrity check.
+function bclone_test
+{
+    typeset -r datatype=$1
+    typeset filesize=$2
+    typeset -r embedded=$3
+    typeset -r srcdir=$4
+    typeset -r dstdir=$5
+    typeset dsize
+
+    typeset -r original="${srcdir}/original"
+    typeset -r clone="${dstdir}/clone"
+
+    log_note "Testing file copy with datatype $datatype, file size $filesize, embedded $embedded"
+
+    # Create a test file with known content.
+    case $datatype in
+        random|text)
+            sync_pool $TESTPOOL
+            if [[ $datatype = "random" ]]; then
+                dd if=/dev/urandom of=$original bs=$filesize count=1 2>/dev/null
+            else
+                filesize=$(((filesize/4)*4))
+                dd if=/dev/urandom bs=$(((filesize/4)*3)) count=1 | \
+                  openssl base64 -A > $original
+            fi
+            sync_pool $TESTPOOL
+            clonefile -f $original "${clone}-tmp"
+            sync_pool $TESTPOOL
+            # It is hard to predict block sizes that will be used,
+            # so just do one clone and take it from bcloneused.
+            filesize=$(zpool get -Hp -o value bcloneused $TESTPOOL)
+            if [[ $embedded = "false" ]]; then
+                log_must test $filesize -gt 0
+            fi
+            rm -f "${clone}-tmp"
+            sync_pool $TESTPOOL
+            dsize=$filesize
+            ;;
+        hole)
+            log_must truncate_test -s $filesize -f $original
+            dsize=0
+            ;;
+        *)
+            log_fail "Unknown datatype $datatype"
+            ;;
+    esac
+    if [[ $embedded = "true" ]]; then
+        dsize=0
+    fi
+
+    typeset -r original_checksum=$(sha256digest $original)
+
+    sync_pool $TESTPOOL
+
+    # Create a first clone of the entire file.
+    clonefile -f $original "${clone}0"
+    # Try to clone the clone in the same transaction group.
+    clonefile -f "${clone}0" "${clone}2"
+
+    # Clone the original again...
+    clonefile -f $original "${clone}1"
+    # ...and overwrite it in the same transaction group.
+    clonefile -f $original "${clone}1"
+
+    # Clone the clone...
+    clonefile -f "${clone}1" "${clone}3"
+    sync_pool $TESTPOOL
+    # ...and overwrite in the new transaction group.
+    clonefile -f "${clone}1" "${clone}3"
+
+    sync_pool $TESTPOOL
+
+    # Test removal of the pending clones (before they are committed to disk).
+    clonefile -f $original "${clone}4"
+    clonefile -f "${clone}4" "${clone}5"
+    rm -f "${clone}4" "${clone}5"
+
+    # Clone into one file, but remove another file, but with the same data in
+    # the same transaction group.
+    clonefile -f $original "${clone}5"
+    sync_pool $TESTPOOL
+    clonefile -f $original "${clone}4"
+    rm -f "${clone}5"
+    test_file_integrity $original_checksum "${clone}4" $filesize
+    sync_pool $TESTPOOL
+    test_file_integrity $original_checksum "${clone}4" $filesize
+
+    clonefile -f "${clone}4" "${clone}5"
+    # Verify integrity of the cloned file before it is committed to disk.
+    test_file_integrity $original_checksum "${clone}5" $filesize
+
+    sync_pool $TESTPOOL
+
+    # Verify integrity in the new transaction group.
+    test_file_integrity $original_checksum "${clone}0" $filesize
+    test_file_integrity $original_checksum "${clone}1" $filesize
+    test_file_integrity $original_checksum "${clone}2" $filesize
+    test_file_integrity $original_checksum "${clone}3" $filesize
+    test_file_integrity $original_checksum "${clone}4" $filesize
+    test_file_integrity $original_checksum "${clone}5" $filesize
+
+    verify_pool_props $dsize 7
+
+    # Clear cache and test after fresh import.
+    log_must zpool export $TESTPOOL
+    log_must zpool import $TESTPOOL
+
+    # Cloned uncached file.
+    clonefile -f $original "${clone}6"
+    # Cloned uncached clone.
+    clonefile -f "${clone}6" "${clone}7"
+
+    # Cache the file.
+    cat $original >/dev/null
+    clonefile -f $original "${clone}8"
+    clonefile -f "${clone}8" "${clone}9"
+
+    test_file_integrity $original_checksum "${clone}6" $filesize
+    test_file_integrity $original_checksum "${clone}7" $filesize
+    test_file_integrity $original_checksum "${clone}8" $filesize
+    test_file_integrity $original_checksum "${clone}9" $filesize
+
+    sync_pool $TESTPOOL
+
+    verify_pool_props $dsize 11
+
+    log_must zpool export $TESTPOOL
+    log_must zpool import $TESTPOOL
+
+    test_file_integrity $original_checksum "${clone}0" $filesize
+    test_file_integrity $original_checksum "${clone}1" $filesize
+    test_file_integrity $original_checksum "${clone}2" $filesize
+    test_file_integrity $original_checksum "${clone}3" $filesize
+    test_file_integrity $original_checksum "${clone}4" $filesize
+    test_file_integrity $original_checksum "${clone}5" $filesize
+    test_file_integrity $original_checksum "${clone}6" $filesize
+    test_file_integrity $original_checksum "${clone}7" $filesize
+    test_file_integrity $original_checksum "${clone}8" $filesize
+    test_file_integrity $original_checksum "${clone}9" $filesize
+
+    rm -f $original
+    rm -f "${clone}1" "${clone}3" "${clone}5" "${clone}7"
+
+    sync_pool $TESTPOOL
+
+    test_file_integrity $original_checksum "${clone}0" $filesize
+    test_file_integrity $original_checksum "${clone}2" $filesize
+    test_file_integrity $original_checksum "${clone}4" $filesize
+    test_file_integrity $original_checksum "${clone}6" $filesize
+    test_file_integrity $original_checksum "${clone}8" $filesize
+    test_file_integrity $original_checksum "${clone}9" $filesize
+
+    verify_pool_props $dsize 6
+
+    rm -f "${clone}0" "${clone}2" "${clone}4" "${clone}8" "${clone}9"
+
+    sync_pool $TESTPOOL
+
+    test_file_integrity $original_checksum "${clone}6" $filesize
+
+    verify_pool_props $dsize 1
+
+    rm -f "${clone}6"
+
+    sync_pool $TESTPOOL
+
+    verify_pool_props $dsize 1
+}

--- a/tests/zfs-tests/tests/functional/bclone/bclone_corner_cases.kshlib
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_corner_cases.kshlib
@@ -1,0 +1,315 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+function first_half_checksum
+{
+    typeset -r file=$1
+
+    dd if=$file bs=$HALFRECORDSIZE count=1 2>/dev/null | sha256digest
+}
+
+function second_half_checksum
+{
+    typeset -r file=$1
+
+    dd if=$file bs=$HALFRECORDSIZE count=1 skip=1 2>/dev/null | sha256digest
+}
+
+function bclone_corner_cases_init
+{
+    typeset -r srcdir=$1
+    typeset -r dstdir=$2
+
+    export RECORDSIZE=4096
+    export HALFRECORDSIZE=$((RECORDSIZE / 2))
+
+    export CLONE="$dstdir/clone0"
+    export ORIG0="$srcdir/orig0"
+    export ORIG1="$srcdir/orig1"
+    export ORIG2="$srcdir/orig2"
+
+    # Create source files.
+    log_must dd if=/dev/urandom of="$ORIG0" bs=$RECORDSIZE count=1
+    log_must dd if=/dev/urandom of="$ORIG1" bs=$RECORDSIZE count=1
+    log_must dd if=/dev/urandom of="$ORIG2" bs=$RECORDSIZE count=1
+
+    export FIRST_HALF_ORIG0_CHECKSUM=$(first_half_checksum $ORIG0)
+    export FIRST_HALF_ORIG1_CHECKSUM=$(first_half_checksum $ORIG1)
+    export FIRST_HALF_ORIG2_CHECKSUM=$(first_half_checksum $ORIG2)
+    export SECOND_HALF_ORIG0_CHECKSUM=$(second_half_checksum $ORIG0)
+    export SECOND_HALF_ORIG1_CHECKSUM=$(second_half_checksum $ORIG1)
+    export SECOND_HALF_ORIG2_CHECKSUM=$(second_half_checksum $ORIG2)
+    export ZEROS_CHECKSUM=$(dd if=/dev/zero bs=$HALFRECORDSIZE count=1 | sha256digest)
+    export FIRST_HALF_CHECKSUM=""
+    export SECOND_HALF_CHECKSUM=""
+}
+
+function cache_clone
+{
+    typeset -r cached=$1
+
+    case "$cached" in
+    "cached")
+        dd if=$CLONE of=/dev/null bs=$RECORDSIZE 2>/dev/null
+        ;;
+    "uncached")
+        ;;
+    *)
+        log_fail "invalid cached: $cached"
+        ;;
+    esac
+}
+
+function create_existing
+{
+    typeset -r existing=$1
+
+    case "$existing" in
+    "no")
+        ;;
+    "small empty")
+        log_must truncate_test -s $HALFRECORDSIZE -f $CLONE
+        ;;
+    "full empty")
+        log_must truncate_test -s $RECORDSIZE -f $CLONE
+        ;;
+    "small data")
+        log_must dd if=/dev/urandom of=$CLONE bs=$HALFRECORDSIZE count=1 \
+         2>/dev/null
+        ;;
+    "full data")
+        log_must dd if=/dev/urandom of=$CLONE bs=$RECORDSIZE count=1 2>/dev/null
+        ;;
+    *)
+        log_fail "invalid existing: $existing"
+        ;;
+    esac
+}
+
+function create_clone
+{
+    typeset -r clone=$1
+    typeset -r file=$2
+
+    case "$clone" in
+    "no")
+        ;;
+    "yes")
+        clonefile -f $file $CLONE
+        case "$file" in
+        $ORIG0)
+            FIRST_HALF_CHECKSUM=$FIRST_HALF_ORIG0_CHECKSUM
+            SECOND_HALF_CHECKSUM=$SECOND_HALF_ORIG0_CHECKSUM
+            ;;
+        $ORIG2)
+            FIRST_HALF_CHECKSUM=$FIRST_HALF_ORIG2_CHECKSUM
+            SECOND_HALF_CHECKSUM=$SECOND_HALF_ORIG2_CHECKSUM
+            ;;
+        *)
+            log_fail "invalid file: $file"
+            ;;
+        esac
+        ;;
+    *)
+        log_fail "invalid clone: $clone"
+        ;;
+    esac
+}
+
+function overwrite_clone
+{
+    typeset -r overwrite=$1
+
+    case "$overwrite" in
+    "no")
+        ;;
+    "free")
+        log_must truncate_test -s 0 -f $CLONE
+        log_must truncate_test -s $RECORDSIZE -f $CLONE
+        FIRST_HALF_CHECKSUM=$ZEROS_CHECKSUM
+        SECOND_HALF_CHECKSUM=$ZEROS_CHECKSUM
+        ;;
+    "full")
+        log_must dd if=$ORIG1 of=$CLONE bs=$RECORDSIZE count=1 2>/dev/null
+        FIRST_HALF_CHECKSUM=$FIRST_HALF_ORIG1_CHECKSUM
+        SECOND_HALF_CHECKSUM=$SECOND_HALF_ORIG1_CHECKSUM
+        ;;
+    "first half")
+        log_must dd if=$ORIG1 of=$CLONE bs=$HALFRECORDSIZE skip=0 seek=0 \
+          count=1 conv=notrunc 2>/dev/null
+        FIRST_HALF_CHECKSUM=$FIRST_HALF_ORIG1_CHECKSUM
+        ;;
+    "second half")
+        log_must dd if=$ORIG1 of=$CLONE bs=$HALFRECORDSIZE skip=1 seek=1 \
+          count=1 conv=notrunc 2>/dev/null
+        SECOND_HALF_CHECKSUM=$SECOND_HALF_ORIG1_CHECKSUM
+        ;;
+    *)
+        log_fail "invalid overwrite: $overwrite"
+        ;;
+    esac
+}
+
+function checksum_compare
+{
+    typeset -r compare=$1
+    typeset first_half_calculated_checksum second_half_calculated_checksum
+
+    case "$compare" in
+    "no")
+        ;;
+    "yes")
+        first_half_calculated_checksum=$(first_half_checksum $CLONE)
+        second_half_calculated_checksum=$(second_half_checksum $CLONE)
+
+        if [[ $first_half_calculated_checksum != $FIRST_HALF_CHECKSUM ]] || \
+           [[ $second_half_calculated_checksum != $SECOND_HALF_CHECKSUM ]]; then
+            return 1
+        fi
+        ;;
+    *)
+        log_fail "invalid compare: $compare"
+        ;;
+    esac
+}
+
+function bclone_corner_cases_test
+{
+    typeset cached existing
+    typeset first_clone first_overwrite
+    typeset read_after read_before
+    typeset second_clone second_overwrite
+    typeset -r srcdir=$1
+    typeset -r dstdir=$2
+    typeset limit=$3
+    typeset -i count=0
+
+    if [[ $srcdir != "count" ]]; then
+        if [[ -n "$limit" ]]; then
+            typeset -r total_count=$(bclone_corner_cases_test count)
+            limit=$(random_int_between 1 $total_count $((limit*2)) | sort -nu | head -n $limit | xargs)
+        fi
+        bclone_corner_cases_init $srcdir $dstdir
+    fi
+
+    #
+    # (create) / (cache) / (clone) / (overwrite) / (read) / (clone) / (overwrite) / (read) / read next txg
+    #
+    for existing in "no" "small empty" "full empty" "small data" "full data"; do
+        for cached in "uncached" "cached"; do
+            for first_clone in "no" "yes"; do
+                for first_overwrite in "no" "free" "full" "first half" "second half"; do
+                    for read_before in "no" "yes"; do
+                        for second_clone in "no" "yes"; do
+                            for second_overwrite in "no" "free" "full" "first half" "second half"; do
+                                for read_after in "no" "yes"; do
+                                    if [[ $first_clone = "no" ]] && \
+                                       [[ $second_clone = "no" ]]; then
+                                        continue
+                                    fi
+                                    if [[ $first_clone = "no" ]] && \
+                                       [[ $read_before = "yes" ]]; then
+                                        continue
+                                    fi
+                                    if [[ $second_clone = "no" ]] && \
+                                       [[ $read_before = "yes" ]] && \
+                                       [[ $read_after = "yes" ]]; then
+                                        continue
+                                    fi
+
+                                    count=$((count+1))
+
+                                    if [[ $srcdir = "count" ]]; then
+                                        # Just counting.
+                                        continue
+                                    fi
+
+                                    if [[ -n "$limit" ]]; then
+                                        if ! echo " $limit " | grep -q " $count "; then
+                                            continue
+                                        fi
+                                    fi
+
+                                    FIRST_HALF_CHECKSUM=""
+                                    SECOND_HALF_CHECKSUM=""
+
+                                    log_must zpool export $TESTPOOL
+                                    log_must zpool import $TESTPOOL
+
+                                    create_existing "$existing"
+
+                                    log_must zpool export $TESTPOOL
+                                    log_must zpool import $TESTPOOL
+
+                                    cache_clone "$cached"
+
+                                    create_clone "$first_clone" "$ORIG0"
+
+                                    overwrite_clone "$first_overwrite"
+
+                                    if checksum_compare $read_before; then
+                                        log_note "existing: $existing / cached: $cached / first_clone: $first_clone / first_overwrite: $first_overwrite / read_before: $read_before"
+                                    else
+                                        log_fail "FAIL: existing: $existing / cached: $cached / first_clone: $first_clone / first_overwrite: $first_overwrite / read_before: $read_before"
+                                    fi
+
+                                    create_clone "$second_clone" "$ORIG2"
+
+                                    overwrite_clone "$second_overwrite"
+
+                                    if checksum_compare $read_after; then
+                                        log_note "existing: $existing / cached: $cached / first_clone: $first_clone / first_overwrite: $first_overwrite / read_before: $read_before / second_clone: $second_clone / read_after: $read_after"
+                                    else
+                                        log_fail "FAIL: existing: $existing / cached: $cached / first_clone: $first_clone / first_overwrite: $first_overwrite / read_before: $read_before / second_clone: $second_clone / read_after: $read_after"
+                                    fi
+
+                                    log_must zpool export $TESTPOOL
+                                    log_must zpool import $TESTPOOL
+
+                                    if checksum_compare "yes"; then
+                                        log_note "existing: $existing / cached: $cached / first_clone: $first_clone / first_overwrite: $first_overwrite / read_before: $read_before / second_clone: $second_clone / read_after: $read_after / read_next_txg"
+                                    else
+                                        log_fail "FAIL: existing: $existing / cached: $cached / first_clone: $first_clone / first_overwrite: $first_overwrite / read_before: $read_before / second_clone: $second_clone / read_after: $read_after / read_next_txg"
+                                    fi
+
+                                    rm -f "$CLONE"
+                                done
+                            done
+                        done
+                    done
+                done
+            done
+        done
+    done
+
+    if [[ $srcdir = "count" ]]; then
+        echo $count
+    fi
+}

--- a/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_corner_cases.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_corner_cases.ksh
@@ -1,0 +1,45 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_corner_cases.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify various corner cases in block cloning across datasets"
+
+# Disable compression to make sure we won't use embedded blocks.
+log_must zfs set compress=off $TESTSRCFS
+log_must zfs set recordsize=$RECORDSIZE $TESTSRCFS
+log_must zfs set compress=off $TESTDSTFS
+log_must zfs set recordsize=$RECORDSIZE $TESTDSTFS
+
+bclone_corner_cases_test $TESTSRCDIR $TESTDSTDIR
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_corner_cases_limited.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_corner_cases_limited.ksh
@@ -1,0 +1,45 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_corner_cases.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify various corner cases in block cloning across datasets"
+
+# Disable compression to make sure we won't use embedded blocks.
+log_must zfs set compress=off $TESTSRCFS
+log_must zfs set recordsize=$RECORDSIZE $TESTSRCFS
+log_must zfs set compress=off $TESTDSTFS
+log_must zfs set recordsize=$RECORDSIZE $TESTDSTFS
+
+bclone_corner_cases_test $TESTSRCDIR $TESTDSTDIR 100
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_data.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_data.ksh
@@ -1,0 +1,46 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify block cloning properly clones regular files across datasets"
+
+# Disable compression to make sure we won't use embedded blocks.
+log_must zfs set compress=off $TESTSRCFS
+log_must zfs set compress=off $TESTDSTFS
+
+for filesize in 1 107 113 511 512 513 4095 4096 4097 131071 131072 131073 \
+  1048575 1048576 1048577 4194303 4194304 4194305; do
+    bclone_test random $filesize false $TESTSRCDIR $TESTDSTDIR
+done
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_embedded.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_embedded.ksh
@@ -1,0 +1,50 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify block cloning properly clones small files (with embedded blocks) across datasets"
+
+# Enable ZLE compression to make sure what is the maximum amount of data we
+# can store in BP.
+log_must zfs set compress=zle $TESTSRCFS
+log_must zfs set compress=zle $TESTDSTFS
+
+# Test BP_IS_EMBEDDED().
+# Maximum embedded payload size is 112 bytes, but the buffer is extended to
+# 512 bytes first and then compressed. 107 random bytes followed by 405 zeros
+# gives exactly 112 bytes after compression with ZLE.
+for filesize in 1 2 4 8 16 32 64 96 107; do
+    bclone_test random $filesize true $TESTSRCDIR $TESTDSTDIR
+done
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_hole.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_crossfs_hole.ksh
@@ -1,0 +1,45 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify block cloning properly clones sparse files (files with holes) across datasets"
+
+# Compression doesn't matter here.
+
+# Test BP_IS_HOLE().
+for filesize in 1 511 512 513 4095 4096 4097 131071 131072 131073 \
+  1048575 1048576 1048577 4194303 4194304 4194305; do
+    bclone_test hole $filesize false $TESTSRCDIR $TESTDSTDIR
+done
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_all.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_all.ksh
@@ -1,0 +1,86 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify block cloning across datasets with different properties"
+
+log_must zfs set checksum=off $TESTSRCFS
+log_must zfs set compress=off $TESTSRCFS
+log_must zfs set copies=1 $TESTSRCFS
+log_must zfs set recordsize=131072 $TESTSRCFS
+log_must zfs set checksum=fletcher2 $TESTDSTFS
+log_must zfs set compress=lz4 $TESTDSTFS
+log_must zfs set copies=3 $TESTDSTFS
+log_must zfs set recordsize=8192 $TESTDSTFS
+
+FILESIZE=$(random_int_between 2 32767)
+FILESIZE=$((FILESIZE * 64))
+bclone_test text $FILESIZE false $TESTSRCDIR $TESTDSTDIR
+
+log_must zfs set checksum=sha256 $TESTSRCFS
+log_must zfs set compress=zstd $TESTSRCFS
+log_must zfs set copies=2 $TESTSRCFS
+log_must zfs set recordsize=262144 $TESTSRCFS
+log_must zfs set checksum=off $TESTDSTFS
+log_must zfs set compress=off $TESTDSTFS
+log_must zfs set copies=1 $TESTDSTFS
+log_must zfs set recordsize=131072 $TESTDSTFS
+
+FILESIZE=$(random_int_between 2 32767)
+FILESIZE=$((FILESIZE * 64))
+bclone_test text $FILESIZE false $TESTSRCDIR $TESTDSTDIR
+
+log_must zfs set checksum=sha512 $TESTSRCFS
+log_must zfs set compress=gzip $TESTSRCFS
+log_must zfs set copies=2 $TESTSRCFS
+log_must zfs set recordsize=512 $TESTSRCFS
+log_must zfs set checksum=fletcher4 $TESTDSTFS
+log_must zfs set compress=lzjb $TESTDSTFS
+log_must zfs set copies=3 $TESTDSTFS
+log_must zfs set recordsize=16384 $TESTDSTFS
+
+FILESIZE=$(random_int_between 2 32767)
+FILESIZE=$((FILESIZE * 64))
+bclone_test text $FILESIZE false $TESTSRCDIR $TESTDSTDIR
+
+log_must zfs inherit checksum $TESTSRCFS
+log_must zfs inherit compress $TESTSRCFS
+log_must zfs inherit copies $TESTSRCFS
+log_must zfs inherit recordsize $TESTSRCFS
+log_must zfs inherit checksum $TESTDSTFS
+log_must zfs inherit compress $TESTDSTFS
+log_must zfs inherit copies $TESTDSTFS
+log_must zfs inherit recordsize $TESTDSTFS
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_checksum.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_checksum.ksh
@@ -1,0 +1,62 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+. $STF_SUITE/include/properties.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify block cloning across datasets with different checksum properties"
+
+log_must zfs set compress=off $TESTSRCFS
+log_must zfs set compress=off $TESTDSTFS
+
+for srcprop in "${checksum_prop_vals[@]}"; do
+    for dstprop in "${checksum_prop_vals[@]}"; do
+        if [[ $srcprop == $dstprop ]]; then
+            continue
+        fi
+        log_must zfs set checksum=$srcprop $TESTSRCFS
+        log_must zfs set checksum=$dstprop $TESTDSTFS
+        # 15*8=120, which is greater than 113, so we are sure the data won't
+        # be embedded into BP.
+        # 32767*8=262136, which is larger than a single default recordsize of
+        # 131072.
+        FILESIZE=$(random_int_between 15 32767)
+        FILESIZE=$((FILESIZE * 8))
+        bclone_test random $FILESIZE false $TESTSRCDIR $TESTDSTDIR
+    done
+done
+
+log_must zfs inherit checksum $TESTSRCFS
+log_must zfs inherit checksum $TESTDSTFS
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_compress.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_compress.ksh
@@ -1,0 +1,59 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+. $STF_SUITE/include/properties.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify block cloning across datasets with different compression properties"
+
+for srcprop in "${compress_prop_vals[@]}"; do
+    for dstprop in "${compress_prop_vals[@]}"; do
+        if [[ $srcprop == $dstprop ]]; then
+            continue
+        fi
+        log_must zfs set compress=$srcprop $TESTSRCFS
+        log_must zfs set compress=$dstprop $TESTDSTFS
+        # 15*8=120, which is greater than 113, so we are sure the data won't
+        # be embedded into BP.
+        # 32767*8=262136, which is larger than a single default recordsize of
+        # 131072.
+        FILESIZE=$(random_int_between 15 32767)
+        FILESIZE=$((FILESIZE * 8))
+        bclone_test text $FILESIZE false $TESTSRCDIR $TESTDSTDIR
+    done
+done
+
+log_must zfs inherit compress $TESTSRCFS
+log_must zfs inherit compress $TESTDSTFS
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_copies.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_copies.ksh
@@ -1,0 +1,59 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+. $STF_SUITE/include/properties.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify block cloning across datasets with different copies properties"
+
+log_must zfs set compress=off $TESTSRCFS
+log_must zfs set compress=off $TESTDSTFS
+
+for srcprop in "${copies_prop_vals[@]}"; do
+    for dstprop in "${copies_prop_vals[@]}"; do
+        log_must zfs set copies=$srcprop $TESTSRCFS
+        log_must zfs set copies=$dstprop $TESTDSTFS
+        # 15*8=120, which is greater than 113, so we are sure the data won't
+        # be embedded into BP.
+        # 32767*8=262136, which is larger than a single default recordsize of
+        # 131072.
+        FILESIZE=$(random_int_between 15 32767)
+        FILESIZE=$((FILESIZE * 8))
+        bclone_test random $FILESIZE false $TESTSRCDIR $TESTDSTDIR
+    done
+done
+
+log_must zfs inherit copies $TESTSRCFS
+log_must zfs inherit copies $TESTDSTFS
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_recordsize.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_diffprops_recordsize.ksh
@@ -1,0 +1,65 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+. $STF_SUITE/include/properties.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify block cloning across datasets with different recordsize properties"
+
+log_must zfs set compress=off $TESTSRCFS
+log_must zfs set compress=off $TESTDSTFS
+
+# recsize_prop_vals[] array contains too many entries and the tests take too
+# long. Let's use only a subset of them.
+typeset -a bclone_recsize_prop_vals=('512' '4096' '131072' '1048576')
+
+for srcprop in "${bclone_recsize_prop_vals[@]}"; do
+    for dstprop in "${bclone_recsize_prop_vals[@]}"; do
+        if [[ $srcprop == $dstprop ]]; then
+            continue
+        fi
+        log_must zfs set recordsize=$srcprop $TESTSRCFS
+        log_must zfs set recordsize=$dstprop $TESTDSTFS
+        # 2*64=128, which is greater than 113, so we are sure the data won't
+        # be embedded into BP.
+        # 32767*64=2097088, which is larger than the largest recordsize (1MB).
+        FILESIZE=$(random_int_between 2 32767)
+        FILESIZE=$((FILESIZE * 64))
+        bclone_test random $FILESIZE false $TESTSRCDIR $TESTDSTDIR
+    done
+done
+
+log_must zfs inherit recordsize $TESTSRCFS
+log_must zfs inherit recordsize $TESTDSTFS
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_prop_sync.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_prop_sync.ksh
@@ -1,0 +1,66 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+. $STF_SUITE/include/properties.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+verify_crossfs_block_cloning
+
+log_assert "Verify block cloning with all sync property settings"
+
+log_must zfs set compress=zle $TESTSRCFS
+log_must zfs set compress=zle $TESTDSTFS
+
+for prop in "${sync_prop_vals[@]}"; do
+    log_must zfs set sync=$prop $TESTSRCFS
+    # 32767*8=262136, which is larger than a single default recordsize of
+    # 131072.
+    FILESIZE=$(random_int_between 1 32767)
+    FILESIZE=$((FILESIZE * 8))
+    bclone_test random $FILESIZE false $TESTSRCDIR $TESTSRCDIR
+done
+
+for srcprop in "${sync_prop_vals[@]}"; do
+    log_must zfs set sync=$srcprop $TESTSRCFS
+    for dstprop in "${sync_prop_vals[@]}"; do
+        log_must zfs set sync=$dstprop $TESTDSTFS
+        # 32767*8=262136, which is larger than a single default recordsize of
+        # 131072.
+        FILESIZE=$(random_int_between 1 32767)
+        FILESIZE=$((FILESIZE * 8))
+        bclone_test random $FILESIZE false $TESTSRCDIR $TESTDSTDIR
+    done
+done
+
+log_must zfs inherit sync $TESTSRCFS
+log_must zfs inherit sync $TESTDSTFS
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_samefs_corner_cases.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_samefs_corner_cases.ksh
@@ -1,0 +1,42 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_corner_cases.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+
+log_assert "Verify various corner cases in block cloning within the same dataset"
+
+# Disable compression to make sure we won't use embedded blocks.
+log_must zfs set compress=off $TESTSRCFS
+log_must zfs set recordsize=$RECORDSIZE $TESTSRCFS
+
+bclone_corner_cases_test $TESTSRCDIR $TESTSRCDIR
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_samefs_corner_cases_limited.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_samefs_corner_cases_limited.ksh
@@ -1,0 +1,42 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_corner_cases.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+
+log_assert "Verify various corner cases in block cloning within the same dataset"
+
+# Disable compression to make sure we won't use embedded blocks.
+log_must zfs set compress=off $TESTSRCFS
+log_must zfs set recordsize=$RECORDSIZE $TESTSRCFS
+
+bclone_corner_cases_test $TESTSRCDIR $TESTSRCDIR 100
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_samefs_data.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_samefs_data.ksh
@@ -1,0 +1,44 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+
+log_assert "Verify block cloning properly clones regular files within the same dataset"
+
+# Disable compression to make sure we won't use embedded blocks.
+log_must zfs set compress=off $TESTSRCFS
+
+for filesize in 1 107 113 511 512 513 4095 4096 4097 131071 131072 131073 \
+  1048575 1048576 1048577 4194303 4194304 4194305; do
+    bclone_test random $filesize false $TESTSRCDIR $TESTSRCDIR
+done
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_samefs_embedded.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_samefs_embedded.ksh
@@ -1,0 +1,48 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+
+log_assert "Verify block cloning properly clones small files (with embedded blocks) within the same dataset"
+
+# Enable ZLE compression to make sure what is the maximum amount of data we
+# can store in BP.
+log_must zfs set compress=zle $TESTSRCFS
+
+# Test BP_IS_EMBEDDED().
+# Maximum embedded payload size is 112 bytes, but the buffer is extended to
+# 512 bytes first and then compressed. 107 random bytes followed by 405 zeros
+# gives exactly 112 bytes after compression with ZLE.
+for filesize in 1 2 4 8 16 32 64 96 107; do
+    bclone_test random $filesize true $TESTSRCDIR $TESTSRCDIR
+done
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/bclone_samefs_hole.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_samefs_hole.ksh
@@ -1,0 +1,44 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
+
+verify_runnable "both"
+
+verify_block_cloning
+
+log_assert "Verify block cloning properly clones sparse files (files with holes) within the same dataset"
+
+# Compression doesn't matter here.
+
+# Test BP_IS_HOLE().
+for filesize in 1 511 512 513 4095 4096 4097 131071 131072 131073 \
+  1048575 1048576 1048577 4194303 4194304 4194305; do
+    bclone_test hole $filesize false $TESTSRCDIR $TESTSRCDIR
+done
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/cleanup.ksh
@@ -1,0 +1,37 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone.cfg
+
+log_must zfs destroy $TESTSRCFS
+log_must zfs destroy $TESTDSTFS
+default_cleanup

--- a/tests/zfs-tests/tests/functional/bclone/setup.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/setup.ksh
@@ -1,0 +1,45 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2023 by Pawel Jakub Dawidek
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/bclone/bclone.cfg
+
+if ! command -v clonefile > /dev/null ; then
+	log_unsupported "clonefile program required to test block cloning"
+fi
+
+DISK=${DISKS%% *}
+
+default_setup_noexit $DISK "true"
+log_must zpool set feature@block_cloning=enabled $TESTPOOL
+log_must zfs create $TESTSRCFS
+log_must zfs create $TESTDSTFS
+log_pass

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning.kshlib
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning.kshlib
@@ -53,6 +53,6 @@ function get_same_blocks
 	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout.a
 	zdb $KEY -vvvvv $3 -O $4 | \
 	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout.b
-	echo $(sort $zdbout.a $zdbout.b | uniq -d | cut -f1 -d' ')
+	echo $(sort -n $zdbout.a $zdbout.b | uniq -d | cut -f1 -d' ')
 }
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_clone_mmap_cached.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_clone_mmap_cached.ksh
@@ -1,0 +1,86 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+#
+# DESCRIPTION:
+#	When the destination file is mmaped and is already cached we need to
+#	update mmaped pages after successful clone.
+#
+# STRATEGY:
+#	1. Create a pool.
+#	2. Create a two test files with random content.
+#	3. mmap the files, read them and clone from one to the other using
+#	   clone_mmap_cached.
+#	4. clone_mmap_cached also verifies if the content of the destination
+#	   file was updated while reading it from mmaped memory.
+#
+
+verify_runnable "global"
+
+if is_linux && [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+  log_unsupported "copy_file_range not available before Linux 4.5"
+fi
+
+VDIR=$TEST_BASE_DIR/disk-bclone
+VDEV="$VDIR/a"
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -rf $VDIR
+}
+
+log_onexit cleanup
+
+log_assert "Test for clone into mmaped and cached file"
+
+log_must rm -rf $VDIR
+log_must mkdir -p $VDIR
+log_must truncate -s 1G $VDEV
+
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $VDEV
+log_must zfs create $TESTPOOL/$TESTFS
+
+for opts in "--" "-i" "-o" "-io"
+do
+	log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/src bs=1M count=1
+	log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/dst bs=1M count=1
+
+	# Clear cache.
+	log_must zpool export $TESTPOOL
+	log_must zpool import -d $VDIR $TESTPOOL
+
+	log_must clone_mmap_cached $opts /$TESTPOOL/$TESTFS/src /$TESTPOOL/$TESTFS/dst
+
+	sync_pool $TESTPOOL
+	log_must sync
+
+	log_must have_same_content /$TESTPOOL/$TESTFS/src /$TESTPOOL/$TESTFS/dst
+	blocks=$(get_same_blocks $TESTPOOL/$TESTFS src $TESTPOOL/$TESTFS dst)
+	# FreeBSD's seq(1) leaves a trailing space, remove it with sed(1).
+	log_must [ "$blocks" = "$(seq -s " " 0 7 | sed 's/ $//')" ]
+done
+
+log_pass "Clone properly updates mmapped and cached pages"

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_clone_mmap_write.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_clone_mmap_write.ksh
@@ -1,0 +1,79 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+#
+# DESCRIPTION:
+#	A PANIC is triggered in dbuf_redirty() if we clone a file, mmap it
+#	and write from the map into the file. PR#15656 fixes this scenario.
+#	This scenario also causes data corruption on FreeBSD, which is fixed
+#	by PR#15665.
+#
+# STRATEGY:
+#	1. Create a pool
+#	2. Create a test file 
+#	3. Clone, mmap and write to the file using clone_mmap_write
+#	5. Synchronize cached writes
+#	6. Verfiy data is correctly written to the disk
+#
+
+verify_runnable "global"
+
+if is_linux && [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+  log_unsupported "copy_file_range not available before Linux 4.5"
+fi
+
+VDIR=$TEST_BASE_DIR/disk-bclone
+VDEV="$VDIR/a"
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -rf $VDIR
+}
+
+log_onexit cleanup
+
+log_assert "Test for clone, mmap and write scenario"
+
+log_must rm -rf $VDIR
+log_must mkdir -p $VDIR
+log_must truncate -s 1G $VDEV
+
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $VDEV
+log_must zfs create $TESTPOOL/$TESTFS
+
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file bs=1M count=512
+log_must clone_mmap_write /$TESTPOOL/$TESTFS/file /$TESTPOOL/$TESTFS/clone
+
+sync_pool $TESTPOOL
+log_must sync
+
+log_must have_same_content /$TESTPOOL/$TESTFS/file /$TESTPOOL/$TESTFS/clone
+blocks=$(get_same_blocks $TESTPOOL/$TESTFS file $TESTPOOL/$TESTFS clone)
+# FreeBSD's seq(1) leaves a trailing space, remove it with sed(1).
+log_must [ "$blocks" = "$(seq -s " " 1 4095 | sed 's/ $//')" ]
+
+log_pass "Clone, mmap and write does not cause data corruption or " \
+	"trigger panic"

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange.ksh
@@ -29,7 +29,7 @@
 
 verify_runnable "global"
 
-if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+if is_linux && [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
   log_unsupported "copy_file_range not available before Linux 4.5"
 fi
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_cross_dataset.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_cross_dataset.ksh
@@ -29,7 +29,7 @@
 
 verify_runnable "global"
 
-if [[ $(linux_version) -lt $(linux_version "5.3") ]]; then
+if is_linux && [[ $(linux_version) -lt $(linux_version "5.3") ]]; then
   log_unsupported "copy_file_range can't copy cross-filesystem before Linux 5.3"
 fi
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback.ksh
@@ -30,7 +30,7 @@
 
 verify_runnable "global"
 
-if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+if is_linux && [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
   log_unsupported "copy_file_range not available before Linux 4.5"
 fi
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback_same_txg.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_fallback_same_txg.ksh
@@ -30,7 +30,7 @@
 
 verify_runnable "global"
 
-if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+if is_linux && [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
   log_unsupported "copy_file_range not available before Linux 4.5"
 fi
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_partial.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_partial.ksh
@@ -29,7 +29,7 @@
 
 verify_runnable "global"
 
-if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+if is_linux && [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
   log_unsupported "copy_file_range not available before Linux 4.5"
 fi
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_cross_enc_dataset.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_cross_enc_dataset.ksh
@@ -29,7 +29,7 @@
 
 verify_runnable "global"
 
-if [[ $(linux_version) -lt $(linux_version "5.3") ]]; then
+if is_linux && [[ $(linux_version) -lt $(linux_version "5.3") ]]; then
   log_unsupported "copy_file_range can't copy cross-filesystem before Linux 5.3"
 fi
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_disabled_copyfilerange.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_disabled_copyfilerange.ksh
@@ -29,7 +29,7 @@
 
 verify_runnable "global"
 
-if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+if is_linux && [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
   log_unsupported "copy_file_range not available before Linux 4.5"
 fi
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_lwb_buffer_overflow.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_lwb_buffer_overflow.ksh
@@ -1,0 +1,89 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023 by iXsystems, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+#
+# DESCRIPTION:
+#	Test for LWB buffer overflow with multiple VDEVs ZIL when 128KB
+#	block write is split into two 68KB ones, trying to write maximum
+#	sizes 128KB TX_CLONE_RANGE record with 1022 block pointers into
+#	68KB buffer.
+#
+# STRATEGY:
+#	1. Create a pool with multiple VDEVs ZIL
+#	2. Write maximum sizes TX_CLONE_RANGE record with 1022 block
+#	   pointers into 68KB buffer
+#	3. Sync TXG
+#	4. Clone the file
+#	5. Synchronize cached writes
+#
+
+verify_runnable "global"
+
+if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+  log_unsupported "copy_file_range not available before Linux 4.5"
+fi
+
+VDIR=$TEST_BASE_DIR/disk-bclone
+VDEV="$VDIR/a $VDIR/b $VDIR/c"
+LDEV="$VDIR/e $VDIR/f"
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -rf $VDIR
+}
+
+log_onexit cleanup
+
+log_assert "Test for LWB buffer overflow with multiple VDEVs ZIL"
+
+log_must rm -rf $VDIR
+log_must mkdir -p $VDIR
+log_must truncate -s $MINVDEVSIZE $VDEV $LDEV
+
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $VDEV \
+	log mirror $LDEV
+log_must zfs create -o recordsize=32K $TESTPOOL/$TESTFS
+# Each ZIL log entry can fit 130816 bytes for a block cloning operation,
+# so it can store 1022 block pointers. When LWB optimization is enabled,
+# an assert is hit when 128KB block write is split into two 68KB ones
+# for 2 SLOG devices
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file1 bs=32K count=1022 \
+	conv=fsync
+sync_pool $TESTPOOL
+log_must clonefile -c /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/file2
+log_must sync
+
+sync_pool $TESTPOOL
+log_must have_same_content /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/file2
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file1 $TESTPOOL/$TESTFS file2)
+log_must [ "$blocks" = "$(seq -s " " 0 1021)" ]
+
+log_pass "LWB buffer overflow is not triggered with multiple VDEVs ZIL"
+

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay.ksh
@@ -42,7 +42,7 @@
 
 verify_runnable "global"
 
-if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+if is_linux && [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
   log_unsupported "copy_file_range not available before Linux 4.5"
 fi
 
@@ -90,8 +90,8 @@ log_must zpool freeze $TESTPOOL
 #
 # 4. TX_CLONE_RANGE: Clone the file
 #
-log_must clonefile -c /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
-log_must clonefile -c /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
+log_must clonefile -f /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
+log_must clonefile -f /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
 
 #
 # 5. Unmount filesystem and export the pool
@@ -126,6 +126,7 @@ log_must [ "$blocks" = "0 1 2 3" ]
 
 typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file2 \
 	$TESTPOOL/$TESTFS clone2)
-log_must [ "$blocks" = "$(seq -s " " 0 2047)" ]
+# FreeBSD's seq(1) leaves a trailing space, remove it with sed(1).
+log_must [ "$blocks" = "$(seq -s " " 0 2047 | sed 's/ $//')" ]
 
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay.ksh
@@ -1,0 +1,131 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+#
+# DESCRIPTION:
+#	Verify slogs are replayed correctly for cloned files. This
+#	test is ported from slog_replay tests for block cloning.
+#
+# STRATEGY:
+#	1. Create an empty file system (TESTFS)
+#	2. Create regular files and sync
+#	3. Freeze TESTFS
+#	4. Clone the file
+#	5. Unmount filesystem
+#	   <At this stage TESTFS is frozen, the intent log contains a
+#	   complete set of deltas to replay it>
+#	6. Remount TESTFS <which replays the intent log>
+#	7. Compare clone file with the original file
+#
+
+verify_runnable "global"
+
+if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+  log_unsupported "copy_file_range not available before Linux 4.5"
+fi
+
+export VDIR=$TEST_BASE_DIR/disk-bclone
+export VDEV="$VDIR/a $VDIR/b $VDIR/c"
+export LDEV="$VDIR/e $VDIR/f"
+log_must rm -rf $VDIR
+log_must mkdir -p $VDIR
+log_must truncate -s $MINVDEVSIZE $VDEV $LDEV
+
+claim="The slogs are replayed correctly for cloned files."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -rf $TESTDIR $VDIR $VDIR2
+}
+
+log_onexit cleanup
+
+#
+# 1. Create an empty file system (TESTFS)
+#
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $VDEV \
+	log mirror $LDEV
+log_must zfs create $TESTPOOL/$TESTFS
+
+#
+# 2. TX_WRITE: Create two files and sync txg
+#
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file1 \
+    oflag=sync bs=128k count=4
+log_must zfs set recordsize=16K $TESTPOOL/$TESTFS
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file2 \
+    oflag=sync bs=16K count=2048
+sync_pool $TESTPOOL
+
+#
+# 3. Checkpoint for ZIL Replay
+#
+log_must zpool freeze $TESTPOOL
+
+#
+# 4. TX_CLONE_RANGE: Clone the file
+#
+log_must clonefile -c /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
+log_must clonefile -c /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
+
+#
+# 5. Unmount filesystem and export the pool
+#
+# At this stage TESTFS is frozen, the intent log contains a complete set
+# of deltas to replay for clone files.
+#
+log_must zfs unmount /$TESTPOOL/$TESTFS
+
+log_note "Verify transactions to replay:"
+log_must zdb -iv $TESTPOOL/$TESTFS
+
+log_must zpool export $TESTPOOL
+
+#
+# 6. Remount TESTFS <which replays the intent log>
+#
+# Import the pool to unfreeze it and claim log blocks.  It has to be
+# `zpool import -f` because we can't write a frozen pool's labels!
+#
+log_must zpool import -f -d $VDIR $TESTPOOL
+
+#
+# 7. Compare clone file with the original file
+#
+log_must have_same_content /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
+log_must have_same_content /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
+
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file1 \
+	$TESTPOOL/$TESTFS clone1)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file2 \
+	$TESTPOOL/$TESTFS clone2)
+log_must [ "$blocks" = "$(seq -s " " 0 2047)" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay_encrypted.ksh
@@ -42,7 +42,7 @@
 
 verify_runnable "global"
 
-if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+if is_linux && [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
   log_unsupported "copy_file_range not available before Linux 4.5"
 fi
 
@@ -92,8 +92,8 @@ log_must zpool freeze $TESTPOOL
 #
 # 4. TX_CLONE_RANGE: Clone the file
 #
-log_must clonefile -c /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
-log_must clonefile -c /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
+log_must clonefile -f /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
+log_must clonefile -f /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
 
 #
 # 5. Unmount filesystem and export the pool
@@ -128,6 +128,7 @@ log_must [ "$blocks" = "0 1 2 3" ]
 
 typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file2 \
 	$TESTPOOL/$TESTFS clone2 $PASSPHRASE)
-log_must [ "$blocks" = "$(seq -s " " 0 2047)" ]
+# FreeBSD's seq(1) leaves a trailing space, remove it with sed(1).
+log_must [ "$blocks" = "$(seq -s " " 0 2047 | sed 's/ $//')" ]
 
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_replay_encrypted.ksh
@@ -1,0 +1,133 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+#
+# DESCRIPTION:
+#	Verify slogs are replayed correctly for encrypted cloned files.
+#	This test is ported from slog_replay tests for block cloning.
+#
+# STRATEGY:
+#	1. Create an encrypted file system (TESTFS)
+#	2. Create regular files and sync
+#	3. Freeze TESTFS
+#	4. Clone the file
+#	5. Unmount filesystem
+#	   <At this stage TESTFS is frozen, the intent log contains a
+#	   complete set of deltas to replay it>
+#	6. Remount encrypted TESTFS <which replays the intent log>
+#	7. Compare clone file with the original file
+#
+
+verify_runnable "global"
+
+if [[ $(linux_version) -lt $(linux_version "4.5") ]]; then
+  log_unsupported "copy_file_range not available before Linux 4.5"
+fi
+
+export VDIR=$TEST_BASE_DIR/disk-bclone
+export VDEV="$VDIR/a $VDIR/b $VDIR/c"
+export LDEV="$VDIR/e $VDIR/f"
+log_must rm -rf $VDIR
+log_must mkdir -p $VDIR
+log_must truncate -s $MINVDEVSIZE $VDEV $LDEV
+export PASSPHRASE="password"
+
+claim="The slogs are replayed correctly for encrypted cloned files."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -rf $TESTDIR $VDIR $VDIR2
+}
+
+log_onexit cleanup
+
+#
+# 1. Create an encrypted file system (TESTFS)
+#
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $VDEV \
+	log mirror $LDEV
+log_must eval "echo $PASSPHRASE | zfs create -o encryption=on" \
+	"-o keyformat=passphrase -o keylocation=prompt $TESTPOOL/$TESTFS"
+
+#
+# 2. TX_WRITE: Create two files and sync txg
+#
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file1 \
+    oflag=sync bs=128k count=4
+log_must zfs set recordsize=16K $TESTPOOL/$TESTFS
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file2 \
+    oflag=sync bs=16K count=2048
+sync_pool $TESTPOOL
+
+#
+# 3. Checkpoint for ZIL Replay
+#
+log_must zpool freeze $TESTPOOL
+
+#
+# 4. TX_CLONE_RANGE: Clone the file
+#
+log_must clonefile -c /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
+log_must clonefile -c /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
+
+#
+# 5. Unmount filesystem and export the pool
+#
+# At this stage TESTFS is frozen, the intent log contains a complete set
+# of deltas to replay for clone files.
+#
+log_must zfs unmount /$TESTPOOL/$TESTFS
+
+log_note "Verify transactions to replay:"
+log_must zdb -iv $TESTPOOL/$TESTFS
+
+log_must zpool export $TESTPOOL
+
+#
+# 6. Remount TESTFS <which replays the intent log>
+#
+# Import the pool to unfreeze it and claim log blocks.  It has to be
+# `zpool import -f` because we can't write a frozen pool's labels!
+#
+log_must eval "echo $PASSPHRASE | zpool import -l -f -d $VDIR $TESTPOOL"
+
+#
+# 7. Compare clone file with the original file
+#
+log_must have_same_content /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/clone1
+log_must have_same_content /$TESTPOOL/$TESTFS/file2 /$TESTPOOL/$TESTFS/clone2
+
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file1 \
+	$TESTPOOL/$TESTFS clone1 $PASSPHRASE)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+typeset blocks=$(get_same_blocks $TESTPOOL/$TESTFS file2 \
+	$TESTPOOL/$TESTFS clone2 $PASSPHRASE)
+log_must [ "$blocks" = "$(seq -s " " 0 2047)" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/setup.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/setup.ksh
@@ -30,6 +30,9 @@
 if ! command -v clonefile > /dev/null ; then
   log_unsupported "clonefile program required to test block cloning"
 fi
+if ! command -v clone_mmap_cached > /dev/null ; then
+  log_unsupported "clone_mmap_cached program required to test block cloning"
+fi
 
 verify_runnable "global"
 

--- a/tests/zfs-tests/tests/functional/redundancy/redundancy.kshlib
+++ b/tests/zfs-tests/tests/functional/redundancy/redundancy.kshlib
@@ -45,28 +45,6 @@ function cleanup
 }
 
 #
-# Get random number between min and max number.
-#
-# $1 Minimal value
-# $2 Maximal value
-#
-function random
-{
-	typeset -i min=$1
-	typeset -i max=$2
-	typeset -i value
-
-	while true; do
-		((value = RANDOM % (max + 1)))
-		if ((value >= min)); then
-			break
-		fi
-	done
-
-	echo $value
-}
-
-#
 # Get the number of checksum errors for the pool.
 #
 # $1 Pool


### PR DESCRIPTION
### Motivation and Context
Backport missing BRT tests and add "fix cloning into mmaped and cached file"

### Description
Backported commits (in order of appliance):
5ff43969e7bf64c21d91afbc121a5e2ea9b307d3 #15614 (ZTS: block_cloning: Use numeric sort for get_same_blocks)
2ebb9a4811ce14dc624cd085d959d74bf2da8e4e #15614 (ZTS: Add test cases for block cloning replay)
dbda45160ffa43e5ecf0498a609230f1afee7b3f #15672 (Test LWB buffer overflow for block cloning)
4cf4bc7334acf145daf6f7f894fbb333710c1cc9 #15631 (Block cloning tests)
c4fa674367776a8ced56df64d56a8797ed2cba48 #15749 (Enable block_cloning tests on FreeBSD)
995734ed12de767f98e1c02ba39efe9595e710b8 #15717 (ZTS: Test for clone, mmap and write for block cloning)
f45dd90f34cf8dadecc0236f9016046a6bf54ee5 #15772 (Fix cloning into mmaped and cached file)
d23444daed9e65e9257f1a5536db75c2e05a2968 #15783 (fix: variable type with zfs-tests/cmd/clonefile.c)

The merges apply in the given order cleanly without conflicts.

### How Has This Been Tested?
Compile and run on FreeBSD and Linux

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
