### PR TITLE
Linux 6.9 compat for ZFS 2.1.x

### DIFF
--- a/config/kernel-blkdev.m4
+++ b/config/kernel-blkdev.m4
@@ -54,6 +54,27 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV_BDEV_OPEN_BY_PATH], [
 	])
 ])
 
+
+dnl #
+dnl # 6.9.x API change
+dnl # bdev_file_open_by_path() replaces bdev_open_by_path()
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_BDEV_FILE_OPEN_BY_PATH], [
+	ZFS_LINUX_TEST_SRC([bdev_file_open_by_path], [
+		#include <linux/fs.h>
+		#include <linux/blkdev.h>
+	], [
+		struct file *bdev_file __attribute__ ((unused)) = NULL;
+		const char *path = "path";
+		fmode_t mode = 0;
+		void *holder = NULL;
+		struct blk_holder_ops h;
+
+		bdev_file = bdev_file_open_by_path(path, mode, holder, &h);
+	])
+])
+
+
 AC_DEFUN([ZFS_AC_KERNEL_BLKDEV_GET_BY_PATH], [
 	AC_MSG_CHECKING([whether blkdev_get_by_path() exists and takes 3 args])
 	ZFS_LINUX_TEST_RESULT([blkdev_get_by_path], [
@@ -73,7 +94,15 @@ AC_DEFUN([ZFS_AC_KERNEL_BLKDEV_GET_BY_PATH], [
 					[bdev_open_by_path() exists])
 				AC_MSG_RESULT(yes)
 			], [
-				ZFS_LINUX_TEST_ERROR([blkdev_get_by_path()])
+				AC_MSG_RESULT(no)
+				AC_MSG_CHECKING([whether bdev_file_open_by_path() exists])
+				ZFS_LINUX_TEST_RESULT([bdev_file_open_by_path], [
+					AC_DEFINE(HAVE_BDEV_FILE_OPEN_BY_PATH, 1,
+						[bdev_file_open_by_path() exists])
+					AC_MSG_RESULT(yes)
+				], [
+					ZFS_LINUX_TEST_ERROR([blkdev_get_by_path() or bdev_open_by_path() or bdev_file_open_by_path()])
+				])
 			])
 		])
 	])
@@ -621,6 +650,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV], [
 	ZFS_AC_KERNEL_SRC_BLKDEV_GET_BY_PATH
 	ZFS_AC_KERNEL_SRC_BLKDEV_GET_BY_PATH_4ARG
 	ZFS_AC_KERNEL_SRC_BLKDEV_BDEV_OPEN_BY_PATH
+	ZFS_AC_KERNEL_SRC_BDEV_FILE_OPEN_BY_PATH
 	ZFS_AC_KERNEL_SRC_BLKDEV_PUT
 	ZFS_AC_KERNEL_SRC_BLKDEV_PUT_HOLDER
 	ZFS_AC_KERNEL_SRC_BLKDEV_BDEV_RELEASE

--- a/config/kernel-blkdev.m4
+++ b/config/kernel-blkdev.m4
@@ -178,6 +178,20 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV_BDEV_RELEASE], [
 	])
 ])
 
+dnl #
+dnl # 6.9.x API change
+dnl # fput() replaces bdev_release()
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV_FPUT], [
+	ZFS_LINUX_TEST_SRC([fput], [
+		#include <linux/fs.h>
+		#include <linux/blkdev.h>
+	], [
+		struct file *f = NULL;
+		fput(f);
+	])
+])
+
 AC_DEFUN([ZFS_AC_KERNEL_BLKDEV_PUT], [
 	AC_MSG_CHECKING([whether blkdev_put() exists])
 	ZFS_LINUX_TEST_RESULT([blkdev_put], [
@@ -197,7 +211,14 @@ AC_DEFUN([ZFS_AC_KERNEL_BLKDEV_PUT], [
 				AC_DEFINE(HAVE_BDEV_RELEASE, 1,
 					[bdev_release() exists])
 			], [
-				ZFS_LINUX_TEST_ERROR([blkdev_put()])
+				ZFS_LINUX_TEST_RESULT([fput], [
+					AC_MSG_RESULT(yes)
+					AC_DEFINE(HAVE_BDEV_RELEASE_VIA_FPUT, 1,
+						[fput() can release a block device and exists]
+					)
+				], [
+					ZFS_LINUX_TEST_ERROR([blkdev_put()])
+				])
 			])
 		])
 	])
@@ -654,6 +675,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV], [
 	ZFS_AC_KERNEL_SRC_BLKDEV_PUT
 	ZFS_AC_KERNEL_SRC_BLKDEV_PUT_HOLDER
 	ZFS_AC_KERNEL_SRC_BLKDEV_BDEV_RELEASE
+	ZFS_AC_KERNEL_SRC_BLKDEV_FPUT
 	ZFS_AC_KERNEL_SRC_BLKDEV_REREAD_PART
 	ZFS_AC_KERNEL_SRC_BLKDEV_INVALIDATE_BDEV
 	ZFS_AC_KERNEL_SRC_BLKDEV_LOOKUP_BDEV

--- a/config/kernel-make-request-fn.m4
+++ b/config/kernel-make-request-fn.m4
@@ -50,6 +50,13 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_MAKE_REQUEST_FN], [
 		disk = blk_alloc_disk(NUMA_NO_NODE);
 	])
 
+	ZFS_LINUX_TEST_SRC([blk_alloc_disk_2args], [
+		#include <linux/blkdev.h>
+	],[
+		struct gendisk *disk __attribute__ ((unused));
+		disk = blk_alloc_disk(NULL, NUMA_NO_NODE);
+	])
+
 	ZFS_LINUX_TEST_SRC([blk_cleanup_disk], [
 		#include <linux/blkdev.h>
 	],[
@@ -71,30 +78,45 @@ AC_DEFUN([ZFS_AC_KERNEL_MAKE_REQUEST_FN], [
 		AC_DEFINE(HAVE_SUBMIT_BIO_IN_BLOCK_DEVICE_OPERATIONS, 1,
 		    [submit_bio is member of struct block_device_operations])
 
+		dnl
+		dnl # Linux 6.9 API change
+		dnl # blk_alloc_disk() takes 2 arguments:
+		dnl # a queue limit and NUMA node ID.
 		dnl #
-		dnl # Linux 5.14 API Change:
-		dnl # blk_alloc_queue() + alloc_disk() combo replaced by
-		dnl # a single call to blk_alloc_disk().
-		dnl #
-		AC_MSG_CHECKING([whether blk_alloc_disk() exists])
-		ZFS_LINUX_TEST_RESULT([blk_alloc_disk], [
+		AC_MSG_CHECKING([whether blk_alloc_disk() takes 2 args])
+		ZFS_LINUX_TEST_RESULT([blk_alloc_disk_2args], [
 			AC_MSG_RESULT(yes)
 			AC_DEFINE([HAVE_BLK_ALLOC_DISK], 1, [blk_alloc_disk() exists])
+			AC_DEFINE([HAVE_BLK_ALLOC_DISK_2ARGS], 1, [blk_alloc_disk() takes 2 args])
+			dnl # put_disk() should be used in 6.9.
+		], [
+			AC_MSG_RESULT(no)
 
 			dnl #
-			dnl # 5.20 API change,
-			dnl # Removed blk_cleanup_disk(), put_disk() should be used.
+			dnl # Linux 5.14 API Change:
+			dnl # blk_alloc_queue() + alloc_disk() combo replaced by
+			dnl # a single call to blk_alloc_disk().
 			dnl #
-			AC_MSG_CHECKING([whether blk_cleanup_disk() exists])
-			ZFS_LINUX_TEST_RESULT([blk_cleanup_disk], [
+			AC_MSG_CHECKING([whether blk_alloc_disk() exists])
+			ZFS_LINUX_TEST_RESULT([blk_alloc_disk], [
 				AC_MSG_RESULT(yes)
-				AC_DEFINE([HAVE_BLK_CLEANUP_DISK], 1,
-				    [blk_cleanup_disk() exists])
+				AC_DEFINE([HAVE_BLK_ALLOC_DISK], 1, [blk_alloc_disk() exists])
+
+				dnl #
+				dnl # 5.20 API change,
+				dnl # Removed blk_cleanup_disk(), put_disk() should be used.
+				dnl #
+				AC_MSG_CHECKING([whether blk_cleanup_disk() exists])
+				ZFS_LINUX_TEST_RESULT([blk_cleanup_disk], [
+					AC_MSG_RESULT(yes)
+					AC_DEFINE([HAVE_BLK_CLEANUP_DISK], 1,
+							[blk_cleanup_disk() exists])
+				], [
+					AC_MSG_RESULT(no)
+				])
 			], [
 				AC_MSG_RESULT(no)
 			])
-		], [
-			AC_MSG_RESULT(no)
 		])
 	],[
 		AC_MSG_RESULT(no)

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -263,6 +263,8 @@ vdev_blkdev_put(zfs_bdev_handle_t *bdh, spa_mode_t mode, void *holder)
 {
 #if defined(HAVE_BDEV_RELEASE)
 	return (bdev_release(bdh));
+#elif defined(HAVE_BDEV_RELEASE_VIA_FPUT)
+	return (fput(bdh));
 #elif defined(HAVE_BLKDEV_PUT_HOLDER)
 	return (blkdev_put(BDH_BDEV(bdh), holder));
 #else

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -874,7 +874,11 @@ zvol_alloc(dev_t dev, const char *name)
 
 #ifdef HAVE_SUBMIT_BIO_IN_BLOCK_DEVICE_OPERATIONS
 #ifdef HAVE_BLK_ALLOC_DISK
+#ifdef HAVE_BLK_ALLOC_DISK_2ARGS
+	zso->zvo_disk = blk_alloc_disk(NULL, NUMA_NO_NODE);
+#else
 	zso->zvo_disk = blk_alloc_disk(NUMA_NO_NODE);
+#endif
 	if (zso->zvo_disk == NULL)
 		goto out_kmem;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context

This brings Linux 6.9 compat for ZFS 2.1.x.

### Description

Applies the deprecations of upstream kernel.

### How Has This Been Tested?

**Untested at the moment.**

- I'm running a ZTS on Linux 6.9.5 (NixOS) right now.
- I will be running this on some production systems (<10TB).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
