### PR TITLE
vdev_id: multi-lun disks & slot num zero pad

### DIFF
--- a/man/man5/vdev_id.conf.5
+++ b/man/man5/vdev_id.conf.5
@@ -92,6 +92,11 @@ before a generic mapping for the same slot.
 In this way a custom mapping may be applied to a particular channel
 and a default mapping applied to the others.
 .
+.It Sy zpad_slot Ar digits
+Pad slot numbers with zeros to make them
+.Ar digits
+long, which can help to make disk names a consistent length and easier to sort.
+.
 .It Sy multipath Sy yes Ns | Ns Sy no
 Specifies whether
 .Xr vdev_id 8
@@ -122,7 +127,7 @@ device is connected to.
 The default is
 .Sy 4 .
 .
-.It Sy slot Sy bay Ns | Ns Sy phy Ns | Ns Sy port Ns | Ns Sy id Ns | Ns Sy lun Ns | Ns Sy ses
+.It Sy slot Sy bay Ns | Ns Sy phy Ns | Ns Sy port Ns | Ns Sy id Ns | Ns Sy lun Ns | Ns Sy bay_lun Ns | Ns Sy ses
 Specifies from which element of a SAS identifier the slot number is
 taken.
 The default is
@@ -138,6 +143,9 @@ use the SAS port as the slot number.
 use the scsi id as the slot number.
 .It Sy lun
 use the scsi lun as the slot number.
+.It Sy bay_lun
+read the slot number from the bay identifier and append the lun number.
+Useful for multi-lun multi-actuator hard drives.
 .It Sy ses
 use the SCSI Enclosure Services (SES) enclosure device slot number,
 as reported by

--- a/udev/vdev_id
+++ b/udev/vdev_id
@@ -124,6 +124,7 @@ TOPOLOGY=
 BAY=
 ENCL_ID=""
 UNIQ_ENCL_ID=""
+ZPAD=1
 
 usage() {
 	cat << EOF
@@ -154,7 +155,7 @@ map_slot() {
 	if [ -z "$MAPPED_SLOT" ] ; then
 		MAPPED_SLOT=$LINUX_SLOT
 	fi
-	printf "%d" "${MAPPED_SLOT}"
+	printf "%0${ZPAD}d" "${MAPPED_SLOT}"
 }
 
 map_channel() {
@@ -430,6 +431,15 @@ sas_handler() {
 		d=$(eval echo '$'{$i})
 		SLOT=$(echo "$d" | sed -e 's/^.*://')
 		;;
+	"bay_lun")
+		# Like 'bay' but with the LUN number appened. Added for SAS 
+		# multi-actuator HDDs, where one physical drive has multiple
+		# LUNs, thus multiple logical drives share the same bay number
+		i=$((i + 2))
+		d=$(eval echo '$'{$i})
+		LUN="-lun$(echo "$d" | sed -e 's/^.*://')"
+		SLOT=$(cat "$end_device_dir/bay_identifier" 2>/dev/null)
+		;;
 	"ses")
 		# look for this SAS path in all SCSI Enclosure Services
 		# (SES) enclosures
@@ -460,7 +470,7 @@ sas_handler() {
 		if [ -z "$CHAN" ] ; then
 			return
 		fi
-		echo "${CHAN}"-"${JBOD}"-"${SLOT}${PART}"
+		echo "${CHAN}"-"${JBOD}"-"${SLOT}${LUN}${PART}"
 	else
 		CHAN=$(map_channel "$PCI_ID" "$PORT")
 		SLOT=$(map_slot "$SLOT" "$CHAN")
@@ -468,7 +478,7 @@ sas_handler() {
 		if [ -z "$CHAN" ] ; then
 			return
 		fi
-		echo "${CHAN}${SLOT}${PART}"
+		echo "${CHAN}${SLOT}${LUN}${PART}"
 	fi
 }
 
@@ -747,6 +757,8 @@ fi
 if [ -z "$BAY" ] ; then
 	BAY=$(awk '($1 == "slot") {print $2; exit}' "$CONFIG")
 fi
+
+ZPAD=$(awk '($1 == "zpad_slot") {print $2; exit}' "$CONFIG")
 
 TOPOLOGY=${TOPOLOGY:-sas_direct}
 


### PR DESCRIPTION
Add ability to generate disk names that contain both a slot number and a lun number in order to support multi-actuator SAS hard drives with multiple luns. Also add the ability to zero pad slot numbers to a desired digit length for easier sorting.

### Motivation and Context
I manage many servers with ZFS pools comprised of dozens of Seagate Mach.2 dual-actuator SAS hard drives. These drives have two SCSI LUNs per physical drive, one per actuator, each giving access to half the storage capacity of the physical drive. Without these changes I can only configure vdev_id.conf to generate slot number based aliases for the first LUN of each drive, only half the capacity. 

### Description
This PR only introduces minor changes to the vdev_id script and associated documentation in the vdev_id.conf man page. 

The first change is to add the option of generating disk names that include both a slot number and a lun number, this feature in enabled by adding one more value, 'bay_lun' to the list of values accepted by the 'slot' setting for vdev_id.conf.

The second little change is to add the option of requesting that disk names generated pad the slot number component to a specific number of digits using leading zeros. This is activated by a new 'zpad_slot' setting for vdev_id.conf whose value is the desired length, "zpad 3" could generate disk001, disk002, ...etc.

### How Has This Been Tested?
I have RHEL 8 and Ubuntu 22.04 servers with  dual-actuator SAS disks that have been using these changes for a couple years. I have not tested this for any other use cases but I figured it was time I offered to contribute my changes back to the community in case this enhancement was applicable to others.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
