### PR TITLE
Makefile.bsd: sort and cleanup source file list

### DIFF
--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -82,11 +82,8 @@ CFLAGS+= -DBITS_PER_LONG=64
 
 SRCS=	vnode_if.h device_if.h bus_if.h
 
-# avl
+#avl
 SRCS+=	avl.c
-
-# icp
-SRCS+=	edonr.c
 
 #icp/algs/blake3
 SRCS+=	blake3.c \
@@ -107,9 +104,12 @@ SRCS+=	blake3_avx2.S \
 	blake3_sse2.S \
 	blake3_sse41.S
 
+#icp/algs/edonr
+SRCS+=	edonr.c
+
 #icp/algs/sha2
-SRCS+=	sha2_generic.c \
-	sha256_impl.c \
+SRCS+=	sha256_impl.c \
+	sha2_generic.c \
 	sha512_impl.c
 
 #icp/asm-arm/sha2
@@ -122,8 +122,8 @@ SRCS+=	sha256-armv8.S \
 
 #icp/asm-ppc64/sha2
 SRCS+=	sha256-p8.S \
-	sha512-p8.S \
 	sha256-ppc.S \
+	sha512-p8.S \
 	sha512-ppc.S
 
 #icp/asm-x86_64/sha2
@@ -157,10 +157,10 @@ SRCS+=	lapi.c \
 	lzio.c
 
 #nvpair
-SRCS+=	nvpair.c \
-	fnvpair.c \
-	nvpair_alloc_spl.c \
-	nvpair_alloc_fixed.c
+SRCS+=	fnvpair.c \
+	nvpair.c \
+	nvpair_alloc_fixed.c \
+	nvpair_alloc_spl.c
 
 #os/freebsd/spl
 SRCS+=	acl_common.c \
@@ -184,7 +184,6 @@ SRCS+=	acl_common.c \
 	spl_zlib.c \
 	spl_zone.c
 
-
 .if ${MACHINE_ARCH} == "i386" || ${MACHINE_ARCH} == "powerpc" || \
 	${MACHINE_ARCH} == "powerpcspe" || ${MACHINE_ARCH} == "arm"
 SRCS+= spl_atomic.c
@@ -207,6 +206,7 @@ SRCS+=	abd_os.c \
 	zfs_ctldir.c \
 	zfs_debug.c \
 	zfs_dir.c \
+	zfs_file_os.c \
 	zfs_ioctl_compat.c \
 	zfs_ioctl_os.c \
 	zfs_racct.c \
@@ -217,19 +217,20 @@ SRCS+=	abd_os.c \
 	zvol_os.c
 
 #unicode
-SRCS+=	uconv.c \
-	u8_textprep.c
+SRCS+= 	u8_textprep.c \
+	uconv.c
 
 #zcommon
-SRCS+=	zfeature_common.c \
+SRCS+=	cityhash.c \
+	zfeature_common.c \
 	zfs_comutil.c \
 	zfs_deleg.c \
-	zfs_fletcher.c \
 	zfs_fletcher_avx512.c \
+	zfs_fletcher.c \
 	zfs_fletcher_intel.c \
 	zfs_fletcher_sse.c \
-	zfs_fletcher_superscalar.c \
 	zfs_fletcher_superscalar4.c \
+	zfs_fletcher_superscalar.c \
 	zfs_namecheck.c \
 	zfs_prop.c \
 	zpool_prop.c \
@@ -243,14 +244,13 @@ SRCS+=	abd.c \
 	blkptr.c \
 	bplist.c \
 	bpobj.c \
-	brt.c \
-	btree.c \
-	cityhash.c \
-	dbuf.c \
-	dbuf_stats.c \
 	bptree.c \
 	bqueue.c \
+	brt.c \
+	btree.c \
 	dataset_kstats.c \
+	dbuf.c \
+	dbuf_stats.c \
 	ddt.c \
 	ddt_stats.c \
 	ddt_zap.c \
@@ -266,13 +266,13 @@ SRCS+=	abd.c \
 	dmu_zfetch.c \
 	dnode.c \
 	dnode_sync.c \
+	dsl_bookmark.c \
+	dsl_crypt.c \
 	dsl_dataset.c \
 	dsl_deadlist.c \
 	dsl_deleg.c \
-	dsl_bookmark.c \
-	dsl_dir.c \
-	dsl_crypt.c \
 	dsl_destroy.c \
+	dsl_dir.c \
 	dsl_pool.c \
 	dsl_prop.c \
 	dsl_scan.c \
@@ -281,9 +281,9 @@ SRCS+=	abd.c \
 	edonr_zfs.c \
 	fm.c \
 	gzip.c \
-	lzjb.c \
 	lz4.c \
 	lz4_zfs.c \
+	lzjb.c \
 	metaslab.c \
 	mmp.c \
 	multilist.c \
@@ -296,6 +296,8 @@ SRCS+=	abd.c \
 	sha2_zfs.c \
 	skein_zfs.c \
 	spa.c \
+	space_map.c \
+	space_reftree.c \
 	spa_checkpoint.c \
 	spa_config.c \
 	spa_errlog.c \
@@ -303,16 +305,14 @@ SRCS+=	abd.c \
 	spa_log_spacemap.c \
 	spa_misc.c \
 	spa_stats.c \
-	space_map.c \
-	space_reftree.c \
 	txg.c \
 	uberblock.c \
 	unique.c \
 	vdev.c \
 	vdev_draid.c \
 	vdev_draid_rand.c \
-	vdev_indirect.c \
 	vdev_indirect_births.c \
+	vdev_indirect.c \
 	vdev_indirect_mapping.c \
 	vdev_initialize.c \
 	vdev_label.c \
@@ -320,11 +320,11 @@ SRCS+=	abd.c \
 	vdev_missing.c \
 	vdev_queue.c \
 	vdev_raidz.c \
-	vdev_raidz_math.c \
-	vdev_raidz_math_scalar.c \
 	vdev_raidz_math_avx2.c \
 	vdev_raidz_math_avx512bw.c \
 	vdev_raidz_math_avx512f.c \
+	vdev_raidz_math.c \
+	vdev_raidz_math_scalar.c \
 	vdev_raidz_math_sse2.c \
 	vdev_raidz_math_ssse3.c \
 	vdev_rebuild.c \
@@ -343,7 +343,6 @@ SRCS+=	abd.c \
 	zfeature.c \
 	zfs_byteswap.c \
 	zfs_chksum.c \
-	zfs_file_os.c \
 	zfs_fm.c \
 	zfs_fuid.c \
 	zfs_impl.c \
@@ -367,29 +366,35 @@ SRCS+=	abd.c \
 	zvol.c
 
 #zstd
-SRCS+=	zfs_zstd.c \
-	entropy_common.c \
+SRCS+=	zfs_zstd.c
+
+#zstd/common
+SRCS+=	entropy_common.c \
 	error_private.c \
-	fse_compress.c \
 	fse_decompress.c \
-	hist.c \
-	huf_compress.c \
-	huf_decompress.c \
 	pool.c \
 	xxhash.c \
 	zstd_common.c \
+
+#zstd/compress
+SRCS+=	fse_compress.c \
+	hist.c \
+	huf_compress.c \
 	zstd_compress.c \
 	zstd_compress_literals.c \
 	zstd_compress_sequences.c \
 	zstd_compress_superblock.c \
-	zstd_ddict.c \
-	zstd_decompress.c \
-	zstd_decompress_block.c \
 	zstd_double_fast.c \
 	zstd_fast.c \
 	zstd_lazy.c \
 	zstd_ldm.c \
 	zstd_opt.c
+
+#zstd/decompress
+SRCS+=	huf_decompress.c \
+	zstd_ddict.c \
+	zstd_decompress_block.c \
+	zstd_decompress.c
 
 beforeinstall:
 .if ${MK_DEBUG_FILES} != "no"


### PR DESCRIPTION
### Motivation and Context

Just a drive-by tidy up.

### Description

All files now in their correct sections, and all sections match on-disk dir layout, and all sorted.

### How Has This Been Tested?

Successful build on FreeBSD 14.0

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
