### PR TITLE
Linux: Fix openzfs kernel module loading on 6.11+ with CONFIG_RANDSTRUCT=y

### DIFF
--- a/config/kernel-register_sysctl_table.m4
+++ b/config/kernel-register_sysctl_table.m4
@@ -36,7 +36,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_REGISTER_SYSCTL_SZ], [
 	ZFS_LINUX_TEST_SRC([has_register_sysctl_sz], [
 		#include <linux/sysctl.h>
 	],[
-		struct ctl_table test_table[] __attribute__((unused)) = {0};
+		struct ctl_table test_table[] __attribute__((unused)) = {{}};
 		register_sysctl_sz("", test_table, 0);
 	])
 ])


### PR DESCRIPTION
Fixes openzfs kernel module loading on 6.11+ with CONFIG_RANDSTRUCT=y
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
This change fixes #16620
It looks like detection logic for register_sysctl_sz() in kernel-register_sysctl_table.m4 doesn't quite work with ```CONFIG_RANDSTRUCT=y```. It causes the same issue as before the original fix in https://github.com/openzfs/zfs/commit/2633075e0905bbe4989a469c7d5892f2cf1108be#diff-cc1bb9d36ff95af7e87e3c4a8fc022ea302ecfdccbc9fa1e9663c9c7b51dc416R722
```
sysctl table check failed: kernel/spl/(null) No proc_handler
```

### Description
The fix is to replace {0} with {{}} in the m4 script, which better matches the sentinels we use in spl-proc.c

### How Has This Been Tested?
  * Verified that register_sysctl_sz is detected correctly on kernels v6.5, v6.10, v6.11.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).