### PR TITLE
Add building support for Artix Linux

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -516,6 +516,8 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 			VENDOR=alpine ;
 		elif test -f /etc/arch-release ; then
 			VENDOR=arch ;
+		elif test -f /etc/artix-release ; then
+			VENDOR=artix ;
 		elif test -f /etc/fedora-release ; then
 			VENDOR=fedora ;
 		elif test -f /bin/freebsd-version ; then
@@ -551,7 +553,7 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 
 	AC_MSG_CHECKING([default package type])
 	case "$VENDOR" in
-		alpine|arch|gentoo|lunar|slackware)
+		alpine|arch|artix|gentoo|lunar|slackware)
 			DEFAULT_PACKAGE=tgz  ;;
 		debian|ubuntu)
 			DEFAULT_PACKAGE=deb  ;;
@@ -576,6 +578,8 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 	case "$VENDOR" in
 		alpine|gentoo)	DEFAULT_INIT_SHELL=/sbin/openrc-run
 				IS_SYSV_RC=false	;;
+		artix)		DEFAULT_INIT_SHELL=/usr/bin/openrc-run
+				IS_SYSV_RC=false	;;
 		*)		DEFAULT_INIT_SHELL=/bin/sh
 				IS_SYSV_RC=true		;;
 	esac
@@ -594,7 +598,7 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 
 	AC_MSG_CHECKING([default init config directory])
 	case "$VENDOR" in
-		alpine|gentoo)
+		alpine|artix|gentoo)
 			initconfdir=/etc/conf.d
 			;;
 		fedora|openeuler|redhat|sles|toss)
@@ -623,7 +627,7 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 
 	AC_MSG_CHECKING([default bash completion directory])
 	case "$VENDOR" in
-		alpine|debian|gentoo|ubuntu)
+		alpine|artix|debian|gentoo|ubuntu)
 			bashcompletiondir=/usr/share/bash-completion/completions
 			;;
 		freebsd)


### PR DESCRIPTION
Artix Linux is systemd free distribution based on Arch Linux, with openrc dinit runit s6 as init alternatives. This patch will make init scripts installation work the way Gentoo Linux with openrc.

The scripts tweaking for other init will be left to packager.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Artix Linux is a active developing distribution with OpenRC support, I hope it will be a Gentoo successor of OpenRC.
This patch will try to make Artix with OpenRC recognised.

### Description
Put Artix Linux alongside Gentoo, to install the OpenRC init scripts.

### How Has This Been Tested?
The package have been build under Artix Linux from https://github.com/mingzym/zfs-utils
It is a success build, was able to be used as a localised pkg.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
