### PR TITLE
Coverity model should know that KM_NOSLEEP means no sleeping

### DIFF
--- a/contrib/coverity/model.c
+++ b/contrib/coverity/model.c
@@ -172,7 +172,7 @@ spl_kmem_alloc(size_t sz, int fl, const char *func, int line)
 
 	__coverity_negative_sink__(sz);
 
-	if (condition1)
+	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) && condition1)
 		__coverity_sleep__();
 
 	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) || condition0) {
@@ -193,7 +193,7 @@ spl_kmem_zalloc(size_t sz, int fl, const char *func, int line)
 
 	__coverity_negative_sink__(sz);
 
-	if (condition1)
+	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) && condition1)
 		__coverity_sleep__();
 
 	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) || condition0) {
@@ -275,7 +275,7 @@ spl_vmem_alloc(size_t sz, int fl, const char *func, int line)
 
 	__coverity_negative_sink__(sz);
 
-	if (condition1)
+	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) && condition1)
 		__coverity_sleep__();
 
 	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) || condition0) {
@@ -294,7 +294,7 @@ spl_vmem_zalloc(size_t sz, int fl, const char *func, int line)
 	(void) func;
 	(void) line;
 
-	if (condition1)
+	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) && condition1)
 		__coverity_sleep__();
 
 	if (((fl & KM_NOSLEEP) != KM_NOSLEEP) || condition0) {


### PR DESCRIPTION
### Motivation and Context
This fixes an old oversight. I doubt it affected the accuracy of coverity very much, but it is an improvement that I caught while discussing the latest coverity results with Rob N.

### Description
The model is updated to only consider sleeping when KM_NOSLEEP is not used. Previously, it always assumed sleeping was possible. Coverity has some checks that can detect issues when sleeping is done, although it is very rare, so it is unlikely this affected us.

### How Has This Been Tested?
The new model file will be uploaded to coverity shortly. We will know if it causes anything to go haywire soon afterward, but that is highly unlikely.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
