### PR TITLE
FreeBSD: Add const qualifier to members of struct opensolaris_utsname

### DIFF
--- a/include/os/freebsd/spl/sys/misc.h
+++ b/include/os/freebsd/spl/sys/misc.h
@@ -45,11 +45,11 @@
 #define	F_SEEK_HOLE	FIOSEEKHOLE
 
 struct opensolaris_utsname {
-	char	*sysname;
-	char	*nodename;
-	char	*release;
-	char	version[32];
-	char	*machine;
+	const char	*sysname;
+	const char	*nodename;
+	const char	*release;
+	char		version[32];
+	const char	*machine;
 };
 
 #define	task_io_account_read(n)

--- a/module/os/freebsd/spl/spl_misc.c
+++ b/module/os/freebsd/spl/spl_misc.c
@@ -37,6 +37,9 @@
 #include <sys/zfs_context.h>
 
 static struct opensolaris_utsname hw_utsname = {
+	.sysname = ostype,
+	.nodename = prison0.pr_hostname,
+	.release = osrelease,
 	.machine = MACHINE
 };
 
@@ -49,10 +52,6 @@ utsname(void)
 static void
 opensolaris_utsname_init(void *arg)
 {
-
-	hw_utsname.sysname = ostype;
-	hw_utsname.nodename = prison0.pr_hostname;
-	hw_utsname.release = osrelease;
 	snprintf(hw_utsname.version, sizeof (hw_utsname.version),
 	    "%d", osreldate);
 }


### PR DESCRIPTION
### Motivation and Context
These members have directly references to the global variables exposed by the kernel. They are not going to be changed by this kernel module.

No functional change intended.

### How Has This Been Tested?
Apply the patch on top of FreeBSD src tree `sys/contrib/openzfs`, build and reboot with new kernel / zfs module .
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

This should unbreak the build with upcoming change of FreeBSD https://reviews.freebsd.org/D45227 . But even without that change, this should be fine.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
