### PR TITLE
Linux 6.10 compat: Remove second parameter of __assign_str()

### DIFF
--- a/include/os/linux/zfs/sys/trace_dbgmsg.h
+++ b/include/os/linux/zfs/sys/trace_dbgmsg.h
@@ -59,7 +59,7 @@ DECLARE_EVENT_CLASS(zfs_dprintf_class,
 	    __string(msg, msg)
 	),
 	TP_fast_assign(
-	    __assign_str(msg, msg);
+	    __assign_str(msg);
 	),
 	TP_printk("%s", __get_str(msg))
 );

--- a/include/os/linux/zfs/sys/trace_dbuf.h
+++ b/include/os/linux/zfs/sys/trace_dbuf.h
@@ -60,18 +60,13 @@
 
 #define	DBUF_TP_FAST_ASSIGN						\
 	if (db != NULL) {						\
-		if (POINTER_IS_VALID(DB_DNODE(db)->dn_objset)) {	\
-			__assign_str(os_spa,				\
-			spa_name(DB_DNODE(db)->dn_objset->os_spa));	\
-		} else {						\
-			__assign_str(os_spa, "NULL");			\
-		}							\
-									\
+		__assign_str(os_spa);			\
+								\
 		__entry->ds_object = db->db_objset->os_dsl_dataset ?	\
 		db->db_objset->os_dsl_dataset->ds_object : 0;		\
 									\
 		__entry->db_object = db->db.db_object;			\
-		__entry->db_level  = db->db_level;			\
+		__entry->db_level  = db->db_level;
 		__entry->db_blkid  = db->db_blkid;			\
 		__entry->db_offset = db->db.db_offset;			\
 		__entry->db_size   = db->db.db_size;			\
@@ -80,7 +75,7 @@
 		snprintf(__get_str(msg), TRACE_DBUF_MSG_MAX,		\
 		    DBUF_TP_PRINTK_FMT, DBUF_TP_PRINTK_ARGS);		\
 	} else {							\
-		__assign_str(os_spa, "NULL");				\
+		__assign_str(os_spa);				\
 		__entry->ds_object = 0;					\
 		__entry->db_object = 0;					\
 		__entry->db_level  = 0;					\


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Remove second parameter of __assign_str()

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The header files in /include/os/Linux/zfs/sys/ are behind some changes in Linux 6.10, which may cause some problems when compiling kernels with the zfs module built in.

### Description
<!--- Describe your changes in detail -->

Simply removed the second parameter of __assign_str().

In Linux kernel commit 2c92ca849fcc6ee7d0c358e9959abc9f58661aea, the second parameter of __assign_str() was removed.  As the instruction says, there is no need to pass the second parameter. But I didn't check if it would break anything to simply remove the second parameter.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

My custom Linux kernel (6.10.1) has compiled successfully with these changes and seems to be running well with no problems.

But I don't have the prerequisites to run the ZFS test suite. If there's a need for more in-depth testing, I'll try running it in a virtual machine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
