### PR TITLE
ZTS: Fix zpool_reguid Makefile.am

### DIFF
--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1185,6 +1185,10 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_prefetch/cleanup.ksh \
 	functional/cli_root/zpool_prefetch/setup.ksh \
 	functional/cli_root/zpool_prefetch/zpool_prefetch_001_pos.ksh \
+	functional/cli_root/zpool_reguid/cleanup.ksh \
+	functional/cli_root/zpool_reguid/setup.ksh \
+	functional/cli_root/zpool_reguid/zpool_reguid_001_pos.ksh \
+	functional/cli_root/zpool_reguid/zpool_reguid_002_neg.ksh \
 	functional/cli_root/zpool_remove/cleanup.ksh \
 	functional/cli_root/zpool_remove/setup.ksh \
 	functional/cli_root/zpool_remove/zpool_remove_001_neg.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reguid/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reguid/Makefile.am
@@ -1,6 +1,0 @@
-pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_reguid
-dist_pkgdata_SCRIPTS = \
-	setup.ksh \
-	cleanup.ksh \
-	zpool_reguid_001_pos.ksh \
-	zpool_reguid_002_neg.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reguid/zpool_reguid_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reguid/zpool_reguid_001_pos.ksh
@@ -62,12 +62,12 @@ if [[ "$initial_guid" == "$new_guid" ]]; then
 	log_fail "GUID change failed; GUID has not changed: $initial_guid"
 fi
 
-for g in "$(bc -e '2^64 - 1')" 0; do
+for g in "$(echo '2^64 - 1' | bc)" "314"; do
 	set_guid "$g"
 done
 # zpool-reguid(8) will strip the leading 0.
 set_guid 0123 "123"
 # GUID "-1" is effectively 2^64 - 1 in value.
-set_guid -1 "$(bc -e '2^64 - 1')"
+set_guid -1 "$(echo '2^64 - 1' | bc)"
 
 log_pass "'zpool reguid' changes GUID as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reguid/zpool_reguid_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reguid/zpool_reguid_002_neg.ksh
@@ -46,7 +46,7 @@ check_guid() {
 
 log_assert "Verify 'zpool reguid' does not accept invalid GUIDs"
 
-for ig in "$(bc -e '2^64')" 0xA 0xa; do
+for ig in "$(echo '2^64' | bc)" 0xA 0xa 0; do
 	check_guid "$ig"
 done
 


### PR DESCRIPTION
### Motivation and Context

CI warnings like the following:

```
vm2: Warning: TestGroup '/var/tmp/tests/functional/cli_root/zpool_reguid' not added to this run.
Auxiliary script '/var/tmp/tests/functional/cli_root/zpool_reguid/setup' failed verification.
```

https://github.com/openzfs/zfs/actions/runs/10984039485/job/30500104089

### Description

The zpool_reguid tests were not being included the dist tarball resulting in them not running.  This is reported as a "failed verification" warning by the CI.  Add the tests to the correct Makefile.am.

@mcmilk @jwk404 what do you think about converting this to a fatal error.  Or if we leave it a warning have the CI report it.  This kind of thing has snuck through a few too many times for my liking.

### How Has This Been Tested?

Will be verified by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)