### PR TITLE
Replace usage of schedule_timeout with schedule_timeout_interruptible

### DIFF
--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -158,7 +158,7 @@ retry:
 		 * throttling the task dispatch rate.
 		 */
 		spin_unlock_irqrestore(&tq->tq_lock, *irqflags);
-		schedule_timeout(HZ / 100);
+		schedule_timeout_interruptible(HZ / 100);
 		spin_lock_irqsave_nested(&tq->tq_lock, *irqflags,
 		    tq->tq_lock_class);
 		if (count < 100) {

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -397,7 +397,7 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 			if (v->vdev_removed)
 				break;
 
-			schedule_timeout(MSEC_TO_TICK(10));
+			schedule_timeout_interruptible(MSEC_TO_TICK(10));
 		} else if (unlikely(BDH_PTR_ERR(bdh) == -ERESTARTSYS)) {
 			timeout = MSEC2NSEC(zfs_vdev_open_timeout_ms * 10);
 			continue;

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -798,7 +798,8 @@ retry:
 				if ((gethrtime() - start) > timeout)
 					return (SET_ERROR(-ERESTARTSYS));
 
-				schedule_timeout(MSEC_TO_TICK(10));
+				schedule_timeout_interruptible(
+					MSEC_TO_TICK(10));
 				goto retry;
 #endif
 			} else {


### PR DESCRIPTION
This commit replaces the current usage of schedule_timeout() with schedule_timeout_interruptible() when device paths cannot be found in vdev_disk_open(). When schedule_timeout() is called without previously calling set_current_state(), the running task never sleeps because the task state remains in TASK_RUNNING. It will instead continue to busy-loop until either zfs_vdev_open_timeout_ms has passed or the device path is found.

By calling schedule_timeout_interruptible() to set the task's state to TASK_INTERRUPTIBLE before calling schedule_timeout() we achieve the intended/desired behavior of making the task sleep in between block device path lookup attempts.

### Motivation and Context
This commit fixes a bug in the current implementation of vdev_disk_open() when a block device path cannot be found during pool import that in our setup occasionally resulted in OOM killers running. This behavior was exhibited on a server with zfs 2.1.7 running on top of a 6.1 based Linux kernel, and should apply to the current master branch of ZFS as well.

### Description
If a block device path is missing during zpool import, the intended behavior of vdev_disk_open() is to retry lookup attempts multiple times until the device path is found or until zfs_vdev_open_timeout_ms milliseconds have passed - sleeping for ~10ms inbetween attempts to yield the CPU to other processes. 

However given the current implementation, this intended behavior is not properly realized and vdev_disk_open() spends zero time sleeping and will continuously retry block device path lookups until one of the previously mentioned conditions are met. This is because the task will not sleep if the current task state is TASK_RUNNING prior to calling schedule_timeout(). The behavior of schedule_timeout() is summarized in some detail here: https://elixir.bootlin.com/linux/v6.1.89/source/kernel/time/timer.c#L1895. 

The effects of this can be reproduced via the following:
```
# Create temporary block devices
dd if=/dev/zero of=/disk.img bs=64M count=1
losetup /dev/loop0 /disk.img
dd if=/dev/zero of=/cache.img bs=100M count=1
losetup /dev/loop1 /cache.img
parted -s /dev/loop1 mklabel gpt
parted -s /dev/loop1 mkpart logical 17408B 99MB

# Create Pool
sudo zpool create temporary-pool /dev/loop0 cache /dev/loop1p1

# Export pool and remove cache device
zpool export temporary-pool
parted /dev/loop1 rm 1

# Import pool and count the number of times blkdev_get_by_path() is called
bpftrace -e 'kprobe:blkdev_get_by_path { @count++; }' &
pid=$!
zpool import temporary-pool
kill $pid

# Output:
@count: 2092665
```

This experiment shows that the device path finding loop contained in vdev_disk_open() was looped through roughly ~2 million times during the import of the zpool.

A Flamegraph also confirms where the CPU is spending most of its cycles during import with a missing device path:

![image (6)](https://github.com/openzfs/zfs/assets/47165314/0d41787c-d09b-4018-af86-dee6fdcfb1ba)

### How Has This Been Tested?
These changes were tested on a Linux 6.1 based server running zfs 2.1.7. By reproducing the same experiment as mentioned in the description we can confirm that the number of loop executions in vdev_disk_open() will be far less and upperbounded by the number of times blkdev_get_by_path() is called.

Reproducer Test Results:
```
# Create temporary block devices
dd if=/dev/zero of=/disk.img bs=64M count=1
losetup /dev/loop0 /disk.img
dd if=/dev/zero of=/cache.img bs=100M count=1
losetup /dev/loop1 /cache.img
parted -s /dev/loop1 mklabel gpt
parted -s /dev/loop1 mkpart logical 17408B 99MB

# Create Pool
sudo zpool create temporary-pool /dev/loop0 cache /dev/loop1p1

# Export pool and remove cache device
zpool export temporary-pool
parted /dev/loop1 rm 1

# Import pool and count the number of times blkdev_get_by_path() is called
bpftrace -e 'kprobe:blkdev_get_by_path { @count++; }' &
pid=$!
zpool import temporary-pool
kill $pid

# Output:
@count: 135
```

These test results indicate that the vdev_disk_open() block device path finding loop executed at most 135 times across all vdevs. This aligns much more with the expected number of times this loop should run with a zfs_vdev_open_timeout_ms setting of 1000 milliseconds.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
