### PR TITLE
ZTS: Apply zfs_bclone_enabled to bclone tests

### DIFF
--- a/tests/zfs-tests/tests/functional/bclone/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/cleanup.ksh
@@ -34,4 +34,11 @@
 
 log_must zfs destroy $TESTSRCFS
 log_must zfs destroy $TESTDSTFS
-default_cleanup
+
+default_cleanup_noexit
+
+if tunable_exists BCLONE_ENABLED ; then
+	log_must restore_tunable BCLONE_ENABLED
+fi
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/setup.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/setup.ksh
@@ -36,6 +36,11 @@ if ! command -v clonefile > /dev/null ; then
 	log_unsupported "clonefile program required to test block cloning"
 fi
 
+if tunable_exists BCLONE_ENABLED ; then
+	log_must save_tunable BCLONE_ENABLED
+	log_must set_tunable32 BCLONE_ENABLED 1
+fi
+
 DISK=${DISKS%% *}
 
 default_setup_noexit $DISK "true"


### PR DESCRIPTION
### Motivation and Context

Ensure the bclone tests run correctly even when disabled by default.

### Description

If block cloning is disabled by default then enable it when running the bclone tests.  Follow up to #15529.

### How Has This Been Tested?

Largely depending on the CI to verify this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
