### PR TITLE
ZTS: Make do_vol_test() more deterministic

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies.kshlib
@@ -84,7 +84,8 @@ function do_vol_test
 	vol=$TESTPOOL/$TESTVOL1
 	vol_b_path=$ZVOL_DEVDIR/$TESTPOOL/$TESTVOL1
 
-	log_must zfs create -V $VOLSIZE -o copies=$copies $vol
+	log_must zfs create -V $VOLSIZE -o compression=off -o copies=$copies \
+	    $vol
 	log_must zfs set refreservation=none $vol
 	block_device_wait $vol_b_path
 
@@ -116,31 +117,30 @@ function do_vol_test
 		else
 			log_must zpool create $TESTPOOL1 $vol_b_path
 		fi
-		log_must zfs create $TESTPOOL1/$TESTFS1
+		log_must zfs create -o compression=off $TESTPOOL1/$TESTFS1
+		sync_pool $TESTPOOL1
 		;;
 	*)
 		log_unsupported "$type test not implemented"
 		;;
 	esac
 
-	((nfilesize = copies * ${FILESIZE%m}))
+	sync_pool $TESTPOOL
 	pre_used=$(get_prop used $vol)
-	((target_size = pre_used + nfilesize))
 
 	if [[ $type == "zfs" ]]; then
 		log_must mkfile $FILESIZE /$TESTPOOL1/$TESTFS1/$FILE
+		sync_pool $TESTPOOL1
 	else
 		log_must mkfile $FILESIZE $mntp/$FILE
+		log_must sync
 	fi
 
+	sync_pool $TESTPOOL
 	post_used=$(get_prop used $vol)
-	((retries = 0))
-	while ((post_used < target_size && retries++ < 42)); do
-		sleep 1
-		post_used=$(get_prop used $vol)
-	done
 
 	((used = post_used - pre_used))
+	((nfilesize = copies * ${FILESIZE%m}))
 	if ((used < nfilesize)); then
 		log_fail "The space is not charged correctly while setting" \
 		    "copies as $copies ($used < $nfilesize)" \


### PR DESCRIPTION
 - Explicitly disable compression since mkfile uses a zero buffer.
 - Explicitly sync file systems instead of waiting for timeout.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
