### PR TITLE
FreeBSD: Remove an incorrect assertion in zfs_getpages()

### DIFF
--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -3960,10 +3960,8 @@ zfs_getpages(struct vnode *vp, vm_page_t *ma, int count, int *rbehind,
 			 * to the page fault handler's OOM logic, but this is
 			 * the best we can do for now.
 			 */
-			for (int i = 0; i < count; i++) {
-				ASSERT(vm_page_none_valid(ma[i]));
+			for (int i = 0; i < count; i++)
 				vm_page_xunbusy(ma[i]);
-			}
 
 			lr = zfs_rangelock_enter(&zp->z_rangelock,
 			    rounddown(start, blksz), len, RL_READER);


### PR DESCRIPTION
Remove an incorrect assertion in zfs_getpages().

Closes #16810

### How Has This Been Tested?

Issue #16810 provided a reproducer; I verified that it triggers the assertion failure locally, then double-checked that the cause of the assertion failure matches what I expect, then ran the reproducer in a loop for some time to look for further problems.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
