### PR TITLE
Linux: remove code gated behind kernel version checks

### DIFF
--- a/include/os/linux/kernel/linux/simd_aarch64.h
+++ b/include/os/linux/kernel/linux/simd_aarch64.h
@@ -56,17 +56,7 @@
 #include <asm/elf.h>
 #include <asm/hwcap.h>
 #include <linux/version.h>
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
 #include <asm/sysreg.h>
-#else
-#define	sys_reg(op0, op1, crn, crm, op2) ( \
-	((op0) << Op0_shift) | \
-	((op1) << Op1_shift) | \
-	((crn) << CRn_shift) | \
-	((crm) << CRm_shift) | \
-	((op2) << Op2_shift))
-#endif
 
 #define	ID_AA64PFR0_EL1		sys_reg(3, 0, 0, 1, 0)
 #define	ID_AA64ISAR0_EL1	sys_reg(3, 0, 0, 6, 0)

--- a/include/os/linux/kernel/linux/simd_powerpc.h
+++ b/include/os/linux/kernel/linux/simd_powerpc.h
@@ -56,16 +56,10 @@
 #include <asm/switch_to.h>
 #include <sys/types.h>
 #include <linux/version.h>
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
 #include <asm/cpufeature.h>
-#else
-#include <asm/cputable.h>
-#endif
 
 #define	kfpu_allowed()			1
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
 #ifdef	CONFIG_ALTIVEC
 #define	ENABLE_KERNEL_ALTIVEC	enable_kernel_altivec();
 #define	DISABLE_KERNEL_ALTIVEC	disable_kernel_altivec();
@@ -101,11 +95,6 @@
 		DISABLE_KERNEL_ALTIVEC		\
 		preempt_enable();		\
 	}
-#else
-/* seems that before 4.5 no-one bothered */
-#define	kfpu_begin()
-#define	kfpu_end()		preempt_enable()
-#endif	/* Linux version >= 4.5 */
 
 #define	kfpu_init()		0
 #define	kfpu_fini()		((void) 0)

--- a/module/os/linux/spl/spl-proc.c
+++ b/module/os/linux/spl/spl-proc.c
@@ -39,7 +39,7 @@
 #include <linux/version.h>
 #include "zfs_gitrev.h"
 
-#if defined(CONSTIFY_PLUGIN) && LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+#if defined(CONSTIFY_PLUGIN)
 typedef struct ctl_table __no_const spl_ctl_table;
 #else
 typedef struct ctl_table spl_ctl_table;


### PR DESCRIPTION
### Motivation and Context

A bit more support for older kernels that we'll never use. Should have been in #16479, just an oversight that it wasn't.

### Description

There's a few places where we tested `LINUX_VERSION_CODE` for versions in the past. Remove those, and the support code for the "older" kernels versions that we'll never see again.

Didn't remove the compound page code for the moment, just the version check, for reasons described within.

### How Has This Been Tested?

Compile checked against 6.1.x only.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).