### PR TITLE
Return boolean_t in inline functions of lib/libspl/include/sys/uio.h

### DIFF
--- a/lib/libspl/include/sys/uio.h
+++ b/lib/libspl/include/sys/uio.h
@@ -92,20 +92,20 @@ zfs_dio_page_aligned(void *buf)
 static inline boolean_t
 zfs_dio_offset_aligned(uint64_t offset, uint64_t blksz)
 {
-	return (IS_P2ALIGNED(offset, blksz));
+	return ((IS_P2ALIGNED(offset, blksz)) ? B_TRUE : B_FALSE);
 }
 
 static inline boolean_t
 zfs_dio_size_aligned(uint64_t size, uint64_t blksz)
 {
-	return ((size % blksz) == 0);
+	return (((size % blksz) == 0) ? B_TRUE : B_FALSE);
 }
 
 static inline boolean_t
 zfs_dio_aligned(uint64_t offset, uint64_t size, uint64_t blksz)
 {
-	return (zfs_dio_offset_aligned(offset, blksz) &&
-	    zfs_dio_size_aligned(size, blksz));
+	return ((zfs_dio_offset_aligned(offset, blksz) &&
+	    zfs_dio_size_aligned(size, blksz)) ? B_TRUE : B_FALSE);
 }
 
 static inline void


### PR DESCRIPTION
### Motivation and Context
The inline functions zfs_dio_offset_aligned(), zfs_dio_size_aligned() and zfs_dio_aligned() are declared as boolean_t but return the bool type.

This fixes the build of FreeBSD zstd.

### Description
Change return type to boolean_t

### How Has This Been Tested?
Build of zstd on FreeBSD

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
