### PR TITLE
Fix null ptr deref when renaming a zvol with snaps and snapdev=visible

### DIFF
--- a/module/zfs/dataset_kstats.c
+++ b/module/zfs/dataset_kstats.c
@@ -201,6 +201,9 @@ dataset_kstats_destroy(dataset_kstats_t *dk)
 void
 dataset_kstats_rename(dataset_kstats_t *dk, const char *name)
 {
+	if (dk->dk_kstats == NULL)
+		return;
+
 	dataset_kstat_values_t *dkv = dk->dk_kstats->ks_data;
 	char *ds_name;
 


### PR DESCRIPTION
### Motivation and Context

Fixes #16274 (a regression introduced by #15486). The issue affects stable releases beginning with 2.2.3.

### Description

Adds a simple NULL check to `dataset_kstats_rename` so that when the function is called for a snapshot (which do not have kstats allocated for them, at least at present), nothing is done.

This fix should have the additional bonus of "just doing the right thing" in the event that things ever change such that kstats _are_ allocated for snapshots: in that case, the NULL check would no longer bail out of the function, and it would instead update the `dataset_name` kstat value for the zvol snapshot in question.

### How Has This Been Tested?
As mentioned over in #16274, I applied the patch here to my own local build of zfs pretty early on, and it was effective at preventing the bug from occurring: I was then able to rename snapshotted zvols with `snapdev=visible` as much as I wanted, without any kthread fatalities or zvol-related stuff hanging indefinitely.

The problem is consistent and very easy to reproduce. I provided some slightly more detailed steps over in the issue thread, but it's really just as simple as:
1. Create pool
2. Create zvol
3. Ensure the zvol has `snapdev=visible`
4. Ensure the zvol has one or more snapshots
5. Do `zfs rename` on the zvol

@asomers helpfully verified that the bug affects FreeBSD too, and that this patch fixes things appropriately there as well.

I suppose that I could also test a build of zfs where I disable the snapshot ignore logic at the beginning of `dataset_kstats_create`, to double-check the assertion I made earlier that this patch would "just work", and cause kstats-for-snapshots-of-zvols to reflect renames properly, in the event that such kstats should ever exist. I haven't actually gone ahead and done this though. Let me know if that's something you'd like me to do.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] **(N/A)** I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] **(See comment below)** I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] **(GitHub CI only)** I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

I haven't run the test suite myself, but I've let GitHub Actions run it.