### PR TITLE
ZTS: handle FreeBSD version numbers correctly

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -62,11 +62,39 @@ function compare_version_gte
 }
 
 # Helper function used by linux_version() and freebsd_version()
+# $1, if provided, should be a MAJOR, MAJOR.MINOR or MAJOR.MINOR.PATCH
+# version number
 function kernel_version
 {
 	typeset ver="$1"
 
-	[ -z "$ver" ] && ver=$(uname -r | grep -Eo "^[0-9]+\.[0-9]+\.[0-9]+")
+	[ -z "$ver" ] && case "$UNAME" in
+	Linux)
+		# Linux version numbers are X.Y.Z followed by optional
+		# vendor/distro specific stuff
+		#   RHEL7:       3.10.0-1160.108.1.el7.x86_64
+		#   Fedora 37:   6.5.12-100.fc37.x86_64
+		#   Debian 12.6: 6.1.0-22-amd64
+		ver=$(uname -r | grep -Eo "^[0-9]+\.[0-9]+\.[0-9]+")
+		;;
+	FreeBSD)
+		# FreeBSD version numbers are X.Y-BRANCH-pZ. Depending on
+		# branch, -pZ may not be present, but this is typically only
+		# on pre-release or true .0 releases, so can be assumed 0
+		# if not present.
+		# eg:
+		#   13.2-RELEASE-p4
+		#   14.1-RELEASE
+		#   15.0-CURRENT
+		ver=$(uname -r | \
+		    grep -Eo "[0-9]+\.[0-9]+(-[A-Z0-9]+-p[0-9]+)?" | \
+		    sed -E "s/-[^-]+-p/./")
+		;;
+	*)
+		# Unknown system
+		log_fail "Don't know how to get kernel version for '$UNAME'"
+		;;
+	esac
 
 	typeset version major minor _
 	IFS='.' read -r version major minor _ <<<"$ver"


### PR DESCRIPTION
### Motivation and Context

@mcmilk wondered why the "FreeBSD 14+" version tests in the block cloning tests were failing. This is at least part of why!

### Description

FreeBSD kernel version numbers (ie the output from `uname -r`) don't match the Linux format; the patchlevel is expressed differently. This sets up OS-specific checks.

### How Has This Been Tested?

By hand on CentOS 7, Fedora 37 and Debian 12.6, and FreeBSD 13.2-RELEASE-p4, 14.0-RELEASE and 15.0-CURRENT.

Note "by hand": I ran ksh, pasted in the `kernel_version` function, set `UNAME`, then called `kernel_version` and eyeballed output. I don't have ZTS on most of these systems so it hasn't been used for real.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
