### PR TITLE
Some improvements to metaslabs eviction

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -10168,6 +10168,9 @@ spa_sync(spa_t *spa, uint64_t txg)
 
 	metaslab_class_evict_old(spa->spa_normal_class, txg);
 	metaslab_class_evict_old(spa->spa_log_class, txg);
+	/* spa_embedded_log_class has only one metaslab per vdev. */
+	metaslab_class_evict_old(spa->spa_special_class, txg);
+	metaslab_class_evict_old(spa->spa_dedup_class, txg);
 
 	spa_sync_close_syncing_log_sm(spa);
 


### PR DESCRIPTION
### Motivation and Context
Quite often analyzing dbgmsg logs from different systems I see repeating metaslabs load/unload cycles during period of low activity.  It seems to be a waste of time.

### Description
 - Add old eviction for special and dedup metaslab classes. Those vdevs may be potentially big and fragmented with large metaslabs, while their asynchronous write pattern is not really different from normal class. It seems an omission to not evict old metaslabs from them.
 - If we have metaslab preload enabled, which means we are not too low on memory, do not evict active metaslabs even if they are not used for some time.  Eviction of active metaslabs means we won't be able to write anything until we load them, that may take some time, that is directly opposite to metaslab preload goals.  For small systems the memory saving should be less important after recent reduction in number of allocators and so active metaslabs.

### How Has This Been Tested?
Without the patch on almost idle system I see ZFS loading and then unloading about ~18 metaslabs for each single activity spike (~4x2 active and 10 preload metaslabs).  With the patch I see load/unload cycle only covering the 10 preload metaslabs, which while still may be a waste, should not affect payload performance.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
