### PR TITLE
Verify parent_dev before calling udev_device_get_sysattr_value

### DIFF
--- a/cmd/zed/zed_disk_event.c
+++ b/cmd/zed/zed_disk_event.c
@@ -139,7 +139,8 @@ dev_event_nvlist(struct udev_device *dev)
 		 * is /dev/sda.
 		 */
 		struct udev_device *parent_dev = udev_device_get_parent(dev);
-		if ((value = udev_device_get_sysattr_value(parent_dev, "size"))
+		if (parent_dev != NULL &&
+		    (value = udev_device_get_sysattr_value(parent_dev, "size"))
 		    != NULL) {
 			uint64_t numval = DEV_BSIZE;
 


### PR DESCRIPTION
Fixes: https://github.com/openzfs/zfs/issues/16705

Not all udev devices have parent devices.
Calling udev_device_get_ functions yield an assertion error if called with a NULL pointer.

Changes to be committed:
	modified:   cmd/zed/zed_disk_event.c


### How Has This Been Tested?
Tested on a test vm

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
