### PR TITLE
config: don't force shared linkage on FreeBSD

### DIFF
--- a/config/Rules.am
+++ b/config/Rules.am
@@ -57,7 +57,7 @@ AM_LDFLAGS += $(ASAN_LDFLAGS)
 AM_LDFLAGS += $(UBSAN_LDFLAGS)
 
 if BUILD_FREEBSD
-AM_LDFLAGS += -fstack-protector-strong -shared
+AM_LDFLAGS += -fstack-protector-strong
 AM_LDFLAGS += -Wl,-x -Wl,--fatal-warnings -Wl,--warn-shared-textrel
 AM_LDFLAGS += -lm
 endif


### PR DESCRIPTION


### Motivation and Context

We tried a static build on FreeBSD, and it failed in a surprising way.

### Description

`-shared` was hardcoded, so when building with `--disable-shared` it amounts to trying to do shared linkage against static libs, which naturally fails.

The fix is straightforward; just don't hardcode it. libtool will work out what to do.

### How Has This Been Tested?

Hand tested: `MAKE=gmake ./configure --disable-shared --disable-pam && gmake`.

Before:

```
  CCLD     libicp.la
libtool:   error: cannot build a shared library See the libtool documentation for more information. Fatal configuration error.
gmake[2]: *** [Makefile:5728: libicp.la] Error 1
```

After:

```
  CCLD     libicp.la
```

(and all the other libs of course).

Linkage with/without `--disable-shared` appears correct. With `--disable-shared`:

```
$ libtool --mode=execute ldd  ./zdb | grep libs/
[no output]
```

Without:

```
$ libtool --mode=execute ldd  ./zdb | grep libs/
/home/robn/zfs/.libs/zdb:
	libzpool.so.5 => /home/robn/zfs/.libs/libzpool.so.5 (0x3d2c3e52b000)
	libzfs_core.so.3 => /home/robn/zfs/.libs/libzfs_core.so.3 (0x3d2c4060c000)
	libnvpair.so.3 => /home/robn/zfs/.libs/libnvpair.so.3 (0x3d2c41ec6000)
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).