### PR TITLE
Bug fix: Replace P2ALIGN with P2ALIGN_TYPED and delete P2ALIGN.

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -5143,7 +5143,7 @@ dump_label(const char *dev)
 	    sizeof (cksum_record_t), offsetof(cksum_record_t, link));
 
 	psize = statbuf.st_size;
-	psize = P2ALIGN(psize, (uint64_t)sizeof (vdev_label_t));
+	psize = P2ALIGN_TYPED(psize, sizeof (vdev_label_t), uint64_t);
 	ashift = SPA_MINBLOCKSHIFT;
 
 	/*

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2529,7 +2529,7 @@ ztest_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
 		ASSERT3P(zio, !=, NULL);
 		size = doi.doi_data_block_size;
 		if (ISP2(size)) {
-			offset = P2ALIGN(offset, size);
+			offset = P2ALIGN_TYPED(offset, size, uint64_t);
 		} else {
 			ASSERT3U(offset, <, size);
 			offset = 0;
@@ -3978,7 +3978,8 @@ raidz_scratch_verify(void)
 	raidvd = vdev_lookup_top(spa, vre->vre_vdev_id);
 	offset = RRSS_GET_OFFSET(&spa->spa_uberblock);
 	state = RRSS_GET_STATE(&spa->spa_uberblock);
-	write_size = P2ALIGN(VDEV_BOOT_SIZE, 1 << raidvd->vdev_ashift);
+	write_size = P2ALIGN_TYPED(VDEV_BOOT_SIZE, 1 << raidvd->vdev_ashift,
+	    uint64_t);
 	logical_size = write_size * raidvd->vdev_children;
 
 	switch (state) {
@@ -5016,7 +5017,8 @@ ztest_dmu_object_next_chunk(ztest_ds_t *zd, uint64_t id)
 	 */
 	mutex_enter(&os->os_obj_lock);
 	object = ztest_random(os->os_obj_next_chunk);
-	os->os_obj_next_chunk = P2ALIGN(object, dnodes_per_chunk);
+	os->os_obj_next_chunk = P2ALIGN_TYPED(object, dnodes_per_chunk,
+	    uint64_t);
 	mutex_exit(&os->os_obj_lock);
 }
 
@@ -6638,7 +6640,8 @@ ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 		 * the end of the disk (vdev_psize) is aligned to
 		 * sizeof (vdev_label_t).
 		 */
-		uint64_t psize = P2ALIGN(fsize, sizeof (vdev_label_t));
+		uint64_t psize = P2ALIGN_TYPED(fsize, sizeof (vdev_label_t),
+		    uint64_t);
 		if ((leaf & 1) == 1 &&
 		    offset + sizeof (bad) > psize - VDEV_LABEL_END_SIZE)
 			continue;
@@ -6962,8 +6965,8 @@ ztest_fletcher_incr(ztest_ds_t *zd, uint64_t id)
 				size_t inc = 64 * ztest_random(size / 67);
 				/* sometimes add few bytes to test non-simd */
 				if (ztest_random(100) < 10)
-					inc += P2ALIGN(ztest_random(64),
-					    sizeof (uint32_t));
+					inc += P2ALIGN_TYPED(ztest_random(64),
+					    sizeof (uint32_t), uint64_t);
 
 				if (inc > (size - pos))
 					inc = size - pos;

--- a/include/os/freebsd/spl/sys/ccompile.h
+++ b/include/os/freebsd/spl/sys/ccompile.h
@@ -138,7 +138,8 @@ typedef int enum_t;
 #define	readdir64 readdir
 #define	dirent64 dirent
 #endif
-#define	P2ALIGN(x, align)		((x) & -(align))
+// Deprecated. Use P2ALIGN_TYPED instead.
+// #define	P2ALIGN(x, align)		((x) & -(align))
 #define	P2CROSS(x, y, align)	(((x) ^ (y)) > (align) - 1)
 #define	P2ROUNDUP(x, align)		((((x) - 1) | ((align) - 1)) + 1)
 #define	P2PHASE(x, align)		((x) & ((align) - 1))

--- a/include/os/freebsd/spl/sys/sysmacros.h
+++ b/include/os/freebsd/spl/sys/sysmacros.h
@@ -191,7 +191,8 @@ extern unsigned char bcd_to_byte[256];
  * eg, P2ALIGN(0x1234, 0x100) == 0x1200 (0x12*align)
  * eg, P2ALIGN(0x5600, 0x100) == 0x5600 (0x56*align)
  */
-#define	P2ALIGN(x, align)		((x) & -(align))
+// Deprecated. Use P2ALIGN_TYPED instead.
+// #define	P2ALIGN(x, align)		((x) & -(align))
 
 /*
  * return x % (mod) align

--- a/include/os/linux/spl/sys/sysmacros.h
+++ b/include/os/linux/spl/sys/sysmacros.h
@@ -159,7 +159,8 @@ makedev(unsigned int major, unsigned int minor)
 /*
  * Compatibility macros/typedefs needed for Solaris -> Linux port
  */
-#define	P2ALIGN(x, align)	((x) & -(align))
+// Deprecated. Use P2ALIGN_TYPED instead.
+// #define	P2ALIGN(x, align)	((x) & -(align))
 #define	P2CROSS(x, y, align)	(((x) ^ (y)) > (align) - 1)
 #define	P2ROUNDUP(x, align)	((((x) - 1) | ((align) - 1)) + 1)
 #define	P2PHASE(x, align)	((x) & ((align) - 1))

--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -1175,8 +1175,8 @@ efi_use_whole_disk(int fd)
 	 * (for performance reasons). The alignment should match the
 	 * alignment used by the "zpool_label_disk" function.
 	 */
-	limit = P2ALIGN(efi_label->efi_last_lba - nblocks - EFI_MIN_RESV_SIZE,
-	    PARTITION_END_ALIGNMENT);
+	limit = P2ALIGN_TYPED(efi_label->efi_last_lba - nblocks -
+	    EFI_MIN_RESV_SIZE, PARTITION_END_ALIGNMENT, diskaddr_t);
 	if (data_start + data_size != limit || resv_start != limit)
 		sync_needed = B_TRUE;
 

--- a/lib/libspl/include/os/linux/sys/sysmacros.h
+++ b/lib/libspl/include/os/linux/sys/sysmacros.h
@@ -52,7 +52,8 @@
 /*
  * Compatibility macros/typedefs needed for Solaris -> Linux port
  */
-#define	P2ALIGN(x, align)	((x) & -(align))
+// Deprecated. Use P2ALIGN_TYPED instead.
+// #define	P2ALIGN(x, align)	((x) & -(align))
 #define	P2CROSS(x, y, align)	(((x) ^ (y)) > (align) - 1)
 #define	P2ROUNDUP(x, align)	((((x) - 1) | ((align) - 1)) + 1)
 #define	P2BOUNDARY(off, len, align) \

--- a/lib/libzfs/os/linux/libzfs_pool_os.c
+++ b/lib/libzfs/os/linux/libzfs_pool_os.c
@@ -268,7 +268,8 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, const char *name)
 	if (start_block == MAXOFFSET_T)
 		start_block = NEW_START_BLOCK;
 	slice_size -= start_block;
-	slice_size = P2ALIGN(slice_size, PARTITION_END_ALIGNMENT);
+	slice_size = P2ALIGN_TYPED(slice_size, PARTITION_END_ALIGNMENT,
+	    uint64_t);
 
 	vtoc->efi_parts[0].p_start = start_block;
 	vtoc->efi_parts[0].p_size = slice_size;

--- a/module/os/freebsd/zfs/vdev_geom.c
+++ b/module/os/freebsd/zfs/vdev_geom.c
@@ -457,7 +457,7 @@ vdev_geom_read_config(struct g_consumer *cp, nvlist_t **configp)
 	ZFS_LOG(1, "Reading config from %s...", pp->name);
 
 	psize = pp->mediasize;
-	psize = P2ALIGN(psize, (uint64_t)sizeof (vdev_label_t));
+	psize = P2ALIGN_TYPED(psize, sizeof (vdev_label_t), uint64_t);
 
 	size = sizeof (*vdev_lists[0]) + pp->sectorsize -
 	    ((sizeof (*vdev_lists[0]) - 1) % pp->sectorsize) - 1;

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -384,7 +384,7 @@ zvol_discard(zv_request_t *zvr)
 	 */
 	if (!io_is_secure_erase(bio, rq)) {
 		start = P2ROUNDUP(start, zv->zv_volblocksize);
-		end = P2ALIGN(end, zv->zv_volblocksize);
+		end = P2ALIGN_TYPED(end, zv->zv_volblocksize, uint64_t);
 		size = end - start;
 	}
 

--- a/module/zcommon/zfs_fletcher.c
+++ b/module/zcommon/zfs_fletcher.c
@@ -471,7 +471,8 @@ fletcher_4_native(const void *buf, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
 	(void) ctx_template;
-	const uint64_t p2size = P2ALIGN(size, FLETCHER_MIN_SIMD_SIZE);
+	const uint64_t p2size = P2ALIGN_TYPED(size, FLETCHER_MIN_SIMD_SIZE,
+	    uint64_t);
 
 	ASSERT(IS_P2ALIGNED(size, sizeof (uint32_t)));
 
@@ -519,7 +520,8 @@ fletcher_4_byteswap(const void *buf, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {
 	(void) ctx_template;
-	const uint64_t p2size = P2ALIGN(size, FLETCHER_MIN_SIMD_SIZE);
+	const uint64_t p2size = P2ALIGN_TYPED(size, FLETCHER_MIN_SIMD_SIZE,
+	    uint64_t);
 
 	ASSERT(IS_P2ALIGNED(size, sizeof (uint32_t)));
 
@@ -878,7 +880,7 @@ abd_fletcher_4_iter(void *data, size_t size, void *private)
 	fletcher_4_ctx_t *ctx = cdp->acd_ctx;
 	fletcher_4_ops_t *ops = (fletcher_4_ops_t *)cdp->acd_private;
 	boolean_t native = cdp->acd_byteorder == ZIO_CHECKSUM_NATIVE;
-	uint64_t asize = P2ALIGN(size, FLETCHER_MIN_SIMD_SIZE);
+	uint64_t asize = P2ALIGN_TYPED(size, FLETCHER_MIN_SIMD_SIZE, uint64_t);
 
 	ASSERT(IS_P2ALIGNED(size, sizeof (uint32_t)));
 

--- a/module/zfs/btree.c
+++ b/module/zfs/btree.c
@@ -218,7 +218,7 @@ zfs_btree_create_custom(zfs_btree_t *tree,
 	    zfs_btree_find_in_buf : bt_find_in_buf;
 	tree->bt_elem_size = size;
 	tree->bt_leaf_size = lsize;
-	tree->bt_leaf_cap = P2ALIGN(esize / size, 2);
+	tree->bt_leaf_cap = P2ALIGN_TYPED(esize / size, 2, size_t);
 	tree->bt_height = -1;
 	tree->bt_bulk = NULL;
 }

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -537,7 +537,8 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 	if (dn->dn_datablkshift) {
 		int blkshift = dn->dn_datablkshift;
 		nblks = (P2ROUNDUP(offset + length, 1ULL << blkshift) -
-		    P2ALIGN(offset, 1ULL << blkshift)) >> blkshift;
+		    P2ALIGN_TYPED(offset, 1ULL << blkshift, uint64_t))
+		    >> blkshift;
 	} else {
 		if (offset + length > dn->dn_datablksz) {
 			zfs_panic_recover("zfs: accessing past end of object "
@@ -854,7 +855,7 @@ get_next_chunk(dnode_t *dn, uint64_t *start, uint64_t minimum, uint64_t *l1blks)
 		}
 
 		/* set start to the beginning of this L1 indirect */
-		*start = P2ALIGN(*start, iblkrange);
+		*start = P2ALIGN_TYPED(*start, iblkrange, uint64_t);
 	}
 	if (*start < minimum)
 		*start = minimum;

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -160,7 +160,7 @@ dmu_object_alloc_impl(objset_t *os, dmu_object_type_t ot, int blocksize,
 			 * is not suitably aligned.
 			 */
 			os->os_obj_next_chunk =
-			    P2ALIGN(object, dnodes_per_chunk) +
+			    P2ALIGN_TYPED(object, dnodes_per_chunk, uint64_t) +
 			    dnodes_per_chunk;
 			(void) atomic_swap_64(cpuobj, object);
 			mutex_exit(&os->os_obj_lock);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -627,8 +627,8 @@ metaslab_class_expandable_space(metaslab_class_t *mc)
 		 * metaslabs. We report the expandable space in terms
 		 * of the metaslab size since that's the unit of expansion.
 		 */
-		space += P2ALIGN(tvd->vdev_max_asize - tvd->vdev_asize,
-		    1ULL << tvd->vdev_ms_shift);
+		space += P2ALIGN_TYPED(tvd->vdev_max_asize - tvd->vdev_asize,
+		    1ULL << tvd->vdev_ms_shift, uint64_t);
 	}
 	spa_config_exit(mc->mc_spa, SCL_VDEV, FTAG);
 	return (space);

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -348,7 +348,8 @@ vdev_get_min_asize(vdev_t *vd)
 	 * to the nearest metaslab.
 	 */
 	if (vd == vd->vdev_top)
-		return (P2ALIGN(vd->vdev_asize, 1ULL << vd->vdev_ms_shift));
+		return (P2ALIGN_TYPED(vd->vdev_asize, 1ULL << vd->vdev_ms_shift,
+		    uint64_t));
 
 	return (pvd->vdev_ops->vdev_op_min_asize(pvd));
 }
@@ -2115,8 +2116,8 @@ vdev_open(vdev_t *vd)
 		}
 	}
 
-	osize = P2ALIGN(osize, (uint64_t)sizeof (vdev_label_t));
-	max_osize = P2ALIGN(max_osize, (uint64_t)sizeof (vdev_label_t));
+	osize = P2ALIGN_TYPED(osize, sizeof (vdev_label_t), uint64_t);
+	max_osize = P2ALIGN_TYPED(max_osize, sizeof (vdev_label_t), uint64_t);
 
 	if (vd->vdev_children == 0) {
 		if (osize < SPA_MINDEVSIZE) {
@@ -4764,9 +4765,9 @@ vdev_get_stats_ex(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx)
 		 * can expand.
 		 */
 		if (vd->vdev_aux == NULL && tvd != NULL) {
-			vs->vs_esize = P2ALIGN(
+			vs->vs_esize = P2ALIGN_TYPED(
 			    vd->vdev_max_asize - vd->vdev_asize,
-			    1ULL << tvd->vdev_ms_shift);
+			    1ULL << tvd->vdev_ms_shift, uint64_t);
 		}
 
 		vs->vs_configured_ashift = vd->vdev_top != NULL

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -4039,7 +4039,8 @@ raidz_reflow_scratch_sync(void *arg, dmu_tx_t *tx)
 	spa_config_enter(spa, SCL_STATE, FTAG, RW_READER);
 	vdev_t *raidvd = vdev_lookup_top(spa, vre->vre_vdev_id);
 	int ashift = raidvd->vdev_ashift;
-	uint64_t write_size = P2ALIGN(VDEV_BOOT_SIZE, 1 << ashift);
+	uint64_t write_size = P2ALIGN_TYPED(VDEV_BOOT_SIZE, 1 << ashift,
+	    uint64_t);
 	uint64_t logical_size = write_size * raidvd->vdev_children;
 	uint64_t read_size =
 	    P2ROUNDUP(DIV_ROUND_UP(logical_size, (raidvd->vdev_children - 1)),


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Recently, our zfs-2.2.3-1 on 5.4.265-1.el8.elrepo.x86_64 always hung on write requests without hardware problems. Restarting server made no effect.
dmesg gave logs below:
```
[Mon Feb 26 13:18:56 2024] INFO: task txg_quiesce:44850 blocked for more than 122 seconds.
[Mon Feb 26 13:18:56 2024]       Tainted: P           OE     5.4.265-1.el8.elrepo.x86_64 #1
[Mon Feb 26 13:18:56 2024] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
[Mon Feb 26 13:18:56 2024] txg_quiesce     D    0 44850      2 0x80004080
[Mon Feb 26 13:18:56 2024] Call Trace:
[Mon Feb 26 13:18:56 2024]  __schedule+0x284/0x6d0
[Mon Feb 26 13:18:56 2024]  schedule+0x2f/0xa0
[Mon Feb 26 13:18:56 2024]  cv_wait_common+0xf8/0x130 [spl]
[Mon Feb 26 13:18:56 2024]  ? wait_woken+0x80/0x80
[Mon Feb 26 13:18:56 2024]  txg_quiesce+0x1c1/0x250 [zfs]
[Mon Feb 26 13:18:56 2024]  txg_quiesce_thread+0xe7/0x170 [zfs]
[Mon Feb 26 13:18:56 2024]  ? txg_sync_thread+0x3e0/0x3e0 [zfs]
[Mon Feb 26 13:18:56 2024]  ? spl_taskq_fini+0x70/0x70 [spl]
[Mon Feb 26 13:18:56 2024]  thread_generic_wrapper+0x6f/0x80 [spl]
[Mon Feb 26 13:18:56 2024]  kthread+0x10c/0x130
[Mon Feb 26 13:18:56 2024]  ? kthread_park+0x80/0x80
[Mon Feb 26 13:18:56 2024]  ret_from_fork+0x1f/0x40
```
After adding debug messages in codes, build and reinstall, we found our write requests hung in the for loop in `dmu_object_alloc_impl`. With more logs below and analyzing, we finally found this bug in P2ALIGN.
```
1709025269   dmu_object.c:102:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 32640, dnodes_per_chunk 128, dn_slots 2, cond true
1709025269   dmu_object.c:178:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 32640, dn_slots 2
1709025269   dmu_object.c:189:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 32640, dnode_hold_impl error 28
1709025269   dmu_object.c:102:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 32768, dnodes_per_chunk 128, dn_slots 2, cond true
1709025269   dmu_object.c:157:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 32768, dnode_next_offset error 0
1709025269   dmu_object.c:178:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 4294969024, dn_slots 2
1709025269   dmu_object.c:189:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 4294969024, dnode_hold_impl error 28
1709025269   dmu_object.c:102:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 4294969056, dnodes_per_chunk 128, dn_slots 2, cond false
1709025269   dmu_object.c:178:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 4294969056, dn_slots 2
1709025269   dmu_object.c:189:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 4294969056, dnode_hold_impl error 28
1709025269   dmu_object.c:102:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 4294969088, dnodes_per_chunk 128, dn_slots 2, cond true
1709025269   dmu_object.c:178:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 1792, dn_slots 2
1709025269   dmu_object.c:189:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 1792, dnode_hold_impl error 28
1709025269   dmu_object.c:102:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 1920, dnodes_per_chunk 128, dn_slots 2, cond true
1709025269   dmu_object.c:178:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 1920, dn_slots 2
1709025269   dmu_object.c:189:dmu_object_alloc_impl(): txg 556663, dmu_tx 00000000be568d82, object 1920, dnode_hold_impl error 28
```

```C
			/*
			 * Note: if "restarted", we may find a L0 that
			 * is not suitably aligned.
			 */
			os->os_obj_next_chunk =
			    P2ALIGN(object, dnodes_per_chunk) +
			    dnodes_per_chunk;
			(void) atomic_swap_64(cpuobj, object);
			mutex_exit(&os->os_obj_lock);
```
```C
#define        P2ALIGN(x, align)               ((x) & -(align))
```
In P2ALIGN, the result would be incorrect when align is unsigned integer and x is larger than max value of the type of align. In that case, `-(align)` would be a positive integer, which means high bits would be zero and finally stay zero after `&` when align is converted to a larger integer type.

### Description
<!--- Describe your changes in detail -->

Replace P2ALIGN with P2ALIGN_TYPED and delete P2ALIGN.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

After fixed with this commit, our zfs has never hung again.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
