### PR TITLE
Make sure avl_tree.avl_pad is not in kernel module

### DIFF
--- a/include/sys/avl_impl.h
+++ b/include/sys/avl_impl.h
@@ -34,6 +34,7 @@
  */
 
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #ifdef	__cplusplus
 extern "C" {

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -35,11 +35,10 @@
 #ifndef _SYS_SPA_H
 #define	_SYS_SPA_H
 
-#include <sys/avl.h>
 #include <sys/zfs_context.h>
+#include <sys/avl.h>
 #include <sys/kstat.h>
 #include <sys/nvpair.h>
-#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/fs/zfs.h>
 #include <sys/spa_checksum.h>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Make sure avl_tree.avl_pad is not in kernel module.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The commit b192a2c0a19133234972b491e9c06093b3d21358 (Remove avl_size field from struct avl_tree) uses a def _KERNEL to decide to include avl_pad or not, but this _KERNEL is defined in sys/sysmacros.h. If avl.h and sysmacros.h are not included in the right order, it can cause a headache when working on a zfs related kernel module.

### Description
<!--- Describe your changes in detail -->
This PR changes avl_impl.h to use ```__KERNEL__``` instead of _KERNEL, it also moves avl.h after sysmacros.h in spa.h.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
