### PR TITLE
freebsd: Use compiler.h from FreeBSD's base's linuxkpi

### DIFF
--- a/include/os/freebsd/linux/compiler.h
+++ b/include/os/freebsd/linux/compiler.h
@@ -1,10 +1,5 @@
 /*
- * Copyright (c) 2010 Isilon Systems, Inc.
- * Copyright (c) 2010 iXsystems, Inc.
- * Copyright (c) 2010 Panasas, Inc.
- * Copyright (c) 2013-2016 Mellanox Technologies, Ltd.
- * Copyright (c) 2015 François Tigeot
- * All rights reserved.
+ * Copyright (c) 2024 Warner Losh.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,76 +21,14 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * $FreeBSD$
  */
-#ifndef	_LINUX_COMPILER_H_
-#define	_LINUX_COMPILER_H_
 
-#include <sys/cdefs.h>
+/*
+ * FreeBSD's LinuxKPI compiler.h as far back as FreeBSD 12 has what we need,
+ * except zfs_fallthrough.
+ */
+#pragma once
 
-#define	__user
-#define	__kernel
-#define	__safe
-#define	__force
-#define	__nocast
-#define	__iomem
-#define	__chk_user_ptr(x)		((void)0)
-#define	__chk_io_ptr(x)			((void)0)
-#define	__builtin_warning(x, y...)	(1)
-#define	__acquires(x)
-#define	__releases(x)
-#define	__acquire(x)			do { } while (0)
-#define	__release(x)			do { } while (0)
-#define	__cond_lock(x, c)		(c)
-#define	__bitwise
-#define	__devinitdata
-#define	__deprecated
-#define	__init
-#define	__initconst
-#define	__devinit
-#define	__devexit
-#define	__exit
-#define	__rcu
-#define	__percpu
-#define	__weak __weak_symbol
-#define	__malloc
-#define	___stringify(...)		#__VA_ARGS__
-#define	__stringify(...)		___stringify(__VA_ARGS__)
-#define	__attribute_const__		__attribute__((__const__))
-#undef __always_inline
-#define	__always_inline			inline
-#define	noinline			__noinline
-#define	____cacheline_aligned		__aligned(CACHE_LINE_SIZE)
+#include <compat/linuxkpi/common/include/linux/compiler.h>
+
 #define	zfs_fallthrough			__attribute__((__fallthrough__))
-
-#if !defined(_KERNEL) && !defined(_STANDALONE)
-#define	likely(x)			__builtin_expect(!!(x), 1)
-#define	unlikely(x)			__builtin_expect(!!(x), 0)
-#endif
-#define	typeof(x)			__typeof(x)
-
-#define	uninitialized_var(x)		x = x
-#define	__maybe_unused			__unused
-#define	__always_unused			__unused
-#define	__must_check			__result_use_check
-
-#define	__printf(a, b)			__printflike(a, b)
-
-#define	barrier()			__asm__ __volatile__("": : :"memory")
-#define	___PASTE(a, b) a##b
-#define	__PASTE(a, b) ___PASTE(a, b)
-
-#define	ACCESS_ONCE(x)			(*(volatile __typeof(x) *)&(x))
-
-#define	WRITE_ONCE(x, v) do {		\
-	barrier();			\
-	ACCESS_ONCE(x) = (v);		\
-	barrier();			\
-} while (0)
-
-#define	lockless_dereference(p) READ_ONCE(p)
-
-#define	_AT(T, X)	((T)(X))
-
-#endif	/* _LINUX_COMPILER_H_ */

--- a/include/os/freebsd/spl/sys/ccompat.h
+++ b/include/os/freebsd/spl/sys/ccompat.h
@@ -70,15 +70,6 @@ hlist_del(struct hlist_node *n)
 		n->next->pprev = n->pprev;
 }
 	/* BEGIN CSTYLED */
-#define	READ_ONCE(x) ({			\
-	__typeof(x) __var = ({		\
-		barrier();		\
-		ACCESS_ONCE(x);		\
-	});				\
-	barrier();			\
-	__var;				\
-})
-
 #define	HLIST_HEAD_INIT { }
 #define	HLIST_HEAD(name) struct hlist_head name = HLIST_HEAD_INIT
 #define	INIT_HLIST_HEAD(head) (head)->first = NULL

--- a/include/os/freebsd/spl/sys/debug.h
+++ b/include/os/freebsd/spl/sys/debug.h
@@ -95,10 +95,6 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 #ifndef expect
 #define	expect(expr, value) (__builtin_expect((expr), (value)))
 #endif
-#ifndef __linux__
-#define	likely(expr)   expect((expr) != 0, 1)
-#define	unlikely(expr) expect((expr) != 0, 0)
-#endif
 
 #define	PANIC(fmt, a...)						\
 	spl_panic(__FILE__, __FUNCTION__, __LINE__, fmt, ## a)


### PR DESCRIPTION
The FreeBSD linux/compiler.h in OpenZFS was copied from a very old version of FreeBSD's linuxkpi's linux/compiler.h. There's no need for this duplication. Use FreeBSD's linuxkpi version instead, and provide zfs_fallthrough to augment it (it's all that's needed). Use #pragma once to avoid naming issues for guard variables. Since this is a complete rewrite, use my copyright here (the original code in FreeBSD still credits everybody). This works back at least to FreeBSD 12.4, which is not out of support, and all newer releases.

Remove extra copies of macros that were defined elsewhere, but are now properly defined in LinuxKPI so are redundant.

Sponsored-by:		Netflix
Signed-off-by:		Warner Losh <imp@bsdimp.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
OpenZFS has an ancient copy of FreeBSD's LKPI compiler.h. Rather than make yet another copy in an indirect tree that has to be maintained, make the OpenZFS one use FreeBSD's directly. Since at least FreeBSD 12, this has everything needed except zfs_fallthrough, so define that here.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Ran FreeBSD's make universe with these changes on FreeBSD main. I ran make buildworld and buildkernel on aarch64 and amd64 for stable/14, stable/13 and stable/12. I booted the result on main with a fresh world and observed no regressions.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [NA] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [NA] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied. (earlier freebsd version)
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
