### PR TITLE
dmu_objset: replace `dnode_hash` impl with `cityhash4`

### DIFF
--- a/cmd/zstream/zstream_redup.c
+++ b/cmd/zstream/zstream_redup.c
@@ -132,7 +132,7 @@ static void
 rdt_insert(redup_table_t *rdt,
     uint64_t guid, uint64_t object, uint64_t offset, uint64_t stream_offset)
 {
-	uint64_t ch = cityhash4(guid, object, offset, 0);
+	uint64_t ch = cityhash3(guid, object, offset);
 	uint64_t hashcode = BF64_GET(ch, 0, rdt->numhashbits);
 	redup_entry_t **rdepp;
 
@@ -152,7 +152,7 @@ rdt_lookup(redup_table_t *rdt,
     uint64_t guid, uint64_t object, uint64_t offset,
     uint64_t *stream_offsetp)
 {
-	uint64_t ch = cityhash4(guid, object, offset, 0);
+	uint64_t ch = cityhash3(guid, object, offset);
 	uint64_t hashcode = BF64_GET(ch, 0, rdt->numhashbits);
 
 	for (redup_entry_t *rde = rdt->redup_hash_array[hashcode];

--- a/include/cityhash.h
+++ b/include/cityhash.h
@@ -32,6 +32,13 @@
 extern "C" {
 #endif
 
+/*
+ * Define 1/2/3-argument specialized versions of cityhash4, which can reduce
+ * instruction count (especially multiplication) on some 32-bit arches.
+ */
+_SYS_CITYHASH_H uint64_t cityhash1(uint64_t);
+_SYS_CITYHASH_H uint64_t cityhash2(uint64_t, uint64_t);
+_SYS_CITYHASH_H uint64_t cityhash3(uint64_t, uint64_t, uint64_t);
 _SYS_CITYHASH_H uint64_t cityhash4(uint64_t, uint64_t, uint64_t, uint64_t);
 
 #ifdef	__cplusplus

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -154,6 +154,9 @@
     <elf-symbol name='avl_update_lt' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='avl_walk' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='bookmark_namecheck' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='cityhash1' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='cityhash2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='cityhash3' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='cityhash4' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='color_end' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='color_start' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -9241,6 +9244,21 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='module/zcommon/cityhash.c' language='LANG_C99'>
+    <function-decl name='cityhash1' mangled-name='cityhash1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='cityhash1'>
+      <parameter type-id='9c313c2d' name='w'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
+    <function-decl name='cityhash2' mangled-name='cityhash2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='cityhash2'>
+      <parameter type-id='9c313c2d' name='w1'/>
+      <parameter type-id='9c313c2d' name='w2'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
+    <function-decl name='cityhash3' mangled-name='cityhash3' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='cityhash3'>
+      <parameter type-id='9c313c2d' name='w1'/>
+      <parameter type-id='9c313c2d' name='w2'/>
+      <parameter type-id='9c313c2d' name='w3'/>
+      <return type-id='9c313c2d'/>
+    </function-decl>
     <function-decl name='cityhash4' mangled-name='cityhash4' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='cityhash4'>
       <parameter type-id='9c313c2d' name='w1'/>
       <parameter type-id='9c313c2d' name='w2'/>

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -551,8 +551,8 @@ zvol_request_impl(zvol_state_t *zv, struct bio *bio, struct request *rq,
 		blk_mq_hw_queue =
 		    rq->q->queue_hw_ctx[rq->q->mq_map[rq->cpu]]->queue_num;
 #endif
-	taskq_hash = cityhash4((uintptr_t)zv, offset >> ZVOL_TASKQ_OFFSET_SHIFT,
-	    blk_mq_hw_queue, 0);
+	taskq_hash = cityhash3((uintptr_t)zv, offset >> ZVOL_TASKQ_OFFSET_SHIFT,
+	    blk_mq_hw_queue);
 	tq_idx = taskq_hash % ztqs->tqs_cnt;
 
 	if (rw == WRITE) {

--- a/module/zcommon/cityhash.c
+++ b/module/zcommon/cityhash.c
@@ -49,8 +49,8 @@ cityhash_helper(uint64_t u, uint64_t v, uint64_t mul)
 	return (b);
 }
 
-uint64_t
-cityhash4(uint64_t w1, uint64_t w2, uint64_t w3, uint64_t w4)
+static inline uint64_t
+cityhash_impl(uint64_t w1, uint64_t w2, uint64_t w3, uint64_t w4)
 {
 	uint64_t mul = HASH_K2 + 64;
 	uint64_t a = w1 * HASH_K1;
@@ -59,9 +59,38 @@ cityhash4(uint64_t w1, uint64_t w2, uint64_t w3, uint64_t w4)
 	uint64_t d = w3 * HASH_K2;
 	return (cityhash_helper(rotate(a + b, 43) + rotate(c, 30) + d,
 	    a + rotate(b + HASH_K2, 18) + c, mul));
+}
 
+/*
+ * Passing w as the 2nd argument could save one 64-bit multiplication.
+ */
+uint64_t
+cityhash1(uint64_t w)
+{
+	return (cityhash_impl(0, w, 0, 0));
+}
+
+uint64_t
+cityhash2(uint64_t w1, uint64_t w2)
+{
+	return (cityhash_impl(w1, w2, 0, 0));
+}
+
+uint64_t
+cityhash3(uint64_t w1, uint64_t w2, uint64_t w3)
+{
+	return (cityhash_impl(w1, w2, w3, 0));
+}
+
+uint64_t
+cityhash4(uint64_t w1, uint64_t w2, uint64_t w3, uint64_t w4)
+{
+	return (cityhash_impl(w1, w2, w3, w4));
 }
 
 #if defined(_KERNEL)
+EXPORT_SYMBOL(cityhash1);
+EXPORT_SYMBOL(cityhash2);
+EXPORT_SYMBOL(cityhash3);
 EXPORT_SYMBOL(cityhash4);
 #endif

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -405,13 +405,13 @@ dmu_objset_byteswap(void *buf, size_t size)
 }
 
 /*
- * Runs cityhash4 on the objset_t pointer and the object number.
+ * Runs cityhash on the objset_t pointer and the object number.
  */
 static uint64_t
 dnode_hash(const objset_t *os, uint64_t obj)
 {
 	uintptr_t osv = (uintptr_t)os;
-	return (cityhash4((uint64_t)osv, obj, 0, 0));
+	return (cityhash2((uint64_t)osv, obj));
 }
 
 static unsigned int

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -4182,8 +4182,8 @@ zio_alloc_zil(spa_t *spa, objset_t *os, uint64_t txg, blkptr_t *new_bp,
 	 * some parallelism.
 	 */
 	int flags = METASLAB_ZIL;
-	int allocator = (uint_t)cityhash4(0, 0, 0,
-	    os->os_dsl_dataset->ds_object) % spa->spa_alloc_count;
+	int allocator = (uint_t)cityhash1(os->os_dsl_dataset->ds_object)
+	    % spa->spa_alloc_count;
 	error = metaslab_alloc(spa, spa_log_class(spa), size, new_bp, 1,
 	    txg, NULL, flags, &io_alloc_list, NULL, allocator);
 	*slog = (error == 0);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As mentioned in PR #16131, replacing CRC-based hash with cityhash4 could slightly improve the performance by eliminating memory access. Replacing the algorithm is safe since the hash result is not persisted.

Moreover, `cityhash4` yields more instructions and larger stack frame on 32-bit arches. Replacing it with specialized versions (i.e. setting some arguments to 0) can also provide boost.

See: openzfs/zfs#16131

### Description
<!--- Describe your changes in detail -->

1. replace CRC-based hash with `cityhash4`.
2. add specialized version `cityhash2` and `cityhash3`.
3. replace invocations to `cityhash4` with specialized versions whenever possible.

Please see commit message for more details.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Compiled on my machine. Let's see the ZTS results on CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
