### PR TITLE
config: add HAVE_DEQUEUE_SIGNAL_3ARG_SIGINFO

### DIFF
--- a/module/os/linux/spl/spl-thread.c
+++ b/module/os/linux/spl/spl-thread.c
@@ -171,7 +171,8 @@ issig(void)
 #if defined(HAVE_DEQUEUE_SIGNAL_4ARG)
 	enum pid_type __type;
 	if (dequeue_signal(current, &set, &__info, &__type) != 0) {
-#elif defined(HAVE_DEQUEUE_SIGNAL_3ARG_TASK)
+#elif defined(HAVE_DEQUEUE_SIGNAL_3ARG_TASK) || \
+	defined(HAVE_DEQUEUE_SIGNAL_3ARG_SIGINFO)
 	if (dequeue_signal(current, &set, &__info) != 0) {
 #else
 	enum pid_type __type;


### PR DESCRIPTION
When I use the latest stable version of ZFS(2.3-release), I find that it cannot compile on my Kylin OS, which is based on the 4.19 kernel version.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have figured out that both 4.18 and 4.19 still use siginfo_t as the third parameter of the dequeue_signal function, which takes three parameters.

[https://elixir.bootlin.com/linux/v4.18/source/include/linux/sched/signal.h](url)
[https://elixir.bootlin.com/linux/v4.19.322/source/include/linux/sched/signal.h](url)

### Description
<!--- Describe your changes in detail -->
Besides the current 3arg version checking, I add kthread_dequeue_signal_3arg_siginfo.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
