### PR TITLE
FreeBSD: Use a statement expression to implement SET_ERROR()

### DIFF
--- a/include/os/freebsd/spl/sys/sdt.h
+++ b/include/os/freebsd/spl/sys/sdt.h
@@ -31,13 +31,14 @@
 
 #include_next <sys/sdt.h>
 #ifdef KDTRACE_HOOKS
-/* CSTYLED */
+/* BEGIN CSTYLED */
 SDT_PROBE_DECLARE(sdt, , , set__error);
 
-#define	SET_ERROR(err) \
-	((sdt_sdt___set__error->id ? \
-	(*sdt_probe_func)(sdt_sdt___set__error->id, \
-	    (uintptr_t)err, 0, 0, 0, 0) : 0), err)
+#define	SET_ERROR(err)	({ 					\
+	SDT_PROBE1(sdt, , , set__error, (uintptr_t)err);	\
+	err;							\
+})
+/* END CSTYLED */
 #else
 #define	SET_ERROR(err) (err)
 #endif


### PR DESCRIPTION
Use a statement expression to implement SET_ERROR().

### Motivation and Context
The current implementation makes assumptions about how SDT_PROBE* is implemented on FreeBSD. These assumptions will become false after a forthcoming FreeBSD kernel change.

### Description
SET_ERROR() can be implemented using a statement expression in a way that avoids making assumptions about SDT internals. OpenZFS uses statement expressions elsewhere in the kernel module, so I presume that doing so here is allowed.

### How Has This Been Tested?
Interactively, using `dtrace -n 'sdt:::set-error {printf("%d", args[0]); stack();}'` and using a kernel debugger to validate dtrace's output.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
