### PR TITLE
Temporarily disable Direct IO by default

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -78,7 +78,7 @@ static int zfs_bclone_wait_dirty = 0;
  * directed through the ARC acting as though the dataset property direct was
  * set to disabled.
  */
-static int zfs_dio_enabled = 1;
+static int zfs_dio_enabled = 0;
 
 
 /*


### PR DESCRIPTION
### Motivation and Context

Prior to creating the 2.3 release branch disable direct IO by default.  Direct IO will be disabled in the -RC1 tag, we expect to finishing integrating fixes for the known issues and enable it by default in -RC2.

### Description

While some remaining issues are resolved with the recently merged Direct IO functionality disable it by default.

Outstanding issues: #16594, #16596, read-only-verify PR pending.

### How Has This Been Tested?

Will be tested by the CI.  The direct IO test cases are already aware of this tuning and should be skipped.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
