### PR TITLE
ZTS: Fix redacted_send failures on FreeBSD

### DIFF
--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_deleted.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_deleted.ksh
@@ -96,7 +96,7 @@ log_must zfs destroy -R $clone2
 log_must eval "zfs send -i $sendfs#book2 --redact book3 $sendfs@snap2 >$stream"
 log_must eval "zfs recv $recvfs <$stream"
 log_must mount_redacted -f $recvfs
-log_must diff <(ls $send_mnt) <(ls $recv_mnt)
+log_must [ "$(ls $send_mnt)" == "$(ls $recv_mnt)" ]
 log_must zfs destroy -R $recvfs
 log_must zfs rollback -R $sendfs@snap
 

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_mounts.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_mounts.ksh
@@ -71,8 +71,7 @@ log_must ismounted $recvfs
 # deleted.
 contents=$(log_must find $recv_mnt)
 contents_orig=$(log_must find $send_mnt)
-log_must diff <(echo ${contents//$recv_mnt/}) \
-    <(echo ${contents_orig//$send_mnt/})
+log_must [ "${contents//$recv_mnt/}" == "${contents_orig//$send_mnt/}" ]
 log_must zfs redact $sendvol@snap book2 $clonevol@snap
 log_must eval "zfs send --redact book2 $sendvol@snap >$stream"
 log_must eval "zfs receive $recvvol <$stream"
@@ -103,7 +102,6 @@ log_must mount_redacted -f $recvfs
 log_must ismounted $recvfs
 contents=$(log_must find $recv_mnt)
 contents_orig=$(log_must find $send_mnt)
-log_must diff <(echo ${contents//$recv_mnt/}) \
-    <(echo ${contents_orig//$send_mnt/})
+log_must [ "${contents//$recv_mnt/}" == "${contents_orig//$send_mnt/}" ]
 
 log_pass "Received redacted streams can be mounted."


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->


### Motivation and Context
Fix redacted_send ZTS errors on FreeBSD

### Description
We're seeing failures for redacted_deleted and redacted_mount on FreeBSD 13-15:
```
    09:58:34.74 diff: /dev/fd/3: No such file or directory
    09:58:34.74 ERROR: diff /dev/fd/3 /dev/fd/4 exited 2
```
The test was trying to diff the file listings between two directories to see if they are the same.  The workaround is to do a string comparison of the directory listings instead of using `diff`.

### How Has This Been Tested?
Ran ZTS and the tests passed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
