### PR TITLE
sys/types32.h: Remove struct timeval32 from libspl's header

### DIFF
--- a/lib/libspl/include/sys/types32.h
+++ b/lib/libspl/include/sys/types32.h
@@ -65,11 +65,6 @@ typedef	int32_t		ssize32_t;
 typedef	int32_t		time32_t;
 typedef	int32_t		clock32_t;
 
-struct timeval32 {
-	time32_t	tv_sec;		/* seconds */
-	int32_t		tv_usec;	/* and microseconds */
-};
-
 typedef struct timespec32 {
 	time32_t	tv_sec;		/* seconds */
 	int32_t		tv_nsec;	/* and nanoseconds */


### PR DESCRIPTION
macOS Sequoia's sys/sockio.h, as included by various bootstrap tools
whilst building FreeBSD, has started to include net/if.h, which then
includes sys/_types/_timeval32.h and provide a conflicting definition
for struct timeval32. Since this type is entirely unused within OpenZFS,
simply delete the type rather than adding in some kind of OS detection.

This fixes building FreeBSD on macOS Sequoia (Beta).

Signed-off-by: Jessica Clarke <jrtc27@jrtc27.com>
