### PR TITLE
ZTS: Fix zpool_status_008_pos false positive

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_008_pos.ksh
@@ -69,15 +69,16 @@ for raid_type in "draid2:3d:6c:1s" "raidz2"; do
 	log_mustnot eval "zpool status -e $TESTPOOL2 | grep ONLINE"
 
 	# Check no ONLINE slow vdevs are show.  Then mark IOs greater than
-	# 160ms slow, delay IOs 320ms to vdev6, check slow IOs.
+	# 750ms slow, delay IOs 1000ms to vdev6, check slow IOs.
 	log_must check_vdev_state $TESTPOOL2 $TESTDIR/vdev6 "ONLINE"
 	log_mustnot eval "zpool status -es $TESTPOOL2 | grep ONLINE"
 
-	log_must set_tunable64 ZIO_SLOW_IO_MS 160
-	log_must zinject -d $TESTDIR/vdev6 -D320:100 $TESTPOOL2
+	log_must set_tunable64 ZIO_SLOW_IO_MS 750
+	log_must zinject -d $TESTDIR/vdev6 -D1000:100 $TESTPOOL2
 	log_must mkfile 1048576 /$TESTPOOL2/testfile
 	sync_pool $TESTPOOL2
 	log_must set_tunable64 ZIO_SLOW_IO_MS $OLD_SLOW_IO
+	log_must zinject -c all
 
 	# Check vdev6 slow IOs are only shown when requested with -s.
 	log_mustnot eval "zpool status -e $TESTPOOL2 | grep $TESTDIR/vdev6 | grep ONLINE"
@@ -95,10 +96,9 @@ for raid_type in "draid2:3d:6c:1s" "raidz2"; do
 	log_mustnot eval "zpool status -es $TESTPOOL2 | grep $TESTDIR/vdev2 | grep ONLINE"
 	log_mustnot eval "zpool status -es $TESTPOOL2 | grep $TESTDIR/vdev3 | grep ONLINE"
 
-	log_must zinject -c all
 	log_must zpool status -es $TESTPOOL2
 
-	zpool destroy $TESTPOOL2
+	log_must zpool destroy $TESTPOOL2
 done
 
 log_pass "Verify zpool status -e shows only unhealthy vdevs"


### PR DESCRIPTION
### Motivation and Context

Resolve false positives reported by the CI for the `zpool_status_008_pos` test case.

https://github.com/openzfs/zfs/actions/runs/11848141397/job/33027753860?pr=16755
https://github.com/openzfs/zfs/actions/runs/11848141397/job/33027755132?pr=16755

### Description

~When checking that healthy vdevs[1-3] aren't shown omit the -s flag so slow vdevs are not considered as described by the comment.  This avoids the possibility of a false positive in the CI when ZIO_SLOW_IO_MS is reduce to 160ms.  Additionally, clear the fault injection as soon as it is no longer required for the test case.~

Increase the injected delay to 1000ms and the ZIO_SLOW_IO_MS threshold to 750ms to avoid false positives due to unrelated slow IOs which may occur in the CI environment.  Additionally, clear the fault injection as soon as it is no longer required for the test case.

### How Has This Been Tested?

Updated only the test case which will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
