### PR TITLE
Add support for multiple lines to the sharenfs property for FreeBSD

### DIFF
--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -38,7 +38,7 @@
 .\" Copyright (c) 2019, Kjeld Schouten-Lebbing
 .\" Copyright (c) 2022 Hewlett Packard Enterprise Development LP.
 .\"
-.Dd August 8, 2023
+.Dd June 29, 2024
 .Dt ZFSPROPS 7
 .Os
 .
@@ -1726,6 +1726,18 @@ Please note that the options are comma-separated, unlike those found in
 .Xr exports 5 .
 This is done to negate the need for quoting, as well as to make parsing
 with scripts easier.
+.Pp
+For
+.Fx ,
+there may be multiple sets of options separated by semicolon(s).
+Each set of options must apply to different hosts or networks and each
+set of options will create a separate line for
+.Xr exports 5 .
+Any semicolon separated option set that consists entirely of whitespace
+will be ignored.
+This use of semicolons is only for
+.Fx
+at this time.
 .Pp
 See
 .Xr exports 5


### PR DESCRIPTION
There has been a bugzilla PR#147881 requesting this for a long time (14 years!). It extends the syntax of the ZFS shanenfs property (for FreeBSD only) to allow multiple sets of options for different hosts/nets, separated by ';'s.

Signed-off-by:	Rick Macklem <rmacklem@FreeBSD.org>

### Motivation and Context
On FreeBSD, exports with separate sets of options can be provided for the
same file system for different hosts/subnets.  A FreeBSD bugzilla PR to allow ZFS's sharenfs
property to do this has existed for 14years.

### Description
Allows multiple sets of export options to be expressed in the sharenfs property
separated by semicolons.  Each set generates a line in /etc/zfs/exports.
The patch also replaces the use of arrays of size OPTSSIZE with malloc'd arrays
to hold the option lists.  This change was suggested by mav@freebsd.org.

### How Has This Been Tested?
A variety of settings for the sharenfs property, with and without semicolons in
it were tried on FreeBSD and the resultant /etc/zfs/exports was checked for
correctness.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x ] I have updated the documentation accordingly.
- [x ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x ] I have run the ZFS Test Suite with this change applied.
- [x ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
