### PR TITLE
ARC statistics reset

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -843,6 +843,10 @@ The target number of bytes the ARC should leave as free memory on the system.
 If zero, equivalent to the bigger of
 .Sy 512 KiB No and Sy all_system_memory/64 .
 .
+.It Sy zfs_arc_stats_reset Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Reset ARC statistics.
+Note: it currently resets L2ARC bad checksum and error stats only.
+.
 .It Sy zfs_autoimport_disable Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Disable pool import at module load by ignoring the cache file
 .Pq Sy spa_config_path .

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -944,6 +944,9 @@ static uint64_t l2arc_trim_ahead = 0;
 static int l2arc_rebuild_enabled = B_TRUE;
 static uint64_t l2arc_rebuild_blocks_min_l2size = 1024 * 1024 * 1024;
 
+/* zfs_arc_stats_reset : reset ARC statistics */
+static int zfs_arc_stats_reset = 0;
+
 /* L2ARC persistence rebuild control routines. */
 void l2arc_rebuild_vdev(vdev_t *vd, boolean_t reopen);
 static __attribute__((noreturn)) void l2arc_dev_rebuild_thread(void *arg);
@@ -6919,6 +6922,13 @@ arc_kstat_update(kstat_t *ksp, int rw)
 	if (rw == KSTAT_WRITE)
 		return (SET_ERROR(EACCES));
 
+        /* reset ARC statistics */
+	if (zfs_arc_stats_reset) {
+		ARCSTAT_INCR(arcstat_l2_cksum_bad, -(as->arcstat_l2_cksum_bad.value.ui64));
+		ARCSTAT_INCR(arcstat_l2_io_error, -(as->arcstat_l2_io_error.value.ui64));
+		zfs_arc_stats_reset = 0;
+	}
+
 	as->arcstat_hits.value.ui64 =
 	    wmsum_value(&arc_sums.arcstat_hits);
 	as->arcstat_iohits.value.ui64 =
@@ -10817,3 +10827,6 @@ ZFS_MODULE_PARAM(zfs_arc, zfs_arc_, evict_batch_limit, UINT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs_arc, zfs_arc_, prune_task_threads, INT, ZMOD_RW,
 	"Number of arc_prune threads");
+
+ZFS_MODULE_PARAM(zfs_arc, zfs_arc_, stats_reset, INT, ZMOD_RW,
+	"Reset ARC statistics");


### PR DESCRIPTION
Fixes https://github.com/openzfs/zfs/issues/16437

This patch introduces a means to reset some ARC statistics without rebooting the machine or reimporting the zfs module. Please note that it currently only resets `l2_cksum_bad` and `l2_io_error`

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ZFS is not currently able to reset ARC statistics without rebooting the machine or reimporting the ZFS module. This patch changes that behavior for two L2ARC error-related statistics.

### Description
Currently, a single L2ARC cksum/io error is going to leave the cache device as `DEGRADED` in `arc_summary` output until the machine is rebooted or the ZFS kernel module is exported/reimported. With this patch, echoing `1` into `zfs_arc_stats_reset` will clear the two counters described above.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
