### PR TITLE
libspl_assert: always link -lpthread on FreeBSD

### DIFF
--- a/lib/libspl/Makefile.am
+++ b/lib/libspl/Makefile.am
@@ -45,3 +45,7 @@ libspl_la_LIBADD = \
 libspl_la_LIBADD += $(LIBATOMIC_LIBS) $(LIBCLOCK_GETTIME)
 
 libspl_assert_la_LIBADD = $(BACKTRACE_LIBS) $(LIBUNWIND_LIBS)
+
+if BUILD_FREEBSD
+libspl_assert_la_LIBADD += -lpthread
+endif


### PR DESCRIPTION
### Motivation and Context

Build failure on FreeBSD 13.

### Description

The `pthread_*` functions are in `-lpthread` on FreeBSD. Some of them are implicitly linked through libc, but on FreeBSD 13 at least `pthread_getname_np()` is not. Just be explicit, since `-lpthread` is the documented interface anyway.

### How Has This Been Tested?

Checked build on 13 & 14 with and without. 13 didn't build without previously, now does.

I suspect this made it past CI in #16140 because it found libunwind there, and that brought libpthread along. Can't confirm because the checks appear to be gone from that PR now, but it feels plausible.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
