### PR TITLE
WIP: Remove spa_namespace_lock from zpool status

### DIFF
--- a/TEST
+++ b/TEST
@@ -35,7 +35,7 @@
 #TEST_ZFSTESTS_ITERS="1"
 #TEST_ZFSTESTS_OPTIONS="-vx"
 #TEST_ZFSTESTS_RUNFILE="linux.run"
-#TEST_ZFSTESTS_TAGS="functional"
+TEST_ZFSTESTS_TAGS="zpool_import,zpool_export,zpool_status,zpool_add"
 
 ### zfsstress
 #TEST_ZFSSTRESS_SKIP="yes"

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -484,6 +484,7 @@ struct spa {
 extern char *spa_config_path;
 extern const char *zfs_deadman_failmode;
 extern uint_t spa_slop_shift;
+extern uint_t spa_namespace_delay_ms;
 extern void spa_taskq_dispatch(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
     task_func_t *func, zio_t *zio, boolean_t cutinline);
 extern void spa_load_spares(spa_t *spa);

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -769,6 +769,8 @@ void ksiddomain_rele(ksiddomain_t *);
 		(void) nanosleep(&ts, NULL);				\
 	} while (0)
 
+#define	zfs_msleep(ms) zfs_sleep_until(gethrtime() + (MSEC2NSEC(ms)))
+
 typedef int fstrans_cookie_t;
 
 extern fstrans_cookie_t spl_fstrans_mark(void);

--- a/include/sys/zfs_delay.h
+++ b/include/sys/zfs_delay.h
@@ -37,5 +37,6 @@
 			usleep_range(delta_us, delta_us + 100);		\
 		}							\
 	} while (0)
+#define	zfs_msleep(ms) zfs_sleep_until(gethrtime() + (MSEC2NSEC(ms)))
 
 #endif	/* _SYS_FS_ZFS_DELAY_H */

--- a/module/os/freebsd/zfs/spa_os.c
+++ b/module/os/freebsd/zfs/spa_os.c
@@ -192,7 +192,7 @@ spa_import_rootpool(const char *name, bool checkpointrewind)
 	 */
 	config = spa_generate_rootconf(name);
 
-	mutex_enter(&spa_namespace_lock);
+	mutex_enter_ns(&spa_namespace_lock);
 	if (config != NULL) {
 		pname = fnvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME);
 		VERIFY0(strcmp(name, pname));

--- a/module/os/freebsd/zfs/zfs_ioctl_os.c
+++ b/module/os/freebsd/zfs/zfs_ioctl_os.c
@@ -107,7 +107,7 @@ zfs_ioc_nextboot(const char *unused, nvlist_t *innvl, nvlist_t *outnvl)
 	    "command", &command) != 0)
 		return (EINVAL);
 
-	mutex_enter(&spa_namespace_lock);
+	mutex_enter_ns(&spa_namespace_lock);
 	spa = spa_by_guid(pool_guid, vdev_guid);
 	if (spa != NULL)
 		strcpy(name, spa_name(spa));

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -8205,7 +8205,7 @@ l2arc_dev_get_next(void)
 	 * of cache devices (l2arc_dev_mtx).  Once a device has been selected,
 	 * both locks will be dropped and a spa config lock held instead.
 	 */
-	mutex_enter(&spa_namespace_lock);
+	mutex_enter_ns(&spa_namespace_lock);
 	mutex_enter(&l2arc_dev_mtx);
 
 	/* if there are no vdevs, there is nothing to do */

--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -728,7 +728,7 @@ mmp_signal_all_threads(void)
 {
 	spa_t *spa = NULL;
 
-	mutex_enter(&spa_namespace_lock);
+	mutex_enter_ns(&spa_namespace_lock);
 	while ((spa = spa_next(spa))) {
 		if (spa->spa_state == POOL_STATE_ACTIVE)
 			mmp_signal_thread(spa);

--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -1562,7 +1562,7 @@ zfs_ereport_zvol_post(const char *subclass, const char *name,
 	char *r;
 
 	boolean_t locked = mutex_owned(&spa_namespace_lock);
-	if (!locked) mutex_enter(&spa_namespace_lock);
+	if (!locked) mutex_enter_ns(&spa_namespace_lock);
 	spa_t *spa = spa_lookup(name);
 	if (!locked) mutex_exit(&spa_namespace_lock);
 

--- a/module/zfs/zio_inject.c
+++ b/module/zfs/zio_inject.c
@@ -907,7 +907,7 @@ zio_inject_fault(char *name, int flags, int *id, zinject_record_t *record)
 			if (zio_pool_handler_exists(name, record->zi_cmd))
 				return (SET_ERROR(EEXIST));
 
-			mutex_enter(&spa_namespace_lock);
+			mutex_enter_ns(&spa_namespace_lock);
 			boolean_t has_spa = spa_lookup(name) != NULL;
 			mutex_exit(&spa_namespace_lock);
 
@@ -994,7 +994,7 @@ zio_inject_list_next(int *id, char *name, size_t buflen,
 	inject_handler_t *handler;
 	int ret;
 
-	mutex_enter(&spa_namespace_lock);
+	mutex_enter_ns(&spa_namespace_lock);
 	rw_enter(&inject_lock, RW_READER);
 
 	for (handler = list_head(&inject_handlers); handler != NULL;

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -559,7 +559,7 @@ tests = ['zpool_status_001_pos', 'zpool_status_002_pos',
     'zpool_status_003_pos', 'zpool_status_004_pos',
     'zpool_status_005_pos', 'zpool_status_006_pos',
     'zpool_status_007_pos', 'zpool_status_008_pos',
-    'zpool_status_features_001_pos']
+    'zpool_status_features_001_pos', 'zpool_status_namespace_lock']
 tags = ['functional', 'cli_root', 'zpool_status']
 
 [tests/functional/cli_root/zpool_sync]

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -90,6 +90,7 @@ export SYSTEM_FILES_COMMON='awk
     sync
     tail
     tar
+    time
     timeout
     touch
     tr
@@ -230,6 +231,7 @@ export ZFSTEST_FILES='badsend
     edonr_test
     skein_test
     sha2_test
+    time
     ctime
     truncate_test
     ereports

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -98,6 +98,7 @@ VOL_INHIBIT_DEV			UNSUPPORTED			zvol_inhibit_dev
 VOL_MODE			vol.mode			zvol_volmode
 VOL_RECURSIVE			vol.recursive			UNSUPPORTED
 VOL_USE_BLK_MQ			UNSUPPORTED			zvol_use_blk_mq
+SPA_NAMESPACE_DELAY_MS	spa.namespace_delay_ms	spa_namespace_delay_ms
 BCLONE_ENABLED			bclone_enabled			zfs_bclone_enabled
 BCLONE_WAIT_DIRTY		bclone_wait_dirty		zfs_bclone_wait_dirty
 XATTR_COMPAT			xattr_compat			zfs_xattr_compat

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1256,6 +1256,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_status/zpool_status_007_pos.ksh \
 	functional/cli_root/zpool_status/zpool_status_008_pos.ksh \
 	functional/cli_root/zpool_status/zpool_status_features_001_pos.ksh \
+	functional/cli_root/zpool_status/zpool_status_namespace_lock.ksh \
 	functional/cli_root/zpool_sync/cleanup.ksh \
 	functional/cli_root/zpool_sync/setup.ksh \
 	functional/cli_root/zpool_sync/zpool_sync_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_namespace_lock.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_namespace_lock.ksh
@@ -1,0 +1,144 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 	Test out that zpool status|get|list are not affected by the
+# 	'spa_namespace_lock' being held.  This was an issue in the past
+# 	where a pool would hang while holding the lock, and 'zpool status'
+# 	would hang waiting for the lock.
+#
+# STRATEGY:
+#	1. Create a test pool.  It should be created quickly.
+#	2. Set SPA_NAMESPACE_DELAY_MS to 1 second.
+#	3. Create another test pool.  It should take over 1 second due to the
+#	   delay.
+#	4. Run zpool status|get|list.  They should all run quickly.
+#	5. In the background, destroy one of the pools and export the other one
+#	   at the same time.  This should cause a lot of lock contention.  Note
+#	   that the 1 sec delay is still in effect.
+#	6. At the same time run some zpool commands and verify they still run in
+#	   200ms or less, and without error.
+
+verify_runnable "global"
+
+FILEDEV1="$TEST_BASE_DIR/filedev1.$$"
+FILEDEV2="$TEST_BASE_DIR/filedev2.$$"
+
+log_must truncate -s 100M "$FILEDEV1" "$FILEDEV2"
+TESTPOOL1=testpool1
+TESTPOOL2=testpool2
+
+function cleanup
+{
+	restore_tunable SPA_NAMESPACE_DELAY_MS
+	datasetexists $TESTPOOL1 && log_must zpool destroy $TESTPOOL1
+	datasetexists $TESTPOOL2 && log_must zpool destroy $TESTPOOL2
+	rm -f $FILEDEV1 $FILEDEV2
+
+	log_note "debug: $(cat /tmp/out)"
+}
+
+# Run a command and test how long it takes.  Fail the test if the command
+# fails or takes the wrong amount of time to run.
+#
+# The arguments consist of an array like this:
+#
+#	 zpool get all -le 200
+#
+# The first part of the array is the command and its arguments.
+# The 2nd to last argument is a ksh comparator operation like "-le" or "-ge"
+# The last argument is the expected time in milliseconds for the comparator.
+#
+# So the example above reads as "run 'zpool get all' and check that it runs in
+# 200 milliseconds or less".
+#
+function timetest_cmd
+{
+	# Run the command and record 'real' time.  dec will be a factional value
+	# like '1.05' representing the number of seconds it took to run.
+	array=($@)
+
+	# Save the last two arguments and remove them from the array
+	target_ms="${array[@]: -1}"
+	unset array[-1]
+	comp="${array[@]: -1}"
+	unset array[-1]
+
+	out="$({ time -p "${array[@]}" 1> /dev/null; } 2>&1)"
+	rc=$?
+	dec=$(echo "$out" | awk '/^real /{print $2}')
+
+	# Calculate milliseconds.  The divide by one at the end removes the
+	# decimal places.
+	ms=$(bc <<< "scale=0; $dec * 1000 / 1")
+
+	log_note "${array[@]}: $ms $comp $target_ms"
+
+	# For debugging failures
+	echo "$@: dec=$dec; rc=$rc; ms=$ms; $out" >> /tmp/out2
+	if [ -z "$ms" ] || [ $rc != 0 ] ; then
+		log_fail "Bad value: ms=$ms, rc=$rc: $out"
+	fi
+
+	if eval ! [ $ms $comp $target_ms ] ; then
+		log_fail "Expected time wrong: $ms $comp $target_ms"
+	fi
+}
+
+log_assert "Verify spa_namespace_lock isn't held by zpool status|get|list"
+
+log_onexit cleanup
+
+# A normal zpool create should take 200ms or less
+timetest_cmd zpool create $TESTPOOL1 $FILEDEV1 -le 200
+
+log_must save_tunable SPA_NAMESPACE_DELAY_MS
+log_must set_tunable32 SPA_NAMESPACE_DELAY_MS 1000
+
+# We added 1 sec hold time on spa_namespace lock.  zpool create
+# should now take at least 1000ms.
+timetest_cmd zpool create $TESTPOOL2 $FILEDEV2 -ge 1000
+
+# zpool status|get|list should not take spa_namespace_lock, so they should run
+# quickly, even loaded down with options.
+timetest_cmd zpool status -pPstvLD -le 200
+timetest_cmd zpool get all -le 200
+timetest_cmd zpool list -gLPv -le 200
+
+# In the background, destroy one of the pools and export the other one at the
+# same time.  This should cause a lot of lock contention.  At the same time
+# run some zpool commands and verify they still run in 200ms or less, and
+# without error.
+zpool destroy $TESTPOOL1 &
+zpool export $TESTPOOL2 &
+for i in 1 2 3 4 ; do
+	timetest_cmd zpool status -pPstvLD -le 200
+	timetest_cmd zpool get all -le 200
+	timetest_cmd zpool list -gLPv -le 200
+	sleep 0.1
+done
+wait
+
+log_pass "zpool status|get|list was not delayed by the spa_namespace_lock"


### PR DESCRIPTION
### Motivation and Context
Prevent `zpool status` from hanging if the zfs module is holding the `spa_namespace_lock`.

### Description
This commit removes `spa_namespace_lock` from the `zpool status` codepath. This means that zpool status will not hang if a pool fails while holding the `spa_namespace_lock`.

Background:

The `spa_namespace_lock` was originally meant to protect the `spa_namespace_avl` AVL tree.  The `spa_namespace_avl` tree holds the mappings from pool names to their `spa_t`.  So if you wanted to lookup the `spa_t` for the "tank" pool, you would do an AVL search for "tank" while holding `spa_namespace_lock`.

Over time though the `spa_namespace_lock` was re-purposed to protect other critical codepaths in the spa subsystem.  In many cases we don't know what the original authors meant to protect with it, or if they needed it for read-only or read-write protection.  It is simply "too big and risky to fix properly".

The workaround is to add a new lightweight version of the `spa_namespace_lock` called `spa_namespace_lite_lock`. `spa_namespace_lite_lock` only protects the AVL tree, and nothing else. It can be used for read-only access to the AVL tree without requiring the `spa_namespace_lock`.  Calls to `spa_lookup_lite()` and `spa_next_lite()` only need to acquire a reader lock on `spa_namespace_lite_lock`; they do not need to also acquire the old `spa_namespace_lock`.  This allows us to still run `zpool status` even if the zfs module has `spa_namespace_lock` held.  Note that these AVL tree locks only protect the tree, not the actual `spa_t` contents.

### How Has This Been Tested?
I added a new module param `spa_namespace_delay_ms` to introduce an artificial delay right after acquiring the `spa_namespace_lock`.  I added a one-second delay and could see `zpool create`, `zpool destory`, and `zpool import` take at least one second longer.  At the same time, I could see `zpool status`, `zpool get` and `zpool list` run instantaneously.  I added a test case for this as well.

**Marking this as WIP since I want to do some more manual testing**

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
