### PR TITLE
module: unicode: #if out unused bits of libunicode (#13224)

### DIFF
--- a/include/sys/u8_textprep.h
+++ b/include/sys/u8_textprep.h
@@ -90,8 +90,12 @@ extern int uconv_u8tou32(const uchar_t *, size_t *, uint32_t *, size_t *, int);
 #define	U8_TEXTPREP_IGNORE_INVALID	(0x00020000)
 #define	U8_TEXTPREP_NOWAIT		(0x00040000)
 
+#if 0
 #define	U8_UNICODE_320			(0)
 #define	U8_UNICODE_500			(1)
+#else
+#define	U8_UNICODE_500			(0)
+#endif
 #define	U8_UNICODE_LATEST		(U8_UNICODE_500)
 
 #define	U8_VALIDATE_ENTIRE		(0x00100000)

--- a/include/sys/u8_textprep.h
+++ b/include/sys/u8_textprep.h
@@ -67,7 +67,9 @@ extern int uconv_u8tou32(const uchar_t *, size_t *, uint32_t *, size_t *, int);
  */
 #define	U8_STRCMP_CS			(0x00000001)
 #define	U8_STRCMP_CI_UPPER		(0x00000002)
+#if 0
 #define	U8_STRCMP_CI_LOWER		(0x00000004)
+#endif
 
 #define	U8_CANON_DECOMP			(0x00000010)
 #define	U8_COMPAT_DECOMP		(0x00000020)
@@ -79,7 +81,9 @@ extern int uconv_u8tou32(const uchar_t *, size_t *, uint32_t *, size_t *, int);
 #define	U8_STRCMP_NFKC			(U8_COMPAT_DECOMP | U8_CANON_COMP)
 
 #define	U8_TEXTPREP_TOUPPER		(U8_STRCMP_CI_UPPER)
+#ifdef U8_STRCMP_CI_LOWER
 #define	U8_TEXTPREP_TOLOWER		(U8_STRCMP_CI_LOWER)
+#endif
 
 #define	U8_TEXTPREP_NFD			(U8_STRCMP_NFD)
 #define	U8_TEXTPREP_NFC			(U8_STRCMP_NFC)

--- a/include/sys/u8_textprep_data.h
+++ b/include/sys/u8_textprep_data.h
@@ -147,6 +147,7 @@ typedef struct {
  * toupper case conversion mappings.
  */
 static const uchar_t u8_common_b1_tbl[U8_UNICODE_LATEST + 1][256] = {
+#ifdef U8_UNICODE_320
 	{
 		0,  N_, N_, N_, N_, N_, N_, N_,
 		N_, N_, N_, N_, N_, N_, N_, N_,
@@ -181,6 +182,7 @@ static const uchar_t u8_common_b1_tbl[U8_UNICODE_LATEST + 1][256] = {
 		1,  N_, N_, N_, N_, N_, N_, N_,
 		N_, N_, N_, N_, N_, N_, N_, N_,
 	},
+#endif
 	{
 		0,  N_, N_, N_, N_, N_, N_, N_,
 		N_, N_, N_, N_, N_, N_, N_, N_,
@@ -219,6 +221,7 @@ static const uchar_t u8_common_b1_tbl[U8_UNICODE_LATEST + 1][256] = {
 
 static const uchar_t u8_combining_class_b2_tbl[U8_UNICODE_LATEST + 1][2][256] =
 {
+#ifdef U8_UNICODE_320
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -290,6 +293,7 @@ static const uchar_t u8_combining_class_b2_tbl[U8_UNICODE_LATEST + 1][2][256] =
 		},
 
 	},
+#endif
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -366,6 +370,7 @@ static const uchar_t u8_combining_class_b2_tbl[U8_UNICODE_LATEST + 1][2][256] =
 
 static const uchar_t u8_combining_class_b3_tbl[U8_UNICODE_LATEST + 1][9][256] =
 {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Third byte table 0. */
 			N_, N_, N_, N_, N_, N_, N_, N_,
@@ -674,6 +679,7 @@ static const uchar_t u8_combining_class_b3_tbl[U8_UNICODE_LATEST + 1][9][256] =
 			N_, N_, N_, N_, N_, N_, N_, N_,
 		},
 	},
+#endif
 	{
 		{	/* Third byte table 0. */
 			N_, N_, N_, N_, N_, N_, N_, N_,
@@ -990,6 +996,7 @@ static const uchar_t u8_combining_class_b3_tbl[U8_UNICODE_LATEST + 1][9][256] =
  */
 static const uchar_t u8_combining_class_b4_tbl[U8_UNICODE_LATEST + 1][55][256] =
 {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -2862,6 +2869,7 @@ static const uchar_t u8_combining_class_b4_tbl[U8_UNICODE_LATEST + 1][55][256] =
 			0,   0,   0,   0,   0,   0,   0,   0,
 		},
 	},
+#endif
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -4737,6 +4745,7 @@ static const uchar_t u8_combining_class_b4_tbl[U8_UNICODE_LATEST + 1][55][256] =
 };
 
 static const uchar_t u8_composition_b1_tbl[U8_UNICODE_LATEST + 1][256] = {
+#ifdef U8_UNICODE_320
 	{
 		0,  N_, N_, N_, N_, N_, N_, N_,
 		N_, N_, N_, N_, N_, N_, N_, N_,
@@ -4771,6 +4780,7 @@ static const uchar_t u8_composition_b1_tbl[U8_UNICODE_LATEST + 1][256] = {
 		N_, N_, N_, N_, N_, N_, N_, N_,
 		N_, N_, N_, N_, N_, N_, N_, N_,
 	},
+#endif
 	{
 		0,  N_, N_, N_, N_, N_, N_, N_,
 		N_, N_, N_, N_, N_, N_, N_, N_,
@@ -4808,6 +4818,7 @@ static const uchar_t u8_composition_b1_tbl[U8_UNICODE_LATEST + 1][256] = {
 };
 
 static const uchar_t u8_composition_b2_tbl[U8_UNICODE_LATEST + 1][1][256] = {
+#ifdef U8_UNICODE_320
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -4845,6 +4856,7 @@ static const uchar_t u8_composition_b2_tbl[U8_UNICODE_LATEST + 1][1][256] = {
 		},
 
 	},
+#endif
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -4888,6 +4900,7 @@ static const uchar_t u8_composition_b2_tbl[U8_UNICODE_LATEST + 1][1][256] = {
 static const u8_displacement_t u8_composition_b3_tbl[
     U8_UNICODE_LATEST + 1][5][256] =
 {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Third byte table 0. */
 			{ 0x8000, 0 }, { N_, 0 }, { N_, 0 },
@@ -5330,6 +5343,7 @@ static const u8_displacement_t u8_composition_b3_tbl[
 			{ N_, 0 },
 		},
 	},
+#endif
 	{
 		{	/* Third byte table 0. */
 			{ 0x8000, 0 }, { N_, 0 }, { N_, 0 },
@@ -5775,6 +5789,7 @@ static const u8_displacement_t u8_composition_b3_tbl[
 };
 
 static const uchar_t u8_composition_b4_tbl[U8_UNICODE_LATEST + 1][41][257] = {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -7212,6 +7227,7 @@ static const uchar_t u8_composition_b4_tbl[U8_UNICODE_LATEST + 1][41][257] = {
 			0,
 		},
 	},
+#endif
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -8654,6 +8670,7 @@ static const uchar_t u8_composition_b4_tbl[U8_UNICODE_LATEST + 1][41][257] = {
 static const uint16_t u8_composition_b4_16bit_tbl[
     U8_UNICODE_LATEST + 1][5][257] =
 {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Fourth byte 16-bit table 0. */
 			0,    0,    0,    0,    0,    0,    0,    0,
@@ -8831,6 +8848,7 @@ static const uint16_t u8_composition_b4_16bit_tbl[
 			362,
 		},
 	},
+#endif
 	{
 		{	/* Fourth byte 16-bit table 0. */
 			0,    0,    0,    0,    0,    0,    0,    0,
@@ -9011,6 +9029,7 @@ static const uint16_t u8_composition_b4_16bit_tbl[
 };
 
 static const uchar_t u8_composition_final_tbl[U8_UNICODE_LATEST + 1][6623] = {
+#ifdef U8_UNICODE_320
 	{
 		0x01, 0xCC, 0xB8, FIL_, 0xE2, 0x89, 0xAE, FIL_,
 		0x01, 0xCC, 0xB8, FIL_, 0xE2, 0x89, 0xA0, FIL_,
@@ -9841,6 +9860,7 @@ static const uchar_t u8_composition_final_tbl[U8_UNICODE_LATEST + 1][6623] = {
 		0,    0,    0,    0,    0,    0,    0,    0,
 		0,    0,    0,    0,    0,    0,    0,
 	},
+#endif
 	{
 		0x01, 0xCC, 0xB8, FIL_, 0xE2, 0x89, 0xAE, FIL_,
 		0x01, 0xCC, 0xB8, FIL_, 0xE2, 0x89, 0xA0, FIL_,
@@ -10674,6 +10694,7 @@ static const uchar_t u8_composition_final_tbl[U8_UNICODE_LATEST + 1][6623] = {
 };
 
 static const uchar_t u8_decomp_b2_tbl[U8_UNICODE_LATEST + 1][2][256] = {
+#ifdef U8_UNICODE_320
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -10745,6 +10766,7 @@ static const uchar_t u8_decomp_b2_tbl[U8_UNICODE_LATEST + 1][2][256] = {
 		},
 
 	},
+#endif
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -10821,6 +10843,7 @@ static const uchar_t u8_decomp_b2_tbl[U8_UNICODE_LATEST + 1][2][256] = {
 
 static const u8_displacement_t u8_decomp_b3_tbl[U8_UNICODE_LATEST + 1][8][256] =
 {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Third byte table 0. */
 			{ N_, 0 }, { N_, 0 }, { N_, 0 },
@@ -11527,6 +11550,7 @@ static const u8_displacement_t u8_decomp_b3_tbl[U8_UNICODE_LATEST + 1][8][256] =
 			{ N_, 0 },
 		},
 	},
+#endif
 	{
 		{	/* Third byte table 0. */
 			{ N_, 0 }, { N_, 0 }, { N_, 0 },
@@ -12236,6 +12260,7 @@ static const u8_displacement_t u8_decomp_b3_tbl[U8_UNICODE_LATEST + 1][8][256] =
 };
 
 static const uchar_t u8_decomp_b4_tbl[U8_UNICODE_LATEST + 1][118][257] = {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -16368,6 +16393,7 @@ static const uchar_t u8_decomp_b4_tbl[U8_UNICODE_LATEST + 1][118][257] = {
 			0,
 		},
 	},
+#endif
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -20503,6 +20529,7 @@ static const uchar_t u8_decomp_b4_tbl[U8_UNICODE_LATEST + 1][118][257] = {
 };
 
 static const uint16_t u8_decomp_b4_16bit_tbl[U8_UNICODE_LATEST + 1][30][257] = {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Fourth byte 16-bit table 0. */
 			0,    0,    0,    0,    0,    0,    0,    0,
@@ -21555,6 +21582,7 @@ static const uint16_t u8_decomp_b4_16bit_tbl[U8_UNICODE_LATEST + 1][30][257] = {
 			0,
 		},
 	},
+#endif
 	{
 		{	/* Fourth byte 16-bit table 0. */
 			0,    0,    0,    0,    0,    0,    0,    0,
@@ -22610,6 +22638,7 @@ static const uint16_t u8_decomp_b4_16bit_tbl[U8_UNICODE_LATEST + 1][30][257] = {
 };
 
 static const uchar_t u8_decomp_final_tbl[U8_UNICODE_LATEST + 1][19370] = {
+#ifdef U8_UNICODE_320
 	{
 		0x20, 0x20, 0xCC, 0x88, 0x61, 0x20, 0xCC, 0x84,
 		0x32, 0x33, 0x20, 0xCC, 0x81, 0xCE, 0xBC, 0x20,
@@ -25034,6 +25063,7 @@ static const uchar_t u8_decomp_final_tbl[U8_UNICODE_LATEST + 1][19370] = {
 		0,    0,    0,    0,    0,    0,    0,    0,
 		0,    0,
 	},
+#endif
 	{
 		0x20, 0x20, 0xCC, 0x88, 0x61, 0x20, 0xCC, 0x84,
 		0x32, 0x33, 0x20, 0xCC, 0x81, 0xCE, 0xBC, 0x20,
@@ -27461,6 +27491,7 @@ static const uchar_t u8_decomp_final_tbl[U8_UNICODE_LATEST + 1][19370] = {
 };
 
 static const uchar_t u8_case_common_b2_tbl[U8_UNICODE_LATEST + 1][2][256] = {
+#ifdef U8_UNICODE_320
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -27532,6 +27563,7 @@ static const uchar_t u8_case_common_b2_tbl[U8_UNICODE_LATEST + 1][2][256] = {
 		},
 
 	},
+#endif
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -27609,6 +27641,7 @@ static const uchar_t u8_case_common_b2_tbl[U8_UNICODE_LATEST + 1][2][256] = {
 static const u8_displacement_t u8_tolower_b3_tbl[
     U8_UNICODE_LATEST + 1][5][256] =
 {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Third byte table 0. */
 			{ N_, 0 }, { N_, 0 }, { N_, 0 }, { N_, 0 },
@@ -27941,6 +27974,7 @@ static const u8_displacement_t u8_tolower_b3_tbl[
 			{ N_, 0 }, { N_, 0 }, { N_, 0 }, { N_, 0 },
 		},
 	},
+#endif
 	{
 		{	/* Third byte table 0. */
 			{ N_, 0 }, { N_, 0 }, { N_, 0 }, { N_, 0 },
@@ -28276,6 +28310,7 @@ static const u8_displacement_t u8_tolower_b3_tbl[
 };
 
 static const uchar_t u8_tolower_b4_tbl[U8_UNICODE_LATEST + 1][36][257] = {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -29538,6 +29573,7 @@ static const uchar_t u8_tolower_b4_tbl[U8_UNICODE_LATEST + 1][36][257] = {
 			0,
 		},
 	},
+#endif
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -30803,6 +30839,7 @@ static const uchar_t u8_tolower_b4_tbl[U8_UNICODE_LATEST + 1][36][257] = {
 };
 
 static const uchar_t u8_tolower_final_tbl[U8_UNICODE_LATEST + 1][2299] = {
+#ifdef U8_UNICODE_320
 	{
 		0xC3, 0xA0, 0xC3, 0xA1, 0xC3, 0xA2, 0xC3, 0xA3,
 		0xC3, 0xA4, 0xC3, 0xA5, 0xC3, 0xA6, 0xC3, 0xA7,
@@ -31093,6 +31130,7 @@ static const uchar_t u8_tolower_final_tbl[U8_UNICODE_LATEST + 1][2299] = {
 		0,    0,    0,    0,    0,    0,    0,    0,
 		0,    0,    0,
 	},
+#endif
 	{
 		0xC3, 0xA0, 0xC3, 0xA1, 0xC3, 0xA2, 0xC3, 0xA3,
 		0xC3, 0xA4, 0xC3, 0xA5, 0xC3, 0xA6, 0xC3, 0xA7,
@@ -31388,6 +31426,7 @@ static const uchar_t u8_tolower_final_tbl[U8_UNICODE_LATEST + 1][2299] = {
 static const u8_displacement_t u8_toupper_b3_tbl[
     U8_UNICODE_LATEST + 1][5][256] =
 {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Third byte table 0. */
 			{ N_, 0 }, { N_, 0 }, { N_, 0 }, { N_, 0 },
@@ -31720,6 +31759,7 @@ static const u8_displacement_t u8_toupper_b3_tbl[
 			{ N_, 0 }, { N_, 0 }, { N_, 0 }, { N_, 0 },
 		},
 	},
+#endif
 	{
 		{	/* Third byte table 0. */
 			{ N_, 0 }, { N_, 0 }, { N_, 0 }, { N_, 0 },
@@ -32055,6 +32095,7 @@ static const u8_displacement_t u8_toupper_b3_tbl[
 };
 
 static const uchar_t u8_toupper_b4_tbl[U8_UNICODE_LATEST + 1][39][257] = {
+#ifdef U8_UNICODE_320
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -33422,6 +33463,7 @@ static const uchar_t u8_toupper_b4_tbl[U8_UNICODE_LATEST + 1][39][257] = {
 			0,
 		},
 	},
+#endif
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -34792,6 +34834,7 @@ static const uchar_t u8_toupper_b4_tbl[U8_UNICODE_LATEST + 1][39][257] = {
 };
 
 static const uchar_t u8_toupper_final_tbl[U8_UNICODE_LATEST + 1][2318] = {
+#ifdef U8_UNICODE_320
 	{
 		0xCE, 0x9C, 0xC3, 0x80, 0xC3, 0x81, 0xC3, 0x82,
 		0xC3, 0x83, 0xC3, 0x84, 0xC3, 0x85, 0xC3, 0x86,
@@ -35084,6 +35127,7 @@ static const uchar_t u8_toupper_final_tbl[U8_UNICODE_LATEST + 1][2318] = {
 		0,    0,    0,    0,    0,    0,    0,    0,
 		0,    0,    0,    0,    0,    0,
 	},
+#endif
 	{
 		0xCE, 0x9C, 0xC3, 0x80, 0xC3, 0x81, 0xC3, 0x82,
 		0xC3, 0x83, 0xC3, 0x84, 0xC3, 0x85, 0xC3, 0x86,

--- a/include/sys/u8_textprep_data.h
+++ b/include/sys/u8_textprep_data.h
@@ -27638,6 +27638,7 @@ static const uchar_t u8_case_common_b2_tbl[U8_UNICODE_LATEST + 1][2][256] = {
 
 };
 
+#ifdef U8_STRCMP_CI_LOWER
 static const u8_displacement_t u8_tolower_b3_tbl[
     U8_UNICODE_LATEST + 1][5][256] =
 {
@@ -31422,6 +31423,7 @@ static const uchar_t u8_tolower_final_tbl[U8_UNICODE_LATEST + 1][2299] = {
 		0x90, 0x91, 0x8F,
 	},
 };
+#endif
 
 static const u8_displacement_t u8_toupper_b3_tbl[
     U8_UNICODE_LATEST + 1][5][256] =

--- a/include/sys/u8_textprep_data.h
+++ b/include/sys/u8_textprep_data.h
@@ -146,7 +146,7 @@ typedef struct {
  * The common b1_tbl for combining class, decompositions, tolower, and
  * toupper case conversion mappings.
  */
-static const uchar_t u8_common_b1_tbl[2][256] = {
+static const uchar_t u8_common_b1_tbl[U8_UNICODE_LATEST + 1][256] = {
 	{
 		0,  N_, N_, N_, N_, N_, N_, N_,
 		N_, N_, N_, N_, N_, N_, N_, N_,
@@ -217,7 +217,8 @@ static const uchar_t u8_common_b1_tbl[2][256] = {
 	},
 };
 
-static const uchar_t u8_combining_class_b2_tbl[2][2][256] = {
+static const uchar_t u8_combining_class_b2_tbl[U8_UNICODE_LATEST + 1][2][256] =
+{
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -363,7 +364,8 @@ static const uchar_t u8_combining_class_b2_tbl[2][2][256] = {
 
 };
 
-static const uchar_t u8_combining_class_b3_tbl[2][9][256] = {
+static const uchar_t u8_combining_class_b3_tbl[U8_UNICODE_LATEST + 1][9][256] =
+{
 	{
 		{	/* Third byte table 0. */
 			N_, N_, N_, N_, N_, N_, N_, N_,
@@ -986,7 +988,8 @@ static const uchar_t u8_combining_class_b3_tbl[2][9][256] = {
  * Unlike other b4_tbl, the b4_tbl for combining class data has
  * the combining class values not indices to the final tables.
  */
-static const uchar_t u8_combining_class_b4_tbl[2][55][256] = {
+static const uchar_t u8_combining_class_b4_tbl[U8_UNICODE_LATEST + 1][55][256] =
+{
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -4733,7 +4736,7 @@ static const uchar_t u8_combining_class_b4_tbl[2][55][256] = {
 	},
 };
 
-static const uchar_t u8_composition_b1_tbl[2][256] = {
+static const uchar_t u8_composition_b1_tbl[U8_UNICODE_LATEST + 1][256] = {
 	{
 		0,  N_, N_, N_, N_, N_, N_, N_,
 		N_, N_, N_, N_, N_, N_, N_, N_,
@@ -4804,7 +4807,7 @@ static const uchar_t u8_composition_b1_tbl[2][256] = {
 	},
 };
 
-static const uchar_t u8_composition_b2_tbl[2][1][256] = {
+static const uchar_t u8_composition_b2_tbl[U8_UNICODE_LATEST + 1][1][256] = {
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -4882,7 +4885,9 @@ static const uchar_t u8_composition_b2_tbl[2][1][256] = {
 
 };
 
-static const u8_displacement_t u8_composition_b3_tbl[2][5][256] = {
+static const u8_displacement_t u8_composition_b3_tbl[
+    U8_UNICODE_LATEST + 1][5][256] =
+{
 	{
 		{	/* Third byte table 0. */
 			{ 0x8000, 0 }, { N_, 0 }, { N_, 0 },
@@ -5769,7 +5774,7 @@ static const u8_displacement_t u8_composition_b3_tbl[2][5][256] = {
 	},
 };
 
-static const uchar_t u8_composition_b4_tbl[2][41][257] = {
+static const uchar_t u8_composition_b4_tbl[U8_UNICODE_LATEST + 1][41][257] = {
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -8646,7 +8651,9 @@ static const uchar_t u8_composition_b4_tbl[2][41][257] = {
 	},
 };
 
-static const uint16_t u8_composition_b4_16bit_tbl[2][5][257] = {
+static const uint16_t u8_composition_b4_16bit_tbl[
+    U8_UNICODE_LATEST + 1][5][257] =
+{
 	{
 		{	/* Fourth byte 16-bit table 0. */
 			0,    0,    0,    0,    0,    0,    0,    0,
@@ -9003,7 +9010,7 @@ static const uint16_t u8_composition_b4_16bit_tbl[2][5][257] = {
 	},
 };
 
-static const uchar_t u8_composition_final_tbl[2][6623] = {
+static const uchar_t u8_composition_final_tbl[U8_UNICODE_LATEST + 1][6623] = {
 	{
 		0x01, 0xCC, 0xB8, FIL_, 0xE2, 0x89, 0xAE, FIL_,
 		0x01, 0xCC, 0xB8, FIL_, 0xE2, 0x89, 0xA0, FIL_,
@@ -10666,7 +10673,7 @@ static const uchar_t u8_composition_final_tbl[2][6623] = {
 	},
 };
 
-static const uchar_t u8_decomp_b2_tbl[2][2][256] = {
+static const uchar_t u8_decomp_b2_tbl[U8_UNICODE_LATEST + 1][2][256] = {
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -10812,7 +10819,8 @@ static const uchar_t u8_decomp_b2_tbl[2][2][256] = {
 
 };
 
-static const u8_displacement_t u8_decomp_b3_tbl[2][8][256] = {
+static const u8_displacement_t u8_decomp_b3_tbl[U8_UNICODE_LATEST + 1][8][256] =
+{
 	{
 		{	/* Third byte table 0. */
 			{ N_, 0 }, { N_, 0 }, { N_, 0 },
@@ -12227,7 +12235,7 @@ static const u8_displacement_t u8_decomp_b3_tbl[2][8][256] = {
 	},
 };
 
-static const uchar_t u8_decomp_b4_tbl[2][118][257] = {
+static const uchar_t u8_decomp_b4_tbl[U8_UNICODE_LATEST + 1][118][257] = {
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -20494,7 +20502,7 @@ static const uchar_t u8_decomp_b4_tbl[2][118][257] = {
 	},
 };
 
-static const uint16_t u8_decomp_b4_16bit_tbl[2][30][257] = {
+static const uint16_t u8_decomp_b4_16bit_tbl[U8_UNICODE_LATEST + 1][30][257] = {
 	{
 		{	/* Fourth byte 16-bit table 0. */
 			0,    0,    0,    0,    0,    0,    0,    0,
@@ -22601,7 +22609,7 @@ static const uint16_t u8_decomp_b4_16bit_tbl[2][30][257] = {
 	},
 };
 
-static const uchar_t u8_decomp_final_tbl[2][19370] = {
+static const uchar_t u8_decomp_final_tbl[U8_UNICODE_LATEST + 1][19370] = {
 	{
 		0x20, 0x20, 0xCC, 0x88, 0x61, 0x20, 0xCC, 0x84,
 		0x32, 0x33, 0x20, 0xCC, 0x81, 0xCE, 0xBC, 0x20,
@@ -27452,7 +27460,7 @@ static const uchar_t u8_decomp_final_tbl[2][19370] = {
 	},
 };
 
-static const uchar_t u8_case_common_b2_tbl[2][2][256] = {
+static const uchar_t u8_case_common_b2_tbl[U8_UNICODE_LATEST + 1][2][256] = {
 	{
 		{
 			0,  N_, N_, N_, N_, N_, N_, N_,
@@ -27598,7 +27606,9 @@ static const uchar_t u8_case_common_b2_tbl[2][2][256] = {
 
 };
 
-static const u8_displacement_t u8_tolower_b3_tbl[2][5][256] = {
+static const u8_displacement_t u8_tolower_b3_tbl[
+    U8_UNICODE_LATEST + 1][5][256] =
+{
 	{
 		{	/* Third byte table 0. */
 			{ N_, 0 }, { N_, 0 }, { N_, 0 }, { N_, 0 },
@@ -28265,7 +28275,7 @@ static const u8_displacement_t u8_tolower_b3_tbl[2][5][256] = {
 	},
 };
 
-static const uchar_t u8_tolower_b4_tbl[2][36][257] = {
+static const uchar_t u8_tolower_b4_tbl[U8_UNICODE_LATEST + 1][36][257] = {
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -30792,7 +30802,7 @@ static const uchar_t u8_tolower_b4_tbl[2][36][257] = {
 	},
 };
 
-static const uchar_t u8_tolower_final_tbl[2][2299] = {
+static const uchar_t u8_tolower_final_tbl[U8_UNICODE_LATEST + 1][2299] = {
 	{
 		0xC3, 0xA0, 0xC3, 0xA1, 0xC3, 0xA2, 0xC3, 0xA3,
 		0xC3, 0xA4, 0xC3, 0xA5, 0xC3, 0xA6, 0xC3, 0xA7,
@@ -31375,7 +31385,9 @@ static const uchar_t u8_tolower_final_tbl[2][2299] = {
 	},
 };
 
-static const u8_displacement_t u8_toupper_b3_tbl[2][5][256] = {
+static const u8_displacement_t u8_toupper_b3_tbl[
+    U8_UNICODE_LATEST + 1][5][256] =
+{
 	{
 		{	/* Third byte table 0. */
 			{ N_, 0 }, { N_, 0 }, { N_, 0 }, { N_, 0 },
@@ -32042,7 +32054,7 @@ static const u8_displacement_t u8_toupper_b3_tbl[2][5][256] = {
 	},
 };
 
-static const uchar_t u8_toupper_b4_tbl[2][39][257] = {
+static const uchar_t u8_toupper_b4_tbl[U8_UNICODE_LATEST + 1][39][257] = {
 	{
 		{	/* Fourth byte table 0. */
 			0,   0,   0,   0,   0,   0,   0,   0,
@@ -34779,7 +34791,7 @@ static const uchar_t u8_toupper_b4_tbl[2][39][257] = {
 	},
 };
 
-static const uchar_t u8_toupper_final_tbl[2][2318] = {
+static const uchar_t u8_toupper_final_tbl[U8_UNICODE_LATEST + 1][2318] = {
 	{
 		0xCE, 0x9C, 0xC3, 0x80, 0xC3, 0x81, 0xC3, 0x82,
 		0xC3, 0x83, 0xC3, 0x84, 0xC3, 0x85, 0xC3, 0x86,


### PR DESCRIPTION
### Motivation and Context
The second (non-uconv) half of #13224, minus U8_TEXTPREP_NOWAIT, U8_VALIDATE_CHECK_ADDITIONAL, and U8_VALIDATE_UCS2_RANGE (rejected in review below)

### Description

The API remains, the removed bits are `#if`ed out.

```
$ size -G ./module/zfs.ko ./module/zfs.new.ko
      text       data        bss      total filename
   2865126    1597982     755768    5218876 ./module/zfs.ko
   2864038    1429784     755768    5049590 ./module/zfs.new.ko
     -1088    -168198
       -1k      -164k
```
### How Has This Been Tested?
Builds.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. — none apply
- [ ] I have run the ZFS Test Suite with this change applied. — CI take my hand
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
