### PR TITLE
Updating dio_read_verify ZTS test

### DIFF
--- a/tests/zfs-tests/tests/functional/direct/dio_read_verify.ksh
+++ b/tests/zfs-tests/tests/functional/direct/dio_read_verify.ksh
@@ -56,8 +56,6 @@ log_must  truncate -s $MINVDEVSIZE $DIO_VDEVS
 # while manipulating the buffer contents while the I/O is still in flight and
 # also that Direct I/O checksum verify failures and dio_verify_rd zevents are
 # reported.
-
-
 for type in "" "mirror" "raidz" "draid"; do
 	typeset vdev_type=$type
 	if [[ "${vdev_type}" == "" ]]; then
@@ -82,25 +80,28 @@ for type in "" "mirror" "raidz" "draid"; do
 	log_must manipulate_user_buffer -f "$mntpnt/direct-write.iso" \
 	    -n $NUMBLOCKS -b $BS -r
 
-	# Getting new Direct I/O and ARC Write counts.
+	# Getting new Direct I/O and ARC read counts.
 	curr_dio_rd=$(kstat_pool $TESTPOOL1 iostats.direct_read_count)
 	curr_arc_rd=$(kstat_pool $TESTPOOL1 iostats.arc_read_count)
 	total_dio_rd=$((curr_dio_rd - prev_dio_rd))
 	total_arc_rd=$((curr_arc_rd - prev_arc_rd))
 
-	log_note "Making sure there are no checksum errors with the ZPool"
-	log_must check_pool_status $TESTPOOL "errors" "No known data errors"
-
-	log_note "Making sure we have Direct I/O and ARC reads logged"
+	log_note "Making sure we have Direct I/O reads logged"
 	if [[ $total_dio_rd -lt 1 ]]; then
 		log_fail "No Direct I/O reads $total_dio_rd"
 	fi
+
+	log_note "Making sure we have Direct I/O read checksum verifies with ZPool"
+	check_dio_chksum_verify_failures "$TESTPOOL1" "$vdev_type" 1 "rd"
+
+	log_note "Making sure we have ARC reads logged"
 	if [[ $total_arc_rd -lt 1 ]]; then
 		log_fail "No ARC reads $total_arc_rd"
 	fi
 
-	log_note "Making sure we have Direct I/O write checksum verifies with ZPool"
-	check_dio_chksum_verify_failures "$TESTPOOL1" "$vdev_type" 1 "rd"
+	log_note "Making sure there are no checksum errors with the ZPool"
+	log_must check_pool_status $TESTPOOL "errors" "No known data errors"	
+
 	destroy_pool $TESTPOOL1
 done
 


### PR DESCRIPTION
There was a recent CI ZTS test failure on FreeBSD 14 for the dio_read_verify test case. The failure reported there was no ARC reads while the buffer wes being manipulated. All checksum verify errors for Direct I/O reads are rerouted through the ARC, so there should be ARC reads accounted for. In order to help debug any future failures of this test case, the order of checks has been changed. First there is a check for DIO verify failures for the reads and then ARC read counts are checked.

This PR also contains general cleanup of the comments in the test script.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Reordering some calls in dio_read_verify test to help with debugging recent CI test failure in FreeBSD 14.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change will allow for further debugging in the event of another `dio_read_verify` test failure in the CI runs. It is helpful first to see if there are DIO read verify failures before checking if there are any ARC reads.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Reordered checks in `dio_read_verify`. First there are checks to make sure there are in fact DIO read verify failures before checking there are ARC reads. There always should be DIO read verify failures, as the buffer is constantly being manipulated while Direct I/O reads are taking place in the test.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested locally on Linux kernel 4.18.0-408.el8.x86_64.
<!--- Include details of your testing environment, and the tests you ran to -->
 Ran `direct` ZTS tests for multiple iterations without failure after updating this test case.
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
