### PR TITLE
issue #14223: fix generation of kernel uevents for snapshot rename on linux

### DIFF
--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -2987,6 +2987,7 @@ dsl_dataset_rename_snapshot_sync_impl(dsl_pool_t *dp,
 	dsl_dataset_t *ds;
 	uint64_t val;
 	dmu_tx_t *tx = ddrsa->ddrsa_tx;
+	char *oldname, *newname;
 	int error;
 
 	error = dsl_dataset_snap_lookup(hds, ddrsa->ddrsa_oldsnapname, &val);
@@ -3011,8 +3012,14 @@ dsl_dataset_rename_snapshot_sync_impl(dsl_pool_t *dp,
 	VERIFY0(zap_add(dp->dp_meta_objset,
 	    dsl_dataset_phys(hds)->ds_snapnames_zapobj,
 	    ds->ds_snapname, 8, 1, &ds->ds_object, tx));
-	zvol_rename_minors(dp->dp_spa, ddrsa->ddrsa_oldsnapname,
-	    ddrsa->ddrsa_newsnapname, B_TRUE);
+
+	oldname = kmem_asprintf("%s@%s", ddrsa->ddrsa_fsname,
+	    ddrsa->ddrsa_oldsnapname);
+	newname = kmem_asprintf("%s@%s", ddrsa->ddrsa_fsname,
+	    ddrsa->ddrsa_newsnapname);
+	zvol_rename_minors(dp->dp_spa, oldname, newname, B_TRUE);
+	kmem_strfree(oldname);
+	kmem_strfree(newname);
 
 	dsl_dataset_rele(ds, FTAG);
 	return (0);

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_snapdev.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_snapdev.ksh
@@ -117,5 +117,18 @@ log_must zfs set snapdev=visible $TESTPOOL
 verify_inherited 'snapdev' 'hidden' $SUBZVOL $VOLFS
 blockdev_missing $SUBSNAPDEV
 blockdev_exists $SNAPDEV
+log_must zfs destroy $SNAP
+
+# 4. Verify "rename" is correctly reflected when "snapdev=visible"
+# 4.1 First create a snapshot and verify the device is present
+log_must zfs snapshot $SNAP
+log_must zfs set snapdev=visible $ZVOL
+blockdev_exists $SNAPDEV
+# 4.2 rename the snapshot and verify the devices are updated
+log_must zfs rename $SNAP $SNAP-new
+blockdev_missing $SNAPDEV
+blockdev_exists $SNAPDEV-new
+# 4.3 cleanup
+log_must zfs destroy $SNAP-new
 
 log_pass "ZFS volume property 'snapdev' works as expected"


### PR DESCRIPTION
`zvol_rename_minors()` needs to be given the full path not just the snapshot name.  Use code removed in a0bd735adb1b1eb81fef10b4db102ee051c4d4ff as a guide to providing the necessary values.

Closes #14223

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Renaming a snapshot `zfs rename zpool/volume@snap1 zpool/volume@snap2` should result in the udev generated link for /dev/zvol/zpool/volume@snap1 being removed and a new /dev/zvol/zpool/volume@snap2 being created.  Without this then trying to access the snapshot content via the old name results in `ENOENT` and the new name is not present.

<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/openzfs/zfs/issues/14223

### Description
<!--- Describe your changes in detail -->

The change here ensures that the full path to the snapshot is provided to `zvol_rename_minors()` and not just the plain snapshot name.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The kernel module has been rebuilt on the test system with this change and the behaviour of the rename is now as expected, the old link is removed and a new link exists.  Content of the snapshot is available via the new link.

`make deb` has also been executed and the full set of packages has been used to rebuild a virtual machine disk image.  The image has been booted and no regressions have been noted.

<!--- Include details of your testing environment, and the tests you ran to -->

```
# modinfo zfs | grep version
version:        2.2.6-7_ge638f31346
srcversion:     A2EB6FF13910945DA37E614
vermagic:       6.8.0-40-generic SMP preempt mod_unload modversions 

# lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.4 LTS
Release:        22.04
Codename:       jammy

# uname -a
Linux hostname 6.8.0-40-generic #40~22.04.1 SMP PREEMPT_DYNAMIC Tue Jul 30 17:51:21 UTC  x86_64 x86_64 x86_64 GNU/Linux
```

I am not a FreeBSD user so I'm unsure if there was an issue on that platform or how this code may affect it.

<!--- see how your change affects other areas of the code, etc. -->

<!--- If your change is a performance enhancement, please provide benchmarks here. -->
N/A.

<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
