### PR TITLE
CI: cancel workflows when PRs are updated

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   checkstyle:
     runs-on: ubuntu-22.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -4,8 +4,11 @@ on:
   push:
   pull_request:
 
-jobs:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
+jobs:
   qemu-vm:
     name: qemu-x86
     strategy:

--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   zloop:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### Motivation and Context

We want to cancel in-progress workflows for PRs which are updated to ensure the workers are testing useful changes.  At the same time we always want to fully test changes which are merged to a branch.

@mcmilk @rincebrain I think this should handle the case mentioned in https://github.com/openzfs/zfs/pull/16537#issuecomment-2360741553.  

### Description

For checkstyle, zloop, zfs-qemu, and codeql workflows cancel in-progress jobs when the PR is updated.

Directly from GitHub Actions documentation:

    The following concurrency group cancels in-progress jobs or run
    on pull_request events only; if github.head_ref is undefined, the
    concurrency group will fallback to the run ID, which is guaranteed
    to be both unique and defined for the run.
  
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value

### How Has This Been Tested?

It hasn't.  This is change is solely based on the example in the GitHub documentation. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)