### PR TITLE
zinject: show more device fault fields

### DIFF
--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2017, Intel Corporation.
+ * Copyright (c) 2024, Klara Inc.
  */
 
 /*
@@ -208,6 +209,37 @@ type_to_name(uint64_t type)
 	}
 }
 
+struct errstr {
+	int		err;
+	const char	*str;
+};
+static const struct errstr errstrtable[] = {
+	{ EIO,		"io" },
+	{ ECKSUM,	"checksum" },
+	{ EINVAL,	"decompress" },
+	{ EACCES,	"decrypt" },
+	{ ENXIO,	"nxio" },
+	{ ECHILD,	"dtl" },
+	{ EILSEQ,	"corrupt" },
+	{ 0, NULL },
+};
+
+static int
+str_to_err(const char *str)
+{
+	for (int i = 0; errstrtable[i].str != NULL; i++)
+		if (strcasecmp(errstrtable[i].str, str) == 0)
+			return (errstrtable[i].err);
+	return (-1);
+}
+static const char *
+err_to_str(int err)
+{
+	for (int i = 0; errstrtable[i].str != NULL; i++)
+		if (errstrtable[i].err == err)
+			return (errstrtable[i].str);
+	return ("[unknown]");
+}
 
 /*
  * Print usage message.
@@ -392,6 +424,10 @@ static int
 print_device_handler(int id, const char *pool, zinject_record_t *record,
     void *data)
 {
+	static const char *iotypestr[] = {
+	    "null", "read", "write", "free", "claim", "ioctl", "trim", "all",
+	};
+
 	int *count = data;
 
 	if (record->zi_guid == 0 || record->zi_func[0] != '\0')
@@ -401,14 +437,21 @@ print_device_handler(int id, const char *pool, zinject_record_t *record,
 		return (0);
 
 	if (*count == 0) {
-		(void) printf("%3s  %-15s  %s\n", "ID", "POOL", "GUID");
-		(void) printf("---  ---------------  ----------------\n");
+		(void) printf("%3s  %-15s  %-16s  %-5s  %-10s  %-9s\n",
+		    "ID", "POOL", "GUID", "TYPE", "ERROR", "FREQ");
+		(void) printf(
+		    "---  ---------------  ----------------  "
+		    "-----  ----------  ---------\n");
 	}
 
 	*count += 1;
 
-	(void) printf("%3d  %-15s  %llx\n", id, pool,
-	    (u_longlong_t)record->zi_guid);
+	double freq = record->zi_freq == 0 ? 100.0f :
+	    (((double)record->zi_freq) / ZI_PERCENTAGE_MAX) * 100.0f;
+
+	(void) printf("%3d  %-15s  %llx  %-5s  %-10s  %8.4f%%\n", id, pool,
+	    (u_longlong_t)record->zi_guid, iotypestr[record->zi_iotype],
+	    err_to_str(record->zi_error), freq);
 
 	return (0);
 }
@@ -842,24 +885,12 @@ main(int argc, char **argv)
 			}
 			break;
 		case 'e':
-			if (strcasecmp(optarg, "io") == 0) {
-				error = EIO;
-			} else if (strcasecmp(optarg, "checksum") == 0) {
-				error = ECKSUM;
-			} else if (strcasecmp(optarg, "decompress") == 0) {
-				error = EINVAL;
-			} else if (strcasecmp(optarg, "decrypt") == 0) {
-				error = EACCES;
-			} else if (strcasecmp(optarg, "nxio") == 0) {
-				error = ENXIO;
-			} else if (strcasecmp(optarg, "dtl") == 0) {
-				error = ECHILD;
-			} else if (strcasecmp(optarg, "corrupt") == 0) {
-				error = EILSEQ;
-			} else {
+			error = str_to_err(optarg);
+			if (error < 0) {
 				(void) fprintf(stderr, "invalid error type "
-				    "'%s': must be 'io', 'checksum' or "
-				    "'nxio'\n", optarg);
+				    "'%s': must be one of: io decompress "
+				    "decrypt nxio dtl corrupt\n",
+				    optarg);
 				usage();
 				libzfs_fini(g_zfs);
 				return (1);

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -153,6 +153,12 @@ tests = [ 'clean_mirror_001_pos', 'clean_mirror_002_pos',
     'clean_mirror_003_pos', 'clean_mirror_004_pos']
 tags = ['functional', 'clean_mirror']
 
+[tests/functional/cli_root/zinject]
+tests = ['zinject_args']
+pre =
+post =
+tags = ['functional', 'cli_root', 'zinject']
+
 [tests/functional/cli_root/zdb]
 tests = ['zdb_002_pos', 'zdb_003_pos', 'zdb_004_pos', 'zdb_005_pos',
     'zdb_006_pos', 'zdb_args_neg', 'zdb_args_pos',

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -606,6 +606,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/clean_mirror/clean_mirror_004_pos.ksh \
 	functional/clean_mirror/cleanup.ksh \
 	functional/clean_mirror/setup.ksh \
+	functional/cli_root/zinject/zinject_args.ksh \
 	functional/cli_root/zdb/zdb_002_pos.ksh \
 	functional/cli_root/zdb/zdb_003_pos.ksh \
 	functional/cli_root/zdb/zdb_004_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zinject/zinject_args.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zinject/zinject_args.ksh
@@ -1,0 +1,62 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2024, Klara Inc.
+#
+
+#
+# TODO: this only checks that the set of valid device fault types. It should
+#       check all the other options, and that they work, and everything really.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+log_assert "Check zinject parameters."
+
+log_onexit cleanup
+
+DISK1=${DISKS%% *}
+
+function cleanup
+{
+	zinject -c all
+	default_cleanup_noexit
+}
+
+function test_device_fault
+{
+	typeset -a errno=("io" "decompress" "decrypt" "nxio" "dtl" "corrupt")
+	for e in ${errno[@]}; do
+		log_must eval \
+		    "zinject -d $DISK1 -e $e -T read -f 0.001 $TESTPOOL"
+	done
+	zinject -c all
+}
+
+default_mirror_setup_noexit $DISKS
+
+test_device_fault
+
+log_pass "zinject parameters work as expected."


### PR DESCRIPTION
### Motivation and Context

Once there's a few different kinds injected, its pretty hard to see them otherwise.

### Description

Show IO type, error type and frequency fields in the table too.

Since we now have to convert from error code to pretty string, refactor the error names into a table and add lookup functions.

### How Has This Been Tested?

Hand tested. Since its all in `zinject` itself, should be no operational changes. As an output change it may upset things that parse the output, however, I don't see any of those in ZTS and as a debug tool I'd be surprised if anyone were relying on it too heavily. I expect the tests to pass.

Sample output:

```
+ zinject -d loop0 -e io -T read -f 0.001 tank
Added handler 1 with the following properties:
  pool: tank
  vdev: 3a2b36841f0f5da7
+ zinject -d loop0 -e decompress -T free tank
Added handler 2 with the following properties:
  pool: tank
  vdev: 3a2b36841f0f5da7
+ zinject -d loop0 -e decrypt -T claim tank
Added handler 3 with the following properties:
  pool: tank
  vdev: 3a2b36841f0f5da7
+ zinject -d loop0 -e dtl -T all -L pad1 tank
Added handler 4 with the following properties:
  pool: tank
  vdev: 3a2b36841f0f5da7
+ zinject -d loop0 -e corrupt -T read -f 23 tank
Added handler 5 with the following properties:
  pool: tank
  vdev: 3a2b36841f0f5da7
+ zinject
 ID  POOL             GUID              TYPE   ERROR       FREQ
---  ---------------  ----------------  -----  ----------  ---------
  1  tank             3a2b36841f0f5da7  read   io            0.0010%
  2  tank             3a2b36841f0f5da7  free   decompress  100.0000%
  3  tank             3a2b36841f0f5da7  claim  decrypt     100.0000%
  4  tank             3a2b36841f0f5da7  all    dtl         100.0000%
  5  tank             3a2b36841f0f5da7  read   corrupt      23.0000%
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
