### PR TITLE
ZTS: Make use of CPU pinning and KSM

### DIFF
--- a/.github/workflows/scripts/qemu-1-setup.sh
+++ b/.github/workflows/scripts/qemu-1-setup.sh
@@ -18,19 +18,21 @@ ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -q -N ""
 
 # we expect RAM shortage
 cat << EOF | sudo tee /etc/ksmtuned.conf > /dev/null
+# /etc/ksmtuned.conf - Configuration file for ksmtuned
 # https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/virtualization_tuning_and_optimization_guide/chap-ksm
 KSM_MONITOR_INTERVAL=60
 
 # Millisecond sleep between ksm scans for 16Gb server.
 # Smaller servers sleep more, bigger sleep less.
-KSM_SLEEP_MSEC=10
-KSM_NPAGES_BOOST=300
-KSM_NPAGES_DECAY=-50
-KSM_NPAGES_MIN=64
-KSM_NPAGES_MAX=2048
+KSM_SLEEP_MSEC=30
 
-KSM_THRES_COEF=25
-KSM_THRES_CONST=2048
+KSM_NPAGES_BOOST=0
+KSM_NPAGES_DECAY=0
+KSM_NPAGES_MIN=1000
+KSM_NPAGES_MAX=25000
+
+KSM_THRES_COEF=80
+KSM_THRES_CONST=8192
 
 LOGFILE=/var/log/ksmtuned.log
 DEBUG=1

--- a/.github/workflows/scripts/qemu-5-setup.sh
+++ b/.github/workflows/scripts/qemu-5-setup.sh
@@ -18,10 +18,12 @@ sudo virsh undefine openzfs
 VMs=2
 CPU=2
 
-# definitions of per operating system
+# cpu pinning
+CPUSET=("0,1" "2,3")
+
 case "$OS" in
-  # FreeBSD can't be optimized via ksmtuned
   freebsd*)
+    # FreeBSD can't be optimized via ksmtuned
     RAM=6
     ;;
   *)
@@ -75,6 +77,7 @@ EOF
     --cpu host-passthrough \
     --virt-type=kvm --hvm \
     --vcpus=$CPU,sockets=1 \
+    --cpuset=${CPUSET[$((i-1))]} \
     --memory $((1024*RAM)) \
     --memballoon model=virtio \
     --graphics none \

--- a/.github/workflows/scripts/qemu-5-setup.sh
+++ b/.github/workflows/scripts/qemu-5-setup.sh
@@ -14,17 +14,19 @@ PID=$(pidof /usr/bin/qemu-system-x86_64)
 tail --pid=$PID -f /dev/null
 sudo virsh undefine openzfs
 
+# default values per test vm:
+VMs=2
+CPU=2
+
 # definitions of per operating system
 case "$OS" in
+  # FreeBSD can't be optimized via ksmtuned
   freebsd*)
-    VMs=2
-    CPU=3
     RAM=6
     ;;
   *)
-    VMs=2
-    CPU=3
-    RAM=7
+    # Linux can be optimized via ksmtuned
+    RAM=8
     ;;
 esac
 


### PR DESCRIPTION
### Motivation and Context

Within the Linux VM's the current memory (7GiB) seems sometimes a bit too short for some tests.
The first commit will optimize the Kernel Same-page Merging (KSM) settings, so we can easily increase the RAM to 8GiB.

With CPU pinning, we should get some speedup because of better cpu cache re-use.
The second commit will set the cores 0+1 to VM1 and the cores 2+3 to VM2.

### How Has This Been Tested?

Testing was done via ZTS, and the Performance went up a bit:
Image | [without optimization](https://github.com/mcmilk/zfs/actions/runs/11261966725/usage)| [with optimization](https://github.com/mcmilk/zfs/actions/runs/11304191773/usage)
-------------------|-------------------------------|------------
AlmaLinux 8 | 3h 42m 35s	| 3h 6m 52s
AlmaLinux 9 | 3h 30m 50s	| 3h 32m 43s
Centos Stream 9 | 3h 30m 5s | 3h 24m 52s
Debian11 | 3h 16m 30s | 3h 1m 47s
Debian12 | 3h 12m 44s | 2h 56m 48s
Fedora 39 | 3h 21m 34s | 3h 29m 40s
Fedora 40| 3h 18m 11s | 3h 20m 32s
Freebsd13-4r | 2h 18m 26s | 2h 24m 57s
Freebsd14-0r |2h 32m 59s | 2h 28m 7s
Freebsd14-1s | 2h 28m 18s | 2h 21m 29s
Ubuntu20 | 3h 3m 33s | 2h 43m 30s
Ubuntu22 | 3h 42m 29s| 3h 18m 38s
Ubuntu24 | 3h 32m 4s | 3h 33m 0s
Total sum |  1d 17h 30m  |1d 15h 43m

Maybe some tests, which needed more memory will also be fine now.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
