### PR TITLE
config/zfs-build.m4: sort vendors & add Alpine Linux bash-completion path

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -512,32 +512,33 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		[with_vendor=$withval],
 		[with_vendor=check])
 	AS_IF([test "x$with_vendor" = "xcheck"],[
-		if test -f /etc/toss-release ; then
-			VENDOR=toss ;
-		elif test -f /etc/fedora-release ; then
-			VENDOR=fedora ;
-		elif test -f /etc/redhat-release ; then
-			VENDOR=redhat ;
-		elif test -f /etc/gentoo-release ; then
-			VENDOR=gentoo ;
+		if test -f /etc/alpine-release ; then
+			VENDOR=alpine ;
 		elif test -f /etc/arch-release ; then
 			VENDOR=arch ;
+		elif test -f /etc/fedora-release ; then
+			VENDOR=fedora ;
+		elif test -f /bin/freebsd-version ; then
+			VENDOR=freebsd ;
+		elif test -f /etc/gentoo-release ; then
+			VENDOR=gentoo ;
+		elif test -f /etc/lunar.release ; then
+			VENDOR=lunar ;
+		elif test -f /etc/openEuler-release ; then
+			VENDOR=openeuler ;
 		elif test -f /etc/SuSE-release ; then
 			VENDOR=sles ;
 		elif test -f /etc/slackware-version ; then
 			VENDOR=slackware ;
-		elif test -f /etc/lunar.release ; then
-			VENDOR=lunar ;
+		elif test -f /etc/toss-release ; then
+			VENDOR=toss ;
 		elif test -f /etc/lsb-release ; then
 			VENDOR=ubuntu ;
+		# put debian and redhat last as derivatives may have also their file
 		elif test -f /etc/debian_version ; then
 			VENDOR=debian ;
-		elif test -f /etc/alpine-release ; then
-			VENDOR=alpine ;
-		elif test -f /bin/freebsd-version ; then
-			VENDOR=freebsd ;
-		elif test -f /etc/openEuler-release ; then
-			VENDOR=openeuler ;
+		elif test -f /etc/redhat-release ; then
+			VENDOR=redhat ;
 		else
 			VENDOR= ;
 		fi],
@@ -550,20 +551,15 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 
 	AC_MSG_CHECKING([default package type])
 	case "$VENDOR" in
-		toss)       DEFAULT_PACKAGE=rpm  ;;
-		redhat)     DEFAULT_PACKAGE=rpm  ;;
-		fedora)     DEFAULT_PACKAGE=rpm  ;;
-		gentoo)     DEFAULT_PACKAGE=tgz  ;;
-		alpine)     DEFAULT_PACKAGE=tgz  ;;
-		arch)       DEFAULT_PACKAGE=tgz  ;;
-		sles)       DEFAULT_PACKAGE=rpm  ;;
-		slackware)  DEFAULT_PACKAGE=tgz  ;;
-		lunar)      DEFAULT_PACKAGE=tgz  ;;
-		ubuntu)     DEFAULT_PACKAGE=deb  ;;
-		debian)     DEFAULT_PACKAGE=deb  ;;
-		freebsd)    DEFAULT_PACKAGE=pkg  ;;
-		openeuler)  DEFAULT_PACKAGE=rpm  ;;
-		*)          DEFAULT_PACKAGE=rpm  ;;
+		alpine|arch|gentoo|lunar|slackware)
+			DEFAULT_PACKAGE=tgz  ;;
+		debian|ubuntu)
+			DEFAULT_PACKAGE=deb  ;;
+		freebsd)
+			DEFAULT_PACKAGE=pkg  ;;
+		*)
+		# fedora|openeuler|redhat|sles|toss
+			DEFAULT_PACKAGE=rpm  ;;
 	esac
 	AC_MSG_RESULT([$DEFAULT_PACKAGE])
 	AC_SUBST(DEFAULT_PACKAGE)
@@ -578,7 +574,7 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 
 	AC_MSG_CHECKING([default shell])
 	case "$VENDOR" in
-		gentoo|alpine)	DEFAULT_INIT_SHELL=/sbin/openrc-run
+		alpine|gentoo)	DEFAULT_INIT_SHELL=/sbin/openrc-run
 				IS_SYSV_RC=false	;;
 		*)		DEFAULT_INIT_SHELL=/bin/sh
 				IS_SYSV_RC=true		;;
@@ -598,17 +594,19 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 
 	AC_MSG_CHECKING([default init config directory])
 	case "$VENDOR" in
-		alpine)     initconfdir=/etc/conf.d    ;;
-		gentoo)     initconfdir=/etc/conf.d    ;;
-		toss)       initconfdir=/etc/sysconfig ;;
-		redhat)     initconfdir=/etc/sysconfig ;;
-		fedora)     initconfdir=/etc/sysconfig ;;
-		sles)       initconfdir=/etc/sysconfig ;;
-		openeuler)  initconfdir=/etc/sysconfig ;;
-		ubuntu)     initconfdir=/etc/default   ;;
-		debian)     initconfdir=/etc/default   ;;
-		freebsd)    initconfdir=$sysconfdir/rc.conf.d;;
-		*)          initconfdir=/etc/default   ;;
+		alpine|gentoo)
+			initconfdir=/etc/conf.d
+			;;
+		fedora|openeuler|redhat|sles|toss)
+			initconfdir=/etc/sysconfig
+			;;
+		freebsd)
+			initconfdir=$sysconfdir/rc.conf.d
+			;;
+		*)
+		# debian|ubuntu
+			initconfdir=/etc/default
+			;;
 	esac
 	AC_MSG_RESULT([$initconfdir])
 	AC_SUBST(initconfdir)
@@ -625,11 +623,15 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 
 	AC_MSG_CHECKING([default bash completion directory])
 	case "$VENDOR" in
-		ubuntu)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
-		debian)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
-		freebsd)    bashcompletiondir=$sysconfdir/bash_completion.d;;
-		gentoo)     bashcompletiondir=/usr/share/bash-completion/completions   ;;
-		*)          bashcompletiondir=/etc/bash_completion.d   ;;
+		debian|gentoo|ubuntu)
+			bashcompletiondir=/usr/share/bash-completion/completions
+			;;
+		freebsd)
+			bashcompletiondir=$sysconfdir/bash_completion.d
+			;;
+		*)
+			bashcompletiondir=/etc/bash_completion.d
+			;;
 	esac
 	AC_MSG_RESULT([$bashcompletiondir])
 	AC_SUBST(bashcompletiondir)

--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -623,7 +623,7 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 
 	AC_MSG_CHECKING([default bash completion directory])
 	case "$VENDOR" in
-		debian|gentoo|ubuntu)
+		alpine|debian|gentoo|ubuntu)
 			bashcompletiondir=/usr/share/bash-completion/completions
 			;;
 		freebsd)


### PR DESCRIPTION
It is often easier to find what you are looking for when it is alphabetically sorted.

This is what I suggested in #16163 and also an alternative to that PR, since I added a similar commit to this one.