### PR TITLE
`spa_taskq_dispatch`: cleanup and simplify

### DIFF
--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -480,8 +480,6 @@ extern const char *zfs_deadman_failmode;
 extern uint_t spa_slop_shift;
 extern void spa_taskq_dispatch_ent(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
     task_func_t *func, void *arg, uint_t flags, taskq_ent_t *ent, zio_t *zio);
-extern void spa_taskq_dispatch_sync(spa_t *, zio_type_t t, zio_taskq_type_t q,
-    task_func_t *func, void *arg, uint_t flags);
 extern void spa_load_spares(spa_t *spa);
 extern void spa_load_l2cache(spa_t *spa);
 extern sysevent_t *spa_event_create(spa_t *spa, vdev_t *vd, nvlist_t *hist_nvl,

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -478,8 +478,8 @@ struct spa {
 extern char *spa_config_path;
 extern const char *zfs_deadman_failmode;
 extern uint_t spa_slop_shift;
-extern void spa_taskq_dispatch_ent(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
-    task_func_t *func, void *arg, uint_t flags, taskq_ent_t *ent, zio_t *zio);
+extern void spa_taskq_dispatch(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
+    task_func_t *func, zio_t *zio, boolean_t cutinline);
 extern void spa_load_spares(spa_t *spa);
 extern void spa_load_l2cache(spa_t *spa);
 extern sysevent_t *spa_event_create(spa_t *spa, vdev_t *vd, nvlist_t *hist_nvl,

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1489,8 +1489,9 @@ spa_taskq_write_param(ZFS_MODULE_PARAM_ARGS)
  * Note that a type may have multiple discrete taskqs to avoid lock contention
  * on the taskq itself.
  */
-static taskq_t *
-spa_taskq_dispatch_select(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
+void
+spa_taskq_dispatch_ent(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
+    task_func_t *func, void *arg, uint_t flags, taskq_ent_t *ent,
     zio_t *zio)
 {
 	spa_taskqs_t *tqs = &spa->spa_zio_taskq[t][q];
@@ -1507,15 +1508,7 @@ spa_taskq_dispatch_select(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
 	} else {
 		tq = tqs->stqs_taskq[((uint64_t)gethrtime()) % tqs->stqs_count];
 	}
-	return (tq);
-}
 
-void
-spa_taskq_dispatch_ent(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
-    task_func_t *func, void *arg, uint_t flags, taskq_ent_t *ent,
-    zio_t *zio)
-{
-	taskq_t *tq = spa_taskq_dispatch_select(spa, t, q, zio);
 	taskq_dispatch_ent(tq, func, arg, flags, ent);
 }
 

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1519,19 +1519,6 @@ spa_taskq_dispatch_ent(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
 	taskq_dispatch_ent(tq, func, arg, flags, ent);
 }
 
-/*
- * Same as spa_taskq_dispatch_ent() but block on the task until completion.
- */
-void
-spa_taskq_dispatch_sync(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
-    task_func_t *func, void *arg, uint_t flags)
-{
-	taskq_t *tq = spa_taskq_dispatch_select(spa, t, q, NULL);
-	taskqid_t id = taskq_dispatch(tq, func, arg, flags);
-	if (id)
-		taskq_wait_id(tq, id);
-}
-
 static void
 spa_create_zio_taskqs(spa_t *spa)
 {

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -38,7 +38,7 @@
  * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
  * Copyright (c) 2019 Datto Inc.
  * Copyright (c) 2019, 2020 by Christian Schwarz. All rights reserved.
- * Copyright (c) 2019, 2021, Klara Inc.
+ * Copyright (c) 2019, 2021, 2024, Klara Inc.
  * Copyright (c) 2019, Allan Jude
  * Copyright 2024 Oxide Computer Company
  */
@@ -5514,6 +5514,14 @@ out:
 	return (error);
 }
 
+/*
+ * When stack space is limited, we write replication stream data to the target
+ * on a separate taskq thread, to make sure there's enough stack space.
+ */
+#ifndef HAVE_LARGE_STACKS
+#define	USE_SEND_TASKQ	1
+#endif
+
 typedef struct dump_bytes_io {
 	zfs_file_t	*dbi_fp;
 	caddr_t		dbi_buf;
@@ -5534,29 +5542,63 @@ dump_bytes_cb(void *arg)
 	dbi->dbi_err = zfs_file_write(fp, buf, dbi->dbi_len, NULL);
 }
 
+typedef struct dump_bytes_arg {
+	zfs_file_t	*dba_fp;
+#ifdef USE_SEND_TASKQ
+	taskq_t		*dba_tq;
+	taskq_ent_t	dba_tqent;
+#endif
+} dump_bytes_arg_t;
+
 static int
 dump_bytes(objset_t *os, void *buf, int len, void *arg)
 {
+	dump_bytes_arg_t *dba = (dump_bytes_arg_t *)arg;
 	dump_bytes_io_t dbi;
 
-	dbi.dbi_fp = arg;
+	dbi.dbi_fp = dba->dba_fp;
 	dbi.dbi_buf = buf;
 	dbi.dbi_len = len;
 
-#if defined(HAVE_LARGE_STACKS)
-	dump_bytes_cb(&dbi);
+#ifdef USE_SEND_TASKQ
+	taskq_dispatch_ent(dba->dba_tq, dump_bytes_cb, &dbi, TQ_SLEEP,
+	    &dba->dba_tqent);
+	taskq_wait(dba->dba_tq);
 #else
-	/*
-	 * The vn_rdwr() call is performed in a taskq to ensure that there is
-	 * always enough stack space to write safely to the target filesystem.
-	 * The ZIO_TYPE_FREE threads are used because there can be a lot of
-	 * them and they are used in vdev_file.c for a similar purpose.
-	 */
-	spa_taskq_dispatch_sync(dmu_objset_spa(os), ZIO_TYPE_FREE,
-	    ZIO_TASKQ_ISSUE, dump_bytes_cb, &dbi, TQ_SLEEP);
-#endif /* HAVE_LARGE_STACKS */
+	dump_bytes_cb(&dbi);
+#endif
 
 	return (dbi.dbi_err);
+}
+
+static int
+dump_bytes_init(dump_bytes_arg_t *dba, int fd, dmu_send_outparams_t *out)
+{
+	zfs_file_t *fp = zfs_file_get(fd);
+	if (fp == NULL)
+		return (SET_ERROR(EBADF));
+
+	dba->dba_fp = fp;
+#ifdef USE_SEND_TASKQ
+	dba->dba_tq = taskq_create("z_send", 1, defclsyspri, 0, 0, 0);
+	taskq_init_ent(&dba->dba_tqent);
+#endif
+
+	memset(out, 0, sizeof (dmu_send_outparams_t));
+	out->dso_outfunc = dump_bytes;
+	out->dso_arg = dba;
+	out->dso_dryrun = B_FALSE;
+
+	return (0);
+}
+
+static void
+dump_bytes_fini(dump_bytes_arg_t *dba)
+{
+	zfs_file_put(dba->dba_fp);
+#ifdef USE_SEND_TASKQ
+	taskq_destroy(dba->dba_tq);
+#endif
 }
 
 /*
@@ -5643,21 +5685,18 @@ zfs_ioc_send(zfs_cmd_t *zc)
 		dsl_dataset_rele(tosnap, FTAG);
 		dsl_pool_rele(dp, FTAG);
 	} else {
-		zfs_file_t *fp;
-		dmu_send_outparams_t out = {0};
+		dump_bytes_arg_t dba;
+		dmu_send_outparams_t out;
+		error = dump_bytes_init(&dba, zc->zc_cookie, &out);
+		if (error)
+			return (error);
 
-		if ((fp = zfs_file_get(zc->zc_cookie)) == NULL)
-			return (SET_ERROR(EBADF));
-
-		off = zfs_file_off(fp);
-		out.dso_outfunc = dump_bytes;
-		out.dso_arg = fp;
-		out.dso_dryrun = B_FALSE;
+		off = zfs_file_off(dba.dba_fp);
 		error = dmu_send_obj(zc->zc_name, zc->zc_sendobj,
 		    zc->zc_fromobj, embedok, large_block_ok, compressok,
 		    rawok, savedok, zc->zc_cookie, &off, &out);
 
-		zfs_file_put(fp);
+		dump_bytes_fini(&dba);
 	}
 	return (error);
 }
@@ -6604,7 +6643,6 @@ zfs_ioc_send_new(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 	offset_t off;
 	const char *fromname = NULL;
 	int fd;
-	zfs_file_t *fp;
 	boolean_t largeblockok;
 	boolean_t embedok;
 	boolean_t compressok;
@@ -6629,20 +6667,19 @@ zfs_ioc_send_new(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 
 	(void) nvlist_lookup_string(innvl, "redactbook", &redactbook);
 
-	if ((fp = zfs_file_get(fd)) == NULL)
-		return (SET_ERROR(EBADF));
+	dump_bytes_arg_t dba;
+	dmu_send_outparams_t out;
+	error = dump_bytes_init(&dba, fd, &out);
+	if (error)
+		return (error);
 
-	off = zfs_file_off(fp);
-
-	dmu_send_outparams_t out = {0};
-	out.dso_outfunc = dump_bytes;
-	out.dso_arg = fp;
-	out.dso_dryrun = B_FALSE;
+	off = zfs_file_off(dba.dba_fp);
 	error = dmu_send(snapname, fromname, embedok, largeblockok,
 	    compressok, rawok, savedok, resumeobj, resumeoff,
 	    redactbook, fd, &off, &out);
 
-	zfs_file_put(fp);
+	dump_bytes_fini(&dba);
+
 	return (error);
 }
 


### PR DESCRIPTION
### Motivation and Context

A collection of small `spa_taskq` cleanups from a much larger refactor I'm working on. These are relatively small and focused and seem reasonable to include now.

The dollar summary is that once you remove the extremely weird `spa_taskq_dispatch_sync()`, `spa_taskq_dispatch_ent()` is actually far simpler than its signature suggests, and a lot of it can be simplified.

### Description

See commit messages. In short:
- when `HAVE_LARGE_STACKS=0`, run replication streams on a dedicated taskq for each stream, rather than misusing the FREE IO taskq
- remove the now-unused `spa_taskq_dispatch_sync()`
- remodel `spa_taskq_dispatch_ent()` as `spa_taskq_dispatch()`, with much simpler arguments

The replication taskq change should be the only functional change; the rest is just moving things around.

There's some further cleanups which I've opted not to explore for the moment (at least, not here):
- there's only two task functions in use now, `zio_execute()` and `zio_reexecute()`. This could be reduced to just `zio_execute()`, and a `ZIO_FLAG_REEXECUTING` or similar be set on the zio (or, maybe, check `zio->io_reexecute`) but it was more complicated than I wanted to think about right now
- `zio_taskq_dispatch()` and `spa_taskq_dispatch()` could really be combined, but that would suggest moving all the `spa_taskq` setup infrastructure alongside, which is definitely too much for this PR
- the coupling between allocator, syncthreads and dispatch feels a little fuzzier than I'd like (though #16130 massively improved that and let me throw out about half a day of work from the start of the week, thanks @amotin :wink:)

Not a cleanup, but more an observation: `zio_taskq_dispatch()` and `spa_taskq_dispatch()` are now very close to being decoupled from taskqueues as an implementation detail.

### How Has This Been Tested?

Manual sanity checks. `zfs_send` and `rsend` test suites passed.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).