### PR TITLE
man: update recordsize max size info

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1749,6 +1749,11 @@ Therefore, we formerly forbade creating blocks larger than 1M.
 Larger blocks could be created by changing it,
 and pools with larger blocks can always be imported and used,
 regardless of this setting.
+.Pp
+Note that it is still limited by default to
+.Ar 1 MiB
+on x86_32, because Linux's
+3/1 memory split doesn't leave much room for 16M chunks.
 .
 .It Sy zfs_allow_redacted_dataset_mount Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Allow datasets received with redacted send/receive to be mounted.

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1527,10 +1527,21 @@ and less than or equal to
 If the
 .Sy large_blocks
 feature is enabled on the pool, the size may be up to
-.Ar 1 MiB .
+.Ar 16 MiB .
 See
 .Xr zpool-features 7
 for details on ZFS feature flags.
+.Pp
+However, blocks larger than
+.Ar 1 MiB
+can have an impact on i/o latency (e.g. tying up a spinning disk for
+~300ms), and also potentially on the memory allocator.
+.Pp
+Note that maximum size is still limited by default to
+.Ar 1 MiB
+on x86_32, see
+.Sy zfs_max_recordsize
+module parameter.
 .Pp
 Changing the file system's
 .Sy recordsize


### PR DESCRIPTION
Reflect https://github.com/openzfs/zfs/commit/f2330bd1568489ae1fb16d975a5a9bcfe12ed219 change in our man pages and add some context.

Wording is primarily copy-pasted from code comments.

### How Has This Been Tested?
`man ./man/man7/zfsprops.7` and looked with my eyes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [X] Documentation (a change to man pages or other documentation)
