### PR TITLE
zdb: show bp in uberblock dump

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -4266,6 +4266,10 @@ dump_uberblock(uberblock_t *ub, const char *header, const char *footer)
 	(void) printf("\ttimestamp = %llu UTC = %s",
 	    (u_longlong_t)ub->ub_timestamp, ctime(&timestamp));
 
+	char blkbuf[BP_SPRINTF_LEN];
+	snprintf_blkptr(blkbuf, sizeof (blkbuf), &ub->ub_rootbp);
+	(void) printf("\tbp = %s\n", blkbuf);
+
 	(void) printf("\tmmp_magic = %016llx\n",
 	    (u_longlong_t)ub->ub_mmp_magic);
 	if (MMP_VALID(ub)) {


### PR DESCRIPTION
### Motivation and Context

I was helping a friend with a broken pool. `zdb -lu` didn't show a head block pointer, and it annoyed me.

### Description

Just format and print the block pointer in the uberblock when dumping it.

### How Has This Been Tested?

Run program, enjoy block pointer:

```
$ sudo ./zdb -lqu /dev/nvme0n1p2
    Uberblock[0]
	magic = 0000000000bab10c
	version = 5000
	txg = 2476320
	guid_sum = 17693405506996517599
	timestamp = 1729339026 UTC = Sat Oct 19 22:57:06 2024
	bp = DVA[0]=<0:62290b6000:1000> DVA[1]=<0:5f41c5b000:1000> DVA[2]=<0:10016b9000:1000> [L0 DMU objset] fletcher4 uncompressed unencrypted LE contiguous unique triple size=1000L/1000P birth=2476320L/2476320P fill=264 cksum=00000004118c836b:00000fa5d98389b1:001e1fc53b6ba384:26b43e0bf0e15a8f
	mmp_magic = 00000000a11cea11
	mmp_delay = 0
	mmp_valid = 0
	checkpoint_txg = 0
	raidz_reflow state=0 off=0
        labels = 0 1 2 3
    Uberblock[1]
	magic = 0000000000bab10c
	version = 5000
...
```

`zdb` test tag ran to success.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
