### PR TITLE
zvol: ensure device minors are properly cleaned up

### DIFF
--- a/include/sys/zvol_impl.h
+++ b/include/sys/zvol_impl.h
@@ -24,16 +24,9 @@
 
 #include <sys/zfs_context.h>
 
-#define	ZVOL_RDONLY	0x1
-/*
- * Whether the zvol has been written to (as opposed to ZVOL_RDONLY, which
- * specifies whether or not the zvol _can_ be written to)
- */
-#define	ZVOL_WRITTEN_TO	0x2
-
-#define	ZVOL_DUMPIFIED	0x4
-
-#define	ZVOL_EXCL	0x8
+#define	ZVOL_RDONLY	(1<<0)	/* zvol is readonly (writes rejected) */
+#define	ZVOL_WRITTEN_TO	(1<<1)	/* zvol has been written to (needs flush) */
+#define	ZVOL_EXCL	(1<<2)	/* zvol has O_EXCL client right now */
 
 /*
  * The in-core state of each volume.

--- a/include/sys/zvol_impl.h
+++ b/include/sys/zvol_impl.h
@@ -18,6 +18,9 @@
  *
  * CDDL HEADER END
  */
+/*
+ * Copyright (c) 2024, Klara, Inc.
+ */
 
 #ifndef	_SYS_ZVOL_IMPL_H
 #define	_SYS_ZVOL_IMPL_H
@@ -27,6 +30,7 @@
 #define	ZVOL_RDONLY	(1<<0)	/* zvol is readonly (writes rejected) */
 #define	ZVOL_WRITTEN_TO	(1<<1)	/* zvol has been written to (needs flush) */
 #define	ZVOL_EXCL	(1<<2)	/* zvol has O_EXCL client right now */
+#define	ZVOL_REMOVING	(1<<3)	/* zvol waiting to remove minor */
 
 /*
  * The in-core state of each volume.
@@ -50,6 +54,7 @@ typedef struct zvol_state {
 	kmutex_t		zv_state_lock;	/* protects zvol_state_t */
 	atomic_t		zv_suspend_ref;	/* refcount for suspend */
 	krwlock_t		zv_suspend_lock;	/* suspend lock */
+	kcondvar_t		zv_removing_cv;	/* ready to remove minor */
 	struct zvol_state_os	*zv_zso;	/* private platform state */
 	boolean_t		zv_threading;	/* volthreading property */
 } zvol_state_t;

--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -30,6 +30,7 @@
  * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
+ * Copyright (c) 2024, Klara, Inc.
  */
 
 /* Portions Copyright 2011 Martin Matuska <mm@FreeBSD.org> */
@@ -250,7 +251,7 @@ retry:
 	}
 
 	mutex_enter(&zv->zv_state_lock);
-	if (zv->zv_zso->zso_dying) {
+	if (zv->zv_zso->zso_dying || zv->zv_flags & ZVOL_REMOVING) {
 		rw_exit(&zvol_state_lock);
 		err = SET_ERROR(ENXIO);
 		goto out_zv_locked;
@@ -682,6 +683,11 @@ zvol_geom_bio_strategy(struct bio *bp)
 	}
 
 	rw_enter(&zv->zv_suspend_lock, ZVOL_RW_READER);
+
+	if (zv->zv_flags & ZVOL_REMOVING) {
+		error = SET_ERROR(ENXIO);
+		goto resume;
+	}
 
 	switch (bp->bio_cmd) {
 	case BIO_READ:
@@ -1362,6 +1368,7 @@ zvol_os_free(zvol_state_t *zv)
 	}
 
 	mutex_destroy(&zv->zv_state_lock);
+	cv_destroy(&zv->zv_removing_cv);
 	dataset_kstats_destroy(&zv->zv_kstat);
 	kmem_free(zv->zv_zso, sizeof (struct zvol_state_os));
 	kmem_free(zv, sizeof (zvol_state_t));
@@ -1419,6 +1426,7 @@ zvol_os_create_minor(const char *name)
 	zv = kmem_zalloc(sizeof (*zv), KM_SLEEP);
 	zv->zv_hash = hash;
 	mutex_init(&zv->zv_state_lock, NULL, MUTEX_DEFAULT, NULL);
+	cv_init(&zv->zv_removing_cv, NULL, CV_DEFAULT, NULL);
 	zv->zv_zso = kmem_zalloc(sizeof (struct zvol_state_os), KM_SLEEP);
 	zv->zv_volmode = volmode;
 	if (zv->zv_volmode == ZFS_VOLMODE_GEOM) {

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2012, 2020 by Delphix. All rights reserved.
+ * Copyright (c) 2024, Klara, Inc.
  */
 
 #include <sys/dataset_kstats.h>
@@ -526,6 +527,11 @@ zvol_request_impl(zvol_state_t *zv, struct bio *bio, struct request *rq,
 	uint64_t size = io_size(bio, rq);
 	int rw = io_data_dir(bio, rq);
 
+	if (unlikely(zv->zv_flags & ZVOL_REMOVING)) {
+		END_IO(zv, bio, rq, -SET_ERROR(ENXIO));
+		goto out;
+	}
+
 	if (zvol_request_sync || zv->zv_threading == B_FALSE)
 		force_sync = 1;
 
@@ -734,6 +740,13 @@ retry:
 	}
 
 	mutex_enter(&zv->zv_state_lock);
+
+	if (unlikely(zv->zv_flags & ZVOL_REMOVING)) {
+		mutex_exit(&zv->zv_state_lock);
+		rw_exit(&zvol_state_lock);
+		return (-SET_ERROR(ENXIO));
+	}
+
 	/*
 	 * Make sure zvol is not suspended during first open
 	 * (hold zv_suspend_lock) and respect proper lock acquisition
@@ -1313,6 +1326,7 @@ zvol_alloc(dev_t dev, const char *name)
 
 	list_link_init(&zv->zv_next);
 	mutex_init(&zv->zv_state_lock, NULL, MUTEX_DEFAULT, NULL);
+	cv_init(&zv->zv_removing_cv, NULL, CV_DEFAULT, NULL);
 
 #ifdef HAVE_BLK_MQ
 	zv->zv_zso->use_blk_mq = zvol_use_blk_mq;
@@ -1438,6 +1452,7 @@ zvol_os_free(zvol_state_t *zv)
 	ida_simple_remove(&zvol_ida,
 	    MINOR(zv->zv_zso->zvo_dev) >> ZVOL_MINOR_BITS);
 
+	cv_destroy(&zv->zv_removing_cv);
 	mutex_destroy(&zv->zv_state_lock);
 	dataset_kstats_destroy(&zv->zv_kstat);
 

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -730,7 +730,7 @@ retry:
 #endif
 	if (zv == NULL) {
 		rw_exit(&zvol_state_lock);
-		return (SET_ERROR(-ENXIO));
+		return (-SET_ERROR(ENXIO));
 	}
 
 	mutex_enter(&zv->zv_state_lock);
@@ -795,10 +795,10 @@ retry:
 
 #ifdef HAVE_BLKDEV_GET_ERESTARTSYS
 				schedule();
-				return (SET_ERROR(-ERESTARTSYS));
+				return (-SET_ERROR(ERESTARTSYS));
 #else
 				if ((gethrtime() - start) > timeout)
-					return (SET_ERROR(-ERESTARTSYS));
+					return (-SET_ERROR(ERESTARTSYS));
 
 				schedule_timeout_interruptible(
 					MSEC_TO_TICK(10));
@@ -821,7 +821,7 @@ retry:
 			if (zv->zv_open_count == 0)
 				zvol_last_close(zv);
 
-			error = SET_ERROR(-EROFS);
+			error = -SET_ERROR(EROFS);
 		} else {
 			zv->zv_open_count++;
 		}

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -350,10 +350,6 @@ elif sys.platform.startswith('linux'):
         'mmp/mmp_active_import': ['FAIL', known_reason],
         'mmp/mmp_exported_import': ['FAIL', known_reason],
         'mmp/mmp_inactive_import': ['FAIL', known_reason],
-        'zvol/zvol_misc/zvol_misc_fua': ['SKIP', 14872],
-        'zvol/zvol_misc/zvol_misc_snapdev': ['FAIL', 12621],
-        'zvol/zvol_misc/zvol_misc_trim': ['SKIP', 14872],
-        'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', known_reason],
     })
 
 # Not all Github actions runners have scsi_debug module, so we may skip

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_fua.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_fua.ksh
@@ -45,15 +45,6 @@ fi
 
 if ! is_linux ; then
 	log_unsupported "Only linux supports dd with oflag=dsync for FUA writes"
-else
-	if [[ $(linux_version) -gt $(linux_version "6.2") ]]; then
-		log_unsupported "Disabled while issue #14872 is being worked"
-	fi
-
-	# Disabled for the CentOS 9 kernel
-	if [[ $(linux_version) -eq $(linux_version "5.14") ]]; then
-		log_unsupported "Disabled while issue #14872 is being worked"
-	fi
 fi
 
 typeset datafile1="$(mktemp zvol_misc_fua1.XXXXXX)"

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_trim.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_trim.ksh
@@ -44,15 +44,6 @@
 verify_runnable "global"
 
 if is_linux ; then
-	if [[ $(linux_version) -gt $(linux_version "6.2") ]]; then
-		log_unsupported "Disabled while issue #14872 is being worked"
-	fi
-
-	# Disabled for the CentOS 9 kernel
-	if [[ $(linux_version) -eq $(linux_version "5.14") ]]; then
-		log_unsupported "Disabled while issue #14872 is being worked"
-	fi
-
 	# We need '--force' here since the prior tests may leave a filesystem
 	# on the zvol, and blkdiscard will see that filesystem and print a
 	# warning unless you force it.


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

While running the test suite to validate a ZIL change, I kept tripping #14872. Since it was important to me to ensure that I wasn't inadvertently making a bad situation worse, I decided I had to understand that issue first, and ideally fix it.

#14872 is not actually related to the ZIL; the assertion is just thing that noticed a problem at the end of a sequence of "impossible" events. This PR is attempting to tackle the root cause.

I should say that I am pretty unfamiliar with the zvol code, and since this was definitely not on my main quest line, I have not been as diligent with my research as I usually am. So I'll explain what I think is happening first, then talk about the patches and how they attempt to sort it out.

Fixes #14872.
May also fix #12621, #12733.

---

So as far as ZFS is concerned, a device node in `/dev` is for zvols what a mount is for filesystems: some connection point that makes a certain type of dataset available to the rest of the system. That is, creating or destroying a device node (what the code calls a "minor") is roughly analogous to mounting or unmounting a filesystem.

The equivalent to “unmounting” is ultimately handled in `zvol_remove_minors_impl()` and `zvol_remove_minor_impl()`, which are effectively identical; one just loops over all the zvols, the other just for a single zvol. They remove the node from `/dev`, remove the associated `zvol_state_t` from `zvol_global_list`, free up the block device resources in the kernel and release any other memory.

These functions contain this check:

```c
		/* If in use, leave alone */
		if (zv->zv_open_count > 0 ||
			atomic_read(&zv->zv_suspend_ref)) {
				mutex_exit(&zv->zv_state_lock);
				continue;
		}
```

As the comment says, if the zvol is in use (someone has called `open()`) or has been suspended (incoming requests held, used during rollback and recv), then it is skipped.

The key problem here is that nothing ever comes back to actually remove the minor, so there’s a live node in `/dev` at a time when ZFS believes it’s gone.

Happily, there’s not many cases where this matters in practice. Minors are removed when changing the `volmode` and `snapdev` properties, and when renaming a volume. Since the effect of `open()`'ing a zvol device node is a name->`objset_t` lookup, the worst case is that you get a handle on a block device that used to be available by that name, or you get nothing because it no longer exists.

At pool export, it’s a different matter. At the top of `spa_export_common()`, we see:

```c
	if (spa->spa_zvol_taskq) {
		zvol_remove_minors(spa, spa_name(spa), B_TRUE);
		taskq_wait(spa->spa_zvol_taskq);
	}
```

The `zvol_remove_minors()` call creates a task that calls `zvol_remove_minors_impl()`, and then waits until the the taskq it knows it will be dispatched on becomes empty. As above, if the zvol is in use at this moment, it is skipped, and ZFS continues with the export with the device node still visible place, and, crucially, a `zvol_state_t` for that zvol on the global `zvol_state_list`.

There is a check a little further down in `spa_export_common()` to prevent export if the pool is still in use:

```c
        /*
         * A pool cannot be exported or destroyed if there are active
         * references.  If we are resetting a pool, allow references by
         * fault injection handlers.
         */
        if (!spa_refcount_zero(spa) || (spa->spa_inject_ref != 0)) {
                error = SET_ERROR(EBUSY);
                goto fail;
        }
```

However, it’s trivial to closing the last reference between after minor removal is skipped but before this check; there’s real work and possibly a whole transaction sync in that time.

So at this point there’s a device node in `/dev`, with the “old” `zvol_state_t` behind it. Remarkably, an attempt to open it at this point will make it as far as `dmu_objset_own()`. The pool hold will fail, because the pool isn’t there, so `ENOENT` will come back up and the open will be rejected.

And if the pool is reimported? Well. The named objset probably actually exists now, so we now have this extraordinarily strange situation where the `zvol_state_t` from the previous import of the pool is being used for the current import. A very vague description of the result is that the zvol state and the pool state look more-or-less right to each other, so they mostly accept each other, but they are not what they seem, and may perform strangely.

---

#14872 is merely a symptom of all this; something noticing the strange behaviour. It goes like this.

`zvol_misc_trim` and `zvol_misc_fua` both arrange for a write (a TRIM counts as a write for these purposes) to be issued very late in the pool’s lifecycle. In this case the kernel itself is actually the client; the filesystem on top of the zvol has been written to, and the kernel is flushing it.

At export, the minor is removed, but the kernel has the device open, so it gets skipped, and the kernel can continue. It’s issuing sync writes, which of course go to the ZIL. If the timing is just right, these writes can continue after the call to `txg_wait_synced()` in `spa_export_common()`. Since the next txg doesn’t pass, these writes are only on the ZIL attached to the zvol dataset.

At import, the ZIL blocks are found on the zvol dataset, and the claim is issued, setting `zh_claim_txg`. The ZIL now must be replayed before the dataset can be used. The assertion `ASSERT(zh->zh_claim_txg == 0)` in `zil_create()` ensures this, as the only thing that can zero `zh_claim_txg` is `zil_sync()` with `zl_destroy_txg` set, and that is only done by `zil_replay()`.

ZIL replay is done at “mount” time, which for a zvol is when the minor is created. This happens in `zvol_os_create_minor()`, which is called from `zvol_create_minors_recursive()` during import. Early on, this calls `zvol_find_by_name_hash()` to see if the `zvol_state_t` already exists for the name. It finds the one left over from the previous pool run, and so just returns, because the minor already exists. Because of that, it never gets to calling `zil_replay()`.

Soon, a write happens. `zvol_write()` calls `zil_commit()`, which calls `zil_create()`, and the unprocessed claim is discovered, and the assertion tripped.

### Description

First things first: the first two commits are trivial cleanup. They could easily stand alone, and I will break them into a separate PR if wanted. Meanwhile, the final commit is just re-enabling the disabled `zvol_misc` tests that this should fix.

The real meat is in the third commit.

If the minor is not in use at the moment we check it, nothing changes - it just gets cleaned up on the spot.

If it is in use however, the behaviour changes. Instead of skipping the zvol, a new flag `ZVOL_REMOVING` gets set on the `zvol_state_t`, and then arrangements are made for something to wait on a new per-zvol condvar `zv_removing_cv`. When the last user finishes, if the flag is set, this condvar will be signaled and the waiter will go on to do the removal.

Since we know we’re about to wait, we want to throw off any new clients. So `ZVOL_REMOVING` also causes new open or IO requests to return `ENXIO` immediately.

For `zvol_remove_minor_impl()`, the calling thread immediately starts waiting. This is a utility function that implements the minor removal for `snapdev` and `volmode` changes and volume rename, which are all admin actions, so blocking the thread won’t affect anything else.

For `zvol_remove_minors_impl()` this is a little more complicated. This is always called on a task running from `spa_zvol_taskq`, and it runs through all the matching zvols on a loop. Rather than wait on the spot, we set `ZVOL_REMOVING` immediately and then dispatched a new task on that queue that immediately goes to sleep waiting for its zvol to finish.

The `zvol_remove_minors_impl()` task is dispatched from `zvol_remove_minors()`, which is always called with its `async` flag set, and only one of its callers actually cares about waiting for the minors to be removed. That caller is the snippet of`spa_export_common()` shown earlier, and it waits for `spa_zvol_taskq` to be empty, and so will end up waiting until all minors are gone before completing the export.

#### Notes

Having spent some time in this code, there’s a lot I don’t love about about how it does its async work. However, as noted above, I really don’t have time for anything more here at the moment, so what I’ve done is kind of the first step towards the improvements I’d like to do, while still solving the immediate problem.

* It seems like in general there’s a lot of stuff that can go wrong that isn’t considered at all, usually through `void` returns. I’d want to check everything and make sure failures are sensible. This seems particularly important when there’s sequences
* `zvol_remove_minors()` and `zvol_rename_minors()` both have an “async” flag option that is _always_ set. This is pointless. This also means that I’ve technically broken sync `zvol_remove_minors()`, because it only waits for the initial task to complete, not any followups. I decided for this that I didn’t care; the one place that might benefit from it (`spa_export_common`) is already doing its own thing to sync up. I could have just done a `delay_list` in `zvol_remove_minors_impl()` like I did in `zvol_remove_minor_impl()`, but I suspect in the long run a taskq is more likely to be a better model.
* While this generally should be more robust, there’s still probably cases where the caller really should wait until the remove is done before proceeding. I have not considered these cases at all; this analysis is hard work and has gone on long enough anyway.
* If its possible to remove the device nodes without removing the device as such, there might be a better structure where we can do this every time immediately and then clean up at our leisure.
* Waiting “forever” at export might be too much; its quite possible for a caller to hold the device open. I don’t think a timeout is really the right thing here; maybe it could time out and return `EBUSY`, or maybe there could be a more forcible detach.

As with everything, I’ll get to it someday. For now, hopefully what’s here is enough to solve the problem at hand. If someone else wants a project, please take it on with my blessing :grimacing:



### How Has This Been Tested?

All testing done on Linux.

`zvol_misc` test tag has been run a few hundred times on kernel 6.1.94. Previously it would trip the assert described in #14872 after `zvol_misc_trim` and/or `zvol_misc_fua` maybe four out of five runs. Since then, no hits.

`zvol` test tag has been run a few dozen times, all passes. Full ZTS run twice, also all passes (modulo normal test suite flakiness).

Meanwhile on FreeBSD, this has been compile checked only. The OS-specific changes are very small and conceptually identical to the Linux one, so I just followed the local style. Obviously needs a test, which I will try to do myself, but I’d appreciate it if someone could take a closer look.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).