### PR TITLE
Avoid a gcc -Wint-to-pointer-cast warning

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6827,7 +6827,7 @@ spa_tryimport(nvlist_t *tryconfig)
 	 */
 	char *name = kmem_alloc(MAXPATHLEN, KM_SLEEP);
 	(void) snprintf(name, MAXPATHLEN, "%s-%llx-%s",
-	    TRYIMPORT_NAME, (u_longlong_t)curthread, poolname);
+	    TRYIMPORT_NAME, (u_longlong_t)(uintptr_t)curthread, poolname);
 
 	mutex_enter(&spa_namespace_lock);
 	spa = spa_add(name, tryconfig, NULL);


### PR DESCRIPTION
On 32-bit platforms long long is generally 64-bits.  Sufficiently modern versions of gcc (13 in my testing) complains when casting a pointer to an integer of a different width so cast to uintptr_t first to avoid the warning.

Fixes: c183d164aa Parallel pool import

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
