### PR TITLE
ZTS: Fix Summary Page

### DIFF
--- a/.github/workflows/scripts/qemu-7-prepare.sh
+++ b/.github/workflows/scripts/qemu-7-prepare.sh
@@ -18,6 +18,7 @@ if [ -z ${VMs:-} ]; then
   cd $RESPATH
   echo ":exclamation: ZFS module didn't build successfully :exclamation:" \
     | tee summary.txt | tee /tmp/summary.txt
+  cp /var/tmp/*.txt .
   tar cf /tmp/qemu-$OS.tar -C $RESPATH -h . || true
   exit 0
 fi

--- a/.github/workflows/scripts/qemu-9-summary-page.sh
+++ b/.github/workflows/scripts/qemu-9-summary-page.sh
@@ -34,13 +34,14 @@ function send2github() {
 if [ ! -f out-1.md ]; then
   logfile="1"
   for tarfile in Logs-functional-*/qemu-*.tar; do
+    rm -rf vm* *.txt
     if [ ! -s "$tarfile" ]; then
       output "\n## Functional Tests: unknown\n"
       output ":exclamation: Tarfile $tarfile is empty :exclamation:"
       continue
     fi
-    rm -rf vm* *.txt
     tar xf "$tarfile"
+    test -s env.txt || continue
     source env.txt
     output "\n## Functional Tests: $OSNAME\n"
     outfile_plain uname.txt


### PR DESCRIPTION
### Motivation and Context

The `qemu-9-summary-page.sh` script reads the file env.txt in the first lines. When the module didn't build, this file was not copied into the tarfile - causing the scipt to abort.

Fix: copy needed files into the tarfile in case of module build failures.
The fix ignores also empty tarfiles in future.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?

Currently not tested, will see what ZTS thinks about it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
