### PR TITLE
Correct level handling in zstream recompress.

### DIFF
--- a/cmd/zstream/zstream_recompress.c
+++ b/cmd/zstream/zstream_recompress.c
@@ -77,7 +77,7 @@ zstream_do_recompress(int argc, char *argv[])
 	while ((c = getopt(argc, argv, "l:")) != -1) {
 		switch (c) {
 		case 'l':
-			if (sscanf(optarg, "%d", &level) == EOF) {
+			if (sscanf(optarg, "%d", &level) != 1) {
 				fprintf(stderr,
 				    "failed to parse level '%s'\n",
 				    optarg);

--- a/cmd/zstream/zstream_recompress.c
+++ b/cmd/zstream/zstream_recompress.c
@@ -77,7 +77,7 @@ zstream_do_recompress(int argc, char *argv[])
 	while ((c = getopt(argc, argv, "l:")) != -1) {
 		switch (c) {
 		case 'l':
-			if (sscanf(optarg, "%d", &level) != 0) {
+			if (sscanf(optarg, "%d", &level) == EOF) {
 				fprintf(stderr,
 				    "failed to parse level '%s'\n",
 				    optarg);


### PR DESCRIPTION
### Motivation and Context
sscanf returns number of items parsed on success and EOF on failure.

As-is, this errors on all valid options, and succeeds on all invalid options.

### Description

### How Has This Been Tested?
What's a test?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
