### PR TITLE
Fix /proc/spl/kstat/simd on x86

### DIFF
--- a/module/zcommon/simd_stat.c
+++ b/module/zcommon/simd_stat.c
@@ -34,6 +34,14 @@ kstat_t *simd_stat_kstat;
 #endif /* _KERNEL */
 
 #ifdef _KERNEL
+/* Sometimes, we don't define these at all. */
+#ifndef HAVE_KERNEL_FPU
+#define	HAVE_KERNEL_FPU (0)
+#endif
+#ifndef HAVE_UNDERSCORE_KERNEL_FPU
+#define	HAVE_UNDERSCORE_KERNEL_FPU (0)
+#endif
+
 #define	SIMD_STAT_PRINT(s, feat, val) \
 	kmem_scnprintf(s + off, MAX(4095-off, 0), "%-16s\t%1d\n", feat, (val))
 
@@ -48,7 +56,7 @@ simd_stat_kstat_data(char *buf, size_t size, void *data)
 	if (off == 0) {
 		off += SIMD_STAT_PRINT(simd_stat_kstat_payload,
 		    "kfpu_allowed", kfpu_allowed());
-#ifdef __x86__
+#if defined(__x86_64__) || defined(__i386__)
 		off += SIMD_STAT_PRINT(simd_stat_kstat_payload,
 		    "kfpu", HAVE_KERNEL_FPU);
 		off += SIMD_STAT_PRINT(simd_stat_kstat_payload,


### PR DESCRIPTION
Evidently while reworking it on aarch64, I broke it on x86 and didn't notice.

Oops.

### Motivation and Context
^

### Description
`__x86__` is not the correct define. 

### How Has This Been Tested?
Loading on an x86_64 box.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
