### PR TITLE
config/zfs-build.m4: add Alpine Linux bash-completion path

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -629,6 +629,7 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		debian)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
 		freebsd)    bashcompletiondir=$sysconfdir/bash_completion.d;;
 		gentoo)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
+		alpine)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
 		*)          bashcompletiondir=/etc/bash_completion.d   ;;
 	esac
 	AC_MSG_RESULT([$bashcompletiondir])


### PR DESCRIPTION
as with c57ff818f61483c3131dc4fb6dd87ede7ab29bba, this is our `bash-completion` path too https://git.alpinelinux.org/aports/tree/main/zfs/alpine-bash-completion-dir.patch

btw, perhaps this and other similar lists should be alphabetically sorted, here I just added it last as was done in the previously mentioned commit
