### PR TITLE
[2.2]  vdev_disk: fix alignment check when buffer has non-zero starting offset

### DIFF
--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -865,7 +865,7 @@ vdev_disk_check_pages_cb(struct page *page, size_t off, size_t len, void *priv)
 	 * Note if we're taking less than a full block, so we can check it
 	 * above on the next call.
 	 */
-	s->end = len & s->bmask;
+	s->end = (off+len) & s->bmask;
 
 	/* All blocks after the first must start on a block size boundary. */
 	if (s->npages != 0 && (off & s->bmask) != 0)


### PR DESCRIPTION
### Motivation and Context

Backporting #16076 to 2.2.

In an internal stress test, we tripped the `VERIFY` on the ABD copy, after the first had failed the alignment check:

```
Apr 08 16:05:23 XR3-U32 kernel: VERIFY(vdev_disk_check_pages(abd, zio->io_size, bdev)) failed
Apr 08 16:05:23 XR3-U32 kernel: PANIC at vdev_disk.c:857:vdev_disk_io_rw()
```

Investigation showed that the check was faulty.

### Description

If a linear buffer spans multiple pages, and the first page has a non-zero starting offset, the checker would not include the offset, and so would think there was an alignment gap at the end of the first page, rather than at the start.

That is, for a 16K buffer spread across five pages with an initial 512B offset:

```
        [.XXXXXXX][XXXXXXXX][XXXXXXXX][XXXXXXXX][XXXXXXX.]
```

It would be interpreted as:

```
        [XXXXXXX.][XXXXXXXX]...
```

And be rejected as misaligned.

Since it's already a linear ABD, the "linearising" copy would just reuse the buffer as-is, and the second check would failing, tripping the `VERIFY` in `vdev_disk_io_rw()`.

This commit fixes all this by including the offset in the check for end-of-page alignment.

### How Has This Been Tested?

Compile checked. No additional testing beyond #16076. I have not brought the tests back, since they're not actually testing the live code anyway and any change required is going to hit master before 2.2.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).