### PR TITLE
libzdb 1: the libening

### DIFF
--- a/cmd/zdb/Makefile.am
+++ b/cmd/zdb/Makefile.am
@@ -10,6 +10,7 @@ zdb_SOURCES = \
 	%D%/zdb_il.c
 
 zdb_LDADD = \
+	libzdb.la \
 	libzpool.la \
 	libzfs_core.la \
 	libnvpair.la

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -186,6 +186,7 @@ USER_H = \
 	libuutil.h \
 	libuutil_common.h \
 	libuutil_impl.h \
+	libzdb.h \
 	libzfs.h \
 	libzfs_core.h \
 	libzfsbootenv.h \

--- a/include/libzdb.h
+++ b/include/libzdb.h
@@ -1,0 +1,68 @@
+#define	ZDB_COMPRESS_NAME(idx) ((idx) < ZIO_COMPRESS_FUNCTIONS ?	\
+	zio_compress_table[(idx)].ci_name : "UNKNOWN")
+#define	ZDB_CHECKSUM_NAME(idx) ((idx) < ZIO_CHECKSUM_FUNCTIONS ?	\
+	zio_checksum_table[(idx)].ci_name : "UNKNOWN")
+#define	ZDB_OT_TYPE(idx) ((idx) < DMU_OT_NUMTYPES ? (idx) :		\
+	(idx) == DMU_OTN_ZAP_DATA || (idx) == DMU_OTN_ZAP_METADATA ?	\
+	DMU_OT_ZAP_OTHER : \
+	(idx) == DMU_OTN_UINT64_DATA || (idx) == DMU_OTN_UINT64_METADATA ? \
+	DMU_OT_UINT64_OTHER : DMU_OT_NUMTYPES)
+
+/* Some platforms require part of inode IDs to be remapped */
+#ifdef __APPLE__
+#define	ZDB_MAP_OBJECT_ID(obj) INO_XNUTOZFS(obj, 2)
+#else
+#define	ZDB_MAP_OBJECT_ID(obj) (obj)
+#endif
+
+#define	ZOR_FLAG_PLAIN_FILE	0x0001
+#define	ZOR_FLAG_DIRECTORY	0x0002
+#define	ZOR_FLAG_SPACE_MAP	0x0004
+#define	ZOR_FLAG_ZAP		0x0008
+#define	ZOR_FLAG_ALL_TYPES	-1
+#define	ZOR_SUPPORTED_FLAGS	(ZOR_FLAG_PLAIN_FILE	| \
+				ZOR_FLAG_DIRECTORY	| \
+				ZOR_FLAG_SPACE_MAP	| \
+				ZOR_FLAG_ZAP)
+
+#define	ZDB_FLAG_CHECKSUM	0x0001
+#define	ZDB_FLAG_DECOMPRESS	0x0002
+#define	ZDB_FLAG_BSWAP		0x0004
+#define	ZDB_FLAG_GBH		0x0008
+#define	ZDB_FLAG_INDIRECT	0x0010
+#define	ZDB_FLAG_RAW		0x0020
+#define	ZDB_FLAG_PRINT_BLKPTR	0x0040
+#define	ZDB_FLAG_VERBOSE	0x0080
+
+
+typedef struct zdb_ctx {
+} zdb_ctx_t;
+
+typedef struct zopt_object_range {
+	uint64_t zor_obj_start;
+	uint64_t zor_obj_end;
+	uint64_t zor_flags;
+} zopt_object_range_t;
+
+
+typedef struct sublivelist_verify {
+	/* FREE's that haven't yet matched to an ALLOC, in one sub-livelist */
+	zfs_btree_t sv_pair;
+
+	/* ALLOC's without a matching FREE, accumulates across sub-livelists */
+	zfs_btree_t sv_leftover;
+} sublivelist_verify_t;
+
+typedef struct sublivelist_verify_block {
+	dva_t svb_dva;
+
+	/*
+	 * We need this to check if the block marked as allocated
+	 * in the livelist was freed (and potentially reallocated)
+	 * in the metaslab spacemaps at a later TXG.
+	 */
+	uint64_t svb_allocated_txg;
+} sublivelist_verify_block_t;
+
+const char *zdb_ot_name(dmu_object_type_t type);
+int livelist_compare(const void *larg, const void *rarg);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -62,6 +62,7 @@ include $(srcdir)/%D%/libspl/Makefile.am
 include $(srcdir)/%D%/libtpool/Makefile.am
 include $(srcdir)/%D%/libunicode/Makefile.am
 include $(srcdir)/%D%/libuutil/Makefile.am
+include $(srcdir)/%D%/libzdb/Makefile.am
 include $(srcdir)/%D%/libzfs_core/Makefile.am
 include $(srcdir)/%D%/libzfs/Makefile.am
 include $(srcdir)/%D%/libzfsbootenv/Makefile.am

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -9,11 +9,11 @@
 # These library interfaces are subject to change at any time.
 #
 #
-# CMDS:   zhack/ztest/zdb/            zfs/zpool/zed/
+# CMDS:   zhack/ztest/                zfs/zpool/zed/
 #        raidz_{test,bench}          zinject/zstream
 #                |                          |
 # LIBS:          |                          |              libzfsbootenv*
-#                |                          |                    |
+#                |--libzdb--zdb             |                    |
 #                |                          |                    |
 #             libzpool                   libzfs* ----------------+
 #             | | |  \                  / | | |

--- a/lib/libzdb/Makefile.am
+++ b/lib/libzdb/Makefile.am
@@ -1,0 +1,6 @@
+libzdb_la_CFLAGS = $(AM_CFLAGS) $(KERNEL_CFLAGS) $(LIBRARY_CFLAGS)
+
+noinst_LTLIBRARIES += libzdb.la
+
+nodist_libzdb_la_SOURCES = \
+	%D%/libzdb.c

--- a/lib/libzdb/Makefile.am
+++ b/lib/libzdb/Makefile.am
@@ -2,5 +2,5 @@ libzdb_la_CFLAGS = $(AM_CFLAGS) $(KERNEL_CFLAGS) $(LIBRARY_CFLAGS)
 
 noinst_LTLIBRARIES += libzdb.la
 
-nodist_libzdb_la_SOURCES = \
+libzdb_la_SOURCES = \
 	%D%/libzdb.c

--- a/lib/libzdb/Makefile.am
+++ b/lib/libzdb/Makefile.am
@@ -1,4 +1,5 @@
-libzdb_la_CFLAGS = $(AM_CFLAGS) $(KERNEL_CFLAGS) $(LIBRARY_CFLAGS)
+libzdb_la_CFLAGS = $(AM_CFLAGS) $(LIBRARY_CFLAGS)
+libzdb_la_CFLAGS += -fvisibility=hidden
 
 noinst_LTLIBRARIES += libzdb.la
 

--- a/lib/libzdb/libzdb.c
+++ b/lib/libzdb/libzdb.c
@@ -1,0 +1,102 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <getopt.h>
+#include <openssl/evp.h>
+#include <sys/zfs_context.h>
+#include <sys/spa.h>
+#include <sys/spa_impl.h>
+#include <sys/dmu.h>
+#include <sys/zap.h>
+#include <sys/fs/zfs.h>
+#include <sys/zfs_znode.h>
+#include <sys/zfs_sa.h>
+#include <sys/sa.h>
+#include <sys/sa_impl.h>
+#include <sys/vdev.h>
+#include <sys/vdev_impl.h>
+#include <sys/metaslab_impl.h>
+#include <sys/dmu_objset.h>
+#include <sys/dsl_dir.h>
+#include <sys/dsl_dataset.h>
+#include <sys/dsl_pool.h>
+#include <sys/dsl_bookmark.h>
+#include <sys/dbuf.h>
+#include <sys/zil.h>
+#include <sys/zil_impl.h>
+#include <sys/stat.h>
+#include <sys/resource.h>
+#include <sys/dmu_send.h>
+#include <sys/dmu_traverse.h>
+#include <sys/zio_checksum.h>
+#include <sys/zio_compress.h>
+#include <sys/zfs_fuid.h>
+#include <sys/arc.h>
+#include <sys/arc_impl.h>
+#include <sys/ddt.h>
+#include <sys/zfeature.h>
+#include <sys/abd.h>
+#include <sys/blkptr.h>
+#include <sys/dsl_crypt.h>
+#include <sys/dsl_scan.h>
+#include <sys/btree.h>
+#include <sys/brt.h>
+#include <sys/brt_impl.h>
+#include <zfs_comutil.h>
+#include <sys/zstd/zstd.h>
+
+#include <libnvpair.h>
+#include <libzutil.h>
+
+#include <libzdb.h>
+
+const char *
+zdb_ot_name(dmu_object_type_t type)
+{
+	if (type < DMU_OT_NUMTYPES)
+		return (dmu_ot[type].ot_name);
+	else if ((type & DMU_OT_NEWTYPE) &&
+	    ((type & DMU_OT_BYTESWAP_MASK) < DMU_BSWAP_NUMFUNCS))
+		return (dmu_ot_byteswap[type & DMU_OT_BYTESWAP_MASK].ob_name);
+	else
+		return ("UNKNOWN");
+}
+
+int
+livelist_compare(const void *larg, const void *rarg)
+{
+	const blkptr_t *l = larg;
+	const blkptr_t *r = rarg;
+
+	/* Sort them according to dva[0] */
+	uint64_t l_dva0_vdev, r_dva0_vdev;
+	l_dva0_vdev = DVA_GET_VDEV(&l->blk_dva[0]);
+	r_dva0_vdev = DVA_GET_VDEV(&r->blk_dva[0]);
+	if (l_dva0_vdev < r_dva0_vdev)
+		return (-1);
+	else if (l_dva0_vdev > r_dva0_vdev)
+		return (+1);
+
+	/* if vdevs are equal, sort by offsets. */
+	uint64_t l_dva0_offset;
+	uint64_t r_dva0_offset;
+	l_dva0_offset = DVA_GET_OFFSET(&l->blk_dva[0]);
+	r_dva0_offset = DVA_GET_OFFSET(&r->blk_dva[0]);
+	if (l_dva0_offset < r_dva0_offset) {
+		return (-1);
+	} else if (l_dva0_offset > r_dva0_offset) {
+		return (+1);
+	}
+
+	/*
+	 * Since we're storing blkptrs without cancelling FREE/ALLOC pairs,
+	 * it's possible the offsets are equal. In that case, sort by txg
+	 */
+	if (l->blk_birth < r->blk_birth) {
+		return (-1);
+	} else if (l->blk_birth > r->blk_birth) {
+		return (+1);
+	}
+	return (0);
+}

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -167,6 +167,21 @@ for managing zpools
 %postun -n libzpool5 -p /sbin/ldconfig
 %endif
 
+%package -n libzdb1
+Summary:        ZDB library
+Group:          System Environment/Kernel
+
+%description -n libzdb1
+This package contains the zdb library, which is an unstable
+library exposing the innards of zdb.
+
+%if %{defined ldconfig_scriptlets}
+%ldconfig_scriptlets -n libzdb1
+%else
+%post -n libzdb1 -p /sbin/ldconfig
+%postun -n libzdb1 -p /sbin/ldconfig
+%endif
+
 %package -n libnvpair3
 Summary:        Solaris name-value library for Linux
 Group:          System Environment/Kernel

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -167,21 +167,6 @@ for managing zpools
 %postun -n libzpool5 -p /sbin/ldconfig
 %endif
 
-%package -n libzdb1
-Summary:        ZDB library
-Group:          System Environment/Kernel
-
-%description -n libzdb1
-This package contains the zdb library, which is an unstable
-library exposing the innards of zdb.
-
-%if %{defined ldconfig_scriptlets}
-%ldconfig_scriptlets -n libzdb1
-%else
-%post -n libzdb1 -p /sbin/ldconfig
-%postun -n libzdb1 -p /sbin/ldconfig
-%endif
-
 %package -n libnvpair3
 Summary:        Solaris name-value library for Linux
 Group:          System Environment/Kernel


### PR DESCRIPTION
### Motivation and Context
Ultimately, I'd like to break out zdb's unique functionality into something more accessible for...not-zdb, because often you might want to script zdb, or make zdb do something bespoke, and a lot of global state in one huge binary makes these kinds of changes or use cases hard.

So I'd like to start cleaning that up by ripping the giant .c file into a library and then zdb.c becomes a much smaller consumer of that library's functionality.

This is a baby step of creating a mostly empty library and statically loading it in zdb. I've got a lot more progress than this, in another branch, but my goal was more to try and see how much pushback I'd get on this so that I'm not opening a huge PR with thousands of lines of diff in dozens of commits and trying to get feedback on all of it at once.

### Description
Just creates a mostly-empty libzdb and libzdb.h, and moves a few functions and defines into it.

As I said in the commit, I wouldn't suggest making any promises anytime soon about this being a stable interface - the goal is to rapidly iterate to rip chunks out, so I wouldn't suggest anyone try consuming this until the rate of churn is substantially lower, other than, obviously, zdb itself, and it's statically loaded there so you don't have some .so incompatibility breaking zdb when you needed it most...

### How Has This Been Tested?
It ran. I haven't noticed any failures, and when I ran tests locally, all the failures were not, as far I saw, in zdb-related things, and were inconsistent, so I think that's just the normal ZTS flakiness.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
