### PR TITLE
ZTS: Use /dev/urandom instead of /dev/random

### DIFF
--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class.kshlib
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class.kshlib
@@ -55,7 +55,7 @@ function display_status
 	((ret |= $?))
 
 	typeset mntpnt=$(get_prop mountpoint $pool)
-	dd if=/dev/random of=$mntpnt/testfile.$$ &
+	dd if=/dev/urandom of=$mntpnt/testfile.$$ &
 	typeset pid=$!
 
 	zpool iostat -v 1 3 > /dev/null

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_rlimit_fsize.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_rlimit_fsize.ksh
@@ -54,7 +54,7 @@ log_must truncate -s 1G $VDEV
 
 log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $VDEV
 
-log_must dd if=/dev/random of=/$TESTPOOL/file1 bs=1 count=1000
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=1 count=1000
 
 ulimit -f 2
 log_must clonefile -f /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 all

--- a/tests/zfs-tests/tests/functional/fault/suspend_resume_single.ksh
+++ b/tests/zfs-tests/tests/functional/fault/suspend_resume_single.ksh
@@ -42,7 +42,7 @@ log_onexit cleanup
 log_assert "ensure single-disk pool resumes properly after suspend and clear"
 
 # create a file, and take a checksum, so we can compare later
-log_must dd if=/dev/random of=$DATAFILE bs=128K count=1
+log_must dd if=/dev/urandom of=$DATAFILE bs=128K count=1
 typeset sum1=$(cat $DATAFILE | md5sum)
 
 # make a debug device that we can "unplug"


### PR DESCRIPTION
### Motivation and Context
Use /dev/urandom so we never have to wait on entropy.

### Description
Psudorandom numbers are fine for ZTS.  Use /dev/urandom since it's faster than /dev/random.

### How Has This Been Tested?
buildbot will test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
