### PR TITLE
ZTS: Get rid of old Ubuntu runners

### DIFF
--- a/.github/workflows/zfs-linux-tests.yml
+++ b/.github/workflows/zfs-linux-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       os:
-        description: 'The ubuntu version: 20.02 or 22.04'
+        description: 'The ubuntu version: 22.04'
         required: true
         type: string
 
@@ -50,75 +50,4 @@ jobs:
         path: |
           /var/tmp/zloop/*/vdev/
         retention-days: 14
-        if-no-files-found: ignore
-
-  sanity:
-    runs-on: ubuntu-${{ inputs.os }}
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-    - uses: actions/download-artifact@v4
-      with:
-        name: modules-${{ inputs.os }}
-    - name: Install modules
-      run: |
-        tar xzf modules-${{ inputs.os }}.tgz
-        .github/workflows/scripts/setup-dependencies.sh tests
-    - name: Tests
-      timeout-minutes: 60
-      shell: bash
-      run: |
-        set -o pipefail
-        /usr/share/zfs/zfs-tests.sh -vKR -s 3G -r sanity | scripts/zfs-tests-color.sh
-    - name: Prepare artifacts
-      if: success() || failure()
-      run: |
-        RESPATH="/var/tmp/test_results"
-        mv -f $RESPATH/current $RESPATH/testfiles
-        tar cf $RESPATH/sanity.tar -h -C $RESPATH testfiles
-    - uses: actions/upload-artifact@v4
-      if: success() || failure()
-      with:
-        name: Logs-${{ inputs.os }}-sanity
-        path: /var/tmp/test_results/sanity.tar
-        if-no-files-found: ignore
-
-  functional:
-    runs-on: ubuntu-${{ inputs.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        tests: [ part1, part2, part3, part4 ]
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-    - uses: actions/download-artifact@v4
-      with:
-        name: modules-${{ inputs.os }}
-    - name: Install modules
-      run: |
-        tar xzf modules-${{ inputs.os }}.tgz
-        .github/workflows/scripts/setup-dependencies.sh tests
-    - name: Setup tests
-      run: |
-        .github/workflows/scripts/setup-functional.sh ${{ matrix.tests }} >> $GITHUB_ENV
-    - name: Tests
-      timeout-minutes: 120
-      shell: bash
-      run: |
-        set -o pipefail
-        /usr/share/zfs/zfs-tests.sh -vKR -s 3G -T ${{ env.TODO }} | scripts/zfs-tests-color.sh
-    - name: Prepare artifacts
-      if: success() || failure()
-      run: |
-        RESPATH="/var/tmp/test_results"
-        mv -f $RESPATH/current $RESPATH/testfiles
-        tar cf $RESPATH/${{ matrix.tests }}.tar -h -C $RESPATH testfiles
-    - uses: actions/upload-artifact@v4
-      if: success() || failure()
-      with:
-        name: Logs-${{ inputs.os }}-functional-${{ matrix.tests }}
-        path: /var/tmp/test_results/${{ matrix.tests }}.tar
         if-no-files-found: ignore

--- a/.github/workflows/zfs-linux.yml
+++ b/.github/workflows/zfs-linux.yml
@@ -2,7 +2,6 @@ name: zfs-linux
 
 on:
   push:
-  pull_request:
 
 jobs:
 
@@ -11,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [20.04, 22.04]
+        os: [22.04]
     runs-on: ubuntu-${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -32,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [20.04, 22.04]
+        os: [22.04]
     needs: build
     uses: ./.github/workflows/zfs-linux-tests.yml
     with:


### PR DESCRIPTION

### Motivation and Context
Remove unneeded github runners.

### Description
Remove the old Ubuntu 'sanity' and part1-4 tests.  These are no longer needed since we now test Ubuntu under the QEMU runners.  This should free up some runners.

### How Has This Been Tested?
github runners willt est

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
