### PR TITLE
Add SIMD metadata in /proc on Linux follow up

### DIFF
--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -1075,9 +1075,6 @@ EXPORT_SYMBOL(zfs_kfpu_fpregs);
 extern int __init zcommon_init(void);
 extern void zcommon_fini(void);
 
-extern void simd_stat_init(void);
-extern void simd_stat_fini(void);
-
 int __init
 zcommon_init(void)
 {


### PR DESCRIPTION
### Motivation and Context

Follow up for #16530 where I rushed the merge and broke the FreeBSD.  Let me clean up my mess.

### Description

This change accidentally broke the FreeBSD build due to a conflict between the simd_stat_init()/simd_stat_fini() macro on FreeBSD and the extern function prototype.

### How Has This Been Tested?

Locally build on Linux will be checked by the CI for FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
