### PR TITLE
Value strings: infrastructure for bitfield/enum pretty printers (with support in `zpool events`)

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -75,6 +75,7 @@
 #include "zpool_util.h"
 #include "zfs_comutil.h"
 #include "zfeature_common.h"
+#include "zfs_valstr.h"
 
 #include "statcommon.h"
 
@@ -11936,6 +11937,7 @@ static void
 zpool_do_events_nvprint(nvlist_t *nvl, int depth)
 {
 	nvpair_t *nvp;
+	static char flagstr[256];
 
 	for (nvp = nvlist_next_nvpair(nvl, NULL);
 	    nvp != NULL; nvp = nvlist_next_nvpair(nvl, nvp)) {
@@ -11995,7 +11997,21 @@ zpool_do_events_nvprint(nvlist_t *nvl, int depth)
 
 		case DATA_TYPE_UINT32:
 			(void) nvpair_value_uint32(nvp, &i32);
-			printf(gettext("0x%x"), i32);
+			if (strcmp(name,
+			    FM_EREPORT_PAYLOAD_ZFS_ZIO_STAGE) == 0 ||
+			    strcmp(name,
+			    FM_EREPORT_PAYLOAD_ZFS_ZIO_PIPELINE) == 0) {
+				zfs_valstr_zio_stage(i32, flagstr,
+				    sizeof (flagstr));
+				printf(gettext("0x%x [%s]"), i32, flagstr);
+			} else if (strcmp(name,
+			    FM_EREPORT_PAYLOAD_ZFS_ZIO_PRIORITY) == 0) {
+				zfs_valstr_zio_priority(i32, flagstr,
+				    sizeof (flagstr));
+				printf(gettext("0x%x [%s]"), i32, flagstr);
+			} else {
+				printf(gettext("0x%x"), i32);
+			}
 			break;
 
 		case DATA_TYPE_INT64:
@@ -12016,6 +12032,12 @@ zpool_do_events_nvprint(nvlist_t *nvl, int depth)
 				printf(gettext("\"%s\" (0x%llx)"),
 				    zpool_state_to_name(i64, VDEV_AUX_NONE),
 				    (u_longlong_t)i64);
+			} else if (strcmp(name,
+			    FM_EREPORT_PAYLOAD_ZFS_ZIO_FLAGS) == 0) {
+				zfs_valstr_zio_flag(i64, flagstr,
+				    sizeof (flagstr));
+				printf(gettext("0x%llx [%s]"),
+				    (u_longlong_t)i64, flagstr);
 			} else {
 				printf(gettext("0x%llx"), (u_longlong_t)i64);
 			}

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -14,6 +14,7 @@ COMMON_H = \
 	zfs_fletcher.h \
 	zfs_namecheck.h \
 	zfs_prop.h \
+	zfs_valstr.h \
 	\
 	sys/abd.h \
 	sys/abd_impl.h \

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -167,6 +167,9 @@ typedef enum zio_suspend_reason {
  * This was originally an enum type. However, those are 32-bit and there is no
  * way to make a 64-bit enum type. Since we ran out of bits for flags, we were
  * forced to upgrade it to a uint64_t.
+ *
+ * NOTE: PLEASE UPDATE THE BITFIELD STRINGS IN zfs_valstr.c IF YOU ADD ANOTHER
+ * FLAG.
  */
 typedef uint64_t zio_flag_t;
 	/*

--- a/include/sys/zio_impl.h
+++ b/include/sys/zio_impl.h
@@ -120,6 +120,9 @@ extern "C" {
 
 /*
  * zio pipeline stage definitions
+ *
+ * NOTE: PLEASE UPDATE THE BITFIELD STRINGS IN zfs_valstr.c IF YOU ADD ANOTHER
+ * FLAG.
  */
 enum zio_stage {
 	ZIO_STAGE_OPEN			= 1 << 0,	/* RWFCXT */

--- a/include/sys/zio_priority.h
+++ b/include/sys/zio_priority.h
@@ -22,6 +22,10 @@
 extern "C" {
 #endif
 
+/*
+ * NOTE: PLEASE UPDATE THE ENUM STRINGS IN zfs_valstr.c IF YOU ADD ANOTHER
+ * VALUE.
+ */
 typedef enum zio_priority {
 	ZIO_PRIORITY_SYNC_READ,
 	ZIO_PRIORITY_SYNC_WRITE,	/* ZIL */

--- a/include/zfs_valstr.h
+++ b/include/zfs_valstr.h
@@ -1,0 +1,84 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2024, Klara Inc.
+ */
+
+#ifndef	_ZFS_VALSTR_H
+#define	_ZFS_VALSTR_H extern __attribute__((visibility("default")))
+
+#include <sys/fs/zfs.h>
+#include <sys/types.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+/*
+ * These macros create function prototypes for pretty-printing or stringifying
+ * certain kinds of numeric types.
+ *
+ * _ZFS_VALSTR_DECLARE_BITFIELD(name) creates:
+ *
+ *   size_t zfs_valstr_<name>_bits(uint64_t bits, char *out, size_t outlen);
+ *     expands single char for each set bit, and space for each clear bit
+ *
+ *   size_t zfs_valstr_<name>_pairs(uint64_t bits, char *out, size_t outlen);
+ *     expands two-char mnemonic for each bit set in `bits`, separated by `|`
+ *
+ *   size_t zfs_valstr_<name>(uint64_t bits, char *out, size_t outlen);
+ *     expands full name of each bit set in `bits`, separated by spaces
+ *
+ * _ZFS_VALSTR_DECLARE_ENUM(name) creates:
+ *
+ *   size_t zfs_valstr_<name>(int v, char *out, size_t outlen);
+ *     expands full name of enum value
+ *
+ * Each _ZFS_VALSTR_DECLARE_xxx needs a corresponding _VALSTR_xxx_IMPL string
+ * table in vfs_valstr.c.
+ */
+
+#define	_ZFS_VALSTR_DECLARE_BITFIELD(name)			\
+	_ZFS_VALSTR_H size_t zfs_valstr_ ## name ## _bits(	\
+	    uint64_t bits, char *out, size_t outlen);		\
+	_ZFS_VALSTR_H size_t zfs_valstr_ ## name ## _pairs(	\
+	    uint64_t bits, char *out, size_t outlen);		\
+	_ZFS_VALSTR_H size_t zfs_valstr_ ## name(		\
+	    uint64_t bits, char *out, size_t outlen);		\
+
+#define	_ZFS_VALSTR_DECLARE_ENUM(name)				\
+	_ZFS_VALSTR_H size_t zfs_valstr_ ## name(		\
+	    int v, char *out, size_t outlen);			\
+
+_ZFS_VALSTR_DECLARE_BITFIELD(zio_flag)
+_ZFS_VALSTR_DECLARE_BITFIELD(zio_stage)
+
+_ZFS_VALSTR_DECLARE_ENUM(zio_priority)
+
+#undef _ZFS_VALSTR_DECLARE_BITFIELD
+#undef _ZFS_VALSTR_DECLARE_ENUM
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _ZFS_VALSTR_H */

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -47,6 +47,7 @@ nodist_libzfs_la_SOURCES = \
 	module/zcommon/zfs_fletcher_superscalar4.c \
 	module/zcommon/zfs_namecheck.c \
 	module/zcommon/zfs_prop.c \
+	module/zcommon/zfs_valstr.c \
 	module/zcommon/zpool_prop.c \
 	module/zcommon/zprop_common.c
 

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -454,6 +454,13 @@
     <elf-symbol name='zfs_userns' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_userspace' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_valid_proplist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_valstr_zio_flag' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_valstr_zio_flag_bits' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_valstr_zio_flag_pairs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_valstr_zio_priority' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_valstr_zio_stage' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_valstr_zio_stage_bits' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_valstr_zio_stage_pairs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_version_kernel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_version_nvlist' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_version_print' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -9829,6 +9836,50 @@
     <function-decl name='zfs_prop_align_right' mangled-name='zfs_prop_align_right' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_align_right'>
       <parameter type-id='58603c44' name='prop'/>
       <return type-id='c19b74c3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='module/zcommon/zfs_valstr.c' language='LANG_C99'>
+    <function-decl name='zfs_valstr_zio_flag' mangled-name='zfs_valstr_zio_flag' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valstr_zio_flag'>
+      <parameter type-id='9c313c2d' name='bits'/>
+      <parameter type-id='26a90f95' name='out'/>
+      <parameter type-id='b59d7dce' name='outlen'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
+    <function-decl name='zfs_valstr_zio_flag_bits' mangled-name='zfs_valstr_zio_flag_bits' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valstr_zio_flag_bits'>
+      <parameter type-id='9c313c2d' name='bits'/>
+      <parameter type-id='26a90f95' name='out'/>
+      <parameter type-id='b59d7dce' name='outlen'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
+    <function-decl name='zfs_valstr_zio_flag_pairs' mangled-name='zfs_valstr_zio_flag_pairs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valstr_zio_flag_pairs'>
+      <parameter type-id='9c313c2d' name='bits'/>
+      <parameter type-id='26a90f95' name='out'/>
+      <parameter type-id='b59d7dce' name='outlen'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
+    <function-decl name='zfs_valstr_zio_stage' mangled-name='zfs_valstr_zio_stage' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valstr_zio_stage'>
+      <parameter type-id='9c313c2d' name='bits'/>
+      <parameter type-id='26a90f95' name='out'/>
+      <parameter type-id='b59d7dce' name='outlen'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
+    <function-decl name='zfs_valstr_zio_stage_bits' mangled-name='zfs_valstr_zio_stage_bits' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valstr_zio_stage_bits'>
+      <parameter type-id='9c313c2d' name='bits'/>
+      <parameter type-id='26a90f95' name='out'/>
+      <parameter type-id='b59d7dce' name='outlen'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
+    <function-decl name='zfs_valstr_zio_stage_pairs' mangled-name='zfs_valstr_zio_stage_pairs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valstr_zio_stage_pairs'>
+      <parameter type-id='9c313c2d' name='bits'/>
+      <parameter type-id='26a90f95' name='out'/>
+      <parameter type-id='b59d7dce' name='outlen'/>
+      <return type-id='b59d7dce'/>
+    </function-decl>
+    <function-decl name='zfs_valstr_zio_priority' mangled-name='zfs_valstr_zio_priority' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_valstr_zio_priority'>
+      <parameter type-id='95e97e5e' name='v'/>
+      <parameter type-id='26a90f95' name='out'/>
+      <parameter type-id='b59d7dce' name='outlen'/>
+      <return type-id='b59d7dce'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='module/zcommon/zpool_prop.c' language='LANG_C99'>

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -64,6 +64,7 @@ nodist_libzpool_la_SOURCES = \
 	module/zcommon/zfs_fletcher_superscalar4.c \
 	module/zcommon/zfs_namecheck.c \
 	module/zcommon/zfs_prop.c \
+	module/zcommon/zfs_valstr.c \
 	module/zcommon/zpool_prop.c \
 	module/zcommon/zprop_common.c \
 	\

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -240,6 +240,7 @@ ZCOMMON_OBJS := \
 	zfs_fletcher_superscalar4.o \
 	zfs_namecheck.o \
 	zfs_prop.o \
+	zfs_valstr.o \
 	zpool_prop.o \
 	zprop_common.o
 

--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -233,6 +233,7 @@ SRCS+=	cityhash.c \
 	zfs_fletcher_superscalar.c \
 	zfs_namecheck.c \
 	zfs_prop.c \
+	zfs_valstr.c \
 	zpool_prop.c \
 	zprop_common.c
 

--- a/module/zcommon/zfs_valstr.c
+++ b/module/zcommon/zfs_valstr.c
@@ -1,0 +1,277 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2024, Klara Inc.
+ */
+
+#include <sys/fs/zfs.h>
+#include <sys/types.h>
+#include <sys/sysmacros.h>
+#include <sys/string.h>
+#include <sys/debug.h>
+#include "zfs_valstr.h"
+
+/*
+ * Each bit in a bitfield has three possible string representations:
+ * - single char
+ * - two-char pair
+ * - full name
+ */
+typedef struct {
+	const char	vb_bit;
+	const char	vb_pair[2];
+	const char	*vb_name;
+} valstr_bit_t;
+
+/*
+ * Emits a character for each bit in `bits`, up to the number of elements
+ * in the table. Set bits get the character in vb_bit, clear bits get a
+ * space. This results in all strings having the same width, for easier
+ * visual comparison.
+ */
+static size_t
+valstr_bitfield_bits(const valstr_bit_t *table, const size_t nelems,
+    uint64_t bits, char *out, size_t outlen)
+{
+	ASSERT(out);
+	size_t n = 0;
+	for (int b = 0; b < nelems; b++) {
+		if (n == outlen)
+			break;
+		uint64_t mask = (1ULL << b);
+		out[n++] = (bits & mask) ? table[b].vb_bit : ' ';
+	}
+	if (n < outlen)
+		out[n++] = '\0';
+	return (n);
+}
+
+/*
+ * Emits a two-char pair for each bit set in `bits`, taken from vb_pair, and
+ * separated by a `|` character. This gives a concise representation of the
+ * whole value.
+ */
+static size_t
+valstr_bitfield_pairs(const valstr_bit_t *table, const size_t nelems,
+    uint64_t bits, char *out, size_t outlen)
+{
+	ASSERT(out);
+	size_t n = 0;
+	for (int b = 0; b < nelems; b++) {
+		ASSERT3U(n, <=, outlen);
+		if (n == outlen)
+			break;
+		uint64_t mask = (1ULL << b);
+		if (bits & mask) {
+			size_t len = (n > 0) ? 3 : 2;
+			if (n > outlen-len)
+				break;
+			if (n > 0)
+				out[n++] = '|';
+			out[n++] = table[b].vb_pair[0];
+			out[n++] = table[b].vb_pair[1];
+		}
+	}
+	if (n < outlen)
+		out[n++] = '\0';
+	return (n);
+}
+
+/*
+ * Emits the full name for each bit set in `bits`, taken from vb_name, and
+ * separated by a space. This unambiguously shows the entire set of bits, but
+ * can get very long.
+ */
+static size_t
+valstr_bitfield_str(const valstr_bit_t *table, const size_t nelems,
+    uint64_t bits, char *out, size_t outlen)
+{
+	ASSERT(out);
+	size_t n = 0;
+	for (int b = 0; b < nelems; b++) {
+		ASSERT3U(n, <=, outlen);
+		if (n == outlen)
+			break;
+		uint64_t mask = (1ULL << b);
+		if (bits & mask) {
+			size_t len = strlen(table[b].vb_name);
+			if (n > 0)
+				len++;
+			if (n > outlen-len)
+				break;
+			if (n > 0) {
+				out[n++] = ' ';
+				len--;
+			}
+			memcpy(&out[n], table[b].vb_name, len);
+			n += len;
+		}
+	}
+	if (n < outlen)
+		out[n++] = '\0';
+	return (n);
+}
+
+/*
+ * Emits the name of the given enum value in the table.
+ */
+static size_t
+valstr_enum_str(const char **table, const size_t nelems,
+    int v, char *out, size_t outlen)
+{
+	ASSERT(out);
+	ASSERT3U(v, <, nelems);
+	if (v >= nelems)
+		return (0);
+	return (MIN(strlcpy(out, table[v], outlen), outlen));
+}
+
+/*
+ * These macros create the string tables for the given name, and implement
+ * the public functions described in zfs_valstr.h.
+ */
+#define	_VALSTR_BITFIELD_IMPL(name, ...)				\
+static const valstr_bit_t valstr_ ## name ## _table[] = { __VA_ARGS__ };\
+size_t									\
+zfs_valstr_ ## name ## _bits(uint64_t bits, char *out, size_t outlen)	\
+{									\
+	return (valstr_bitfield_bits(valstr_ ## name ## _table,		\
+	    ARRAY_SIZE(valstr_ ## name ## _table), bits, out, outlen));	\
+}									\
+									\
+size_t									\
+zfs_valstr_ ## name ## _pairs(uint64_t bits, char *out, size_t outlen)	\
+{									\
+	return (valstr_bitfield_pairs(valstr_ ## name ## _table,	\
+	    ARRAY_SIZE(valstr_ ## name ## _table), bits, out, outlen));	\
+}									\
+									\
+size_t									\
+zfs_valstr_ ## name(uint64_t bits, char *out, size_t outlen)		\
+{									\
+	return (valstr_bitfield_str(valstr_ ## name ## _table,		\
+	    ARRAY_SIZE(valstr_ ## name ## _table), bits, out, outlen));	\
+}									\
+
+#define	_VALSTR_ENUM_IMPL(name, ...)					\
+static const char *valstr_ ## name ## _table[] = { __VA_ARGS__ };	\
+size_t									\
+zfs_valstr_ ## name(int v, char *out, size_t outlen)			\
+{									\
+	return (valstr_enum_str(valstr_ ## name ## _table,		\
+	    ARRAY_SIZE(valstr_ ## name ## _table), v, out, outlen));	\
+}									\
+
+
+/* String tables */
+
+/* ZIO flags: zio_flag_t, typically zio->io_flags */
+/* BEGIN CSTYLED */
+_VALSTR_BITFIELD_IMPL(zio_flag,
+	{ '.', "DA", "DONT_AGGREGATE" },
+	{ '.', "RP", "IO_REPAIR" },
+	{ '.', "SH", "SELF_HEAL" },
+	{ '.', "RS", "RESILVER" },
+	{ '.', "SC", "SCRUB" },
+	{ '.', "ST", "SCAN_THREAD" },
+	{ '.', "PH", "PHYSICAL" },
+	{ '.', "CF", "CANFAIL" },
+	{ '.', "SP", "SPECULATIVE" },
+	{ '.', "CW", "CONFIG_WRITER" },
+	{ '.', "DR", "DONT_RETRY" },
+	{ '?', "??", "[UNUSED 11]" },
+	{ '.', "ND", "NODATA" },
+	{ '.', "ID", "INDUCE_DAMAGE" },
+	{ '.', "AL", "IO_ALLOCATING" },
+	{ '.', "RE", "IO_RETRY" },
+	{ '.', "PR", "PROBE" },
+	{ '.', "TH", "TRYHARD" },
+	{ '.', "OP", "OPTIONAL" },
+	{ '.', "DQ", "DONT_QUEUE" },
+	{ '.', "DP", "DONT_PROPAGATE" },
+	{ '.', "BY", "IO_BYPASS" },
+	{ '.', "RW", "IO_REWRITE" },
+	{ '.', "CM", "RAW_COMPRESS" },
+	{ '.', "EN", "RAW_ENCRYPT" },
+	{ '.', "GG", "GANG_CHILD" },
+	{ '.', "DD", "DDT_CHILD" },
+	{ '.', "GF", "GODFATHER" },
+	{ '.', "NP", "NOPWRITE" },
+	{ '.', "EX", "REEXECUTED" },
+	{ '.', "DG", "DELEGATED" },
+)
+/* END CSTYLED */
+
+/*
+ * ZIO pipeline stage(s): enum zio_stage, typically zio->io_stage or
+ *                        zio->io_pipeline.
+ */
+/* BEGIN CSTYLED */
+_VALSTR_BITFIELD_IMPL(zio_stage,
+	{ 'O', "O ", "OPEN" },
+	{ 'I', "RI", "READ_BP_INIT" },
+	{ 'I', "WI", "WRITE_BP_INIT" },
+	{ 'I', "FI", "FREE_BP_INIT" },
+	{ 'A', "IA", "ISSUE_ASYNC" },
+	{ 'W', "WC", "WRITE_COMPRESS" },
+	{ 'E', "EN", "ENCRYPT" },
+	{ 'C', "CG", "CHECKSUM_GENERATE" },
+	{ 'N', "NW", "NOP_WRITE" },
+	{ 'B', "BF", "BRT_FREE" },
+	{ 'd', "dS", "DDT_READ_START" },
+	{ 'd', "dD", "DDT_READ_DONE" },
+	{ 'd', "dW", "DDT_WRITE" },
+	{ 'd', "dF", "DDT_FREE" },
+	{ 'G', "GA", "GANG_ASSEMBLE" },
+	{ 'G', "GI", "GANG_ISSUE" },
+	{ 'D', "DT", "DVA_THROTTLE" },
+	{ 'D', "DA", "DVA_ALLOCATE" },
+	{ 'D', "DF", "DVA_FREE" },
+	{ 'D', "DC", "DVA_CLAIM" },
+	{ 'R', "R ", "READY" },
+	{ 'V', "VS", "VDEV_IO_START" },
+	{ 'V', "VD", "VDEV_IO_DONE" },
+	{ 'V', "VA", "VDEV_IO_ASSESS" },
+	{ 'C', "CV", "CHECKSUM_VERIFY" },
+	{ 'X', "X ", "DONE" },
+)
+/* END CSTYLED */
+
+/* ZIO priority: zio_priority_t, typically zio->io_priority */
+/* BEGIN CSTYLED */
+_VALSTR_ENUM_IMPL(zio_priority,
+	"SYNC_READ",
+	"SYNC_WRITE",
+	"ASYNC_READ",
+	"ASYNC_WRITE",
+	"SCRUB",
+	"REMOVAL",
+	"INITIALIZING",
+	"TRIM",
+	"REBUILD",
+	"[NUM_QUEUEABLE]",
+	"NOW",
+)
+/* END CSTYLED */
+
+#undef _VALSTR_BITFIELD_IMPL
+#undef _VALSTR_ENUM_IMPL


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

As a good C program, OpenZFS uses bitfields and enums all over. I am extremely bad at decoding these in my head, so I frequently find myself writing weird custom formatters. I got sick of that, so I made some more generic formatting facilities for bitfields and enums.

(This is the fully armed and operational version of #15945).

### Description

This add `zfs_valstr.h`, which has some macros to help generation functions to emit string representations of bitfield and enum types. See the comments for details.

Formatters for ZIO flags (`zio_flag_t`), stage/pipeline (`enum zio_stage`) and priority (`zio_priority_t`) are included, and hooked up to `zpool events -v` for those fields:

```
Aug 22 2024 10:27:40.191979873 ereport.fs.zfs.io
        class = "ereport.fs.zfs.io"
...
        zio_err = 0x5
        zio_flags = 0x1802c0 [PHYSICAL CANFAIL CONFIG_WRITER DONT_QUEUE DONT_PROPAGATE]
        zio_stage = 0x2000000 [DONE]
        zio_pipeline = 0x2100000 [READY DONE]
        zio_delay = 0x52b2
        zio_timestamp = 0xa5c8e385
        zio_delta = 0x5475
        zio_priority = 0x1 [SYNC_WRITE]
        zio_offset = 0x22000
        zio_size = 0x400
```

Note that nothing here uses the "bit" and "pairs" formatters, as I don't have any "production" use for them right now. I still want these facilities available though, as they're very useful during development. #15945 has examples.

I'm somewhat concerned about the string tables falling out of sync with the actual values. There's probably more we could to to make this tighter, from validating the number of items in the tables to actually generating the tables at the same place the bitfield or enum type are declared. That's more work than I wanted to do right now, which is mostly about reviving an old idea so I can use it. I don't think it has to be a huge issue but I'm happy to tackle it up front if people feel there's more danger than I do.

Requires #16469.

### How Has This Been Tested?

Generating errors and eyeballing output, and then running the `events` suite, which has a few calls of `zpool events`, though nothing that cares about the formatting of those fields.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
