### PR TITLE
Remove set but not used variable in ddt.c

### DIFF
--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -2609,7 +2609,7 @@ ddt_prune_walk(spa_t *spa, uint64_t cutoff, ddt_age_histo_t *histogram)
 	};
 	ddt_lightweight_entry_t ddlwe = {0};
 	int error;
-	int total = 0, valid = 0;
+	int valid = 0;
 	int candidates = 0;
 	uint64_t now = gethrestime_sec();
 	ddt_prune_info_t dpi;
@@ -2633,7 +2633,6 @@ ddt_prune_walk(spa_t *spa, uint64_t cutoff, ddt_age_histo_t *histogram)
 
 		if (spa_shutting_down(spa) || issig())
 			break;
-		total++;
 
 		ASSERT(ddt->ddt_flags & DDT_FLAG_FLAT);
 		ASSERT3U(ddlwe.ddlwe_phys.ddp_flat.ddp_refcnt, <=, 1);


### PR DESCRIPTION

### Description

While testing the qemu runners, FreeBSD does not build the module right now.

This is the error we have:
```
  --- ddt.o ---
886
  /usr/home/zfs/zfs/module/zfs/ddt.c:2612:6: error: variable 'total' set but not used [-Werror,-Wunused-but-set-variable]
887
   2612 |         int total = 0, valid = 0;
888
        |             ^
889
  1 error generated.
890
  *** [ddt.o] Error code 1
```

@don-brady: I removed this (testing?) variable.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
