### PR TITLE
vdev_file: implement TRIM-like support for FreeBSD 14

### DIFF
--- a/include/sys/zfs_file.h
+++ b/include/sys/zfs_file.h
@@ -53,7 +53,7 @@ int zfs_file_pread(zfs_file_t *fp, void *buf, size_t len, loff_t off,
 int zfs_file_seek(zfs_file_t *fp, loff_t *offp, int whence);
 int zfs_file_getattr(zfs_file_t *fp, zfs_file_attr_t *zfattr);
 int zfs_file_fsync(zfs_file_t *fp, int flags);
-int zfs_file_fallocate(zfs_file_t *fp, int mode, loff_t offset, loff_t len);
+int zfs_file_deallocate(zfs_file_t *fp, loff_t offset, loff_t len);
 loff_t zfs_file_off(zfs_file_t *fp);
 int zfs_file_unlink(const char *);
 

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -1367,24 +1367,26 @@ zfs_file_fsync(zfs_file_t *fp, int flags)
 }
 
 /*
- * fallocate - allocate or free space on disk
+ * deallocate - zero and/or deallocate file storage
  *
  * fp - file pointer
- * mode (non-standard options for hole punching etc)
- * offset - offset to start allocating or freeing from
- * len - length to free / allocate
- *
- * OPTIONAL
+ * offset - offset to start zeroing or deallocating
+ * len - length to zero or deallocate
  */
 int
-zfs_file_fallocate(zfs_file_t *fp, int mode, loff_t offset, loff_t len)
+zfs_file_deallocate(zfs_file_t *fp, loff_t offset, loff_t len)
 {
-#ifdef __linux__
-	return (fallocate(fp->f_fd, mode, offset, len));
+	int rc;
+#if defined(__linux__)
+	rc = fallocate(fp->f_fd,
+	    FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, len);
 #else
-	(void) fp, (void) mode, (void) offset, (void) len;
-	return (EOPNOTSUPP);
+	(void) fp, (void) offset, (void) len;
+	rc = EOPNOTSUPP;
 #endif
+	if (rc)
+		return (SET_ERROR(rc));
+	return (0);
 }
 
 /*

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -1380,6 +1380,12 @@ zfs_file_deallocate(zfs_file_t *fp, loff_t offset, loff_t len)
 #if defined(__linux__)
 	rc = fallocate(fp->f_fd,
 	    FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, len);
+#elif defined(__FreeBSD__) && (__FreeBSD_version >= 1400029)
+	struct spacectl_range rqsr = {
+		.r_offset = offset,
+		.r_len = len,
+	};
+	rc = fspacectl(fp->f_fd, SPACECTL_DEALLOC, &rqsr, 0, &rqsr);
 #else
 	(void) fp, (void) offset, (void) len;
 	rc = EOPNOTSUPP;

--- a/module/os/freebsd/zfs/vdev_file.c
+++ b/module/os/freebsd/zfs/vdev_file.c
@@ -260,16 +260,9 @@ vdev_file_io_start(zio_t *zio)
 		zio_execute(zio);
 		return;
 	} else if (zio->io_type == ZIO_TYPE_TRIM) {
-#ifdef notyet
-		int mode = 0;
-
 		ASSERT3U(zio->io_size, !=, 0);
-
-		/* XXX FreeBSD has no fallocate routine in file ops */
-		zio->io_error = zfs_file_fallocate(vf->vf_file,
-		    mode, zio->io_offset, zio->io_size);
-#endif
-		zio->io_error = SET_ERROR(ENOTSUP);
+		zio->io_error = zfs_file_deallocate(vf->vf_file,
+		    zio->io_offset, zio->io_size);
 		zio_execute(zio);
 		return;
 	}

--- a/module/os/freebsd/zfs/zfs_file_os.c
+++ b/module/os/freebsd/zfs/zfs_file_os.c
@@ -285,6 +285,20 @@ zfs_file_fsync(zfs_file_t *fp, int flags)
 	return (zfs_vop_fsync(fp->f_vnode));
 }
 
+/*
+ * deallocate - zero and/or deallocate file storage
+ *
+ * fp - file pointer
+ * offset - offset to start zeroing or deallocating
+ * len - length to zero or deallocate
+ */
+int
+zfs_file_deallocate(zfs_file_t *fp, loff_t offset, loff_t len)
+{
+	(void) fp, (void) offset, (void) len;
+	return (SET_ERROR(EOPNOTSUPP));
+}
+
 zfs_file_t *
 zfs_file_get(int fd)
 {

--- a/module/os/linux/zfs/vdev_file.c
+++ b/module/os/linux/zfs/vdev_file.c
@@ -274,14 +274,9 @@ vdev_file_io_start(zio_t *zio)
 		zio_execute(zio);
 		return;
 	} else if (zio->io_type == ZIO_TYPE_TRIM) {
-		int mode = 0;
-
 		ASSERT3U(zio->io_size, !=, 0);
-#ifdef __linux__
-		mode = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
-#endif
-		zio->io_error = zfs_file_fallocate(vf->vf_file,
-		    mode, zio->io_offset, zio->io_size);
+		zio->io_error = zfs_file_deallocate(vf->vf_file,
+		    zio->io_offset, zio->io_size);
 		zio_execute(zio);
 		return;
 	}

--- a/module/os/linux/zfs/zfs_file_os.c
+++ b/module/os/linux/zfs/zfs_file_os.c
@@ -328,17 +328,14 @@ zfs_file_fsync(zfs_file_t *filp, int flags)
 }
 
 /*
- * fallocate - allocate or free space on disk
+ * deallocate - zero and/or deallocate file storage
  *
  * fp - file pointer
- * mode (non-standard options for hole punching etc)
- * offset - offset to start allocating or freeing from
- * len - length to free / allocate
- *
- * OPTIONAL
+ * offset - offset to start zeroing or deallocating
+ * len - length to zero or deallocate
  */
 int
-zfs_file_fallocate(zfs_file_t *fp, int mode, loff_t offset, loff_t len)
+zfs_file_deallocate(zfs_file_t *fp, loff_t offset, loff_t len)
 {
 	/*
 	 * May enter XFS which generates a warning when PF_FSTRANS is set.
@@ -354,12 +351,16 @@ zfs_file_fallocate(zfs_file_t *fp, int mode, loff_t offset, loff_t len)
 	 */
 	int error = EOPNOTSUPP;
 	if (fp->f_op->fallocate)
-		error = fp->f_op->fallocate(fp, mode, offset, len);
+		error = -fp->f_op->fallocate(fp,
+		    FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, len);
 
 	if (fstrans)
 		current->flags |= __SPL_PF_FSTRANS;
 
-	return (error);
+	if (error)
+		return (SET_ERROR(error));
+
+	return (0);
 }
 
 /*


### PR DESCRIPTION
### Motivation and Context

Just reading code and noticed FreeBSD support for TRIM to file-backed vdevs was commented out. Looked further and found FreeBSD 14 implemented support for it, so for fun I wired it up.

### Description

First, rename `vfs_file_fallocate` to `vfs_file_deallocate`, and push the Linux-specific hole-punching flags down to the Linux implementation, and make a FreeBSD no-op implementation.

Then, fill out the FreeBSD implementation with calls to `fspacectl()` (userspace) or `fo_fspacectl()` (kernel).

### How Has This Been Tested?

Compile checked on Linux 6.1, FreeBSD 13 & 14.

On Linux, `zpool_trim` and `trim` test tags continue to pass.

On FreeBSD its a little more complicated. Currently UFS doesn't implement a specific `VOP_DEALLOCATE`, so the generic fallback is used, which simply writes zeroes. As a result, enabling the test tags just gives a bunch of failed tests because they all look for the effective size on disk, that is, they assume the deallocated regions will become sparse. I don't really want to attempt to change the test suite to use a different filesystem (my FreeBSD test runner is already in tenuous shape as it is).

But, [`tmpfs(5)`](https://man.freebsd.org/cgi/man.cgi?tmpfs(5)) does support `VOP_DEALLOCATE`, so we can faff around a bit to try and prove it that way.

Lets make a tmpfs, and then make a file full of data:

```
$ mkdir /tmpfs
$ mount -t tmpfs tmpfs /tmpfs
$ dd if=/dev/random of=/tmpfs/file bs=100M count=1
```

Because its full of data, its effective size is 100K 1K-blocks:

```
$ du -s /tmpfs/file
102400	/tmpfs/file
```

I wrote a daft little program, [`dumpholes`](https://gist.github.com/robn/6776df7fd9066803f54ef7392194dc44), to show the data/hole structure of a file. That also shows that it's all-data:

```
$ dumpholes /tmpfs/file
DATA 0
END 104857600
```

So we make a pool over the top, then issue the trim:

```
$ sudo zpool create tank /tmpfs/file
$ sudo zpool trim -w tank
$ zpool status -t
  pool: tank
 state: ONLINE
config:

	NAME           STATE     READ WRITE CKSUM
	tank           ONLINE       0     0     0
	 /tmpfs/file  ONLINE       0     0     0  (100% trimmed, completed at Sun Sep  1 13:29:55 2024)

errors: No known data errors
```

For extra fun, we can use `dtrace` to see that yes, its really doing things:

```
$ dtrace -n 'vfs::vop_deallocate:entry { ap = (struct vop_deallocate_args *)arg1; printf("off=%x len=%x", *ap->a_offset, *ap->a_len); }'
dtrace: description 'vfs::vop_deallocate:entry ' matched 1 probe
CPU     ID                    FUNCTION:NAME
  0  79177             vop_deallocate:entry off=410000 len=ff0000
  1  79177             vop_deallocate:entry off=1800000 len=c00000
  1  79177             vop_deallocate:entry off=2800000 len=c00000
  1  79177             vop_deallocate:entry off=3800000 len=c00000
  1  79177             vop_deallocate:entry off=4800000 len=c00000
```

After, we can see the effective size of the file has dropped, and its now full of holes:

```
$ du -s /tmpfs/file
36980	/tmpfs/file
$ dumpholes /tmpfs/file
DATA 0
HOLE 4313088
DATA 20971520
HOLE 25165824
DATA 37748736
HOLE 41943040
DATA 54525952
HOLE 58720256
DATA 71303168
HOLE 75497472
DATA 88080384
END 104857600
```

And if we read back part of the zeroed region, it is, indeed, zeroes:

```
$ xxd -a -s 0x4800000 -l 0xc00000 /tmp/file
04800000: 0000 0000 0000 0000 0000 0000 0000 0000  ................
*
053ffff0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
```

So I suppose that works?

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
