### PR TITLE
ZTS: Fix summary page creation

### DIFF
--- a/.github/workflows/scripts/qemu-9-summary-page.sh
+++ b/.github/workflows/scripts/qemu-9-summary-page.sh
@@ -11,10 +11,12 @@ function output() {
 }
 
 function outfile() {
+  test -s "$1" || return
   cat "$1" >> "out-$logfile.md"
 }
 
 function outfile_plain() {
+  test -s "$1" || return
   output "<pre>"
   cat "$1" >> "out-$logfile.md"
   output "</pre>"


### PR DESCRIPTION
### Motivation and Context

There are cases, where some needed files for the summary page aren't created. Currently the whole Summary Page creation will fail then. Sample run: https://github.com/openzfs/zfs/actions/runs/11148248072/job/30999748588

Fix this, by properly checking for existence of the needed files.

### How Has This Been Tested?

The ZTS will do.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
