### PR TITLE
isa_defs.h: fix freebsd loongarch compilation errors("ISA not support…

### DIFF
--- a/include/os/freebsd/spl/sys/isa_defs.h
+++ b/include/os/freebsd/spl/sys/isa_defs.h
@@ -159,6 +159,17 @@ extern "C" {
 #endif
 #define	_SUNOS_VTOC_16
 
+#elif defined(__loongarch__) && defined(__loongarch_lp64)
+/*
+ * LoongArch arch specific defines
+ * only LoongArch64 is supported yet
+ * Define the appropriate "implementation choices"
+ */
+#if !defined(_LP64)
+#define	_LP64
+#endif
+#define	_SUNOS_VTOC_16
+
 #elif defined(__arm__)
 
 /*


### PR DESCRIPTION
### Motivation and Context
Attempting to port freebsd to loongarch architecture, compilation error occurred

### Description
Added LoongArch related code with reference to RISC-V

### How Has This Been Tested?
```
===> libsa (all)
mkdir -p xlocale arpa;  for i in a.out.h assert.h elf.h inttypes.h limits.h nlist.h setjmp.h stddef.h stdbool.h string.h strings.h time.h unistd.h uuid.h; do  ln -sf /usr/src/include/$i $i;  done;  ln -sf /usr/src/sys/loongarch/include/stdarg.h stdarg.h;  ln -sf /usr/src/sys/sys/errno.h errno.h;  ln -sf /usr/src/sys/sys/stdint.h stdint.h;  ln -sf /usr/src/include/arpa/inet.h arpa/inet.h;  ln -sf /usr/src/include/arpa/tftp.h arpa/tftp.h;  for i in _time.h _strings.h _string.h; do  [ -f xlocale/$i ] || :> xlocale/$i;  done;  for i in ctype.h fcntl.h signal.h stdio.h stdlib.h; do  ln -sf /usr/src/stand/libsa/stand.h $i;  done
/usr/local/bin/ccache cc -target loongarch64-unknown-freebsd14.2 --sysroot=/usr/obj/usr/src/loongarch.loongarch64/tmp -B/usr/obj/usr/src/loongarch.loongarch64/tmp/usr/bin -ftls-model=initial-exec -O2 -pipe -fno-common -march=loongarch64 -mabi=lp64d   -nostdinc  -I/usr/src/stand/libsa/zfs/spl                                  -I/usr/src/sys/contrib/openzfs/include/os/freebsd                   -I/usr/src/sys/contrib/openzfs/include/os/freebsd/spl                            -I/usr/src/sys/contrib/openzfs/include/os/freebsd/zfs  -I/usr/obj/usr/src/loongarch.loongarch64/stand/libsa -I/usr/src/stand/libsa -D_STANDALONE -I/usr/src/sys -Ddouble=jagged-little-pill -Dfloat=floaty-mcfloatface -DLOADER_GELI_SUPPORT -I/usr/src/stand/libsa/geli -DLOADER_DISK_SUPPORT -ffreestanding  -march=loongarch64 -mabi=lp64d -fPIC -mno-relax -I. -Iinclude -g -gz=zlib -MD  -MF.depend.zfs_zstd.o -MTzfs_zstd.o -std=gnu99 -Wno-format-zero-length -Wsystem-headers -Werror -Wno-pointer-sign -Wdate-time -Wno-empty-body -Wno-string-plus-int -Wno-unused-const-variable -Wno-error=unused-but-set-parameter -Wno-tautological-compare -Wno-unused-value -Wno-parentheses-equality -Wno-unused-function -Wno-enum-conversion -Wno-unused-local-typedef -Wno-address-of-packed-member -Wno-switch -Wno-switch-enum -Wno-knr-promoted-parameter -Wno-parentheses  -Qunused-arguments -include /usr/src/sys/contrib/openzfs/include/os/freebsd/spl/sys/ccompile.h -Wformat -Wall -I/usr/src/sys/contrib/openzfs/include  -DNEED_SOLARIS_BOOLEAN -DIN_BASE -DIN_LIBSA   -c /usr/src/sys/contrib/openzfs/module/zstd/zfs_zstd.c -o zfs_zstd.o
In file included from /usr/src/sys/contrib/openzfs/module/zstd/zfs_zstd.c:43:
In file included from /usr/src/sys/contrib/openzfs/include/os/freebsd/spl/sys/sysmacros.h:35:
/usr/src/sys/contrib/openzfs/include/os/freebsd/spl/sys/isa_defs.h:288:2: error: "ISA not supported"
  288 | #error "ISA not supported"
      |  ^
1 error generated.
*** Error code 1

Stop.
make[3]: stopped in /usr/src/stand/libsa
*** Error code 1

Stop.
make[2]: stopped in /usr/src/stand
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
