### PR TITLE
ZTS: Fix summary page creation again - second try

### DIFF
--- a/.github/workflows/scripts/qemu-9-summary-page.sh
+++ b/.github/workflows/scripts/qemu-9-summary-page.sh
@@ -11,12 +11,10 @@ function output() {
 }
 
 function outfile() {
-  test -s "$1" || return
   cat "$1" >> "out-$logfile.md"
 }
 
 function outfile_plain() {
-  test -s "$1" || return
   output "<pre>"
   cat "$1" >> "out-$logfile.md"
   output "</pre>"
@@ -45,6 +43,8 @@ if [ ! -f out-1.md ]; then
     tar xf "$tarfile"
     test -s env.txt || continue
     source env.txt
+    # when uname.txt is there, the other files are also ok
+    test -s uname.txt || continue
     output "\n## Functional Tests: $OSNAME\n"
     outfile_plain uname.txt
     outfile_plain summary.txt


### PR DESCRIPTION
### Motivation and Context

In PR #16599 I used `return` like in `C` - which is wrong :/
The `return` will return / exit the whole script with an error... so no summary will be genereted et all.

This fix generates the summary as needed again.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
