### PR TITLE
Fallback to strerror() when strerror_l() isn't available

### DIFF
--- a/config/user.m4
+++ b/config/user.m4
@@ -33,7 +33,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER], [
 	ZFS_AC_CONFIG_USER_MAKEDEV_IN_MKDEV
 	ZFS_AC_CONFIG_USER_ZFSEXEC
 
-	AC_CHECK_FUNCS([execvpe issetugid mlockall strlcat strlcpy gettid])
+	AC_CHECK_FUNCS([execvpe issetugid mlockall strerror_l strlcat strlcpy gettid])
 
 	AC_SUBST(RM)
 ])

--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -276,7 +276,11 @@ _LIBZUTIL_H void update_vdev_config_dev_sysfs_path(nvlist_t *nv,
  * Thread-safe strerror() for use in ZFS libraries
  */
 static inline char *zfs_strerror(int errnum) {
+#ifdef HAVE_STRERROR_L
 	return (strerror_l(errnum, uselocale(0)));
+#else
+	return (strerror(errnum));
+#endif
 }
 
 #ifdef	__cplusplus


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/issues/16636

### Description

Some C libraries, such as uClibc, do not provide strerror_l() in which case we fallback to strerror().

### How Has This Been Tested?

@jlsalvador would you mind testing this in your environment.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
