### PR TITLE
zinject: "no-op" error injection

### DIFF
--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -221,6 +221,7 @@ static const struct errstr errstrtable[] = {
 	{ ENXIO,	"nxio" },
 	{ ECHILD,	"dtl" },
 	{ EILSEQ,	"corrupt" },
+	{ ENOSYS,	"noop" },
 	{ 0, NULL },
 };
 
@@ -269,8 +270,8 @@ usage(void)
 	    "\t\tInject a fault into a particular device or the device's\n"
 	    "\t\tlabel.  Label injection can either be 'nvlist', 'uber',\n "
 	    "\t\t'pad1', or 'pad2'.\n"
-	    "\t\t'errno' can be 'nxio' (the default), 'io', 'dtl', or\n"
-	    "\t\t'corrupt' (bit flip).\n"
+	    "\t\t'errno' can be 'nxio' (the default), 'io', 'dtl',\n"
+	    "\t\t'corrupt' (bit flip), or 'noop' (successfully do nothing).\n"
 	    "\t\t'frequency' is a value between 0.0001 and 100.0 that limits\n"
 	    "\t\tdevice error injection to a percentage of the IOs.\n"
 	    "\n"
@@ -889,7 +890,7 @@ main(int argc, char **argv)
 			if (error < 0) {
 				(void) fprintf(stderr, "invalid error type "
 				    "'%s': must be one of: io decompress "
-				    "decrypt nxio dtl corrupt\n",
+				    "decrypt nxio dtl corrupt noop\n",
 				    optarg);
 				usage();
 				libzfs_fini(g_zfs);

--- a/man/man8/zinject.8
+++ b/man/man8/zinject.8
@@ -211,9 +211,11 @@ to flip a bit in the data after a read,
 .It Sy dtl
 for an ECHILD error,
 .It Sy io
-for an EIO error where reopening the device will succeed, or
+for an EIO error where reopening the device will succeed,
 .It Sy nxio
-for an ENXIO error where reopening the device will fail.
+for an ENXIO error where reopening the device will fail, or
+.It Sy noop
+to drop the IO without executing it, and return success.
 .El
 .Pp
 For EIO and ENXIO, the "failed" reads or writes still occur.

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -4058,6 +4058,16 @@ zio_vdev_io_start(zio_t *zio)
 	    zio->io_type == ZIO_TYPE_WRITE ||
 	    zio->io_type == ZIO_TYPE_TRIM)) {
 
+		if (zio_handle_device_injection(vd, zio, ENOSYS) != 0) {
+			/*
+			 * "no-op" injections return success, but do no actual
+			 * work. Just skip the remaining vdev stages.
+			 */
+			zio_vdev_io_bypass(zio);
+			zio_interrupt(zio);
+			return (NULL);
+		}
+
 		if ((zio = vdev_queue_io(zio)) == NULL)
 			return (NULL);
 

--- a/tests/zfs-tests/tests/functional/cli_root/zinject/zinject_args.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zinject/zinject_args.ksh
@@ -47,7 +47,7 @@ function cleanup
 
 function test_device_fault
 {
-	typeset -a errno=("io" "decompress" "decrypt" "nxio" "dtl" "corrupt")
+	typeset -a errno=("io" "decompress" "decrypt" "nxio" "dtl" "corrupt" "noop")
 	for e in ${errno[@]}; do
 		log_must eval \
 		    "zinject -d $DISK1 -e $e -T read -f 0.001 $TESTPOOL"


### PR DESCRIPTION
### Motivation and Context

I'm working on flush responses. This adds a tool I need to finish a test case.

### Description

When injected, this causes the matching IO to appear to succeed, but the actual work is never submitted to the physical device. This can be used to simulate a write-back cache services a write, but the backing device has failed and the cache cannot complete the operation in the background.

### How Has This Been Tested?

By hand:

```
$ zpool create tank loop0
$ zinject -d loop0 -e noop -T write tank
Added handler 1 with the following properties:
  pool: tank
  vdev: fea1aeb4bb30f83c
$ dd if=/dev/random of=/tank/file bs=128K count=1 conv=fsync
1+0 records in
1+0 records out
131072 bytes (131 kB, 128 KiB) copied, 0.00280807 s, 46.7 MB/s
$ zpool scrub -w tank
$ zpool status -v
  pool: tank
 state: ONLINE
status: One or more devices has experienced an error resulting in data
	corruption.  Applications may be affected.
action: Restore the file in question if possible.  Otherwise restore the
	entire pool from backup.
   see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-8A
  scan: scrub repaired 0B in 00:00:00 with 28 errors on Fri Apr 12 11:47:49 2024
config:

	NAME        STATE     READ WRITE CKSUM
	tank        ONLINE       0     0     0
	 loop0     ONLINE       0     0    92

errors: Permanent errors have been detected in the following files:

        <metadata>:<0x36>
        <metadata>:<0x49>
        <metadata>:<0x4b>
        /tank/file
        tank:<0x24>
```

I could put this into a test, and probably should. Its not super deterministic though, so it might just be to see if we got checksum errors at the end and that it.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).