### PR TITLE
FreeBSD: Update use of UMA-related symbols in arc_available_memory

### DIFF
--- a/module/os/freebsd/zfs/arc_os.c
+++ b/module/os/freebsd/zfs/arc_os.c
@@ -89,17 +89,17 @@ arc_available_memory(void)
 	if (n < lowest) {
 		lowest = n;
 	}
-#if defined(__i386) || !defined(UMA_MD_SMALL_ALLOC)
+#if !defined(UMA_MD_SMALL_ALLOC) && !defined(UMA_USE_DMAP)
 	/*
-	 * If we're on an i386 platform, it's possible that we'll exhaust the
-	 * kernel heap space before we ever run out of available physical
-	 * memory.  Most checks of the size of the heap_area compare against
-	 * tune.t_minarmem, which is the minimum available real memory that we
-	 * can have in the system.  However, this is generally fixed at 25 pages
-	 * which is so low that it's useless.  In this comparison, we seek to
-	 * calculate the total heap-size, and reclaim if more than 3/4ths of the
-	 * heap is allocated.  (Or, in the calculation, if less than 1/4th is
-	 * free)
+	 * If we're on a platform without a direct map, it's possible that we'll
+	 * exhaust the kernel heap space before we ever run out of available
+	 * physical memory.  Most checks of the size of the heap_area compare
+	 * against tune.t_minarmem, which is the minimum available real memory
+	 * that we can have in the system.  However, this is generally fixed at
+	 * 25 pages which is so low that it's useless.  In this comparison, we
+	 * seek to calculate the total heap-size, and reclaim if more than
+	 * 3/4ths of the heap is allocated.  (Or, in the calculation, if less
+	 * than 1/4th is free)
 	 */
 	n = uma_avail() - (long)(uma_limit() / 4);
 	if (n < lowest) {


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[da76d34](https://github.com/freebsd/freebsd-src/commit/da76d349b6b104f4e70562304c800a0793dea18d) repurposed the use of `UMA_MD_SMALL_ALLOC` in a way that breaks `arc_available_memory` on -CURRENT. 
This change ensures that `arc_available_memory` uses the new symbol while maintaining compatibility with older FreeBSD releases.

### How Has This Been Tested?
Tested build on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
