### PR TITLE
zfs-kmod: fix empty rpm requires/conflicts

### DIFF
--- a/rpm/redhat/zfs-kmod.spec.in
+++ b/rpm/redhat/zfs-kmod.spec.in
@@ -17,7 +17,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 # by generating a preamble text file which kmodtool can append to the spec file.
 %(/bin/echo -e "\
 Requires:       @PACKAGE@ = %{version}\n\
-Conflicts:      @PACKAGE@-dkms)
+Conflicts:      @PACKAGE@-dkms" > %{_sourcedir}/kmod-preamble)
 
 # LDFLAGS are not sanitized by arch/*/Makefile for these architectures.
 %ifarch ppc ppc64 ppc64le aarch64


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Fix an error in zfs-kmod.spec that causes kmod-zfs packages not to include the correct RPM requires/conflicts relationships.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Building zfs 2.2.x (or current master) results in kmod-zfs packages with empty requires/conflicts, as well as the following (non-fatal) error message from `rpmbuild`:
```
sh: -c: line 1: unexpected EOF while looking for matching `"'
sh: -c: line 4: syntax error: unexpected end of file
```

This bug will incorrectly allow kmod-zfs & zfs-dkms packages to coexist on the same machine, potentially causing issues:
```
$ rpm -qa | grep zfs
<no output>

# Built rpms/created yum repo as below
$ sudo yum -y install zfs kmod-zfs zfs-dkms

$ rpm -qa | grep zfs
libzfs5-2.2.99-448_gf4f156157.el9.aarch64
kmod-zfs-2.2.99-448_gf4f156157.el9.aarch64
zfs-2.2.99-448_gf4f156157.el9.aarch64
zfs-dkms-2.2.99-448_gf4f156157.el9.noarch
```

With this change applied, RPM correctly no longer allows kmod-zfs & zfs-dkms packages to be installed together:
```
$ sudo yum -y install zfs kmod-zfs zfs-dkms
Repository 'zfs-local' is missing name in configuration, using id.
zfs-local                                                                                                                                                                     36 MB/s | 112 kB     00:00
Last metadata expiration check: 0:00:01 ago on Mon 22 Apr 2024 05:24:45 PM GMT.
Error:
 Problem: package kmod-zfs-2.2.99-449_g72192945e.el9.aarch64 from zfs-local conflicts with zfs-dkms provided by zfs-dkms-2.2.99-449_g72192945e.el9.noarch from zfs-local
  - conflicting requests
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Fix a script syntax error in the rpm specfile and put the generated output in the preamble file expected by the `%kernel_module_package` macro elsewhere in the specfile.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested Environments:
Rocky 9.3 aarch64
Rocky 9.3 x86_64
Centos 7.9 x86_64

Build/install process:
```
git clone https://github.com/openzfs/zfs.git
# generate the autotools stuff and rpm specfile
pushd zfs
./autogen.sh
./configure
cp rpm/redhat/*spec ~/rpmbuild/SPECS
popd
# put the source in a versioned tarball/directory as rpm expects
ln -s zfs zfs-2.2.99
tar hczf ~/rpmbuild/SOURCES/zfs-2.2.99.tar.gz zfs-2.2.99
# build it
pushd ~/rpmbuild/SPECS
for file in *spec; do rpmbuild -bb "$file"; done
popd
# check for correct rpm relationships
rpm -qp ~/rpmbuild/RPMS/`uname -m`/zfs-kmod*rpm --conflicts
rpm -qp ~/rpmbuild/RPMS/`uname -m`/zfs-kmod*rpm --requires | grep zfs
# create a clean local yum repo for this build
[ -d /tmp/zfs-local-repo ] && rm -rf /tmp/zfs-local-repo
mkdir /tmp/zfs-local-repo
echo -e "[zfs-local]\nbaseurl=file:///tmp/zfs-local-repo\nenabled=1\ngpgcheck=0\nmetadata_expire=1s" | sudo tee /etc/yum.repos.d/zfs-local.repo
for file in `find ~/rpmbuild/RPMS -type f`; do cp "$file" /tmp/zfs-local-repo; done
createrepo /tmp/zfs-local-repo
sudo yum -y install zfs zfs-dkms kmod-zfs
```
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
