### PR TITLE
Add missing parenthesis in VERIFYF()

### DIFF
--- a/include/os/freebsd/spl/sys/debug.h
+++ b/include/os/freebsd/spl/sys/debug.h
@@ -105,7 +105,7 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 	    __FILE__, __FUNCTION__, __LINE__))
 
 #define	VERIFYF(cond, str, ...)		do {				\
-		if (unlikely(!cond))					\
+		if (unlikely(!(cond)))					\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY(" #cond ") failed " str "\n", __VA_ARGS__);\
 	} while (0)

--- a/include/os/linux/spl/sys/debug.h
+++ b/include/os/linux/spl/sys/debug.h
@@ -109,7 +109,7 @@ spl_assert(const char *buf, const char *file, const char *func, int line)
 	    __FILE__, __FUNCTION__, __LINE__))
 
 #define	VERIFYF(cond, str, ...)		do {				\
-		if (unlikely(!cond))					\
+		if (unlikely(!(cond)))					\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY(" #cond ") failed " str "\n", __VA_ARGS__);\
 	} while (0)


### PR DESCRIPTION
Without them the order of operations might get unexpected.

### How Has This Been Tested?
Used ASSERTF() with complicated expression and observed Clang complains, fixed by the change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
