### PR TITLE
[2.1 backport] Avoid save/restoring AMX registers to avoid a SPR erratum

### DIFF
--- a/include/os/linux/kernel/linux/simd_x86.h
+++ b/include/os/linux/kernel/linux/simd_x86.h
@@ -157,6 +157,15 @@
 #endif
 #endif
 
+#ifndef XFEATURE_MASK_XTILE
+/*
+ * For kernels where this doesn't exist yet, we still don't want to break
+ * by save/restoring this broken nonsense.
+ * See issue #14989 or Intel errata SPR4 for why
+ */
+#define	XFEATURE_MASK_XTILE	0x60000
+#endif
+
 #include <linux/mm.h>
 #include <linux/slab.h>
 
@@ -290,7 +299,7 @@ kfpu_begin(void)
 	 */
 	union fpregs_state *state = zfs_kfpu_fpregs[smp_processor_id()];
 	if (static_cpu_has(X86_FEATURE_XSAVE)) {
-		kfpu_save_xsave(&state->xsave, ~0);
+		kfpu_save_xsave(&state->xsave, ~XFEATURE_MASK_XTILE);
 	} else if (static_cpu_has(X86_FEATURE_FXSR)) {
 		kfpu_save_fxsr(&state->fxsave);
 	} else {
@@ -319,18 +328,18 @@ kfpu_begin(void)
 	union fpregs_state *state = zfs_kfpu_fpregs[smp_processor_id()];
 #if defined(HAVE_XSAVES)
 	if (static_cpu_has(X86_FEATURE_XSAVES)) {
-		kfpu_do_xsave("xsaves", &state->xsave, ~0);
+		kfpu_do_xsave("xsaves", &state->xsave, ~XFEATURE_MASK_XTILE);
 		return;
 	}
 #endif
 #if defined(HAVE_XSAVEOPT)
 	if (static_cpu_has(X86_FEATURE_XSAVEOPT)) {
-		kfpu_do_xsave("xsaveopt", &state->xsave, ~0);
+		kfpu_do_xsave("xsaveopt", &state->xsave, ~XFEATURE_MASK_XTILE);
 		return;
 	}
 #endif
 	if (static_cpu_has(X86_FEATURE_XSAVE)) {
-		kfpu_do_xsave("xsave", &state->xsave, ~0);
+		kfpu_do_xsave("xsave", &state->xsave, ~XFEATURE_MASK_XTILE);
 	} else if (static_cpu_has(X86_FEATURE_FXSR)) {
 		kfpu_save_fxsr(&state->fxsave);
 	} else {
@@ -396,7 +405,7 @@ kfpu_end(void)
 	union fpregs_state *state = zfs_kfpu_fpregs[smp_processor_id()];
 
 	if (static_cpu_has(X86_FEATURE_XSAVE)) {
-		kfpu_restore_xsave(&state->xsave, ~0);
+		kfpu_restore_xsave(&state->xsave, ~XFEATURE_MASK_XTILE);
 	} else if (static_cpu_has(X86_FEATURE_FXSR)) {
 		kfpu_restore_fxsr(&state->fxsave);
 	} else {
@@ -415,12 +424,12 @@ kfpu_end(void)
 	union fpregs_state *state = zfs_kfpu_fpregs[smp_processor_id()];
 #if defined(HAVE_XSAVES)
 	if (static_cpu_has(X86_FEATURE_XSAVES)) {
-		kfpu_do_xrstor("xrstors", &state->xsave, ~0);
+		kfpu_do_xrstor("xrstors", &state->xsave, ~XFEATURE_MASK_XTILE);
 		goto out;
 	}
 #endif
 	if (static_cpu_has(X86_FEATURE_XSAVE)) {
-		kfpu_do_xrstor("xrstor", &state->xsave, ~0);
+		kfpu_do_xrstor("xrstor", &state->xsave, ~XFEATURE_MASK_XTILE);
 	} else if (static_cpu_has(X86_FEATURE_FXSR)) {
 		kfpu_restore_fxsr(&state->fxsave);
 	} else {


### PR DESCRIPTION
### Motivation and Context
Someone hit #14989 on 2.1.x, and I noticed this hadn't ever ended up there.

I don't know if we're cutting a 2.1.16, but I figured I'd push it out in case someone needed it.

### Description
See #15168 

### How Has This Been Tested?
Isn't that what CI is for?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
