### PR TITLE
Fix gcc unused value warning in FreeBSD simd.h

### DIFF
--- a/include/os/freebsd/spl/sys/simd.h
+++ b/include/os/freebsd/spl/sys/simd.h
@@ -50,7 +50,7 @@
 #define	kfpu_fini()		do {} while (0)
 #endif
 
-#define	simd_stat_init()	0
-#define	simd_stat_fini()	0
+#define	simd_stat_init()	do {} while (0)
+#define	simd_stat_fini()	do {} while (0)
 
 #endif


### PR DESCRIPTION
With gcc we are seeing the following -Werror warnings:

```text
/workspace/src/sys/contrib/openzfs/include/os/freebsd/spl/sys/simd.h:53:33: error: statement with no effect [-Werror=unused-value]
   53 | #define simd_stat_init()        0
      |                                 ^
/workspace/src/sys/contrib/openzfs/module/zcommon/zfs_prop.c:1092:9: note: in expansion of macro 'simd_stat_init'
 1092 |         simd_stat_init();
      |         ^~~~~~~~~~~~~~
/workspace/src/sys/contrib/openzfs/module/zcommon/zfs_prop.c: In function 'zcommon_fini':
/workspace/src/sys/contrib/openzfs/include/os/freebsd/spl/sys/simd.h:54:33: error: statement with no effect [-Werror=unused-value]
   54 | #define simd_stat_fini()        0
      |                                 ^
/workspace/src/sys/contrib/openzfs/module/zcommon/zfs_prop.c:1100:9: note: in expansion of macro 'simd_stat_fini'
 1100 |         simd_stat_fini();
      |         ^~~~~~~~~~~~~~
```

Both `simd_stat_init()` and `simd_stat_fini()` are defined in the FreeBSD specific version of `simd.h`:

```c
#define     simd_stat_init()        0
#define     simd_stat_fini()        0
```

These should both be defined as `do {} while (0)` instead, similar to other macros in this file.
