### PR TITLE
ZTS: Fix zpool_import_hostid_changed_cachefile_unclean_export

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_hostid_changed_cachefile_unclean_export.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_hostid_changed_cachefile_unclean_export.ksh
@@ -28,9 +28,8 @@
 #	2. Create a pool.
 #	3. Backup the cachefile.
 #	4. Simulate the pool being torn down without export:
-#	4.1. Copy the underlying device state.
-#	4.2. Export the pool.
-#	4.3. Restore the device state from the copy.
+#	4.1. Sync then freeze the pool.
+#	4.2. Export the pool (uncleanly).
 #	5. Change the hostid.
 #	6. Verify that importing the pool from the cachefile fails.
 #	7. Verify that importing the pool from the cachefile with force
@@ -57,10 +56,9 @@ log_must zpool create -o cachefile=$CPATH $TESTPOOL1 $VDEV0
 log_must cp $CPATH $CPATHBKP
 
 # 4. Simulate the pool being torn down without export.
-log_must cp $VDEV0 $VDEV0.bak
+sync_pool $TESTPOOL1
+log_must zpool freeze $TESTPOOL1
 log_must zpool export $TESTPOOL1
-log_must cp -f $VDEV0.bak $VDEV0
-log_must rm -f $VDEV0.bak
 
 # 5. Change the hostid.
 log_must zgenhostid -f $HOSTID2


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/11035507045/job/30660961625

```
  Test (Linux): /usr/share/zfs/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_hostid_changed_cachefile_unclean_export (run as root) [00:00] [FAIL]
  19:36:30.10 SUCCESS: zgenhostid -f 01234567
  19:36:30.25 SUCCESS: zpool create -o cachefile=/var/tmp/cachefile.483896 testpool1 /var/tmp/dev_import-test/disk0
  19:36:30.26 SUCCESS: cp /var/tmp/cachefile.483896 /var/tmp/cachefile.483896.bkp
  19:36:30.28 SUCCESS: cp /var/tmp/dev_import-test/disk0 /var/tmp/dev_import-test/disk0.bak
  19:36:30.36 SUCCESS: zpool export testpool1
  19:36:30.38 SUCCESS: cp -f /var/tmp/dev_import-test/disk0.bak /var/tmp/dev_import-test/disk0
  19:36:30.38 SUCCESS: rm -f /var/tmp/dev_import-test/disk0.bak
  19:36:30.39 SUCCESS: zgenhostid -f 89abcdef
  19:36:30.46 cachefile import failed, retrying
  19:36:30.46 SUCCESS: zpool import -c /var/tmp/cachefile.483896.bkp testpool1 exited 1
  19:36:30.79 	Recovery is possible, but will result in some data loss.
  19:36:30.79 	Returning the pool to its state as of Wed Sep 25 19:36:30 2024
  19:36:30.79 	should correct the problem.  Recovery can be attempted
  19:36:30.79 	by executing 'zpool import -F testpool1'.  A scrub of the pool
  19:36:30.79 	is strongly recommended after recovery.
  19:36:30.79 cachefile import failed, retrying
  19:36:30.79 	Recovery is possible, but will result in some data loss.
  19:36:30.79 	Returning the pool to its state as of Wed Sep 25 19:36:30 2024
  19:36:30.79 	should correct the problem.  Recovery can be attempted
  19:36:30.79 	by executing 'zpool import -F testpool1'.  A scrub of the pool
  19:36:30.79 	is strongly recommended after recovery.
  19:36:30.79 cannot import 'testpool1': insufficient replicas
  19:36:30.79 cannot import 'testpool1': insufficient replicas
  19:36:30.79 ERROR: zpool import -f -c /var/tmp/cachefile.483896.bkp testpool1 exited 1
```

### Description

Update the test case to freeze the pool then export it to better simulate a hard failure.  This is preferable to copying the vdev while the pool's imported since with a copy we're not guaranteed the on-disk state will be consistent.  That can in turn result in a pool import failure and a spurious test failure.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
