### PR TITLE
Update to man pages for zpool-iostat, zpool-list, zpool-status and zpool-wait to resolve time(2) -> time(1)

### DIFF
--- a/man/man8/zpool-iostat.8
+++ b/man/man8/zpool-iostat.8
@@ -146,7 +146,7 @@ Specify
 .Sy u
 for a printed representation of the internal representation of time.
 See
-.Xr time 2 .
+.Xr time 1 .
 Specify
 .Sy d
 for standard date format.

--- a/man/man8/zpool-list.8
+++ b/man/man8/zpool-list.8
@@ -95,7 +95,7 @@ Specify
 .Sy u
 for a printed representation of the internal representation of time.
 See
-.Xr time 2 .
+.Xr time 1 .
 Specify
 .Sy d
 for standard date format.

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -112,7 +112,7 @@ Specify
 .Sy u
 for a printed representation of the internal representation of time.
 See
-.Xr time 2 .
+.Xr time 1 .
 Specify
 .Sy d
 for standard date format.

--- a/man/man8/zpool-wait.8
+++ b/man/man8/zpool-wait.8
@@ -99,7 +99,7 @@ Specify
 .Sy u
 for a printed representation of the internal representation of time.
 See
-.Xr time 2 .
+.Xr time 1 .
 Specify
 .Sy d
 for standard date format.


### PR DESCRIPTION
zpool-iostat.8: Updated time(2) -> time(1) to align to manual page
zpool-list.8: Updated time(2) -> time(1) to align to manual page
zpool-status.8: Updated time(2) -> time(1) to align to manual page
zpool-wait.8: Update time(2) -> time(1) to align to manual page

Signed-off-by: Christopher Davidson <christopher.davidson@gmail.com>

### Motivation and Context
This change was applied to the manual pages to resolve misaligned .Xr references in the manual pages as they were in FreeBSD-CURRENT. 

### Description
The manual pages were confirmed to be aligned to time(2) and double checked with a few spots checks:
1. main time -> which resulted in time(1) and not time(2) showing
2. https://man.freebsd.org/cgi/man.cgi?query=time&apropos=0&sektion=0&manpath=FreeBSD+15.0-CURRENT&arch=default&format=html -> to confirm the manual page on machine matched what was expected on website with man output.

### How Has This Been Tested?
The testing conducted was spot check with the above items and checking multiple releases of FreeBSD: FreeBSD 14.0 (amd64) FreeBSD(arm - raspberry pi) FreeBSD-CURRENT (amd64) and all confirmed same result.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ X] I have updated the documentation accordingly.
- [ X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
