### PR TITLE
Fix missing semicolon in trace_dbuf.h

### DIFF
--- a/include/os/linux/zfs/sys/trace_dbuf.h
+++ b/include/os/linux/zfs/sys/trace_dbuf.h
@@ -80,7 +80,7 @@
 		snprintf(__get_str(msg), TRACE_DBUF_MSG_MAX,		\
 		    DBUF_TP_PRINTK_FMT, DBUF_TP_PRINTK_ARGS);		\
 	} else {							\
-		__assign_str(os_spa, "NULL")				\
+		__assign_str(os_spa, "NULL");				\
 		__entry->ds_object = 0;					\
 		__entry->db_object = 0;					\
 		__entry->db_level  = 0;					\


### PR DESCRIPTION
### Motivation and Context

Missing semicolon in trace_dbuf causes compilation errors on newer kernels.

### Description
On fedora 40, on the 6.9.4 kernel (in updates-testing), assign_str expands to a "do {<stuff> } while(0)" loop.  Without this semicolon, the while(0) is unterminated, causing a cascade of unhelpful errors (admittedly, it does identify the missing semicolon in that jumble, just not in a helpful way).  With this semicolon, it compiles fine.  It also compiles fine on 6.8.11 (the previous kernel).  I have not tested earlier kernels than that, but at worst it should add a pointless semicolon.

Also, all other instances in the source tree are already terminated with semicolons:
```
include/os/linux/zfs/sys/trace_dbuf.h
64:                     __assign_str(os_spa,                            \
			spa_name(DB_DNODE(db)->dn_objset->os_spa));	\
67:                     __assign_str(os_spa, "NULL");                   \
83:             __assign_str(os_spa, "NULL")                            \

include/os/linux/zfs/sys/trace_dbgmsg.h
62:         __assign_str(msg, msg);
```

(This change is fixing is line 83 above)


### How Has This Been Tested?
Compilation of 6.8.11 kernel module, compilation of 6.9.4 kernel module on fedora 40

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
