### PR TITLE
Restrict raidz faulted vdev count

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -125,7 +125,8 @@ tests = ['auto_offline_001_pos', 'auto_online_001_pos', 'auto_online_002_pos',
     'auto_replace_001_pos', 'auto_replace_002_pos', 'auto_spare_001_pos',
     'auto_spare_002_pos', 'auto_spare_multiple', 'auto_spare_ashift',
     'auto_spare_shared', 'decrypt_fault', 'decompress_fault',
-    'scrub_after_resilver', 'suspend_resume_single', 'zpool_status_-s']
+    'fault_limits', 'scrub_after_resilver', 'suspend_resume_single',
+    'zpool_status_-s']
 tags = ['functional', 'fault']
 
 [tests/functional/features/large_dnode:Linux]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1525,6 +1525,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/fault/cleanup.ksh \
 	functional/fault/decompress_fault.ksh \
 	functional/fault/decrypt_fault.ksh \
+	functional/fault/fault_limits.ksh \
 	functional/fault/scrub_after_resilver.ksh \
 	functional/fault/suspend_resume_single.ksh \
 	functional/fault/setup.ksh \

--- a/tests/zfs-tests/tests/functional/fault/fault_limits.ksh
+++ b/tests/zfs-tests/tests/functional/fault/fault_limits.ksh
@@ -1,0 +1,96 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright (c) 2024 by Klara, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/fault/fault.cfg
+
+#
+# DESCRIPTION: Verify that raidz children vdev fault count is restricted
+#
+# STRATEGY:
+# 1. Create a raidz2 or raidz3 pool and add some data to it
+# 2. Replace one of the child vdevs to create a replacing vdev
+# 3. While it is resilvering, attempt to fault disks
+# 4. Verify that less than parity count was faulted while replacing
+#
+
+TESTPOOL="fault-test-pool"
+PARITY=$((RANDOM%(2) + 2))
+VDEV_CNT=$((4 + (2 * PARITY)))
+VDEV_SIZ=512M
+
+function cleanup
+{
+	poolexists "$TESTPOOL" && log_must_busy zpool destroy "$TESTPOOL"
+
+	for i in {0..$((VDEV_CNT - 1))}; do
+		log_must rm -f "$TEST_BASE_DIR/dev-$i"
+	done
+}
+
+log_onexit cleanup
+log_assert "restricts raidz children vdev fault count"
+
+log_note "creating $VDEV_CNT vdevs for parity $PARITY test"
+typeset -a disks
+for i in {0..$((VDEV_CNT - 1))}; do
+	device=$TEST_BASE_DIR/dev-$i
+	log_must truncate -s $VDEV_SIZ $device
+	disks[${#disks[*]}+1]=$device
+done
+
+log_must zpool create -f ${TESTPOOL} raidz${PARITY} ${disks[1..$((VDEV_CNT - 1))]}
+
+# Add some data to the pool
+log_must zfs create $TESTPOOL/fs
+MNTPOINT="$(get_prop mountpoint $TESTPOOL/fs)"
+log_must fill_fs $MNTPOINT $PARITY 200 32768 1000 Z
+sync_pool $TESTPOOL
+
+# Replace the last child vdev to form a replacing vdev
+log_must zpool replace ${TESTPOOL} ${disks[$((VDEV_CNT - 1))]} ${disks[$VDEV_CNT]}
+# imediately offline replacement disk to keep replacing vdev around
+log_must zpool offline ${TESTPOOL} ${disks[$VDEV_CNT]}
+
+# Fault disks while a replacing vdev is still active
+for disk in ${disks[0..$PARITY]}; do
+	log_must zpool offline -tf ${TESTPOOL} $disk
+done
+
+zpool status $TESTPOOL
+
+# Count the faults that succeeded
+faults=0
+for disk in ${disks[0..$PARITY]}; do
+	state=$(zpool get -H -o value state ${TESTPOOL} ${disk})
+	if [ "$state" = "FAULTED" ] ; then
+		((faults=faults+1))
+	fi
+done
+
+log_must test "$faults" -lt "$PARITY"
+log_must test "$faults" -gt 0
+
+log_pass "restricts raidz children vdev fault count"


### PR DESCRIPTION
### Motivation and Context
In a ZFS pool, leaf vdevs can be faulted after tripping a diagnostic failure (ZED). However ZFS prevents faulting a drive if it would cause data loss.  For example, in a raidz2, faulting more than 2 disks would cause read failures.

In determining if a vdev can be faulted, the check in `vdev_dtl_required()` doesn't consider the case where a marginal drive is being resilvered.  If the marginal disk is considered valid during the checks, then zfs can start encountering read errors when the faulted vdev count matches the parity count.

### Description
When a drive replacement is active, the replacing vdev should not be considered when checking if a peer can be faulted.  I.e., treat it as if it is offline and cannot contribute.  Specifically, a child in a replacing vdev won't count when assessing the dtl during a `vdev_fault()`.

Sponsored-by: Klara, Inc.
Sponsored-by: Wasabi Technology, Inc.

### How Has This Been Tested?
1. Added a new test: `functional/fault/fault_limits`
2. Manual testing

Example result from `fault_limits` showing that the third request to fault a leaf vdev in a raidz3 group was denied and turned instead to a degrade due to presence of a replacing vdev.
```
  pool: fault-test-pool
 state: DEGRADED
status: One or more devices are faulted in response to persistent errors.
        Sufficient replicas exist for the pool to continue functioning in a
        degraded state.
action: Replace the faulted device, or use 'zpool clear' to mark the device
        repaired.
  scan: resilvered 654K in 00:00:02 with 0 errors on Wed Sep 25 17:27:33 2024
config:

        NAME                  STATE     READ WRITE CKSUM
        fault-test-pool       DEGRADED     0     0     0
          raidz3-0            DEGRADED     0     0     0
            /var/tmp/dev-0    FAULTED      0     0     0  external device fault
            /var/tmp/dev-1    FAULTED      0     0     0  external device fault
            /var/tmp/dev-2    DEGRADED     0     0     0  external device fault
            /var/tmp/dev-3    ONLINE       0     0     0
            /var/tmp/dev-4    ONLINE       0     0     0
            /var/tmp/dev-5    ONLINE       0     0     0
            /var/tmp/dev-6    ONLINE       0     0     0
            /var/tmp/dev-7    ONLINE       0     0     0
            replacing-8       DEGRADED     0     0     0
              /var/tmp/dev-8  ONLINE       0     0     0
              /var/tmp/dev-9  OFFLINE      0     0     0

errors: No known data errors
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
