### PR TITLE
ZTS: use openssl for md5digest and sha256digest

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3460,18 +3460,7 @@ function tunable_exists
 #
 function md5digest
 {
-	typeset file=$1
-
-	case "$UNAME" in
-	FreeBSD)
-		md5 -q $file
-		;;
-	*)
-		typeset sum _
-		read -r sum _ < <(md5sum -b $file)
-		echo $sum
-		;;
-	esac
+	openssl md5 -r $1 | awk '{print $1}'
 }
 
 #
@@ -3492,18 +3481,7 @@ function cmp_md5s {
 #
 function sha256digest
 {
-	typeset file=$1
-
-	case "$UNAME" in
-	FreeBSD)
-		sha256 -q $file
-		;;
-	*)
-		typeset sum _
-		read -r sum _ < <(sha256sum -b $file)
-		echo $sum
-		;;
-	esac
+	openssl sha256 -r $1 | awk '{print $1}'
 }
 
 function new_fs #<args>

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_backup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_backup.ksh
@@ -47,8 +47,8 @@ sync_pool $TESTPOOL
 log_must eval "zfs send -ecL $snap > $tmpfile.1"
 log_must eval "zdb -B $TESTPOOL/$objsetid ecL > $tmpfile.2"
 
-typeset sum1=$(cat $tmpfile.1 | md5sum)
-typeset sum2=$(cat $tmpfile.2 | md5sum)
+typeset sum1=$(md5digest $tmpfile.1)
+typeset sum2=$(md5digest $tmpfile.2)
 
 log_must test "$sum1" = "$sum2"
 

--- a/tests/zfs-tests/tests/functional/fault/suspend_resume_single.ksh
+++ b/tests/zfs-tests/tests/functional/fault/suspend_resume_single.ksh
@@ -43,7 +43,7 @@ log_assert "ensure single-disk pool resumes properly after suspend and clear"
 
 # create a file, and take a checksum, so we can compare later
 log_must dd if=/dev/urandom of=$DATAFILE bs=128K count=1
-typeset sum1=$(cat $DATAFILE | md5sum)
+typeset sum1=$(md5digest $DATAFILE)
 
 # make a debug device that we can "unplug"
 load_scsi_debug 100 1 1 1 '512b'
@@ -94,7 +94,7 @@ log_must zpool export $TESTPOOL
 log_must zpool import $TESTPOOL
 
 # sum the file we wrote earlier
-typeset sum2=$(cat /$TESTPOOL/file | md5sum)
+typeset sum2=$(md5digest /$TESTPOOL/file)
 
 # make sure the checksums match
 log_must test "$sum1" = "$sum2"


### PR DESCRIPTION

### Motivation and Context

On larger files this should improve the speed for the testings a bit. It also
simplifies things a bit.

Sample values of my system:
```
[mcmilk@xz]$ time dd if=/dev/zero bs=128k count=1k | sha256sum
254bcc3fc4f27172636df4bf32de9f107f620d559b20d760197e452b97453917  -
real    0m1,050s
user    0m0,985s
sys     0m0,153s

[mcmilk@xz]$ time dd if=/dev/zero bs=128k count=1k | openssl sha256 -r
254bcc3fc4f27172636df4bf32de9f107f620d559b20d760197e452b97453917 *stdin
real    0m0,254s
user    0m0,206s
sys     0m0,160s
```

I think the `cli_root/zdb/zdb_backup.ksh` test runs also on FreeBSD and depends on md5sum,
which is not provided per default on FreeBSD. I needed to include the `sysutils/coreutils`
package for the QEMU patchset - I think.
This could be reverted, when this pull request gets upstream.

Signed-off-by: Tino Reichardt <milky-zfs@mcmilk.de>

### How Has This Been Tested?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
