### PR TITLE
zts: clean up quota tests a bit

### DIFF
--- a/tests/zfs-tests/tests/functional/quota/quota.kshlib
+++ b/tests/zfs-tests/tests/functional/quota/quota.kshlib
@@ -95,3 +95,10 @@ function exceed_quota
 	    log_fail "Returned error code: $zret. Expected: $EDQUOT."
 	return 0
 }
+
+function reset_quota
+{
+	typeset FILESYSTEM="$1"
+
+	log_must zfs set quota=none $FILESYSTEM
+}

--- a/tests/zfs-tests/tests/functional/quota/quota_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_001_pos.ksh
@@ -64,6 +64,8 @@ function cleanup
 	#
 	wait_freeing $TESTPOOL
 	sync_pool $TESTPOOL
+
+	reset_quota $TESTPOOL/$TESTFS
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/quota/quota_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_002_pos.ksh
@@ -64,6 +64,8 @@ function cleanup
 
 	wait_freeing $TESTPOOL
 	sync_pool $TESTPOOL
+
+	reset_quota $TESTPOOL/$TESTFS
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/quota/quota_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_003_pos.ksh
@@ -67,6 +67,8 @@ function cleanup
 	#
 	wait_freeing $TESTPOOL
 	sync_pool $TESTPOOL
+
+	reset_quota $TESTPOOL/$TESTCTR/$TESTFS1
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/quota/quota_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_004_pos.ksh
@@ -65,6 +65,8 @@ function cleanup
 
 	wait_freeing $TESTPOOL
 	sync_pool $TESTPOOL
+
+	reset_quota $TESTPOOL/$TESTCTR/$TESTFS1
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/quota/quota_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_005_pos.ksh
@@ -55,15 +55,14 @@ function cleanup
 
 log_onexit cleanup
 
-log_assert "Verify that quota doesnot inherit its value from parent."
-log_onexit cleanup
+log_assert "Verify that quota does not inherit its value from parent."
 
 fs=$TESTPOOL/$TESTFS
 fs_child=$TESTPOOL/$TESTFS/$TESTFS
 
 space_avail=$(get_prop available $fs)
 quota_val=$(get_prop quota $fs)
-typeset -i quotasize=$space_avail
+typeset -li quotasize=$space_avail
 ((quotasize = quotasize * 2 ))
 log_must zfs set quota=$quotasize $fs
 
@@ -72,4 +71,4 @@ quota_space=$(get_prop quota $fs_child)
 [[ $quota_space == $quotasize ]] && \
 	log_fail "The quota of child dataset inherits its value from parent."
 
-log_pass "quota doesnot inherit its value from parent as expected."
+log_pass "quota does not inherit its value from parent as expected."

--- a/tests/zfs-tests/tests/functional/quota/quota_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_005_pos.ksh
@@ -50,7 +50,7 @@ function cleanup
 {
 	datasetexists $fs_child && destroy_dataset $fs_child
 
-	log_must zfs set quota=$quota_val $fs
+	reset_quota $fs
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/quota/quota_006_neg.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_006_neg.ksh
@@ -50,7 +50,7 @@ log_assert "Verify cannot set quota lower than the space currently in use"
 
 function cleanup
 {
-	log_must zfs set quota=none $TESTPOOL/$TESTFS
+	reset_quota $TESTPOOL/$TESTFS
 }
 
 log_onexit cleanup


### PR DESCRIPTION
### Motivation and Context

I had cause to run `quota_005_pos` specifically during some unrelated work, and saw it failed when it shouldn't have. Digging in found some bugs/quirks, which I fixed up and offer here.

### Description

1. `quota_005_pos` will try and set quota to 2x the available space on the dataset. Run in isolation, that's 2x the size of the empty dataset, which overflows a 32-bit int (`typeset -i`), and so ends up trying to set a negative quota. When run in the test group, the dataset has leftover stuff in it, so the available space is smaller, and we avoid the overflow.
2. `quota_005_pos` will try and reset the quota to whatever it was at the start of the test. Run in isolation, that's `0`, which is an invalid value for `quota=`, so cleanup fails. With the full test group, its left set from the previous test, so is non-zero and succeeds.

The real problem is a much broader issue, in that individual tests aren't really isolated from each other. Sorting that out is a mountain, so for this one I've just tried to make each test reset the quota after each run, and for the 2x space math, use a larger int type.

### How Has This Been Tested?

Variously running `zfs-tests.sh -t quota_005_pos` and `zfs-tests.sh -T quota` and considering the differences in the test log.

Both the old errors are now gone:

```
10:22:15.23 cannot set property for 'testpool/testfs': bad numeric value '-805778432'
10:22:15.23 ERROR: zfs set quota=-805778432 testpool/testfs exited 255
```

```
10:19:26.71 cannot set property for 'testpool/testfs': use 'none' to disable quota/refquota
10:19:26.71 ERROR: zfs set quota=0 testpool/testfs exited 255
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
