### PR TITLE
FreeBSD: Return ifndef IN_BASE back to fix the build

### DIFF
--- a/include/os/freebsd/spl/sys/vnode.h
+++ b/include/os/freebsd/spl/sys/vnode.h
@@ -68,30 +68,18 @@ enum symfollow { NO_FOLLOW = NOFOLLOW };
 #include <vm/vm_object.h>
 
 typedef	struct vop_vector	vnodeops_t;
-#define	VOP_FID		VOP_VPTOFH
 #define	vop_fid		vop_vptofh
 #define	vop_fid_args	vop_vptofh_args
 #define	a_fid		a_fhp
 
-#define	rootvfs		(rootvnode == NULL ? NULL : rootvnode->v_mount)
-
-#ifndef IN_BASE
-static __inline int
-vn_is_readonly(vnode_t *vp)
-{
-	return (vp->v_mount->mnt_flag & MNT_RDONLY);
-}
-#endif
 #define	vn_vfswlock(vp)		(0)
 #define	vn_vfsunlock(vp)	do { } while (0)
-#define	vn_ismntpt(vp)	   \
-	((vp)->v_type == VDIR && (vp)->v_mountedhere != NULL)
-#define	vn_mountedvfs(vp)	((vp)->v_mountedhere)
+
+#ifndef IN_BASE
 #define	vn_has_cached_data(vp)	\
 	((vp)->v_object != NULL && \
 	(vp)->v_object->resident_page_count > 0)
 
-#ifndef IN_BASE
 static __inline void
 vn_flush_cached_data(vnode_t *vp, boolean_t sync)
 {
@@ -104,9 +92,6 @@ vn_flush_cached_data(vnode_t *vp, boolean_t sync)
 }
 #endif
 
-#define	vn_exists(vp)		do { } while (0)
-#define	vn_invalid(vp)		do { } while (0)
-#define	vn_free(vp)		do { } while (0)
 #define	vn_matchops(vp, vops)	((vp)->v_op == &(vops))
 
 #define	VN_HOLD(v)	vref(v)
@@ -120,9 +105,6 @@ vn_flush_cached_data(vnode_t *vp, boolean_t sync)
 #define	vnevent_rename_src(vp, dvp, name, ct)	do { } while (0)
 #define	vnevent_rename_dest(vp, dvp, name, ct)	do { } while (0)
 #define	vnevent_rename_dest_dir(vp, ct)		do { } while (0)
-
-#define	specvp(vp, rdev, type, cr)	(VN_HOLD(vp), (vp))
-#define	MANDLOCK(vp, mode)	(0)
 
 /*
  * We will use va_spare is place of Solaris' va_mask.

--- a/include/os/freebsd/spl/sys/vnode.h
+++ b/include/os/freebsd/spl/sys/vnode.h
@@ -91,6 +91,7 @@ vn_is_readonly(vnode_t *vp)
 	((vp)->v_object != NULL && \
 	(vp)->v_object->resident_page_count > 0)
 
+#ifndef IN_BASE
 static __inline void
 vn_flush_cached_data(vnode_t *vp, boolean_t sync)
 {
@@ -101,6 +102,7 @@ vn_flush_cached_data(vnode_t *vp, boolean_t sync)
 		zfs_vmobject_wunlock(vp->v_object);
 	}
 }
+#endif
 
 #define	vn_exists(vp)		do { } while (0)
 #define	vn_invalid(vp)		do { } while (0)

--- a/module/os/freebsd/zfs/zfs_znode_os.c
+++ b/module/os/freebsd/zfs/zfs_znode_os.c
@@ -370,8 +370,6 @@ zfs_znode_sa_init(zfsvfs_t *zfsvfs, znode_t *zp,
 	 */
 	if (zp->z_id == zfsvfs->z_root && zfsvfs->z_parent == zfsvfs)
 		ZTOV(zp)->v_flag |= VROOT;
-
-	vn_exists(ZTOV(zp));
 }
 
 void


### PR DESCRIPTION
FreeBSD's libprocstat seems to build kernel code in user space, which does not work here due to undefined vnode_t.  It's a mess.

While there, remove some unused illumos compat from vnode.h.

### How Has This Been Tested?
Run FreeBSD world+kernel build with this change in.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
