### PR TITLE
Fix handling of DNS names with '-' in them for sharenfs

### DIFF
--- a/lib/libshare/os/freebsd/nfs.c
+++ b/lib/libshare/os/freebsd/nfs.c
@@ -93,7 +93,9 @@ translate_opts(char *oldopts, FILE *out)
 		return (EOF);
 	newopts[0] = '\0';
 	s = oldopts;
-	while ((o = strsep(&s, "-, ")) != NULL) {
+	while ((o = strsep(&s, ", ")) != NULL) {
+		if (o[0] == '-')
+			o++;
 		if (o[0] == '\0')
 			continue;
 		for (i = 0; i < ARRAY_SIZE(known_opts); ++i) {


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Without this patch, the sharenfs property cannot have DNS names with '-' in them on FreeBSD.
This was reported to FreeBSD in a bugzilla report#168158 over 10 years ago.

### Description
Change the parser slightly so that '-' no longer is an option separator and
then strip any leading '-' off of the option (since it is no longer stripped out
as a separator).

### How Has This Been Tested?
Did a "zfs set sharenfs" with a '-' in the DNS name and then looked at
the resultant /etc/zfs/exports file.
The only negative effect might be that, if a bogus sharenfs setting used
'-' to separate options, it will no longer work with this patch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ x] I have run the ZFS Test Suite with this change applied.
- [ x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
