### PR TITLE
Add support for parallel pool exports

### DIFF
--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -237,6 +237,7 @@ struct spa {
 	dsl_pool_t	*spa_dsl_pool;
 	boolean_t	spa_is_initializing;	/* true while opening pool */
 	boolean_t	spa_is_exporting;	/* true while exporting pool */
+	kthread_t	*spa_export_thread;	/* valid during pool export */
 	kthread_t	*spa_load_thread;	/* loading, no namespace lock */
 	metaslab_class_t *spa_normal_class;	/* normal data class */
 	metaslab_class_t *spa_log_class;	/* intent log data class */

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -8143,11 +8143,11 @@ l2arc_dev_get_next(void)
 
 		ASSERT3P(next, !=, NULL);
 	} while (vdev_is_dead(next->l2ad_vdev) || next->l2ad_rebuild ||
-	    next->l2ad_trim_all);
+	    next->l2ad_trim_all || next->l2ad_spa->spa_is_exporting);
 
 	/* if we were unable to find any usable vdevs, return NULL */
 	if (vdev_is_dead(next->l2ad_vdev) || next->l2ad_rebuild ||
-	    next->l2ad_trim_all)
+	    next->l2ad_trim_all || next->l2ad_spa->spa_is_exporting)
 		next = NULL;
 
 	l2arc_dev_last = next;

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1227,20 +1227,7 @@ spa_vdev_enter(spa_t *spa)
 	mutex_enter(&spa->spa_vdev_top_lock);
 	mutex_enter(&spa_namespace_lock);
 
-	/*
-	 * We have a reference on the spa and a spa export could be
-	 * starting but no longer holding the spa_namespace_lock. So
-	 * check if there is an export and if so wait. It will fail
-	 * fast (EBUSY) since we are still holding a spa reference.
-	 *
-	 * Note that we can be woken by a different spa transitioning
-	 * through an import/export, so we must wait for our condition
-	 * to change before proceeding.
-	 */
-	while (spa->spa_export_thread != NULL &&
-	    spa->spa_export_thread != curthread) {
-		cv_wait(&spa_namespace_cv, &spa_namespace_lock);
-	}
+	ASSERT0(spa->spa_export_thread);
 
 	vdev_autotrim_stop_all(spa);
 
@@ -1259,11 +1246,7 @@ spa_vdev_detach_enter(spa_t *spa, uint64_t guid)
 	mutex_enter(&spa->spa_vdev_top_lock);
 	mutex_enter(&spa_namespace_lock);
 
-	/* See comment in spa_vdev_enter() */
-	while (spa->spa_export_thread != NULL &&
-	    spa->spa_export_thread != curthread) {
-		cv_wait(&spa_namespace_cv, &spa_namespace_lock);
-	}
+	ASSERT0(spa->spa_export_thread);
 
 	vdev_autotrim_stop_all(spa);
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -27,7 +27,7 @@
  * Copyright (c) 2017 Datto Inc.
  * Copyright (c) 2017, Intel Corporation.
  * Copyright (c) 2019, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
- * Copyright (c) 2023, Klara Inc.
+ * Copyright (c) 2023, 2024, Klara Inc.
  */
 
 #include <sys/zfs_context.h>
@@ -82,8 +82,8 @@
  *		- Check if spa_refcount is zero
  *		- Rename a spa_t
  *		- add/remove/attach/detach devices
- *		- Held for the duration of create/destroy/export
- *		- Held at the start and end of import
+ *		- Held for the duration of create/destroy
+ *		- Held at the start and end of import and export
  *
  *	It does not need to handle recursion.  A create or destroy may
  *	reference objects (files or zvols) in other pools, but by
@@ -635,8 +635,14 @@ retry:
 	if (spa == NULL)
 		return (NULL);
 
-	if (spa->spa_load_thread != NULL &&
-	    spa->spa_load_thread != curthread) {
+	/*
+	 * Avoid racing with import/export, which don't hold the namespace
+	 * lock for their entire duration.
+	 */
+	if ((spa->spa_load_thread != NULL &&
+	    spa->spa_load_thread != curthread) ||
+	    (spa->spa_export_thread != NULL &&
+	    spa->spa_export_thread != curthread)) {
 		cv_wait(&spa_namespace_cv, &spa_namespace_lock);
 		goto retry;
 	}
@@ -937,14 +943,15 @@ spa_open_ref(spa_t *spa, const void *tag)
 
 /*
  * Remove a reference to the given spa_t.  Must have at least one reference, or
- * have the namespace lock held.
+ * have the namespace lock held or be part of a pool import/export.
  */
 void
 spa_close(spa_t *spa, const void *tag)
 {
 	ASSERT(zfs_refcount_count(&spa->spa_refcount) > spa->spa_minref ||
 	    MUTEX_HELD(&spa_namespace_lock) ||
-	    spa->spa_load_thread == curthread);
+	    spa->spa_load_thread == curthread ||
+	    spa->spa_export_thread == curthread);
 	(void) zfs_refcount_remove(&spa->spa_refcount, tag);
 }
 
@@ -964,13 +971,15 @@ spa_async_close(spa_t *spa, const void *tag)
 
 /*
  * Check to see if the spa refcount is zero.  Must be called with
- * spa_namespace_lock held.  We really compare against spa_minref, which is the
- * number of references acquired when opening a pool
+ * spa_namespace_lock held or be the spa export thread.  We really
+ * compare against spa_minref, which is the  number of references
+ * acquired when opening a pool
  */
 boolean_t
 spa_refcount_zero(spa_t *spa)
 {
-	ASSERT(MUTEX_HELD(&spa_namespace_lock));
+	ASSERT(MUTEX_HELD(&spa_namespace_lock) ||
+	    spa->spa_export_thread == curthread);
 
 	return (zfs_refcount_count(&spa->spa_refcount) == spa->spa_minref);
 }
@@ -1218,6 +1227,21 @@ spa_vdev_enter(spa_t *spa)
 	mutex_enter(&spa->spa_vdev_top_lock);
 	mutex_enter(&spa_namespace_lock);
 
+	/*
+	 * We have a reference on the spa and a spa export could be
+	 * starting but no longer holding the spa_namespace_lock. So
+	 * check if there is an export and if so wait. It will fail
+	 * fast (EBUSY) since we are still holding a spa reference.
+	 *
+	 * Note that we can be woken by a different spa transitioning
+	 * through an import/export, so we must wait for our condition
+	 * to change before proceeding.
+	 */
+	while (spa->spa_export_thread != NULL &&
+	    spa->spa_export_thread != curthread) {
+		cv_wait(&spa_namespace_cv, &spa_namespace_lock);
+	}
+
 	vdev_autotrim_stop_all(spa);
 
 	return (spa_vdev_config_enter(spa));
@@ -1234,6 +1258,12 @@ spa_vdev_detach_enter(spa_t *spa, uint64_t guid)
 {
 	mutex_enter(&spa->spa_vdev_top_lock);
 	mutex_enter(&spa_namespace_lock);
+
+	/* See comment in spa_vdev_enter() */
+	while (spa->spa_export_thread != NULL &&
+	    spa->spa_export_thread != curthread) {
+		cv_wait(&spa_namespace_cv, &spa_namespace_lock);
+	}
 
 	vdev_autotrim_stop_all(spa);
 

--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -682,7 +682,8 @@ vdev_initialize_stop_wait(spa_t *spa, list_t *vd_list)
 	(void) spa;
 	vdev_t *vd;
 
-	ASSERT(MUTEX_HELD(&spa_namespace_lock));
+	ASSERT(MUTEX_HELD(&spa_namespace_lock) ||
+	    spa->spa_export_thread == curthread);
 
 	while ((vd = list_remove_head(vd_list)) != NULL) {
 		mutex_enter(&vd->vdev_initialize_lock);
@@ -724,7 +725,8 @@ vdev_initialize_stop(vdev_t *vd, vdev_initializing_state_t tgt_state,
 	if (vd_list == NULL) {
 		vdev_initialize_stop_wait_impl(vd);
 	} else {
-		ASSERT(MUTEX_HELD(&spa_namespace_lock));
+		ASSERT(MUTEX_HELD(&spa_namespace_lock) ||
+		    vd->vdev_spa->spa_export_thread == curthread);
 		list_insert_tail(vd_list, vd);
 	}
 }
@@ -756,7 +758,8 @@ vdev_initialize_stop_all(vdev_t *vd, vdev_initializing_state_t tgt_state)
 	spa_t *spa = vd->vdev_spa;
 	list_t vd_list;
 
-	ASSERT(MUTEX_HELD(&spa_namespace_lock));
+	ASSERT(MUTEX_HELD(&spa_namespace_lock) ||
+	    spa->spa_export_thread == curthread);
 
 	list_create(&vd_list, sizeof (vdev_t),
 	    offsetof(vdev_t, vdev_initialize_node));

--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -1087,7 +1087,8 @@ vdev_rebuild_stop_wait(vdev_t *vd)
 {
 	spa_t *spa = vd->vdev_spa;
 
-	ASSERT(MUTEX_HELD(&spa_namespace_lock));
+	ASSERT(MUTEX_HELD(&spa_namespace_lock) ||
+	    spa->spa_export_thread == curthread);
 
 	if (vd == spa->spa_root_vdev) {
 		for (uint64_t i = 0; i < vd->vdev_children; i++)

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -1040,7 +1040,8 @@ vdev_trim_stop_wait(spa_t *spa, list_t *vd_list)
 	(void) spa;
 	vdev_t *vd;
 
-	ASSERT(MUTEX_HELD(&spa_namespace_lock));
+	ASSERT(MUTEX_HELD(&spa_namespace_lock) ||
+	    spa->spa_export_thread == curthread);
 
 	while ((vd = list_remove_head(vd_list)) != NULL) {
 		mutex_enter(&vd->vdev_trim_lock);
@@ -1079,7 +1080,8 @@ vdev_trim_stop(vdev_t *vd, vdev_trim_state_t tgt_state, list_t *vd_list)
 	if (vd_list == NULL) {
 		vdev_trim_stop_wait_impl(vd);
 	} else {
-		ASSERT(MUTEX_HELD(&spa_namespace_lock));
+		ASSERT(MUTEX_HELD(&spa_namespace_lock) ||
+		    vd->vdev_spa->spa_export_thread == curthread);
 		list_insert_tail(vd_list, vd);
 	}
 }
@@ -1115,7 +1117,8 @@ vdev_trim_stop_all(vdev_t *vd, vdev_trim_state_t tgt_state)
 	list_t vd_list;
 	vdev_t *vd_l2cache;
 
-	ASSERT(MUTEX_HELD(&spa_namespace_lock));
+	ASSERT(MUTEX_HELD(&spa_namespace_lock) ||
+	    spa->spa_export_thread == curthread);
 
 	list_create(&vd_list, sizeof (vdev_t),
 	    offsetof(vdev_t, vdev_trim_node));

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -430,7 +430,8 @@ tags = ['functional', 'cli_root', 'zpool_events']
 
 [tests/functional/cli_root/zpool_export]
 tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
-    'zpool_export_003_neg', 'zpool_export_004_pos']
+    'zpool_export_003_neg', 'zpool_export_004_pos',
+    'zpool_export_parallel_pos', 'zpool_export_parallel_admin']
 tags = ['functional', 'cli_root', 'zpool_export']
 
 [tests/functional/cli_root/zpool_get]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1084,6 +1084,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_export/zpool_export_002_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_003_neg.ksh \
 	functional/cli_root/zpool_export/zpool_export_004_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh \
+	functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh \
 	functional/cli_root/zpool_get/cleanup.ksh \
 	functional/cli_root/zpool_get/setup.ksh \
 	functional/cli_root/zpool_get/vdev_get_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh
@@ -1,0 +1,72 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2024 Klara, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 	Verify that admin commands cannot race a pool export
+#
+# STRATEGY:
+#	1. Create a pool
+#	2. Import the pool with an injected delay in the background
+#	3. Execute some admin commands against the pool
+#
+
+verify_runnable "global"
+
+DEVICE_DIR=$TEST_BASE_DIR/dev_export-test
+
+function cleanup
+{
+	zinject -c all
+	poolexists $TESTPOOL1 && destroy_pool $TESTPOOL1
+	[[ -d $DEVICE_DIR ]] && log_must rm -rf $DEVICE_DIR
+}
+
+log_assert "admin commands cannot race a pool export"
+
+log_onexit cleanup
+
+[[ ! -d $DEVICE_DIR ]] && log_must mkdir -p $DEVICE_DIR
+log_must truncate -s $MINVDEVSIZE ${DEVICE_DIR}/disk0 ${DEVICE_DIR}/disk1
+
+log_must zpool create -f $TESTPOOL1 mirror ${DEVICE_DIR}/disk0 ${DEVICE_DIR}/disk1
+
+log_must zinject -P export -s 10 $TESTPOOL1
+
+log_must zpool export $TESTPOOL1 &
+
+zpool set comment=hello $TESTPOOL1
+zpool reguid $TESTPOOL1 &
+zpool split $TESTPOOL1 &
+
+log_pass "admin commands cannot race a pool export"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh
@@ -1,0 +1,129 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2024 Klara, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_import/zpool_import.cfg
+. $STF_SUITE/tests/functional/cli_root/zpool_import/zpool_import.kshlib
+
+# test uses 8 vdevs
+MAX_NUM=8
+DEVICE_DIR=$TEST_BASE_DIR/dev_import-test
+
+
+#
+# DESCRIPTION:
+# 	Verify that pool exports can occur in parallel
+#
+# STRATEGY:
+#	1. Create 8 pools
+#	2. Inject an export delay using zinject
+#	3. Export half of the pools synchronously to baseline sequential cost
+#	4. Export the other half asynchronously to demonstrate parallel savings
+#	6. Import 4 pools
+#	7. Test zpool export -a
+#
+
+verify_runnable "global"
+
+#
+# override the minimum sized vdevs
+#
+
+POOLNAME="test_pool"
+
+function cleanup
+{
+	zinject -c all
+
+	for i in {0..$(($MAX_NUM - 1))}; do
+		poolexists $POOLNAME-$i && destroy_pool $POOLNAME-$i
+	done
+
+	[[ -d $DEVICE_DIR ]] && log_must rm -rf $DEVICE_DIR
+}
+
+log_assert "Pool exports can occur in parallel"
+
+log_onexit cleanup
+
+[[ ! -d $DEVICE_DIR ]] && log_must mkdir -p $DEVICE_DIR
+
+#
+# Create some pools with export delay injectors
+#
+for i in {0..$(($MAX_NUM - 1))}; do
+	log_must truncate -s $MINVDEVSIZE ${DEVICE_DIR}/disk$i
+	log_must zpool create $POOLNAME-$i $DEVICE_DIR/disk$i
+	log_must zinject -P export -s 8 $POOLNAME-$i
+done
+
+#
+# Export half of the pools synchronously
+#
+SECONDS=0
+for i in {0..3}; do
+	log_must zpool export $POOLNAME-$i
+done
+sequential_time=$SECONDS
+log_note "sequentially exported 4 pools in $sequential_time seconds"
+
+#
+# Export half of the pools in parallel
+#
+SECONDS=0
+for i in {4..7}; do
+	log_must zpool export $POOLNAME-$i &
+done
+wait
+parallel_time=$SECONDS
+log_note "asyncronously exported 4 pools in $parallel_time seconds"
+
+log_must test $parallel_time -lt $(($sequential_time / 3))
+
+#
+# import 4 pools with export delay injectors
+#
+for i in {4..7}; do
+	log_must zpool import -d $DEVICE_DIR/disk$i $POOLNAME-$i
+	log_must zinject -P export -s 8 $POOLNAME-$i
+done
+
+#
+# now test zpool export -a
+#
+SECONDS=0
+log_must zpool export -a
+parallel_time=$SECONDS
+log_note "asyncronously exported 4 pools, using '-a', in $parallel_time seconds"
+
+log_must test $parallel_time -lt $(($sequential_time / 3))
+
+log_pass "Pool exports occur in parallel"


### PR DESCRIPTION
### Motivation and Context
This is a follow-on that was inspired by the recent commit -- parallel pool import #16093.
Systems with multiple pools, and especially in an HA setting, can benefit from allowing pool exports to proceed in parallel.

### Description
Changed `spa_export_common()` such that it no longer holds the `spa_namespace_lock` for the entire duration and instead uses `spa->spa_export_thread` to indicate an import is in progress on the spa. This  allows for another export to proceed in parallel while an export is still processing potentially long operations like `spa_unload_log_sm_flush_all()`.
 
Calls like `spa_lookup()` and `spa_vdev_enter()` that were relying on the `spa_namespace_lock` to serialize them against a concurrent export, now wait for any in-progress export thread to complete before proceeding.
 
The `zpool import -a` sub-command also provides multi-threaded support, using a thread pool to submit the exports in parallel.

Sponsored-By: Klara Inc.
Sponsored-by: Wasabi Technology, Inc.

### How Has This Been Tested?
1. Manual testing to confirm exports are proceeding in parallel
2. Targeted ZTS testing using following suites: `zpool_export, zpool_import, zpool_initialize, zpool_trim, zpool_remove, pool_checkpoint, raidz`
3. Extended `ztest` runs via `zloop`

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
