### PR TITLE
ZTS: Increase zpool_import_parallel_pos import margin

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_parallel_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_parallel_pos.ksh
@@ -113,7 +113,7 @@ wait
 parallel_time=$SECONDS
 log_note "asyncronously imported 4 pools in $parallel_time seconds"
 
-log_must test $parallel_time -lt $(($sequential_time / 3))
+log_must test $parallel_time -lt $(($sequential_time / 2))
 
 #
 # export pools with import delay injectors
@@ -132,6 +132,6 @@ log_must zpool import -a -d $DEVICE_DIR -f
 parallel_time=$SECONDS
 log_note "asyncronously imported 4 pools in $parallel_time seconds"
 
-log_must test $parallel_time -lt $(($sequential_time / 3))
+log_must test $parallel_time -lt $(($sequential_time / 2))
 
 log_pass "Pool imports occur in parallel"


### PR DESCRIPTION
### Motivation and Context

More gray area resulting is occasional CI failures.

https://github.com/openzfs/zfs/actions/runs/11247820032/job/31287396141

```
  07:52:57.81 NOTE: asyncronously imported 4 pools in 16.981 seconds
  07:52:57.81 ERROR: test 16.981 -lt 16.353 exited 1
```

### Description

Increase the pool import time allowed by assuming a minimum reduction to 1/2 instead of 1/3 when comparing sequential to parallel import times.  This is sufficient to verify parallel imports are working as intended and should address the occasional false positive failure when the time is slightly exceeded.

### How Has This Been Tested?

Will be tested by the CI.
