### PR TITLE
Increase limit of zpool comment property from 32 characters to 8192

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -261,8 +261,7 @@ typedef enum {
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
-/* Small enough to not hog a whole line of printout in zpool(8). */
-#define	ZPROP_MAX_COMMENT	32
+#define	ZPROP_MAX_COMMENT	8192
 #define	ZPROP_BOOLEAN_NA	2
 
 #define	ZPROP_VALUE		"value"


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- The zpool property 'comment' allows a 'zpool import' to display useful information about the pool without really import it. 
- However, the current size limit is only 32 characters, which is too small. 
- This PR bumps up the size limit of 'comment' to 8192 characters, so more information can be saved. The new limit is consistent with a user zpool property (i.e. user property names can be at most 256 characters, Property values are limited to 8192 bytes.)

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
Before the code change
```
$ sudo zpool set comment="domain0PoolGUID=123&engineUUID=345&engineBuildVersion=sduhunkhhdj&engineType=sduhhd&engineInstallationTime=121333ddsd&hostname=test.dlpxdc.co" domain0
cannot set property for 'domain0': comment must not exceed 32 characters
```

After the code change
```
$ sudo zpool set comment="repaveVersion=v1&domain0PoolGUID=932031118914016167&engineUUID=ec2660a0-4b2a-a091-fe17-d85cb9213d16&engineBuildVersion=23.0.0.0-snapshot.20240502050332551+jenkins-ops-appliance-build-develop-post-push-1807&engineType=VIRTUALIZATION&engineInstallationTime=Thu May 02 10:30:07 PDT 2024&hostname=ip-10-110-254-106&apiVersion=1.11.34" domain0
$ sudo zpool import
   pool: domain0
     id: 932031118914016167
  state: ONLINE
status: Some supported features are not enabled on the pool.
	(Note that they may be intentionally disabled if the
	'compatibility' property is set.)
 action: The pool can be imported using its name or numeric identifier, though
	some features will not be available without an explicit 'zpool upgrade'.
comment: repaveVersion=v1&domain0PoolGUID=932031118914016167&engineUUID=ec2660a0-4b2a-a091-fe17-d85cb9213d16&engineBuildVersion=23.0.0.0-snapshot.20240502050332551+jenkins-ops-appliance-build-develop-post-push-1807&engineType=VIRTUALIZATION&engineInstallationTime=Thu May 02 10:30:07 PDT 2024&hostname=ip-10-110-254-106&apiVersion=1.11.34
 config:

	domain0                  ONLINE
	  dcoa-prod-repave-pool  ONLINE
	logs
	  xvdb1                  ONLINE
```

The change is backwards compatible, if a pool has the `comment` greater than 32, it can still be imported on a system not running this change.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
