### PR TITLE
config: fix dequeue_signal check for kernels <4.20

### DIFF
--- a/config/kernel-kthread.m4
+++ b/config/kernel-kthread.m4
@@ -17,14 +17,21 @@ AC_DEFUN([ZFS_AC_KERNEL_KTHREAD_COMPLETE_AND_EXIT], [
 
 AC_DEFUN([ZFS_AC_KERNEL_KTHREAD_DEQUEUE_SIGNAL], [
 	dnl #
-	dnl # 5.17 API: enum pid_type * as new 4th dequeue_signal() argument,
-	dnl # 5768d8906bc23d512b1a736c1e198aa833a6daa4 ("signal: Requeue signals in the appropriate queue")
+	dnl # prehistory:
+	dnl #     int dequeue_signal(struct task_struct *task, sigset_t *mask,
+	dnl #         siginfo_t *info)
 	dnl #
-	dnl # int dequeue_signal(struct task_struct *task, sigset_t *mask, kernel_siginfo_t *info);
-	dnl # int dequeue_signal(struct task_struct *task, sigset_t *mask, kernel_siginfo_t *info, enum pid_type *type);
+	dnl # 4.20: kernel_siginfo_t introduced, replaces siginfo_t
+	dnl #     int dequeue_signal(struct task_struct *task, sigset_t *mask,
+	dnl           kernel_siginfo_t *info)
 	dnl #
-	dnl # 6.12 API: first arg struct_task* removed
-	dnl # int dequeue_signal(sigset_t *mask, kernel_siginfo_t *info, enum pid_type *type);
+	dnl # 5.17: enum pid_type introduced as 4th arg
+	dnl #     int dequeue_signal(struct task_struct *task, sigset_t *mask,
+	dnl #         kernel_siginfo_t *info, enum pid_type *type)
+	dnl #
+	dnl # 6.12: first arg struct_task* removed
+	dnl #     int dequeue_signal(sigset_t *mask, kernel_siginfo_t *info,
+	dnl #         enum pid_type *type)
 	dnl #
 	AC_MSG_CHECKING([whether dequeue_signal() takes 4 arguments])
 	ZFS_LINUX_TEST_RESULT([kthread_dequeue_signal_4arg], [
@@ -33,11 +40,11 @@ AC_DEFUN([ZFS_AC_KERNEL_KTHREAD_DEQUEUE_SIGNAL], [
 		    [dequeue_signal() takes 4 arguments])
 	], [
 		AC_MSG_RESULT(no)
-		AC_MSG_CHECKING([whether dequeue_signal() a task argument])
-		ZFS_LINUX_TEST_RESULT([kthread_dequeue_signal_3arg_task], [
+		AC_MSG_CHECKING([whether 3-arg dequeue_signal() takes a type argument])
+		ZFS_LINUX_TEST_RESULT([kthread_dequeue_signal_3arg_type], [
 			AC_MSG_RESULT(yes)
-			AC_DEFINE(HAVE_DEQUEUE_SIGNAL_3ARG_TASK, 1,
-			    [dequeue_signal() takes a task argument])
+			AC_DEFINE(HAVE_DEQUEUE_SIGNAL_3ARG_TYPE, 1,
+			    [3-arg dequeue_signal() takes a type argument])
 		], [
 			AC_MSG_RESULT(no)
 		])
@@ -56,17 +63,6 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_KTHREAD_COMPLETE_AND_EXIT], [
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_SRC_KTHREAD_DEQUEUE_SIGNAL], [
-	ZFS_LINUX_TEST_SRC([kthread_dequeue_signal_3arg_task], [
-		#include <linux/sched/signal.h>
-	], [
-		struct task_struct *task = NULL;
-		sigset_t *mask = NULL;
-		kernel_siginfo_t *info = NULL;
-		int error __attribute__ ((unused));
-
-		error = dequeue_signal(task, mask, info);
-	])
-
 	ZFS_LINUX_TEST_SRC([kthread_dequeue_signal_4arg], [
 		#include <linux/sched/signal.h>
 	], [
@@ -77,6 +73,17 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_KTHREAD_DEQUEUE_SIGNAL], [
 		int error __attribute__ ((unused));
 
 		error = dequeue_signal(task, mask, info, type);
+	])
+
+	ZFS_LINUX_TEST_SRC([kthread_dequeue_signal_3arg_type], [
+		#include <linux/sched/signal.h>
+	], [
+		sigset_t *mask = NULL;
+		kernel_siginfo_t *info = NULL;
+		enum pid_type *type = NULL;
+		int error __attribute__ ((unused));
+
+		error = dequeue_signal(mask, info, type);
 	])
 ])
 

--- a/module/os/linux/spl/spl-thread.c
+++ b/module/os/linux/spl/spl-thread.c
@@ -171,11 +171,11 @@ issig(void)
 #if defined(HAVE_DEQUEUE_SIGNAL_4ARG)
 	enum pid_type __type;
 	if (dequeue_signal(current, &set, &__info, &__type) != 0) {
-#elif defined(HAVE_DEQUEUE_SIGNAL_3ARG_TASK)
-	if (dequeue_signal(current, &set, &__info) != 0) {
-#else
+#elif defined(HAVE_DEQUEUE_SIGNAL_3ARG_TYPE)
 	enum pid_type __type;
 	if (dequeue_signal(&set, &__info, &__type) != 0) {
+#else
+	if (dequeue_signal(current, &set, &__info) != 0) {
 #endif
 		spin_unlock_irq(&current->sighand->siglock);
 		kernel_signal_stop();


### PR DESCRIPTION
### Motivation and Context

Compile failure against Linux <4.20.

This solves the same problem as #16662, but I prefer this way because it's one less configure check and easier to maintain, especially if this API changes again.

Closes #16662.

### Description

Before 4.20, kernel_siginfo_t was just called siginfo_t. This was causing the
kthread_dequeue_signal_3arg_task check, which uses kernel_siginfo_t, to fail on
older kernels.

In d6b8c17f1, we started checking for the "new" three-arg dequeue_signal() by
testing for the "old" version. Because that test is explicitly using
kernel_siginfo_t, it would fail, leading to the build trying to use the new
three-arg version, which would then not comile.

This commit fixes that by avoiding checking for the old 3-arg dequeue_signal
entirely. Instead, we check for the new one, as well as the 4-arg form, and we
use the old form as a fallback. This way, we never have to test for it
explicitly, and once we're building HAVE_SIGINFO will make sure we get the
right kernel_siginfo_t for it, so everything works out nice.

### How Has This Been Tested?

Compiled against kernels:
 - 6.12.0-rc2
 - 6.11
 - 6.10
 - 6.9
 - 6.8
 - 6.7
 - 6.6
 - 6.5
 - 6.4
 - 6.3
 - 6.
 - 6.1
 - 5.15
 - 5.10
 - 5.4
 - 4.19

and distros:
- 5.4.0-84-generic (Ubuntu 18.04)
- 5.13.0-30-generic (Ubuntu 20.04)
- 5.15.0-25-generic (Ubuntu 22.04)
- 6.8.0-31-generic (Ubuntu 24.04)
- 4.18.0-348.7.1.el8_5.x86_64 (CentOS 8.4.2105)
- 4.18.0-553.8.1.el8_10.x86_64 (Rocky 8.6)
- 5.14.0-427.28.1.el9_4.x86_64 (Rocky 9)
- 6.10.5-200.fc40.x86_64 (Fedora 40)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).