### PR TITLE
zstream: remove duplicate highbit64 definition

### DIFF
--- a/cmd/zstream/zstream_redup.c
+++ b/cmd/zstream/zstream_redup.c
@@ -56,15 +56,6 @@ typedef struct redup_table {
 	int		numhashbits;
 } redup_table_t;
 
-int
-highbit64(uint64_t i)
-{
-	if (i == 0)
-		return (0);
-
-	return (NBBY * sizeof (uint64_t) - __builtin_clzll(i));
-}
-
 void *
 safe_calloc(size_t n)
 {


### PR DESCRIPTION
### Motivation and Context

I tried a static build and it didn't work, oh no!

### Description

When building a static build (`--disable-shared`), zstream fails to link because of the duplicate `highbit64()` in `libzpool/kernel.c`. Since they're identical, and the libzpool one is visible to zstream, we remove zstream's copy and just use the common one.

### How Has This Been Tested?

Build with `--disable-shared`. Before:

```
  CCLD     zstream
/usr/bin/ld: ./.libs/libzpool.a(libzpool_la-kernel.o): in function `highbit64':
/home/robn/code/zfs/lib/libzpool/kernel.c:712: multiple definition of `highbit64'; cmd/zstream/zstream_redup.o:/home/robn/code/zfs/cmd/zstream/zstream_redup.c:63: first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:7359: zstream] Error 1
```

After:

```
  CCLD     zstream
```

(Thrills amirite).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
