### PR TITLE
spl: fix compilation without HAVE_BACKTRACE

### DIFF
--- a/lib/libspl/backtrace.c
+++ b/lib/libspl/backtrace.c
@@ -110,6 +110,8 @@ libspl_backtrace(int fd)
 	backtrace_symbols_fd(btptrs, nptrs, fd);
 }
 #else
+#include <sys/debug.h>
+
 void
 libspl_backtrace(int fd __maybe_unused)
 {


### PR DESCRIPTION
### Motivation and Context
Without HAVE_BACKTRACE, the compilation of lib/libspl/backtrace.c fails on undefined __maybe_unused macro on both Linux and FreeBSD. This macro is defined in spl/sys/debug.h for both Linux and FreeBSD platforms.

### Description
Add the sys/debug.h header to lib/libspl/backtrace.c

### How Has This Been Tested?
Tested build on Linux, FreeBSD and FreeBSD base (bundled version of OpenZFS)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
