### PR TITLE
Encryption: document snapshot corruption

### DIFF
--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -162,18 +162,15 @@ For encrypted datasets, indicates where the dataset is currently inheriting its
 encryption key from.
 Loading or unloading a key for the
 .Sy encryptionroot
-will implicitly load / unload the key for any inheriting datasets (see
-.Nm zfs Cm load-key
-and
-.Nm zfs Cm unload-key
-for details).
+will implicitly load/unload the key for any inheriting datasets.
 Clones will always share an
 encryption key with their origin.
 See the
 .Sx Encryption
 section of
 .Xr zfs-load-key 8
-for details.
+for details and known
+.Sx BUGS .
 .It Sy filesystem_count
 The total number of filesystems and volumes that exist under this location in
 the dataset tree.
@@ -188,9 +185,9 @@ The possible values are
 and
 .Sy unavailable .
 See
-.Nm zfs Cm load-key
+.Xr zfs-load-key 8
 and
-.Nm zfs Cm unload-key .
+.Xr zfs-unload-key 8 .
 .It Sy guid
 The 64 bit GUID of this dataset or bookmark which does not change over its
 entire lifetime.
@@ -1148,7 +1145,9 @@ selected, which is currently
 In order to provide consistent data protection, encryption must be specified at
 dataset creation time and it cannot be changed afterwards.
 .Pp
-For more details and caveats about encryption see the
+For more details about encryption and known
+.Sx BUGS ,
+see the
 .Sx Encryption
 section of
 .Xr zfs-load-key 8 .

--- a/man/man8/zfs-load-key.8
+++ b/man/man8/zfs-load-key.8
@@ -222,7 +222,9 @@ that has an encrypted parent.
 .Ss Encryption
 Enabling the
 .Sy encryption
-feature allows for the creation of encrypted filesystems and volumes.
+feature allows for the creation of encrypted filesystems and volumes,
+but not yet snapshots
+.Pq see Sx BUGS .
 ZFS will encrypt file and volume data, file attributes, ACLs, permission bits,
 directory listings, FUID mappings, and
 .Sy userused Ns / Ns Sy groupused
@@ -302,3 +304,7 @@ written.
 .Xr zfsprops 7 ,
 .Xr zfs-create 8 ,
 .Xr zfs-set 8
+.Sh BUGS
+There is a known issue causing occasional runtime data corruption
+when creating snapshots of ZFS encrypted volumes via
+.Xr zfs-receive 8 .


### PR DESCRIPTION
There is a known issue reported on Linux and FreeBSD whereby snapshots experience runtime corruption when using ZFS native encryption. This filesystem is far too reliable for that to be a surprise until it can be fixed.

OpenZFS bug:	[#12014](https://github.com/openzfs/zfs/issues/12014)
FreeBSD bug:	[#282622](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=282622)
Signed-off-by:	Alexander Ziaee <ziaee@google.com>
Co-authored-by:	Lexi Winter <lexi@le-fay.org>

Cc @amotin @mmatuska, thanks.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
