### PR TITLE
ZTS: Change cp_stress to fit timings

### DIFF
--- a/tests/zfs-tests/tests/functional/cp_files/cp_stress.ksh
+++ b/tests/zfs-tests/tests/functional/cp_files/cp_stress.ksh
@@ -57,13 +57,8 @@ MYPWD="$PWD"
 cd /$TESTPOOL/cp_stress
 CPUS=$(get_num_cpus)
 
-if is_freebsd ; then
-	# 'seekflood' takes longer on FreeBSD and can timeout the test
-	RUNS=3
-else
-	RUNS=10
-fi
-
+# should run in ~2 minutes on Linux and FreeBSD
+RUNS=3
 for i in $(seq 1 $RUNS) ; do
 	# Each run takes around 12 seconds.
 	log_must $STF_SUITE/tests/functional/cp_files/seekflood 2000 $CPUS


### PR DESCRIPTION

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

cp_stress is getting killed on the new QEMU-based github runners we're developing. The problem is that the Linux based runners should do 10 RUNS, where the FreeBSD based runners only have 3 RUNS to succeed.


### Description

This patch removes this different handling of Linux and FreeBSD. The cp_stress test is running fine in around 2 minutes now.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
