### PR TITLE
Linux: syncfs(2) should sync all cached files

### DIFF
--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -49,6 +49,8 @@ extern const struct inode_operations zpl_special_inode_operations;
 extern const struct address_space_operations zpl_address_space_operations;
 extern const struct file_operations zpl_file_operations;
 extern const struct file_operations zpl_dir_file_operations;
+extern int zpl_writepages(struct address_space *mapping,
+    struct writeback_control *wbc);
 
 /* zpl_super.c */
 extern void zpl_prune_sb(uint64_t nr_to_scan, void *arg);

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -546,7 +546,7 @@ zpl_write_cache_pages(struct address_space *mapping,
 	return (result);
 }
 
-static int
+int
 zpl_writepages(struct address_space *mapping, struct writeback_control *wbc)
 {
 	znode_t		*zp = ITOZ(mapping->host);


### PR DESCRIPTION
### Motivation and Context

While debugging problem with data not being synced on umount for #16817, we've noticed that even `syncfs(2)` doesn't help to get the data written out correctly. It is because it doesn't actually sync any of the live znodes.

### Description

I've used `zpl_fsync` unlike `filemap_write_and_wait` in #16817 since that one calls `zil_commit` and this `syncfs(2)` is about on-disk permanence - I _think_ that if the file is opened with `O_SYNC`, all the dirtied pages should be flushed right away so perhaps `filemap_write_and_wait` would suffice, but I'm not 100% sure (and this is how we fixed it for the time being on our infra) 

edit: it seems that writes to mmaped pages aren't flushed immediately, unless `msync(2)` is called - there is the `MAP_SYNC` mmap flag, but it's not supported on FS that doesn't support DAX

edit: see discussion below please

### How Has This Been Tested?

Locally along with #16817

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
