### PR TITLE
Linux: mount.zfs(8) didn't propagate dataset properties into mount options

### DIFF
--- a/cmd/mount_zfs.c
+++ b/cmd/mount_zfs.c
@@ -269,8 +269,7 @@ main(int argc, char **argv)
 		return (MOUNT_USAGE);
 	}
 
-	if (!zfsutil || sloppy ||
-	    libzfs_envvar_is_set("ZFS_MOUNT_HELPER")) {
+	if (sloppy || libzfs_envvar_is_set("ZFS_MOUNT_HELPER")) {
 		zfs_adjust_mount_options(zhp, mntpoint, mntopts, mtabopt);
 	}
 
@@ -337,7 +336,7 @@ main(int argc, char **argv)
 		    dataset, mntpoint, mntflags, zfsflags, mntopts, mtabopt);
 
 	if (!fake) {
-		if (zfsutil && !sloppy &&
+		if (!remount && !sloppy &&
 		    !libzfs_envvar_is_set("ZFS_MOUNT_HELPER")) {
 			error = zfs_mount_at(zhp, mntopts, mntflags, mntpoint);
 			if (error) {

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -1101,8 +1101,8 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	zfsvfs_t *snap_zfsvfs;
 	zfs_snapentry_t *se;
 	char *full_name, *full_path;
-	char *argv[] = { "/usr/bin/env", "mount", "-t", "zfs", "-n", NULL, NULL,
-	    NULL };
+	char *argv[] = { "/usr/bin/env", "mount", "-i", "-t", "zfs", "-n",
+	    NULL, NULL, NULL };
 	char *envp[] = { NULL };
 	int error;
 	struct path spath;
@@ -1153,8 +1153,8 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	 * value from call_usermodehelper() will be (exitcode << 8 + signal).
 	 */
 	dprintf("mount; name=%s path=%s\n", full_name, full_path);
-	argv[5] = full_name;
-	argv[6] = full_path;
+	argv[6] = full_name;
+	argv[7] = full_path;
 	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
 	if (error) {
 		if (!(error & MOUNT_BUSY << 8)) {


### PR DESCRIPTION
### Motivation and Context
This issue is basically #7947; while #13021 attempted fixing it, the fix is
incomplete. Specifically if the root dataset have `mountpoint` set to
`legacy`, the mount script in initrd will have to drop `-o zfsutil`, then the
original issue will appear again.

### Description
To reprocude the issue, create a dataset with `mountpoint=legacy` and
`atime=off`:
```
# zfs create -o mountpoint=legacy -o atime=off storage/test
# zfs get mountpoint,atime storage/test
NAME          PROPERTY    VALUE       SOURCE
storage/test  mountpoint  legacy      local
storage/test  atime       off         local
```

Because mount point setting of this dataset is `legacy`, the user will have to
use **mount.zfs(8)**, or indirectly use `mount -t zfs ...`, in order to mount
it; but then the `noatime` mount option didn't get passed by **mount.zfs(8)**:
```
# mount -t zfs storage/test /mnt/test/
# grep ^storage/test /proc/mounts
storage/test /mnt/test zfs rw,relatime,xattr,noacl 0 0
```

The proposed fix is extending the cases of calling `zfs_mount_at`, without the
requirement of using `-o zfsutil`. I have carefully read the corresponding
source code, as well related commit log, I think there's no reason to not use
`zfs_mount_at` without `-o zfsutil`.

This issue didn't present in FreeBSD; from my testing, dataset with
`mountpoint=legacy` mounted using `mount -t zfs ...` have correctly set mount
options based on dataset properties.

### How Has This Been Tested?
With the change applied, the `noatime` option got passed as expected:
```
# mount.zfs storage/test /mnt/test/
# grep ^storage/test /proc/mounts
storage/test /mnt/test zfs rw,noatime,xattr,noacl 0 0
```

Also, overriding mount options from command line works too:
```
# umount /mnt/test 
# mount.zfs storage/test /mnt/test/ -o atime
# grep ^storage/test /proc/mounts 
storage/test /mnt/test zfs rw,xattr,noacl 0 0
# umount /mnt/test 
# mount.zfs storage/test /mnt/test/ -o relatime
# grep ^storage/test /proc/mounts 
storage/test /mnt/test zfs rw,relatime,xattr,noacl 0 0
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).


