### PR TITLE
Remove extra newline from spa_set_allocator()

### DIFF
--- a/module/os/freebsd/zfs/zfs_debug.c
+++ b/module/os/freebsd/zfs/zfs_debug.c
@@ -218,12 +218,19 @@ __dprintf(boolean_t dprint, const char *file, const char *func,
 	}
 
 	/*
-	 * Get rid of trailing newline.
+	 * Get rid of trailing newline for dprintf logs.
 	 */
-	nl = strrchr(buf, '\n');
-	if (nl != NULL)
-		*nl = '\0';
+	if (dprint && buf[0] != '\0') {
+		nl = &buf[strlen(buf) - 1];
+		if (*nl == '\n')
+			*nl = '\0';
+	}
 
+	/*
+	 * To get this data:
+	 *
+	 * $ sysctl -n kstat.zfs.misc.dbgmsg
+	 */
 	__zfs_dbgmsg(buf);
 
 	kmem_free(buf, size);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -1679,7 +1679,7 @@ spa_set_allocator(spa_t *spa, const char *allocator)
 	int a = spa_find_allocator_byname(allocator);
 	if (a < 0) a = 0;
 	spa->spa_active_allocator = a;
-	zfs_dbgmsg("spa allocator: %s\n", metaslab_allocators[a].msop_name);
+	zfs_dbgmsg("spa allocator: %s", metaslab_allocators[a].msop_name);
 }
 
 int


### PR DESCRIPTION
zfs_dbgmsg() does not need newline at the end of the message.

While there, slightly update/sync FreeBSD __dprintf().

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
