### PR TITLE
Avoid error in cleanup if test if unsupported

### DIFF
--- a/tests/zfs-tests/tests/functional/user_namespace/user_namespace_004.ksh
+++ b/tests/zfs-tests/tests/functional/user_namespace/user_namespace_004.ksh
@@ -44,8 +44,6 @@ user_ns_cleanup() {
 	log_must zfs destroy -r "$TESTPOOL/userns"
 }
 
-log_onexit user_ns_cleanup
-
 log_assert "Check zfs zone command handling of non-namespace files"
 
 # Pass if user namespaces are not supported.
@@ -53,6 +51,8 @@ unshare -Urm echo test
 if [ "$?" -ne "0" ]; then
 	log_unsupported "Failed to create user namespace"
 fi
+
+log_onexit user_ns_cleanup
 
 # Create the baseline datasets.
 log_must zfs create -o zoned=on "$TESTPOOL/userns"


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I built and tested zfs on a clean machine (not VM) with ubuntu 24.04 and got a failure in `user_namespace/user_namespace_004`, looking at the logs this test should be skipped on my machine but because the test setup (`log_onexit` with `log_must zfs destroy`) the test FAILs.

### Description
<!--- Describe your changes in detail -->
Moved `log_onexit` below the check to see this test is supported.

log_onexit almost always appears as the 1st or 2nd real line in the file. I could instead add a variable `SHOULD_CLEANUP=0`, set it true after the log_unsupported check, and conditionally perform the cleanup in `user_ns_cleanup` but that felt less clean IMHO.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Tested with `./scripts/zfs-tests.sh -v -t tests/zfs-tests/tests/functional/user_namespace/user_namespace_004` after my change `SKIP 1` before my change `FAIL 1`


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
