### PR TITLE
libzutil: allow to display powers of 1000 bytes

### DIFF
--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -144,13 +144,15 @@ _LIBZUTIL_H boolean_t zfs_isnumber(const char *);
  * ZFS_NICENUM_TIME:	Print nanosecs, microsecs, millisecs, seconds...
  * ZFS_NICENUM_RAW:	Print the raw number without any formatting
  * ZFS_NICENUM_RAWTIME:	Same as RAW, but print dashes ('-') for zero.
+ * ZFS_NICENUM_1000: Same as ZFS_NICENUM_BYTES but use powers of 1000.
  */
 enum zfs_nicenum_format {
 	ZFS_NICENUM_1024 = 0,
 	ZFS_NICENUM_BYTES = 1,
 	ZFS_NICENUM_TIME = 2,
 	ZFS_NICENUM_RAW = 3,
-	ZFS_NICENUM_RAWTIME = 4
+	ZFS_NICENUM_RAWTIME = 4,
+	ZFS_NICENUM_1000 = 5
 };
 
 /*

--- a/lib/libzutil/zutil_nicenum.c
+++ b/lib/libzutil/zutil_nicenum.c
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <libzutil.h>
 #include <string.h>
 
@@ -64,19 +65,22 @@ zfs_nicenum_format(uint64_t num, char *buf, size_t buflen,
 	uint64_t n = num;
 	int index = 0;
 	const char *u;
-	const char *units[3][7] = {
+	const char *units[6][7] = {
 	    [ZFS_NICENUM_1024] = {"", "K", "M", "G", "T", "P", "E"},
 	    [ZFS_NICENUM_BYTES] = {"B", "K", "M", "G", "T", "P", "E"},
-	    [ZFS_NICENUM_TIME] = {"ns", "us", "ms", "s", "?", "?", "?"}
+	    [ZFS_NICENUM_TIME] = {"ns", "us", "ms", "s", "?", "?", "?"},
+	    [ZFS_NICENUM_1000] = {"B", "K", "M", "G", "T", "P", "E"}
 	};
 
 	const int units_len[] = {[ZFS_NICENUM_1024] = 6,
 	    [ZFS_NICENUM_BYTES] = 6,
-	    [ZFS_NICENUM_TIME] = 4};
+	    [ZFS_NICENUM_TIME] = 4,
+	    [ZFS_NICENUM_1000] = 6};
 
 	const int k_unit[] = {	[ZFS_NICENUM_1024] = 1024,
 	    [ZFS_NICENUM_BYTES] = 1024,
-	    [ZFS_NICENUM_TIME] = 1000};
+	    [ZFS_NICENUM_TIME] = 1000,
+	    [ZFS_NICENUM_1000] = 1000};
 
 	double val;
 
@@ -180,5 +184,9 @@ zfs_niceraw(uint64_t num, char *buf, size_t buflen)
 void
 zfs_nicebytes(uint64_t num, char *buf, size_t buflen)
 {
-	zfs_nicenum_format(num, buf, buflen, ZFS_NICENUM_BYTES);
+	if (getenv("ZFS_OUTPUT_BYTES_SI") != NULL) {
+		zfs_nicenum_format(num, buf, buflen, ZFS_NICENUM_1000);
+	} else {
+		zfs_nicenum_format(num, buf, buflen, ZFS_NICENUM_BYTES);
+	}
 }

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -567,6 +567,15 @@ refcnt   blocks   LSIZE   PSIZE   DSIZE   blocks   LSIZE   PSIZE   DSIZE
 dedup = 1.11, compress = 1.80, copies = 1.00, dedup * compress / copies = 2.00
 .Ed
 .
+.Sh ENVIRONMENT VARIABLES
+.Bl -tag -width "ZFS_OUTPUT_BYTES_SI"
+.\" Shared with zfs.8 and zpool.8
+.It Sy ZFS_OUTPUT_BYTES_SI
+Make K/M/G/T/P/E prefixes in
+.Nm zdb
+output to represent powers of 1000 bytes, i.e. KB, MB, GB, TB, PB, EB.
+.El
+.
 .Sh SEE ALSO
 .Xr zfs 8 ,
 .Xr zpool 8

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -763,6 +763,12 @@ to set the maximum pipe size for sends/recieves.
 Disabled by default on Linux
 due to an unfixed deadlock in Linux's pipe size handling code.
 .
+.\" Shared with zdb.8 and zpool.8
+.It Sy ZFS_OUTPUT_BYTES_SI
+Make K/M/G/T/P/E prefixes in
+.Nm zfs
+output to represent powers of 1000 bytes, i.e. KB, MB, GB, TB, PB, EB.
+.
 .\" Shared with zpool.8
 .It Sy ZFS_MODULE_TIMEOUT
 Time, in seconds, to wait for

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -561,6 +561,12 @@ If
 .Sy ZPOOL_SCRIPTS_ENABLED
 is not set, it is assumed that the user is allowed to run
 .Nm zpool Cm status Ns / Ns Cm iostat Fl c .
+.\" Shared with zdb.8 and zfs.8
+.It Sy ZFS_OUTPUT_BYTES_SI
+Make K/M/G/T/P/E prefixes in
+.Nm zpool
+output to represent powers of 1000 bytes, i.e. KB, MB, GB, TB, PB, EB.
+.
 .\" Shared with zfs.8
 .It Sy ZFS_MODULE_TIMEOUT
 Time, in seconds, to wait for


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
ZFS displays bytes with K/M/G/T/P/E prefixes. They represent powers of 1024 bytes, i.e. KiB, MiB, GiB, TiB, PiB, EiB.
Some users may want these prefixes to represent powers of 1000 bytes, i.e. KB, MB, GB, TB, PB, EB.

### Description
This adds the new unit format and allows to use such display by defining an environment variable.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Not tested. If this draft gathers interest then I will add tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
