### PR TITLE
Linux: zpl_tmpfile: ensure ACL init succeeds before d_tmpfile

### DIFF
--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -317,19 +317,19 @@ zpl_tmpfile(struct inode *dir, struct dentry *dentry, umode_t mode)
 		/* d_tmpfile will do drop_nlink, so we should set it first */
 		set_nlink(ip, 1);
 #ifndef HAVE_TMPFILE_DENTRY
-		d_tmpfile(file, ip);
-
 		error = zpl_xattr_security_init(ip, dir,
 		    &file->f_path.dentry->d_name);
-#else
-		d_tmpfile(dentry, ip);
-
-		error = zpl_xattr_security_init(ip, dir, &dentry->d_name);
-#endif
 		if (error == 0)
 			error = zpl_init_acl(ip, dir);
-#ifndef HAVE_TMPFILE_DENTRY
+		if (error == 0)
+			d_tmpfile(file, ip);
 		error = finish_open_simple(file, error);
+#else
+		error = zpl_xattr_security_init(ip, dir, &dentry->d_name);
+		if (error == 0)
+			error = zpl_init_acl(ip, dir);
+		if (error == 0)
+			d_tmpfile(dentry, ip);
 #endif
 		/*
 		 * don't need to handle error here, file is already in


### PR DESCRIPTION
### Motivation and Context
Other than #16612, this is the only place I see where trouble similar to #16608 could arise. One hint pointing to tmpfile is that the crashes are now way more frequent with 6.10 kernel, which introduced O_TMPFILE support for overlayfs, which agrees with that with our workload, if there's a general bug with O_TMPFILE, we'd be hitting it lot more often.

I'm not sure all the supported kernel versions will be okay with these modifications, I'm posting this as a draft to let the bots chew on it to find out.
### Description
Linux: zpl_tmpfile: ensure ACL init succeeds before d_tmpfile                   
                                                                                
Inode should be linked to dentry and hashed only after both                     
zpl_xattr_security_init and zpl_init_acl were successful, which                 
apparently isn't always true for example when memory is tight.    
### How Has This Been Tested?
Still waiting for vpsAdminOS container templates build to complete, if it does, then this fixes #16608. The major PITA here is that it takes 8.5hrs for it to fail currently :D

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
