### PR TITLE
Move "no name changes" from compression to checksum table

### DIFF
--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -160,6 +160,12 @@ abd_fletcher_4_byteswap(abd_t *abd, uint64_t size,
 	abd_fletcher_4_impl(abd, size, &acd);
 }
 
+/*
+ * Checksum vectors.
+ *
+ * Note: you cannot change the name string for these functions, as they are
+ * embedded in on-disk data in some places (eg dedup table names).
+ */
 zio_checksum_info_t zio_checksum_table[ZIO_CHECKSUM_FUNCTIONS] = {
 	{{NULL, NULL}, NULL, NULL, 0, "inherit"},
 	{{NULL, NULL}, NULL, NULL, 0, "on"},

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -44,10 +44,6 @@ static unsigned long zio_decompress_fail_fraction = 0;
 
 /*
  * Compression vectors.
- *
- * NOTE: DO NOT CHANGE THE NAMES OF THESE COMPRESSION FUNCTIONS.
- * THEY ARE USED AS ZAP KEY NAMES BY FAST DEDUP AND THEREFORE
- * PART OF THE ON-DISK FORMAT.
  */
 zio_compress_info_t zio_compress_table[ZIO_COMPRESS_FUNCTIONS] = {
 	{"inherit",	0,	NULL,	NULL, NULL},


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

A comment that confused me. Compression names actually aren't used in dedup table names, but checksum names are.

Was introduced in review https://github.com/openzfs/zfs/pull/15892#discussion_r1679835046.

### Description

Moved the comment (and de-shouted it) to where I think it should have been.

I wonder how necessary this really is. It's not wrong, but I expect there's lots of things that are stored on disk that aren't immediately obvious, so it feels weird to call out just this case. On the other hand, maybe this is just a step towards someday calling them all out, so its no big deal :)

### How Has This Been Tested?

Comment change. no testing done.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
