### PR TITLE
Revert commit to fix LUKS write errors

### DIFF
--- a/.github/workflows/scripts/qemu-3-deps.sh
+++ b/.github/workflows/scripts/qemu-3-deps.sh
@@ -13,10 +13,10 @@ function archlinux() {
   echo "##[endgroup]"
 
   echo "##[group]Install Development Tools"
-  sudo pacman -Sy --noconfirm base-devel bc cpio dhclient dkms fakeroot \
-    fio gdb inetutils jq less linux linux-headers lsscsi nfs-utils parted \
-    pax perf python-packaging python-setuptools qemu-guest-agent ksh samba \
-    sysstat rng-tools rsync wget xxhash
+  sudo pacman -Sy --noconfirm base-devel bc cpio cryptsetup dhclient dkms \
+    fakeroot fio gdb inetutils jq less linux linux-headers lsscsi nfs-utils \
+    parted pax perf python-packaging python-setuptools qemu-guest-agent ksh \
+    samba sysstat rng-tools rsync wget xxhash
   echo "##[endgroup]"
 }
 
@@ -68,14 +68,15 @@ function rhel() {
   echo "##[group]Install Development Tools"
   sudo dnf group install -y "Development Tools"
   sudo dnf install -y \
-    acl attr bc bzip2 curl dbench dkms elfutils-libelf-devel fio gdb git \
-    jq kernel-rpm-macros ksh libacl-devel libaio-devel libargon2-devel \
-    libattr-devel libblkid-devel libcurl-devel libffi-devel ncompress \
-    libselinux-devel libtirpc-devel libtool libudev-devel libuuid-devel \
-    lsscsi mdadm nfs-utils openssl-devel pam-devel pamtester parted perf \
-    python3 python3-cffi python3-devel python3-packaging kernel-devel \
-    python3-setuptools qemu-guest-agent rng-tools rpcgen rpm-build rsync \
-    samba sysstat systemd watchdog wget xfsprogs-devel xxhash zlib-devel
+    acl attr bc bzip2 cryptsetup curl dbench dkms elfutils-libelf-devel fio \
+    gdb git jq kernel-rpm-macros ksh libacl-devel libaio-devel \
+    libargon2-devel libattr-devel libblkid-devel libcurl-devel libffi-devel \
+    ncompress libselinux-devel libtirpc-devel libtool libudev-devel \
+    libuuid-devel lsscsi mdadm nfs-utils openssl-devel pam-devel pamtester \
+    parted perf python3 python3-cffi python3-devel python3-packaging \
+    kernel-devel python3-setuptools qemu-guest-agent rng-tools rpcgen \
+    rpm-build rsync samba sysstat systemd watchdog wget xfsprogs-devel xxhash \
+    zlib-devel
   echo "##[endgroup]"
 }
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -159,22 +159,23 @@ zio_init(void)
 	zio_link_cache = kmem_cache_create("zio_link_cache",
 	    sizeof (zio_link_t), 0, NULL, NULL, NULL, NULL, NULL, 0);
 
+	/*
+	 * For small buffers, we want a cache for each multiple of
+	 * SPA_MINBLOCKSIZE.  For larger buffers, we want a cache
+	 * for each quarter-power of 2.
+	 */
 	for (c = 0; c < SPA_MAXBLOCKSIZE >> SPA_MINBLOCKSHIFT; c++) {
 		size_t size = (c + 1) << SPA_MINBLOCKSHIFT;
-		size_t align, cflags, data_cflags;
-		char name[32];
-
-		/*
-		 * Create cache for each half-power of 2 size, starting from
-		 * SPA_MINBLOCKSIZE.  It should give us memory space efficiency
-		 * of ~7/8, sufficient for transient allocations mostly using
-		 * these caches.
-		 */
 		size_t p2 = size;
+		size_t align = 0;
+		size_t data_cflags, cflags;
+
+		data_cflags = KMC_NODEBUG;
+		cflags = (zio_exclude_metadata || size > zio_buf_debug_limit) ?
+		    KMC_NODEBUG : 0;
+
 		while (!ISP2(p2))
 			p2 &= p2 - 1;
-		if (!IS_P2ALIGNED(size, p2 / 2))
-			continue;
 
 #ifndef _KERNEL
 		/*
@@ -185,41 +186,47 @@ zio_init(void)
 		 */
 		if (arc_watch && !IS_P2ALIGNED(size, PAGESIZE))
 			continue;
+		/*
+		 * Here's the problem - on 4K native devices in userland on
+		 * Linux using O_DIRECT, buffers must be 4K aligned or I/O
+		 * will fail with EINVAL, causing zdb (and others) to coredump.
+		 * Since userland probably doesn't need optimized buffer caches,
+		 * we just force 4K alignment on everything.
+		 */
+		align = 8 * SPA_MINBLOCKSIZE;
+#else
+		if (size < PAGESIZE) {
+			align = SPA_MINBLOCKSIZE;
+		} else if (IS_P2ALIGNED(size, p2 >> 2)) {
+			align = PAGESIZE;
+		}
 #endif
 
-		if (IS_P2ALIGNED(size, PAGESIZE))
-			align = PAGESIZE;
-		else
-			align = 1 << (highbit64(size ^ (size - 1)) - 1);
+		if (align != 0) {
+			char name[36];
+			if (cflags == data_cflags) {
+				/*
+				 * Resulting kmem caches would be identical.
+				 * Save memory by creating only one.
+				 */
+				(void) snprintf(name, sizeof (name),
+				    "zio_buf_comb_%lu", (ulong_t)size);
+				zio_buf_cache[c] = kmem_cache_create(name,
+				    size, align, NULL, NULL, NULL, NULL, NULL,
+				    cflags);
+				zio_data_buf_cache[c] = zio_buf_cache[c];
+				continue;
+			}
+			(void) snprintf(name, sizeof (name), "zio_buf_%lu",
+			    (ulong_t)size);
+			zio_buf_cache[c] = kmem_cache_create(name, size,
+			    align, NULL, NULL, NULL, NULL, NULL, cflags);
 
-		cflags = (zio_exclude_metadata || size > zio_buf_debug_limit) ?
-		    KMC_NODEBUG : 0;
-		data_cflags = KMC_NODEBUG;
-		if (abd_size_alloc_linear(size)) {
-			cflags |= KMC_RECLAIMABLE;
-			data_cflags |= KMC_RECLAIMABLE;
+			(void) snprintf(name, sizeof (name), "zio_data_buf_%lu",
+			    (ulong_t)size);
+			zio_data_buf_cache[c] = kmem_cache_create(name, size,
+			    align, NULL, NULL, NULL, NULL, NULL, data_cflags);
 		}
-		if (cflags == data_cflags) {
-			/*
-			 * Resulting kmem caches would be identical.
-			 * Save memory by creating only one.
-			 */
-			(void) snprintf(name, sizeof (name),
-			    "zio_buf_comb_%lu", (ulong_t)size);
-			zio_buf_cache[c] = kmem_cache_create(name, size, align,
-			    NULL, NULL, NULL, NULL, NULL, cflags);
-			zio_data_buf_cache[c] = zio_buf_cache[c];
-			continue;
-		}
-		(void) snprintf(name, sizeof (name), "zio_buf_%lu",
-		    (ulong_t)size);
-		zio_buf_cache[c] = kmem_cache_create(name, size, align,
-		    NULL, NULL, NULL, NULL, NULL, cflags);
-
-		(void) snprintf(name, sizeof (name), "zio_data_buf_%lu",
-		    (ulong_t)size);
-		zio_data_buf_cache[c] = kmem_cache_create(name, size, align,
-		    NULL, NULL, NULL, NULL, NULL, data_cflags);
 	}
 
 	while (--c != 0) {

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -147,6 +147,12 @@ tags = ['functional', 'largest_pool']
 tests = ['longname_001_pos', 'longname_002_pos', 'longname_003_pos']
 tags = ['functional', 'longname']
 
+[tests/functional/luks:Linux]
+pre =
+post =
+tests = ['luks_sanity']
+tags = ['functional', 'luks']
+
 [tests/functional/mmap:Linux]
 tests = ['mmap_libaio_001_pos', 'mmap_sync_001_pos']
 tags = ['functional', 'mmap']

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -129,6 +129,7 @@ export SYSTEM_FILES_LINUX='attr
     blkdiscard
     blockdev
     chattr
+    cryptsetup
     exportfs
     fallocate
     flock

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -80,7 +80,8 @@ if BUILD_LINUX
 nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/simd/simd_supported.ksh \
 	functional/tmpfile/cleanup.ksh \
-	functional/tmpfile/setup.ksh
+	functional/tmpfile/setup.ksh \
+	functional/luks/luks_sanity.ksh
 endif
 
 nobase_dist_datadir_zfs_tests_tests_DATA += \

--- a/tests/zfs-tests/tests/functional/luks/luks_sanity.ksh
+++ b/tests/zfs-tests/tests/functional/luks/luks_sanity.ksh
@@ -1,0 +1,89 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2024 by Lawrence Livermore National Security, LLC.
+# Use is subject to license terms.
+#
+
+# DESCRIPTION:
+#	Verify ZFS works on a LUKS-backed pool
+#
+# STRATEGY:
+#	1. Create a LUKS device
+#	2. Make a pool with it
+#      3. Write files to the pool
+#	4. Verify no errors
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "both"
+
+VDEV=$(mktemp --suffix=luks_sanity)
+TESTPOOL=testpool
+
+function cleanup
+{
+	log_must zpool destroy $TESTPOOL
+
+	log_must cryptsetup luksClose /dev/mapper/luksdev
+	log_must rm -f $VDEV
+}
+
+log_assert "Verify ZFS on LUKS works"
+log_onexit cleanup
+
+PASS="fdsjfosdijfsdkjsldfjdlk"
+
+# Make a small LUKS device since LUKS formatting takes time and we want to
+# make this test run as quickly as possible.
+truncate -s 100M $VDEV
+
+log_must cryptsetup luksFormat --type luks2 $VDEV <<< $PASS
+log_must cryptsetup luksOpen $VDEV luksdev <<< $PASS
+
+log_must zpool create $TESTPOOL /dev/mapper/luksdev
+
+CPUS=$(get_num_cpus)
+
+# Use these specific size and offset ranges as they often cause errors with
+# https://github.com/openzfs/zfs/issues/16631
+# and we want to try to test for that.
+for SIZE in {70..100} ; do
+	for OFF in {70..100} ; do
+		for i in {1..$CPUS} ; do
+			dd if=/dev/urandom of=/$TESTPOOL/file$i-bs$SIZE-off$OFF \
+			    seek=$OFF bs=$SIZE count=1 &>/dev/null &
+		done
+		wait
+	done
+	rm -f /$TESTPOOL/file*
+done
+
+# Verify no read/write/checksum errors.  Don't use JSON here so that we could
+# could potentially backport this test case to the 2.2.x branch.
+if zpool status -e | grep -q "luksdev" ; then
+	log_note "$(zpool status -v)"
+	log_fail "Saw errors writing to LUKS device"
+fi
+
+log_pass "Verified ZFS on LUKS works"


### PR DESCRIPTION
### Motivation and Context
Workaround ZFS on LUKS write errors on master branch.

### Description
Revert bd7a02c251d8c119937e847d5161b512913667e6 as a workaround for #16631 and add a LUKS test case.  This revert is more of a stop-gap for 2.3.x while we come up with a proper fix for #16631.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
