### PR TITLE
Fix  name of module parameter in man page

### DIFF
--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1639,7 +1639,7 @@ then only metadata are prefetched.
 The default value is
 .Sy all .
 .Pp
-Please note that the module parameter zfs_disable_prefetch=1 can
+Please note that the module parameter zfs_prefetch_disable=1 can
 be used to totally disable speculative prefetch, bypassing anything
 this property does.
 .It Sy setuid Ns = Ns Sy on Ns | Ns Sy off


### PR DESCRIPTION
The ZFS module parameter name is zfs_prefetch_disable, not zfs_disable_prefetch.

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
The man page mentioned a module parameter that is not correct.

### Description
Change the name of the ZFS module parameter in the man page from zfs_disable_prefetch to the actual parameter name of zfs_prefetch_disable.  This was introduced in #15436

### How Has This Been Tested?
Documentation update.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ x ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ x ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
