### PR TITLE
FreeBSD: Enable Direct IO by default

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -89,15 +89,8 @@ int zfs_bclone_wait_dirty = 1;
  * Enable Direct I/O. If this setting is 0, then all I/O requests will be
  * directed through the ARC acting as though the dataset property direct was
  * set to disabled.
- *
- * Disabled by default on FreeBSD until a potential range locking issue in
- * zfs_getpages() can be resolved.
  */
-#ifdef __FreeBSD__
-static int zfs_dio_enabled = 0;
-#else
 static int zfs_dio_enabled = 1;
-#endif
 
 /*
  * Strictly enforce alignment for Direct I/O requests, returning EINVAL


### PR DESCRIPTION
### Motivation and Context

Enable Direct IO for FreeBSD.

### Description

Commits 25eb538778, 178682506f, and 8dc452d907 resolve the remaining known issues with Direct IO on FreeBSD. Enable it by default on all platforms.

### How Has This Been Tested?

Locally tested in the PRs which resolved the above remaining issues.  Additional tests to be done by the CI.

@markjdb thanks for sorting out these issues.  Unless you know of any other problems let's enable this by default.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
