### PR TITLE
ZTS: Fix zpool_import_hostid_changed_unclean_export

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_hostid_changed_unclean_export.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_hostid_changed_unclean_export.ksh
@@ -27,8 +27,8 @@
 #	1. Set a hostid.
 #	2. Create a pool.
 #	3. Simulate the pool being torn down without export:
-#	3.1. Copy the underlying device state.
-#	3.2. Export the pool.
+#	3.1. Sync then freeze the pool.
+#	3.2. Export the pool (uncleanly).
 #	3.3. Restore the device state from the copy.
 #	4. Change the hostid.
 #	5. Verify that importing the pool fails.
@@ -52,10 +52,9 @@ log_must zgenhostid -f $HOSTID1
 log_must zpool create $TESTPOOL1 $VDEV0
 
 # 3. Simulate the pool being torn down without export.
-log_must cp $VDEV0 $VDEV0.bak
+sync_pool $TESTPOOL1
+log_must zpool freeze $TESTPOOL1
 log_must zpool export $TESTPOOL1
-log_must cp -f $VDEV0.bak $VDEV0
-log_must rm -f $VDEV0.bak
 
 # 4. Change the hostid.
 log_must zgenhostid -f $HOSTID2


### PR DESCRIPTION
### Motivation and Context

Apply the same fix from #16570 to this similar test case.

https://github.com/openzfs/zfs/actions/runs/11074121440/job/30772504124

```
   Test (Linux): /usr/share/zfs/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_hostid_changed_unclean_export (run as root) [00:00] [FAIL]
  21:53:15.14 SUCCESS: zgenhostid -f 01234567
  21:53:15.25 SUCCESS: zpool create testpool1 /var/tmp/dev_import-test/disk0
  21:53:15.27 SUCCESS: cp /var/tmp/dev_import-test/disk0 /var/tmp/dev_import-test/disk0.bak
  21:53:15.31 SUCCESS: zpool export testpool1
  21:53:15.32 SUCCESS: cp -f /var/tmp/dev_import-test/disk0.bak /var/tmp/dev_import-test/disk0
  21:53:15.32 SUCCESS: rm -f /var/tmp/dev_import-test/disk0.bak
  21:53:15.33 SUCCESS: zgenhostid -f 89abcdef
  21:53:15.36 SUCCESS: zpool import -d /var/tmp/dev_import-test testpool1 exited 1
  21:53:15.46 	Recovery is possible, but will result in some data loss.
  21:53:15.46 	Returning the pool to its state as of Fri Sep 27 21:53:15 2024
  21:53:15.46 	should correct the problem.  Recovery can be attempted
  21:53:15.46 	by executing 'zpool import -F testpool1'.  A scrub of the pool
  21:53:15.46 	is strongly recommended after recovery.
  21:53:15.46 cannot import 'testpool1': I/O error
```

### Description

Update the test case to freeze the pool then export it to better simulate a hard failure.  This is preferable to copying the vdev while the pool's imported since with a copy we're not guaranteed the on-disk state will be consistent.  That can in turn result in a pool import failure and a spurious test failure.

### How Has This Been Tested?

Will be tested by the CI, but the fix is identical to ab1b87e7479b6a615d7882de0579c9085eeaebac.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
