### PR TITLE
ZTS: Slightly increase dedup_quota limit

### DIFF
--- a/tests/zfs-tests/tests/functional/dedup/dedup_quota.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_quota.ksh
@@ -221,7 +221,7 @@ function ddt_dedup_vdev_limit
 	# For here, we just set the entry count a little higher than what we
 	# expect to allow for some instability.
 	#
-	log_must test $(ddt_entries) -le 600000
+	log_must test $(ddt_entries) -le 650000
 
 	do_clean
 }


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/11287671313/job/31394030452?pr=16635

```
  08:15:47.16 DDT size 226209792, with 613376 entries
  08:15:47.18 ERROR: test 613376 -le 600000 exited 1
```

### Description

As described in the comment above this check the space used by logged entries is not accounted for and some margin needs to be added in.  While uncommon we have slightly exceeded the 600,000 threshold on some CI run so we increase the limit a bit more.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
