### PR TITLE
FreeBSD: unregister mountroot eventhandler on unload

### DIFF
--- a/module/os/freebsd/zfs/kmod_core.c
+++ b/module/os/freebsd/zfs/kmod_core.c
@@ -111,6 +111,7 @@ static int zfs__fini(void);
 static void zfs_shutdown(void *, int);
 
 static eventhandler_tag zfs_shutdown_event_tag;
+static eventhandler_tag zfs_mountroot_event_tag;
 
 #define	ZFS_MIN_KSTACK_PAGES 4
 
@@ -305,16 +306,25 @@ zfs_modevent(module_t mod, int type, void *unused __unused)
 	switch (type) {
 	case MOD_LOAD:
 		err = zfs__init();
-		if (err == 0)
+		if (err == 0) {
 			zfs_shutdown_event_tag = EVENTHANDLER_REGISTER(
 			    shutdown_post_sync, zfs_shutdown, NULL,
 			    SHUTDOWN_PRI_FIRST);
+			zfs_mountroot_event_tag = EVENTHANDLER_REGISTER(
+			    mountroot, spa_boot_init, NULL,
+			    SI_ORDER_ANY);
+		}
 		return (err);
 	case MOD_UNLOAD:
 		err = zfs__fini();
-		if (err == 0 && zfs_shutdown_event_tag != NULL)
-			EVENTHANDLER_DEREGISTER(shutdown_post_sync,
-			    zfs_shutdown_event_tag);
+		if (err == 0) {
+			if (zfs_shutdown_event_tag != NULL)
+				EVENTHANDLER_DEREGISTER(shutdown_post_sync,
+				    zfs_shutdown_event_tag);
+			if (zfs_mountroot_event_tag != NULL)
+				EVENTHANDLER_DEREGISTER(mountroot,
+				    zfs_mountroot_event_tag);
+		}
 		return (err);
 	case MOD_SHUTDOWN:
 		return (0);
@@ -330,9 +340,6 @@ static moduledata_t zfs_mod = {
 	0
 };
 
-#ifdef _KERNEL
-EVENTHANDLER_DEFINE(mountroot, spa_boot_init, NULL, 0);
-#endif
 
 FEATURE(zfs, "OpenZFS support");
 


### PR DESCRIPTION
Otherwise if zfs is unloaded and reroot is being used it trips over a stale pointer.

Sponsored by:	Rubicon Communications, LLC ("Netgate")
Signed-off-by: Mateusz Guzik <mjguzik@gmail.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
