### PR TITLE
CI: Add logs to zloop workflow

### DIFF
--- a/.github/workflows/scripts/qemu-3-deps.sh
+++ b/.github/workflows/scripts/qemu-3-deps.sh
@@ -32,9 +32,9 @@ function debian() {
   sudo apt-get install -y \
     acl alien attr autoconf bc cpio curl dbench dh-python dkms fakeroot \
     fio gdb gdebi git ksh lcov isc-dhcp-client jq libacl1-dev libaio-dev \
-    libattr1-dev libblkid-dev libcurl4-openssl-dev libdevmapper-dev \
-    libelf-dev libffi-dev libmount-dev libpam0g-dev libselinux-dev \
-    libssl-dev libtool libtool-bin libudev-dev linux-headers-$(uname -r) \
+    libattr1-dev libblkid-dev libcurl4-openssl-dev libdevmapper-dev libelf-dev \
+    libffi-dev libmount-dev libpam0g-dev libselinux-dev libssl-dev libtool \
+    libtool-bin libudev-dev libunwind-dev linux-headers-$(uname -r) \
     lsscsi nfs-kernel-server pamtester parted python3 python3-all-dev \
     python3-cffi python3-dev python3-distlib python3-packaging \
     python3-setuptools python3-sphinx qemu-guest-agent rng-tools rpm2cpio \

--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -43,11 +43,23 @@ jobs:
         sudo mkdir -p $TEST_DIR
         # run for 10 minutes or at most 6 iterations for a maximum runner
         # time of 60 minutes.
-        sudo /usr/share/zfs/zloop.sh -t 600 -I 6 -l -m1 -- -T 120 -P 60
+        sudo /usr/share/zfs/zloop.sh -t 600 -I 6 -l -m 1 -- -T 120 -P 60
     - name: Prepare artifacts
       if: failure()
       run: |
         sudo chmod +r -R $TEST_DIR/
+    - name: Ztest log
+      if: failure()
+      run: |
+        grep -B10 -A1000 'ASSERT' $TEST_DIR/*/ztest.out || tail -n 1000 $TEST_DIR/*/ztest.out
+    - name: Gdb log
+      if: failure()
+      run: |
+        sed -n '/Backtraces (full)/q;p' $TEST_DIR/*/ztest.gdb
+    - name: Zdb log
+      if: failure()
+      run: |
+        cat $TEST_DIR/*/ztest.zdb
     - uses: actions/upload-artifact@v4
       if: failure()
       with:


### PR DESCRIPTION
### Motivation and Context

Leverage the updated CI to make it easier to see what caused a zloop failure.

### Description

On failure attempt to include the most relevant portions of the ztest logs in the CI output.  This full logs are still available for download but often a backtrace and the last output is enough.

Install libunwind to improve the odds of a useful backtrace.

### How Has This Been Tested?

I'll need to iterate on this with the CI to catch some failures and verify it works.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
