### PR TITLE
zpool wait: print timestamp before the header

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -11042,6 +11042,9 @@ print_wait_status_row(wait_data_t *wd, zpool_handle_t *zhp, int row)
 		col_widths[i] = MAX(strlen(headers[i]), 6) + 2;
 	}
 
+	if (timestamp_fmt != NODATE)
+		print_timestamp(timestamp_fmt);
+
 	/* Print header if appropriate */
 	int term_height = terminal_height();
 	boolean_t reprint_header = (!wd->wd_headers_once && term_height > 0 &&
@@ -11115,9 +11118,6 @@ print_wait_status_row(wait_data_t *wd, zpool_handle_t *zhp, int row)
 	 */
 	if (vdev_any_spare_replacing(nvroot))
 		bytes_rem[ZPOOL_WAIT_REPLACE] =  bytes_rem[ZPOOL_WAIT_RESILVER];
-
-	if (timestamp_fmt != NODATE)
-		print_timestamp(timestamp_fmt);
 
 	for (i = 0; i < ZPOOL_WAIT_NUM_ACTIVITIES; i++) {
 		char buf[64];


### PR DESCRIPTION
### Motivation and Context

`zpool list`, `status` and `iostat` all display the `-T` timestamp before the header, but wait showed it after. Make it be like the others.

### Description

Just moves the print up.

### How Has This Been Tested?

By hand. Before:

```
$ ./zpool wait -T u lucy 1
  DISCARD    FREE  INITIALIZE  REPLACE  REMOVE  RESILVER   SCRUB    TRIM  RAIDZ_EXPAND
1706247328
        0       0           0        0       0         0       0       0             0
```

after:

```
$ ./zpool wait -T u lucy 1
1706247336
  DISCARD    FREE  INITIALIZE  REPLACE  REMOVE  RESILVER   SCRUB    TRIM  RAIDZ_EXPAND
        0       0           0        0       0         0       0       0             0
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
