### PR TITLE
Handle current UBSAN errors on Fedora 39 and Fedora 40

### DIFF
--- a/include/sys/sa_impl.h
+++ b/include/sys/sa_impl.h
@@ -177,7 +177,7 @@ typedef struct sa_hdr_phys {
 	 *
 	 */
 	uint16_t sa_layout_info;
-	uint16_t sa_lengths[1];	/* optional sizes for variable length attrs */
+	uint16_t sa_lengths[];	/* optional sizes for variable length attrs */
 	/* ... Data follows the lengths.  */
 } sa_hdr_phys_t;
 


### PR DESCRIPTION

### Motivation and Context

The fixed size array sa_lengths[1] is used dynamicly and UBSAN warns about it:

```
[ 1110.124477] ------------[ cut here ]------------
[ 1110.126140] UBSAN: array-index-out-of-bounds in .../sa.c:766:21
[ 1110.130745] index 1 is out of range for type 'uint16_t [1]'

[ 1110.406282] UBSAN: array-index-out-of-bounds in .../sa.c:1934:29
[ 1110.411905] index 1 is out of range for type 'uint16_t [1]'

[ 1110.817251] UBSAN: array-index-out-of-bounds in .../sa.c:1734:24
[ 1110.821635] index 1 is out of range for type 'uint16_t [1]'

```
### Description

Fix the header file and make sa_lengths variable: sa_lengths[1] -> sa_lengths[]

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
