### PR TITLE
Remove list_size struct member from list implementation

### DIFF
--- a/include/os/freebsd/spl/sys/list_impl.h
+++ b/include/os/freebsd/spl/sys/list_impl.h
@@ -39,7 +39,6 @@ struct list_node {
 };
 
 struct list {
-	size_t	list_size;
 	size_t	list_offset;
 	struct list_node list_head;
 };

--- a/include/os/linux/spl/sys/list.h
+++ b/include/os/linux/spl/sys/list.h
@@ -48,7 +48,6 @@
 typedef struct list_head list_node_t;
 
 typedef struct list {
-	size_t list_size;
 	size_t list_offset;
 	list_node_t list_head;
 } list_t;
@@ -72,7 +71,8 @@ list_link_init(list_node_t *node)
 static inline void
 list_create(list_t *list, size_t size, size_t offset)
 {
-	list->list_size = size;
+	(void) size;
+
 	list->list_offset = offset;
 	INIT_LIST_HEAD(&list->list_head);
 }

--- a/lib/libspl/include/sys/list_impl.h
+++ b/lib/libspl/include/sys/list_impl.h
@@ -39,7 +39,6 @@ struct list_node {
 };
 
 struct list {
-	size_t	list_size;
 	size_t	list_offset;
 	struct list_node list_head;
 };

--- a/lib/libspl/list.c
+++ b/lib/libspl/list.c
@@ -65,7 +65,8 @@ list_create(list_t *list, size_t size, size_t offset)
 	ASSERT(size > 0);
 	ASSERT(size >= offset + sizeof (list_node_t));
 
-	list->list_size = size;
+	(void) size;
+
 	list->list_offset = offset;
 	list->list_head.next = list->list_head.prev = &list->list_head;
 }
@@ -194,7 +195,6 @@ list_move_tail(list_t *dst, list_t *src)
 	list_node_t *dstnode = &dst->list_head;
 	list_node_t *srcnode = &src->list_head;
 
-	ASSERT(dst->list_size == src->list_size);
 	ASSERT(dst->list_offset == src->list_offset);
 
 	if (list_empty(src))

--- a/module/os/freebsd/spl/list.c
+++ b/module/os/freebsd/spl/list.c
@@ -64,7 +64,8 @@ list_create(list_t *list, size_t size, size_t offset)
 	ASSERT3P(list, !=, NULL);
 	ASSERT3U(size, >=, offset + sizeof (list_node_t));
 
-	list->list_size = size;
+	(void) size;
+
 	list->list_offset = offset;
 	list->list_head.list_next = list->list_head.list_prev =
 	    &list->list_head;
@@ -194,7 +195,6 @@ list_move_tail(list_t *dst, list_t *src)
 	list_node_t *dstnode = &dst->list_head;
 	list_node_t *srcnode = &src->list_head;
 
-	ASSERT3U(dst->list_size, ==, src->list_size);
 	ASSERT3U(dst->list_offset, ==, src->list_offset);
 
 	if (list_empty(src))


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In a previous pull request I opened (#15478), I added an additional counter to track the number of pending sync IO operations as it wasn't properly being tracked before. This adds extra space requirements to the vdev_queue struct and to counteract this increase it was suggested to remove the list_size struct member as it was only used in a few asserts in the code. 
### Description
<!--- Describe your changes in detail -->
I removed the list_size struct member in the list implementations in two separate commits, in order to keep the kernel list and the user-space list changes separate, in case this has to be reverted in the future. 
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I ran zloop.sh and no apparent crashes were seen. 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
