### PR TITLE
Set ZFS_MAXPROPLEN and ZPOOL_MAXPROPLEN to ZAP_MAXVALUELEN

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -51,8 +51,8 @@ extern "C" {
 /*
  * Miscellaneous ZFS constants
  */
-#define	ZFS_MAXPROPLEN		MAXPATHLEN
-#define	ZPOOL_MAXPROPLEN	MAXPATHLEN
+#define	ZFS_MAXPROPLEN		ZAP_MAXVALUELEN
+#define	ZPOOL_MAXPROPLEN	ZAP_MAXVALUELEN
 
 /*
  * libzfs errors

--- a/man/man7/zpoolprops.7
+++ b/man/man7/zpoolprops.7
@@ -28,7 +28,7 @@
 .\" Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
 .\" Copyright (c) 2023, Klara Inc.
 .\"
-.Dd January 14, 2024
+.Dd July 29, 2024
 .Dt ZPOOLPROPS 7
 .Os
 .
@@ -488,7 +488,7 @@ The expected convention is that the property name is divided into two portions
 such as
 .Ar module : Ns Ar property ,
 but this namespace is not enforced by ZFS.
-User property names can be at most 256 characters, and cannot begin with a dash
+User property names can be at most 255 characters, and cannot begin with a dash
 .Pq Qq Sy - .
 .Pp
 When making programmatic use of user properties, it is strongly suggested to use

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_010_pos.ksh
@@ -210,19 +210,15 @@ log_must local_cleanup
 log_note "verify clone list truncated correctly"
 fs=$TESTPOOL/$TESTFS1
 xs=""; for i in {1..200}; do xs+="x"; done
-if is_linux; then
-	ZFS_MAXPROPLEN=4096
-else
-	ZFS_MAXPROPLEN=1024
-fi
+maxproplen=8192
 log_must zfs create $fs
 log_must zfs snapshot $fs@snap
-for (( i = 1; i <= (ZFS_MAXPROPLEN / 200 + 1); i++ )); do
+for (( i = 1; i <= (maxproplen / 200 + 1); i++ )); do
 	log_must zfs clone ${fs}@snap ${fs}/${TESTCLONE}${xs}.${i}
 done
 clone_list=$(zfs list -o clones $fs@snap)
 char_count=$(echo "$clone_list" | tail -1 | wc -c)
-[[ $char_count -eq $ZFS_MAXPROPLEN ]] || \
+[[ $char_count -eq $maxproplen ]] || \
     log_fail "Clone list not truncated correctly. Unexpected character count" \
         "$char_count"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_001_pos.ksh
@@ -80,8 +80,8 @@ while ((i < ${#names[@]})); do
 	typeset name="${names[$i]}"
 	typeset value="${values[$i]}"
 
-	log_must eval "zpool set $name='$value' $TESTPOOL"
-	log_must eval "check_user_prop $TESTPOOL $name '$value'"
+	log_must zpool set "$name=$value" "$TESTPOOL"
+	log_must check_user_prop "$TESTPOOL" "$name" "$value"
 
 	((i += 1))
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_001_pos.ksh
@@ -56,16 +56,10 @@ typeset -a values=()
 # for the null byte)
 names+=("$(awk 'BEGIN { printf "x:"; while (c++ < (256 - 2 - 1)) printf "a" }')")
 values+=("long-property-name")
-# Longest property value (the limits are 1024 on FreeBSD and 4096 on Linux, so
-# pick the right one; the longest value can use limit minus 1 bytes for the
-# null byte)
-if is_linux; then
-	typeset ZFS_MAXPROPLEN=4096
-else
-	typeset ZFS_MAXPROPLEN=1024
-fi
+# Longest property value (8191 bytes, which is the 8192-byte limit minus 1 byte
+# for the null byte).
 names+=("long:property:value")
-values+=("$(awk -v max="$ZFS_MAXPROPLEN" 'BEGIN { while (c++ < (max - 1)) printf "A" }')")
+values+=("$(awk 'BEGIN { while (c++ < (8192 - 1)) printf "A" }')")
 # Valid property names
 for i in {1..10}; do
 	typeset -i len

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_002_neg.ksh
@@ -51,13 +51,23 @@ log_onexit cleanup_user_prop $TESTPOOL
 typeset -a names=()
 typeset -a values=()
 
-# Too long property name (256 bytes, which is the 256-byte limit minus 1 byte
-# for the null byte plus 1 byte to reach back over the limit)
-names+=("$(awk 'BEGIN { printf "x:"; while (c++ < (256 - 2 - 1 + 1)) printf "a" }')")
+# A property name that is too long consists of 256 or more bytes (which is (1)
+# the 256-byte limit (2) minus 1 byte for the null byte (3) plus 1 byte to
+# reach back over the limit).
+names+=("$(awk '
+	BEGIN {
+		# Print a 2-byte prefix of the name.
+		printf "x:";
+		# Print the remaining 254 bytes.
+		while (c++ < (256 - 2 - 1 + 1))
+			printf "a"
+	}'
+)")
 values+=("too-long-property-name")
-# Too long property value (the limits are 1024 on FreeBSD and 4096 on Linux, so
-# pick the right one; the too long value is, e.g., the limit minus 1 bytes for the
-# null byte plus 1 byte to reach back over the limit)
+# A property value that is too long consists of at least 1024 bytes on FreeBSD
+# and 4096 bytes on Linux.
+# The smallest too-long value is (1) the limit (2) minus 1 byte for the null
+# byte (2) plus 1 byte to reach back over the limit).
 if is_linux; then
 	typeset ZFS_MAXPROPLEN=4096
 else

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/user_property_002_neg.ksh
@@ -64,17 +64,11 @@ names+=("$(awk '
 	}'
 )")
 values+=("too-long-property-name")
-# A property value that is too long consists of at least 1024 bytes on FreeBSD
-# and 4096 bytes on Linux.
+# A property value that is too long consists of at least 8192 bytes.
 # The smallest too-long value is (1) the limit (2) minus 1 byte for the null
 # byte (2) plus 1 byte to reach back over the limit).
-if is_linux; then
-	typeset ZFS_MAXPROPLEN=4096
-else
-	typeset ZFS_MAXPROPLEN=1024
-fi
 names+=("too:long:property:value")
-values+=("$(awk -v max="$ZFS_MAXPROPLEN" 'BEGIN { while (c++ < (max - 1 + 1)) printf "A" }')")
+values+=("$(awk 'BEGIN { while (c++ < (8192 - 1 + 1)) printf "A" }')")
 # Invalid property names
 for i in {1..10}; do
 	typeset -i len


### PR DESCRIPTION
### Motivation and Context

So far, the values of `ZFS_MAXPROPLEN` and `ZPOOL_MAXPROPLEN` were equal to
`MAXPATHLEN`, which is:
- `1024` on FreeBSD and 
- `4096` on Linux. 
This wasn't ideal. Some of the surprising outcomes of this implementation are:

1. When creating a pool user property with zpool-set(8), libzfs makes
   sure that the length of the property's value is less than
   `ZFS_MAXPROPLEN`. However, the ZFS kernel module does not do that.
   Instead, it checks the length against `ZAP_MAXVALUELEN`. As a result,
   it is possible to create a property the length of which is going to
   be larger than zpool(8) is ready to read.
2. A pool user property created on Linux is too big to be read on
   FreeBSD.

### Description

This change sets both `ZFS_MAXPROPLEN` and `ZPOOL_MAXPROPLEN` to `ZAP_MAXVALUELEN`, which is `8192` at the moment.

This PR also fixes some documentation issues in zpoolprops.7 and cleans up user_property tests.

Sponsored-by: Klara, Inc.
Sponsored-by: Wasabi Technology, Inc.

### How Has This Been Tested?

I've run tests of the following tags: `zpool_set`, `zfs_set`, and `zfs_clone`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
