### PR TITLE
Update zfs-snapshot.8 to fix a small inaccuracy in the description of snapshot atomicity

### DIFF
--- a/man/man8/zfs-snapshot.8
+++ b/man/man8/zfs-snapshot.8
@@ -44,13 +44,21 @@
 .Ar dataset Ns @ Ns Ar snapname Ns …
 .
 .Sh DESCRIPTION
-All previous modifications by successful system calls to the file system are
-part of the snapshots.
-Snapshots are taken atomically, so that all snapshots correspond to the same
-moment in time.
+Creates a snapshot of a dataset or multiple snapshots of different
+datasets.
+.Pp
+Snapshots are created atomically.
+That is, a snapshot is a consistent image of a dataset at a specific
+point in time; it includes all modifications to the dataset made by
+system calls that have successfully completed before that point in time.
+Recursive snapshots created through the
+.Fl r
+option are all created at the same time.
+.Pp
 .Nm zfs Cm snap
 can be used as an alias for
 .Nm zfs Cm snapshot .
+.Pp
 See the
 .Sx Snapshots
 section of


### PR DESCRIPTION
Fixes a small inaccuracy in the description of snapshot atomicity

zfs-snapshot(8) appears to contain a small error.  The existing version reads "Snapshots are taken atomically, so that all snapshots correspond to the same moment in time."  Per zfs_main.c, which in do_snapshot() simply loops over argv, this does not appear to be correct when multiple snapshots are specified explicitly on the command line.  I believe the intent of the man page was to say that *recursive* snapshots are all created atomically.

This proposed change fixes that error.  Because the existing statement may confuse some readers anyway, the commit also also adds a small amount of general explanatory information that may be helpful.

The change also adds an introductory sentence that summarizes what 'zfs snapshot' does in the first place.  In that sentence, the text "different datasets" is intended to indicate that (again per the code) the same dataset cannot be specified multiple times on the command line.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
