### PR TITLE
[2.2.5-only] Make 'rmmod zfs' work after zfs-2.2.4

### DIFF
--- a/module/os/linux/zfs/zfs_sysfs.c
+++ b/module/os/linux/zfs/zfs_sysfs.c
@@ -110,8 +110,17 @@ zfs_kobj_fini(zfs_mod_kobj_t *zkobj)
 	}
 
 	/* kobject_put() will call zfs_kobj_release() to release memory */
-	kobject_del(&zkobj->zko_kobj);
-	kobject_put(&zkobj->zko_kobj);
+	/*
+	 * Special case note:
+	 *
+	 * We have to check for 'zkobj->zko_kobj.name != NULL' as
+	 * a workaround for #16249 which was added to zfs-2.2.4
+	 * and fixed (with this change) in zfs-2.2.5.
+	 */
+	if (zkobj->zko_kobj.name != NULL) {
+		kobject_del(&zkobj->zko_kobj);
+		kobject_put(&zkobj->zko_kobj);
+	}
 }
 
 static void


### PR DESCRIPTION
### Motivation and Context
Fix broken `rmmod zfs` from zfs-2.2.4: https://github.com/openzfs/zfs/issues/16249

### Description
db65272ae was added to zfs-2.2.4 to stub in the VDEV_PROP_RAIDZ_EXPANDING enum without adding the RAIDz expansion feature.  This was needed to provide the right enum count for when the VDEV_PROP_SLOW_IO proprieties got added.  This had the unfortunate side effect of breaking module removal though.

Specifically, with the VDEV_PROP_RAIDZ_EXPANDING stub added, the module would correctly omit making kobjects for the RAIDz expansion vdev property, but then would try to blindly remove its non-existent kobjects during module unload.

This commit fixes the issue by checking for an uninitialized kobject.

### How Has This Been Tested?
Verified multiple module unload/reload cycles on Almalinux 9.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
