### PR TITLE
Switch to CodeQL to detect prohibited function use

### DIFF
--- a/.github/codeql-cpp.yml
+++ b/.github/codeql-cpp.yml
@@ -1,0 +1,4 @@
+name: "Custom CodeQL Analysis"
+
+queries:
+  - uses: ./.github/codeql/custom-queries/cpp/deprecatedFunctionUsage.ql

--- a/.github/codeql-python.yml
+++ b/.github/codeql-python.yml
@@ -1,0 +1,4 @@
+name: "Custom CodeQL Analysis"
+
+paths-ignore:
+  - tests

--- a/.github/codeql/custom-queries/cpp/deprecatedFunctionUsage.ql
+++ b/.github/codeql/custom-queries/cpp/deprecatedFunctionUsage.ql
@@ -1,0 +1,59 @@
+/**
+ * @name Deprecated function usage detection
+ * @description Detects functions whose usage is banned from the OpenZFS
+ *              codebase due to QA concerns.
+ * @kind problem
+ * @severity error
+ * @id cpp/deprecated-function-usage
+*/
+
+import cpp
+
+predicate isDeprecatedFunction(Function f) {
+  f.getName() = "strtok" or
+  f.getName() = "__xpg_basename" or
+  f.getName() = "basename" or
+  f.getName() = "dirname" or
+  f.getName() = "bcopy" or
+  f.getName() = "bcmp" or
+  f.getName() = "bzero" or
+  f.getName() = "asctime" or
+  f.getName() = "asctime_r" or
+  f.getName() = "gmtime" or
+  f.getName() = "localtime" or
+  f.getName() = "strncpy"
+
+}
+
+string getReplacementMessage(Function f) {
+  if f.getName() = "strtok" then
+    result = "Use strtok_r(3) instead!"
+  else if f.getName() = "__xpg_basename" then
+    result = "basename(3) is underspecified. Use zfs_basename() instead!"
+  else if f.getName() = "basename" then
+    result = "basename(3) is underspecified. Use zfs_basename() instead!"
+  else if f.getName() = "dirname" then
+    result = "dirname(3) is underspecified. Use zfs_dirnamelen() instead!"
+  else if f.getName() = "bcopy" then
+    result = "bcopy(3) is deprecated. Use memcpy(3)/memmove(3) instead!"
+  else if f.getName() = "bcmp" then
+    result = "bcmp(3) is deprecated. Use memcmp(3) instead!"
+  else if f.getName() = "bzero" then
+    result = "bzero(3) is deprecated. Use memset(3) instead!"
+  else if f.getName() = "asctime" then
+    result = "Use strftime(3) instead!"
+  else if f.getName() = "asctime_r" then
+    result = "Use strftime(3) instead!"
+  else if f.getName() = "gmtime" then
+    result = "gmtime(3) isn't thread-safe. Use gmtime_r(3) instead!"
+  else if f.getName() = "localtime" then
+    result = "localtime(3) isn't thread-safe. Use localtime_r(3) instead!"
+  else
+    result = "strncpy(3) is deprecated. Use strlcpy(3) instead!"
+}
+
+from FunctionCall fc, Function f
+where
+  fc.getTarget() = f and
+  isDeprecatedFunction(f)
+select fc, getReplacementMessage(f)

--- a/.github/codeql/custom-queries/cpp/qlpack.yml
+++ b/.github/codeql/custom-queries/cpp/qlpack.yml
@@ -1,0 +1,4 @@
+name: openzfs-cpp-queries
+version: 0.0.0
+libraryPathDependencies: codeql-cpp
+suites: openzfs-cpp-suite

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
+        config-file: .github/codeql-${{ matrix.language }}.yml
         languages: ${{ matrix.language }}
 
     - name: Autobuild

--- a/config/Rules.am
+++ b/config/Rules.am
@@ -42,21 +42,6 @@ AM_CPPFLAGS += $(DEBUG_CPPFLAGS)
 AM_CPPFLAGS += $(CODE_COVERAGE_CPPFLAGS)
 AM_CPPFLAGS += -DTEXT_DOMAIN=\"zfs-@ac_system_l@-user\"
 
-AM_CPPFLAGS_NOCHECK  = -D"strtok(...)=strtok(__VA_ARGS__) __attribute__((deprecated(\"Use strtok_r(3) instead!\")))"
-AM_CPPFLAGS_NOCHECK += -D"__xpg_basename(...)=__xpg_basename(__VA_ARGS__) __attribute__((deprecated(\"basename(3) is underspecified. Use zfs_basename() instead!\")))"
-AM_CPPFLAGS_NOCHECK += -D"basename(...)=basename(__VA_ARGS__) __attribute__((deprecated(\"basename(3) is underspecified. Use zfs_basename() instead!\")))"
-AM_CPPFLAGS_NOCHECK += -D"dirname(...)=dirname(__VA_ARGS__) __attribute__((deprecated(\"dirname(3) is underspecified. Use zfs_dirnamelen() instead!\")))"
-AM_CPPFLAGS_NOCHECK += -D"bcopy(...)=__attribute__((deprecated(\"bcopy(3) is deprecated. Use memcpy(3)/memmove(3) instead!\"))) bcopy(__VA_ARGS__)"
-AM_CPPFLAGS_NOCHECK += -D"bcmp(...)=__attribute__((deprecated(\"bcmp(3) is deprecated. Use memcmp(3) instead!\"))) bcmp(__VA_ARGS__)"
-AM_CPPFLAGS_NOCHECK += -D"bzero(...)=__attribute__((deprecated(\"bzero(3) is deprecated. Use memset(3) instead!\"))) bzero(__VA_ARGS__)"
-AM_CPPFLAGS_NOCHECK += -D"asctime(...)=__attribute__((deprecated(\"Use strftime(3) instead!\"))) asctime(__VA_ARGS__)"
-AM_CPPFLAGS_NOCHECK += -D"asctime_r(...)=__attribute__((deprecated(\"Use strftime(3) instead!\"))) asctime_r(__VA_ARGS__)"
-AM_CPPFLAGS_NOCHECK += -D"gmtime(...)=__attribute__((deprecated(\"gmtime(3) isn't thread-safe. Use gmtime_r(3) instead!\"))) gmtime(__VA_ARGS__)"
-AM_CPPFLAGS_NOCHECK += -D"localtime(...)=__attribute__((deprecated(\"localtime(3) isn't thread-safe. Use localtime_r(3) instead!\"))) localtime(__VA_ARGS__)"
-AM_CPPFLAGS_NOCHECK += -D"strncpy(...)=__attribute__((deprecated(\"strncpy(3) is deprecated. Use strlcpy(3) instead!\"))) strncpy(__VA_ARGS__)"
-
-AM_CPPFLAGS += $(AM_CPPFLAGS_NOCHECK)
-
 if ASAN_ENABLED
 AM_CPPFLAGS += -DZFS_ASAN_ENABLED
 endif


### PR DESCRIPTION
### Motivation and Context
The LLVM/Clang developers pointed out that using the CPP to detect use of functions that our QA policies prohibit risks invoking undefined behavior.

### Description
We remove the CPP macros from automake in favor of adding a custom CodeQL query. 

### How Has This Been Tested?
I have tested this in my fork of the openzfs/zfs github repository with an experimental patch that added strncpy() to the codebase:

```
diff --git a/module/zfs/arc.c b/module/zfs/arc.c
index 3bcffb3c7ede..75a104251336 100644
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4432,6 +4432,11 @@ arc_kmem_reap_soon(void)
 	kmem_cache_t		*prev_data_cache = NULL;
 
 #ifdef _KERNEL
+	char source[] = "example";
+	char destination[10];
+
+	strncpy(destination, source, sizeof(destination));
+	destination[sizeof(destination) - 1] = '\0';
 #if defined(_ILP32)
 	/*
 	 * Reclaim unused memory from all kmem caches.
```

The issue was detected and the appropriate message was shown in the security tab. I did not test a PR to see what would be displayed, but I assume that the message would also show there, just as it does for the stock CodeQL queries. I can push a test commit to this PR to verify that if people feel it is necessary.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
