### PR TITLE
RFC: flag/bitfield pretty printers

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -75,6 +75,7 @@
 #include "zpool_util.h"
 #include "zfs_comutil.h"
 #include "zfeature_common.h"
+#include "zfs_pretty.h"
 
 #include "statcommon.h"
 
@@ -10338,7 +10339,15 @@ zpool_do_events_nvprint(nvlist_t *nvl, int depth)
 
 		case DATA_TYPE_INT32:
 			(void) nvpair_value_int32(nvp, (void *)&i32);
-			printf(gettext("0x%x"), i32);
+			if (strcmp(name,
+			    FM_EREPORT_PAYLOAD_ZFS_ZIO_FLAGS) == 0) {
+				static char flagstr[512];
+				zfs_pretty_zio_flag_str(i32, flagstr,
+				    sizeof (flagstr));
+				printf(gettext("0x%x [%s]"), i32, flagstr);
+			} else {
+				printf(gettext("0x%x"), i32);
+			}
 			break;
 
 		case DATA_TYPE_UINT32:

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -13,6 +13,7 @@ COMMON_H = \
 	zfs_deleg.h \
 	zfs_fletcher.h \
 	zfs_namecheck.h \
+	zfs_pretty.h \
 	zfs_prop.h \
 	\
 	sys/abd.h \

--- a/include/zfs_pretty.h
+++ b/include/zfs_pretty.h
@@ -33,19 +33,18 @@
 extern "C" {
 #endif
 
-_ZFS_PRETTY_H size_t zfs_pretty_zio_flag_bits(
-    uint64_t bits, char *out, size_t outlen);
-_ZFS_PRETTY_H size_t zfs_pretty_zio_flag_pairs(
-    uint64_t bits, char *out, size_t outlen);
-_ZFS_PRETTY_H size_t zfs_pretty_zio_flag_str(
-    uint64_t bits, char *out, size_t outlen);
+#define	_ZFS_PRETTY_DECLARE(name)	\
+	_ZFS_PRETTY_H size_t zfs_pretty_ ## name ## _bits( \
+	    uint64_t bits, char *out, size_t outlen); \
+	_ZFS_PRETTY_H size_t zfs_pretty_ ## name ## _pairs( \
+	    uint64_t bits, char *out, size_t outlen); \
+	_ZFS_PRETTY_H size_t zfs_pretty_ ## name ## _str( \
+	    uint64_t bits, char *out, size_t outlen); \
 
-_ZFS_PRETTY_H size_t zfs_pretty_abd_flag_bits(
-    uint64_t bits, char *out, size_t outlen);
-_ZFS_PRETTY_H size_t zfs_pretty_abd_flag_pairs(
-    uint64_t bits, char *out, size_t outlen);
-_ZFS_PRETTY_H size_t zfs_pretty_abd_flag_str(
-    uint64_t bits, char *out, size_t outlen);
+_ZFS_PRETTY_DECLARE(zio_flag)
+_ZFS_PRETTY_DECLARE(abd_flag)
+
+#undef _ZFS_PRETTY_DECLARE
 
 #ifdef	__cplusplus
 }

--- a/include/zfs_pretty.h
+++ b/include/zfs_pretty.h
@@ -40,6 +40,13 @@ _ZFS_PRETTY_H size_t zfs_pretty_zio_flag_pairs(
 _ZFS_PRETTY_H size_t zfs_pretty_zio_flag_str(
     uint64_t bits, char *out, size_t outlen);
 
+_ZFS_PRETTY_H size_t zfs_pretty_abd_flag_bits(
+    uint64_t bits, char *out, size_t outlen);
+_ZFS_PRETTY_H size_t zfs_pretty_abd_flag_pairs(
+    uint64_t bits, char *out, size_t outlen);
+_ZFS_PRETTY_H size_t zfs_pretty_abd_flag_str(
+    uint64_t bits, char *out, size_t outlen);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/include/zfs_pretty.h
+++ b/include/zfs_pretty.h
@@ -43,6 +43,7 @@ extern "C" {
 
 _ZFS_PRETTY_DECLARE(zio_flag)
 _ZFS_PRETTY_DECLARE(abd_flag)
+_ZFS_PRETTY_DECLARE(arc_flag)
 
 #undef _ZFS_PRETTY_DECLARE
 

--- a/include/zfs_pretty.h
+++ b/include/zfs_pretty.h
@@ -1,0 +1,47 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2024, Klara Inc.
+ */
+
+#ifndef	_ZFS_PRETTY_H
+#define	_ZFS_PRETTY_H extern __attribute__((visibility("default")))
+
+#include <sys/fs/zfs.h>
+#include <sys/types.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+_ZFS_PRETTY_H size_t zfs_pretty_zio_flag_bits(
+    uint64_t bits, char *out, size_t outlen);
+_ZFS_PRETTY_H size_t zfs_pretty_zio_flag_pairs(
+    uint64_t bits, char *out, size_t outlen);
+_ZFS_PRETTY_H size_t zfs_pretty_zio_flag_str(
+    uint64_t bits, char *out, size_t outlen);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _ZFS_PRETTY_H */

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -46,6 +46,7 @@ nodist_libzfs_la_SOURCES = \
 	module/zcommon/zfs_fletcher_superscalar.c \
 	module/zcommon/zfs_fletcher_superscalar4.c \
 	module/zcommon/zfs_namecheck.c \
+	module/zcommon/zfs_pretty.c \
 	module/zcommon/zfs_prop.c \
 	module/zcommon/zpool_prop.c \
 	module/zcommon/zprop_common.c

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -61,6 +61,7 @@ nodist_libzpool_la_SOURCES = \
 	module/zcommon/zfs_fletcher_superscalar.c \
 	module/zcommon/zfs_fletcher_superscalar4.c \
 	module/zcommon/zfs_namecheck.c \
+	module/zcommon/zfs_pretty.c \
 	module/zcommon/zfs_prop.c \
 	module/zcommon/zpool_prop.c \
 	module/zcommon/zprop_common.c \

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -239,6 +239,7 @@ ZCOMMON_OBJS := \
 	zfs_fletcher_superscalar.o \
 	zfs_fletcher_superscalar4.o \
 	zfs_namecheck.o \
+	zfs_pretty.o \
 	zfs_prop.o \
 	zpool_prop.o \
 	zprop_common.o

--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -232,6 +232,7 @@ SRCS+=	cityhash.c \
 	zfs_fletcher_superscalar4.c \
 	zfs_fletcher_superscalar.c \
 	zfs_namecheck.c \
+	zfs_pretty.c \
 	zfs_prop.c \
 	zpool_prop.c \
 	zprop_common.c

--- a/module/zcommon/zfs_pretty.c
+++ b/module/zcommon/zfs_pretty.c
@@ -109,7 +109,34 @@ zfs_pretty_str(const pretty_bit_t *table, const size_t nelems,
 	return (n);
 }
 
-static const pretty_bit_t pretty_zio_flag_table[] = {
+#define	_PRETTY_BIT_IMPL(name, ...)					\
+static const pretty_bit_t pretty_ ## name ## _table[] = { __VA_ARGS__ };\
+size_t									\
+zfs_pretty_ ## name ## _bits(uint64_t bits, char *out, size_t outlen)	\
+{									\
+	return (zfs_pretty_bits(pretty_ ## name ## _table,		\
+	    sizeof (pretty_ ## name ## _table) / sizeof (pretty_bit_t),	\
+	    bits, out, outlen));					\
+}									\
+									\
+size_t									\
+zfs_pretty_ ## name ## _pairs(uint64_t bits, char *out, size_t outlen)	\
+{									\
+	return (zfs_pretty_pairs(pretty_ ## name ## _table,		\
+	    sizeof (pretty_ ## name ## _table) / sizeof (pretty_bit_t),	\
+	    bits, out, outlen));					\
+}									\
+									\
+size_t									\
+zfs_pretty_ ## name ## _str(uint64_t bits, char *out, size_t outlen)	\
+{									\
+	return (zfs_pretty_str(pretty_ ## name ## _table,		\
+	    sizeof (pretty_ ## name ## _table) / sizeof (pretty_bit_t),	\
+	    bits, out, outlen));					\
+}									\
+
+/* BEGIN CSTYLED */
+_PRETTY_BIT_IMPL(zio_flag,
     { '.', "DA", "DONT_AGGREGATE" },
     { '.', "RP", "IO_REPAIR" },
     { '.', "SH", "SELF_HEAL" },
@@ -140,33 +167,11 @@ static const pretty_bit_t pretty_zio_flag_table[] = {
     { '.', "NP", "NOPWRITE" },
     { '.', "EX", "REEXECUTED" },
     { '.', "DG", "DELEGATED" },
-};
+)
+/* END CSTYLED */
 
-size_t
-zfs_pretty_zio_flag_bits(uint64_t bits, char *out, size_t outlen)
-{
-	return (zfs_pretty_bits(pretty_zio_flag_table,
-	    sizeof (pretty_zio_flag_table) / sizeof (pretty_bit_t),
-	    bits, out, outlen));
-}
-
-size_t
-zfs_pretty_zio_flag_pairs(uint64_t bits, char *out, size_t outlen)
-{
-	return (zfs_pretty_pairs(pretty_zio_flag_table,
-	    sizeof (pretty_zio_flag_table) / sizeof (pretty_bit_t),
-	    bits, out, outlen));
-}
-
-size_t
-zfs_pretty_zio_flag_str(uint64_t bits, char *out, size_t outlen)
-{
-	return (zfs_pretty_str(pretty_zio_flag_table,
-	    sizeof (pretty_zio_flag_table) / sizeof (pretty_bit_t),
-	    bits, out, outlen));
-}
-
-static const pretty_bit_t pretty_abd_flag_table[] = {
+/* BEGIN CSTYLED */
+_PRETTY_BIT_IMPL(abd_flag,
     { 'L', "LN", "LINEAR" },
     { 'O', "OW", "OWNER" },
     { 'M', "MT", "META" },
@@ -177,28 +182,7 @@ static const pretty_bit_t pretty_abd_flag_table[] = {
     { 'F', "GF", "GANG_FREE" },
     { 'Z', "ZR", "ZEROS" },
     { 'A', "AL", "ALLOCD" },
-};
+)
+/* END CSTYLED */
 
-size_t
-zfs_pretty_abd_flag_bits(uint64_t bits, char *out, size_t outlen)
-{
-	return (zfs_pretty_bits(pretty_abd_flag_table,
-	    sizeof (pretty_abd_flag_table) / sizeof (pretty_bit_t),
-	    bits, out, outlen));
-}
-
-size_t
-zfs_pretty_abd_flag_pairs(uint64_t bits, char *out, size_t outlen)
-{
-	return (zfs_pretty_pairs(pretty_abd_flag_table,
-	    sizeof (pretty_abd_flag_table) / sizeof (pretty_bit_t),
-	    bits, out, outlen));
-}
-
-size_t
-zfs_pretty_abd_flag_str(uint64_t bits, char *out, size_t outlen)
-{
-	return (zfs_pretty_str(pretty_abd_flag_table,
-	    sizeof (pretty_abd_flag_table) / sizeof (pretty_bit_t),
-	    bits, out, outlen));
-}
+#undef _PRETTY_BIT_IMPL

--- a/module/zcommon/zfs_pretty.c
+++ b/module/zcommon/zfs_pretty.c
@@ -185,4 +185,40 @@ _PRETTY_BIT_IMPL(abd_flag,
 )
 /* END CSTYLED */
 
+/* BEGIN CSTYLED */
+_PRETTY_BIT_IMPL(arc_flag,
+    { '.', "WT", "WAIT" },
+    { '.', "NW", "NOWAIT" },
+    { '.', "PF", "PREFETCH" },
+    { '.', "1C", "CACHED" },
+    { '.', "2C", "L2CACHE" },
+    { '.', "UC", "UNCACHED" },
+    { '.', "PP", "PRESCIENT_PREFETCH" },
+    { '.', "HT", "IN_HASH_TABLE" },
+    { '.', "IO", "IO_IN_PROGRESS" },
+    { '.', "ER", "IO_ERROR" },
+    { '.', "ID", "INDIRECT" },
+    { '.', "AS", "PRIO_ASYNC_READ" },
+    { '.', "2W", "L2_WRITING" },
+    { '.', "2E", "L2_EVICTED" },
+    { '.', "2A", "L2_WRITE_HEAD" },
+    { '.', "PR", "PROTECTED" },
+    { '.', "NA", "NOAUTH" },
+    { '.', "MD", "BUFC_METADATA" },
+    { '.', "1H", "HAS_L1HDR" },
+    { '.', "2H", "HAS_L2HDR" },
+    { '.', "CA", "COMPRESSED_ARC" },
+    { '.', "SD", "SHARED_DATA" },
+    { '.', "CO", "CACHED_ONLY" },
+    { '.', "NB", "NO_BUF" },
+    { '.', "C0", "COMPRESS_0" },
+    { '.', "C1", "COMPRESS_1" },
+    { '.', "C2", "COMPRESS_2" },
+    { '.', "C3", "COMPRESS_3" },
+    { '.', "C4", "COMPRESS_4" },
+    { '.', "C5", "COMPRESS_5" },
+    { '.', "C6", "COMPRESS_6" },
+)
+/* END CSTYLED */
+
 #undef _PRETTY_BIT_IMPL

--- a/module/zcommon/zfs_pretty.c
+++ b/module/zcommon/zfs_pretty.c
@@ -1,0 +1,142 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2024, Klara Inc.
+ */
+
+#include <sys/fs/zfs.h>
+#include <sys/types.h>
+#include <sys/string.h>
+#include <sys/debug.h>
+#include "zfs_pretty.h"
+
+typedef struct {
+	const char	pb_bit;
+	const char	pb_pair[2];
+	const char	*pb_name;
+} pretty_bit_t;
+
+static const pretty_bit_t pretty_zio_flag_table[] = {
+    { '.', "DA", "DONT_AGGREGATE" },
+    { '.', "RP", "IO_REPAIR" },
+    { '.', "SH", "SELF_HEAL" },
+    { '.', "RS", "RESILVER" },
+    { '.', "SC", "SCRUB" },
+    { '.', "ST", "SCAN_THREAD" },
+    { '.', "PH", "PHYSICAL" },
+    { '.', "CF", "CANFAIL" },
+    { '.', "SP", "SPECULATIVE" },
+    { '.', "CW", "CONFIG_WRITER" },
+    { '.', "DR", "DONT_RETRY" },
+    { '.', "ND", "NODATA" },
+    { '.', "ID", "INDUCE_DAMAGE" },
+    { '.', "AL", "IO_ALLOCATING" },
+    { '.', "RE", "IO_RETRY" },
+    { '.', "PR", "PROBE" },
+    { '.', "TH", "TRYHARD" },
+    { '.', "OP", "OPTIONAL" },
+    { '.', "DQ", "DONT_QUEUE" },
+    { '.', "DP", "DONT_PROPAGATE" },
+    { '.', "BY", "IO_BYPASS" },
+    { '.', "RW", "IO_REWRITE" },
+    { '.', "CM", "RAW_COMPRESS" },
+    { '.', "EN", "RAW_ENCRYPT" },
+    { '.', "GG", "GANG_CHILD" },
+    { '.', "DD", "DDT_CHILD" },
+    { '.', "GF", "GODFATHER" },
+    { '.', "NP", "NOPWRITE" },
+    { '.', "EX", "REEXECUTED" },
+    { '.', "DG", "DELEGATED" },
+};
+static const size_t pretty_zio_flag_table_elems =
+    sizeof (pretty_zio_flag_table) / sizeof (pretty_bit_t);
+
+size_t
+zfs_pretty_zio_flag_bits(uint64_t bits, char *out, size_t outlen)
+{
+	ASSERT(out);
+	size_t n = 0;
+	for (int b = pretty_zio_flag_table_elems; b >= 0; b--) {
+		if (n == outlen)
+			break;
+		uint64_t mask = (1ULL << b);
+		out[n++] =
+		    (bits & mask) ? pretty_zio_flag_table[b].pb_bit : ' ';
+	}
+	if (n < outlen)
+		out[n++] = '\0';
+	return (n);
+}
+
+size_t
+zfs_pretty_zio_flag_pairs(uint64_t bits, char *out, size_t outlen)
+{
+	ASSERT(out);
+	size_t n = 0;
+	for (int b = pretty_zio_flag_table_elems; b >= 0; b--) {
+		ASSERT3U(n, <=, outlen);
+		if (n == outlen)
+			break;
+		uint64_t mask = (1ULL << b);
+		if (bits & mask) {
+			size_t len = (n > 0) ? 3 : 2;
+			if (n > outlen-len)
+				break;
+			if (n > 0)
+				out[n++] = '|';
+			out[n++] = pretty_zio_flag_table[b].pb_pair[0];
+			out[n++] = pretty_zio_flag_table[b].pb_pair[1];
+		}
+	}
+	if (n < outlen)
+		out[n++] = '\0';
+	return (n);
+}
+
+size_t
+zfs_pretty_zio_flag_str(uint64_t bits, char *out, size_t outlen)
+{
+	ASSERT(out);
+	size_t n = 0;
+	for (int b = pretty_zio_flag_table_elems; b >= 0; b--) {
+		ASSERT3U(n, <=, outlen);
+		if (n == outlen)
+			break;
+		uint64_t mask = (1ULL << b);
+		if (bits & mask) {
+			size_t len = strlen(pretty_zio_flag_table[b].pb_name);
+			if (n > 0)
+				len++;
+			if (n > outlen-len)
+				break;
+			if (n > 0) {
+				out[n++] = ' ';
+				len--;
+			}
+			memcpy(&out[n], pretty_zio_flag_table[b].pb_name, len);
+			n += len;
+		}
+	}
+	if (n < outlen)
+		out[n++] = '\0';
+	return (n);
+}

--- a/module/zcommon/zfs_pretty.c
+++ b/module/zcommon/zfs_pretty.c
@@ -140,3 +140,89 @@ zfs_pretty_zio_flag_str(uint64_t bits, char *out, size_t outlen)
 		out[n++] = '\0';
 	return (n);
 }
+
+static const pretty_bit_t pretty_abd_flag_table[] = {
+    { 'L', "LN", "LINEAR" },
+    { 'O', "OW", "OWNER" },
+    { 'M', "MT", "META" },
+    { 'Z', "MZ", "MULTI_ZONE" },
+    { 'C', "MC", "MULTI_CHUNK" },
+    { 'P', "LP", "LINEAR_PAGE" },
+    { 'G', "GG", "GANG" },
+    { 'F', "GF", "GANG_FREE" },
+    { 'Z', "ZR", "ZEROS" },
+    { 'A', "AL", "ALLOCD" },
+};
+static const size_t pretty_abd_flag_table_elems =
+    sizeof (pretty_abd_flag_table) / sizeof (pretty_bit_t);
+
+size_t
+zfs_pretty_abd_flag_bits(uint64_t bits, char *out, size_t outlen)
+{
+	ASSERT(out);
+	size_t n = 0;
+	for (int b = pretty_abd_flag_table_elems; b >= 0; b--) {
+		if (n == outlen)
+			break;
+		uint64_t mask = (1ULL << b);
+		out[n++] =
+		    (bits & mask) ? pretty_abd_flag_table[b].pb_bit : ' ';
+	}
+	if (n < outlen)
+		out[n++] = '\0';
+	return (n);
+}
+
+size_t
+zfs_pretty_abd_flag_pairs(uint64_t bits, char *out, size_t outlen)
+{
+	ASSERT(out);
+	size_t n = 0;
+	for (int b = pretty_abd_flag_table_elems; b >= 0; b--) {
+		ASSERT3U(n, <=, outlen);
+		if (n == outlen)
+			break;
+		uint64_t mask = (1ULL << b);
+		if (bits & mask) {
+			size_t len = (n > 0) ? 3 : 2;
+			if (n > outlen-len)
+				break;
+			if (n > 0)
+				out[n++] = '|';
+			out[n++] = pretty_abd_flag_table[b].pb_pair[0];
+			out[n++] = pretty_abd_flag_table[b].pb_pair[1];
+		}
+	}
+	if (n < outlen)
+		out[n++] = '\0';
+	return (n);
+}
+
+size_t
+zfs_pretty_abd_flag_str(uint64_t bits, char *out, size_t outlen)
+{
+	ASSERT(out);
+	size_t n = 0;
+	for (int b = 0; b <= pretty_abd_flag_table_elems; b++) {
+		ASSERT3U(n, <=, outlen);
+		if (n == outlen)
+			break;
+		uint64_t mask = (1ULL << b);
+		if (bits & mask) {
+			size_t len = strlen(pretty_abd_flag_table[b].pb_name);
+			if (n > 0)
+				len++;
+			if (n > outlen-len)
+				break;
+			if (n > 0) {
+				out[n++] = ' ';
+				len--;
+			}
+			memcpy(&out[n], pretty_abd_flag_table[b].pb_name, len);
+			n += len;
+		}
+	}
+	if (n < outlen)
+		out[n++] = '\0';
+	return (n);
+}

--- a/module/zfs/dbuf_stats.c
+++ b/module/zfs/dbuf_stats.c
@@ -22,6 +22,7 @@
 #include <sys/zfs_context.h>
 #include <sys/dbuf.h>
 #include <sys/dmu_objset.h>
+#include <zfs_pretty.h>
 
 /*
  * Calculate the index of the arc header for the state, disabled by default.
@@ -48,7 +49,7 @@ dbuf_stats_hash_table_headers(char *buf, size_t size)
 	(void) snprintf(buf, size,
 	    "%-105s | %-119s | %s\n"
 	    "%-16s %-8s %-8s %-8s %-8s %-10s %-8s %-8s %-5s %-5s %-7s %3s | "
-	    "%-5s %-5s %-9s %-6s %-8s %-12s "
+	    "%-5s %-5s %-20s %-6s %-8s %-12s "
 	    "%-6s %-6s %-6s %-6s %-6s %-8s %-8s %-8s %-6s | "
 	    "%-6s %-6s %-8s %-8s %-6s %-6s %-6s %-8s %-8s\n",
 	    "dbuf", "arcbuf", "dnode", "pool", "objset", "object", "level",
@@ -74,9 +75,12 @@ __dbuf_stats_hash_table_data(char *buf, size_t size, dmu_buf_impl_t *db)
 
 	__dmu_object_info_from_dnode(dn, &doi);
 
+	char flagstr[128];
+	zfs_pretty_arc_flag_pairs(abi.abi_flags, flagstr, sizeof (flagstr));
+
 	nwritten = snprintf(buf, size,
 	    "%-16s %-8llu %-8lld %-8lld %-8lld %-10llu %-8llu %-8llu "
-	    "%-5d %-5d %-7lu %-3d | %-5d %-5d 0x%-7x %-6lu %-8llu %-12llu "
+	    "%-5d %-5d %-7lu %-3d | %-5d %-5d %-20s %-6lu %-8llu %-12llu "
 	    "%-6lu %-6lu %-6lu %-6lu %-6lu %-8llu %-8llu %-8d %-6lu | "
 	    "%-6d %-6d %-8lu %-8lu %-6llu %-6lu %-6lu %-8llu %-8llu\n",
 	    /* dmu_buf_impl_t */
@@ -95,7 +99,7 @@ __dbuf_stats_hash_table_data(char *buf, size_t size, dmu_buf_impl_t *db)
 	    /* arc_buf_info_t */
 	    abi.abi_state_type,
 	    abi.abi_state_contents,
-	    abi.abi_flags,
+	    flagstr,
 	    (ulong_t)abi.abi_bufcnt,
 	    (u_longlong_t)abi.abi_size,
 	    (u_longlong_t)abi.abi_access,

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -52,6 +52,7 @@
 #include <sys/abd.h>
 #include <sys/dsl_crypt.h>
 #include <cityhash.h>
+#include <zfs_pretty.h>
 
 /*
  * ==========================================================================
@@ -4607,6 +4608,18 @@ zio_ready(zio_t *zio)
 	if (bp != NULL && bp != &zio->io_bp_copy)
 		zio->io_bp_copy = *bp;
 #endif
+
+	if (zio->io_abd) {
+		char zioflagstr[256], abdflagstr[256];
+		zfs_pretty_zio_flag_bits(zio->io_flags,
+		    zioflagstr, sizeof (zioflagstr));
+		zfs_pretty_abd_flag_bits(zio->io_abd->abd_flags,
+		    abdflagstr, sizeof (abdflagstr));
+		cmn_err(CE_NOTE, "zio_ready: zio %p type %d flags [%s];"
+		    " abd %p size %08x flags [%s]",
+		    zio, zio->io_type, zioflagstr,
+		    zio->io_abd, zio->io_abd->abd_size, abdflagstr);
+	}
 
 	if (zio->io_error != 0) {
 		zio->io_pipeline = ZIO_INTERLOCK_PIPELINE;


### PR DESCRIPTION
### Motivation and Context

As a good C program, OpenZFS uses bitfields everywhere. I am extremely bad at decoding these in my head, so I frequently find myself writing weird custom formatters. Today I finally got sick of that, so I had a go at making some formatting facilities for bitfields.

I'm looking for code review, suggestions for improvements and any other thoughts you might have. It might be that a generic facility isn't worth it, but it'd be nice to have something available we can reach for for the common cases, and as you see, there's opportunity to improve user tools as well.

### Description

In the commits you will find `zfs_pretty`, which is a bunch of tables that describe display styles for a handful of bitfield types, and functions to take a value and format it. There's three display styles available for each value: a single character, a character pair, and a full name.

There's then three example applications, which I will show here.

When we've got plenty of space to work with and/or being explicit is important, there's a full expansion mode available (`zfs_pretty_<type>_str()`). An example is when showing ZIO contents in `zio_events` after an error:

```
Feb 29 2024 04:56:28.413337691 ereport.fs.zfs.data
...
        zio_err = 0x5
        zio_flags = 0x8181 [DONT_AGGREGATE CANFAIL SPECULATIVE PROBE]
        zio_stage = 0x2000000
```

When a much tighter format is wanted, there's a one-char-per-bit mode available (`zfs_pretty_<type>_bits()`). This is likely to be more useful for types with relatively few defined bits, as there's a limited number of unambiguous characters available. However, since unset bits are shown as blank space, this mode may still be useful in some cases as a visual representation of shape or sequence. This example shows something I do pretty often, which is to dump bits of ZIOs or ABDs in flight:

```
[    3.986551] NOTICE: zio_ready: zio 00000000b250d408 type 2 flags [             ..        ..     .]; abd 00000000acb026fc size 00002000 flags [ A   P  MOL]
[    3.987872] NOTICE: zio_ready: zio 000000004afb4d15 type 1 flags [                     ....      ]; abd 00000000acb026fc size 0001c000 flags [ A      MOL]
[    4.009248] NOTICE: zio_ready: zio 0000000050402b45 type 2 flags [                     . ..      ]; abd 000000002d5d83f2 size 0001c000 flags [ A      MOL]
[    4.009463] NOTICE: zio_ready: zio 00000000865d0834 type 2 flags [                     . ..      ]; abd 000000001d844cd8 size 00002000 flags [ A   P  MOL]
[    4.017214] NOTICE: zio_ready: zio 000000009a426bbb type 2 flags [                .              ]; abd 00000000beda36e4 size 00000200 flags [ A        L]
[    4.017377] NOTICE: zio_ready: zio 0000000068990b19 type 2 flags [                               ]; abd 0000000076fe7aa3 size 00000200 flags [ A        L]
```

Finally, there's a compact "pairs" mode (`zfs_pretty_<type>_pairs()`), which has two chars per bit, with a visual separator. This can work well when there's too many bits defined for the "bits" mode to be useful, but there's still a limited amount of space available. Here's an example showing ARC header flags in the dbuf stats:

```
# cat /proc/spl/kstat/zfs/dbufs | perl -F'/\s+\|\s+/' -lanE 'print $F[1]'

arcbuf
list  atype flags                count  asize    access       mru    gmru   mfu    gmfu   l2     l2_dattr l2_asize l2_comp  aholds
1     1     C3|C2|C1|C0|CA|1H|MD|HT|2C 1      1024     4294893222   0      0      0      0      0      0        0        0        1
1     1     C3|C2|C1|C0|CA|1H|MD|HT|2C 1      512      4294894529   0      0      0      0      0      0        0        0        1
1     1     C3|C2|C1|C0|CA|1H|MD|HT|2C 1      1024     4294893229   0      0      0      0      0      0        0        0        1
1     1     C3|C2|C1|C0|CA|1H|MD|HT|2C 1      1024     4294894530   0      0      0      0      0      0        0        0        1
3     1     C3|C2|C1|C0|CA|1H|MD|HT|2C 1      512      4294932928   11     0      33     0      0      0        0        0        1
1     1     C3|C2|C1|C0|CA|1H|MD|HT|2C 1      1024     4294894529   0      0      0      0      0      0        0        0        1
1     1     C3|C2|C1|C0|CA|1H|MD|HT|2C 1      1024     4294894530   0      0      0      0      0      0        0        0        1
1     1     C3|C2|C1|C0|CA|1H|MD|HT|2C 1      1024     4294894530   0      0      0      0      0      0        0        0        1
1     0     C1|CA|1H|HT|2C       1      131072   4294893229   0      0      0      0      0      0        0        0        1
1     0     C1|CA|1H|HT|2C       1      131072   4294893229   0      0      0      0      0      0        0        0        1
1     0     C1|CA|1H|HT|2C       1      131072   4294893229   0      0      0      0      0      0        0        0        1
1     0     C1|CA|1H|HT|2C       1      131072   4294893229   0      0      0      0      0      0        0        0        1
```

I don't claim that these are _good_ uses (well, I like the `zpool events` one); they were just convenient ways to show what's going on.

(I will spare you further experiments involving colour and emojis ... for now!)

### How Has This Been Tested?

Draft, so minimal; just hand testing for now.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
