### PR TITLE
sa_impl: fix SA header bitfield docs

### DIFF
--- a/include/sys/sa_impl.h
+++ b/include/sys/sa_impl.h
@@ -167,8 +167,8 @@ typedef struct sa_hdr_phys {
 	 * | hdrsz  |layout |
 	 * +--------+-------+
 	 *
-	 * Bits 0-10 are the layout number
-	 * Bits 11-16 are the size of the header.
+	 * Bits 0-9 (10 bits) are the layout number (0-1023)
+	 * Bits 10-15 (6 bits) are the size of the header (0-63)
 	 * The hdrsize is the number * 8
 	 *
 	 * For example.


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

Docs didn't quite match, and I got confused.

### Description

Just a little doc comment fix.

### How Has This Been Tested?

Look at on-disk data in gdb, thought very hard.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
