### PR TITLE
zpool/zfs: allow `--json` wherever `-j` is allowed

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -2162,6 +2162,7 @@ zfs_do_get(int argc, char **argv)
 	cb.cb_type = ZFS_TYPE_DATASET;
 
 	struct option long_options[] = {
+		{"json", no_argument, NULL, 'j'},
 		{"json-int", no_argument, NULL, ZFS_OPTION_JSON_NUMS_AS_INT},
 		{0, 0, 0, 0}
 	};
@@ -3852,6 +3853,7 @@ zfs_do_list(int argc, char **argv)
 	nvlist_t *data = NULL;
 
 	struct option long_options[] = {
+		{"json", no_argument, NULL, 'j'},
 		{"json-int", no_argument, NULL, ZFS_OPTION_JSON_NUMS_AS_INT},
 		{0, 0, 0, 0}
 	};
@@ -7436,9 +7438,15 @@ share_mount(int op, int argc, char **argv)
 	uint_t nthr;
 	jsobj = data = item = NULL;
 
+	struct option long_options[] = {
+		{"json", no_argument, NULL, 'j'},
+		{0, 0, 0, 0}
+	};
+
 	/* check options */
-	while ((c = getopt(argc, argv, op == OP_MOUNT ? ":ajRlvo:Of" : "al"))
-	    != -1) {
+	while ((c = getopt_long(argc, argv,
+	    op == OP_MOUNT ? ":ajRlvo:Of" : "al",
+	    op == OP_MOUNT ? long_options : NULL, NULL)) != -1) {
 		switch (c) {
 		case 'a':
 			do_all = 1;
@@ -8374,8 +8382,14 @@ zfs_do_channel_program(int argc, char **argv)
 	boolean_t sync_flag = B_TRUE, json_output = B_FALSE;
 	zpool_handle_t *zhp;
 
+	struct option long_options[] = {
+		{"json", no_argument, NULL, 'j'},
+		{0, 0, 0, 0}
+	};
+
 	/* check options */
-	while ((c = getopt(argc, argv, "nt:m:j")) != -1) {
+	while ((c = getopt_long(argc, argv, "nt:m:j", long_options,
+	    NULL)) != -1) {
 		switch (c) {
 		case 't':
 		case 'm': {
@@ -9083,7 +9097,13 @@ zfs_do_version(int argc, char **argv)
 	int c;
 	nvlist_t *jsobj = NULL, *zfs_ver = NULL;
 	boolean_t json = B_FALSE;
-	while ((c = getopt(argc, argv, "j")) != -1) {
+
+	struct option long_options[] = {
+		{"json", no_argument, NULL, 'j'},
+		{0, 0, 0, 0}
+	};
+
+	while ((c = getopt_long(argc, argv, "j", long_options, NULL)) != -1) {
 		switch (c) {
 		case 'j':
 			json = B_TRUE;

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -7340,6 +7340,7 @@ zpool_do_list(int argc, char **argv)
 	current_prop_type = ZFS_TYPE_POOL;
 
 	struct option long_options[] = {
+		{"json", no_argument, NULL, 'j'},
 		{"json-int", no_argument, NULL, ZPOOL_OPTION_JSON_NUMS_AS_INT},
 		{"json-pool-key-guid", no_argument, NULL,
 		    ZPOOL_OPTION_POOL_KEY_GUID},
@@ -10981,6 +10982,7 @@ zpool_do_status(int argc, char **argv)
 
 	struct option long_options[] = {
 		{"power", no_argument, NULL, ZPOOL_OPTION_POWER},
+		{"json", no_argument, NULL, 'j'},
 		{"json-int", no_argument, NULL, ZPOOL_OPTION_JSON_NUMS_AS_INT},
 		{"json-flat-vdevs", no_argument, NULL,
 		    ZPOOL_OPTION_JSON_FLAT_VDEVS},
@@ -12589,6 +12591,7 @@ zpool_do_get(int argc, char **argv)
 	current_prop_type = cb.cb_type;
 
 	struct option long_options[] = {
+		{"json", no_argument, NULL, 'j'},
 		{"json-int", no_argument, NULL, ZPOOL_OPTION_JSON_NUMS_AS_INT},
 		{"json-pool-key-guid", no_argument, NULL,
 		    ZPOOL_OPTION_POOL_KEY_GUID},
@@ -13503,7 +13506,12 @@ zpool_do_version(int argc, char **argv)
 	int c;
 	nvlist_t *jsobj = NULL, *zfs_ver = NULL;
 	boolean_t json = B_FALSE;
-	while ((c = getopt(argc, argv, "j")) != -1) {
+
+	struct option long_options[] = {
+		{"json", no_argument, NULL, 'j'},
+	};
+
+	while ((c = getopt_long(argc, argv, "j", long_options, NULL)) != -1) {
 		switch (c) {
 		case 'j':
 			json = B_TRUE;

--- a/man/man8/zfs-list.8
+++ b/man/man8/zfs-list.8
@@ -71,7 +71,7 @@ The following fields are displayed:
 Used for scripting mode.
 Do not print headers and separate fields by a single tab instead of arbitrary
 white space.
-.It Fl j Op Ar --json-int
+.It Fl j , -json Op Ar --json-int
 Print the output in JSON format.
 Specify
 .Sy --json-int

--- a/man/man8/zfs-mount.8
+++ b/man/man8/zfs-mount.8
@@ -59,7 +59,7 @@
 .Xc
 Displays all ZFS file systems currently mounted.
 .Bl -tag -width "-j"
-.It Fl j
+.It Fl j , -json
 Displays all mounted file systems in JSON format.
 .El
 .It Xo

--- a/man/man8/zfs-program.8
+++ b/man/man8/zfs-program.8
@@ -50,7 +50,7 @@ and any attempts to access or modify other pools will cause an error.
 .
 .Sh OPTIONS
 .Bl -tag -width "-t"
-.It Fl j
+.It Fl j , -json
 Display channel program output in JSON format.
 When this flag is specified and standard output is empty -
 channel program encountered an error.

--- a/man/man8/zfs-set.8
+++ b/man/man8/zfs-set.8
@@ -130,7 +130,7 @@ The value
 can be used to display all properties that apply to the given dataset's type
 .Pq Sy filesystem , volume , snapshot , No or Sy bookmark .
 .Bl -tag -width "-s source"
-.It Fl j Op Ar --json-int
+.It Fl j , -json Op Ar --json-int
 Display the output in JSON format.
 Specify
 .Sy --json-int

--- a/man/man8/zpool-get.8
+++ b/man/man8/zpool-get.8
@@ -98,7 +98,7 @@ See the
 .Xr zpoolprops 7
 manual page for more information on the available pool properties.
 .Bl -tag -compact -offset Ds -width "-o field"
-.It Fl j Op Ar --json-int, --json-pool-key-guid
+.It Fl j , -json Op Ar --json-int, --json-pool-key-guid
 Display the list of properties in JSON format.
 Specify
 .Sy --json-int
@@ -157,7 +157,7 @@ See the
 .Xr vdevprops 7
 manual page for more information on the available pool properties.
 .Bl -tag -compact -offset Ds -width "-o field"
-.It Fl j Op Ar --json-int
+.It Fl j , -json Op Ar --json-int
 Display the list of properties in JSON format.
 Specify
 .Sy --json-int

--- a/man/man8/zpool-list.8
+++ b/man/man8/zpool-list.8
@@ -59,7 +59,7 @@ is specified, the command exits after
 .Ar count
 reports are printed.
 .Bl -tag -width Ds
-.It Fl j Op Ar --json-int, --json-pool-key-guid
+.It Fl j , -json Op Ar --json-int, --json-pool-key-guid
 Display the list of pools in JSON format.
 Specify
 .Sy --json-int

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -70,7 +70,7 @@ See the
 option of
 .Nm zpool Cm iostat
 for complete details.
-.It Fl j Op Ar --json-int, --json-flat-vdevs, --json-pool-key-guid
+.It Fl j , -json Op Ar --json-int, --json-flat-vdevs, --json-pool-key-guid
 Display the status for ZFS pools in JSON format.
 Specify
 .Sy --json-int

--- a/tests/zfs-tests/tests/functional/cli_root/json/json_sanity.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/json/json_sanity.ksh
@@ -30,28 +30,39 @@
 # STRATEGY:
 # 1. Run different zfs/zpool -j commands and check for valid JSON
 
+#
+# -j and --json mean the same thing. Each command will be run twice, replacing
+# JSONFLAG with the flag under test.
 list=(
-    "zpool status -j -g --json-int --json-flat-vdevs --json-pool-key-guid"
-    "zpool status -p -j -g --json-int --json-flat-vdevs --json-pool-key-guid"
-    "zpool status -j -c upath"
-    "zpool status -j"
-    "zpool status -j testpool1"
-    "zpool list -j"
-    "zpool list -j -g"
-    "zpool list -j -o fragmentation"
-    "zpool get -j size"
-    "zpool get -j all"
-    "zpool version -j"
-    "zfs list -j"
-    "zfs list -j testpool1"
-    "zfs get -j all"
-    "zfs get -j available"
-    "zfs mount -j"
-    "zfs version -j"
+    "zpool status JSONFLAG -g --json-int --json-flat-vdevs --json-pool-key-guid"
+    "zpool status -p JSONFLAG -g --json-int --json-flat-vdevs --json-pool-key-guid"
+    "zpool status JSONFLAG -c upath"
+    "zpool status JSONFLAG"
+    "zpool status JSONFLAG testpool1"
+    "zpool list JSONFLAG"
+    "zpool list JSONFLAG -g"
+    "zpool list JSONFLAG -o fragmentation"
+    "zpool get JSONFLAG size"
+    "zpool get JSONFLAG all"
+    "zpool version JSONFLAG"
+    "zfs list JSONFLAG"
+    "zfs list JSONFLAG testpool1"
+    "zfs get JSONFLAG all"
+    "zfs get JSONFLAG available"
+    "zfs mount JSONFLAG"
+    "zfs version JSONFLAG"
 )
 
-for cmd in "${list[@]}" ; do
-    log_must eval "$cmd | jq > /dev/null" 
-done
+function run_json_tests
+{
+	typeset flag=$1
+	for cmd in "${list[@]}" ; do
+	    cmd=${cmd//JSONFLAG/$flag}
+	    log_must eval "$cmd | jq > /dev/null"
+	done
+}
+
+log_must run_json_tests -j
+log_must run_json_tests --json
 
 log_pass "zpool and zfs commands outputted valid JSON"


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

Mostly so that with the JSON formatting options are also used, they all look the same. To my eye, `-j --json-flat-vdevs` suggests that they are different or unrelated, while `--json --json-flat-vdevs` invites no further questions.

### Description

Anywhere `-j` is accepted, also allow `--json`. For a couple of things, this means changing to `getopt_long()`, but its no big deal.

I have left the usage doc using `-j`, and added `--json` to the flag descriptions in the manpages only. This is roughly in keeping with existing practice (`zpool initialize`). Trying to express both just clutters it up, and I'm not some longopt absolutist!

### How Has This Been Tested?

By hand. For all commands change, made sure `-j` and `--json` appear to do the same thing. Special double-check for `zfs mount` and `zfs unmount`, which is slightly twisted. Everything looks good to me!

Update: `json_sanity` updated by request, now checking both forms.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
