### PR TITLE
Define HAVE_KERNEL_NEON as (0) if not defined for simd_stat

### DIFF
--- a/module/zcommon/simd_stat.c
+++ b/module/zcommon/simd_stat.c
@@ -38,6 +38,12 @@ kstat_t *simd_stat_kstat;
 #ifndef HAVE_KERNEL_FPU
 #define	HAVE_KERNEL_FPU (0)
 #endif
+#ifndef HAVE_KERNEL_NEON
+#define	HAVE_KERNEL_NEON (0)
+#endif
+#ifndef HAVE_KERNEL_FPU_INTERNAL
+#define	HAVE_KERNEL_FPU_INTERNAL (0)
+#endif
 #ifndef HAVE_UNDERSCORE_KERNEL_FPU
 #define	HAVE_UNDERSCORE_KERNEL_FPU (0)
 #endif


### PR DESCRIPTION
### Motivation and Context

Currently does not build for aarch64 on linux >= 6.2, as `HAVE_KERNEL_NEON` will not be defined, but used in `simd_stat.c`. 

### Description

This adds the `HAVE_KERNEL_NEON` to `simd_stat.c` defaulted to `0` to make it build again.

### How Has This Been Tested?

Built for aarch64 with latest `master` before, does not build with `error: 'HAVE_KERNEL_NEON' undeclared`.

Built for aarch64 again with this patch, does build again. 

No other builds or tests were done.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Signed-off-by: Sebastian Wuerl <s.wuerl@mailbox.org>

Requires-builders: style arch