### PR TITLE
On-demand log-spacemap flush; `zpool condense` command

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -366,7 +366,8 @@ static const char *vdev_trim_state_str[] = {
 };
 
 static const char *condense_unit(const char *type) {
-	(void) type;
+	if (strcmp(type, POOL_CONDENSE_LOG_SPACEMAP) == 0)
+		return ("metaslabs");
 #ifdef ZFS_DEBUG
 	if (strcmp(type, "debug") == 0)
 		return ("nits");	/* fundamental unit of debugging? ;) */
@@ -8870,6 +8871,7 @@ zpool_do_trim(int argc, char **argv)
 }
 
 static const char *condense_types[] = {
+	POOL_CONDENSE_LOG_SPACEMAP,
 #ifdef ZFS_DEBUG
 	"debug",
 #endif

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -33,8 +33,9 @@
  * Copyright (c) 2017, Intel Corporation.
  * Copyright (c) 2019, loli10K <ezomori.nozomu@gmail.com>
  * Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
- * Copyright (c) 2021, 2023, 2025, Klara, Inc.
+ * Copyright (c) 2021, 2023-2026, Klara, Inc.
  * Copyright (c) 2021, 2025 Hewlett Packard Enterprise Development LP.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #include <assert.h>
@@ -127,6 +128,7 @@ static int zpool_do_get(int, char **);
 static int zpool_do_set(int, char **);
 
 static int zpool_do_sync(int, char **);
+static int zpool_do_condense(int, char **);
 
 static int zpool_do_version(int, char **);
 
@@ -146,7 +148,8 @@ enum zpool_options {
 	ZPOOL_OPTION_ALLOW_ASHIFT_MISMATCH,
 	ZPOOL_OPTION_POOL_KEY_GUID,
 	ZPOOL_OPTION_JSON_NUMS_AS_INT,
-	ZPOOL_OPTION_JSON_FLAT_VDEVS
+	ZPOOL_OPTION_JSON_FLAT_VDEVS,
+	ZPOOL_OPTION_CONDENSE_LIST_TYPES
 };
 
 /*
@@ -174,6 +177,7 @@ typedef enum {
 	HELP_CLEAR,
 	HELP_CREATE,
 	HELP_CHECKPOINT,
+	HELP_CONDENSE,
 	HELP_DDT_PRUNE,
 	HELP_DESTROY,
 	HELP_DETACH,
@@ -361,6 +365,15 @@ static const char *vdev_trim_state_str[] = {
 	"COMPLETE"
 };
 
+static const char *condense_unit(const char *type) {
+	(void) type;
+#ifdef ZFS_DEBUG
+	if (strcmp(type, "debug") == 0)
+		return ("nits");	/* fundamental unit of debugging? ;) */
+#endif
+	return ("items");
+}
+
 #define	ZFS_NICE_TIMESTAMP	100
 
 /*
@@ -417,6 +430,7 @@ static zpool_command_t command_table[] = {
 	{ "resilver",	zpool_do_resilver,	HELP_RESILVER		},
 	{ "scrub",	zpool_do_scrub,		HELP_SCRUB		},
 	{ "trim",	zpool_do_trim,		HELP_TRIM		},
+	{ "condense",	zpool_do_condense,	HELP_CONDENSE		},
 	{ NULL },
 	{ "import",	zpool_do_import,	HELP_IMPORT		},
 	{ "export",	zpool_do_export,	HELP_EXPORT		},
@@ -428,6 +442,7 @@ static zpool_command_t command_table[] = {
 	{ NULL },
 	{ "get",	zpool_do_get,		HELP_GET		},
 	{ "set",	zpool_do_set,		HELP_SET		},
+	{ NULL },
 	{ "sync",	zpool_do_sync,		HELP_SYNC		},
 	{ NULL },
 	{ "wait",	zpool_do_wait,		HELP_WAIT		},
@@ -547,6 +562,10 @@ get_usage(zpool_help_t idx)
 		return (gettext("\treguid [-g guid] <pool>\n"));
 	case HELP_SYNC:
 		return (gettext("\tsync [pool] ...\n"));
+	case HELP_CONDENSE:
+		return (gettext("\tcondense [-t <type>] [-c | -w] "
+		    "[-a | <pool> ...]\n"
+		    "\tcondense --types\n"));
 	case HELP_VERSION:
 		return (gettext("\tversion [-j]\n"));
 	case HELP_WAIT:
@@ -8850,6 +8869,155 @@ zpool_do_trim(int argc, char **argv)
 	return (error);
 }
 
+static const char *condense_types[] = {
+#ifdef ZFS_DEBUG
+	"debug",
+#endif
+	NULL,
+};
+
+typedef struct {
+	const char *cmd;
+	const char *type;
+} condense_cb_t;
+
+static int
+condense_cb(zpool_handle_t *zhp, void *data)
+{
+	condense_cb_t *cb = data;
+	if (cb->type != NULL)
+		return (zpool_condense(zhp, cb->cmd, cb->type));
+
+	int err = 0;
+	for (uint_t i = 0; condense_types[i] != NULL; i++) {
+#ifdef ZFS_DEBUG
+		/*
+		 * Skip the debug type when no type is specificed. This is
+		 * the "condense everything" mode, and people _do_ run debug
+		 * builds, and we don't want them to be accidentally running
+		 * the debug condense op.
+		 */
+		if (strcmp(condense_types[i], "debug") == 0)
+			continue;
+#endif
+		err = zpool_condense(zhp, cb->cmd, condense_types[i]);
+
+		/*
+		 * Quietly ignore ENOTSUP, so we don't fail all condense types
+		 * just because one isn't supporte.d
+		 */
+		if (err != 0 && err != ENOTSUP)
+			break;
+	}
+
+	return (err);
+}
+
+/*
+ * zpool condense [-t <type>] [-c | -w] [-a | <pool> ...]
+ *
+ *	-t <type>	What to condense.
+ *	-a		Condense all pools.
+ *	-c		Cancel. Ends any in-progress condense.
+ *	-w		Wait. Blocks until condense has completed.
+ *
+ * Condense (flush, garbage-collect) the pool metadata on the specfied pools.
+ */
+static int
+zpool_do_condense(int argc, char **argv)
+{
+	struct option long_options[] = {
+		{"type",	required_argument,	NULL,	't'},
+		{"all",		no_argument,		NULL,	'a'},
+		{"cancel",	no_argument,		NULL,	'c'},
+		{"wait",	no_argument,		NULL,	'w'},
+		{"types",	no_argument,		NULL,
+		    ZPOOL_OPTION_CONDENSE_LIST_TYPES},
+		{0, 0, 0, 0}
+	};
+
+	condense_cb_t cb = {
+		.cmd = "start",
+		.type = NULL,
+	};
+
+	boolean_t cancel = B_FALSE;
+	boolean_t all_pools = B_FALSE;
+	boolean_t wait = B_FALSE;
+
+	int c;
+	while ((c = getopt_long(argc, argv, "at:cw", long_options, NULL))
+	    != -1) {
+		switch (c) {
+		case 'a':
+			all_pools = B_TRUE;
+			break;
+		case 't': {
+			for (uint_t i = 0; condense_types[i] != NULL; i++) {
+				if (strcmp(condense_types[i], optarg) == 0) {
+					cb.type = condense_types[i];
+					break;
+				}
+			}
+			if (cb.type == NULL) {
+				(void) fprintf(stderr,
+				    gettext("invalid condense type '%s'\n"),
+				    optarg);
+				usage(B_FALSE);
+			}
+			break;
+		}
+		case 'c':
+			cb.cmd = "cancel";
+			cancel = B_TRUE;
+			break;
+		case 'w':
+			wait = B_TRUE;
+			break;
+		case ZPOOL_OPTION_CONDENSE_LIST_TYPES:
+			for (uint_t i = 0; condense_types[i] != NULL; i++)
+				printf("%s\n", condense_types[i]);
+			return (0);
+		case '?':
+			if (optopt != 0) {
+				(void) fprintf(stderr,
+				    gettext("invalid option '%c'\n"), optopt);
+			} else {
+				(void) fprintf(stderr,
+				    gettext("invalid option '%s'\n"),
+				    argv[optind - 1]);
+			}
+			usage(B_FALSE);
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (argc < 1 && !all_pools) {
+		(void) fprintf(stderr, gettext("missing pool name argument\n"));
+		usage(B_FALSE);
+		return (-1);
+	}
+
+	if (wait && cancel) {
+		(void) fprintf(stderr, gettext("-w cannot be used with -c\n"));
+		usage(B_FALSE);
+	}
+
+	int error = for_each_pool(argc, argv, B_FALSE, NULL, ZFS_TYPE_POOL,
+	    B_FALSE, condense_cb, &cb);
+
+	if (wait && !error) {
+		zpool_wait_activity_t act = ZPOOL_WAIT_CONDENSE;
+		error = for_each_pool(argc, argv, B_FALSE, NULL, ZFS_TYPE_POOL,
+		    B_FALSE, wait_callback, &act);
+	}
+
+	return (error);
+}
+
+
 /*
  * Converts a total number of seconds to a human readable string broken
  * down in to days/hours/minutes/seconds.
@@ -9930,6 +10098,53 @@ removal_status_nvlist(zpool_handle_t *zhp, status_cbdata_t *cb,
 }
 
 static void
+condense_status_nvlist(nvlist_t *nvroot, status_cbdata_t *cb, nvlist_t *item)
+{
+	nvlist_t *cnv = NULL;
+	nvlist_lookup_nvlist(nvroot, ZPOOL_CONFIG_CONDENSE_STATS, &cnv);
+	if (cnv == NULL)
+		return;
+
+	nvlist_t *onv = fnvlist_alloc();
+	for (nvpair_t *nvp = nvlist_next_nvpair(cnv, NULL);
+	    nvp != NULL; nvp = nvlist_next_nvpair(cnv, nvp)) {
+		const char *type = nvpair_name(nvp);
+		nvlist_t *tnv = fnvpair_value_nvlist(nvp);
+
+		uint64_t start_time = fnvlist_lookup_uint64(tnv, "start_time");
+		if (start_time == 0)
+			continue;
+
+		uint64_t end_time = fnvlist_lookup_uint64(tnv, "end_time");
+		uint64_t processed = fnvlist_lookup_uint64(tnv, "processed");
+		uint64_t total = fnvlist_lookup_uint64(tnv, "total");
+
+		nvlist_t *nv = fnvlist_alloc();
+		nice_num_str_nvlist(nv, "start_time", start_time,
+		    cb->cb_literal, cb->cb_json_as_int, ZFS_NICE_TIMESTAMP);
+		if (end_time > 0)
+			nice_num_str_nvlist(nv, "end_time", end_time,
+			    cb->cb_literal, cb->cb_json_as_int,
+			    ZFS_NICE_TIMESTAMP);
+		nice_num_str_nvlist(nv, "processed", processed,
+		    cb->cb_literal, cb->cb_json_as_int, ZFS_NICENUM_1024);
+		nice_num_str_nvlist(nv, "total", total,
+		    cb->cb_literal, cb->cb_json_as_int, ZFS_NICENUM_1024);
+
+		fnvlist_add_string(nv, "unit", condense_unit(type));
+
+		fnvlist_add_nvlist(onv, type, nv);
+		fnvlist_free(nv);
+	}
+
+	if (fnvlist_num_pairs(onv))
+		fnvlist_add_nvlist(item, "condense", onv);
+
+	fnvlist_free(onv);
+}
+
+
+static void
 scan_status_nvlist(zpool_handle_t *zhp, status_cbdata_t *cb,
     nvlist_t *nvroot, nvlist_t *item)
 {
@@ -10371,6 +10586,50 @@ print_checkpoint_status(pool_checkpoint_stat_t *pcs)
 
 	(void) printf(gettext("discarding, %s remaining.\n"),
 	    space_buf);
+}
+
+static void
+print_condense_status(nvlist_t *nv)
+{
+	if (nv == NULL)
+		return;
+
+	for (nvpair_t *nvp = nvlist_next_nvpair(nv, NULL);
+	    nvp != NULL; nvp = nvlist_next_nvpair(nv, nvp)) {
+		const char *type = nvpair_name(nvp);
+		nvlist_t *tnv = fnvpair_value_nvlist(nvp);
+
+		uint64_t start_time = fnvlist_lookup_uint64(tnv, "start_time");
+		if (start_time == 0)
+			continue;
+
+		uint64_t end_time = fnvlist_lookup_uint64(tnv, "end_time");
+		uint64_t processed = fnvlist_lookup_uint64(tnv, "processed");
+		uint64_t total = fnvlist_lookup_uint64(tnv, "total");
+
+		const char *units = condense_unit(type);
+
+		char cur[32], tot[32], elapsed[32];
+		zfs_nicenum(processed, cur, sizeof (cur));
+		zfs_nicenum(total, tot, sizeof (tot));
+
+		if (end_time == 0) {
+			secs_to_dhms(time(NULL) - start_time, elapsed);
+			(void) printf(gettext(
+			    "condense: %s: condensing, %s/%s %s done in %s\n"),
+			    type, cur, tot, units, elapsed);
+		} else if (processed < total) {
+			secs_to_dhms(end_time - start_time, elapsed);
+			(void) printf(gettext(
+			    "condense: %s: cancelled, %s/%s %s done in %s\n"),
+			    type, cur, tot, units, elapsed);
+		} else {
+			secs_to_dhms(end_time - start_time, elapsed);
+			(void) printf(gettext(
+			    "condense: %s: done, %s %s done in %s\n"),
+			    type, cur, units, elapsed);
+		}
+	}
 }
 
 static void
@@ -10952,6 +11211,7 @@ status_callback_json(zpool_handle_t *zhp, void *data)
 		scan_status_nvlist(zhp, cbp, nvroot, item);
 		removal_status_nvlist(zhp, cbp, nvroot, item);
 		checkpoint_status_nvlist(nvroot, cbp, item);
+		condense_status_nvlist(nvroot, cbp, item);
 		raidz_expand_status_nvlist(zhp, cbp, nvroot, item);
 		vdev_stats_nvlist(zhp, cbp, nvroot, 0, B_FALSE, NULL, vds);
 		if (cbp->cb_flat_vdevs) {
@@ -11098,6 +11358,10 @@ status_callback(zpool_handle_t *zhp, void *data)
 		(void) nvlist_lookup_uint64_array(nvroot,
 		    ZPOOL_CONFIG_RAIDZ_EXPAND_STATS, (uint64_t **)&pres, &c);
 		print_raidz_expand_status(zhp, pres);
+
+		nvlist_t *cnv = NULL;
+		nvlist_lookup_nvlist(nvroot, ZPOOL_CONFIG_CONDENSE_STATS, &cnv);
+		print_condense_status(cnv);
 
 		cbp->cb_namewidth = max_width(zhp, nvroot, 0, 0,
 		    cbp->cb_name_flags | VDEV_NAME_TYPE_ID);
@@ -13325,8 +13589,10 @@ print_wait_status_row(wait_data_t *wd, zpool_handle_t *zhp, int row)
 	pool_scan_stat_t *pss = NULL;
 	pool_removal_stat_t *prs = NULL;
 	pool_raidz_expand_stat_t *pres = NULL;
+	nvlist_t *cnv = NULL;
 	const char *const headers[] = {"DISCARD", "FREE", "INITIALIZE",
-	    "REPLACE", "REMOVE", "RESILVER", "SCRUB", "TRIM", "RAIDZ_EXPAND"};
+	    "REPLACE", "REMOVE", "RESILVER", "SCRUB", "TRIM", "RAIDZ_EXPAND",
+	    "CONDENSE"};
 	int col_widths[ZPOOL_WAIT_NUM_ACTIVITIES];
 
 	/* Calculate the width of each column */
@@ -13393,6 +13659,22 @@ print_wait_status_row(wait_data_t *wd, zpool_handle_t *zhp, int row)
 	if (pres != NULL && pres->pres_state == DSS_SCANNING) {
 		int64_t rem = pres->pres_to_reflow - pres->pres_reflowed;
 		bytes_rem[ZPOOL_WAIT_RAIDZ_EXPAND] = rem;
+	}
+
+	/*
+	 * Count each outstanding condense item as a "byte". Its not true,
+	 * but its a counter, and it'll display nicely.
+	 */
+	if (nvlist_lookup_nvlist(nvroot,
+	    ZPOOL_CONFIG_CONDENSE_STATS, &cnv) == 0) {
+		for (nvpair_t *nvp = nvlist_next_nvpair(cnv, NULL);
+		    nvp != NULL; nvp = nvlist_next_nvpair(cnv, nvp)) {
+			nvlist_t *tnv = fnvpair_value_nvlist(nvp);
+			uint64_t total = fnvlist_lookup_uint64(tnv, "total");
+			uint64_t processed =
+			    fnvlist_lookup_uint64(tnv, "processed");
+			bytes_rem[ZPOOL_WAIT_CONDENSE] += (total - processed);
+		}
 	}
 
 	bytes_rem[ZPOOL_WAIT_INITIALIZE] =
@@ -13533,7 +13815,7 @@ zpool_do_wait(int argc, char **argv)
 				static const char *const col_opts[] = {
 				    "discard", "free", "initialize", "replace",
 				    "remove", "resilver", "scrub", "trim",
-				    "raidz_expand" };
+				    "raidz_expand", "condense" };
 
 				for (i = 0; i < ARRAY_SIZE(col_opts); ++i)
 					if (strcmp(tok, col_opts[i]) == 0) {

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -27,7 +27,8 @@
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2017 Joyent, Inc.
  * Copyright (c) 2017, Intel Corporation.
- * Copyright (c) 2023, Klara, Inc.
+ * Copyright (c) 2023-2026, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 /*
@@ -450,6 +451,8 @@ ztest_func_t ztest_fletcher_incr;
 ztest_func_t ztest_verify_dnode_bt;
 ztest_func_t ztest_pool_prefetch_ddt;
 ztest_func_t ztest_ddt_prune;
+ztest_func_t ztest_spa_log_flushall_start;
+ztest_func_t ztest_spa_log_flushall_cancel;
 
 static uint64_t zopt_always = 0ULL * NANOSEC;		/* all the time */
 static uint64_t zopt_incessant = 1ULL * NANOSEC / 10;	/* every 1/10 second */
@@ -507,6 +510,8 @@ static ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_verify_dnode_bt, 1, &zopt_sometimes),
 	ZTI_INIT(ztest_pool_prefetch_ddt, 1, &zopt_rarely),
 	ZTI_INIT(ztest_ddt_prune, 1, &zopt_rarely),
+	ZTI_INIT(ztest_spa_log_flushall_start, 1, &zopt_rarely),
+	ZTI_INIT(ztest_spa_log_flushall_cancel, 1, &zopt_rarely),
 };
 
 #define	ZTEST_FUNCS	(sizeof (ztest_info) / sizeof (ztest_info_t))
@@ -6220,6 +6225,20 @@ ztest_verify_dnode_bt(ztest_ds_t *zd, uint64_t id)
 		dmu_buf_rele(db, FTAG);
 		ztest_object_unlock(zd, obj);
 	}
+}
+
+void
+ztest_spa_log_flushall_start(ztest_ds_t *zd, uint64_t id)
+{
+	(void) zd, (void) id;
+	spa_log_flushall_start(ztest_spa, SPA_LOG_FLUSHALL_REQUEST, 0);
+}
+
+void
+ztest_spa_log_flushall_cancel(ztest_ds_t *zd, uint64_t id)
+{
+	(void) zd, (void) id;
+	spa_log_flushall_cancel(ztest_spa);
 }
 
 void

--- a/contrib/debian/openzfs-zfsutils.install
+++ b/contrib/debian/openzfs-zfsutils.install
@@ -102,6 +102,7 @@ usr/share/man/man8/zpool-add.8
 usr/share/man/man8/zpool-attach.8
 usr/share/man/man8/zpool-checkpoint.8
 usr/share/man/man8/zpool-clear.8
+usr/share/man/man8/zpool-condense.8
 usr/share/man/man8/zpool-create.8
 usr/share/man/man8/zpool-ddtprune.8
 usr/share/man/man8/zpool-destroy.8

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -31,6 +31,8 @@
  * Copyright (c) 2019 Datto Inc.
  * Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
  * Copyright (c) 2025 Hewlett Packard Enterprise Development LP.
+ * Copyright (c) 2024-2026, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #ifndef	_LIBZFS_H
@@ -311,6 +313,7 @@ _LIBZFS_H int zpool_initialize_wait(zpool_handle_t *, pool_initialize_func_t,
     nvlist_t *);
 _LIBZFS_H int zpool_trim(zpool_handle_t *, pool_trim_func_t, nvlist_t *,
     trimflags_t *);
+_LIBZFS_H int zpool_condense(zpool_handle_t *, const char *, const char *);
 
 _LIBZFS_H int zpool_clear(zpool_handle_t *, const char *, nvlist_t *);
 _LIBZFS_H int zpool_reguid(zpool_handle_t *);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -25,6 +25,8 @@
  * Copyright 2017 RackTop Systems.
  * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
  * Copyright (c) 2019 Datto Inc.
+ * Copyright (c) 2024-2026, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #ifndef	_LIBZFS_CORE_H
@@ -140,6 +142,8 @@ _LIBZFS_CORE_H int lzc_channel_program_nosync(const char *, const char *,
 
 _LIBZFS_CORE_H int lzc_sync(const char *, nvlist_t *, nvlist_t **);
 _LIBZFS_CORE_H int lzc_reopen(const char *, boolean_t);
+
+_LIBZFS_CORE_H int lzc_condense(const char *, const char *, const char *);
 
 _LIBZFS_CORE_H int lzc_pool_checkpoint(const char *);
 _LIBZFS_CORE_H int lzc_pool_checkpoint_discard(const char *);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -870,6 +870,7 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_CHECKPOINT_STATS	"checkpoint_stats" /* not on disk */
 #define	ZPOOL_CONFIG_RAIDZ_EXPAND_STATS	"raidz_expand_stats" /* not on disk */
 #define	ZPOOL_CONFIG_VDEV_STATS		"vdev_stats"	/* not stored on disk */
+#define	ZPOOL_CONFIG_CONDENSE_STATS	"com.klarasystems:condense_stats"
 #define	ZPOOL_CONFIG_INDIRECT_SIZE	"indirect_size"	/* not stored on disk */
 
 /* container nvlist of extended stats */
@@ -1511,6 +1512,11 @@ typedef enum pool_trim_func {
 } pool_trim_func_t;
 
 /*
+ * Condense types.
+ */
+/* ... */
+
+/*
  * DDT statistics.  Note: all fields should be 64-bit because this
  * is passed between kernel and userland as an nvlist uint64 array.
  */
@@ -1689,6 +1695,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_POOL_SCRUB,			/* 0x5a57 */
 	ZFS_IOC_POOL_PREFETCH,			/* 0x5a58 */
 	ZFS_IOC_DDT_PRUNE,			/* 0x5a59 */
+	ZFS_IOC_POOL_CONDENSE,			/* 0x5a5a */
 
 	/*
 	 * Per-platform (Optional) - 8/128 numbers reserved.
@@ -1829,6 +1836,7 @@ typedef enum {
 	ZPOOL_WAIT_SCRUB,
 	ZPOOL_WAIT_TRIM,
 	ZPOOL_WAIT_RAIDZ_EXPAND,
+	ZPOOL_WAIT_CONDENSE,
 	ZPOOL_WAIT_NUM_ACTIVITIES
 } zpool_wait_activity_t;
 
@@ -1916,6 +1924,12 @@ typedef enum {
 #define	ZPOOL_TRIM_VDEVS		"trim_vdevs"
 #define	ZPOOL_TRIM_RATE			"trim_rate"
 #define	ZPOOL_TRIM_SECURE		"trim_secure"
+
+/*
+ * The following are names used when invoking ZPOOL_IOC_POOL_CONDENSE.
+ */
+#define	ZPOOL_CONDENSE_COMMAND		"condense_command"
+#define	ZPOOL_CONDENSE_TYPE		"condense_type"
 
 /*
  * The following are names used when invoking ZFS_IOC_POOL_WAIT.

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1514,7 +1514,7 @@ typedef enum pool_trim_func {
 /*
  * Condense types.
  */
-/* ... */
+#define	POOL_CONDENSE_LOG_SPACEMAP	"log_spacemap"
 
 /*
  * DDT statistics.  Note: all fields should be 64-bit because this

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -29,8 +29,9 @@
  * Copyright 2017 Joyent, Inc.
  * Copyright (c) 2017, Intel Corporation.
  * Copyright (c) 2019, Allan Jude
- * Copyright (c) 2019, 2025, Klara, Inc.
+ * Copyright (c) 2019, 2024-2026, Klara, Inc.
  * Copyright (c) 2019, Datto Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #ifndef _SYS_SPA_H
@@ -944,6 +945,7 @@ typedef struct spa_stats {
 	spa_history_kstat_t	state;		/* pool state */
 	spa_history_kstat_t	guid;		/* pool guid */
 	spa_history_kstat_t	iostats;
+	spa_history_kstat_t	log_spacemaps;
 } spa_stats_t;
 
 typedef enum txg_state {
@@ -1062,6 +1064,7 @@ typedef enum spa_log_state {
 extern spa_log_state_t spa_get_log_state(spa_t *spa);
 extern void spa_set_log_state(spa_t *spa, spa_log_state_t state);
 extern int spa_reset_logs(spa_t *spa);
+extern void spa_log_sm_stats_update(spa_t *spa);
 
 /* Log claim callback */
 extern void spa_claim_notify(zio_t *zio);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1273,6 +1273,12 @@ extern int spa_wait_tag(const char *name, zpool_wait_activity_t activity,
 extern void spa_notify_waiters(spa_t *spa);
 extern void spa_wake_waiters(spa_t *spa);
 
+/* a no-op condense op for test & debug */
+#ifdef ZFS_DEBUG
+extern void spa_condense_debug_start(spa_t *spa);
+extern void spa_condense_debug_cancel(spa_t *spa);
+#endif
+
 extern void spa_import_os(spa_t *spa);
 extern void spa_export_os(spa_t *spa);
 extern void spa_activate_os(spa_t *spa);

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -220,6 +220,7 @@ typedef enum spa_config_source {
 } spa_config_source_t;
 
 typedef enum spa_condense_type {
+	SPA_CONDENSE_LOG_SPACEMAP = 0,
 #ifdef ZFS_DEBUG
 	SPA_CONDENSE_DEBUG,
 #endif
@@ -231,7 +232,6 @@ typedef struct spa_condense_stat {
 	uint64_t scns_end_time;		/* time_t */
 	uint64_t scns_processed;	/* items processed */
 	uint64_t scns_total;		/* total items to process */
-	kmutex_t scns_lock;		/* protects all of the above */
 } spa_condense_stat_t;
 
 
@@ -382,6 +382,7 @@ struct spa {
 	avl_tree_t	spa_metaslabs_by_flushed;
 	spa_unflushed_stats_t	spa_unflushed_stats;
 	list_t		spa_log_summary;
+	spa_log_flushall_mode_t	spa_log_flushall_mode;
 	uint64_t	spa_log_flushall_txg;
 
 	zthr_t		*spa_livelist_delete_zthr; /* deleting livelists */

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -28,6 +28,8 @@
  * Copyright (c) 2016 Actifio, Inc. All rights reserved.
  * Copyright (c) 2017, Intel Corporation.
  * Copyright (c) 2019 Datto Inc.
+ * Copyright (c) 2024-2026, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #ifndef _SYS_SPA_IMPL_H
@@ -216,6 +218,22 @@ typedef enum spa_config_source {
 	SPA_CONFIG_SRC_SPLIT,		/* new pool in a pool split */
 	SPA_CONFIG_SRC_MOS		/* MOS, but not always from right txg */
 } spa_config_source_t;
+
+typedef enum spa_condense_type {
+#ifdef ZFS_DEBUG
+	SPA_CONDENSE_DEBUG,
+#endif
+	SPA_CONDENSE_TYPES
+} spa_condense_type_t;
+
+typedef struct spa_condense_stat {
+	uint64_t scns_start_time;	/* time_t */
+	uint64_t scns_end_time;		/* time_t */
+	uint64_t scns_processed;	/* items processed */
+	uint64_t scns_total;		/* total items to process */
+	kmutex_t scns_lock;		/* protects all of the above */
+} spa_condense_stat_t;
+
 
 struct spa {
 	/*
@@ -480,6 +498,15 @@ struct spa {
 	uint64_t	spa_dedup_table_quota;	/* property DDT maximum size */
 	uint64_t	spa_dedup_dsize;	/* cached on-disk size of DDT */
 	uint64_t	spa_dedup_class_full_txg; /* txg dedup class was full */
+
+	/* stats for user-initiated condense operations */
+	spa_condense_stat_t	spa_condense_stats[SPA_CONDENSE_TYPES];
+	kmutex_t		spa_condense_stats_lock;
+
+#ifdef ZFS_DEBUG
+	/* see spa_condense_debug_task() */
+	taskqid_t	spa_condense_debug_tqid;
+#endif
 
 	/*
 	 * spa_refcount & spa_config_lock must be the last elements

--- a/include/sys/spa_log_spacemap.h
+++ b/include/sys/spa_log_spacemap.h
@@ -42,6 +42,7 @@ typedef struct log_summary_entry {
 typedef struct spa_unflushed_stats  {
 	/* used for memory heuristic */
 	uint64_t sus_memused;	/* current memory used for unflushed trees */
+	uint64_t sus_nmetaslabs;	/* # metaslabs with unflushed trees */
 
 	/* used for block heuristic */
 	uint64_t sus_blocklimit;	/* max # of log blocks allowed */
@@ -69,6 +70,10 @@ uint64_t spa_log_sm_blocklimit(spa_t *);
 void spa_log_sm_set_blocklimit(spa_t *);
 uint64_t spa_log_sm_nblocks(spa_t *);
 uint64_t spa_log_sm_memused(spa_t *);
+
+uint64_t spa_log_sm_unflushed_metaslabs(spa_t *);
+void spa_log_sm_increment_unflushed_metaslabs(spa_t *);
+void spa_log_sm_decrement_unflushed_metaslabs(spa_t *);
 
 void spa_log_sm_decrement_mscount(spa_t *, uint64_t);
 void spa_log_sm_increment_current_mscount(spa_t *);

--- a/include/sys/spa_log_spacemap.h
+++ b/include/sys/spa_log_spacemap.h
@@ -22,6 +22,8 @@
 
 /*
  * Copyright (c) 2018, 2019 by Delphix. All rights reserved.
+ * Copyright (c) 2024-2026, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #ifndef _SYS_SPA_LOG_SPACEMAP_H
@@ -58,6 +60,12 @@ typedef struct spa_log_sm {
 	space_map_t *sls_sm;	/* space map pointer, if open */
 } spa_log_sm_t;
 
+typedef enum spa_log_flushall_mode {
+	SPA_LOG_FLUSHALL_NONE = 0,	/* flushall inactive */
+	SPA_LOG_FLUSHALL_REQUEST,	/* flushall active by admin request */
+	SPA_LOG_FLUSHALL_EXPORT,	/* flushall active for pool export */
+} spa_log_flushall_mode_t;
+
 int spa_ld_log_spacemaps(spa_t *);
 
 void spa_generate_syncing_log_sm(spa_t *, dmu_tx_t *);
@@ -83,7 +91,11 @@ void spa_log_summary_dirty_flushed_metaslab(spa_t *, uint64_t);
 void spa_log_summary_decrement_mscount(spa_t *, uint64_t, boolean_t);
 void spa_log_summary_decrement_blkcount(spa_t *, uint64_t);
 
-boolean_t spa_flush_all_logs_requested(spa_t *);
+void spa_log_flushall_start(spa_t *spa, spa_log_flushall_mode_t mode,
+    uint64_t txg);
+void spa_log_flushall_done(spa_t *spa);
+void spa_log_flushall_cancel(spa_t *spa);
+boolean_t spa_log_flushall_active(spa_t *spa);
 
 extern int zfs_keep_log_spacemaps_at_export;
 

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -537,6 +537,7 @@
     <elf-symbol name='zpool_close' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_collect_leaves' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_collect_unsup_feat' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_condense' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_ddt_prune' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_default_search_paths' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -6609,6 +6610,7 @@
       <enumerator name='ZFS_IOC_POOL_SCRUB' value='23127'/>
       <enumerator name='ZFS_IOC_POOL_PREFETCH' value='23128'/>
       <enumerator name='ZFS_IOC_DDT_PRUNE' value='23129'/>
+      <enumerator name='ZFS_IOC_POOL_CONDENSE' value='23130'/>
       <enumerator name='ZFS_IOC_PLATFORM' value='23168'/>
       <enumerator name='ZFS_IOC_EVENTS_NEXT' value='23169'/>
       <enumerator name='ZFS_IOC_EVENTS_CLEAR' value='23170'/>
@@ -6634,7 +6636,8 @@
       <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
       <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
       <enumerator name='ZPOOL_WAIT_RAIDZ_EXPAND' value='8'/>
-      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='9'/>
+      <enumerator name='ZPOOL_WAIT_CONDENSE' value='9'/>
+      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='10'/>
     </enum-decl>
     <typedef-decl name='zpool_wait_activity_t' type-id='849338e3' id='73446457'/>
     <enum-decl name='zpool_prefetch_type_t' naming-typedef-id='e55ff6bc' id='0299ab50'>
@@ -6781,6 +6784,12 @@
     <function-decl name='lzc_reopen' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='80f4b756'/>
       <parameter type-id='c19b74c3'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_condense' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='80f4b756'/>
+      <parameter type-id='80f4b756'/>
+      <parameter type-id='80f4b756'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='lzc_pool_checkpoint' visibility='default' binding='global' size-in-bits='64'>
@@ -7393,6 +7402,12 @@
     <function-decl name='zpool_sync_one' mangled-name='zpool_sync_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_sync_one'>
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_condense' mangled-name='zpool_condense' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_condense'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='cmd'/>
+      <parameter type-id='80f4b756' name='type'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zpool_vdev_name' mangled-name='zpool_vdev_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_vdev_name'>

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -30,8 +30,9 @@
  * Copyright (c) 2017, Intel Corporation.
  * Copyright (c) 2018, loli10K <ezomori.nozomu@gmail.com>
  * Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
- * Copyright (c) 2021, 2023, Klara Inc.
+ * Copyright (c) 2021, 2023-2026, Klara, Inc.
  * Copyright (c) 2025 Hewlett Packard Enterprise Development LP.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #include <errno.h>
@@ -4686,6 +4687,22 @@ zpool_sync_one(zpool_handle_t *zhp, void *data)
 		    dgettext(TEXT_DOMAIN, "sync '%s' failed"), pool_name));
 	}
 	nvlist_free(innvl);
+
+	return (0);
+}
+
+int
+zpool_condense(zpool_handle_t *zhp, const char *cmd, const char *type)
+{
+	int ret;
+
+	libzfs_handle_t *hdl = zpool_get_handle(zhp);
+	const char *pool_name = zpool_get_name(zhp);
+
+	if ((ret = lzc_condense(pool_name, cmd, type)) != 0) {
+		return (zpool_standard_error_fmt(hdl, ret,
+		    dgettext(TEXT_DOMAIN, "condense '%s' failed"), pool_name));
+	}
 
 	return (0);
 }

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -189,6 +189,7 @@
     <elf-symbol name='lzc_channel_program' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzc_channel_program_nosync' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzc_clone' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_condense' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzc_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzc_ddt_prune' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzc_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1489,6 +1490,12 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libspl/os/linux/mnttab.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='d315442e' size-in-bits='16' id='811205dc'>
+      <subrange length='1' type-id='7359adad' id='52f813b4'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='d3130597' size-in-bits='768' id='f63f23b9'>
+      <subrange length='12' type-id='7359adad' id='84827bdc'/>
+    </array-type-def>
     <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -1501,6 +1508,93 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='mnt_mntopts' type-id='26a90f95' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__u16' type-id='8efea9e5' id='d315442e'/>
+    <typedef-decl name='__s32' type-id='95e97e5e' id='3158a266'/>
+    <typedef-decl name='__u32' type-id='f0981eeb' id='3f1a6b60'/>
+    <typedef-decl name='__s64' type-id='1eb56b1e' id='49659421'/>
+    <typedef-decl name='__u64' type-id='3a47d82b' id='d3130597'/>
+    <class-decl name='statx_timestamp' size-in-bits='128' is-struct='yes' visibility='default' id='94101016'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='49659421' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_nsec' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__reserved' type-id='3158a266' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='statx' size-in-bits='2048' is-struct='yes' visibility='default' id='720b04c5'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='stx_mask' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='stx_blksize' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='stx_attributes' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stx_nlink' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='stx_uid' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='stx_gid' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='stx_mode' type-id='d315442e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='240'>
+        <var-decl name='__spare0' type-id='811205dc' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='stx_ino' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='stx_size' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='stx_blocks' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='stx_attributes_mask' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='stx_atime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='stx_btime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='stx_ctime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='stx_mtime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='stx_rdev_major' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='stx_rdev_minor' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='stx_dev_major' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='stx_dev_minor' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='stx_mnt_id' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='__spare2' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='__spare3' type-id='f63f23b9' visibility='default'/>
       </data-member>
     </class-decl>
     <class-decl name='mntent' size-in-bits='320' is-struct='yes' visibility='default' id='56fe4a37'>
@@ -1577,6 +1671,8 @@
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
     <qualified-type-def type-id='62f7a03d' restrict='yes' id='f1cadedf'/>
+    <pointer-type-def type-id='720b04c5' size-in-bits='64' id='936b8e35'/>
+    <qualified-type-def type-id='936b8e35' restrict='yes' id='31d265b7'/>
     <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>
       <parameter type-id='3cad23cd'/>
@@ -1591,6 +1687,14 @@
     <function-decl name='strerror' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
       <return type-id='26a90f95'/>
+    </function-decl>
+    <function-decl name='statx' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='9d26089a'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='f0981eeb'/>
+      <parameter type-id='31d265b7'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='stat64' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='9d26089a'/>
@@ -2599,6 +2703,7 @@
       <enumerator name='ZFS_IOC_POOL_SCRUB' value='23127'/>
       <enumerator name='ZFS_IOC_POOL_PREFETCH' value='23128'/>
       <enumerator name='ZFS_IOC_DDT_PRUNE' value='23129'/>
+      <enumerator name='ZFS_IOC_POOL_CONDENSE' value='23130'/>
       <enumerator name='ZFS_IOC_PLATFORM' value='23168'/>
       <enumerator name='ZFS_IOC_EVENTS_NEXT' value='23169'/>
       <enumerator name='ZFS_IOC_EVENTS_CLEAR' value='23170'/>
@@ -2624,7 +2729,8 @@
       <enumerator name='ZPOOL_WAIT_SCRUB' value='6'/>
       <enumerator name='ZPOOL_WAIT_TRIM' value='7'/>
       <enumerator name='ZPOOL_WAIT_RAIDZ_EXPAND' value='8'/>
-      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='9'/>
+      <enumerator name='ZPOOL_WAIT_CONDENSE' value='9'/>
+      <enumerator name='ZPOOL_WAIT_NUM_ACTIVITIES' value='10'/>
     </enum-decl>
     <typedef-decl name='zpool_wait_activity_t' type-id='849338e3' id='73446457'/>
     <enum-decl name='zfs_wait_activity_t' naming-typedef-id='3024501a' id='527d5dc6'>
@@ -3895,6 +4001,12 @@
       <parameter type-id='80f4b756' name='pool_name'/>
       <parameter type-id='5ce45b60' name='innvl'/>
       <parameter type-id='857bb57e' name='outnvl'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_condense' mangled-name='lzc_condense' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_condense'>
+      <parameter type-id='80f4b756' name='pool_name'/>
+      <parameter type-id='80f4b756' name='cmd'/>
+      <parameter type-id='80f4b756' name='type'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='lzc_hold' mangled-name='lzc_hold' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_hold'>

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -27,6 +27,8 @@
  * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
  * Copyright (c) 2019, 2020 by Christian Schwarz. All rights reserved.
  * Copyright (c) 2019 Datto Inc.
+ * Copyright (c) 2024-2026, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 /*
@@ -536,6 +538,22 @@ lzc_sync(const char *pool_name, nvlist_t *innvl, nvlist_t **outnvl)
 {
 	(void) outnvl;
 	return (lzc_ioctl(ZFS_IOC_POOL_SYNC, pool_name, innvl, NULL));
+}
+
+int
+lzc_condense(const char *pool_name, const char *cmd, const char *type)
+{
+	int error;
+
+	nvlist_t *args = fnvlist_alloc();
+	fnvlist_add_string(args, ZPOOL_CONDENSE_COMMAND, cmd);
+	fnvlist_add_string(args, ZPOOL_CONDENSE_TYPE, type);
+
+	error = lzc_ioctl(ZFS_IOC_POOL_CONDENSE, pool_name, args, NULL);
+
+	fnvlist_free(args);
+
+	return (error);
 }
 
 /*

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -74,6 +74,7 @@ dist_man_MANS = \
 	%D%/man8/zpool-attach.8 \
 	%D%/man8/zpool-checkpoint.8 \
 	%D%/man8/zpool-clear.8 \
+	%D%/man8/zpool-condense.8 \
 	%D%/man8/zpool-create.8 \
 	%D%/man8/zpool-destroy.8 \
 	%D%/man8/zpool-detach.8 \

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -5,6 +5,7 @@
 .\" Copyright (c) 2019 Datto Inc.
 .\" Copyright (c) 2023, 2024, 2025, Klara, Inc.
 .\" Copyright (c) 2026, Mateusz Piotrowski <0mp@FreeBSD.org>
+.\" Copyright (c) 2026, TrueNAS.
 .\"
 .\" The contents of this file are subject to the terms of the Common Development
 .\" and Distribution License (the "License").  You may not use this file except
@@ -19,7 +20,7 @@
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
 .\"
-.Dd May 8, 2026
+.Dd May 26, 2026
 .Dt ZFS 4
 .Os
 .
@@ -1997,6 +1998,12 @@ Normally disabled because these datasets may be missing key data.
 .
 .It Sy zfs_min_metaslabs_to_flush Ns = Ns Sy 1 Pq u64
 Minimum number of metaslabs to flush per dirty TXG.
+.
+.It Sy zfs_min_metaslabs_to_condense_pct Ns = Ns Sy 5 Pq u64
+Minimum number of metaslabs to flush every TXG when condensing log spacemaps,
+as a percentage of the number of unflushed metaslabs at the time the
+.Nm zpool Cm condense
+command was run.
 .
 .It Sy zfs_metaslab_fragmentation_threshold Ns = Ns Sy 77 Ns % Pq uint
 Allow metaslabs to keep their active state as long as their fragmentation

--- a/man/man8/zpool-condense.8
+++ b/man/man8/zpool-condense.8
@@ -1,0 +1,73 @@
+.\" SPDX-License-Identifier: CDDL-1.0
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright (c) 2024-2026, Klara, Inc.
+.\" Copyright (c) 2026, TrueNAS.
+.\"
+.Dd May 26, 2026
+.Dt ZPOOL-CONDENSE 8
+.Os
+.
+.Sh NAME
+.Nm zpool-condense
+.Nd Condense, flush, garbage collect or otherwise clean up pool metadata
+.Sh SYNOPSIS
+.Nm zpool
+.Cm condense
+.Op Fl t Ar type
+.Op Fl c | w
+.Fl a Ns | Ns Ar pool Ns …
+.Nm zpool
+.Cm condense
+.Fl -types
+.Sh DESCRIPTION
+Many internal pool metadata updates are performed in the background at a rate
+chosen to limit the performance impact to normal use of the pool.
+Sometimes it is desirable to accelerate these operations,
+even if it affects overall performance.
+.Sy condense
+allows an operator to request that a specific background operation be
+prioritised to complete as soon as possible.
+.Bl -tag -width Ds
+.It Fl t , -type
+What to condense.
+If not specified, all types will be condensed.
+These are the possible values for
+.Ar type :
+.Bl -tag -compact -offset Ds -width "..."
+.It Sy ...
+.El
+.It Fl a , -all
+Begin, cancel or wait on condense for all pools.
+.It Fl c , -cancel
+Cancel a previous
+.Sy condense .
+This will return background updates to their normal rate.
+.It Fl w , -wait
+Wait until the condense has completed before returning.
+.It Fl -types
+List condense types supported by this build of
+.Sy condense .
+.El
+.Sh SEE ALSO
+.Xr zpool-status 8 ,
+.Xr zpool-wait 8

--- a/man/man8/zpool-condense.8
+++ b/man/man8/zpool-condense.8
@@ -53,8 +53,9 @@ What to condense.
 If not specified, all types will be condensed.
 These are the possible values for
 .Ar type :
-.Bl -tag -compact -offset Ds -width "..."
-.It Sy ...
+.Bl -tag -compact -offset Ds -width "log_spacemap"
+.It Sy log_spacemap
+flushing log spacemap entries to their underlying metaslabs.
 .El
 .It Fl a , -all
 Begin, cancel or wait on condense for all pools.
@@ -68,6 +69,20 @@ Wait until the condense has completed before returning.
 List condense types supported by this build of
 .Sy condense .
 .El
+.Sh EXAMPLES
+.Ss Example 1
+Status of pool with
+.Sy log_spacemap
+condense in progress:
+.sp
+.Bd -literal -compact
+.No # Nm zpool Cm condense -t log_spacemap
+.No # Nm zpool Cm status
+  pool: tank
+  state: ONLINE
+  condense: log_spacemap: condensing, 104/321 metaslabs done in 00:00:15
+  ...
+.Ed
 .Sh SEE ALSO
 .Xr zpool-status 8 ,
 .Xr zpool-wait 8

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -26,8 +26,10 @@
 .\" Copyright (c) 2018 George Melikov. All Rights Reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+.\" Copyright (c) 2024-2026, Klara, Inc.
+.\" Copyright (c) 2026, TrueNAS.
 .\"
-.Dd March 16, 2026
+.Dd May 26, 2026
 .Dt ZPOOL-STATUS 8
 .Os
 .
@@ -365,6 +367,7 @@ can be used to run a script on each VDEV.
 .Ed
 .
 .Sh SEE ALSO
+.Xr zpool-condense 8 ,
 .Xr zpool-events 8 ,
 .Xr zpool-history 8 ,
 .Xr zpool-iostat 8 ,

--- a/man/man8/zpool-wait.8
+++ b/man/man8/zpool-wait.8
@@ -27,8 +27,10 @@
 .\" Copyright (c) 2018 George Melikov. All Rights Reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+.\" Copyright (c) 2024-2026, Klara, Inc.
+.\" Copyright (c) 2026, TrueNAS.
 .\"
-.Dd January 29, 2024
+.Dd May 26, 2026
 .Dt ZPOOL-WAIT 8
 .Os
 .
@@ -79,6 +81,8 @@ Scrub to cease
 Manual trim to cease
 .It Sy raidz_expand
 Attaching to a RAID-Z vdev to complete
+.It Sy condense
+Metadata condense operations to complete
 .El
 .Pp
 If an
@@ -110,6 +114,7 @@ See
 .
 .Sh SEE ALSO
 .Xr zpool-checkpoint 8 ,
+.Xr zpool-condense 8 ,
 .Xr zpool-initialize 8 ,
 .Xr zpool-remove 8 ,
 .Xr zpool-replace 8 ,

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -26,8 +26,10 @@
 .\" Copyright (c) 2018 George Melikov. All Rights Reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+.\" Copyright (c) 2024-2026, Klara, Inc.
+.\" Copyright (c) 2026, TrueNAS.
 .\"
-.Dd November 19, 2024
+.Dd May 26, 2026
 .Dt ZPOOL 8
 .Os
 .
@@ -180,6 +182,8 @@ specified.
 Prefetches specific types of pool data.
 .It Xr zpool-scrub 8
 Begins a scrub or resumes a paused scrub.
+.It Xr zpool-condense 8
+Condense, flush, garbage collect or otherwise clean up pool metadata.
 .It Xr zpool-checkpoint 8
 Checkpoints the current state of
 .Ar pool ,

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -4048,6 +4048,8 @@ metaslab_unflushed_add(metaslab_t *msp, dmu_tx_t *tx)
 
 	spa_log_sm_increment_current_mscount(spa);
 	spa_log_summary_add_flushed_metaslab(spa, B_TRUE);
+
+	spa_log_sm_increment_unflushed_metaslabs(spa);
 }
 
 void
@@ -4081,6 +4083,11 @@ metaslab_unflushed_bump(metaslab_t *msp, dmu_tx_t *tx, boolean_t dirty)
 	spa_log_summary_decrement_mscount(spa, ms_prev_flushed_txg,
 	    ms_prev_flushed_dirty);
 	spa_log_summary_add_flushed_metaslab(spa, dirty);
+
+	if (ms_prev_flushed_dirty && !dirty)
+		spa_log_sm_decrement_unflushed_metaslabs(spa);
+	else if (!ms_prev_flushed_dirty && dirty)
+		spa_log_sm_increment_unflushed_metaslabs(spa);
 
 	/* cleanup obsolete logs if any */
 	spa_cleanup_old_sm_logs(spa, tx);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2166,6 +2166,7 @@ spa_unload_log_sm_metadata(spa_t *spa)
 	spa->spa_unflushed_stats.sus_nblocks = 0;
 	spa->spa_unflushed_stats.sus_memused = 0;
 	spa->spa_unflushed_stats.sus_blocklimit = 0;
+	spa->spa_unflushed_stats.sus_nmetaslabs = 0;
 
 	spa_log_sm_stats_update(spa);
 }

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2138,8 +2138,8 @@ spa_unload_log_sm_flush_all(spa_t *spa)
 	dmu_tx_t *tx = dmu_tx_create_dd(spa_get_dsl(spa)->dp_mos_dir);
 	VERIFY0(dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND));
 
-	ASSERT0(spa->spa_log_flushall_txg);
-	spa->spa_log_flushall_txg = dmu_tx_get_txg(tx);
+	spa_log_flushall_start(spa, SPA_LOG_FLUSHALL_EXPORT,
+	    dmu_tx_get_txg(tx));
 
 	dmu_tx_commit(tx);
 	txg_wait_synced(spa_get_dsl(spa), spa->spa_log_flushall_txg);
@@ -2344,6 +2344,8 @@ spa_unload(spa_t *spa)
 		 */
 		if (spa_should_flush_logs_on_unload(spa))
 			spa_unload_log_sm_flush_all(spa);
+		else
+			spa_log_flushall_done(spa);
 
 		/*
 		 * Stop async tasks.

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -35,7 +35,8 @@
  * Copyright (c) 2017, Intel Corporation.
  * Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
  * Copyright (c) 2023 Hewlett Packard Enterprise Development LP.
- * Copyright (c) 2023, 2024, Klara Inc.
+ * Copyright (c) 2023-2026, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 /*
@@ -2165,6 +2166,8 @@ spa_unload_log_sm_metadata(spa_t *spa)
 	spa->spa_unflushed_stats.sus_nblocks = 0;
 	spa->spa_unflushed_stats.sus_memused = 0;
 	spa->spa_unflushed_stats.sus_blocklimit = 0;
+
+	spa_log_sm_stats_update(spa);
 }
 
 static void
@@ -11063,6 +11066,7 @@ spa_sync(spa_t *spa, uint64_t txg)
 	spa_sync_close_syncing_log_sm(spa);
 
 	spa_update_dspace(spa);
+	spa_log_sm_stats_update(spa);
 
 	if (spa_get_autotrim(spa) == SPA_AUTOTRIM_ON)
 		vdev_autotrim_kick(spa);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7751,6 +7751,9 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 	 */
 	spa_open_ref(spa, FTAG);
 	spa_namespace_exit(FTAG);
+#ifdef ZFS_DEBUG
+	spa_condense_debug_cancel(spa);
+#endif
 	spa_async_suspend(spa);
 	if (spa->spa_zvol_taskq) {
 		zvol_remove_minors(spa, spa_name(spa), B_TRUE);
@@ -11603,6 +11606,21 @@ spa_activity_in_progress(spa_t *spa, zpool_wait_activity_t activity,
 		*in_progress = (vre != NULL && vre->vre_state == DSS_SCANNING);
 		break;
 	}
+	case ZPOOL_WAIT_CONDENSE: {
+		*in_progress = B_FALSE;
+		spa_condense_stat_t *scns;
+
+		for (spa_condense_type_t type = 0;
+		    type < SPA_CONDENSE_TYPES; type++) {
+			scns = &spa->spa_condense_stats[type];
+			if (scns->scns_start_time > 0 &&
+			    scns->scns_end_time == 0) {
+				*in_progress = B_TRUE;
+				break;
+			}
+		}
+		break;
+	}
 	default:
 		panic("unrecognized value for activity %d", activity);
 	}
@@ -11737,6 +11755,132 @@ spa_event_notify(spa_t *spa, vdev_t *vd, nvlist_t *hist_nvl, const char *name)
 {
 	spa_event_post(spa_event_create(spa, vd, hist_nvl, name));
 }
+
+#ifdef ZFS_DEBUG
+/*
+ * This runs the "debug" condense type, which does nothing, just updates the
+ * condense counters every second for ten seconds. This exists entirely for
+ * testing and debugging the condense system itself, which is why it is
+ * compiled out of production builds.
+ */
+#define	SPA_CONDENSE_DEBUG_STEP	(10)
+
+static void
+spa_condense_debug_task(void *arg)
+{
+	spa_t *spa = arg;
+	spa_condense_stat_t *scns =
+	    &spa->spa_condense_stats[SPA_CONDENSE_DEBUG];
+
+	mutex_enter(&spa->spa_condense_stats_lock);
+
+	if (spa->spa_condense_debug_tqid == TASKQID_INVALID) {
+		/*
+		 * Task no longer required, probably cancelled by
+		 * spa_condense_debug_cancel(). Just exit.
+		 */
+		mutex_exit(&spa->spa_condense_stats_lock);
+		return;
+	}
+
+	spa->spa_condense_debug_tqid = TASKQID_INVALID;
+
+	/* Move the condense progress along a bit. */
+	scns->scns_processed = MIN(scns->scns_total, scns->scns_processed +
+	    (scns->scns_total / SPA_CONDENSE_DEBUG_STEP));
+	if (scns->scns_processed == scns->scns_total) {
+		/*
+		 * Reached the end. Set the end time to "complete" the
+		 * condense, signal waiters, release resources and we're done.
+		 */
+		scns->scns_end_time = gethrestime_sec();
+		mutex_exit(&spa->spa_condense_stats_lock);
+		spa_notify_waiters(spa);
+		spa_close(spa, scns);
+		return;
+	}
+
+	/* More to do, re-arm the timer for another round. */
+	spa->spa_condense_debug_tqid = taskq_dispatch_delay(system_delay_taskq,
+	    spa_condense_debug_task, spa, TQ_SLEEP,
+	    ddi_get_lbolt() + SEC_TO_TICK(1));
+	mutex_exit(&spa->spa_condense_stats_lock);
+}
+
+void
+spa_condense_debug_start(spa_t *spa)
+{
+	uint32_t nitems = 10 + random_in_range(90) * SPA_CONDENSE_DEBUG_STEP;
+
+	spa_condense_stat_t *scns =
+	    &spa->spa_condense_stats[SPA_CONDENSE_DEBUG];
+
+	mutex_enter(&spa->spa_condense_stats_lock);
+
+	if (scns->scns_start_time == 0 || scns->scns_end_time > 0) {
+		/* Previous run finished, or no previous run. Start fresh. */
+		scns->scns_start_time = gethrestime_sec();
+		scns->scns_end_time = 0;
+		scns->scns_processed = 0;
+		scns->scns_total = nitems;
+	} else {
+		/* In progress, just add some more work. */
+		scns->scns_total += nitems;
+	}
+
+	if (spa->spa_condense_debug_tqid == TASKQID_INVALID) {
+		spa_open_ref(spa, scns);
+		spa->spa_condense_debug_tqid = taskq_dispatch_delay(
+		    system_delay_taskq, spa_condense_debug_task, spa, TQ_SLEEP,
+		    ddi_get_lbolt() + SEC_TO_TICK(1));
+	}
+
+	mutex_exit(&spa->spa_condense_stats_lock);
+}
+
+void
+spa_condense_debug_cancel(spa_t *spa)
+{
+	spa_condense_stat_t *scns =
+	    &spa->spa_condense_stats[SPA_CONDENSE_DEBUG];
+
+	mutex_enter(&spa->spa_condense_stats_lock);
+
+	/* "Cancel" by just setting the end time. */
+	if (scns->scns_end_time == 0)
+		scns->scns_end_time = gethrestime_sec();
+
+	if (spa->spa_condense_debug_tqid == TASKQID_INVALID) {
+		/* No task, so nothing else to do. */
+		mutex_exit(&spa->spa_condense_stats_lock);
+		spa_notify_waiters(spa);
+		return;
+	}
+
+	/*
+	 * Task is either waiting to run, or running and waiting to take
+	 * spa_condense_stats_lock. Clear the tqid, so if it does run after we
+	 * drop the lock, it will immediately exit.
+	 */
+	taskqid_t tqid = spa->spa_condense_debug_tqid;
+	spa->spa_condense_debug_tqid = TASKQID_INVALID;
+
+	mutex_exit(&spa->spa_condense_stats_lock);
+
+	/*
+	 * Cancel the task. If its running, wait for it to complete (ie do
+	 * nothing, per above).
+	 */
+	taskq_cancel_id(system_delay_taskq, tqid, B_TRUE);
+
+	/*
+	 * Task didn't run or aborted, so it never cleaned up. We do it on its
+	 * behalf.
+	 */
+	spa_notify_waiters(spa);
+	spa_close(spa, scns);
+}
+#endif
 
 /* state manipulation functions */
 EXPORT_SYMBOL(spa_open);

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -747,6 +747,24 @@ spa_log_exceeds_memlimit(spa_t *spa)
 	return (B_FALSE);
 }
 
+uint64_t
+spa_log_sm_unflushed_metaslabs(spa_t *spa)
+{
+	return (spa->spa_unflushed_stats.sus_nmetaslabs);
+}
+
+void
+spa_log_sm_increment_unflushed_metaslabs(spa_t *spa)
+{
+	spa->spa_unflushed_stats.sus_nmetaslabs++;
+}
+
+void
+spa_log_sm_decrement_unflushed_metaslabs(spa_t *spa)
+{
+	spa->spa_unflushed_stats.sus_nmetaslabs--;
+}
+
 boolean_t
 spa_flush_all_logs_requested(spa_t *spa)
 {

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -22,6 +22,8 @@
 
 /*
  * Copyright (c) 2018, 2019 by Delphix. All rights reserved.
+ * Copyright (c) 2024-2026, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #include <sys/dmu_objset.h>
@@ -284,6 +286,13 @@ static uint64_t zfs_max_logsm_summary_length = 10;
  * want to flush more metaslabs than our adaptable heuristic plans to flush.
  */
 static uint64_t zfs_min_metaslabs_to_flush = 1;
+
+/*
+ * Tunable that sets the lower bound on the number of unflushed metaslabs
+ * to flush every TXG during a condense operation, as a percentage of the
+ * number of unflushed metaslabs at the time the condense operation started.
+ */
+static uint_t zfs_min_metaslabs_to_condense_pct = 5;
 
 /*
  * Tunable that specifies how far in the past do we want to look when trying to
@@ -765,10 +774,112 @@ spa_log_sm_decrement_unflushed_metaslabs(spa_t *spa)
 	spa->spa_unflushed_stats.sus_nmetaslabs--;
 }
 
-boolean_t
-spa_flush_all_logs_requested(spa_t *spa)
+void
+spa_log_flushall_start(spa_t *spa, spa_log_flushall_mode_t mode, uint64_t txg)
 {
-	return (spa->spa_log_flushall_txg != 0);
+	/* Shouldn't happen, but its not dangerous if it does. */
+	ASSERT3U(mode, !=, SPA_LOG_FLUSHALL_NONE);
+	if (mode == SPA_LOG_FLUSHALL_NONE)
+		return;
+
+	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
+
+	/*
+	 * For condense, we're flushing everything at this point in time, so
+	 * it makes no sense to provide a non-zero txg. Remove this sanity
+	 * check if this ever changes, and you'll need to adjust scns_total
+	 * below as well to make sure the progress is shown correctly.
+	 */
+	IMPLY(mode == SPA_LOG_FLUSHALL_REQUEST, txg == 0);
+	if (txg == 0)
+		txg = spa_last_synced_txg(spa);
+
+	if (spa->spa_log_flushall_mode != SPA_LOG_FLUSHALL_EXPORT) {
+		/*
+		 * We can set _REQUEST even if its already in _REQUEST; this
+		 * has the effect of just pushing out the end txg.
+		 */
+		spa->spa_log_flushall_mode = mode;
+		spa->spa_log_flushall_txg = txg;
+	}
+
+	if (spa->spa_log_flushall_mode == SPA_LOG_FLUSHALL_REQUEST) {
+		/* Reset stats */
+		spa_condense_stat_t *scns =
+		    &spa->spa_condense_stats[SPA_CONDENSE_LOG_SPACEMAP];
+		mutex_enter(&spa->spa_condense_stats_lock);
+		scns->scns_start_time = gethrestime_sec();
+		scns->scns_end_time = 0;
+		scns->scns_processed = 0;
+		scns->scns_total = spa_log_sm_unflushed_metaslabs(spa);
+		mutex_exit(&spa->spa_condense_stats_lock);
+
+		/* Get it started immediately. */
+		txg_kick(spa->spa_dsl_pool, spa_syncing_txg(spa) + 1);
+	}
+
+	spa_config_exit(spa, SCL_VDEV, FTAG);
+}
+
+void
+spa_log_flushall_done(spa_t *spa)
+{
+	if (spa->spa_log_flushall_mode == SPA_LOG_FLUSHALL_NONE)
+		return;
+
+	IMPLY(spa->spa_log_flushall_mode == SPA_LOG_FLUSHALL_REQUEST,
+	    spa_state(spa) == POOL_STATE_ACTIVE);
+	IMPLY(spa->spa_log_flushall_mode == SPA_LOG_FLUSHALL_EXPORT,
+	    spa_state(spa) == POOL_STATE_EXPORTED);
+	ASSERT3U(spa->spa_log_flushall_txg, >, 0);
+
+	if (spa->spa_log_flushall_mode == SPA_LOG_FLUSHALL_REQUEST) {
+		/*
+		 * Finish stats. Note that the condense technically ends when
+		 * all metaslabs have been considered, not when we've flushed
+		 * as many as we've intended. So, we set the processed to the
+		 * total just so everything looks right for the user even if
+		 * if we actually flushed one or two less than requested.
+		 */
+		spa_condense_stat_t *scns =
+		    &spa->spa_condense_stats[SPA_CONDENSE_LOG_SPACEMAP];
+		mutex_enter(&spa->spa_condense_stats_lock);
+		scns->scns_end_time = gethrestime_sec();
+		scns->scns_processed = scns->scns_total;
+		mutex_exit(&spa->spa_condense_stats_lock);
+	}
+
+	spa->spa_log_flushall_mode = SPA_LOG_FLUSHALL_NONE;
+	spa->spa_log_flushall_txg = 0;
+
+	spa_notify_waiters(spa);
+}
+
+void
+spa_log_flushall_cancel(spa_t *spa)
+{
+	if (spa->spa_log_flushall_mode == SPA_LOG_FLUSHALL_NONE)
+		return;
+
+	ASSERT3U(spa->spa_log_flushall_mode, ==, SPA_LOG_FLUSHALL_REQUEST);
+
+	spa->spa_log_flushall_mode = SPA_LOG_FLUSHALL_NONE;
+	spa->spa_log_flushall_txg = 0;
+
+	/* Finish stats. */
+	spa_condense_stat_t *scns =
+	    &spa->spa_condense_stats[SPA_CONDENSE_LOG_SPACEMAP];
+	mutex_enter(&spa->spa_condense_stats_lock);
+	scns->scns_end_time = gethrestime_sec();
+	mutex_exit(&spa->spa_condense_stats_lock);
+
+	spa_notify_waiters(spa);
+}
+
+boolean_t
+spa_log_flushall_active(spa_t *spa)
+{
+	return (!!(spa->spa_log_flushall_mode == SPA_LOG_FLUSHALL_REQUEST));
 }
 
 void
@@ -804,7 +915,7 @@ spa_flush_metaslabs(spa_t *spa, dmu_tx_t *tx)
 	 */
 	if (BP_GET_LOGICAL_BIRTH(&spa->spa_uberblock.ub_rootbp) < txg &&
 	    !dmu_objset_is_dirty(spa_meta_objset(spa), txg) &&
-	    !spa_flush_all_logs_requested(spa))
+	    spa->spa_log_flushall_mode == SPA_LOG_FLUSHALL_NONE)
 		return;
 
 	/*
@@ -822,17 +933,43 @@ spa_flush_metaslabs(spa_t *spa, dmu_tx_t *tx)
 	spa_generate_syncing_log_sm(spa, tx);
 
 	/*
-	 * This variable tells us how many metaslabs we want to flush based
-	 * on the block-heuristic of our flushing algorithm (see block comment
-	 * of log space map feature). We also decrement this as we flush
-	 * metaslabs and attempt to destroy old log space maps.
+	 * Determine how much to flush this this round, depending on the
+	 * flushall mode.
 	 */
 	uint64_t want_to_flush;
-	if (spa_flush_all_logs_requested(spa)) {
-		ASSERT3S(spa_state(spa), ==, POOL_STATE_EXPORTED);
+	switch (spa->spa_log_flushall_mode) {
+	case SPA_LOG_FLUSHALL_EXPORT:
+		/*
+		 * At export, flush everything we can until the export loop
+		 * calls spa_log_flushall_done() to stop us.
+		 */
 		want_to_flush = UINT64_MAX;
-	} else {
+		break;
+
+	case SPA_LOG_FLUSHALL_REQUEST: {
+		/*
+		 * If admin requested flush, flush some percentage of the
+		 * total dirty metaslabs at the moment the request was made.
+		 * Always flush at least as many as would be flushed if
+		 * condense wasn't running.
+		 */
+		spa_condense_stat_t *scns =
+		    &spa->spa_condense_stats[SPA_CONDENSE_LOG_SPACEMAP];
 		want_to_flush = spa_estimate_metaslabs_to_flush(spa);
+		mutex_enter(&spa->spa_condense_stats_lock);
+		want_to_flush = MAX(want_to_flush, scns->scns_total *
+		    MAX(MIN(zfs_min_metaslabs_to_condense_pct, 100), 1) / 100);
+		mutex_exit(&spa->spa_condense_stats_lock);
+		break;
+	}
+	default:
+		/*
+		 * Flush some number of metaslabs based on the block-heuristic
+		 * of our flushing algorithm (see block comment of log space
+		 * map feature).
+		 */
+		want_to_flush = spa_estimate_metaslabs_to_flush(spa);
+		break;
 	}
 
 	/* Used purely for verification purposes */
@@ -855,8 +992,24 @@ spa_flush_metaslabs(spa_t *spa, dmu_tx_t *tx)
 		 * If this metaslab has been flushed this txg then we've done
 		 * a full circle over the metaslabs.
 		 */
-		if (metaslab_unflushed_txg(curr) == txg)
+		uint64_t unflushed_txg = metaslab_unflushed_txg(curr);
+		if (unflushed_txg == txg) {
+			spa_log_flushall_done(spa);
 			break;
+		}
+
+		/*
+		 * If the admin requested flush, and we've reached a metaslab
+		 * was was dirtied after the flush request began, then we've
+		 * done all we can (metaslabs are sorted by their last dirtied
+		 * txg, so all future ones on the list will also be dirtied
+		 * after the requested txg).
+		 */
+		if (spa->spa_log_flushall_mode == SPA_LOG_FLUSHALL_REQUEST &&
+		    unflushed_txg > spa->spa_log_flushall_txg) {
+			spa_log_flushall_done(spa);
+			break;
+		}
 
 		/*
 		 * If we are done flushing for the block heuristic and the
@@ -865,14 +1018,29 @@ spa_flush_metaslabs(spa_t *spa, dmu_tx_t *tx)
 		if (want_to_flush == 0 && !spa_log_exceeds_memlimit(spa))
 			break;
 
+		/*
+		 * If this metaslab had dirty blocks on it, flush it and update
+		 * the counters.
+		 */
 		if (metaslab_unflushed_dirty(curr)) {
 			mutex_enter(&curr->ms_sync_lock);
 			mutex_enter(&curr->ms_lock);
 			metaslab_flush(curr, tx);
 			mutex_exit(&curr->ms_lock);
 			mutex_exit(&curr->ms_sync_lock);
+
 			if (want_to_flush > 0)
 				want_to_flush--;
+
+			if (spa->spa_log_flushall_mode ==
+			    SPA_LOG_FLUSHALL_REQUEST) {
+				spa_condense_stat_t *scns =
+				    &spa->spa_condense_stats
+				    [SPA_CONDENSE_LOG_SPACEMAP];
+				mutex_enter(&spa->spa_condense_stats_lock);
+				scns->scns_processed++;
+				mutex_exit(&spa->spa_condense_stats_lock);
+			}
 		} else
 			metaslab_unflushed_bump(curr, tx, B_FALSE);
 
@@ -920,9 +1088,9 @@ spa_sync_close_syncing_log_sm(spa_t *spa)
 	 * so the last few TXGs before closing the pool can be empty
 	 * (e.g. not dirty).
 	 */
-	if (spa_flush_all_logs_requested(spa)) {
+	if (spa->spa_log_flushall_mode == SPA_LOG_FLUSHALL_EXPORT) {
 		ASSERT3S(spa_state(spa), ==, POOL_STATE_EXPORTED);
-		spa->spa_log_flushall_txg = 0;
+		spa_log_flushall_done(spa);
 	}
 }
 
@@ -1422,3 +1590,7 @@ ZFS_MODULE_PARAM(zfs, zfs_, max_logsm_summary_length, U64, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs, zfs_, min_metaslabs_to_flush, U64, ZMOD_RW,
 	"Minimum number of metaslabs to flush per dirty TXG");
+
+ZFS_MODULE_PARAM(zfs, zfs_, min_metaslabs_to_condense_pct, UINT, ZMOD_RW,
+	"Minimum number of metaslabs to flush per TXG when condensing, "
+	"as a percent of the number of dirty metaslabs at condense start.");

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -769,6 +769,7 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	mutex_init(&spa->spa_flushed_ms_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&spa->spa_activities_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&spa->spa_txg_log_time_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&spa->spa_condense_stats_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	cv_init(&spa->spa_async_cv, NULL, CV_DEFAULT, NULL);
 	cv_init(&spa->spa_evicting_os_cv, NULL, CV_DEFAULT, NULL);
@@ -961,6 +962,7 @@ spa_remove(spa_t *spa)
 	mutex_destroy(&spa->spa_feat_stats_lock);
 	mutex_destroy(&spa->spa_activities_lock);
 	mutex_destroy(&spa->spa_txg_log_time_lock);
+	mutex_destroy(&spa->spa_condense_stats_lock);
 
 	kmem_free(spa, sizeof (spa_t));
 }

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -20,6 +20,11 @@
  * CDDL HEADER END
  */
 
+/*
+ * Copyright (c) 2024-2026, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
+ */
+
 #include <sys/zfs_context.h>
 #include <sys/spa_impl.h>
 #include <sys/vdev_impl.h>
@@ -1037,6 +1042,82 @@ spa_iostats_destroy(spa_t *spa)
 	mutex_destroy(&shk->lock);
 }
 
+/*
+ * Log spacemap stats.
+ */
+typedef struct spa_log_sm_stats {
+	kstat_named_t	unflushed_memused;
+	kstat_named_t	unflushed_blocklimit;
+	kstat_named_t	unflushed_nblocks;
+} spa_log_sm_stats_t;
+
+static spa_log_sm_stats_t spa_log_sm_stats_template = {
+	{ "unflushed_memused",		KSTAT_DATA_UINT64 },
+	{ "unflushed_blocklimit",	KSTAT_DATA_UINT64 },
+	{ "unflushed_nblocks",		KSTAT_DATA_UINT64 }
+};
+
+#define	SPA_LOG_SM_STATS_SET(stat, val) \
+    atomic_store_64(&log_sm_stats->stat.value.ui64, (val));
+
+void
+spa_log_sm_stats_update(spa_t *spa)
+{
+	spa_history_kstat_t *shk = &spa->spa_stats.log_spacemaps;
+	kstat_t *ksp = shk->kstat;
+
+	if (ksp == NULL)
+		return;
+
+	spa_log_sm_stats_t *log_sm_stats = ksp->ks_data;
+
+	SPA_LOG_SM_STATS_SET(unflushed_memused,
+	    spa->spa_unflushed_stats.sus_memused);
+	SPA_LOG_SM_STATS_SET(unflushed_blocklimit,
+	    spa->spa_unflushed_stats.sus_blocklimit);
+	SPA_LOG_SM_STATS_SET(unflushed_nblocks,
+	    spa->spa_unflushed_stats.sus_nblocks);
+}
+
+static void
+spa_log_sm_stats_init(spa_t *spa)
+{
+	spa_history_kstat_t *shk = &spa->spa_stats.log_spacemaps;
+
+	mutex_init(&shk->lock, NULL, MUTEX_DEFAULT, NULL);
+
+	char *name = kmem_asprintf("zfs/%s", spa_name(spa));
+	kstat_t *ksp = kstat_create(name, 0, "log_spacemaps", "misc",
+	    KSTAT_TYPE_NAMED,
+	    sizeof (spa_log_sm_stats_t) / sizeof (kstat_named_t),
+	    KSTAT_FLAG_VIRTUAL);
+
+	shk->kstat = ksp;
+	if (ksp) {
+		ksp->ks_lock = &shk->lock;
+		ksp->ks_data =
+		    kmem_alloc(sizeof (spa_log_sm_stats_t), KM_SLEEP);
+		memcpy(ksp->ks_data, &spa_log_sm_stats_template,
+		    sizeof (spa_log_sm_stats_t));
+		kstat_install(ksp);
+	}
+
+	kmem_strfree(name);
+}
+
+static void
+spa_log_sm_stats_destroy(spa_t *spa)
+{
+	spa_history_kstat_t *shk = &spa->spa_stats.log_spacemaps;
+	kstat_t *ksp = shk->kstat;
+	if (ksp) {
+		kmem_free(ksp->ks_data, sizeof (spa_log_sm_stats_t));
+		kstat_delete(ksp);
+	}
+
+	mutex_destroy(&shk->lock);
+}
+
 void
 spa_stats_init(spa_t *spa)
 {
@@ -1047,11 +1128,13 @@ spa_stats_init(spa_t *spa)
 	spa_state_init(spa);
 	spa_guid_init(spa);
 	spa_iostats_init(spa);
+	spa_log_sm_stats_init(spa);
 }
 
 void
 spa_stats_destroy(spa_t *spa)
 {
+	spa_log_sm_stats_destroy(spa);
 	spa_iostats_destroy(spa);
 	spa_health_destroy(spa);
 	spa_tx_assign_destroy(spa);

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -1047,12 +1047,14 @@ spa_iostats_destroy(spa_t *spa)
  */
 typedef struct spa_log_sm_stats {
 	kstat_named_t	unflushed_memused;
+	kstat_named_t	unflushed_nmetaslabs;
 	kstat_named_t	unflushed_blocklimit;
 	kstat_named_t	unflushed_nblocks;
 } spa_log_sm_stats_t;
 
 static spa_log_sm_stats_t spa_log_sm_stats_template = {
 	{ "unflushed_memused",		KSTAT_DATA_UINT64 },
+	{ "unflushed_nmetaslabs",	KSTAT_DATA_UINT64 },
 	{ "unflushed_blocklimit",	KSTAT_DATA_UINT64 },
 	{ "unflushed_nblocks",		KSTAT_DATA_UINT64 }
 };
@@ -1073,6 +1075,8 @@ spa_log_sm_stats_update(spa_t *spa)
 
 	SPA_LOG_SM_STATS_SET(unflushed_memused,
 	    spa->spa_unflushed_stats.sus_memused);
+	SPA_LOG_SM_STATS_SET(unflushed_nmetaslabs,
+	    spa->spa_unflushed_stats.sus_nmetaslabs);
 	SPA_LOG_SM_STATS_SET(unflushed_blocklimit,
 	    spa->spa_unflushed_stats.sus_blocklimit);
 	SPA_LOG_SM_STATS_SET(unflushed_nblocks,

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -535,12 +535,13 @@ txg_sync_thread(void *arg)
 		uint64_t txg;
 
 		/*
-		 * We sync when we're scanning, there's someone waiting
-		 * on us, or the quiesce thread has handed off a txg to
+		 * We sync when we're scanning or condensing, there's someone
+		 * waiting on us, or the quiesce thread has handed off a txg to
 		 * us, or we have reached our timeout.
 		 */
 		timer = (delta >= timeout ? 0 : timeout - delta);
 		while (!dsl_scan_active(dp->dp_scan) &&
+		    !spa_log_flushall_active(spa) &&
 		    !tx->tx_exiting && timer > 0 &&
 		    tx->tx_synced_txg >= tx->tx_sync_txg_waiting &&
 		    !txg_has_quiesced_to_sync(dp)) {

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -403,6 +403,7 @@ vdev_config_generate_stats(vdev_t *vd, nvlist_t *nv)
 }
 
 static const char *condense_type_keys[] = {
+	POOL_CONDENSE_LOG_SPACEMAP,
 #ifdef ZFS_DEBUG
 	"debug",
 #endif

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -24,6 +24,8 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2020 by Delphix. All rights reserved.
  * Copyright (c) 2017, Intel Corporation.
+ * Copyright (c) 2024-2026, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 /*
@@ -400,6 +402,13 @@ vdev_config_generate_stats(vdev_t *vd, nvlist_t *nv)
 	kmem_free(vsx, sizeof (*vsx));
 }
 
+static const char *condense_type_keys[] = {
+#ifdef ZFS_DEBUG
+	"debug",
+#endif
+	NULL,
+};
+
 static void
 root_vdev_actions_getprogress(vdev_t *vd, nvlist_t *nvl)
 {
@@ -436,6 +445,36 @@ root_vdev_actions_getprogress(vdev_t *vd, nvlist_t *nvl)
 		    ZPOOL_CONFIG_RAIDZ_EXPAND_STATS, (uint64_t *)&pres,
 		    sizeof (pres) / sizeof (uint64_t));
 	}
+
+	nvlist_t *cnv = fnvlist_alloc();
+	for (spa_condense_type_t type = 0; type < SPA_CONDENSE_TYPES; type++) {
+		const spa_condense_stat_t *scns =
+		    &spa->spa_condense_stats[type];
+		if (scns->scns_start_time == 0)
+			continue;
+
+		nvlist_t *tnv = fnvlist_alloc();
+		mutex_enter(&spa->spa_condense_stats_lock);
+
+		if (scns->scns_start_time == 0) {
+			/* It was cleared before we could get the lock, skip. */
+			mutex_exit(&spa->spa_condense_stats_lock);
+			fnvlist_free(tnv);
+			continue;
+		}
+
+		fnvlist_add_uint64(tnv, "start_time", scns->scns_start_time);
+		fnvlist_add_uint64(tnv, "end_time", scns->scns_end_time);
+		fnvlist_add_uint64(tnv, "processed", scns->scns_processed);
+		fnvlist_add_uint64(tnv, "total", scns->scns_total);
+
+		mutex_exit(&spa->spa_condense_stats_lock);
+
+		fnvlist_add_nvlist(cnv, condense_type_keys[type], tnv);
+		fnvlist_free(tnv);
+	}
+	fnvlist_add_nvlist(nvl, ZPOOL_CONFIG_CONDENSE_STATS, cnv);
+	fnvlist_free(cnv);
 }
 
 static void

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -39,9 +39,10 @@
  * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
  * Copyright (c) 2019 Datto Inc.
  * Copyright (c) 2019, 2020 by Christian Schwarz. All rights reserved.
- * Copyright (c) 2019, 2021, 2023, 2024, Klara Inc.
+ * Copyright (c) 2019, 2021, 2023-2026, Klara, Inc.
  * Copyright (c) 2019, Allan Jude
  * Copyright 2026 Oxide Computer Company
+ * Copyright (c) 2026, TrueNAS.
  */
 
 /*
@@ -7569,6 +7570,75 @@ zfs_ioc_pool_sync(const char *pool, nvlist_t *innvl, nvlist_t *onvl)
 }
 
 /*
+ * Control a condense operation.
+ *
+ * innvl: {
+ *     "command" -> "start" or "cancel"
+ *     "type"    -> "debug"
+ * }
+ */
+static const zfs_ioc_key_t zfs_keys_pool_condense[] = {
+	{ZPOOL_CONDENSE_COMMAND,	DATA_TYPE_STRING,	0},
+	{ZPOOL_CONDENSE_TYPE,		DATA_TYPE_STRING,	0},
+};
+
+static int
+zfs_ioc_pool_condense(const char *pool, nvlist_t *innvl, nvlist_t *onvl)
+{
+	(void) onvl;
+
+	const char *cmd = fnvlist_lookup_string(innvl, ZPOOL_CONDENSE_COMMAND);
+	const char *type = fnvlist_lookup_string(innvl, ZPOOL_CONDENSE_TYPE);
+
+	boolean_t start = B_FALSE;
+	if (strcmp(cmd, "start") == 0)
+		start = B_TRUE;
+	else if (strcmp(cmd, "cancel") != 0)
+		return (SET_ERROR(EINVAL));
+
+	spa_condense_type_t ty = SPA_CONDENSE_TYPES;
+#ifdef ZFS_DEBUG
+	if (strcmp(type, "debug") == 0)
+		ty = SPA_CONDENSE_DEBUG;
+#endif
+
+	if (ty == SPA_CONDENSE_TYPES)
+		return (SET_ERROR(EINVAL));
+
+	spa_t *spa;
+	int err = spa_open(pool, &spa, FTAG);
+	if (err != 0)
+		return (err);
+
+	if (spa_suspended(spa)) {
+		spa_close(spa, FTAG);
+		return (SET_ERROR(EAGAIN));
+	}
+
+	if (!spa_writeable(spa)) {
+		spa_close(spa, FTAG);
+		return (SET_ERROR(EROFS));
+	}
+
+	switch (ty) {
+#ifdef ZFS_DEBUG
+	case SPA_CONDENSE_DEBUG:
+		if (start)
+			spa_condense_debug_start(spa);
+		else
+			spa_condense_debug_cancel(spa);
+		break;
+#endif
+	default:
+		__builtin_unreachable();
+	}
+
+	spa_close(spa, FTAG);
+
+	return (0);
+}
+
+/*
  * Load a user's wrapping key into the kernel.
  * innvl: {
  *     "hidden_args" -> { "wkeydata" -> value }
@@ -7921,6 +7991,10 @@ zfs_ioctl_init(void)
 	    zfs_ioc_pool_sync, zfs_secpolicy_none, POOL_NAME,
 	    POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY, B_FALSE, B_FALSE,
 	    zfs_keys_pool_sync, ARRAY_SIZE(zfs_keys_pool_sync));
+	zfs_ioctl_register("condense", ZFS_IOC_POOL_CONDENSE,
+	    zfs_ioc_pool_condense, zfs_secpolicy_none, POOL_NAME,
+	    POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY, B_FALSE, B_FALSE,
+	    zfs_keys_pool_condense, ARRAY_SIZE(zfs_keys_pool_condense));
 	zfs_ioctl_register("reopen", ZFS_IOC_POOL_REOPEN, zfs_ioc_pool_reopen,
 	    zfs_secpolicy_config, POOL_NAME, POOL_CHECK_SUSPENDED, B_TRUE,
 	    B_TRUE, zfs_keys_pool_reopen, ARRAY_SIZE(zfs_keys_pool_reopen));

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7574,7 +7574,7 @@ zfs_ioc_pool_sync(const char *pool, nvlist_t *innvl, nvlist_t *onvl)
  *
  * innvl: {
  *     "command" -> "start" or "cancel"
- *     "type"    -> "debug"
+ *     "type"    -> "log_spacemap" (or "debug" in debug builds)
  * }
  */
 static const zfs_ioc_key_t zfs_keys_pool_condense[] = {
@@ -7597,8 +7597,10 @@ zfs_ioc_pool_condense(const char *pool, nvlist_t *innvl, nvlist_t *onvl)
 		return (SET_ERROR(EINVAL));
 
 	spa_condense_type_t ty = SPA_CONDENSE_TYPES;
+	if (strcmp(type, POOL_CONDENSE_LOG_SPACEMAP) == 0)
+		ty = SPA_CONDENSE_LOG_SPACEMAP;
 #ifdef ZFS_DEBUG
-	if (strcmp(type, "debug") == 0)
+	else if (strcmp(type, "debug") == 0)
 		ty = SPA_CONDENSE_DEBUG;
 #endif
 
@@ -7621,6 +7623,19 @@ zfs_ioc_pool_condense(const char *pool, nvlist_t *innvl, nvlist_t *onvl)
 	}
 
 	switch (ty) {
+	case SPA_CONDENSE_LOG_SPACEMAP:
+		if (!spa_feature_is_active(spa, SPA_FEATURE_LOG_SPACEMAP)) {
+			spa_close(spa, FTAG);
+			return (SET_ERROR(ENOTSUP));
+		}
+
+		if (start)
+			spa_log_flushall_start(spa,
+			    SPA_LOG_FLUSHALL_REQUEST, 0);
+		else
+			spa_log_flushall_cancel(spa);
+		break;
+
 #ifdef ZFS_DEBUG
 	case SPA_CONDENSE_DEBUG:
 		if (start)
@@ -7629,6 +7644,7 @@ zfs_ioc_pool_condense(const char *pool, nvlist_t *innvl, nvlist_t *onvl)
 			spa_condense_debug_cancel(spa);
 		break;
 #endif
+
 	default:
 		__builtin_unreachable();
 	}

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -417,6 +417,10 @@ tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg',
     'zpool_clear_readonly']
 tags = ['functional', 'cli_root', 'zpool_clear']
 
+[tests/functional/cli_root/zpool_condense]
+tests = ['zpool_condense_neg', 'zpool_condense_basic']
+tags = ['functional', 'cli_root', 'zpool_condense']
+
 [tests/functional/cli_root/zpool_create]
 tests = ['zpool_create_001_pos', 'zpool_create_002_pos',
     'zpool_create_003_pos', 'zpool_create_004_pos', 'zpool_create_005_pos',
@@ -615,7 +619,7 @@ tests = ['zpool_upgrade_001_pos', 'zpool_upgrade_002_pos',
 tags = ['functional', 'cli_root', 'zpool_upgrade']
 
 [tests/functional/cli_root/zpool_wait]
-tests = ['zpool_wait_discard', 'zpool_wait_freeing',
+tests = ['zpool_wait_discard', 'zpool_wait_freeing', 'zpool_wait_condense',
     'zpool_wait_initialize_basic', 'zpool_wait_initialize_cancel',
     'zpool_wait_initialize_flag', 'zpool_wait_multiple',
     'zpool_wait_no_activity', 'zpool_wait_remove', 'zpool_wait_remove_cancel',

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -1179,7 +1179,7 @@ tests = ['many_fds', 'libzfs_input', 'libzfs_mnttab_cache']
 tags = ['functional', 'libzfs']
 
 [tests/functional/log_spacemap]
-tests = ['log_spacemap_import_logs']
+tests = ['log_spacemap_import_logs', 'log_spacemap_flushall']
 pre =
 post =
 tags = ['functional', 'log_spacemap']

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -264,6 +264,10 @@ tags = ['functional', 'cli_root', 'zpool_attach']
 tests = ['zpool_clear_002_neg']
 tags = ['functional', 'cli_root', 'zpool_clear']
 
+[tests/functional/cli_root/zpool_condense]
+tests = ['zpool_condense_neg', 'zpool_condense_basic']
+tags = ['functional', 'cli_root', 'zpool_condense']
+
 [tests/functional/cli_root/zpool_create]
 tests = ['zpool_create_001_pos', 'zpool_create_002_pos',
     'zpool_create_003_pos', 'zpool_create_004_pos', 'zpool_create_007_neg',

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1770,6 +1770,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/longname/longname_002_pos.ksh \
 	functional/longname/longname_003_pos.ksh \
 	functional/longname/setup.ksh \
+	functional/log_spacemap/log_spacemap_flushall.ksh \
 	functional/log_spacemap/log_spacemap_import_logs.ksh \
 	functional/migration/cleanup.ksh \
 	functional/migration/migration_001_pos.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -181,6 +181,7 @@ nobase_dist_datadir_zfs_tests_tests_DATA += \
 	functional/cli_root/zpool_add/zpool_add.cfg \
 	functional/cli_root/zpool_add/zpool_add.kshlib \
 	functional/cli_root/zpool_clear/zpool_clear.cfg \
+	functional/cli_root/zpool_condense/zpool_condense.kshlib \
 	functional/cli_root/zpool_create/draidcfg.gz \
 	functional/cli_root/zpool_create/zpool_create.cfg \
 	functional/cli_root/zpool_create/zpool_create.shlib \
@@ -1101,6 +1102,10 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_clear/zpool_clear_002_neg.ksh \
 	functional/cli_root/zpool_clear/zpool_clear_003_neg.ksh \
 	functional/cli_root/zpool_clear/zpool_clear_readonly.ksh \
+	functional/cli_root/zpool_condense/cleanup.ksh \
+	functional/cli_root/zpool_condense/setup.ksh \
+	functional/cli_root/zpool_condense/zpool_condense_basic.ksh \
+	functional/cli_root/zpool_condense/zpool_condense_neg.ksh \
 	functional/cli_root/zpool_create/cleanup.ksh \
 	functional/cli_root/zpool_create/create-o_ashift.ksh \
 	functional/cli_root/zpool_create/setup.ksh \
@@ -1414,6 +1419,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_wait/scan/zpool_wait_scrub_cancel.ksh \
 	functional/cli_root/zpool_wait/scan/zpool_wait_scrub_flag.ksh \
 	functional/cli_root/zpool_wait/setup.ksh \
+	functional/cli_root/zpool_wait/zpool_wait_condense.ksh \
 	functional/cli_root/zpool_wait/zpool_wait_discard.ksh \
 	functional/cli_root/zpool_wait/zpool_wait_freeing.ksh \
 	functional/cli_root/zpool_wait/zpool_wait_initialize_basic.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_condense/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_condense/cleanup.ksh
@@ -1,0 +1,31 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_condense/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_condense/setup.ksh
@@ -1,0 +1,33 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+
+default_setup $DISK

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_condense/zpool_condense.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_condense/zpool_condense.kshlib
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+function is_condense_debug_available {
+	zpool condense --types | grep -qs debug
+	return $?
+}
+
+function is_pool_condensing #pool type <verbose>
+{
+	check_pool_status "$1" "condense" "$2: condensing" $3
+}
+
+function is_pool_condense_cancelled #pool type <verbose>
+{
+	check_pool_status "$1" "condense" "$2: cancelled" $3
+}
+
+function is_pool_condense_done #pool type <verbose>
+{
+	check_pool_status "$1" "condense" "$2: done" $3
+}

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_condense/zpool_condense_basic.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_condense/zpool_condense_basic.ksh
@@ -1,0 +1,43 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_condense/zpool_condense.kshlib
+
+#
+#	Verify basic operation of the condense command. This uses the "debug"
+#	condense type available in debug builds.
+#
+
+verify_runnable "global"
+
+if ! is_condense_debug_available ; then
+	log_unsupported "need 'debug' condense type for this test"
+fi
+
+log_assert "Verify condense start, cancel and wait flags work correctly."
+
+log_must zpool condense -t debug $TESTPOOL
+log_must is_pool_condensing $TESTPOOL debug true
+
+log_must zpool condense -t debug -c $TESTPOOL
+log_must is_pool_condense_cancelled $TESTPOOL debug true
+
+log_must zpool condense -t debug -w $TESTPOOL
+log_must is_pool_condense_done $TESTPOOL debug true
+
+log_assert "Verified condense start, cancel and wait flags work correctly."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_condense/zpool_condense_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_condense/zpool_condense_neg.ksh
@@ -1,0 +1,51 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2019 by Tim Chase. All rights reserved.
+# Copyright (c) 2019 Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#	A badly formed parameter passed to 'zpool condense' should
+#	return an error.
+#
+# STRATEGY:
+#	1. Create an array containing bad 'zpool condense' parameters.
+#	2. For each element, execute the sub-command.
+#	3. Verify it returns an error.
+#
+
+verify_runnable "global"
+
+typeset -a args=( \
+    "-?" "-n" "-1" "-xz1" "--yoyo" \
+    "-t" "-t none" "--type" "--type none" \
+    "-type" "-type none" "-type log_spacemap" "-all" "-cancel" "-wait")
+
+log_assert "Execute 'zpool condense' using invalid parameters."
+
+typeset -i i=0
+while [[ $i -lt ${#args[*]} ]]; do
+	log_mustnot zpool condense ${args[i]} $TESTPOOL
+	((i = i + 1))
+done
+
+log_pass "Invalid parameters to 'zpool condense' fail as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_wait/zpool_wait_condense.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_wait/zpool_wait_condense.ksh
@@ -1,0 +1,48 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_wait/zpool_wait.kshlib
+. $STF_SUITE/tests/functional/cli_root/zpool_condense/zpool_condense.kshlib
+
+verify_runnable "global"
+
+if ! is_condense_debug_available ; then
+	log_unsupported "need 'debug' condense type for this test"
+fi
+
+function cleanup
+{
+	poolexists $TESTPOOL && log_must zpool destroy $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_assert "Verify zpool wait correctly waits for condense."
+
+log_must zpool create -f $TESTPOOL $DISK1 $DISK2
+
+log_must zpool condense -t debug $TESTPOOL
+log_must is_pool_condensing $TESTPOOL debug true
+
+log_must zpool wait -t condense $TESTPOOL
+
+log_must is_pool_condense_done $TESTPOOL debug true
+
+log_must zpool destroy $TESTPOOL
+
+log_assert "Verified zpool wait correctly waits for condense."

--- a/tests/zfs-tests/tests/functional/log_spacemap/log_spacemap_flushall.ksh
+++ b/tests/zfs-tests/tests/functional/log_spacemap/log_spacemap_flushall.ksh
@@ -1,0 +1,97 @@
+#! /bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025-2026, Klara, Inc.
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+
+# This tests the on-demand "flush all spacemap logs" feature. This is the same
+# process is that triggered at pool export, but instead we trigger it ahead of
+# time via `zpool condense`.
+#
+# This test uses `zdb -m` to know how much is waiting to be flushed. All we're
+# looking for is that the flushall function works, not how much it's doing.
+
+#
+# STRATEGY:
+#	1. Create pool.
+#	2. Write things, which will add to the spacemap logs.
+#	3. Save the counters.
+#	4. Request the spacemap logs be flushed.
+#	5. Compare counters against previous values.
+#
+
+verify_runnable "global"
+
+LOGSM_POOL="logsm_flushall"
+
+function cleanup
+{
+	if poolexists $LOGSM_POOL; then
+		log_must zpool destroy -f $LOGSM_POOL
+	fi
+}
+log_onexit cleanup
+
+function get_smp_length {
+	#
+	# zdb -m output includes:
+	#
+	#   Log Space Maps in Pool:
+	#   Log Spacemap object 152330 txg 4493989
+	#   space map object 152330:
+	#     smp_length = 0x670
+	#     smp_alloc = 0x0
+	#   Log Spacemap object 151720 txg 4493990
+	#     space map object 151720:
+	#   ...
+	#
+	# Traditional awk doesn't understand hex numbers, so we run them back
+	# through printf to covert to decimal before summing them.
+	#
+	zdb -m $LOGSM_POOL | awk '
+	    /^Log Spacemap object/ { onoff = 1 }
+	    /smp_length/ && onoff { print $3 }
+	' | xargs -n1 printf '%d\n' | awk '
+	    { sum += $1 } END { print sum }
+	'
+}
+
+log_must zpool create -o cachefile=none -f \
+    -O compression=off -O recordsize=16k \
+    $LOGSM_POOL $DISKS
+
+for s in $(seq 256) ; do
+	log_must file_write -o create -f /$LOGSM_POOL/$s -b 16384 -c 1 -d R
+	sync_pool $LOGSM_POOL
+done
+
+typeset length_1=$(get_smp_length)
+
+log_must zpool condense -t log_spacemap -w $LOGSM_POOL
+
+typeset length_2=$(get_smp_length)
+
+log_must test $length_1 -gt $length_2
+
+log_pass "Log spacemaps on-demand flushall works"


### PR DESCRIPTION
_[Sponsors: TrueNAS, Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

Normally, log spacemaps are flushed out to the metaslabs when the pool is exported. For large logs, this can lead to export taking an inordinate amount of time.

This PR adds a an on-demand variant of the log spacemap flush, and a `zpool condense`  command to trigger it. With it, an operator can request that log spacemaps be flushed ahead of time, so that there is relatively little work to be done at export time.

### Description

There's two halves to this.

First, we add a "mode" to the existing "flushall" behaviour in `spa_flush_metaslabs()`. The traditional behaviour is now "export mode", and flushes all logs. Some new functions are added to start and stop the flush with a given mode. Then we add a "request" mode, for use by the operator. This follows the same logic of walking the logs and flushing them out, but skips any that were modified after the flush request was made.

The second part is the addition of the `zpool condense` command, and support library and ioctl additions. This takes a `-t <target>` parameter, which is the "thing" to condense, flush, garbage-collect or otherwise accelerate background processing for. It's designed so it could be wired up to any similar background process in the future. In particular, I had the dedup log in mind while putting it together.

All the trimmings you'd expect are there. Condense operations can be cancelled, restoring the flushing behaviour to its original pace or schedule. They can be waited on, via `condense -w` or `wait -t condense`. The latter combines all condense targets into one signal value, theoretically allowing multiple things to be condensed at the same time, and wait until they're all finished. Without a second or maybe even third target it's unclear to me if this it what the user will expect, but I don't think this is far off and it can be changes when the next thing gets hooked up.

I've included a kstat exposing the pool "unflushed" counters. We used this in our initial investigations. I thought it was going to be useful for the ZTS test, but it ended up being too difficult to control reliably. So nothing here uses it directly, but it doesn't hurt anything to have it there and may help someone, so why not.

### How Has This Been Tested?

`ztest` gets support, and has had many tens of runs without issue. ZTS test has been added, and the entire suite run to successful completion.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
