### PR TITLE
libzstd: also build with LIBZPOOL_CPPFLAGS

### DIFF
--- a/lib/libzstd/Makefile.am
+++ b/lib/libzstd/Makefile.am
@@ -1,4 +1,6 @@
 libzstd_la_CFLAGS  = $(AM_CFLAGS) $(LIBRARY_CFLAGS)
+libzstd_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBZPOOL_CPPFLAGS)
+
 # -fno-tree-vectorize is set for gcc in zstd/common/compiler.h
 # Set it for other compilers, too.
 libzstd_la_CFLAGS += -fno-tree-vectorize


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

A user reported an `abd_verify()` crash through libzstd, and wondered if it was the same thing as #16477. And it was!

### Description

libzstd now also allocates its own `abd_t`, and so has the same issue as zstream did, so this applies the same workaround: compile it with `ZFS_DEBUG`. See 92fca1c2d.

This looks weird, because libzstd doesn't appear to look related to the ZFS kernel, but there is already a cross-dependency there: zstd needs `zfs_lz4_compress`, and zfs needs `zfs_zstd_compress` (and others), so the two can never really be separated without more work. Another job for another time.

A quick glance suggests zstd isn't using `ZFS_DEBUG` or `DEBUG` for anything else, so I wouldn't expect this to make any meaningful difference elsewhere.

### How Has This Been Tested?

Compile checked only.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
