### PR TITLE
linux: detect if kernel defines intptr_t

### DIFF
--- a/config/kernel-types.m4
+++ b/config/kernel-types.m4
@@ -1,0 +1,40 @@
+dnl #
+dnl # check if kernel provides definitions for given types
+dnl #
+
+dnl _ZFS_AC_KERNEL_SRC_TYPE(type)
+AC_DEFUN([_ZFS_AC_KERNEL_SRC_TYPE], [
+	ZFS_LINUX_TEST_SRC([type_$1], [
+		#include <linux/types.h>
+	],[
+		const $1 __attribute__((unused)) x = ($1) 0;
+	])
+])
+
+dnl _ZFS_AC_KERNEL_TYPE(type)
+AC_DEFUN([_ZFS_AC_KERNEL_TYPE], [
+	AC_MSG_CHECKING([whether kernel defines $1])
+	ZFS_LINUX_TEST_RESULT([type_$1], [
+		AC_MSG_RESULT([yes])
+		AC_DEFINE([HAVE_KERNEL_]m4_quote(m4_translit([$1], [a-z], [A-Z])),
+		    1, [kernel defines $1])
+	], [
+		AC_MSG_RESULT([no])
+	])
+])
+
+dnl ZFS_AC_KERNEL_TYPES([types...])
+AC_DEFUN([ZFS_AC_KERNEL_TYPES], [
+	AC_DEFUN([ZFS_AC_KERNEL_SRC_TYPES], [
+		m4_foreach_w([type], [$1], [
+			_ZFS_AC_KERNEL_SRC_TYPE(type)
+		])
+	])
+	AC_DEFUN([ZFS_AC_KERNEL_TYPES], [
+		m4_foreach_w([type], [$1], [
+			_ZFS_AC_KERNEL_TYPE(type)
+		])
+	])
+])
+
+ZFS_AC_KERNEL_TYPES([intptr_t])

--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -37,6 +37,7 @@ dnl # only once the compilation can be done in parallel significantly
 dnl # speeding up the process.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_TEST_SRC], [
+	ZFS_AC_KERNEL_SRC_TYPES
 	ZFS_AC_KERNEL_SRC_OBJTOOL
 	ZFS_AC_KERNEL_SRC_GLOBAL_PAGE_STATE
 	ZFS_AC_KERNEL_SRC_ACCESS_OK_TYPE
@@ -187,6 +188,7 @@ dnl #
 dnl # Check results of kernel interface tests.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_TEST_RESULT], [
+	ZFS_AC_KERNEL_TYPES
 	ZFS_AC_KERNEL_ACCESS_OK_TYPE
 	ZFS_AC_KERNEL_GLOBAL_PAGE_STATE
 	ZFS_AC_KERNEL_OBJTOOL

--- a/include/os/linux/spl/sys/types.h
+++ b/include/os/linux/spl/sys/types.h
@@ -38,7 +38,9 @@ typedef unsigned long		ulong_t;
 typedef unsigned long long	u_longlong_t;
 typedef long long		longlong_t;
 
+#ifndef HAVE_KERNEL_INTPTR_T
 typedef long			intptr_t;
+#endif
 typedef unsigned long long	rlim64_t;
 
 typedef struct task_struct	kthread_t;


### PR DESCRIPTION
### Motivation and Context

Since Linux 6.7 the kernel has defined `intptr_t`. Clang 18 has `-Wtypedef-redefinition` by default, which causes the build to fail because we also have a typedef for `intptr_t`.

### Description

Adds some autoconf rules to check kernel types, then checks for `intptr_t`. We define our own if we didn't find out.

Typical error before (`clang-18`):

```
make[3]: Entering directory '/home/robn/code/quiz/build/kernel/linux-6.7.12'
  CC [M]  /home/robn/code/zfs/module/os/linux/spl/spl-condvar.o
In file included from /home/robn/code/zfs/module/os/linux/spl/spl-condvar.c:26:
In file included from /home/robn/code/zfs/include/os/linux/spl/sys/condvar.h:29:
In file included from /home/robn/code/zfs/include/os/linux/spl/sys/mutex.h:27:
/home/robn/code/zfs/include/os/linux/spl/sys/types.h:41:16: error: redefinition of typedef 'intptr_t' is a C11 feature [-Werror,-Wtypedef-redefinition]
   41 | typedef long                    intptr_t;
      |                                 ^
./include/linux/types.h:43:16: note: previous definition is here
   43 | typedef long                    intptr_t;
      |                                 ^
1 error generated.
make[5]: *** [scripts/Makefile.build:243: /home/robn/code/zfs/module/os/linux/spl/spl-condvar.o] Error 1
```

### How Has This Been Tested?

Compiled against 6.4.x and 6.7.x with GCC 13 and Clang 18. All seems well.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
