### PR TITLE
Linux: add zpl_drop_inode

### DIFF
--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -560,6 +560,12 @@ spa_history_log_internal(spa_t *spa, const char *operation,
 		}
 	}
 
+	if (htx->tx_txg > spa_final_dirty_txg(spa)) {
+		if (tx == NULL)
+			dmu_tx_abort(htx);
+		return;
+	}
+
 	va_start(adx, fmt);
 	log_internal(fnvlist_alloc(), operation, spa, htx, fmt, adx);
 	va_end(adx);


### PR DESCRIPTION
### Motivation and Context
This is an attempt to rectify the situation in zfs_zget() on Linux, where we might be racing with inode reclaim from the kernel.

The code is ugly and I'm not sure it's perfectly OK to do it this way anyway.

Now I'm moderately sure the refcount check is right, but the more eyes it gets the better.

### Description

There's now VERIFY-wrapped mandatory `igrab()` in `zget()`, because inode lifetime should be guaranteed by the new `zpl_drop_inode` super_op. This should simplify reasoning about znode/inode lifetimes as both alloc and drop are defined by zpl_super_operations now.

### How Has This Been Tested?

Bots + locally (+ hammered by template builds)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
