### PR TITLE
lua: add flex array field to TString type

### DIFF
--- a/module/lua/lobject.h
+++ b/module/lua/lobject.h
@@ -404,19 +404,22 @@ typedef TValue *StkId;  /* index to stack elements */
 /*
 ** Header for string value; string bytes follow the end of this structure
 */
-typedef union TString {
-  L_Umaxalign dummy;  /* ensures maximum alignment for strings */
-  struct {
-    CommonHeader;
-    lu_byte extra;  /* reserved words for short strings; "has hash" for longs */
-    unsigned int hash;
-    size_t len;  /* number of characters in string */
-  } tsv;
+typedef struct TString {
+  union {
+    L_Umaxalign dummy;  /* ensures maximum alignment for strings */
+    struct {
+      CommonHeader;
+      lu_byte extra;  /* reserved words for short strings; "has hash" for longs */
+      unsigned int hash;
+      size_t len;  /* number of characters in string */
+    } tsv;
+  };
+  char contents[];
 } TString;
 
 
 /* get the actual string (array of bytes) from a TString */
-#define getstr(ts)	cast(const char *, (ts) + 1)
+#define getstr(ts)	((ts)->contents)
 
 /* get the actual string (array of bytes) from a Lua value */
 #define svalue(o)       getstr(rawtsvalue(o))

--- a/module/lua/lstate.h
+++ b/module/lua/lstate.h
@@ -185,7 +185,7 @@ struct lua_State {
 */
 union GCObject {
   GCheader gch;  /* common header */
-  union TString ts;
+  struct TString ts;
   union Udata u;
   union Closure cl;
   struct Table h;

--- a/module/lua/lstring.c
+++ b/module/lua/lstring.c
@@ -103,7 +103,7 @@ static TString *createstrobj (lua_State *L, const char *str, size_t l,
   ts->tsv.len = l;
   ts->tsv.hash = h;
   ts->tsv.extra = 0;
-  sbuf = (char *)(TString *)(ts + 1);
+  sbuf = ts->contents;
   memcpy(sbuf, str, l*sizeof(char));
   sbuf[l] = '\0';  /* ending 0 */
   return ts;

--- a/module/lua/lstring.h
+++ b/module/lua/lstring.h
@@ -12,7 +12,7 @@
 #include "lstate.h"
 
 
-#define sizestring(s)	(sizeof(union TString)+((s)->len+1)*sizeof(char))
+#define sizestring(s)	(sizeof(struct TString)+((s)->len+1)*sizeof(char))
 
 #define sizeudata(u)	(sizeof(union Udata)+(u)->len)
 


### PR DESCRIPTION
### Motivation and Context

Silence kernel warnings from the Lua module:

```
[    7.244624] memcpy: detected field-spanning write (size 7) of single field "sbuf" at /home/robn/code/zfs/module/lua/lstring.c:107 (size 0)
```

Closes #16541.

### Description

Linux 6.10+ with CONFIG_FORTIFY_SOURCE notices `memcpy()` accessing past the end of `TString`, because it has no indication that there there may be an additional allocation there.

There's no appropriate upstream change for this (ancient) version of Lua, so this is the narrowest change I could come up with to add a flex array field to the end of `TString` to satisfy the check. It's loosely based on changes from lua/lua@ca41b43f and lua/lua@9514abc2.

### How Has This Been Tested?

Ran `lua_core` test tag on 6.1.102 and 6.11.0 with and without this patch. All tests passed in all cases, 6.11.0 without this patch produced the above warning. With patch, silence.

Also compiled and ran `lua_core` on 14.1-RELEASE-p3, all successful.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
