### PR TITLE
ZTS: small fix for SEEK_DATA/SEEK_HOLE tests

### DIFF
--- a/tests/zfs-tests/cmd/mmap_seek.c
+++ b/tests/zfs-tests/cmd/mmap_seek.c
@@ -35,6 +35,16 @@
 #include <linux/fs.h>
 #endif
 
+/* some older uClibc's lack the defines, so we'll manually define them */
+#ifdef	__UCLIBC__
+#ifndef	SEEK_DATA
+#define	SEEK_DATA 3
+#endif
+#ifndef	SEEK_HOLE
+#define	SEEK_HOLE 4
+#endif
+#endif
+
 static void
 seek_data(int fd, off_t offset, off_t expected)
 {

--- a/tests/zfs-tests/tests/functional/cp_files/seekflood.c
+++ b/tests/zfs-tests/tests/functional/cp_files/seekflood.c
@@ -36,6 +36,13 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 
+/* some older uClibc's lack the defines, so we'll manually define them */
+#ifdef	__UCLIBC__
+#ifndef	SEEK_DATA
+#define	SEEK_DATA 3
+#endif
+#endif
+
 #define	DATASIZE	(4096)
 char data[DATASIZE];
 


### PR DESCRIPTION

### Motivation and Context

Some libc's like uClibc lag the proper definition of SEEK_DATA and SEEK_HOLE.
Since we have only two files in ZTS which use these definitons, let's define them by hand.

There should be no failures, because:
- FreeBSD has support for SEEK_DATA/SEEK_HOLE since FreeBSD 8
- Linux has it since Linux 3.1
- the libc will submit the parameters unchanged to the kernel

There is another pull request for fixing this by skipping the tests here: https://github.com/openzfs/zfs/pull/16169.
This one is a bit more complex and not finished currently.

### Description

I would prefer to make the needed definitions by hand for now:

```
#ifndef SEEK_DATA
#define SEEK_DATA 3
#endif
#ifndef SEEK_HOLE
#define SEEK_HOLE 4
#endif
```

Some more details about the `Defines` themself:
- FreeBSD has SEEK_DATA/SEEK_HOLE since april 2007 (FreeBSD 8): https://github.com/freebsd/freebsd-src/commit/f6521d1c31810b096dd15afff12cf194d1989a0a
- Linux has it since around 2011 (Linux 3.1): https://github.com/torvalds/linux/commit/982d816581eeeacfe5b2b7c6d47d13a157616eff
- POSIX has it defined also now: https://www.austingroupbugs.net/view.php?id=415
- musl supports it: https://github.com/kraj/musl/commit/cbacd638e32a02edbe66c48ae3d1361bc06a492a
- uClibc will hopefully apply them in near future also

So in the end, ZTS uses the `Defines` here:
1. `tests/zfs-tests/cmd/mmap_seek.c`
2. `tests/zfs-tests/tests/functional/cp_files/seekflood.c`

So let's define them in order to do the tests on uClibc based ZTS runs also.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
