### PR TITLE
Use memset to zero stack allocations containing unions

### DIFF
--- a/cmd/zstream/zstream_redup.c
+++ b/cmd/zstream/zstream_redup.c
@@ -186,13 +186,15 @@ static void
 zfs_redup_stream(int infd, int outfd, boolean_t verbose)
 {
 	int bufsz = SPA_MAXBLOCKSIZE;
-	dmu_replay_record_t thedrr = { 0 };
+	dmu_replay_record_t thedrr;
 	dmu_replay_record_t *drr = &thedrr;
 	redup_table_t rdt;
 	zio_cksum_t stream_cksum;
 	uint64_t numbuckets;
 	uint64_t num_records = 0;
 	uint64_t num_write_byref_records = 0;
+
+	memset(&thedrr, 0, sizeof (dmu_replay_record_t));
 
 #ifdef _ILP32
 	uint64_t max_rde_size = SMALLEST_POSSIBLE_MAX_RDT_MB << 20;

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -2170,7 +2170,8 @@ out:
 static int
 send_conclusion_record(int fd, zio_cksum_t *zc)
 {
-	dmu_replay_record_t drr = { 0 };
+	dmu_replay_record_t drr;
+	memset(&drr, 0, sizeof (dmu_replay_record_t));
 	drr.drr_type = DRR_END;
 	if (zc != NULL)
 		drr.drr_u.drr_end.drr_checksum = *zc;
@@ -2272,7 +2273,8 @@ send_prelim_records(zfs_handle_t *zhp, const char *from, int fd,
 	}
 
 	if (!dryrun) {
-		dmu_replay_record_t drr = { 0 };
+		dmu_replay_record_t drr;
+		memset(&drr, 0, sizeof (dmu_replay_record_t));
 		/* write first begin record */
 		drr.drr_type = DRR_BEGIN;
 		drr.drr_u.drr_begin.drr_magic = DMU_BACKUP_MAGIC;

--- a/module/icp/io/aes.c
+++ b/module/icp/io/aes.c
@@ -832,11 +832,13 @@ aes_encrypt_atomic(crypto_mechanism_t *mechanism,
     crypto_key_t *key, crypto_data_t *plaintext, crypto_data_t *ciphertext,
     crypto_spi_ctx_template_t template)
 {
-	aes_ctx_t aes_ctx = {{{{0}}}};
+	aes_ctx_t aes_ctx;
 	off_t saved_offset;
 	size_t saved_length;
 	size_t length_needed;
 	int ret;
+
+	memset(&aes_ctx, 0, sizeof (aes_ctx_t));
 
 	ASSERT(ciphertext != NULL);
 
@@ -956,11 +958,13 @@ aes_decrypt_atomic(crypto_mechanism_t *mechanism,
     crypto_key_t *key, crypto_data_t *ciphertext, crypto_data_t *plaintext,
     crypto_spi_ctx_template_t template)
 {
-	aes_ctx_t aes_ctx = {{{{0}}}};
+	aes_ctx_t aes_ctx;
 	off_t saved_offset;
 	size_t saved_length;
 	size_t length_needed;
 	int ret;
+
+	memset(&aes_ctx, 0, sizeof (aes_ctx_t));
 
 	ASSERT(plaintext != NULL);
 

--- a/tests/zfs-tests/cmd/libzfs_input_check.c
+++ b/tests/zfs-tests/cmd/libzfs_input_check.c
@@ -521,12 +521,14 @@ test_send_new(const char *snapshot, int fd)
 static void
 test_recv_new(const char *dataset, int fd)
 {
-	dmu_replay_record_t drr = { 0 };
+	dmu_replay_record_t drr;
 	nvlist_t *required = fnvlist_alloc();
 	nvlist_t *optional = fnvlist_alloc();
 	nvlist_t *props = fnvlist_alloc();
 	char snapshot[MAXNAMELEN + 32];
 	ssize_t count;
+
+	memset(&drr, 0, sizeof (dmu_replay_record_t));
 
 	int cleanup_fd = open(ZFS_DEV, O_RDWR);
 	if (cleanup_fd == -1) {


### PR DESCRIPTION
### Motivation and Context

Closes #16135.

### Description

[C99 6.7.8.17](https://rgambord.github.io/c99-doc/sections/6/7/8/index.html#p17) says that when an undesignated initialiser is used, only the first element of a union is initialised. If the first element is not the largest within the union, how the remaining space is initialised is up to the compiler.

GCC extends the initialiser to the entire union, while Clang treats the remainder as padding, and so initialises according to whatever automatic/implicit initialisation rules are currently active.

When Linux is compiled with `CONFIG_INIT_STACK_ALL_PATTERN`, `-ftrivial-auto-var-init=pattern` is added to the kernel CFLAGS. This flag sets the policy for automatic/implicit initialisation of variables on the stack.

Taken together, this means that when compiling under `CONFIG_INIT_STACK_ALL_PATTERN` on Clang, the "zero" initialiser will only zero the first element in a union, and the rest will be filled with a pattern. This is significant for `aes_ctx_t`, which in `aes_encrypt_atomic()` and `aes_decrypt_atomic()` is initialised to zero, but then used as a `gcm_ctx_t`, which is the fifth element in the union, and thus gets pattern initialisation. Later, it's assumed to be zero, resulting in a hang.

As confusing and undiscoverable as it is, by the spec, we are at fault when we initialise a structure containing a union with the zero initializer. As such, this commit replaces these uses with an explicit `memset(0)`.

### How Has This Been Tested?

Full test suite run succeeded against a 6.7.12 kernel and this patch, both compiled using Clang 18.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).