### PR TITLE
ZTS: Update deadman_sync threshold

### DIFF
--- a/tests/zfs-tests/tests/functional/deadman/deadman_sync.ksh
+++ b/tests/zfs-tests/tests/functional/deadman/deadman_sync.ksh
@@ -62,7 +62,7 @@ log_must set_tunable64 DEADMAN_FAILMODE "wait"
 default_setup_noexit $DISK1
 log_must zpool events -c
 
-# Force each IO to take 10s by allow them to run concurrently.
+# Force each IO to take 10s but allow them to run concurrently.
 log_must zinject -d $DISK1 -D10000:10 $TESTPOOL
 
 mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
@@ -80,11 +80,11 @@ else
 fi
 log_must zpool events
 
-# Verify at least 4 deadman events were logged.  The first after 5 seconds,
+# Verify at least 3 deadman events were logged.  The first after 5 seconds,
 # and another each second thereafter until the delay  is clearer.
 events=$(zpool events | grep -c ereport.fs.zfs.deadman)
-if [ "$events" -lt 4 ]; then
-	log_fail "Expect >=5 deadman events, $events found"
+if [ "$events" -lt 3 ]; then
+	log_fail "Expect >=3 deadman events, $events found"
 fi
 
 log_pass "Verify spa deadman detected a hung txg and $events deadman events"


### PR DESCRIPTION
### Motivation and Context

Resolve another false positive occasionally observed by the CI.

https://github.com/openzfs/zfs/actions/runs/11061095588/job/30733059003?pr=16539

### Description

Lower the minimum number of expected deadman events from 4 to 3.  All that is strictly required is a single event to consider the test a pass.  However, since I've never seen a count of less than 3 reported by the CI that should be sufficient.

### How Has This Been Tested?

Will be verified by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)