### PR TITLE
Linux: fix zfs_uio_dio_check_for_zero_page

### DIFF
--- a/module/os/linux/zfs/zfs_uio.c
+++ b/module/os/linux/zfs/zfs_uio.c
@@ -546,8 +546,9 @@ zfs_uio_dio_check_for_zero_page(zfs_uio_t *uio)
 			unlock_page(p);
 			put_page(p);
 
-			p = __page_cache_alloc(gfp_zero_page);
-			zfs_mark_page(p);
+			uio->uio_dio.pages[i] =
+			    __page_cache_alloc(gfp_zero_page);
+			zfs_mark_page(uio->uio_dio.pages[i]);
 		} else {
 			unlock_page(p);
 		}


### PR DESCRIPTION
### Motivation and Context
#16689 #16642

### Description
```
Linux: fix zfs_uio_dio_check_for_zero_page

The intent here is to replace the zero page pointer in the array of
pointers to pages in the struct.
```

### How Has This Been Tested?
locally with reproducer in #16689

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
