### PR TITLE
Workaround issue of Linux vdev_disk.c

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -187,6 +187,20 @@ zio_init(void)
 			continue;
 #endif
 
+#if defined(__linux__) && defined(_KERNEL)
+		/*
+		 * Workaround issue of Linux vdev_disk.c, in some cases not
+		 * linearizing buffers with disk sector crossing a page
+		 * boundary. It is fine for hardware, but somehow required by
+		 * LUKS. It is not typical for ZFS to produce such buffers, but
+		 * it may happen if 6KB block is compressed to 4KB, while still
+		 * having 2KB alignment. Banning the 6KB buffers helps vdevs
+		 * with ashifh=12.
+		 */
+		if (size > PAGESIZE && !IS_P2ALIGNED(size, PAGESIZE))
+			continue;
+#endif
+
 		if (IS_P2ALIGNED(size, PAGESIZE))
 			align = PAGESIZE;
 		else


### PR DESCRIPTION
in some cases not linearizing buffers with disk sector crossing a page boundary. It is fine for hardware, but somehow required by LUKS. It is not typical for ZFS to produce such buffers, but it may happen if 6KB block is compressed to 4KB, while still having 2KB alignment. Banning the 6KB buffers helps vdevs with ashifh=12.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
