### PR TITLE
zfs_log: add flex array fields to log record structs

### DIFF
--- a/cmd/zdb/zdb_il.c
+++ b/cmd/zdb/zdb_il.c
@@ -64,7 +64,8 @@ static void
 zil_prt_rec_create(zilog_t *zilog, int txtype, const void *arg)
 {
 	(void) zilog;
-	const lr_create_t *lr = arg;
+	const lr_create_t *lrc = arg;
+	const _lr_create_t *lr = &lrc->lr_create;
 	time_t crtime = lr->lr_crtime[0];
 	char *name, *link;
 	lr_attr_t *lrattr;
@@ -121,7 +122,8 @@ static void
 zil_prt_rec_rename(zilog_t *zilog, int txtype, const void *arg)
 {
 	(void) zilog, (void) txtype;
-	const lr_rename_t *lr = arg;
+	const lr_rename_t *lrr = arg;
+	const _lr_rename_t *lr = &lrr->lr_rename;
 	char *snm = (char *)(lr + 1);
 	char *tnm = snm + strlen(snm) + 1;
 

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -248,6 +248,7 @@ typedef struct {
 	uint32_t	lr_attr_masksize; /* number of elements in array */
 	uint32_t	lr_attr_bitmap; /* First entry of array */
 	/* remainder of array and additional lr_attr_end_t fields */
+	uint8_t		lr_attr_data[];
 } lr_attr_t;
 
 /*
@@ -264,9 +265,14 @@ typedef struct {
 	uint64_t	lr_gen;		/* generation (txg of creation) */
 	uint64_t	lr_crtime[2];	/* creation time */
 	uint64_t	lr_rdev;	/* rdev of object to create */
+} _lr_create_t;
+
+typedef struct {
+	_lr_create_t	lr_create;	/* common create portion */
 	/* name of object to create follows this */
 	/* for symlinks, link content follows name */
 	/* for creates with xvattr data, the name follows the xvattr info */
+	uint8_t		lr_data[];
 } lr_create_t;
 
 /*
@@ -293,18 +299,20 @@ typedef struct {
  * and group will be in lr_create.  Name follows ACL data.
  */
 typedef struct {
-	lr_create_t	lr_create;	/* common create portion */
+	_lr_create_t	lr_create;	/* common create portion */
 	uint64_t	lr_aclcnt;	/* number of ACEs in ACL */
 	uint64_t	lr_domcnt;	/* number of unique domains */
 	uint64_t	lr_fuidcnt;	/* number of real fuids */
 	uint64_t	lr_acl_bytes;	/* number of bytes in ACL */
 	uint64_t	lr_acl_flags;	/* ACL flags */
+	uint8_t		lr_data[];
 } lr_acl_create_t;
 
 typedef struct {
 	lr_t		lr_common;	/* common portion of log record */
 	uint64_t	lr_doid;	/* obj id of directory */
 	/* name of object to remove follows this */
+	uint8_t		lr_data[];
 } lr_remove_t;
 
 typedef struct {
@@ -312,18 +320,24 @@ typedef struct {
 	uint64_t	lr_doid;	/* obj id of directory */
 	uint64_t	lr_link_obj;	/* obj id of link */
 	/* name of object to link follows this */
+	uint8_t		lr_data[];
 } lr_link_t;
 
 typedef struct {
 	lr_t		lr_common;	/* common portion of log record */
 	uint64_t	lr_sdoid;	/* obj id of source directory */
 	uint64_t	lr_tdoid;	/* obj id of target directory */
+} _lr_rename_t;
+
+typedef struct {
+	_lr_rename_t	lr_rename;	/* common rename portion */
 	/* 2 strings: names of source and destination follow this */
+	uint8_t		lr_data[];
 } lr_rename_t;
 
 typedef struct {
-	lr_rename_t	lr_rename;	/* common rename portion */
-	/* members related to the whiteout file (based on lr_create_t) */
+	_lr_rename_t	lr_rename;	/* common rename portion */
+	/* members related to the whiteout file (based on _lr_create_t) */
 	uint64_t	lr_wfoid;	/* obj id of the new whiteout file */
 	uint64_t	lr_wmode;	/* mode of object */
 	uint64_t	lr_wuid;	/* uid of whiteout */
@@ -332,6 +346,7 @@ typedef struct {
 	uint64_t	lr_wcrtime[2];	/* creation time */
 	uint64_t	lr_wrdev;	/* always makedev(0, 0) */
 	/* 2 strings: names of source and destination follow this */
+	uint8_t		lr_data[];
 } lr_rename_whiteout_t;
 
 typedef struct {
@@ -342,6 +357,7 @@ typedef struct {
 	uint64_t	lr_blkoff;	/* no longer used */
 	blkptr_t	lr_blkptr;	/* spa block pointer for replay */
 	/* write data will follow for small writes */
+	uint8_t		lr_data[];
 } lr_write_t;
 
 typedef struct {
@@ -362,6 +378,7 @@ typedef struct {
 	uint64_t	lr_atime[2];	/* access time */
 	uint64_t	lr_mtime[2];	/* modification time */
 	/* optional attribute lr_attr_t may be here */
+	uint8_t		lr_data[];
 } lr_setattr_t;
 
 typedef struct {
@@ -369,6 +386,7 @@ typedef struct {
 	uint64_t	lr_foid;	/* file object to change attributes */
 	uint64_t	lr_size;
 	/* xattr name and value follows */
+	uint8_t		lr_data[];
 } lr_setsaxattr_t;
 
 typedef struct {
@@ -376,6 +394,7 @@ typedef struct {
 	uint64_t	lr_foid;	/* obj id of file */
 	uint64_t	lr_aclcnt;	/* number of acl entries */
 	/* lr_aclcnt number of ace_t entries follow this */
+	uint8_t		lr_data[];
 } lr_acl_v0_t;
 
 typedef struct {
@@ -387,6 +406,7 @@ typedef struct {
 	uint64_t	lr_acl_bytes;	/* number of bytes in ACL */
 	uint64_t	lr_acl_flags;	/* ACL flags */
 	/* lr_acl_bytes number of variable sized ace's follows */
+	uint8_t		lr_data[];
 } lr_acl_t;
 
 typedef struct {
@@ -396,8 +416,8 @@ typedef struct {
 	uint64_t	lr_length;	/* length of the blocks to clone */
 	uint64_t	lr_blksz;	/* file's block size */
 	uint64_t	lr_nbps;	/* number of block pointers */
-	blkptr_t	lr_bps[];
 	/* block pointers of the blocks to clone follows */
+	blkptr_t	lr_bps[];
 } lr_clone_range_t;
 
 /*
@@ -448,7 +468,7 @@ typedef struct itx {
 	uint64_t	itx_oid;	/* object id */
 	uint64_t	itx_gen;	/* gen number for zfs_get_data */
 	lr_t		itx_lr;		/* common part of log record */
-	/* followed by type-specific part of lr_xx_t and its immediate data */
+	uint8_t		itx_lr_data[];	/* type-specific part of lr_xx_t */
 } itx_t;
 
 /*

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -300,14 +300,13 @@ zfs_log_create(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
     zfs_fuid_info_t *fuidp, vattr_t *vap)
 {
 	itx_t *itx;
-	lr_create_t *lr;
-	lr_acl_create_t *lracl;
+	_lr_create_t *lr;
+	lr_acl_create_t *lracl = NULL;
+	uint8_t *lrdata;
 	size_t aclsize = 0;
 	size_t xvatsize = 0;
 	size_t txsize;
 	xvattr_t *xvap = (xvattr_t *)vap;
-	void *end;
-	size_t lrsize;
 	size_t namesize = strlen(name) + 1;
 	size_t fuidsz = 0;
 
@@ -329,18 +328,21 @@ zfs_log_create(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 	if ((int)txtype == TX_CREATE_ATTR || (int)txtype == TX_MKDIR_ATTR ||
 	    (int)txtype == TX_CREATE || (int)txtype == TX_MKDIR ||
 	    (int)txtype == TX_MKXATTR) {
-		txsize = sizeof (*lr) + namesize + fuidsz + xvatsize;
-		lrsize = sizeof (*lr);
+		txsize = sizeof (lr_create_t) + namesize + fuidsz + xvatsize;
+		itx = zil_itx_create(txtype, txsize);
+		lr_create_t *lrc = (lr_create_t *)&itx->itx_lr;
+		lrdata = &lrc->lr_data[0];
 	} else {
 		txsize =
 		    sizeof (lr_acl_create_t) + namesize + fuidsz +
 		    ZIL_ACE_LENGTH(aclsize) + xvatsize;
-		lrsize = sizeof (lr_acl_create_t);
+		itx = zil_itx_create(txtype, txsize);
+		lracl = (lr_acl_create_t *)&itx->itx_lr;
+		lrdata = &lracl->lr_data[0];
 	}
 
-	itx = zil_itx_create(txtype, txsize);
 
-	lr = (lr_create_t *)&itx->itx_lr;
+	lr = (_lr_create_t *)&itx->itx_lr;
 	lr->lr_doid = dzp->z_id;
 	lr->lr_foid = zp->z_id;
 	/* Store dnode slot count in 8 bits above object id. */
@@ -369,16 +371,14 @@ zfs_log_create(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 	 * Fill in xvattr info if any
 	 */
 	if (vap->va_mask & ATTR_XVATTR) {
-		zfs_log_xvattr((lr_attr_t *)((caddr_t)lr + lrsize), xvap);
-		end = (caddr_t)lr + lrsize + xvatsize;
-	} else {
-		end = (caddr_t)lr + lrsize;
+		zfs_log_xvattr((lr_attr_t *)lrdata, xvap);
+		lrdata = &lrdata[xvatsize];
 	}
 
 	/* Now fill in any ACL info */
 
 	if (vsecp) {
-		lracl = (lr_acl_create_t *)&itx->itx_lr;
+		ASSERT3P(lracl, !=, NULL);
 		lracl->lr_aclcnt = vsecp->vsa_aclcnt;
 		lracl->lr_acl_bytes = aclsize;
 		lracl->lr_domcnt = fuidp ? fuidp->z_domain_cnt : 0;
@@ -388,19 +388,19 @@ zfs_log_create(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 		else
 			lracl->lr_acl_flags = 0;
 
-		memcpy(end, vsecp->vsa_aclentp, aclsize);
-		end = (caddr_t)end + ZIL_ACE_LENGTH(aclsize);
+		memcpy(lrdata, vsecp->vsa_aclentp, aclsize);
+		lrdata = &lrdata[ZIL_ACE_LENGTH(aclsize)];
 	}
 
 	/* drop in FUID info */
 	if (fuidp) {
-		end = zfs_log_fuid_ids(fuidp, end);
-		end = zfs_log_fuid_domains(fuidp, end);
+		lrdata = zfs_log_fuid_ids(fuidp, lrdata);
+		lrdata = zfs_log_fuid_domains(fuidp, lrdata);
 	}
 	/*
 	 * Now place file name in log record
 	 */
-	memcpy(end, name, namesize);
+	memcpy(lrdata, name, namesize);
 
 	zil_itx_assign(zilog, itx, tx);
 }
@@ -422,7 +422,7 @@ zfs_log_remove(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 	itx = zil_itx_create(txtype, sizeof (*lr) + namesize);
 	lr = (lr_remove_t *)&itx->itx_lr;
 	lr->lr_doid = dzp->z_id;
-	memcpy(lr + 1, name, namesize);
+	memcpy(&lr->lr_data[0], name, namesize);
 
 	itx->itx_oid = foid;
 
@@ -458,7 +458,7 @@ zfs_log_link(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 	lr = (lr_link_t *)&itx->itx_lr;
 	lr->lr_doid = dzp->z_id;
 	lr->lr_link_obj = zp->z_id;
-	memcpy(lr + 1, name, namesize);
+	memcpy(&lr->lr_data[0], name, namesize);
 
 	zil_itx_assign(zilog, itx, tx);
 }
@@ -471,15 +471,17 @@ zfs_log_symlink(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
     znode_t *dzp, znode_t *zp, const char *name, const char *link)
 {
 	itx_t *itx;
-	lr_create_t *lr;
+	_lr_create_t *lr;
+	lr_create_t *lrc;
 	size_t namesize = strlen(name) + 1;
 	size_t linksize = strlen(link) + 1;
 
 	if (zil_replaying(zilog, tx))
 		return;
 
-	itx = zil_itx_create(txtype, sizeof (*lr) + namesize + linksize);
-	lr = (lr_create_t *)&itx->itx_lr;
+	itx = zil_itx_create(txtype, sizeof (*lrc) + namesize + linksize);
+	lrc = (lr_create_t *)&itx->itx_lr;
+	lr = &lrc->lr_create;
 	lr->lr_doid = dzp->z_id;
 	lr->lr_foid = zp->z_id;
 	lr->lr_uid = KUID_TO_SUID(ZTOUID(zp));
@@ -489,8 +491,8 @@ zfs_log_symlink(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 	    sizeof (uint64_t));
 	(void) sa_lookup(zp->z_sa_hdl, SA_ZPL_CRTIME(ZTOZSB(zp)),
 	    lr->lr_crtime, sizeof (uint64_t) * 2);
-	memcpy((char *)(lr + 1), name, namesize);
-	memcpy((char *)(lr + 1) + namesize, link, linksize);
+	memcpy(&lrc->lr_data[0], name, namesize);
+	memcpy(&lrc->lr_data[namesize], link, linksize);
 
 	zil_itx_assign(zilog, itx, tx);
 }
@@ -500,7 +502,8 @@ do_zfs_log_rename(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype, znode_t *sdzp,
     const char *sname, znode_t *tdzp, const char *dname, znode_t *szp)
 {
 	itx_t *itx;
-	lr_rename_t *lr;
+	_lr_rename_t *lr;
+	lr_rename_t *lrr;
 	size_t snamesize = strlen(sname) + 1;
 	size_t dnamesize = strlen(dname) + 1;
 
@@ -508,11 +511,12 @@ do_zfs_log_rename(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype, znode_t *sdzp,
 		return;
 
 	itx = zil_itx_create(txtype, sizeof (*lr) + snamesize + dnamesize);
-	lr = (lr_rename_t *)&itx->itx_lr;
+	lrr = (lr_rename_t *)&itx->itx_lr;
+	lr = &lrr->lr_rename;
 	lr->lr_sdoid = sdzp->z_id;
 	lr->lr_tdoid = tdzp->z_id;
-	memcpy((char *)(lr + 1), sname, snamesize);
-	memcpy((char *)(lr + 1) + snamesize, dname, dnamesize);
+	memcpy(&lrr->lr_data[0], sname, snamesize);
+	memcpy(&lrr->lr_data[snamesize], dname, dnamesize);
 	itx->itx_oid = szp->z_id;
 
 	zil_itx_assign(zilog, itx, tx);
@@ -590,8 +594,8 @@ zfs_log_rename_whiteout(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 	(void) sa_lookup(wzp->z_sa_hdl, SA_ZPL_RDEV(ZTOZSB(wzp)), &lr->lr_wrdev,
 	    sizeof (lr->lr_wrdev));
 
-	memcpy((char *)(lr + 1), sname, snamesize);
-	memcpy((char *)(lr + 1) + snamesize, dname, dnamesize);
+	memcpy(&lr->lr_data[0], sname, snamesize);
+	memcpy(&lr->lr_data[snamesize], dname, dnamesize);
 	itx->itx_oid = szp->z_id;
 
 	zil_itx_assign(zilog, itx, tx);
@@ -663,8 +667,8 @@ zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 		if (wr_state == WR_COPIED) {
 			int err;
 			DB_DNODE_ENTER(db);
-			err = dmu_read_by_dnode(DB_DNODE(db), off, len, lr + 1,
-			    DMU_READ_NO_PREFETCH);
+			err = dmu_read_by_dnode(DB_DNODE(db), off, len,
+			    &lr->lr_data[0], DMU_READ_NO_PREFETCH);
 			DB_DNODE_EXIT(db);
 			if (err != 0) {
 				zil_itx_destroy(itx);
@@ -733,7 +737,7 @@ zfs_log_setattr(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 	lr_setattr_t	*lr;
 	xvattr_t	*xvap = (xvattr_t *)vap;
 	size_t		recsize = sizeof (lr_setattr_t);
-	void		*start;
+	uint8_t		*start;
 
 	if (zil_replaying(zilog, tx) || zp->z_unlinked)
 		return;
@@ -767,10 +771,10 @@ zfs_log_setattr(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 	lr->lr_size = (uint64_t)vap->va_size;
 	ZFS_TIME_ENCODE(&vap->va_atime, lr->lr_atime);
 	ZFS_TIME_ENCODE(&vap->va_mtime, lr->lr_mtime);
-	start = (lr_setattr_t *)(lr + 1);
+	start = &lr->lr_data[0];
 	if (vap->va_mask & ATTR_XVATTR) {
 		zfs_log_xvattr((lr_attr_t *)start, xvap);
-		start = (caddr_t)start + ZIL_XVAT_SIZE(xvap->xva_mapsize);
+		start = &lr->lr_data[ZIL_XVAT_SIZE(xvap->xva_mapsize)];
 	}
 
 	/*
@@ -794,7 +798,6 @@ zfs_log_setsaxattr(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 	itx_t		*itx;
 	lr_setsaxattr_t	*lr;
 	size_t		recsize = sizeof (lr_setsaxattr_t);
-	void		*xattrstart;
 	int		namelen;
 
 	if (zil_replaying(zilog, tx) || zp->z_unlinked)
@@ -805,10 +808,9 @@ zfs_log_setsaxattr(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 	itx = zil_itx_create(txtype, recsize);
 	lr = (lr_setsaxattr_t *)&itx->itx_lr;
 	lr->lr_foid = zp->z_id;
-	xattrstart = (char *)(lr + 1);
-	memcpy(xattrstart, name, namelen);
+	memcpy(&lr->lr_data[0], name, namelen);
 	if (value != NULL) {
-		memcpy((char *)xattrstart + namelen, value, size);
+		memcpy(&lr->lr_data[namelen], value, size);
 		lr->lr_size = size;
 	} else {
 		lr->lr_size = 0;
@@ -866,13 +868,13 @@ zfs_log_acl(zilog_t *zilog, dmu_tx_t *tx, znode_t *zp,
 
 	if (txtype == TX_ACL_V0) {
 		lrv0 = (lr_acl_v0_t *)lr;
-		memcpy(lrv0 + 1, vsecp->vsa_aclentp, aclbytes);
+		memcpy(&lrv0->lr_data[0], vsecp->vsa_aclentp, aclbytes);
 	} else {
-		void *start = (ace_t *)(lr + 1);
+		uint8_t *start = &lr->lr_data[0];
 
 		memcpy(start, vsecp->vsa_aclentp, aclbytes);
 
-		start = (caddr_t)start + ZIL_ACE_LENGTH(aclbytes);
+		start = &lr->lr_data[ZIL_ACE_LENGTH(aclbytes)];
 
 		if (fuidp) {
 			start = zfs_log_fuid_ids(fuidp, start);


### PR DESCRIPTION
### Motivation and Context

Silence Linux warnings since ~6.11.

Closes #16501.

### Description

ZIL log record structs (`lr_XX_t`) are frequently allocated with extra space after the struct to carry variable-sized "payload" items.

Linux 6.10+ compiled with `CONFIG_FORTIFY_SOURCE` has been doing runtime bounds checking on `memcpy()` calls. Because these types had no indicator that they might use more space than their simple definition, `__fortify_memcpy_chk` will frequently complain about overruns eg:

    memcpy: detected field-spanning write (size 7) of single field "lr + 1" at /home/robn/zfs/module/zfs/zfs_log.c:425 (size 0)
    memcpy: detected field-spanning write (size 9) of single field "(char *)(lr + 1)" at /home/robn/zfs/module/zfs/zfs_log.c:593 (size 0)
    memcpy: detected field-spanning write (size 4) of single field "(char *)(lr + 1) + snamesize" at /home/robn/zfs/module/zfs/zfs_log.c:594 (size 0)
    memcpy: detected field-spanning write (size 7) of single field "lr + 1" at /home/robn/zfs/module/zfs/zfs_log.c:425 (size 0)
    memcpy: detected field-spanning write (size 9) of single field "(char *)(lr + 1)" at /home/robn/zfs/module/zfs/zfs_log.c:593 (size 0)
    memcpy: detected field-spanning write (size 4) of single field "(char *)(lr + 1) + snamesize" at /home/robn/zfs/module/zfs/zfs_log.c:594 (size 0)
    memcpy: detected field-spanning write (size 7) of single field "lr + 1" at /home/robn/zfs/module/zfs/zfs_log.c:425 (size 0)
    memcpy: detected field-spanning write (size 9) of single field "(char *)(lr + 1)" at /home/robn/zfs/module/zfs/zfs_log.c:593 (size 0)
    memcpy: detected field-spanning write (size 4) of single field "(char *)(lr + 1) + snamesize" at /home/robn/zfs/module/zfs/zfs_log.c:594 (size 0)

To fix this, this commit adds flex array fields to all `lr_XX_t` structs that require them, and then uses those fields to access that end-of-struct area rather than more complicated casts and pointer addition.

I'll note here that I wrote this a few weeks ago and kind of forgot about it. I remember I didn't love it; it felt messy in a couple of places. But, it passes tests, and 6.11 is here and 2.3 is looming, so its probably better to post this sooner rather than later.

### How Has This Been Tested?

Full ZTS run completed against 6.11.0.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
