### PR TITLE
zts-report: don't crash on non-UTF-8 chars in the log

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -389,7 +389,7 @@ if os.environ.get('CI') == 'true':
 
 def process_results(pathname):
     try:
-        f = open(pathname)
+        f = open(pathname, errors='replace')
     except IOError as e:
         print('Error opening file:', e)
         sys.exit(1)


### PR DESCRIPTION
### Motivation and Context

I'm very sick of getting Python stacktraces instead of nice test reports.

### Description

The report generator expects the log to be clean and tidy UTF-8. That can be a problem if you use some of the verbose/debug test runner options, which sends all sorts of weird output from arbitrary programs to the log.

This just makes Python a little more relaxed about such things. It shouldn't matter in practice, as those lines didn't match the test result regex anyway, and are discarded immediately.

### How Has This Been Tested?

Do a full test run with super aggressive debug output:

```
$ /usr/local/share/zfs/zfs-tests.sh -DvKx
```

Come back tomorrow, and enjoy the crash:

```
Results Summary
PASS     1712
FAIL      33
SKIP      30
KILLED     4

Running Time:   06:29:26
Percent passed: 96.2%
Log directory:  /var/tmp/test_results/20240831T183324
Traceback (most recent call last):
  File "/usr/local/share/zfs/test-runner/bin/zts-report.py", line 445, in <module>
    results, logdir = process_results(args.logfile)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/share/zfs/test-runner/bin/zts-report.py", line 406, in process_results
    for line in f.readlines():
                ^^^^^^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe1 in position 7761: invalid continuation byte
```

Apply this patch and try again:

```
$ ./tests/test-runner/bin/zts-report.py /var/tmp/test_results/20240831T183324/log

Tests with results other than PASS that are expected:
    FAIL append/threadsappend_001_pos (https://github.com/openzfs/zfs/issues/6136)
    FAIL casenorm/mixed_formd_delete (https://github.com/openzfs/zfs/issues/7633)
    FAIL casenorm/mixed_formd_lookup (https://github.com/openzfs/zfs/issues/7633)
...

Tests with result of PASS that are unexpected:

Tests with results other than PASS that are unexpected:
    FAIL cli_root/json/json_sanity (expected PASS)
    FAIL cli_root/zdb/zdb_args_pos (expected PASS)
    FAIL cli_root/zfs_load-key/zfs_load-key_all (expected PASS)
...
```

Of course, now I gotta fix what I broke, but hey, you can't fix a problem you don't know about.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).