### PR TITLE
Fix ZDB to dump projid for projectquota enabled

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -8905,6 +8905,19 @@ zdb_numeric(char *str)
 	return (B_TRUE);
 }
 
+static int
+dummy_get_file_info(dmu_object_type_t bonustype, const void *data,
+    zfs_file_info_t *zoi)
+{
+	(void) data, (void) zoi;
+
+	if (bonustype != DMU_OT_ZNODE && bonustype != DMU_OT_SA)
+		return (ENOENT);
+
+	(void) fprintf(stderr, "dummy_get_file_info: not implemented");
+	abort();
+}
+
 int
 main(int argc, char **argv)
 {
@@ -9220,6 +9233,7 @@ main(int argc, char **argv)
 		libzfs_core_fini();
 	}
 
+	dmu_objset_register_type(DMU_OST_ZFS, dummy_get_file_info);
 	kernel_init(SPA_MODE_READ);
 	kernel_init_done = B_TRUE;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
ZDB is supposed to dump "projid" via dump_znode(), when projectquota is enabled.

```
static void
dump_znode(objset_t *os, uint64_t object, void *data, size_t size) {
...
    if (dmu_objset_projectquota_enabled(os) && (pflags & ZFS_PROJID)) {
	uint64_t projid;

	if (sa_lookup(hdl, sa_attr_table[ZPL_PROJID], &projid,
	    sizeof (uint64_t)) == 0)
		(void) printf("\tprojid %llu\n", (u_longlong_t)projid);
    }
...
}
```

But its not dumping "projid", even for project quota enabled.

dmu_objset_projectquota_enabled() does following 3 checks,

```
boolean_t
dmu_objset_projectquota_enabled(objset_t *os)
{
        return (file_cbs[os->os_phys->os_type] != NULL &&
            DMU_PROJECTUSED_DNODE(os) != NULL &&
            spa_feature_is_enabled(os->os_spa,
		SPA_FEATURE_PROJECT_QUOTA));
}
```

It fails on file_cbs[] check. file_cbs[] gets initialised via dmu_objset_register_type(); which is not done for the ZDB, its done for the kernel via zfs_init().

Register a dummy callback handle for the DMU_OST_ZFS type in ZDB main() function to dump the projid for projectquota enabled.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
```
$ zfs list
NAME             USED  AVAIL  REFER  MOUNTPOINT
mytestpool       179K   832M    25K  /mytestpool
mytestpool/fs1    25K   832M    25K  /mytestpool/fs1
$ ls -i /mytestpool/fs1/file1
2 /mytestpool/fs1/file1
$ sudo zfs project /mytestpool/fs1/file1
  100 - /mytestpool/fs1/file1
$
```

zdb dump of ino 2 without fix doesn't list projid field.

```
$ sudo zdb -ddddd mytestpool/fs1 2
Dataset mytestpool/fs1 [ZPL], ID 144, cr_txg 11, 25K, 9 objects, rootbp DVA[0]=<0:2c00bc00:200> DVA[1]=<0:3000bc00:200> [L0 DMU objset] fletcher4 lz4 unencrypted LE contiguous unique double size=1000L/200P birth=178L/178P fill=9 cksum=000000117b3a1df4:000005f259dca352:000111b9fd9582ee:002278be1dfbd514

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         2    1   128K    512      0     512    512    0.00  ZFS plain file
                                               184   bonus  System attributes
        dnode flags: USERUSED_ACCOUNTED USEROBJUSED_ACCOUNTED
        dnode maxblkid: 0
        path    /file1
        uid     0
        gid     0
        atime   Sat Jun 22 13:03:02 2024
        mtime   Sat Jun 22 13:03:02 2024
        ctime   Sat Jun 22 13:03:02 2024
        crtime  Sat Jun 22 13:03:02 2024
        gen     56
        mode    100600
        size    0
        parent  34
        links   1
        pflags  840800000004
        xattr   3
Indirect blocks:
```

zdb dump of ino 2 with Fix lists projid field.

```
$ sudo ./zdb -ddddd mytestpool/fs1 2
Dataset mytestpool/fs1 [ZPL], ID 144, cr_txg 11, 25K, 9 objects, rootbp DVA[0]=<0:2c00bc00:200> DVA[1]=<0:3000bc00:200> [L0 DMU objset] fletcher4 lz4 unencrypted LE contiguous unique double size=1000L/200P birth=178L/178P fill=9 cksum=000000117b3a1df4:000005f259dca352:000111b9fd9582ee:002278be1dfbd514

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         2    1   128K    512      0     512    512    0.00  ZFS plain file
                                               184   bonus  System attributes
        dnode flags: USERUSED_ACCOUNTED USEROBJUSED_ACCOUNTED
        dnode maxblkid: 0
        path    /file1
        uid     0
        gid     0
        atime   Sat Jun 22 13:03:02 2024
        mtime   Sat Jun 22 13:03:02 2024
        ctime   Sat Jun 22 13:03:02 2024
        crtime  Sat Jun 22 13:03:02 2024
        gen     56
        mode    100600
        size    0
        parent  34
        links   1
        pflags  840800000004
        projid  100
        xattr   3
Indirect blocks:
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
