### PR TITLE
fix #3963: allow `snapdir=disabled` to prevent automounts

### DIFF
--- a/include/os/freebsd/zfs/sys/zfs_ctldir.h
+++ b/include/os/freebsd/zfs/sys/zfs_ctldir.h
@@ -40,7 +40,7 @@ extern "C" {
 	((zdp)->z_zfsvfs->z_ctldir != NULL))
 #define	zfs_show_ctldir(zdp)	\
 	(zfs_has_ctldir(zdp) && \
-	((zdp)->z_zfsvfs->z_show_ctldir))
+	((zdp)->z_zfsvfs->z_show_ctldir == ZFS_SNAPDIR_VISIBLE))
 
 void zfsctl_create(zfsvfs_t *);
 void zfsctl_destroy(zfsvfs_t *);

--- a/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/freebsd/zfs/sys/zfs_vfsops_os.h
@@ -95,7 +95,7 @@ struct zfsvfs {
 	list_t		z_all_znodes;	/* all vnodes in the fs */
 	kmutex_t	z_znodes_lock;	/* lock for z_all_znodes */
 	struct zfsctl_root	*z_ctldir;	/* .zfs directory pointer */
-	boolean_t	z_show_ctldir;	/* expose .zfs in the root dir */
+	uint_t		z_show_ctldir;	/* how to expose .zfs in the root dir */
 	boolean_t	z_issnap;	/* true if this is a snapshot */
 	boolean_t	z_use_fuids;	/* version allows fuids */
 	boolean_t	z_replay;	/* set during ZIL replay */

--- a/include/os/linux/zfs/sys/zfs_ctldir.h
+++ b/include/os/linux/zfs/sys/zfs_ctldir.h
@@ -45,7 +45,7 @@
 	(ZTOZSB(zdp)->z_ctldir != NULL))
 #define	zfs_show_ctldir(zdp)	\
 	(zfs_has_ctldir(zdp) && \
-	(ZTOZSB(zdp)->z_show_ctldir))
+	(ZTOZSB(zdp)->z_show_ctldir == ZFS_SNAPDIR_VISIBLE))
 
 extern int zfs_expire_snapshot;
 

--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
@@ -110,7 +110,7 @@ struct zfsvfs {
 	kmutex_t	z_znodes_lock;	/* lock for z_all_znodes */
 	arc_prune_t	*z_arc_prune;	/* called by ARC to prune caches */
 	struct inode	*z_ctldir;	/* .zfs directory inode */
-	boolean_t	z_show_ctldir;	/* expose .zfs in the root dir */
+	uint_t		z_show_ctldir;	/* how to expose .zfs in the root dir */
 	boolean_t	z_issnap;	/* true if this is a snapshot */
 	boolean_t	z_use_fuids;	/* version allows fuids */
 	boolean_t	z_replay;	/* set during ZIL replay */

--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -57,6 +57,7 @@ extern "C" {
  */
 #define	ZFS_SNAPDIR_HIDDEN		0
 #define	ZFS_SNAPDIR_VISIBLE		1
+#define	ZFS_SNAPDIR_DISABLED		2
 
 /*
  * Property values for snapdev

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1375,6 +1375,15 @@ which have the
 .Em no_root_squash
 option set.
 .
+.It Sy zfs_snapshot_no_setuid Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Whether to disable
+.Em setuid/setgid
+support for snapshot mounts triggered by access to the
+.Sy .zfs/snapshot
+directory by setting the
+.Em nosuid
+mount option.
+.
 .It Sy zfs_flags Ns = Ns Sy 0 Pq int
 Set additional debugging flags.
 The following flags may be bitwise-ored together:

--- a/man/man7/zfsconcepts.7
+++ b/man/man7/zfsconcepts.7
@@ -71,7 +71,7 @@ File system snapshots can be accessed under the
 directory in the root of the file system.
 Snapshots are automatically mounted on demand and may be unmounted at regular
 intervals.
-The visibility of the
+The availability and visibility of the
 .Pa .zfs
 directory can be controlled by the
 .Sy snapdir

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1773,11 +1773,11 @@ Controls whether the volume snapshot devices under
 are hidden or visible.
 The default value is
 .Sy hidden .
-.It Sy snapdir Ns = Ns Sy hidden Ns | Ns Sy visible
+.It Sy snapdir Ns = Ns Sy disabled Ns | Ns Sy hidden Ns | Ns Sy visible
 Controls whether the
 .Pa .zfs
-directory is hidden or visible in the root of the file system as discussed in
-the
+directory is disabled, hidden or visible in the root of the file system as
+discussed in the
 .Sx Snapshots
 section of
 .Xr zfsconcepts 7 .

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -913,6 +913,8 @@ zfs_lookup(vnode_t *dvp, const char *nm, vnode_t **vpp,
 	}
 	if (zfs_has_ctldir(zdp) && strcmp(nm, ZFS_CTLDIR_NAME) == 0) {
 		zfs_exit(zfsvfs, FTAG);
+		if ((zdp)->z_zfsvfs->z_show_ctldir == ZFS_SNAPDIR_DISABLED)
+			return (SET_ERROR(ENOENT));
 		if ((cnp->cn_flags & ISLASTCN) != 0 && nameiop != LOOKUP)
 			return (SET_ERROR(ENOTSUP));
 		error = zfsctl_root(zfsvfs, cnp->cn_lkflags, vpp);

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -810,7 +810,9 @@ zfsctl_root_lookup(struct inode *dip, const char *name, struct inode **ipp,
 	if ((error = zfs_enter(zfsvfs, FTAG)) != 0)
 		return (error);
 
-	if (strcmp(name, "..") == 0) {
+	if (zfsvfs->z_show_ctldir == ZFS_SNAPDIR_DISABLED) {
+		error = SET_ERROR(ENOENT);
+	} else if (strcmp(name, "..") == 0) {
 		*ipp = dip->i_sb->s_root->d_inode;
 	} else if (strcmp(name, ZFS_SNAPDIR_NAME) == 0) {
 		*ipp = zfsctl_inode_lookup(zfsvfs, ZFSCTL_INO_SNAPDIR,

--- a/module/os/linux/zfs/zfs_dir.c
+++ b/module/os/linux/zfs/zfs_dir.c
@@ -415,6 +415,9 @@ zfs_dirlook(znode_t *dzp, char *name, znode_t **zpp, int flags,
 			*zpp = zp;
 		rw_exit(&dzp->z_parent_lock);
 	} else if (zfs_has_ctldir(dzp) && strcmp(name, ZFS_CTLDIR_NAME) == 0) {
+		if (ZTOZSB(dzp)->z_show_ctldir == ZFS_SNAPDIR_DISABLED) {
+			return (SET_ERROR(ENOENT));
+		}
 		ip = zfsctl_root(dzp);
 		*zpp = ITOZ(ip);
 	} else {

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1764,6 +1764,11 @@ zfs_vget(struct super_block *sb, struct inode **ipp, fid_t *fidp)
 	    (object == ZFSCTL_INO_ROOT || object == ZFSCTL_INO_SNAPDIR)) {
 		*ipp = zfsvfs->z_ctldir;
 		ASSERT(*ipp != NULL);
+
+		if (zfsvfs->z_show_ctldir == ZFS_SNAPDIR_DISABLED) {
+			return (SET_ERROR(ENOENT));
+		}
+
 		if (object == ZFSCTL_INO_SNAPDIR) {
 			VERIFY(zfsctl_root_lookup(*ipp, "snapshot", ipp,
 			    0, kcred, NULL, NULL) == 0);

--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -57,6 +57,10 @@ zpl_root_iterate(struct file *filp, zpl_dir_context_t *ctx)
 	zfsvfs_t *zfsvfs = ITOZSB(file_inode(filp));
 	int error = 0;
 
+	if (zfsvfs->z_show_ctldir == ZFS_SNAPDIR_DISABLED) {
+		return (SET_ERROR(ENOENT));
+	}
+
 	if ((error = zpl_enter(zfsvfs, FTAG)) != 0)
 		return (error);
 

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -237,6 +237,7 @@ zfs_prop_init(void)
 	static const zprop_index_t snapdir_table[] = {
 		{ "hidden",	ZFS_SNAPDIR_HIDDEN },
 		{ "visible",	ZFS_SNAPDIR_VISIBLE },
+		{ "disabled",	ZFS_SNAPDIR_DISABLED },
 		{ NULL }
 	};
 
@@ -428,7 +429,7 @@ zfs_prop_init(void)
 	    "COMPRESS", compress_table, sfeatures);
 	zprop_register_index(ZFS_PROP_SNAPDIR, "snapdir", ZFS_SNAPDIR_HIDDEN,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM,
-	    "hidden | visible", "SNAPDIR", snapdir_table, sfeatures);
+	    "disabled | hidden | visible", "SNAPDIR", snapdir_table, sfeatures);
 	zprop_register_index(ZFS_PROP_SNAPDEV, "snapdev", ZFS_SNAPDEV_HIDDEN,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
 	    "hidden | visible", "SNAPDEV", snapdev_table, sfeatures);

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -698,6 +698,10 @@ dsl_prop_set_iuv(objset_t *mos, uint64_t zapobj, const char *propname,
 		    *(uint64_t *)value == ZFS_REDUNDANT_METADATA_NONE)
 			iuv = B_TRUE;
 		break;
+	case ZFS_PROP_SNAPDIR:
+		if (*(uint64_t *)value == ZFS_SNAPDIR_DISABLED)
+			iuv = B_TRUE;
+		break;
 	default:
 		break;
 	}

--- a/tests/zfs-tests/include/properties.shlib
+++ b/tests/zfs-tests/include/properties.shlib
@@ -30,7 +30,7 @@ typeset -a logbias_prop_vals=('latency' 'throughput')
 typeset -a primarycache_prop_vals=('all' 'none' 'metadata')
 typeset -a redundant_metadata_prop_vals=('all' 'most' 'some' 'none')
 typeset -a secondarycache_prop_vals=('all' 'none' 'metadata')
-typeset -a snapdir_prop_vals=('hidden' 'visible')
+typeset -a snapdir_prop_vals=('disabled' 'hidden' 'visible')
 typeset -a sync_prop_vals=('standard' 'always' 'disabled')
 
 typeset -a fs_props=('compress' 'checksum' 'recsize'


### PR DESCRIPTION
### Motivation and Context
there is currently a gap as described in #3963 that allows potentially problematic access to snapshots via the `.zfs` control dir.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
this PR fixes the issue via two avenues:
- introducing a new property value for `snapdir` that allows disabling access altogether, instead of just hiding
- introducing a new module parameter that makes automounts set `nosuid` on Linux, to at least close the "exploit vulnerable setuid binaries" gap while still allowing snapshot access in general
<!--- Describe your changes in detail -->

### How Has This Been Tested?
tested that the new property value works as expected, including fallback on old ZFS versions. in case of a version mismatch (new kernel module, old userspace) `-` is displayed as value of the property.
tested that the module parameter works as expected. existing mounts are not modified.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
