### PR TITLE
zdb: show dedup table and log attributes

### DIFF
--- a/tests/zfs-tests/tests/functional/dedup/dedup_fdt_create.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_fdt_create.ksh
@@ -70,7 +70,7 @@ log_must zpool sync
 log_must test $(get_pool_prop feature@fast_dedup $TESTPOOL) = "active"
 
 # four entries in the unique table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique:.*entries=4'"
 
 # single containing object in the MOS
 log_must test $(zdb -dddd $TESTPOOL 1 | grep DDT-sha256 | wc -l) -eq 1
@@ -84,7 +84,7 @@ log_must cp /$TESTPOOL/file1 /$TESTPOOL/file2
 log_must zpool sync
 
 # now four entries in the duplicate table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-duplicate: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-duplicate:.*entries=4'"
 
 # now two DDT ZAPs in the container object; DDT ZAPs aren't cleaned up until
 # the entire logical table is destroyed

--- a/tests/zfs-tests/tests/functional/dedup/dedup_fdt_import.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_fdt_import.ksh
@@ -70,7 +70,7 @@ log_must zpool sync
 log_must test $(get_pool_prop feature@fast_dedup $TESTPOOL) = "active"
 
 # four entries in the unique table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique:.*entries=4'"
 
 # single containing object in the MOS
 log_must test $(zdb -dddd $TESTPOOL 1 | grep DDT-sha256 | wc -l) -eq 1
@@ -107,7 +107,7 @@ log_must zpool sync
 log_must test $(get_pool_prop feature@fast_dedup $TESTPOOL) = "active"
 
 # four entries in the unique table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique:.*entries=4'"
 
 # single containing object in the MOS
 log_must test $(zdb -dddd $TESTPOOL 1 | grep DDT-sha256 | wc -l) -eq 1

--- a/tests/zfs-tests/tests/functional/dedup/dedup_legacy_create.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_legacy_create.ksh
@@ -63,7 +63,7 @@ log_must zpool sync
 log_must test $(get_pool_prop feature@fast_dedup $TESTPOOL) = "disabled"
 
 # should be four entries in the unique table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique:.*entries=4'"
 
 # should be just one DDT ZAP in the MOS
 log_must test $(zdb -dddd $TESTPOOL 1 | grep DDT-sha256-zap- | wc -l) -eq 1
@@ -73,7 +73,7 @@ log_must cp /$TESTPOOL/file1 /$TESTPOOL/file2
 log_must zpool sync
 
 # now four entries in the duplicate table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-duplicate: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-duplicate:.*entries=4'"
 
 # now two DDT ZAPs in the MOS; DDT ZAPs aren't cleaned up until the entire
 # logical table is destroyed

--- a/tests/zfs-tests/tests/functional/dedup/dedup_legacy_fdt_mixed.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_legacy_fdt_mixed.ksh
@@ -71,7 +71,7 @@ log_must dd if=/dev/urandom of=/$TESTPOOL/ds1/file1 bs=128k count=4
 log_must zpool sync
 
 # should be four entries in the skein unique table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-skein-zap-unique: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-skein-zap-unique:.*entries=4'"
 
 # should be just one DDT ZAP in the MOS
 log_must test $(zdb -dddd $TESTPOOL 1 | grep DDT-.*-zap- | wc -l) -eq 1
@@ -90,7 +90,7 @@ log_must zpool sync
 log_must test $(get_pool_prop feature@fast_dedup $TESTPOOL) = "active"
 
 # now also four entries in the blake3 unique table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-blake3-zap-unique: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-blake3-zap-unique:.*entries=4'"
 
 # two entries in the MOS: the legacy skein DDT ZAP, and the containing dir for
 # the blake3 FDT table

--- a/tests/zfs-tests/tests/functional/dedup/dedup_legacy_fdt_upgrade.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_legacy_fdt_upgrade.ksh
@@ -71,7 +71,7 @@ log_must zpool sync
 log_must test $(get_pool_prop feature@fast_dedup $TESTPOOL) = "disabled"
 
 # should be four entries in the unique table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique:.*entries=4'"
 
 # should be just one DDT ZAP in the MOS
 log_must test $(zdb -dddd $TESTPOOL 1 | grep DDT-sha256-zap- | wc -l) -eq 1
@@ -90,7 +90,7 @@ log_must zpool sync
 log_must test $(get_pool_prop feature@fast_dedup $TESTPOOL) = "enabled"
 
 # now four entries in the duplicate table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-duplicate: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-duplicate:.*entries=4'"
 
 # now two DDT ZAPs in the MOS; DDT ZAPs aren't cleaned up until the entire
 # logical table is destroyed
@@ -117,7 +117,7 @@ log_must zpool sync
 log_must test $(get_pool_prop feature@fast_dedup $TESTPOOL) = "active"
 
 # four entries in the unique table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique:.*entries=4'"
 
 # single containing object in the MOS
 log_must test $(zdb -dddd $TESTPOOL 1 | grep DDT-sha256 | wc -l) -eq 1

--- a/tests/zfs-tests/tests/functional/dedup/dedup_legacy_import.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_legacy_import.ksh
@@ -63,7 +63,7 @@ log_must zpool sync
 log_must test $(get_pool_prop feature@fast_dedup $TESTPOOL) = "disabled"
 
 # should be four entries in the unique table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique:.*entries=4'"
 
 # should be just one DDT ZAP in the MOS
 log_must test $(zdb -dddd $TESTPOOL 1 | grep DDT-sha256-zap- | wc -l) -eq 1
@@ -96,7 +96,7 @@ log_must zpool sync
 log_must test $(get_pool_prop feature@fast_dedup $TESTPOOL) = "disabled"
 
 # should be four entries in the unique table
-log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique: 4 entries'"
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique:.*entries=4'"
 
 # should be just one DDT ZAP in the MOS
 log_must test $(zdb -dddd $TESTPOOL 1 | grep DDT-sha256-zap- | wc -l) -eq 1


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

Commenting on #16752, and realised we didn't have a way to definitely show what kind dedup options are in place.

### Description

Extends `dump_ddt()` to show container config (version, flags) and log flags and other info. A bit more lowlevel detail as befits a debugger.

```
$ zdb -D tank
DDT-blake3: version=1 [FDT]; flags=0x03 [FLAT LOG]; rootobj=65
DDT-blake3-zap-duplicate: dspace=0xa3400; mspace=0x88000; entries=1888
DDT-blake3-zap-unique: dspace=0x121800; mspace=0x108000; entries=2968
DDT-log-blake3-0: flags=0x01 [FLUSHING]; obj=66; len=0x0; txg=649; entries=0
DDT-log-blake3-1: flags=0x00; obj=67; len=0x160000; txg=657; entries=360
```

```
$ zdb -D tank
DDT-blake3: version=0 [LEGACY]; flags=0x00; rootobj=1
DDT-blake3-zap-duplicate: dspace=0x6e800; mspace=0x48000; entries=1824
DDT-blake3-zap-unique: dspace=0xba400; mspace=0x88000; entries=2752
```

Goes on to show the histograms and etc as it did before, so something for everyone.

### How Has This Been Tested?

Just eyeballing on various test dedup configs and load generators I have lying around.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
