### PR TITLE
CI: Stick with ubuntu-22.04 for CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
### Motivation and Context

Roll back to ubuntu-22.04 to CodeQL autobuild.

https://github.com/openzfs/zfs/actions/runs/11296255456/job/31420716331?pr=16637
https://github.com/actions/runner-images

### Description

The ubuntu-latest alias now refers to ubuntu-24.04 instead of ubuntu-22.04 which causes CodeQL's autobuild to fail with:

```
    cpp/autobuilder: deptrace not supported in ubuntu 24.04
```

Until depbuild is supported by ubuntu-24.04 hosted runners request ubuntu-22.04 which is supported.

### How Has This Been Tested?

We'll have to see if this resolves the CI CodeQL deptrace failure as expected.