### PR TITLE
contrib: bash_completion.d: force zpool symlink recreation

### DIFF
--- a/contrib/bash_completion.d/Makefile.am
+++ b/contrib/bash_completion.d/Makefile.am
@@ -6,4 +6,4 @@ SHELLCHECKSCRIPTS   += $(COMPLETION_FILES)
 $(call SHELLCHECK_OPTS,$(COMPLETION_FILES)): SHELLCHECK_SHELL = bash
 
 %D%/zpool: %D%/zfs
-	$(LN_S) zfs $@
+	$(LN_S) -f zfs $@


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

Following #16376, rebuild fails if the `zpool` symlink already exists (usually after a branch change).

### Description

`ln` will fail if the target already exists, which causes make to bail out. Adding `-f` makes it more "compiler-like", overwriting 

Note this is not fixing the same thing as #16422. That's a separate thing.

### How Has This Been Tested?

By hand!

Before:
```
$ ls -l contrib/bash_completion.d/z*
-rw-r--r-- 1 robn robn 15162 Aug  8 13:14 contrib/bash_completion.d/zfs
-rw-r--r-- 1 robn robn 15150 Aug  8 13:14 contrib/bash_completion.d/zfs.in
lrwxrwxrwx 1 robn robn     3 Aug  8 10:36 contrib/bash_completion.d/zpool -> zfs

$ touch contrib/bash_completion.d/zfs.in

$ make contrib/bash_completion.d/zpool
  GEN      contrib/bash_completion.d/zfs
ln -s zfs contrib/bash_completion.d/zpool
ln: failed to create symbolic link 'contrib/bash_completion.d/zpool': File exists
make: *** [Makefile:14141: contrib/bash_completion.d/zpool] Error 1

$ make contrib/bash_completion.d/zpool
make: 'contrib/bash_completion.d/zpool' is up to date.
```

After:
```
$ ls -l contrib/bash_completion.d/z*
-rw-r--r-- 1 robn robn 15162 Aug  8 13:13 contrib/bash_completion.d/zfs
-rw-r--r-- 1 robn robn 15150 Jul 26 11:51 contrib/bash_completion.d/zfs.in
lrwxrwxrwx 1 robn robn     3 Aug  8 13:13 contrib/bash_completion.d/zpool -> zfs

$ touch contrib/bash_completion.d/zfs.in

$ make contrib/bash_completion.d/zpool
  GEN      contrib/bash_completion.d/zfs
ln -s -f zfs contrib/bash_completion.d/zpool

$ make contrib/bash_completion.d/zpool
make: 'contrib/bash_completion.d/zpool' is up to date.
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).