### PR TITLE
Remove hash_elements_max accounting from DBUF and ARC

### DIFF
--- a/cmd/arc_summary
+++ b/cmd/arc_summary
@@ -662,10 +662,7 @@ def section_arc(kstats_dict):
     print()
 
     print('ARC hash breakdown:')
-    prt_i1('Elements max:', f_hits(arc_stats['hash_elements_max']))
-    prt_i2('Elements current:',
-           f_perc(arc_stats['hash_elements'], arc_stats['hash_elements_max']),
-           f_hits(arc_stats['hash_elements']))
+    prt_i1('Elements:', f_hits(arc_stats['hash_elements']))
     prt_i1('Collisions:', f_hits(arc_stats['hash_collisions']))
 
     prt_i1('Chain max:', f_hits(arc_stats['hash_chain_max']))

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -942,6 +942,7 @@ typedef struct arc_sums {
 	wmsum_t arcstat_evict_l2_eligible_mru;
 	wmsum_t arcstat_evict_l2_ineligible;
 	wmsum_t arcstat_evict_l2_skip;
+	wmsum_t arcstat_hash_elements;
 	wmsum_t arcstat_hash_collisions;
 	wmsum_t arcstat_hash_chains;
 	aggsum_t arcstat_size;


### PR DESCRIPTION
Those values require global atomics to get current hash_elements values in few of the hottest code paths, while in all the years I never cared about it.  If somebody wants, it should be easy to get it by periodic sampling, since neither ARC header nor DBUF counts change so fast that it would be difficult to catch.

For now I've left hash_elements_max kstat for ARC, since it was used/reported by arc_summary and it would break older versions, but now it just reports the current value.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
