### PR TITLE
Updating bash completion build file

### DIFF
--- a/contrib/bash_completion.d/Makefile.am
+++ b/contrib/bash_completion.d/Makefile.am
@@ -1,6 +1,7 @@
 nodist_bashcompletion_DATA  = %D%/zfs %D%/zpool
 COMPLETION_FILES            = %D%/zfs
-SUBSTFILES                 += $(COMPLETION_FILES)
+SUBSTFILES                  += $(COMPLETION_FILES)
+CLEANFILES                  += %D%/zpool
 
 SHELLCHECKSCRIPTS   += $(COMPLETION_FILES)
 $(call SHELLCHECK_OPTS,$(COMPLETION_FILES)): SHELLCHECK_SHELL = bash


### PR DESCRIPTION
Commit 46ebd0a updated the build system to make symbolic link for zpool. However, this commit did not update the automake file to also add the symbolic link to the CLEANFILES variable. This is necessary so the link is removed when running make clean/distclean.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Updated build system to fix error when trying to rebuild the source after running make clean/distclean.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes issue with build system.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Added the symbolic link created to the CLEANFILES variable in the automake file. Before this patch the following error would be issued after running make clean/distclean and then trying to rebuild the ZFS source:
`ln -s zfs contrib/bash_completion.d/zpool
  CCLD     tests/zfs-tests/tests/functional/vdev_disk/page_alignment
ln: failed to create symbolic link 'contrib/bash_completion.d/zpool': File exists
make[2]: *** [Makefile:14110: contrib/bash_completion.d/zpool] Error 1`

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Built ZFS, ran make clean, and rebuilt the source code. Did the same thing with make distclean. With this patch, the build error is no longer reported when rebuilding the source code.
<!--- Include details of your testing environment, and the tests you ran to -->
Distro: Centos Stream 8
Kernel: 4.18.0-408.el8.x86_64
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
