### PR TITLE
[2.2] ZTS: Apply zfs_bclone_enabled to bclone tests

### DIFF
--- a/tests/zfs-tests/tests/functional/bclone/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/cleanup.ksh
@@ -34,4 +34,11 @@
 
 log_must zfs destroy $TESTSRCFS
 log_must zfs destroy $TESTDSTFS
-default_cleanup
+
+default_cleanup_noexit
+
+if tunable_exists BCLONE_ENABLED ; then
+	log_must restore_tunable BCLONE_ENABLED
+fi
+
+log_pass

--- a/tests/zfs-tests/tests/functional/bclone/setup.ksh
+++ b/tests/zfs-tests/tests/functional/bclone/setup.ksh
@@ -36,6 +36,11 @@ if ! command -v clonefile > /dev/null ; then
 	log_unsupported "clonefile program required to test block cloning"
 fi
 
+if tunable_exists BCLONE_ENABLED ; then
+	log_must save_tunable BCLONE_ENABLED
+	log_must set_tunable32 BCLONE_ENABLED 1
+fi
+
 DISK=${DISKS%% *}
 
 default_setup_noexit $DISK "true"


### PR DESCRIPTION
### Motivation and Context

With this change applied the extended block cloning tests are expected to pass in the Linux CIs. 

#15796

### Description

If block cloning is disabled by default then enable it when running the bclone tests.  Follow up to #15529.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)