### PR TITLE
Add -t option to zfs destroy

### DIFF
--- a/man/man8/zfs-destroy.8
+++ b/man/man8/zfs-destroy.8
@@ -40,10 +40,12 @@
 .Nm zfs
 .Cm destroy
 .Op Fl Rfnprv
+.Oo Fl t Ar type Ns Oc
 .Ar filesystem Ns | Ns Ar volume
 .Nm zfs
 .Cm destroy
 .Op Fl Rdnprv
+.Oo Fl t Ar type Ns Oc
 .Ar filesystem Ns | Ns Ar volume Ns @ Ns Ar snap Ns
 .Oo % Ns Ar snap Ns Oo , Ns Ar snap Ns Oo % Ns Ar snap Oc Oc Oc Ns …
 .Nm zfs
@@ -56,6 +58,7 @@
 .Nm zfs
 .Cm destroy
 .Op Fl Rfnprv
+.Oo Fl t Ar type Ns Oc
 .Ar filesystem Ns | Ns Ar volume
 .Xc
 Destroys the given dataset.
@@ -84,6 +87,28 @@ flags to determine what data would be deleted.
 Print machine-parsable verbose information about the deleted data.
 .It Fl r
 Recursively destroy all children.
+.It Fl t Ar type
+The specified type to destroy, where
+.Ar type
+is one of
+.Sy filesystem ,
+.Sy snapshot ,
+.Sy volume ,
+or
+.Sy bookmark .
+For example, specifying
+.Fl t Sy snapshot
+will not destroy data if the supplied argument is not a
+.Sy snapshot .
+.Sy fs ,
+.Sy snap ,
+or
+.Sy vol
+can be used as aliases for
+.Sy filesystem ,
+.Sy snapshot ,
+or
+.Sy volume .
 .It Fl v
 Print verbose information about the deleted data.
 .El
@@ -98,6 +123,7 @@ behavior for mounted file systems in use.
 .Nm zfs
 .Cm destroy
 .Op Fl Rdnprv
+.Oo Fl t Ar type Ns Oc
 .Ar filesystem Ns | Ns Ar volume Ns @ Ns Ar snap Ns
 .Oo % Ns Ar snap Ns Oo , Ns Ar snap Ns Oo % Ns Ar snap Oc Oc Oc Ns …
 .Xc
@@ -155,6 +181,28 @@ Print machine-parsable verbose information about the deleted data.
 Destroy
 .Pq or mark for deferred deletion
 all snapshots with this name in descendent file systems.
+.It Fl t Ar type
+The specified type to destroy, where
+.Ar type
+is one of
+.Sy filesystem ,
+.Sy snapshot ,
+.Sy volume ,
+or
+.Sy bookmark .
+For example, specifying
+.Fl t Sy snapshot
+will not destroy data if the supplied argument is not a
+.Sy snapshot .
+.Sy fs ,
+.Sy snap ,
+or
+.Sy vol
+can be used as aliases for
+.Sy filesystem ,
+.Sy snapshot ,
+or
+.Sy volume .
 .It Fl v
 Print verbose information about the deleted data.
 .Pp

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -210,8 +210,9 @@ tests = ['zfs_clone_livelist_condense_and_disable',
     'zfs_destroy_007_neg', 'zfs_destroy_008_pos', 'zfs_destroy_009_pos',
     'zfs_destroy_010_pos', 'zfs_destroy_011_pos', 'zfs_destroy_012_pos',
     'zfs_destroy_013_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
-    'zfs_destroy_016_pos', 'zfs_destroy_clone_livelist',
-    'zfs_destroy_dev_removal', 'zfs_destroy_dev_removal_condense']
+    'zfs_destroy_016_pos', 'zfs_destroy_017_pos',
+    'zfs_destroy_clone_livelist', 'zfs_destroy_dev_removal',
+    'zfs_destroy_dev_removal_condense']
 tags = ['functional', 'cli_root', 'zfs_destroy']
 
 [tests/functional/cli_root/zfs_diff]

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_017_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_017_pos.ksh
@@ -1,0 +1,77 @@
+#!/bin/ksh -p
+
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2024 by Chris Simons <chris@simons.network>
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_destroy/zfs_destroy.cfg
+
+#
+# DESCRIPTION:
+# Verify that 'zfs destroy' with a type filter only destroys the datasets
+# of the specified type.
+#
+# STRATEGY:
+# 1. Create various types
+# 2. Attempt to destroy with correct and incorrect types
+# 3. Verify only expected items are destroyed
+# 4. Ensure recursive destruction still occurs
+#
+
+function cleanup
+{
+    for ds in $TESTPOOL/$TESTFS1 $TESTPOOL/$TESTVOL; do
+        datasetexists $ds && log_must zfs destroy -r $ds
+    done
+}
+
+log_assert "Verify 'zfs destroy' with a type filter only affects specified type"
+log_onexit cleanup
+
+# Create a filesystem, dataset and a volume
+log_must zfs create $TESTPOOL/$TESTFS1
+log_must zfs create $TESTPOOL/$TESTFS1/testdataset
+log_must zfs create -V $VOLSIZE $TESTPOOL/$TESTVOL
+
+# Take a snapshots
+log_must zfs snapshot $TESTPOOL/$TESTFS1@snap
+log_must zfs snapshot $TESTPOOL/$TESTVOL@snap
+log_must zfs snapshot $TESTPOOL/$TESTFS1@snap_del
+log_must zfs snapshot $TESTPOOL/$TESTVOL@snap_del
+log_must zfs snapshot -r $TESTPOOL/$TESTFS1@snap_recursive
+
+# Destroy only snapshots with the type filter
+log_mustnot zfs destroy -t snapshot $TESTPOOL/$TESTFS1
+log_mustnot zfs destroy -t snapshot -r $TESTPOOL/$TESTFS1
+log_mustnot zfs destroy -t snapshot $TESTPOOL/$TESTVOL
+log_mustnot zfs destroy -t snapshot -r $TESTPOOL/$TESTVOL
+log_must zfs destroy -t snapshot $TESTPOOL/$TESTFS1@snap_del
+log_must zfs destroy -t snapshot $TESTPOOL/$TESTVOL@snap_del
+log_must zfs destroy -t snapshot -r $TESTPOOL/$TESTFS1@snap_recursive
+
+# Verify the filesystem snapshot is destroyed and the volume snapshot remains
+log_must datasetexists $TESTPOOL/$TESTFS1
+log_must datasetexists $TESTPOOL/$TESTVOL
+log_mustnot datasetexists $TESTPOOL/$TESTFS1@snap_del
+log_mustnot datasetexists $TESTPOOL/$TESTVOL@snap_del
+log_mustnot datasetexists $TESTPOOL/$TESTVOL@snap_recursive
+log_mustnot datasetexists $TESTPOOL/$TESTVOL/testdataset@snap_recursive
+
+log_pass "zfs destroy with a snapshot filter only affects specified type"
+


### PR DESCRIPTION
Resolves #9522 by adding an optional `[-t type]` option gate to the `zfs destroy` command. Checks the type of the supplied argument, then checks if the supplied type is the same or one of the aliases that are also used in `zfs list`. If the type doesn't match, it prints an error to stderr and exits. I am aware there have been PRs for this before, but I thought a simpler change might be more likely to be accepted.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a (hopefully) uncomplicated solution to the problem from issue #9522. It just checks the type early and exits if the type isn't a match. This makes something like using `zfs list` with `grep` or `awk` much less of a footgun for scripting and reduces the chances of destroying a dataset instead of a snapshot. I had written [a small utility](https://github.com/simons-public/snapzap) that does this for my own purposes, but when I saw that #9522 was labeled as **good first issue** I decided to submit a PR.

### Description
<!--- Describe your changes in detail -->
This change adds a `[-t type]` option that exits if the supplied volume/filesystem/snapshot argument is not of the specified type.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Tested by adding a functional test in zfs-test suite and running on linux. Passes all Github workflow actions that were not already failing. As an optional flag, should not affect any other items.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly. (zfs-destroy.8)
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. (zfs_destroy_017_pos.ksh)
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
