### PR TITLE
Fix zdb man page for -O

### DIFF
--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -314,7 +314,6 @@ fragmentation,
 and free space histogram, as well as overall pool fragmentation and histogram.
 .It Fl MM
 "Special" vdevs are added to -M's normal output.
-.It Fl O , -object-lookups Ns = Ns Ar dataset path
 Also display information about the maximum contiguous free space and the
 percentage of free space in each space map.
 .It Fl MMM
@@ -327,7 +326,7 @@ but force zdb to interpret the
 in
 .Op Ar poolname Ns Op / Ns Ar dataset Ns | Ns Ar objset-ID
 as a numeric objset ID.
-.It Fl O Ar dataset path
+.It Fl O , -object-lookups Ns = Ns Ar dataset path
 Look up the specified
 .Ar path
 inside of the


### PR DESCRIPTION
Sponsored-by: Klara, Inc.
Sponsored-By: Wasabi Technology, Inc.

### Motivation and Context
A customer noticed that the man page for `zdb` described -O twice, with different meanings

### Description
It looks like a mis-merge from when -N was added after longopts were added, and a chunk of text that is meant to describe what else -MM does got mis-attributed to -O.

The mis-merge also ended up not describing the longopt version in the item that actually describes what -O does

### How Has This Been Tested?
Viewing the man page

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
