### PR TITLE
Linux 6.9: Fix UBSAN errors in sa.c

### DIFF
--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -491,6 +491,7 @@ UBSAN_SANITIZE_zap_leaf.o := n
 UBSAN_SANITIZE_zap_micro.o := n
 UBSAN_SANITIZE_sa.o := n
 UBSAN_SANITIZE_zfs/zap_micro.o := n
+UBSAN_SANITIZE_zfs/sa.o := n
 
 # Suppress incorrect warnings from versions of objtool which are not
 # aware of x86 EVEX prefix instructions used for AVX512.


### PR DESCRIPTION
### Motivation and Context
Workaround UBSAN errors in sa.c on 6.9 kernels.
Closes #16278
Closes #16330

### Description
This is a follow-on to 156a64161b4f9da35f2e0484106173344cf78317 that ignores UBSAN errors in sa.c.
Thank you @thwalker3 for the fix.

### How Has This Been Tested?
You can trigger the UBSAN error with this on Fedora 40 with 6.9.9 kernel:
```
truncate -s 100M file
sudo ./zpool create tank `pwd`/file
sudo cp -a /var/log /tank
< out of disk space >
dmesg
```
Using this PR, the errors do not appear.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
