### PR TITLE
FreeBSD: exclude some includes when building libsa

### DIFF
--- a/include/os/freebsd/zfs/sys/abd_os.h
+++ b/include/os/freebsd/zfs/sys/abd_os.h
@@ -26,8 +26,10 @@
 #ifndef _ABD_OS_H
 #define	_ABD_OS_H
 
+#ifdef _KERNEL
 #include <sys/vm.h>
 #include <vm/vm_page.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,8 +49,10 @@ struct abd_linear {
 #endif
 };
 
+#ifdef _KERNEL
 __attribute__((malloc))
 struct abd *abd_alloc_from_pages(vm_page_t *, unsigned long, uint64_t);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
The function abd_alloc_from_pages() is not used in FreeBSD base libsa.
 Excluding sys/vm.h, and vm/vm_page.h includes avoids dependency problems.

### Description
Exclude abd_alloc_from_pages(), sys/vm.h, and vm/vm_page.h when building libsa.

### How Has This Been Tested?
FreeBSD base build

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).