### PR TITLE
zfs(4): remove "experimental" from `zfs_bclone_enabled`

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -18,7 +18,7 @@
 .\"
 .\" Copyright (c) 2024, Klara, Inc.
 .\"
-.Dd October 2, 2024
+.Dd November 1, 2024
 .Dt ZFS 4
 .Os
 .
@@ -1333,9 +1333,10 @@ results in vector instructions
 from the respective CPU instruction set being used.
 .
 .It Sy zfs_bclone_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
-Enable the experimental block cloning feature.
+Enables access to the block cloning feature.
 If this setting is 0, then even if feature@block_cloning is enabled,
-attempts to clone blocks will act as though the feature is disabled.
+using functions and system calls that attempt to clone blocks will act as
+though the feature is disabled.
 .
 .It Sy zfs_bclone_wait_dirty Ns = Ns Sy 0 Ns | Ns 1 Pq int
 When set to 1 the FICLONE and FICLONERANGE ioctls wait for dirty data to be

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -58,9 +58,9 @@
 #include <sys/zfs_znode.h>
 
 /*
- * Enable the experimental block cloning feature.  If this setting is 0, then
- * even if feature@block_cloning is enabled, attempts to clone blocks will act
- * as though the feature is disabled.
+ * Enables access to the block cloning feature. If this setting is 0, then even
+ * if feature@block_cloning is enabled, using functions and system calls that
+ * attempt to clone blocks will act as though the feature is disabled.
  */
 int zfs_bclone_enabled = 1;
 


### PR DESCRIPTION
### Motivation and Context

If we don't know what we've got by now, we should probably give up and move somewhere nice and without electricity.

Closes #16189.

### Description

Remove "experimental", and slightly reword.

### How Has This Been Tested?

Just `make mancheck`.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
