### PR TITLE
Add a kill switch for SEEK_HOLE/SEEK_DATA

### DIFF
--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -51,6 +51,8 @@
  */
 static unsigned int zfs_fallocate_reserve_percent = 110;
 
+static unsigned int zfs_disable_holey = 1;
+
 static int
 zpl_open(struct inode *ip, struct file *filp)
 {
@@ -550,6 +552,7 @@ zpl_direct_IO(int rw, struct kiocb *kiocb, struct iov_iter *iter, loff_t pos)
 static loff_t
 zpl_llseek(struct file *filp, loff_t offset, int whence)
 {
+if (!(zfs_disable_holey)) {
 #if defined(SEEK_HOLE) && defined(SEEK_DATA)
 	fstrans_cookie_t cookie;
 
@@ -569,7 +572,7 @@ zpl_llseek(struct file *filp, loff_t offset, int whence)
 		return (error);
 	}
 #endif /* SEEK_HOLE && SEEK_DATA */
-
+}
 	return (generic_file_llseek(filp, offset, whence));
 }
 
@@ -1389,3 +1392,8 @@ const struct file_operations zpl_dir_file_operations = {
 module_param(zfs_fallocate_reserve_percent, uint, 0644);
 MODULE_PARM_DESC(zfs_fallocate_reserve_percent,
 	"Percentage of length to use for the available capacity check");
+
+/* CSTYLED */
+module_param(zfs_disable_holey, uint, 0644);
+MODULE_PARM_DESC(zfs_disable_holey,
+	"Disable ZFS-specific implementation of hole detection");

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -63,7 +63,7 @@
  * even if feature@block_cloning is enabled, attempts to clone blocks will act
  * as though the feature is disabled.
  */
-int zfs_bclone_enabled = 1;
+int zfs_bclone_enabled = 0;
 
 /*
  * When set zfs_clone_range() waits for dirty data to be written to disk.


### PR DESCRIPTION
We've had a number of varyingly rare races with trying to cheat and not copy certain file regions from userland come up.

Let's add a kill switch which should hopefully allow people to just hit it and keep running without those optimizations rather than hoping that we've caught them all This Time.

### Motivation and Context
#15994 #15933 #15526 #11900 #14753 

### Description
I'd like a safe option while we debug things further in the future, rather than having to push out a release saying "we think this fixes it but since it's a rare edge case it's hard to be certain".

### How Has This Been Tested?
Again, isn't that what CI is for?

(Really, I'm expecting to need to go modify the tests to set the tunable off to pass, but I wanted to see if anything else breaks first.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
