### PR TITLE
ZTS: fix io_uring test on RHEL 9 variants

### DIFF
--- a/tests/zfs-tests/tests/functional/io/io_uring.ksh
+++ b/tests/zfs-tests/tests/functional/io/io_uring.ksh
@@ -41,13 +41,13 @@ verify_runnable "global"
 
 
 if ! $(grep -q "CONFIG_IO_URING=y" /boot/config-$(uname -r)); then
-	log_unsupported "Requires io_uring support"
+	log_unsupported "Requires io_uring support within Kernel"
 fi
 
 if [ -e /etc/os-release ] ; then
 	source /etc/os-release
-	if [ -n "$REDHAT_SUPPORT_PRODUCT_VERSION" ] && ((floor($REDHAT_SUPPORT_PRODUCT_VERSION) == 9)) ; then
-		log_unsupported "Disabled on CentOS 9, fails with 'Operation not permitted'"
+	if [ $PLATFORM_ID = "platform:el9" ]; then
+		log_unsupported "Disabled on RHEL 9 variants: fails with 'Operation not permitted'"
 	fi
 fi
 


### PR DESCRIPTION

### Motivation and Context

Simplify the test for skipping io_uring, by using the variable "$PLATFORM_ID" in favor of "$REDHAT_SUPPORT_PRODUCT_VERSION".

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
