### PR TITLE
add ARC & L2ARC hit/miss bytes to arcstat

### DIFF
--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -547,6 +547,10 @@ typedef struct arc_stats {
 	kstat_named_t arcstat_mfu_ghost_hits;
 	kstat_named_t arcstat_uncached_hits;
 	kstat_named_t arcstat_deleted;
+	/* Number of bytes that were satisfied without I/O. */
+	kstat_named_t arcstat_hit_bytes;
+	/* Number of bytes for which I/O has to be issued. */
+	kstat_named_t arcstat_miss_bytes;
 	/*
 	 * Number of buffers that could not be evicted because the hash lock
 	 * was held by another thread.  The lock may not necessarily be held
@@ -793,6 +797,8 @@ typedef struct arc_stats {
 	kstat_named_t arcstat_l2_bufc_metadata_asize;
 	kstat_named_t arcstat_l2_feeds;
 	kstat_named_t arcstat_l2_rw_clash;
+	kstat_named_t arcstat_l2_hit_bytes;
+	kstat_named_t arcstat_l2_miss_bytes;
 	kstat_named_t arcstat_l2_read_bytes;
 	kstat_named_t arcstat_l2_write_bytes;
 	kstat_named_t arcstat_l2_writes_sent;
@@ -932,6 +938,8 @@ typedef struct arc_sums {
 	wmsum_t arcstat_mfu_ghost_hits;
 	wmsum_t arcstat_uncached_hits;
 	wmsum_t arcstat_deleted;
+	wmsum_t arcstat_hit_bytes;
+	wmsum_t arcstat_miss_bytes;
 	wmsum_t arcstat_mutex_miss;
 	wmsum_t arcstat_access_skip;
 	wmsum_t arcstat_evict_skip;
@@ -963,6 +971,8 @@ typedef struct arc_sums {
 	wmsum_t arcstat_l2_bufc_metadata_asize;
 	wmsum_t arcstat_l2_feeds;
 	wmsum_t arcstat_l2_rw_clash;
+	wmsum_t arcstat_l2_hit_bytes;
+	wmsum_t arcstat_l2_miss_bytes;
 	wmsum_t arcstat_l2_read_bytes;
 	wmsum_t arcstat_l2_write_bytes;
 	wmsum_t arcstat_l2_writes_sent;


### PR DESCRIPTION
### Motivation and Context
Currently there's no way to see the actual bytes hit/miss from the ARC & L2ARC.

### Description
This PR adds number of bytes that were hit/miss from ARC & L2ARC to arcstat. 

### How Has This Been Tested?
Tested and working in a local VM. Not sure if there're any corner cases though.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
