### PR TITLE
ZTS: Skip cross-fs bclone tests if FreeBSD < 14.0

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -138,7 +138,11 @@ idmap_reason = 'Idmapped mount needs kernel 5.12+'
 # copy_file_range() is not supported by all kernels
 #
 cfr_reason = 'Kernel copy_file_range support required'
-cfr_cross_reason = 'copy_file_range(2) cross-filesystem needs kernel 5.3+'
+
+if sys.platform.startswith('freebsd'):
+    cfr_cross_reason = 'copy_file_range(2) cross-filesystem needs FreeBSD 14+'
+else:
+    cfr_cross_reason = 'copy_file_range(2) cross-filesystem needs kernel 5.3+'
 
 #
 # These tests are known to fail, thus we use this list to prevent these
@@ -268,6 +272,22 @@ if sys.platform.startswith('freebsd'):
         'pool_checkpoint/checkpoint_indirect': ['FAIL', 12623],
         'resilver/resilver_restart_001': ['FAIL', known_reason],
         'snapshot/snapshot_002_pos': ['FAIL', '14831'],
+        'bclone/bclone_crossfs_corner_cases': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_crossfs_corner_cases_limited':
+            ['SKIP', cfr_cross_reason],
+        'bclone/bclone_crossfs_data': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_crossfs_embedded': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_crossfs_hole': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_diffprops_all': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_diffprops_checksum': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_diffprops_compress': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_diffprops_copies': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_diffprops_recordsize': ['SKIP', cfr_cross_reason],
+        'bclone/bclone_prop_sync': ['SKIP', cfr_cross_reason],
+        'block_cloning/block_cloning_cross_enc_dataset':
+            ['SKIP', cfr_cross_reason],
+        'block_cloning/block_cloning_copyfilerange_cross_dataset':
+            ['SKIP', cfr_cross_reason]
     })
 elif sys.platform.startswith('linux'):
     maybe.update({

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -61,13 +61,8 @@ function compare_version_gte
 	[ "$(printf "$1\n$2" | sort -V | tail -n1)" = "$1" ]
 }
 
-# Linux kernel version comparison function
-#
-# $1 Linux version ("4.10", "2.6.32") or blank for installed Linux version
-#
-# Used for comparison: if [ $(linux_version) -ge $(linux_version "2.6.32") ]
-#
-function linux_version
+# Helper function used by linux_version() and freebsd_version()
+function kernel_version
 {
 	typeset ver="$1"
 
@@ -81,6 +76,24 @@ function linux_version
 	[ -z "$minor" ] && minor=0
 
 	echo $((version * 100000 + major * 1000 + minor))
+}
+
+# Linux kernel version comparison function
+#
+# $1 Linux version ("4.10", "2.6.32") or blank for installed Linux version
+#
+# Used for comparison: if [ $(linux_version) -ge $(linux_version "2.6.32") ]
+function linux_version {
+	kernel_version "$1"
+}
+
+# FreeBSD version comparison function
+#
+# $1 FreeBSD version ("13.2", "14.0") or blank for installed FreeBSD version
+#
+# Used for comparison: if [ $(freebsd_version) -ge $(freebsd_version "13.2") ]
+function freebsd_version {
+	kernel_version "$1"
 }
 
 # Determine if this is a Linux test system

--- a/tests/zfs-tests/tests/functional/bclone/bclone_common.kshlib
+++ b/tests/zfs-tests/tests/functional/bclone/bclone_common.kshlib
@@ -42,6 +42,12 @@ function verify_crossfs_block_cloning
 	if is_linux && [[ $(linux_version) -lt $(linux_version "5.3") ]]; then
 		log_unsupported "copy_file_range can't copy cross-filesystem before Linux 5.3"
 	fi
+
+	# Cross dataset block cloning only supported on FreeBSD 14+
+	# https://github.com/freebsd/freebsd-src/commit/969071be938c
+        if is_freebsd && [ $(freebsd_version) -lt $(freebsd_version 14.0) ] ; then
+               log_unsupported "Cloning across datasets not supported in $(uname -r)"
+        fi
 }
 
 # Unused.

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_cross_dataset.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_cross_dataset.ksh
@@ -26,12 +26,11 @@
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
 
 verify_runnable "global"
 
-if is_linux && [[ $(linux_version) -lt $(linux_version "5.3") ]]; then
-  log_unsupported "copy_file_range can't copy cross-filesystem before Linux 5.3"
-fi
+verify_crossfs_block_cloning
 
 claim="The copy_file_range syscall can clone across datasets."
 

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_cross_enc_dataset.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_cross_enc_dataset.ksh
@@ -26,12 +26,11 @@
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+. $STF_SUITE/tests/functional/bclone/bclone_common.kshlib
 
 verify_runnable "global"
 
-if is_linux && [[ $(linux_version) -lt $(linux_version "5.3") ]]; then
-  log_unsupported "copy_file_range can't copy cross-filesystem before Linux 5.3"
-fi
+verify_crossfs_block_cloning
 
 claim="Block cloning across encrypted datasets."
 


### PR DESCRIPTION
### Motivation and Context
Skip cross filesystem block cloning tests on FreeBSD < 14.0, since it's not supported by the OS.

### Description
Skip cross filesystem block cloning tests on FreeBSD if running less than version 14.0.  Cross filesystem copy_file_range() was added in FreeBSD 14.

### How Has This Been Tested?
Ran ZTS locally on FreeBSD 13.2 VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
