### PR TITLE
libspl/backtrace: dump registers in libunwind backtraces

### DIFF
--- a/lib/libspl/backtrace.c
+++ b/lib/libspl/backtrace.c
@@ -79,61 +79,177 @@ libspl_backtrace(int fd)
 	unw_cursor_t cp;
 	unw_word_t v;
 	char buf[128];
-	size_t n, c;
+	size_t n;
+	int err;
 
+	/* Snapshot the current frame and state. */
 	unw_getcontext(&uc);
 
-	unw_init_local(&cp, &uc);
+	/*
+	 * TODO: walk back to the frame that tripped the assertion / the place
+	 *       where the signal was recieved.
+	 */
+
+	/*
+	 * Register dump. We're going to loop over all the registers in the
+	 * top frame, and show them, with names, in a nice three-column
+	 * layout, which keeps us within 80 columns.
+	 */
 	spl_bt_write(fd, "Registers:\n");
-	c = 0;
+
+	/* Initialise a frame cursor, starting at the current frame */
+	unw_init_local(&cp, &uc);
+
+	/*
+	 * libunwind's list of possible registers for this architecture is an
+	 * enum, unw_regnum_t. UNW_TDEP_LAST_REG is the highest-numbered
+	 * register in that list, however, not all register numbers in this
+	 * range are defined by the architecture, and not all defined registers
+	 * will be present on every implementation of that architecture.
+	 * Moreover, libunwind provides nice names for most, but not all
+	 * registers, but these are hardcoded; a name being available does not
+	 * mean that register is available.
+	 *
+	 * So, we have to pull this all together here. We try to get the value
+	 * of every possible register. If we get a value for it, then the
+	 * register must exist, and so we get its name. If libunwind has no
+	 * name for it, we synthesize something. These cases should be rare,
+	 * and they're usually for uninteresting or niche registers, so it
+	 * shouldn't really matter. We can see the value, and that's the main
+	 * thing.
+	 */
+	uint_t cols = 0;
 	for (uint_t regnum = 0; regnum <= UNW_TDEP_LAST_REG; regnum++) {
+		/*
+		 * Get the value. Any error probably means the register
+		 * doesn't exist, and we skip it.
+		 */
 		if (unw_get_reg(&cp, regnum, &v) < 0)
 			continue;
+
+		/*
+		 * Register name. If libunwind doesn't have a name for it,
+		 * it will return "???". As a shortcut, we just treat '?'
+		 * is an alternate end-of-string character.
+		 */
 		const char *name = unw_regname(regnum);
 		for (n = 0; name[n] != '\0' && name[n] != '?'; n++) {}
 		if (n == 0) {
+			/*
+			 * No valid name, so make one of the form "?xx", where
+			 * "xx" is the two-char hex of libunwind's register
+			 * number.
+			 */
 			buf[0] = '?';
 			n = spl_bt_u64_to_hex_str(regnum, 2,
 			    &buf[1], sizeof (buf)-1) + 1;
 			name = buf;
 		}
+
+		/*
+		 * Two spaces of padding before each column, plus extra
+		 * spaces to align register names shorter than three chars.
+		 */
 		spl_bt_write_n(fd, "      ", 5-MIN(n, 3));
+
+		/* Register name and column punctuation */
 		spl_bt_write_n(fd, name, n);
 		spl_bt_write(fd, ": 0x");
-		n = spl_bt_u64_to_hex_str(v, 18, buf, sizeof (buf));
+
+		/*
+		 * Convert register value (from unw_get_reg()) to hex. We're
+		 * assuming that all registers are 64-bits wide, which is
+		 * probably fine for any general-purpose registers on any
+		 * machine currently in use. A more generic way would be to
+		 * look at the width of unw_word_t, but that would also
+		 * complicate the column code a bit. This is fine.
+		 */
+		n = spl_bt_u64_to_hex_str(v, 16, buf, sizeof (buf));
 		spl_bt_write_n(fd, buf, n);
-		if (!(++c % 3))
+
+		/* Every third column, emit a newline */
+		if (!(++cols % 3))
 			spl_bt_write(fd, "\n");
 	}
-	if (c % 3)
+
+	/* If we finished before the third column, emit a newline. */
+	if (cols % 3)
 		spl_bt_write(fd, "\n");
 
-	unw_init_local(&cp, &uc);
+	/* Now the main event, the backtrace. */
 	spl_bt_write(fd, "Call trace:\n");
-	while (unw_step(&cp) > 0) {
-		unw_get_reg(&cp, UNW_REG_IP, &v);
+
+	/* Reset the cursor to the top again. */
+	unw_init_local(&cp, &uc);
+
+	do {
+		/*
+		 * Getting the IP should never fail; libunwind handles it
+		 * specially, because its used a lot internally. Still, no
+		 * point being silly about it, as the last thing we want is
+		 * our crash handler to crash. So if it ever does fail, we'll
+		 * show an error line, but keep going to the next frame.
+		 */
+		if (unw_get_reg(&cp, UNW_REG_IP, &v) < 0) {
+			spl_bt_write(fd, "  [couldn't get IP register; "
+			    "corrupt frame?]");
+			continue;
+		}
+
+		/* IP & punctuation */
+		n = spl_bt_u64_to_hex_str(v, 16, buf, sizeof (buf));
 		spl_bt_write(fd, "  [0x");
-		n = spl_bt_u64_to_hex_str(v, 18, buf, sizeof (buf));
 		spl_bt_write_n(fd, buf, n);
 		spl_bt_write(fd, "] ");
-		unw_get_proc_name(&cp, buf, sizeof (buf), &v);
-		for (n = 0; n < sizeof (buf) && buf[n] != '\0'; n++) {}
-		spl_bt_write_n(fd, buf, n);
-		spl_bt_write(fd, "+0x");
-		n = spl_bt_u64_to_hex_str(v, 2, buf, sizeof (buf));
-		spl_bt_write_n(fd, buf, n);
+
+		/*
+		 * Function ("procedure") name for the current frame. `v`
+		 * receives the offset from the named function to the IP, which
+		 * we show as a "+offset" suffix.
+		 *
+		 * If libunwind can't determine the name, we just show "???"
+		 * instead. We've already displayed the IP above; that will
+		 * have to do.
+		 *
+		 * unw_get_proc_name() will return ENOMEM if the buffer is too
+		 * small, instead truncating the name. So we treat that as a
+		 * success and use whatever is in the buffer.
+		 */
+		err = unw_get_proc_name(&cp, buf, sizeof (buf), &v);
+		if (err == 0 || err == -UNW_ENOMEM) {
+			for (n = 0; n < sizeof (buf) && buf[n] != '\0'; n++) {}
+			spl_bt_write_n(fd, buf, n);
+
+			/* Offset from proc name */
+			spl_bt_write(fd, "+0x");
+			n = spl_bt_u64_to_hex_str(v, 2, buf, sizeof (buf));
+			spl_bt_write_n(fd, buf, n);
+		} else
+			spl_bt_write(fd, "???");
+
 #ifdef HAVE_LIBUNWIND_ELF
-		spl_bt_write(fd, " (in ");
-		unw_get_elf_filename(&cp, buf, sizeof (buf), &v);
-		for (n = 0; n < sizeof (buf) && buf[n] != '\0'; n++) {}
-		spl_bt_write_n(fd, buf, n);
-		spl_bt_write(fd, " +0x");
-		n = spl_bt_u64_to_hex_str(v, 2, buf, sizeof (buf));
-		spl_bt_write_n(fd, buf, n);
-		spl_bt_write(fd, ")");
+		/*
+		 * Newer libunwind has unw_get_elf_filename(), which gets
+		 * the name of the ELF object that the frame was executing in.
+		 * Like `unw_get_proc_name()`, `v` recieves the offset within
+		 * the file, and UNW_ENOMEM indicates that a truncate filename
+		 * was left in the buffer.
+		 */
+		err = unw_get_elf_filename(&cp, buf, sizeof (buf), &v);
+		if (err == 0 || err == -UNW_ENOMEM) {
+			for (n = 0; n < sizeof (buf) && buf[n] != '\0'; n++) {}
+			spl_bt_write(fd, " (in ");
+			spl_bt_write_n(fd, buf, n);
+
+			/* Offset within file */
+			spl_bt_write(fd, " +0x");
+			n = spl_bt_u64_to_hex_str(v, 2, buf, sizeof (buf));
+			spl_bt_write_n(fd, buf, n);
+			spl_bt_write(fd, ")");
+		}
 #endif
 		spl_bt_write(fd, "\n");
-	}
+	} while (unw_step(&cp) > 0);
 }
 #elif defined(HAVE_BACKTRACE)
 #include <execinfo.h>

--- a/lib/libspl/backtrace.c
+++ b/lib/libspl/backtrace.c
@@ -65,32 +65,58 @@ libspl_backtrace(int fd)
 	ssize_t ret __attribute__((unused));
 	unw_context_t uc;
 	unw_cursor_t cp;
-	unw_word_t loc;
+	unw_word_t v;
 	char buf[128];
-	size_t n;
+	size_t n, c;
 
-	ret = write(fd, "Call trace:\n", 12);
 	unw_getcontext(&uc);
+
 	unw_init_local(&cp, &uc);
+	ret = write(fd, "Registers:\n", 11);
+	c = 0;
+	for (uint_t regnum = 0; regnum <= UNW_TDEP_LAST_REG; regnum++) {
+		if (unw_get_reg(&cp, regnum, &v) < 0)
+			continue;
+		const char *name = unw_regname(regnum);
+		for (n = 0; name[n] != '\0' && name[n] != '?'; n++) {}
+		if (n == 0) {
+			buf[0] = '?';
+			n = libspl_u64_to_hex_str(regnum, 2,
+			    &buf[1], sizeof (buf)-1) + 1;
+			name = buf;
+		}
+		ret = write(fd, "      ", 5-MIN(n, 3));
+		ret = write(fd, name, n);
+		ret = write(fd, ": 0x", 4);
+		n = libspl_u64_to_hex_str(v, 18, buf, sizeof (buf));
+		ret = write(fd, buf, n);
+		if (!(++c % 3))
+			ret = write(fd, "\n", 1);
+	}
+	if (c % 3)
+		ret = write(fd, "\n", 1);
+
+	unw_init_local(&cp, &uc);
+	ret = write(fd, "Call trace:\n", 12);
 	while (unw_step(&cp) > 0) {
-		unw_get_reg(&cp, UNW_REG_IP, &loc);
+		unw_get_reg(&cp, UNW_REG_IP, &v);
 		ret = write(fd, "  [0x", 5);
-		n = libspl_u64_to_hex_str(loc, 10, buf, sizeof (buf));
+		n = libspl_u64_to_hex_str(v, 18, buf, sizeof (buf));
 		ret = write(fd, buf, n);
 		ret = write(fd, "] ", 2);
-		unw_get_proc_name(&cp, buf, sizeof (buf), &loc);
+		unw_get_proc_name(&cp, buf, sizeof (buf), &v);
 		for (n = 0; n < sizeof (buf) && buf[n] != '\0'; n++) {}
 		ret = write(fd, buf, n);
 		ret = write(fd, "+0x", 3);
-		n = libspl_u64_to_hex_str(loc, 2, buf, sizeof (buf));
+		n = libspl_u64_to_hex_str(v, 2, buf, sizeof (buf));
 		ret = write(fd, buf, n);
 #ifdef HAVE_LIBUNWIND_ELF
 		ret = write(fd, " (in ", 5);
-		unw_get_elf_filename(&cp, buf, sizeof (buf), &loc);
+		unw_get_elf_filename(&cp, buf, sizeof (buf), &v);
 		for (n = 0; n < sizeof (buf) && buf[n] != '\0'; n++) {}
 		ret = write(fd, buf, n);
 		ret = write(fd, " +0x", 4);
-		n = libspl_u64_to_hex_str(loc, 2, buf, sizeof (buf));
+		n = libspl_u64_to_hex_str(v, 2, buf, sizeof (buf));
 		ret = write(fd, buf, n);
 		ret = write(fd, ")", 1);
 #endif


### PR DESCRIPTION
### Motivation and Context

In postmortem debugging, often all we have is the binary. Having the registers makes it a least possible to follow the disassembly and try to guess how we got here.

### Description

libunwind knows how to fish all the registers out of the stack frame, not just IP. Loop over 'em and spit 'em out.

I've made no effort to do the same in the non-libunwind builds, because libc doesn't typically give you the tools to do it well/at all.

I'm not yet fully satisfied with this. I think I can do better by capturing the register state at the point the assert is tripped, but it will be a lot more invasive. I'll keep working on this, but I think this is still very useful right now.

### How Has This Been Tested?

Induced a crash, enjoyed the output:

```
ASSERT at module/zfs/spa.c:5791:spa_open_common()
"oh no" == 0 (0x7fe60100db1b == 0)
  PID: 870661    COMM: zdb
  TID: 870661    NAME: zdb
Registers:
  RAX: 0x0000000000000037  RDX: 0x0000000000000000  RCX: 0x0000000000000000
  RBX: 0x0000000000000002  RSI: 0x00007ffe7eac2e60  RDI: 0x00007ffe7eac4770
  RBP: 0x00007ffe7eac4f70  RSP: 0x00007ffe7eac46c0   R8: 0x0000000000000000
   R9: 0x0000000000000073  R10: 0x00007ffe7eac4d30  R11: 0x0000000000000021
  R12: 0x00007ffe7eac46f0  R13: 0x0000000000000000  R14: 0x00007ffe7eac4770
  R15: 0x00007ffe7eac4b40  RIP: 0x00007fe600fd8d26
Call trace:
  [0x00007fe600fd8c45] libspl_assertf+0x135 (in /home/robn/code/zfs/.libs/libzpool.so.6.0.0 +0x2ccc45)
  [0x00007fe600e66bc7] spa_open_common+0x57 (in /home/robn/code/zfs/.libs/libzpool.so.6.0.0 +0x15abc7)
  [0x00007fe600e2648f] dsl_pool_hold+0x1f (in /home/robn/code/zfs/.libs/libzpool.so.6.0.0 +0x11a48f)
  [0x00007fe600dd93c7] dmu_objset_hold_flags+0x27 (in /home/robn/code/zfs/.libs/libzpool.so.6.0.0 +0xcd3c7)
  [0x0000562e1ced46cc] open_objset+0x10c (in /home/robn/code/zfs/.libs/zdb +0x126cc)
  [0x0000562e1ceccbfb] main+0x149b (in /home/robn/code/zfs/.libs/zdb +0xabfb)
  [0x00007fe60068724a] __libc_start_call_main+0x7a (in /usr/lib/x86_64-linux-gnu/libc.so.6 +0x2724a)
  [0x00007fe600687305] __libc_start_main_alias_2+0x85 (in /usr/lib/x86_64-linux-gnu/libc.so.6 +0x27305)
  [0x0000562e1cecccf1] _start+0x21 (in /home/robn/code/zfs/.libs/zdb +0xacf1)
```

I haven't tested on non-amd64 architectures, but the libunwind documentation doesn't say anything about particular facilities not being available. At worst, I'd expect it to show nothing, or maybe only the IP.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
