### PR TITLE
JSON output support for zfs and zpool commands

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -1972,26 +1972,6 @@ fill_dataset_info(nvlist_t *list, zfs_handle_t *zhp, boolean_t as_int)
 	}
 }
 
-static int
-zprop_collect_property(const char *name, zprop_get_cbdata_t *cbp,
-    const char *propname, const char *value, zprop_source_t sourcetype,
-    const char *source, const char *recvd_value, nvlist_t *nvl)
-{
-	if (cbp->cb_json) {
-		if ((sourcetype & cbp->cb_sources) == 0)
-			return (0);
-		else {
-			return (zprop_nvlist_one_property(propname, value,
-			    sourcetype, source, recvd_value, nvl,
-			    cbp->cb_json_as_int));
-		}
-	} else {
-		zprop_print_one_property(name, cbp,
-		    propname, value, sourcetype, source, recvd_value);
-		return (0);
-	}
-}
-
 /*
  * zfs get [-rHp] [-j [--json-int]] [-o all | field[,field]...]
  *		[-s source[,source]...]

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -349,6 +349,8 @@ static zpool_command_t command_table[] = {
 
 #define	VDEV_ALLOC_CLASS_LOGS	"logs"
 
+#define	MAX_CMD_LEN	256
+
 static zpool_command_t *current_command;
 static zfs_type_t current_prop_type = (ZFS_TYPE_POOL | ZFS_TYPE_VDEV);
 static char history_str[HIS_MAX_RECORD_LEN];
@@ -452,7 +454,7 @@ get_usage(zpool_help_t idx)
 	case HELP_SYNC:
 		return (gettext("\tsync [pool] ...\n"));
 	case HELP_VERSION:
-		return (gettext("\tversion\n"));
+		return (gettext("\tversion [-j]\n"));
 	case HELP_WAIT:
 		return (gettext("\twait [-Hp] [-T d|u] [-t <activity>[,...]] "
 		    "<pool> [interval]\n"));
@@ -10344,6 +10346,35 @@ zpool_do_history(int argc, char **argv)
 	return (ret);
 }
 
+/*
+ * Generates an nvlist with output version for every command based on params.
+ * Purpose of this is to add a version of JSON output, considering the schema
+ * format might be updated for each command in future.
+ *
+ * Schema:
+ *
+ * "output_version": {
+ *    "command": string,
+ *    "vers_major": integer,
+ *    "vers_minor": integer,
+ *  }
+ */
+static nvlist_t *
+zpool_json_schema(int maj_v, int min_v)
+{
+	char cmd[MAX_CMD_LEN];
+	nvlist_t *sch = fnvlist_alloc();
+	nvlist_t *ov = fnvlist_alloc();
+
+	snprintf(cmd, MAX_CMD_LEN, "zpool %s", current_command->name);
+	fnvlist_add_string(ov, "command", cmd);
+	fnvlist_add_uint32(ov, "vers_major", maj_v);
+	fnvlist_add_uint32(ov, "vers_minor", min_v);
+	fnvlist_add_nvlist(sch, "output_version", ov);
+
+	return (sch);
+}
+
 typedef struct ev_opts {
 	int verbose;
 	int scripted;
@@ -11688,8 +11719,39 @@ find_command_idx(const char *command, int *idx)
 static int
 zpool_do_version(int argc, char **argv)
 {
-	(void) argc, (void) argv;
-	return (zfs_version_print() != 0);
+	int c;
+	nvlist_t *jsobj = NULL, *zfs_ver = NULL;
+	boolean_t json = B_FALSE;
+	while ((c = getopt(argc, argv, "j")) != -1) {
+		switch (c) {
+		case 'j':
+			json = B_TRUE;
+			jsobj = zpool_json_schema(0, 1);
+			break;
+		case '?':
+			(void) fprintf(stderr, gettext("invalid option '%c'\n"),
+			    optopt);
+			usage(B_FALSE);
+		}
+	}
+
+	argc -= optind;
+	if (argc != 0) {
+		(void) fprintf(stderr, "too many arguments\n");
+		usage(B_FALSE);
+	}
+
+	if (json) {
+		zfs_ver = zfs_version_nvlist();
+		if (zfs_ver) {
+			fnvlist_add_nvlist(jsobj, "zfs_version", zfs_ver);
+			zcmd_print_json(jsobj);
+			fnvlist_free(zfs_ver);
+			return (0);
+		} else
+			return (-1);
+	} else
+		return (zfs_version_print() != 0);
 }
 
 /* Display documentation */

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -327,6 +327,8 @@ _LIBZFS_H int zpool_vdev_clear(zpool_handle_t *, uint64_t);
 
 _LIBZFS_H nvlist_t *zpool_find_vdev(zpool_handle_t *, const char *, boolean_t *,
     boolean_t *, boolean_t *);
+_LIBZFS_H nvlist_t *zpool_find_parent_vdev(zpool_handle_t *, const char *,
+    boolean_t *, boolean_t *, boolean_t *);
 _LIBZFS_H nvlist_t *zpool_find_vdev_by_physpath(zpool_handle_t *, const char *,
     boolean_t *, boolean_t *, boolean_t *);
 _LIBZFS_H int zpool_label_disk(libzfs_handle_t *, zpool_handle_t *,

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -631,6 +631,8 @@ _LIBZFS_H int zprop_get_list(libzfs_handle_t *, char *, zprop_list_t **,
     zfs_type_t);
 _LIBZFS_H void zprop_free_list(zprop_list_t *);
 
+_LIBZFS_H void zcmd_print_json(nvlist_t *);
+
 #define	ZFS_GET_NCOLS	5
 
 typedef enum {
@@ -658,9 +660,12 @@ typedef struct zprop_get_cbdata {
 	boolean_t cb_scripted;
 	boolean_t cb_literal;
 	boolean_t cb_first;
+	boolean_t cb_json;
 	zprop_list_t *cb_proplist;
 	zfs_type_t cb_type;
 	vdev_cbdata_t cb_vdevs;
+	nvlist_t *cb_jsobj;
+	boolean_t cb_json_as_int;
 } zprop_get_cbdata_t;
 
 #define	ZFS_SET_NOMOUNT		1
@@ -673,6 +678,9 @@ typedef struct zprop_set_cbdata {
 _LIBZFS_H void zprop_print_one_property(const char *, zprop_get_cbdata_t *,
     const char *, const char *, zprop_source_t, const char *,
     const char *);
+
+_LIBZFS_H int zprop_nvlist_one_property(const char *, const char *,
+    zprop_source_t, const char *, const char *, nvlist_t *, boolean_t);
 
 /*
  * Iterator functions.
@@ -979,6 +987,7 @@ _LIBZFS_H boolean_t libzfs_envvar_is_set(const char *);
 _LIBZFS_H const char *zfs_version_userland(void);
 _LIBZFS_H char *zfs_version_kernel(void);
 _LIBZFS_H int zfs_version_print(void);
+_LIBZFS_H nvlist_t *zfs_version_nvlist(void);
 
 /*
  * Given a device or file, determine if it is part of a pool.

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -666,6 +666,7 @@ typedef struct zprop_get_cbdata {
 	vdev_cbdata_t cb_vdevs;
 	nvlist_t *cb_jsobj;
 	boolean_t cb_json_as_int;
+	boolean_t cb_json_pool_key_guid;
 } zprop_get_cbdata_t;
 
 #define	ZFS_SET_NOMOUNT		1
@@ -681,6 +682,10 @@ _LIBZFS_H void zprop_print_one_property(const char *, zprop_get_cbdata_t *,
 
 _LIBZFS_H int zprop_nvlist_one_property(const char *, const char *,
     zprop_source_t, const char *, const char *, nvlist_t *, boolean_t);
+
+_LIBZFS_H int zprop_collect_property(const char *, zprop_get_cbdata_t *,
+    const char *, const char *, zprop_source_t, const char *,
+    const char *, nvlist_t *);
 
 /*
  * Iterator functions.

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -469,7 +469,8 @@ _LIBZFS_H int zpool_import(libzfs_handle_t *, nvlist_t *, const char *,
     char *altroot);
 _LIBZFS_H int zpool_import_props(libzfs_handle_t *, nvlist_t *, const char *,
     nvlist_t *, int);
-_LIBZFS_H void zpool_print_unsup_feat(nvlist_t *config);
+_LIBZFS_H void zpool_collect_unsup_feat(nvlist_t *config, char *buf,
+    size_t size);
 
 /*
  * Miscellaneous pool functions
@@ -500,7 +501,7 @@ _LIBZFS_H void zpool_obj_to_path(zpool_handle_t *, uint64_t, uint64_t, char *,
     size_t);
 _LIBZFS_H int zfs_ioctl(libzfs_handle_t *, int, struct zfs_cmd *);
 _LIBZFS_H void zpool_explain_recover(libzfs_handle_t *, const char *, int,
-    nvlist_t *);
+    nvlist_t *, char *, size_t);
 _LIBZFS_H int zpool_checkpoint(zpool_handle_t *);
 _LIBZFS_H int zpool_discard_checkpoint(zpool_handle_t *);
 _LIBZFS_H boolean_t zpool_is_draid_spare(const char *);

--- a/lib/libspl/include/statcommon.h
+++ b/lib/libspl/include/statcommon.h
@@ -39,5 +39,7 @@
 void print_timestamp(uint_t);
 /* Return timestamp in either Unix or standard format in provided buffer */
 void get_timestamp(uint_t, char *, int);
+/* convert time_t to standard format */
+void format_timestamp(time_t, char *, int);
 
 #endif /* _STATCOMMON_H */

--- a/lib/libspl/include/statcommon.h
+++ b/lib/libspl/include/statcommon.h
@@ -37,5 +37,7 @@
 
 /* Print a timestamp in either Unix or standard format. */
 void print_timestamp(uint_t);
+/* Return timestamp in either Unix or standard format in provided buffer */
+void get_timestamp(uint_t, char *, int);
 
 #endif /* _STATCOMMON_H */

--- a/lib/libspl/timestamp.c
+++ b/lib/libspl/timestamp.c
@@ -62,3 +62,25 @@ print_timestamp(uint_t timestamp_fmt)
 			(void) printf("%s\n", dstr);
 	}
 }
+
+/*
+ * Return timestamp as decimal reprentation (in string) of time_t
+ * value (-T u was specified) or in date(1) format (-T d was specified).
+ */
+void
+get_timestamp(uint_t timestamp_fmt, char *buf, int len)
+{
+	time_t t = time(NULL);
+	static const char *fmt = NULL;
+
+	/* We only need to retrieve this once per invocation */
+	if (fmt == NULL)
+		fmt = nl_langinfo(_DATE_FMT);
+
+	if (timestamp_fmt == UDATE) {
+		(void) snprintf(buf, len, "%lld", (longlong_t)t);
+	} else if (timestamp_fmt == DDATE) {
+		struct tm tm;
+		strftime(buf, len, fmt, localtime_r(&t, &tm));
+	}
+}

--- a/lib/libspl/timestamp.c
+++ b/lib/libspl/timestamp.c
@@ -84,3 +84,23 @@ get_timestamp(uint_t timestamp_fmt, char *buf, int len)
 		strftime(buf, len, fmt, localtime_r(&t, &tm));
 	}
 }
+
+/*
+ * Format the provided time stamp to human readable format
+ */
+void
+format_timestamp(time_t t, char *buf, int len)
+{
+	struct tm tm;
+	static const char *fmt = NULL;
+
+	if (t == 0) {
+		snprintf(buf, len, "-");
+		return;
+	}
+
+	/* We only need to retrieve this once per invocation */
+	if (fmt == NULL)
+		fmt = nl_langinfo(_DATE_FMT);
+	strftime(buf, len, fmt, localtime_r(&t, &tm));
+}

--- a/lib/libuutil/libuutil.abi
+++ b/lib/libuutil/libuutil.abi
@@ -143,7 +143,9 @@
     <elf-symbol name='avl_update_gt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='avl_update_lt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='avl_walk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='format_timestamp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='get_system_hostid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='get_timestamp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='getexecname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='getextmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='getmntany' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1149,6 +1151,18 @@
     </function-decl>
     <function-decl name='print_timestamp' mangled-name='print_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
       <parameter type-id='3502e3ff' name='timestamp_fmt'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='get_timestamp' mangled-name='get_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_timestamp'>
+      <parameter type-id='3502e3ff' name='timestamp_fmt'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='95e97e5e' name='len'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='format_timestamp' mangled-name='format_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='format_timestamp'>
+      <parameter type-id='c9d12d66' name='t'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='95e97e5e' name='len'/>
       <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -179,10 +179,12 @@
     <elf-symbol name='fletcher_4_native' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_4_native_varsize' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='format_timestamp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fsleep' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='get_dataset_depth' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='get_system_hostid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='getexecname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='get_timestamp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='getextmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='getmntany' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='getprop_uint64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -280,6 +282,7 @@
     <elf-symbol name='vdev_prop_to_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='vdev_prop_user' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='vdev_prop_values' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zcmd_print_json' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfeature_depends_on' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfeature_is_supported' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfeature_is_valid_guid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -452,6 +455,7 @@
     <elf-symbol name='zfs_userspace' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_valid_proplist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_version_kernel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_version_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_version_print' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_version_userland' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_wait_status' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -524,7 +528,7 @@
     <elf-symbol name='zpool_prefetch' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_prepare_and_label_disk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_prepare_disk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='zpool_print_unsup_feat' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_collect_unsup_feat' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_prop_align_right' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_prop_column_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_prop_default_numeric' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -577,12 +581,14 @@
     <elf-symbol name='zpool_vdev_split' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_wait' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_wait_status' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_collect_property' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zprop_free_list' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zprop_get_list' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zprop_index_to_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zprop_iter' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zprop_iter_common' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zprop_name_to_prop' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zprop_nvlist_one_property' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zprop_print_one_property' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zprop_random_value' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zprop_register_hidden' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1282,6 +1288,18 @@
     </function-decl>
     <function-decl name='print_timestamp' mangled-name='print_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
       <parameter type-id='3502e3ff' name='timestamp_fmt'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='get_timestamp' mangled-name='get_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_timestamp'>
+      <parameter type-id='3502e3ff' name='timestamp_fmt'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='95e97e5e' name='len'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='format_timestamp' mangled-name='format_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='format_timestamp'>
+      <parameter type-id='c9d12d66' name='t'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='95e97e5e' name='len'/>
       <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>
@@ -6456,6 +6474,8 @@
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='95e97e5e' name='reason'/>
       <parameter type-id='5ce45b60' name='config'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='b59d7dce' name='size'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='zpool_import' mangled-name='zpool_import' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import'>
@@ -6465,8 +6485,10 @@
       <parameter type-id='26a90f95' name='altroot'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='zpool_print_unsup_feat' mangled-name='zpool_print_unsup_feat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_print_unsup_feat'>
+    <function-decl name='zpool_collect_unsup_feat' mangled-name='zpool_collect_unsup_feat' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_collect_unsup_feat'>
       <parameter type-id='5ce45b60' name='config'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='b59d7dce' name='size'/>
       <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='zpool_import_props' mangled-name='zpool_import_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_import_props'>
@@ -8194,6 +8216,20 @@
       <parameter type-id='2e45de5d' name='argtype'/>
       <return type-id='9200a744'/>
     </function-decl>
+    <function-decl name='zcmd_print_json' mangled-name='zcmd_print_json' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zcmd_print_json'>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zprop_nvlist_one_property' mangled-name='zprop_nvlist_one_property' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_nvlist_one_property'>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='80f4b756' name='value'/>
+      <parameter type-id='a2256d42' name='sourcetype'/>
+      <parameter type-id='80f4b756' name='source'/>
+      <parameter type-id='80f4b756' name='recvd_value'/>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <parameter type-id='c19b74c3' name='as_int'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='zprop_print_one_property' mangled-name='zprop_print_one_property' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_print_one_property'>
       <parameter type-id='80f4b756' name='name'/>
       <parameter type-id='0d2a0670' name='cbp'/>
@@ -8203,6 +8239,17 @@
       <parameter type-id='80f4b756' name='source'/>
       <parameter type-id='80f4b756' name='recvd_value'/>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zprop_collect_property' mangled-name='zprop_collect_property' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_collect_property'>
+      <parameter type-id='80f4b756' name='name'/>
+      <parameter type-id='0d2a0670' name='cbp'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='80f4b756' name='value'/>
+      <parameter type-id='a2256d42' name='sourcetype'/>
+      <parameter type-id='80f4b756' name='source'/>
+      <parameter type-id='80f4b756' name='recvd_value'/>
+      <parameter type-id='5ce45b60' name='nvl'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zprop_get_list' mangled-name='zprop_get_list' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zprop_get_list'>
       <parameter type-id='b0382bb3' name='hdl'/>
@@ -8231,6 +8278,9 @@
     </function-decl>
     <function-decl name='use_color' mangled-name='use_color' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='use_color'>
       <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_version_nvlist' mangled-name='zfs_version_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_version_nvlist'>
+      <return type-id='5ce45b60'/>
     </function-decl>
     <function-decl name='printf_color' mangled-name='printf_color' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='printf_color'>
       <parameter type-id='80f4b756' name='color'/>

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -486,6 +486,7 @@
     <elf-symbol name='zpool_feature_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_find_config' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_find_vdev' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_find_parent_vdev' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_find_vdev_by_physpath' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_free_handles' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_get_all_vdev_props' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -6533,6 +6534,14 @@
       <return type-id='5ce45b60'/>
     </function-decl>
     <function-decl name='zpool_find_vdev' mangled-name='zpool_find_vdev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_vdev'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='37e3bd22' name='avail_spare'/>
+      <parameter type-id='37e3bd22' name='l2cache'/>
+      <parameter type-id='37e3bd22' name='log'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
+    <function-decl name='zpool_find_parent_vdev' mangled-name='zpool_find_parent_vdev' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_find_parent_vdev'>
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='80f4b756' name='path'/>
       <parameter type-id='37e3bd22' name='avail_spare'/>

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1590,6 +1590,26 @@ zprop_print_one_property(const char *name, zprop_get_cbdata_t *cbp,
 	(void) printf("\n");
 }
 
+int
+zprop_collect_property(const char *name, zprop_get_cbdata_t *cbp,
+    const char *propname, const char *value, zprop_source_t sourcetype,
+    const char *source, const char *recvd_value, nvlist_t *nvl)
+{
+	if (cbp->cb_json) {
+		if ((sourcetype & cbp->cb_sources) == 0)
+			return (0);
+		else {
+			return (zprop_nvlist_one_property(propname, value,
+			    sourcetype, source, recvd_value, nvl,
+			    cbp->cb_json_as_int));
+		}
+	} else {
+		zprop_print_one_property(name, cbp,
+		    propname, value, sourcetype, source, recvd_value);
+		return (0);
+	}
+}
+
 /*
  * Given a numeric suffix, convert the value into a number of bits that the
  * resulting value must be shifted.

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -68,6 +68,7 @@
  * as necessary.
  */
 #define	URI_REGEX	"^\\([A-Za-z][A-Za-z0-9+.\\-]*\\):"
+#define	STR_NUMS	"0123456789"
 
 int
 libzfs_errno(libzfs_handle_t *hdl)
@@ -1267,6 +1268,14 @@ zcmd_read_dst_nvlist(libzfs_handle_t *hdl, zfs_cmd_t *zc, nvlist_t **nvlp)
  * ================================================================
  */
 
+void
+zcmd_print_json(nvlist_t *nvl)
+{
+	nvlist_print_json(stdout, nvl);
+	(void) putchar('\n');
+	nvlist_free(nvl);
+}
+
 static void
 zprop_print_headers(zprop_get_cbdata_t *cbp, zfs_type_t type)
 {
@@ -1391,6 +1400,103 @@ zprop_print_headers(zprop_get_cbdata_t *cbp, zfs_type_t type)
 		}
 	}
 	(void) printf("\n");
+}
+
+/*
+ * Add property value and source to provided nvlist, according to
+ * settings in cb structure. Later to be printed in JSON format.
+ */
+int
+zprop_nvlist_one_property(const char *propname,
+    const char *value, zprop_source_t sourcetype, const char *source,
+    const char *recvd_value, nvlist_t *nvl, boolean_t as_int)
+{
+	int ret = 0;
+	nvlist_t *src_nv, *prop;
+	boolean_t all_numeric = strspn(value, STR_NUMS) == strlen(value);
+	src_nv = prop = NULL;
+
+	if ((nvlist_alloc(&prop, NV_UNIQUE_NAME, 0) != 0) ||
+	    (nvlist_alloc(&src_nv, NV_UNIQUE_NAME, 0) != 0)) {
+		ret = -1;
+		goto err;
+	}
+
+	if (as_int && all_numeric) {
+		uint64_t val;
+		sscanf(value, "%lld", (u_longlong_t *)&val);
+		if (nvlist_add_uint64(prop, "value", val) != 0) {
+			ret = -1;
+			goto err;
+		}
+	} else {
+		if (nvlist_add_string(prop, "value", value) != 0) {
+			ret = -1;
+			goto err;
+		}
+	}
+
+	switch (sourcetype) {
+	case ZPROP_SRC_NONE:
+		if (nvlist_add_string(src_nv, "type", "NONE") != 0 ||
+		    (nvlist_add_string(src_nv, "data", "-") != 0)) {
+			ret = -1;
+			goto err;
+		}
+		break;
+	case ZPROP_SRC_DEFAULT:
+		if (nvlist_add_string(src_nv, "type", "DEFAULT") != 0 ||
+		    (nvlist_add_string(src_nv, "data", "-") != 0)) {
+			ret = -1;
+			goto err;
+		}
+		break;
+	case ZPROP_SRC_LOCAL:
+		if (nvlist_add_string(src_nv, "type", "LOCAL") != 0 ||
+		    (nvlist_add_string(src_nv, "data", "-") != 0)) {
+			ret = -1;
+			goto err;
+		}
+		break;
+	case ZPROP_SRC_TEMPORARY:
+		if (nvlist_add_string(src_nv, "type", "TEMPORARY") != 0 ||
+		    (nvlist_add_string(src_nv, "data", "-") != 0)) {
+			ret = -1;
+			goto err;
+		}
+		break;
+	case ZPROP_SRC_INHERITED:
+		if (nvlist_add_string(src_nv, "type", "INHERITED") != 0 ||
+		    (nvlist_add_string(src_nv, "data", source) != 0)) {
+			ret = -1;
+			goto err;
+		}
+		break;
+	case ZPROP_SRC_RECEIVED:
+		if (nvlist_add_string(src_nv, "type", "RECEIVED") != 0 ||
+		    (nvlist_add_string(src_nv, "data",
+		    (recvd_value == NULL ? "-" : recvd_value)) != 0)) {
+			ret = -1;
+			goto err;
+		}
+		break;
+	default:
+		assert(!"unhandled zprop_source_t");
+		if (nvlist_add_string(src_nv, "type",
+		    "unhandled zprop_source_t") != 0) {
+			ret = -1;
+			goto err;
+		}
+	}
+	if ((nvlist_add_nvlist(prop, "source", src_nv) != 0) ||
+	    (nvlist_add_nvlist(nvl, propname, prop)) != 0) {
+		ret = -1;
+		goto err;
+	}
+err:
+	nvlist_free(src_nv);
+	nvlist_free(prop);
+	return (ret);
 }
 
 /*
@@ -1997,6 +2103,34 @@ zfs_version_print(void)
 	(void) printf("zfs-kmod-%s\n", kver);
 	free(kver);
 	return (0);
+}
+
+/*
+ * Returns an nvlist with both zfs userland and kernel versions.
+ * Returns NULL on error.
+ */
+nvlist_t *
+zfs_version_nvlist(void)
+{
+	nvlist_t *nvl;
+	char kmod_ver[64];
+	if (nvlist_alloc(&nvl, NV_UNIQUE_NAME, 0) != 0)
+		return (NULL);
+	if (nvlist_add_string(nvl, "userland", ZFS_META_ALIAS) != 0)
+		goto err;
+	char *kver = zfs_version_kernel();
+	if (kver == NULL) {
+		fprintf(stderr, "zfs_version_kernel() failed: %s\n",
+		    zfs_strerror(errno));
+		goto err;
+	}
+	(void) snprintf(kmod_ver, 64, "zfs-kmod-%s", kver);
+	if (nvlist_add_string(nvl, "kernel", kmod_ver) != 0)
+		goto err;
+	return (nvl);
+err:
+	nvlist_free(nvl);
+	return (NULL);
 }
 
 /*

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -126,7 +126,9 @@
     <elf-symbol name='atomic_swap_uint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_swap_ulong' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='atomic_swap_ushort' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='format_timestamp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='get_system_hostid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='get_timestamp' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='getexecname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='getextmntent' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='getmntany' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1108,6 +1110,18 @@
     </function-decl>
     <function-decl name='print_timestamp' mangled-name='print_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='print_timestamp'>
       <parameter type-id='3502e3ff' name='timestamp_fmt'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='get_timestamp' mangled-name='get_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_timestamp'>
+      <parameter type-id='3502e3ff' name='timestamp_fmt'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='95e97e5e' name='len'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='format_timestamp' mangled-name='format_timestamp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='format_timestamp'>
+      <parameter type-id='c9d12d66' name='t'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='95e97e5e' name='len'/>
       <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>

--- a/man/man8/zfs-list.8
+++ b/man/man8/zfs-list.8
@@ -41,6 +41,7 @@
 .Cm list
 .Op Fl r Ns | Ns Fl d Ar depth
 .Op Fl Hp
+.Op Fl j Op Ar --json-int
 .Oo Fl o Ar property Ns Oo , Ns Ar property Oc Ns … Oc
 .Oo Fl s Ar property Oc Ns …
 .Oo Fl S Ar property Oc Ns …
@@ -70,6 +71,11 @@ The following fields are displayed:
 Used for scripting mode.
 Do not print headers and separate fields by a single tab instead of arbitrary
 white space.
+.It Fl j Op Ar --json-int
+Print the output in JSON format.
+Specify
+.Sy --json-int
+to print the numbers in integer format instead of strings in JSON output.
 .It Fl d Ar depth
 Recursively display any children of the dataset, limiting the recursion to
 .Ar depth .
@@ -185,6 +191,161 @@ pool                      450K   457G    18K  /pool
 pool/home                 315K   457G    21K  /export/home
 pool/home/anne             18K   457G    18K  /export/home/anne
 pool/home/bob             276K   457G   276K  /export/home/bob
+.Ed
+.Ss Example 2 : No Listing ZFS filesystems and snapshots in JSON format
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm list Fl j Fl t Ar filesystem,snapshot | Cm jq
+{
+  "output_version": {
+    "command": "zfs list",
+    "vers_major": 0,
+    "vers_minor": 1
+  },
+  "datasets": {
+    "pool": {
+      "name": "pool",
+      "type": "FILESYSTEM",
+      "pool": "pool",
+      "properties": {
+        "used": {
+          "value": "290K",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "available": {
+          "value": "30.5G",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "referenced": {
+          "value": "24K",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "mountpoint": {
+          "value": "/pool",
+          "source": {
+            "type": "DEFAULT",
+            "data": "-"
+          }
+        }
+      }
+    },
+    "pool/home": {
+      "name": "pool/home",
+      "type": "FILESYSTEM",
+      "pool": "pool",
+      "properties": {
+        "used": {
+          "value": "48K",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "available": {
+          "value": "30.5G",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "referenced": {
+          "value": "24K",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "mountpoint": {
+          "value": "/mnt/home",
+          "source": {
+            "type": "LOCAL",
+            "data": "-"
+          }
+        }
+      }
+    },
+    "pool/home/bob": {
+      "name": "pool/home/bob",
+      "type": "FILESYSTEM",
+      "pool": "pool",
+      "properties": {
+        "used": {
+          "value": "24K",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "available": {
+          "value": "30.5G",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "referenced": {
+          "value": "24K",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "mountpoint": {
+          "value": "/mnt/home/bob",
+          "source": {
+            "type": "INHERITED",
+            "data": "pool/home"
+          }
+        }
+      }
+    },
+    "pool/home/bob@v1": {
+      "name": "pool/home/bob@v1",
+      "type": "SNAPSHOT",
+      "pool": "pool",
+      "dataset": "pool/home/bob",
+      "snapshot_name": "v1",
+      "properties": {
+        "used": {
+          "value": "0B",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "available": {
+          "value": "-",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "referenced": {
+          "value": "24K",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "mountpoint": {
+          "value": "-",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        }
+      }
+    }
+  }
+}
 .Ed
 .
 .Sh SEE ALSO

--- a/man/man8/zfs-mount.8
+++ b/man/man8/zfs-mount.8
@@ -39,6 +39,7 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm mount
+.Op Fl j
 .Nm zfs
 .Cm mount
 .Op Fl Oflv
@@ -54,8 +55,13 @@
 .It Xo
 .Nm zfs
 .Cm mount
+.Op Fl j
 .Xc
 Displays all ZFS file systems currently mounted.
+.Bl -tag -width "-j"
+.It Fl j
+Displays all mounted file systems in JSON format.
+.El
 .It Xo
 .Nm zfs
 .Cm mount

--- a/man/man8/zfs-set.8
+++ b/man/man8/zfs-set.8
@@ -46,6 +46,7 @@
 .Cm get
 .Op Fl r Ns | Ns Fl d Ar depth
 .Op Fl Hp
+.Op Fl j Op Ar --json-int
 .Oo Fl o Ar field Ns Oo , Ns Ar field Oc Ns … Oc
 .Oo Fl s Ar source Ns Oo , Ns Ar source Oc Ns … Oc
 .Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns … Oc
@@ -91,6 +92,7 @@ dataset.
 .Cm get
 .Op Fl r Ns | Ns Fl d Ar depth
 .Op Fl Hp
+.Op Fl j Op Ar --json-int
 .Oo Fl o Ar field Ns Oo , Ns Ar field Oc Ns … Oc
 .Oo Fl s Ar source Ns Oo , Ns Ar source Oc Ns … Oc
 .Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns … Oc
@@ -128,6 +130,11 @@ The value
 can be used to display all properties that apply to the given dataset's type
 .Pq Sy filesystem , volume , snapshot , No or Sy bookmark .
 .Bl -tag -width "-s source"
+.It Fl j Op Ar --json-int
+Display the output in JSON format.
+Specify
+.Sy --json-int
+to display numbers in integer format instead of strings for JSON output.
 .It Fl H
 Display output in a form more easily parsed by scripts.
 Any headers are omitted, and fields are explicitly separated by a single tab
@@ -281,6 +288,50 @@ The following command gets a single property value:
 .Bd -literal -compact -offset Ds
 .No # Nm zfs Cm get Fl H o Sy value compression Ar pool/home/bob
 on
+.Ed
+.Pp
+The following command gets a single property value recursively in JSON format:
+.Bd -literal -compact -offset Ds
+.No # Nm zfs Cm get Fl j Fl r Sy mountpoint Ar pool/home | Nm jq
+{
+  "output_version": {
+    "command": "zfs get",
+    "vers_major": 0,
+    "vers_minor": 1
+  },
+  "datasets": {
+    "pool/home": {
+      "name": "pool/home",
+      "type": "FILESYSTEM",
+      "pool": "pool",
+      "createtxg": "10",
+      "properties": {
+        "mountpoint": {
+          "value": "/pool/home",
+          "source": {
+            "type": "DEFAULT",
+            "data": "-"
+          }
+        }
+      }
+    },
+    "pool/home/bob": {
+      "name": "pool/home/bob",
+      "type": "FILESYSTEM",
+      "pool": "pool",
+      "createtxg": "1176",
+      "properties": {
+        "mountpoint": {
+          "value": "/pool/home/bob",
+          "source": {
+            "type": "DEFAULT",
+            "data": "-"
+          }
+        }
+      }
+    }
+  }
+}
 .Ed
 .Pp
 The following command lists all properties with local settings for

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -48,6 +48,7 @@
 .Fl ?V
 .Nm
 .Cm version
+.Op Fl j
 .Nm
 .Cm subcommand
 .Op Ar arguments
@@ -153,10 +154,14 @@ Displays a help message.
 .It Xo
 .Nm
 .Cm version
+.Op Fl j
 .Xc
 Displays the software version of the
 .Nm
 userland utility and the zfs kernel module.
+Use
+.Fl j
+option to output in JSON format.
 .El
 .
 .Ss Dataset Management

--- a/man/man8/zpool-get.8
+++ b/man/man8/zpool-get.8
@@ -37,6 +37,7 @@
 .Nm zpool
 .Cm get
 .Op Fl Hp
+.Op Fl j Op Ar --json-int, --json-pool-key-guid
 .Op Fl o Ar field Ns Oo , Ns Ar field Oc Ns …
 .Sy all Ns | Ns Ar property Ns Oo , Ns Ar property Oc Ns …
 .Oo Ar pool Oc Ns …
@@ -44,6 +45,7 @@
 .Nm zpool
 .Cm get
 .Op Fl Hp
+.Op Fl j Op Ar --json-int
 .Op Fl o Ar field Ns Oo , Ns Ar field Oc Ns …
 .Sy all Ns | Ns Ar property Ns Oo , Ns Ar property Oc Ns …
 .Ar pool
@@ -67,6 +69,7 @@
 .Nm zpool
 .Cm get
 .Op Fl Hp
+.Op Fl j Op Ar --json-int, --json-pool-key-guid
 .Op Fl o Ar field Ns Oo , Ns Ar field Oc Ns …
 .Sy all Ns | Ns Ar property Ns Oo , Ns Ar property Oc Ns …
 .Oo Ar pool Oc Ns …
@@ -95,6 +98,14 @@ See the
 .Xr zpoolprops 7
 manual page for more information on the available pool properties.
 .Bl -tag -compact -offset Ds -width "-o field"
+.It Fl j Op Ar --json-int, --json-pool-key-guid
+Display the list of properties in JSON format.
+Specify
+.Sy --json-int
+to display the numbers in integer format instead of strings in JSON output.
+Specify
+.Sy --json-pool-key-guid
+to set pool GUID as key for pool objects instead of pool name.
 .It Fl H
 Scripted mode.
 Do not display headers, and separate fields by a single tab instead of arbitrary
@@ -108,6 +119,7 @@ Display numbers in parsable (exact) values.
 .It Xo
 .Nm zpool
 .Cm get
+.Op Fl j Op Ar --json-int
 .Op Fl Hp
 .Op Fl o Ar field Ns Oo , Ns Ar field Oc Ns …
 .Sy all Ns | Ns Ar property Ns Oo , Ns Ar property Oc Ns …
@@ -145,6 +157,11 @@ See the
 .Xr vdevprops 7
 manual page for more information on the available pool properties.
 .Bl -tag -compact -offset Ds -width "-o field"
+.It Fl j Op Ar --json-int
+Display the list of properties in JSON format.
+Specify
+.Sy --json-int
+to display the numbers in integer format instead of strings in JSON output.
 .It Fl H
 Scripted mode.
 Do not display headers, and separate fields by a single tab instead of arbitrary

--- a/man/man8/zpool-list.8
+++ b/man/man8/zpool-list.8
@@ -37,6 +37,7 @@
 .Nm zpool
 .Cm list
 .Op Fl HgLpPv
+.Op Fl j Op Ar --json-int, --json-pool-key-guid
 .Op Fl o Ar property Ns Oo , Ns Ar property Oc Ns …
 .Op Fl T Sy u Ns | Ns Sy d
 .Oo Ar pool Oc Ns …
@@ -58,6 +59,14 @@ is specified, the command exits after
 .Ar count
 reports are printed.
 .Bl -tag -width Ds
+.It Fl j Op Ar --json-int, --json-pool-key-guid
+Display the list of pools in JSON format.
+Specify
+.Sy --json-int
+to display the numbers in integer format instead of strings.
+Specify
+.Sy --json-pool-key-guid
+to set pool GUID as key for pool objects instead of pool names.
 .It Fl g
 Display vdev GUIDs instead of the normal device names.
 These GUIDs can be used in place of device names for the zpool
@@ -139,6 +148,104 @@ data        23.9G  14.6G  9.30G         -    48%    61%  1.00x  ONLINE  -
     sda         -      -      -         -      -
     sdb         -      -      -       10G      -
     sdc         -      -      -         -      -
+.Ed
+.
+.Ss Example 3 : No Displaying expanded space on a device
+The following command lists all available pools on the system in JSON
+format.
+.Bd -literal -compact -offset Ds
+.No # Nm zpool Cm list Fl j | Nm jq
+{
+  "output_version": {
+    "command": "zpool list",
+    "vers_major": 0,
+    "vers_minor": 1
+  },
+  "pools": {
+    "tank": {
+      "name": "tank",
+      "type": "POOL",
+      "state": "ONLINE",
+      "guid": "15220353080205405147",
+      "txg": "2671",
+      "spa_version": "5000",
+      "zpl_version": "5",
+      "properties": {
+        "size": {
+          "value": "111G",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "allocated": {
+          "value": "30.8G",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "free": {
+          "value": "80.2G",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "checkpoint": {
+          "value": "-",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "expandsize": {
+          "value": "-",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "fragmentation": {
+          "value": "0%",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "capacity": {
+          "value": "27%",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "dedupratio": {
+          "value": "1.00x",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "health": {
+          "value": "ONLINE",
+          "source": {
+            "type": "NONE",
+            "data": "-"
+          }
+        },
+        "altroot": {
+          "value": "-",
+          "source": {
+            "type": "DEFAULT",
+            "data": "-"
+          }
+        }
+      }
+    }
+  }
+}
+
 .Ed
 .
 .Sh SEE ALSO

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -41,6 +41,7 @@
 .Op Fl c Op Ar SCRIPT1 Ns Oo , Ns Ar SCRIPT2 Oc Ns …
 .Oo Ar pool Oc Ns …
 .Op Ar interval Op Ar count
+.Op Fl j Op Ar --json-int, --json-flat-vdevs, --json-pool-key-guid
 .
 .Sh DESCRIPTION
 Displays the detailed health status for the given pools.
@@ -69,6 +70,17 @@ See the
 option of
 .Nm zpool Cm iostat
 for complete details.
+.It Fl j Op Ar --json-int, --json-flat-vdevs, --json-pool-key-guid
+Display the status for ZFS pools in JSON format.
+Specify
+.Sy --json-int
+to display numbers in integer format instead of strings.
+Specify
+.Sy --json-flat-vdevs
+to display vdevs in flat hierarchy instead of nested vdev objects.
+Specify
+.Sy --json-pool-key-guid
+to set pool GUID as key for pool objects instead of pool names.
 .It Fl D
 Display a histogram of deduplication statistics, showing the allocated
 .Pq physically present on disk
@@ -159,6 +171,175 @@ pool        alloc   free   read  write   read  write  size
 rpool       14.6G  54.9G      4     55   250K  2.69M
   sda1      14.6G  54.9G      4     55   250K  2.69M   70G
 ----------  -----  -----  -----  -----  -----  -----  ----
+.Ed
+.
+.Ss Example 2 : No Display the status output in JSON format
+.Nm zpool Cm status No can output in JSON format if
+.Fl j
+is specified.
+.Fl c
+can be used to run a script on each VDEV.
+.Bd -literal -compact -offset Ds
+.No # Nm zpool Cm status Fl j Fl c Pa vendor , Ns Pa model , Ns Pa size | Nm jq
+{
+  "output_version": {
+    "command": "zpool status",
+    "vers_major": 0,
+    "vers_minor": 1
+  },
+  "pools": {
+    "tank": {
+      "name": "tank",
+      "state": "ONLINE",
+      "guid": "3920273586464696295",
+      "txg": "16597",
+      "spa_version": "5000",
+      "zpl_version": "5",
+      "status": "OK",
+      "vdevs": {
+        "tank": {
+          "name": "tank",
+          "alloc_space": "62.6G",
+          "total_space": "15.0T",
+          "def_space": "11.3T",
+          "read_errors": "0",
+          "write_errors": "0",
+          "checksum_errors": "0",
+          "vdevs": {
+            "raidz1-0": {
+              "name": "raidz1-0",
+              "vdev_type": "raidz",
+              "guid": "763132626387621737",
+              "state": "HEALTHY",
+              "alloc_space": "62.5G",
+              "total_space": "10.9T",
+              "def_space": "7.26T",
+              "rep_dev_size": "10.9T",
+              "read_errors": "0",
+              "write_errors": "0",
+              "checksum_errors": "0",
+              "vdevs": {
+                "ca1eb824-c371-491d-ac13-37637e35c683": {
+                  "name": "ca1eb824-c371-491d-ac13-37637e35c683",
+                  "vdev_type": "disk",
+                  "guid": "12841765308123764671",
+                  "path": "/dev/disk/by-partuuid/ca1eb824-c371-491d-ac13-37637e35c683",
+                  "state": "HEALTHY",
+                  "rep_dev_size": "3.64T",
+                  "phys_space": "3.64T",
+                  "read_errors": "0",
+                  "write_errors": "0",
+                  "checksum_errors": "0",
+                  "vendor": "ATA",
+                  "model": "WDC WD40EFZX-68AWUN0",
+                  "size": "3.6T"
+                },
+                "97cd98fb-8fb8-4ac4-bc84-bd8950a7ace7": {
+                  "name": "97cd98fb-8fb8-4ac4-bc84-bd8950a7ace7",
+                  "vdev_type": "disk",
+                  "guid": "1527839927278881561",
+                  "path": "/dev/disk/by-partuuid/97cd98fb-8fb8-4ac4-bc84-bd8950a7ace7",
+                  "state": "HEALTHY",
+                  "rep_dev_size": "3.64T",
+                  "phys_space": "3.64T",
+                  "read_errors": "0",
+                  "write_errors": "0",
+                  "checksum_errors": "0",
+                  "vendor": "ATA",
+                  "model": "WDC WD40EFZX-68AWUN0",
+                  "size": "3.6T"
+                },
+                "e9ddba5f-f948-4734-a472-cb8aa5f0ff65": {
+                  "name": "e9ddba5f-f948-4734-a472-cb8aa5f0ff65",
+                  "vdev_type": "disk",
+                  "guid": "6982750226085199860",
+                  "path": "/dev/disk/by-partuuid/e9ddba5f-f948-4734-a472-cb8aa5f0ff65",
+                  "state": "HEALTHY",
+                  "rep_dev_size": "3.64T",
+                  "phys_space": "3.64T",
+                  "read_errors": "0",
+                  "write_errors": "0",
+                  "checksum_errors": "0",
+                  "vendor": "ATA",
+                  "model": "WDC WD40EFZX-68AWUN0",
+                  "size": "3.6T"
+                }
+              }
+            }
+          }
+        }
+      },
+      "dedup": {
+        "mirror-2": {
+          "name": "mirror-2",
+          "vdev_type": "mirror",
+          "guid": "2227766268377771003",
+          "state": "HEALTHY",
+          "alloc_space": "89.1M",
+          "total_space": "3.62T",
+          "def_space": "3.62T",
+          "rep_dev_size": "3.62T",
+          "read_errors": "0",
+          "write_errors": "0",
+          "checksum_errors": "0",
+          "vdevs": {
+            "db017360-d8e9-4163-961b-144ca75293a3": {
+              "name": "db017360-d8e9-4163-961b-144ca75293a3",
+              "vdev_type": "disk",
+              "guid": "17880913061695450307",
+              "path": "/dev/disk/by-partuuid/db017360-d8e9-4163-961b-144ca75293a3",
+              "state": "HEALTHY",
+              "rep_dev_size": "3.63T",
+              "phys_space": "3.64T",
+              "read_errors": "0",
+              "write_errors": "0",
+              "checksum_errors": "0",
+              "vendor": "ATA",
+              "model": "WDC WD40EFZX-68AWUN0",
+              "size": "3.6T"
+            },
+            "952c3baf-b08a-4a8c-b7fa-33a07af5fe6f": {
+              "name": "952c3baf-b08a-4a8c-b7fa-33a07af5fe6f",
+              "vdev_type": "disk",
+              "guid": "10276374011610020557",
+              "path": "/dev/disk/by-partuuid/952c3baf-b08a-4a8c-b7fa-33a07af5fe6f",
+              "state": "HEALTHY",
+              "rep_dev_size": "3.63T",
+              "phys_space": "3.64T",
+              "read_errors": "0",
+              "write_errors": "0",
+              "checksum_errors": "0",
+              "vendor": "ATA",
+              "model": "WDC WD40EFZX-68AWUN0",
+              "size": "3.6T"
+            }
+          }
+        }
+      },
+      "special": {
+        "25d418f8-92bd-4327-b59f-7ef5d5f50d81": {
+          "name": "25d418f8-92bd-4327-b59f-7ef5d5f50d81",
+          "vdev_type": "disk",
+          "guid": "3935742873387713123",
+          "path": "/dev/disk/by-partuuid/25d418f8-92bd-4327-b59f-7ef5d5f50d81",
+          "state": "HEALTHY",
+          "alloc_space": "37.4M",
+          "total_space": "444G",
+          "def_space": "444G",
+          "rep_dev_size": "444G",
+          "phys_space": "447G",
+          "read_errors": "0",
+          "write_errors": "0",
+          "checksum_errors": "0",
+          "vendor": "ATA",
+          "model": "Micron_5300_MTFDDAK480TDS",
+          "size": "447.1G"
+        }
+      },
+      "error_count": "0"
+    }
+  }
+}
 .Ed
 .
 .Sh SEE ALSO

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -38,6 +38,7 @@
 .Fl ?V
 .Nm
 .Cm version
+.Op Fl j
 .Nm
 .Cm subcommand
 .Op Ar arguments
@@ -79,10 +80,14 @@ Displays a help message.
 .It Xo
 .Nm
 .Cm version
+.Op Fl j
 .Xc
 Displays the software version of the
 .Nm
 userland utility and the ZFS kernel module.
+Use
+.Fl j
+option to output in JSON format.
 .El
 .
 .Ss Creation

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -153,6 +153,10 @@ tests = [ 'clean_mirror_001_pos', 'clean_mirror_002_pos',
     'clean_mirror_003_pos', 'clean_mirror_004_pos']
 tags = ['functional', 'clean_mirror']
 
+[tests/functional/cli_root/json]
+tests = ['json_sanity']
+tags = ['functional', 'cli_root', 'json']
+
 [tests/functional/cli_root/zinject]
 tests = ['zinject_args']
 pre =

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -46,6 +46,7 @@ export SYSTEM_FILES_COMMON='awk
     hostname
     id
     iostat
+    jq
     kill
     ksh
     ldd

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -606,6 +606,9 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/clean_mirror/clean_mirror_004_pos.ksh \
 	functional/clean_mirror/cleanup.ksh \
 	functional/clean_mirror/setup.ksh \
+	functional/cli_root/json/cleanup.ksh \
+	functional/cli_root/json/setup.ksh \
+	functional/cli_root/json/json_sanity.ksh \
 	functional/cli_root/zinject/zinject_args.ksh \
 	functional/cli_root/zdb/zdb_002_pos.ksh \
 	functional/cli_root/zdb/zdb_003_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/json/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/json/cleanup.ksh
@@ -1,0 +1,31 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+# Copyright (c) 2024 by Lawrence Livermore National Security, LLC.
+
+. $STF_SUITE/include/libtest.shlib
+
+zpool destroy testpool1
+zpool destroy testpool2
+
+rm $TESTDIR/file{1..28}
+rmdir $TESTDIR

--- a/tests/zfs-tests/tests/functional/cli_root/json/json_sanity.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/json/json_sanity.ksh
@@ -1,0 +1,57 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+
+# Copyright (c) 2024 by Lawrence Livermore National Security, LLC.
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Basic sanity check for valid JSON from zfs & zpool commands.
+#
+# STRATEGY:
+# 1. Run different zfs/zpool -j commands and check for valid JSON
+
+list=(
+    "zpool status -j -g --json-int --json-flat-vdevs --json-pool-key-guid"
+    "zpool status -p -j -g --json-int --json-flat-vdevs --json-pool-key-guid"
+    "zpool status -j -c upath"
+    "zpool status -j"
+    "zpool status -j testpool1"
+    "zpool list -j"
+    "zpool list -j -g"
+    "zpool list -j -o fragmentation"
+    "zpool get -j size"
+    "zpool get -j all"
+    "zpool version -j"
+    "zfs list -j"
+    "zfs list -j testpool1"
+    "zfs get -j all"
+    "zfs get -j available"
+    "zfs mount -j"
+    "zfs version -j"
+)
+
+for cmd in "${list[@]}" ; do
+    log_must eval "$cmd | jq > /dev/null" 
+done
+
+log_pass "zpool and zfs commands outputted valid JSON"

--- a/tests/zfs-tests/tests/functional/cli_root/json/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/json/setup.ksh
@@ -1,0 +1,50 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+# Copyright (c) 2024 by Lawrence Livermore National Security, LLC.
+
+. $STF_SUITE/include/libtest.shlib
+
+# Sanity check that 'testpool1' or 'testpool2' don't exist
+log_mustnot zpool status -j | \
+	jq -e '.pools | has("testpool1") or has("testpool2")' &> /dev/null
+
+mkdir -p $TESTDIR
+truncate -s 80M $TESTDIR/file{1..28}
+
+DISK=${DISKS%% *}
+
+# Create complex pool configs to exercise JSON
+zpool create -f testpool1 draid $TESTDIR/file{1..10} \
+	special $DISK \
+	dedup $TESTDIR/file11 \
+	special $TESTDIR/file12 \
+	cache $TESTDIR/file13 \
+	log $TESTDIR/file14
+
+zpool create -f testpool2 mirror $TESTDIR/file{15,16} \
+	raidz1 $TESTDIR/file{17,18,19} \
+	cache $TESTDIR/file20 \
+	log $TESTDIR/file21 \
+	special mirror $TESTDIR/file{22,23} \
+	dedup mirror $TESTDIR/file{24,25} \
+	spare $TESTDIR/file{26,27,28}


### PR DESCRIPTION
### Motivation and Context
JSON output for ZFS commands can help enhance the consumability of ZFS data. Apart from libzfs, JSON output can provide a more friendly way to access ZFS data to external API users.

### Description
This PR adds JSON output support for following `zfs` and `zpool` commands:

- `zfs list`
- `zfs get`
- `zfs mount`
- `zfs version`
- `zpool status`
- `zpool list`
- `zpool get`
- `zpool version`

Information is collected in an nvlist object in callback structure and later printed to stdout using `nvlist_print_json`.

For future improvements and modifications, the output contains an `output_version` object that contains the version number:
```
"output_version": {
  "command": <str>,
  "vers_major": <int>,
  "vers_minor": <int>
}
``` 

ZFS properties for datasets and pools are organized as below:
```
"property": {
  "value": <str>,
  "source": {
    "type": <str>, 
    "data": <str>             // If property is inherited, where is it inherited from
  }
}
```

A dataset object for dataset will look like below:
```
"dataset_name" : {
  "name": <str>,
  "type": <str>,
  "pool": <str>,
  "createtxg": <str>
  "properties": {
    .
    .
  }
}
```
A pool object will contain following information:
```
<pool_guid> : {
  "name": <str>,
  "type": <str>,
  "state": <str>,
  "guid": <str>,
  "txg": <str>,
  "spa_version": <str>,
  "zpl_version": <str>,
  "properties" : {
  .
  .
  }
}
```

man pages for above listed commands have been updated and some examples have been added. Below are some more examples to demonstrate the JSON output:

```
# query zfs version in JSON format
$ zfs version -j | jq
{
  "output_version": {
    "command": "zfs version",
    "vers_major": 0,
    "vers_minor": 1
  },
  "zfs_version": {
    "userland": "zfs-2.2.99-1",
    "kernel": "zfs-kmod-2.2.99-1"
  }
}

# list a dataset and only show mountpoint property in JSON format
$ zfs list -j -o mountpoint tank | jq
{
  "output_version": {
    "command": "zfs list",
    "vers_major": 0,
    "vers_minor": 1
  },
  "data": {
    "tank": {
      "name": "tank",
      "type": "FILESYSTEM",
      "pool": "tank",
      "createtxg": "1",
      "properties": {
        "mountpoint": {
          "value": "/mnt/tank",
          "source": {
            "type": "DEFAULT",
            "data": "-"
          }
        }
      }
    }
  }
}

# list all pools and only show size property
$  zpool list -j -o size | jq
{
  "output_version": {
    "command": "zpool list",
    "vers_major": 0,
    "vers_minor": 1
  },
  "data": {
    "1409156761762403139": {
      "name": "tpool",
      "type": "POOL",
      "state": "ONLINE",
      "guid": "1409156761762403139",
      "txg": "134928",
      "spa_version": "5000",
      "zpl_version": "5",
      "properties": {
        "size": {
          "value": "31.5G",
          "source": {
            "type": "NONE",
            "data": "-"
          }
        }
      }
    }
  }
}

# below is a zpool status of a single disk stripe pool:
$  zpool status -j tpool | jq
{
  "output_version": {
    "command": "zpool status",
    "vers_major": 0,
    "vers_minor": 1
  },
  "data": {
    "1409156761762403139": {
      "name": "tpool",
      "state": "ONLINE",
      "guid": "1409156761762403139",
      "txg": "134928",
      "spa_version": "5000",
      "zpl_version": "5",
      "status": "OK",
      "vdev_stats": {
        "tpool": {
          "name": "tpool",
          "alloc_space": "812K",
          "total_space": "31.5G",
          "def_space": "31.5G",
          "read_errors": "0",
          "write_errors": "0",
          "checksum_errors": "0",
          "children": {
            "scsi-0QEMU_QEMU_HARDDISK_drive-scsi1": {
              "name": "scsi-0QEMU_QEMU_HARDDISK_drive-scsi1",
              "vdev_type": "disk",
              "guid": "5501883177021187658",
              "path": "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi1-part1",
              "phys_path": "pci-0000:09:02.0-scsi-0:0:0:1",
              "devid": "scsi-0QEMU_QEMU_HARDDISK_drive-scsi1-part1",
              "state": "HEALTHY",
              "alloc_space": "812K",
              "total_space": "31.5G",
              "def_space": "31.5G",
              "rep_dev_size": "31.5G",
              "phys_space": "32.0G",
              "read_errors": "0",
              "write_errors": "0",
              "checksum_errors": "0"
            }
          }
        }
      },
      "error_count": "0"
    }
  }
}
```

### How Has This Been Tested?
Manually tested in different pool configurations.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
