### PR TITLE
ZTS: Apply small changes for speeding up the tests

### DIFF
--- a/.github/workflows/scripts/setup-dependencies.sh
+++ b/.github/workflows/scripts/setup-dependencies.sh
@@ -55,29 +55,24 @@ function mod_install() {
   cat /proc/spl/kstat/zfs/chksum_bench
   echo "::endgroup::"
 
-  echo "::group::Reclaim and report disk space"
-  # remove 4GiB of images
-  sudo systemd-run docker system prune --force --all --volumes
+  echo "::group::Optimize storage for ZFS testings"
+  # remove swap and umount fast storage
+  # 89GiB -> rootfs + bootfs with ~80MB/s -> don't care
+  # 64GiB -> /mnt with 420MB/s -> new testing ssd
+  sudo swapoff -a
 
-  # remove unused software
-  sudo systemd-run --wait rm -rf \
-    "$AGENT_TOOLSDIRECTORY" \
-    /opt/* \
-    /usr/local/* \
-    /usr/share/az* \
-    /usr/share/dotnet \
-    /usr/share/gradle* \
-    /usr/share/miniconda \
-    /usr/share/swift \
-    /var/lib/gems \
-    /var/lib/mysql \
-    /var/lib/snapd
-
-  # trim the cleaned space
-  sudo fstrim /
+  # this one is fast and mounted @ /mnt
+  # -> we reformat with ext4 + move it to /var/tmp
+  DEV="/dev/disk/azure/resource-part1"
+  sudo umount /mnt
+  sudo mkfs.ext4 -O ^has_journal -F $DEV
+  sudo mount -o noatime,barrier=0 $DEV /var/tmp
+  sudo chmod 1777 /var/tmp
 
   # disk usage afterwards
-  df -h /
+  sudo df -h /
+  sudo df -h /var/tmp
+  sudo fstrim -a
   echo "::endgroup::"
 }
 


### PR DESCRIPTION

### Motivation and Context

The Github Action Runner got some new hardware metrics.
We should use the provided and empty disk which is pre-mounted at /mnt now.

Disk1: 89GiB -> rootfs + bootfs with ~80MB/s -> don't care
Disk2: 64GiB -> /mnt with 420MB/s -> new testing ssd

### Description

This commit will mount the new disk to /var/tmp and provide hopefully some speedups within our testings.

### How Has This Been Tested?

We will see, how much seepup we can get... when the ZTS is done with it ;-)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
