### PR TITLE
Expand `zpool-remove.8` manpage with example results

### DIFF
--- a/man/man8/zpool-remove.8
+++ b/man/man8/zpool-remove.8
@@ -109,7 +109,7 @@ Stops and cancels an in-progress removal of a top-level vdev.
 .El
 .
 .Sh EXAMPLES
-.\" These are, respectively, examples 14 from zpool.8
+.\" These are, respectively, examples 15 from zpool.8
 .\" Make sure to update them bidirectionally
 .Ss Example 1 : No Removing a Mirrored top-level (Log or Data) Device
 The following commands remove the mirrored log device
@@ -142,9 +142,43 @@ The command to remove the mirrored log
 .Ar mirror-2 No is :
 .Dl # Nm zpool Cm remove Ar tank mirror-2
 .Pp
+At this point, the log device no longer exists
+(both sides of the mirror have been removed):
+.Bd -literal -compact -offset Ds
+  pool: tank
+ state: ONLINE
+  scan: none requested
+config:
+
+        NAME        STATE     READ WRITE CKSUM
+        tank        ONLINE       0     0     0
+          mirror-0  ONLINE       0     0     0
+            sda     ONLINE       0     0     0
+            sdb     ONLINE       0     0     0
+          mirror-1  ONLINE       0     0     0
+            sdc     ONLINE       0     0     0
+            sdd     ONLINE       0     0     0
+.Ed
+.Pp
 The command to remove the mirrored data
 .Ar mirror-1 No is :
 .Dl # Nm zpool Cm remove Ar tank mirror-1
+.Pp
+After
+.Ar mirror-1 No has been evacuated, the pool remains redundant, but
+the total amount of space is reduced:
+.Bd -literal -compact -offset Ds
+  pool: tank
+ state: ONLINE
+  scan: none requested
+config:
+
+        NAME        STATE     READ WRITE CKSUM
+        tank        ONLINE       0     0     0
+          mirror-0  ONLINE       0     0     0
+            sda     ONLINE       0     0     0
+            sdb     ONLINE       0     0     0
+.Ed
 .
 .Sh SEE ALSO
 .Xr zpool-add 8 ,

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -405,9 +405,43 @@ The command to remove the mirrored log
 .Ar mirror-2 No is :
 .Dl # Nm zpool Cm remove Ar tank mirror-2
 .Pp
+At this point, the log device no longer exists
+(both sides of the mirror have been removed):
+.Bd -literal -compact -offset Ds
+  pool: tank
+ state: ONLINE
+  scan: none requested
+config:
+
+        NAME        STATE     READ WRITE CKSUM
+        tank        ONLINE       0     0     0
+          mirror-0  ONLINE       0     0     0
+            sda     ONLINE       0     0     0
+            sdb     ONLINE       0     0     0
+          mirror-1  ONLINE       0     0     0
+            sdc     ONLINE       0     0     0
+            sdd     ONLINE       0     0     0
+.Ed
+.Pp
 The command to remove the mirrored data
 .Ar mirror-1 No is :
 .Dl # Nm zpool Cm remove Ar tank mirror-1
+.Pp
+After
+.Ar mirror-1 No has been evacuated, the pool remains redundant, but
+the total amount of space is reduced:
+.Bd -literal -compact -offset Ds
+  pool: tank
+ state: ONLINE
+  scan: none requested
+config:
+
+        NAME        STATE     READ WRITE CKSUM
+        tank        ONLINE       0     0     0
+          mirror-0  ONLINE       0     0     0
+            sda     ONLINE       0     0     0
+            sdb     ONLINE       0     0     0
+.Ed
 .
 .Ss Example 16 : No Displaying expanded space on a device
 The following command displays the detailed information for the pool


### PR DESCRIPTION
### Motivation and Context
In the `zpool-remove` manpage's example of removing mirrors, it wasn't clear to me whether the removal commands would remove the _entire vdev_, or merely cause the mirrored vdev become _unmirrored_ (reduce its redundancy).  I performed a test and confirmed that it's the former, so I figured it might be useful to include the results in the example.

Also, `zpool-remove.8` has a comment cross-referencing to `zpool.8`, but the example number was off, so I fixed it.

### How Has This Been Tested?
Verified formatting by running:
```sh
man ./man/man8/zpool-remove.8
man ./man/man8/zpool.8
```
Also ran:
```sh
./scripts/mancheck.sh man
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
   - I didn't find a style guide for manpages.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
   - n/a
- [ ] I have run the ZFS Test Suite with this change applied.
   - n/a
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
