### PR TITLE
Add compatibility file for GRUB versions up to v2.06

### DIFF
--- a/cmd/zpool/Makefile.am
+++ b/cmd/zpool/Makefile.am
@@ -140,7 +140,8 @@ dist_zpoolcompat_DATA = \
 	%D%/compatibility.d/freebsd-11.2 \
 	%D%/compatibility.d/freebsd-11.3 \
 	%D%/compatibility.d/freenas-9.10.2 \
-	%D%/compatibility.d/grub2 \
+	%D%/compatibility.d/grub2-2.06 \
+	%D%/compatibility.d/grub2-2.12 \
 	%D%/compatibility.d/openzfs-2.0-freebsd \
 	%D%/compatibility.d/openzfs-2.0-linux \
 	%D%/compatibility.d/openzfs-2.1-freebsd \
@@ -171,6 +172,7 @@ zpoolcompatlinks = \
 	"freebsd-11.3		freebsd-12.2" \
 	"freebsd-11.3		freebsd-12.3" \
 	"freebsd-11.3		freebsd-12.4" \
+	"grub2-2.12		grub2" \
 	"openzfs-2.1-freebsd	freebsd-13.0" \
 	"openzfs-2.1-freebsd	freebsd-13.1" \
 	"openzfs-2.1-freebsd	freebsd-13.2" \

--- a/cmd/zpool/compatibility.d/grub2-2.06
+++ b/cmd/zpool/compatibility.d/grub2-2.06
@@ -1,0 +1,23 @@
+# Features which are supported by GRUB2 versions prior to v2.12.
+#
+# GRUB is not able to detect ZFS pool if snaphsot of top level boot pool
+# is created. This issue is observed with GRUB versions before v2.12 if
+# extensible_dataset feature is enabled on ZFS boot pool.
+#
+# This file lists all read-only comaptible features except
+# extensible_dataset and any other feature that depends on it.
+#
+allocation_classes
+async_destroy
+block_cloning
+device_rebuild
+embedded_data
+empty_bpobj
+enabled_txg
+hole_birth
+log_spacemap
+lz4_compress
+resilver_defer
+spacemap_histogram
+spacemap_v2
+zpool_checkpoint

--- a/cmd/zpool/compatibility.d/grub2-2.12
+++ b/cmd/zpool/compatibility.d/grub2-2.12
@@ -1,4 +1,4 @@
-# Features which are supported by GRUB2
+# Features which are supported by GRUB2 versions from v2.12 onwards.
 allocation_classes
 async_destroy
 block_cloning

--- a/man/man7/zpool-features.7
+++ b/man/man7/zpool-features.7
@@ -219,7 +219,7 @@ to the end of the line is ignored.
 .Sy Example :
 .Bd -literal -compact -offset 4n
 .No example# Nm cat Pa /usr/share/zfs/compatibility.d/grub2
-# Features which are supported by GRUB2
+# Features which are supported by GRUB2 versions from v2.12 onwards.
 allocation_classes
 async_destroy
 block_cloning
@@ -241,6 +241,31 @@ spacemap_histogram
 spacemap_v2
 userobj_accounting
 zilsaxattr
+zpool_checkpoint
+
+.No example# Nm cat Pa /usr/share/zfs/compatibility.d/grub2-2.06
+# Features which are supported by GRUB2 versions prior to v2.12.
+#
+# GRUB is not able to detect ZFS pool if snaphsot of top level boot pool
+# is created. This issue is observed with GRUB versions before v2.12 if
+# extensible_dataset feature is enabled on ZFS boot pool.
+#
+# This file lists all read-only comaptible features except
+# extensible_dataset and any other feature that depends on it.
+#
+allocation_classes
+async_destroy
+block_cloning
+device_rebuild
+embedded_data
+empty_bpobj
+enabled_txg
+hole_birth
+log_spacemap
+lz4_compress
+resilver_defer
+spacemap_histogram
+spacemap_v2
 zpool_checkpoint
 
 .No example# Nm zpool Cm create Fl o Sy compatibility Ns = Ns Ar grub2 Ar bootpool Ar vdev
@@ -681,7 +706,7 @@ are destroyed.
 Large dnodes allow more data to be stored in the bonus buffer,
 thus potentially improving performance by avoiding the use of spill blocks.
 .
-.feature com.delphix livelist yes
+.feature com.delphix livelist yes extensible_dataset
 This feature allows clones to be deleted faster than the traditional method
 when a large number of random/sparse writes have been made to the clone.
 All blocks allocated and freed after a clone is created are tracked by the

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.shlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.shlib
@@ -119,9 +119,8 @@ function check_feature_set
 	while read line; do
 		typeset flag=1
 
-		if [[ "$line" == "#*" ]]; then
-			continue
-		fi
+		# Skip comments
+		[[ $line = \#* ]] && continue
 
 		for set in "$@"; do
 			if ! grep -q "$line" $ZPOOL_COMPAT_DIR/$set; then


### PR DESCRIPTION
### Motivation and Context

GRUB is not able to detect ZFS pool if snaphsot of top level boot
pool dataset is created. This issue is observed with GRUB versions
up to v2.06 if extensible_dataset feature is enabled on ZFS boot pool.

https://github.com/openzfs/zfs/issues/15261
https://github.com/openzfs/zfs/issues/13873

### Description
A new compatibility file is added `grub2-2.06` for GRUB versions
upto 2.06. `compatibility=grub2-2.06` would enable all read-only
compatible zpool features except `extensible_datase`t and other
features that depend on it.

The existing grub2 compatibility file lists all read-only features
that can be enabled on boot pool for grub with version 2.12
onwards. The issue is fixed on GRUB v2.12.

Documented both `grub2` and `grub2-2.06` files in zpool-features.7.

`livelist` feature also depends on `extensible_dataset`, but it was
documented. zpool-features.7 is updated for that as well.

### How Has This Been Tested?
Tried creating boot pool with `compatibility=grub2-2.06`, after 
creating the snapshot of top level dataset of ZFS boot pool.
Verified `grub-probe` still detects the ZFS pool.

Confirmed after re-enabling `extensible_dataset` feature and issue
occurs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

