### PR TITLE
Revert "Temporarily disable Direct IO by default"

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -77,8 +77,15 @@ static int zfs_bclone_wait_dirty = 0;
  * Enable Direct I/O. If this setting is 0, then all I/O requests will be
  * directed through the ARC acting as though the dataset property direct was
  * set to disabled.
+ *
+ * Disabled by default on FreeBSD until a potential range locking issue in
+ * zfs_getpages() can be resolved.
  */
+#ifdef __FreeBSD__
 static int zfs_dio_enabled = 0;
+#else
+static int zfs_dio_enabled = 1;
+#endif
 
 
 /*


### PR DESCRIPTION
### Motivation and Context

Re-enable direct IO by default now that the #16598 has been resolved.

### Description

~This reverts commit 412105977c5cb1dcdd9a0b742ceaf04c75da24d0 now that b4e4cbeb20240cc7a780fb0e4bebd0134701fee8 has been merged.~

This partially reverts commit 41210597.  Now that b4e4cbeb2 has been merged Direct IO can be enabled by default for Linux, but for FreeBSD there still remains a potentially insufficient range locking in zfs_getpages() which needs to be resolved.

### How Has This Been Tested?

This functional has been manually tested in #16598 and by all previous CI runs since it was integrated.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
