### PR TITLE
ztest: use ASSERT3P to compare pointers

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8045,7 +8045,7 @@ ztest_raidz_expand_run(ztest_shared_t *zs, spa_t *spa)
 	ztest_expand_io_t *thread_args;
 
 	ASSERT3U(ztest_opts.zo_raidz_expand_test, !=, RAIDZ_EXPAND_NONE);
-	ASSERT3U(rzvd->vdev_ops, ==, &vdev_raidz_ops);
+	ASSERT3P(rzvd->vdev_ops, ==, &vdev_raidz_ops);
 	ztest_opts.zo_raidz_expand_test = RAIDZ_EXPAND_STARTED;
 
 	/* Setup a 1 MiB buffer of random data */


### PR DESCRIPTION
With a sufficently modern gcc (I saw this with gcc13), gcc complains when casting pointers to an integer of a different type (even a larger one).  On 32-bt ASSERT3U does this on 32-bit systems by casting a 32-bit pointer to uint64_t so use ASSERT3P which uses uintptr_t.

Fixes: 5caeef02fa53 RAID-Z expansion feature

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
