### PR TITLE
Try to unify punctuation of messages.

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -8758,7 +8758,7 @@ zdb_decompress_block(abd_t *pabd, void *buf, void *lbuf, uint64_t lsize,
 	umem_free(lbuf2, SPA_MAXBLOCKSIZE);
 
 	if (*cfuncp == ZIO_COMPRESS_ZLE) {
-		printf("\nZLE decompression was selected. If you "
+		printf("\nZLE decompression was selected.  If you "
 		    "suspect the results are wrong,\ntry avoiding ZLE "
 		    "by setting and exporting ZDB_NO_ZLE=\"true\"\n");
 	}

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -1003,7 +1003,7 @@ default_volblocksize(zpool_handle_t *zhp, nvlist_t *props)
 			(void) fprintf(stderr, gettext("Warning: "
 			    "volblocksize (%llu) is much less than the "
 			    "minimum allocation\nunit (%llu), which wastes "
-			    "at least %llu%% of space. To reduce wasted "
+			    "at least %llu%% of space.  To reduce wasted "
 			    "space,\nuse a larger volblocksize (%llu is "
 			    "recommended), fewer dRAID data disks\n"
 			    "per group, or smaller sector size (ashift).\n"),
@@ -4988,7 +4988,7 @@ zfs_do_send(int argc, char **argv)
 			 * warning, and assume snapshot.
 			 */
 			(void) fprintf(stderr, "Warning: incremental source "
-			    "didn't specify type, assuming snapshot. Use '@' "
+			    "didn't specify type, assuming snapshot.  Use '@' "
 			    "or '#' prefix to avoid ambiguity.\n");
 			(void) snprintf(frombuf, sizeof (frombuf), "@%s",
 			    fromname);
@@ -5880,7 +5880,7 @@ deleg_perm_comment(zfs_deleg_note_t note)
 		break;
 	case ZFS_DELEG_NOTE_DIFF:
 		str = gettext("Allows lookup of paths within a dataset;"
-		    "\n\t\t\t\tgiven an object number. Ordinary users need this"
+		    "\n\t\t\t\tgiven an object number.  Ordinary users need this"
 		    "\n\t\t\t\tin order to use zfs diff");
 		break;
 	case ZFS_DELEG_NOTE_HOLD:
@@ -8540,7 +8540,7 @@ zfs_do_channel_program(int argc, char **argv)
 				errstring = "Timed out.";
 				break;
 			case EPERM:
-				errstring = "Permission denied. Channel "
+				errstring = "Permission denied.  Channel "
 				    "programs must be run as root.";
 				break;
 			default:

--- a/cmd/zpool/os/freebsd/zpool_vdev_os.c
+++ b/cmd/zpool/os/freebsd/zpool_vdev_os.c
@@ -114,7 +114,7 @@ after_zpool_upgrade(zpool_handle_t *zhp)
 	    strcmp(bootfs, "-") != 0) {
 		(void) printf(gettext("Pool '%s' has the bootfs "
 		    "property set, you might need to update\nthe boot "
-		    "code. See gptzfsboot(8) and loader.efi(8) for "
+		    "code.  See gptzfsboot(8) and loader.efi(8) for "
 		    "details.\n"), zpool_get_name(zhp));
 	}
 }

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1901,7 +1901,7 @@ zpool_do_labelclear(int argc, char **argv)
 
 		if (force) {
 			(void) fprintf(stderr, gettext(
-			    ". Offline the disk first to clear its label."));
+			    ".  Offline the disk first to clear its label."));
 		}
 		printf("\n");
 		ret = 1;
@@ -3503,7 +3503,7 @@ show_import(nvlist_t *config, boolean_t report_error)
 
 	case ZPOOL_STATUS_UNSUP_FEAT_WRITE:
 		printf_color(ANSI_YELLOW, gettext("The pool can only be "
-		    "accessed in read-only mode on this system. It\n"
+		    "accessed in read-only mode on this system.  It\n"
 		    "\t%scannot be accessed in read-write mode because it uses "
 		    "the following\n"
 		    "\t%sfeature(s) not supported on this system:\n"),
@@ -3617,7 +3617,7 @@ show_import(nvlist_t *config, boolean_t report_error)
 				(void) printf(gettext("Existing encrypted "
 				    "datasets contain an on-disk "
 				    "incompatibility, which\n"
-				    "\t%sneeds to be corrected. Backup these "
+				    "\t%sneeds to be corrected.  Backup these "
 				    "datasets to new encrypted datasets\n"
 				    "\t%sand destroy the old ones.\n"),
 				    indent, indent);
@@ -3627,16 +3627,16 @@ show_import(nvlist_t *config, boolean_t report_error)
 				(void) printf(gettext("Existing encrypted "
 				    "snapshots and bookmarks contain an "
 				    "on-disk\n"
-				    "\t%sincompatibility. This may cause "
+				    "\t%sincompatibility.  This may cause "
 				    "on-disk corruption if they are used\n"
-				    "\t%swith 'zfs recv'. To correct the "
+				    "\t%swith 'zfs recv'.  To correct the "
 				    "issue, enable the bookmark_v2 feature.\n"
 				    "\t%sNo additional action is needed if "
 				    "there are no encrypted snapshots or\n"
-				    "\t%sbookmarks. If preserving the "
+				    "\t%sbookmarks.  If preserving the "
 				    "encrypted snapshots and bookmarks is\n"
 				    "\t%srequired, use a non-raw send to "
-				    "backup and restore them. Alternately,\n"
+				    "backup and restore them.  Alternately,\n"
 				    "\t%sthey may be removed to resolve the "
 				    "incompatibility.\n"), indent, indent,
 				    indent, indent, indent, indent);
@@ -3672,7 +3672,7 @@ show_import(nvlist_t *config, boolean_t report_error)
 			break;
 		case ZPOOL_STATUS_UNSUP_FEAT_WRITE:
 			(void) printf(gettext("The pool cannot be imported in "
-			    "read-write mode. Import the pool with\n"
+			    "read-write mode.  Import the pool with\n"
 			    "\t%s'-o readonly=on', access the pool on a system "
 			    "that supports the\n"
 			    "\t%srequired feature(s), or recreate the pool "
@@ -3848,7 +3848,7 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 		} else if (mmp_state == MMP_STATE_NO_HOSTID) {
 			(void) fprintf(stderr, gettext("Cannot import '%s': "
 			    "pool has the multihost property on and the\n"
-			    "system's hostid is not set. Set a unique hostid "
+			    "system's hostid is not set.  Set a unique hostid "
 			    "with the zgenhostid(8) command.\n"), name);
 		} else {
 			const char *hostname = "<unknown>";
@@ -4182,7 +4182,7 @@ zpool_do_checkpoint(int argc, char **argv)
 		/* As a special case, check for use of '/' in the name */
 		if (strchr(pool, '/') != NULL)
 			(void) fprintf(stderr, gettext("'zpool checkpoint' "
-			    "doesn't work on datasets. To save the state "
+			    "doesn't work on datasets.  To save the state "
 			    "of a dataset from a specific point in time "
 			    "please use 'zfs snapshot'\n"));
 		return (1);
@@ -10464,15 +10464,15 @@ print_status_reason(zpool_handle_t *zhp, status_cbdata_t *cbp,
 		    "The pool can still be used, but some features are "
 		    "unavailable.\n"));
 		snprintf(action, AC_SIZE, gettext("Enable all features using "
-		    "'zpool upgrade'. Once this is done,\n\tthe pool may no "
+		    "'zpool upgrade'.  Once this is done,\n\tthe pool may no "
 		    "longer be accessible by software that does not support\n\t"
-		    "the features. See zpool-features(7) for details.\n"));
+		    "the features.  See zpool-features(7) for details.\n"));
 		break;
 
 	case ZPOOL_STATUS_COMPATIBILITY_ERR:
 		snprintf(status, ST_SIZE, gettext("This pool has a "
 		    "compatibility list specified, but it could not be\n\t"
-		    "read/parsed at this time. The pool can still be used, "
+		    "read/parsed at this time.  The pool can still be used, "
 		    "but this\n\tshould be investigated.\n"));
 		snprintf(action, AC_SIZE, gettext("Check the value of the "
 		    "'compatibility' property against the\n\t"
@@ -10503,13 +10503,13 @@ print_status_reason(zpool_handle_t *zhp, status_cbdata_t *cbp,
 
 	case ZPOOL_STATUS_UNSUP_FEAT_WRITE:
 		snprintf(status, ST_SIZE, gettext("The pool can only be "
-		    "accessed in read-only mode on this system. It\n\tcannot be"
+		    "accessed in read-only mode on this system.  It\n\tcannot be"
 		    " accessed in read-write mode because it uses the "
 		    "following\n\tfeature(s) not supported on this system:\n"));
 		zpool_collect_unsup_feat(zpool_get_config(zhp, NULL), status,
 		    1024);
 		snprintf(action, AC_SIZE, gettext("The pool cannot be accessed "
-		    "in read-write mode. Import the pool with\n"
+		    "in read-write mode.  Import the pool with\n"
 		    "\t\"-o readonly=on\", access the pool from a system that "
 		    "supports the\n\trequired feature(s), or restore the "
 		    "pool from backup.\n"));
@@ -10609,11 +10609,11 @@ print_status_reason(zpool_handle_t *zhp, status_cbdata_t *cbp,
 		case ZPOOL_ERRATA_ZOL_8308_ENCRYPTION:
 			(void) strlcat(status, gettext("\tExisting encrypted "
 			    "snapshots and bookmarks contain an on-disk\n\t"
-			    "incompatibility. This may cause on-disk "
+			    "incompatibility.  This may cause on-disk "
 			    "corruption if they are used\n\twith "
 			    "'zfs recv'.\n"), ST_SIZE);
 			snprintf(action, AC_SIZE, gettext("To correct the"
-			    "issue, enable the bookmark_v2 feature. No "
+			    "issue, enable the bookmark_v2 feature.  No "
 			    "additional\n\taction is needed if there are no "
 			    "encrypted snapshots or bookmarks.\n\tIf preserving"
 			    "the encrypted snapshots and bookmarks is required,"
@@ -11442,7 +11442,7 @@ upgrade_list_disabled_cb(zpool_handle_t *zhp, void *arg)
 					    "Once a\nfeature is enabled the "
 					    "pool may become incompatible with "
 					    "software\nthat does not support "
-					    "the feature. See "
+					    "the feature.  See "
 					    "zpool-features(7) for "
 					    "details.\n\n"
 					    "Note that the pool "

--- a/etc/systemd/system-generators/zfs-mount-generator.c
+++ b/etc/systemd/system-generators/zfs-mount-generator.c
@@ -592,7 +592,7 @@ line_worker(char *line, const char *cachefile)
 			/* Don't log for canmount=noauto */
 			if (strcmp(p_canmount, "on") == 0)
 				fprintf(stderr, PROGNAME "[%d]: %s: "
-				    "%s already exists. Skipping.\n",
+				    "%s already exists.  Skipping.\n",
 				    getpid(), dataset, mountfile);
 		}
 

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -518,7 +518,7 @@ zfs_mount_at(zfs_handle_t *zhp, const char *options, int flags,
 			VERIFY(zfs_spa_version(zhp, &spa_version) == 0);
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 			    "Can't mount a version %llu "
-			    "file system on a version %d pool. Pool must be"
+			    "file system on a version %d pool.  Pool must be"
 			    " upgraded to mount this file system."),
 			    (u_longlong_t)zfs_prop_get_int(zhp,
 			    ZFS_PROP_VERSION), spa_version);

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -5245,7 +5245,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 			break;
 		case ZFS_ERR_FROM_IVSET_GUID_MISSING:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "IV set guid missing. See errata %u at "
+			    "IV set guid missing.  See errata %u at "
 			    "https://openzfs.github.io/openzfs-docs/msg/"
 			    "ZFS-8000-ER."),
 			    ZPOOL_ERRATA_ZOL_8308_ENCRYPTION);
@@ -5253,7 +5253,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 			break;
 		case ZFS_ERR_FROM_IVSET_GUID_MISMATCH:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "IV set guid mismatch. See the 'zfs receive' "
+			    "IV set guid mismatch.  See the 'zfs receive' "
 			    "man page section\n discussing the limitations "
 			    "of raw encrypted send streams."));
 			(void) zfs_error(hdl, EZFS_BADSTREAM, errbuf);
@@ -5281,7 +5281,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		case E2BIG:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 			    "zfs receive required kernel memory allocation "
-			    "larger than the system can support. Please file "
+			    "larger than the system can support.  Please file "
 			    "an issue at the OpenZFS issue tracker:\n"
 			    "https://github.com/openzfs/zfs/issues/new"));
 			(void) zfs_error(hdl, EZFS_BADSTREAM, errbuf);

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -493,7 +493,7 @@ zfs_standard_error_fmt(libzfs_handle_t *hdl, int error, const char *fmt, ...)
 	case ZFS_ERR_UNKNOWN_SEND_STREAM_FEATURE:
 	case ZFS_ERR_IOC_CMD_UNAVAIL:
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "the loaded zfs "
-		    "module does not support this operation. A reboot may "
+		    "module does not support this operation.  A reboot may "
 		    "be required to enable this operation."));
 		zfs_verror(hdl, EZFS_IOC_NOTSUPPORTED, fmt, ap);
 		break;
@@ -755,7 +755,7 @@ zpool_standard_error_fmt(libzfs_handle_t *hdl, int error, const char *fmt, ...)
 		break;
 	case ZFS_ERR_IOC_CMD_UNAVAIL:
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "the loaded zfs "
-		    "module does not support this operation. A reboot may "
+		    "module does not support this operation.  A reboot may "
 		    "be required to enable this operation."));
 		zfs_verror(hdl, EZFS_IOC_NOTSUPPORTED, fmt, ap);
 		break;

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -809,7 +809,7 @@ zfsvfs_init(zfsvfs_t *zfsvfs, objset_t *os)
 	if (zfsvfs->z_version >
 	    zfs_zpl_version_map(spa_version(dmu_objset_spa(os)))) {
 		(void) printf("Can't mount a version %lld file system "
-		    "on a version %lld pool\n. Pool must be upgraded to mount "
+		    "on a version %lld pool\n.  Pool must be upgraded to mount "
 		    "this file system.", (u_longlong_t)zfsvfs->z_version,
 		    (u_longlong_t)spa_version(dmu_objset_spa(os)));
 		return (SET_ERROR(ENOTSUP));

--- a/module/os/linux/spl/spl-generic.c
+++ b/module/os/linux/spl/spl-generic.c
@@ -794,7 +794,7 @@ spl_random_init(void)
 			(void) memcpy(s, "improbable seed", 16);
 		}
 		printk("SPL: get_random_bytes() returned 0 "
-		    "when generating random seed. Setting initial seed to "
+		    "when generating random seed.  Setting initial seed to "
 		    "0x%016llx%016llx%016llx%016llx.\n", cpu_to_be64(s[0]),
 		    cpu_to_be64(s[1]), cpu_to_be64(s[2]), cpu_to_be64(s[3]));
 	}

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -646,7 +646,7 @@ zfsvfs_init(zfsvfs_t *zfsvfs, objset_t *os)
 	if (zfsvfs->z_version >
 	    zfs_zpl_version_map(spa_version(dmu_objset_spa(os)))) {
 		(void) printk("Can't mount a version %lld file system "
-		    "on a version %lld pool\n. Pool must be upgraded to mount "
+		    "on a version %lld pool\n.  Pool must be upgraded to mount "
 		    "this file system.\n", (u_longlong_t)zfsvfs->z_version,
 		    (u_longlong_t)spa_version(dmu_objset_spa(os)));
 		return (SET_ERROR(ENOTSUP));

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -1907,7 +1907,7 @@ module_param(zvol_major, uint, 0444);
 MODULE_PARM_DESC(zvol_major, "Major number for zvol device");
 
 module_param(zvol_threads, uint, 0444);
-MODULE_PARM_DESC(zvol_threads, "Number of threads to handle I/O requests. Set"
+MODULE_PARM_DESC(zvol_threads, "Number of threads to handle I/O requests.  Set"
     "to 0 to use all active CPUs");
 
 module_param(zvol_request_sync, uint, 0644);

--- a/module/zcommon/zfs_namecheck.c
+++ b/module/zcommon/zfs_namecheck.c
@@ -464,4 +464,4 @@ EXPORT_SYMBOL(get_dataset_depth);
 EXPORT_SYMBOL(zfs_max_dataset_nesting);
 
 ZFS_MODULE_PARAM(zfs, zfs_, max_dataset_nesting, INT, ZMOD_RW,
-	"Limit to the amount of nesting a path can have. Defaults to 50.");
+	"Limit to the amount of nesting a path can have.  Defaults to 50.");

--- a/module/zfs/btree.c
+++ b/module/zfs/btree.c
@@ -2210,6 +2210,6 @@ zfs_btree_verify(zfs_btree_t *tree)
 
 /* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs, zfs_, btree_verify_intensity, UINT, ZMOD_RW,
-	"Enable btree verification. Levels above 4 require ZFS be built "
+	"Enable btree verification.  Levels above 4 require ZFS be built "
 	"with debugging");
 /* END CSTYLED */

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2853,7 +2853,7 @@ spa_load_verify(spa_t *spa)
 	if (spa_load_verify_metadata) {
 		if (spa->spa_extreme_rewind) {
 			spa_load_note(spa, "performing a complete scan of the "
-			    "pool since extreme rewind is on. This may take "
+			    "pool since extreme rewind is on.  This may take "
 			    "a very long time.\n  (spa_load_verify_data=%u, "
 			    "spa_load_verify_metadata=%u)",
 			    spa_load_verify_data, spa_load_verify_metadata);
@@ -4469,7 +4469,7 @@ spa_ld_trusted_config(spa_t *spa, spa_import_type_t type,
 			vdev_dbgmsg_print_tree(rvd, 2);
 			if (reloading) {
 				spa_load_failed(spa, "config was already "
-				    "provided from MOS. Aborting.");
+				    "provided from MOS.  Aborting.");
 				return (spa_vdev_err(rvd,
 				    VDEV_AUX_CORRUPT_DATA, EIO));
 			}

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -3833,7 +3833,7 @@ vdev_load(vdev_t *vd)
 		if (vd->vdev_ashift == 0 || vd->vdev_asize == 0) {
 			vdev_set_state(vd, B_FALSE, VDEV_STATE_CANT_OPEN,
 			    VDEV_AUX_CORRUPT_DATA);
-			vdev_dbgmsg(vd, "vdev_load: invalid size. ashift=%llu, "
+			vdev_dbgmsg(vd, "vdev_load: invalid size.  ashift=%llu, "
 			    "asize=%llu", (u_longlong_t)vd->vdev_ashift,
 			    (u_longlong_t)vd->vdev_asize);
 			return (SET_ERROR(ENXIO));

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -1917,7 +1917,7 @@ ZFS_MODULE_PARAM(zfs_condense, zfs_condense_, max_obsolete_bytes, U64,
 ZFS_MODULE_PARAM(zfs_condense, zfs_condense_, indirect_commit_entry_delay_ms,
 	UINT, ZMOD_RW,
 	"Used by tests to ensure certain actions happen in the middle of a "
-	"condense. A maximum value of 1 should be sufficient.");
+	"condense.  A maximum value of 1 should be sufficient.");
 
 ZFS_MODULE_PARAM(zfs_reconstruct, zfs_reconstruct_, indirect_combinations_max,
 	UINT, ZMOD_RW,

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2636,7 +2636,7 @@ zio_resume(spa_t *spa)
 	mutex_enter(&spa->spa_suspend_lock);
 	if (spa->spa_suspended != ZIO_SUSPEND_NONE)
 		cmn_err(CE_WARN, "Pool '%s' was suspended and is being "
-		    "resumed. Failed I/O will be retried.",
+		    "resumed.  Failed I/O will be retried.",
 		    spa_name(spa));
 	spa->spa_suspended = ZIO_SUSPEND_NONE;
 	cv_broadcast(&spa->spa_suspend_cv);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
I noticed this just recently when I was tinkering around with one of my pools and got some ZFS error messages. It seemed to me that not all messages were formatted the same way.
Most of the error messages that are printed by the "zpool" or "zfs" commands use the common punctuation, where after a dot, there are *two* spaces before the capital letter of the next sentence. This is also true for most of the comments. However, there were a couple of messages that used a different punctuation, where only one space was used between the dot and the next sentence. I tried to unify the formatting of all error and info messages, such that everywhere the same punctuation is used. All comments, copyrights and so on are, of course, completely untouched, just the strings that are printed on the console, and are therefore visible to users, I have corrected in the sense that they are all using identical punctuation.
Technically for sure useless, I just noticed that not everything is formatted in the same way and thought maybe it would be nice if this was the case. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
