### PR TITLE
abd: lift ABD zero scan from `zio_compress_data()` to `abd_cmp_zero()`

### DIFF
--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -137,6 +137,7 @@ void abd_copy_from_buf_off(abd_t *, const void *, size_t, size_t);
 void abd_copy_to_buf_off(void *, abd_t *, size_t, size_t);
 int abd_cmp(abd_t *, abd_t *);
 int abd_cmp_buf_off(abd_t *, const void *, size_t, size_t);
+int abd_cmp_zero_off(abd_t *, size_t, size_t);
 void abd_zero_off(abd_t *, size_t, size_t);
 void abd_verify(abd_t *);
 
@@ -181,6 +182,12 @@ static inline void
 abd_zero(abd_t *abd, size_t size)
 {
 	abd_zero_off(abd, 0, size);
+}
+
+static inline int
+abd_cmp_zero(abd_t *abd, size_t size)
+{
+	return (abd_cmp_zero_off(abd, 0, size));
 }
 
 /*

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -1051,6 +1051,31 @@ abd_cmp(abd_t *dabd, abd_t *sabd)
 }
 
 /*
+ * Check if ABD content is all-zeroes.
+ */
+static int
+abd_cmp_zero_off_cb(void *data, size_t len, void *private)
+{
+	(void) private;
+
+	/* This function can only check whole uint64s. Enforce that. */
+	ASSERT0(P2PHASE(len, 8));
+
+	uint64_t *end = (uint64_t *)((char *)data + len);
+	for (uint64_t *word = (uint64_t *)data; word < end; word++)
+		if (*word != 0)
+			return (1);
+
+	return (0);
+}
+
+int
+abd_cmp_zero_off(abd_t *abd, size_t off, size_t size)
+{
+	return (abd_iterate_func(abd, off, size, abd_cmp_zero_off_cb, NULL));
+}
+
+/*
  * Iterate over code ABDs and a data ABD and call @func_raidz_gen.
  *
  * @cabds          parity ABDs, must have equal size


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

In #16323 I made all compression users call `zio_compress_data()` rather than doing their own bounce through `zio_compress_table`. It was (rightly) pointed out that this meant things that were not getting hole detection/flattening before now would.

For now I've reverted that change there. This PR is how I think I want to tackle that particular interface quirk though,

### Description

This lifts the zero-detection code from inside `zio_compress_data()` into `abd_cmp_zero()` and `abd_cmp_zero_off()`, matching the interface of the other `abd_cmp_*` functions.

It's now the caller's responsibility do special handling for holes if that's something it wants.

All call sites have been checked and updated where necessary. The ones that haven't been touched are believed to either be impossible to have fully-zero data for input, or already did not properly handle a zero return from `abd_compress_data()`.

### How Has This Been Tested?

`compression` and `rsend` test tags pass successfully.

### Types of changes<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
