### PR TITLE
cstyle: add basic understanding of top-level macro invocations

### DIFF
--- a/include/os/freebsd/spl/sys/sdt.h
+++ b/include/os/freebsd/spl/sys/sdt.h
@@ -31,9 +31,9 @@
 
 #include_next <sys/sdt.h>
 #ifdef KDTRACE_HOOKS
-/* BEGIN CSTYLED */
 SDT_PROBE_DECLARE(sdt, , , set__error);
 
+/* BEGIN CSTYLED */
 #define	SET_ERROR(err)	({ 					\
 	SDT_PROBE1(sdt, , , set__error, (uintptr_t)err);	\
 	err;							\

--- a/lib/libspl/atomic.c
+++ b/lib/libspl/atomic.c
@@ -35,7 +35,6 @@
 		(void) __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST);	\
 	}
 
-/* BEGIN CSTYLED */
 ATOMIC_INC(8, uint8_t)
 ATOMIC_INC(16, uint16_t)
 ATOMIC_INC(32, uint32_t)
@@ -44,7 +43,6 @@ ATOMIC_INC(uchar, uchar_t)
 ATOMIC_INC(ushort, ushort_t)
 ATOMIC_INC(uint, uint_t)
 ATOMIC_INC(ulong, ulong_t)
-/* END CSTYLED */
 
 
 #define	ATOMIC_DEC(name, type) \
@@ -53,7 +51,6 @@ ATOMIC_INC(ulong, ulong_t)
 		(void) __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST);	\
 	}
 
-/* BEGIN CSTYLED */
 ATOMIC_DEC(8, uint8_t)
 ATOMIC_DEC(16, uint16_t)
 ATOMIC_DEC(32, uint32_t)
@@ -62,7 +59,6 @@ ATOMIC_DEC(uchar, uchar_t)
 ATOMIC_DEC(ushort, ushort_t)
 ATOMIC_DEC(uint, uint_t)
 ATOMIC_DEC(ulong, ulong_t)
-/* END CSTYLED */
 
 
 #define	ATOMIC_ADD(name, type1, type2) \
@@ -77,7 +73,6 @@ atomic_add_ptr(volatile void *target, ssize_t bits)
 	(void) __atomic_add_fetch((void **)target, bits, __ATOMIC_SEQ_CST);
 }
 
-/* BEGIN CSTYLED */
 ATOMIC_ADD(8, uint8_t, int8_t)
 ATOMIC_ADD(16, uint16_t, int16_t)
 ATOMIC_ADD(32, uint32_t, int32_t)
@@ -86,7 +81,6 @@ ATOMIC_ADD(char, uchar_t, signed char)
 ATOMIC_ADD(short, ushort_t, short)
 ATOMIC_ADD(int, uint_t, int)
 ATOMIC_ADD(long, ulong_t, long)
-/* END CSTYLED */
 
 
 #define	ATOMIC_SUB(name, type1, type2) \
@@ -101,7 +95,6 @@ atomic_sub_ptr(volatile void *target, ssize_t bits)
 	(void) __atomic_sub_fetch((void **)target, bits, __ATOMIC_SEQ_CST);
 }
 
-/* BEGIN CSTYLED */
 ATOMIC_SUB(8, uint8_t, int8_t)
 ATOMIC_SUB(16, uint16_t, int16_t)
 ATOMIC_SUB(32, uint32_t, int32_t)
@@ -110,7 +103,6 @@ ATOMIC_SUB(char, uchar_t, signed char)
 ATOMIC_SUB(short, ushort_t, short)
 ATOMIC_SUB(int, uint_t, int)
 ATOMIC_SUB(long, ulong_t, long)
-/* END CSTYLED */
 
 
 #define	ATOMIC_OR(name, type) \
@@ -119,7 +111,6 @@ ATOMIC_SUB(long, ulong_t, long)
 		(void) __atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST); \
 	}
 
-/* BEGIN CSTYLED */
 ATOMIC_OR(8, uint8_t)
 ATOMIC_OR(16, uint16_t)
 ATOMIC_OR(32, uint32_t)
@@ -128,7 +119,6 @@ ATOMIC_OR(uchar, uchar_t)
 ATOMIC_OR(ushort, ushort_t)
 ATOMIC_OR(uint, uint_t)
 ATOMIC_OR(ulong, ulong_t)
-/* END CSTYLED */
 
 
 #define	ATOMIC_AND(name, type) \
@@ -137,7 +127,6 @@ ATOMIC_OR(ulong, ulong_t)
 		(void) __atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST); \
 	}
 
-/* BEGIN CSTYLED */
 ATOMIC_AND(8, uint8_t)
 ATOMIC_AND(16, uint16_t)
 ATOMIC_AND(32, uint32_t)
@@ -146,7 +135,6 @@ ATOMIC_AND(uchar, uchar_t)
 ATOMIC_AND(ushort, ushort_t)
 ATOMIC_AND(uint, uint_t)
 ATOMIC_AND(ulong, ulong_t)
-/* END CSTYLED */
 
 
 /*
@@ -159,7 +147,6 @@ ATOMIC_AND(ulong, ulong_t)
 		return (__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST)); \
 	}
 
-/* BEGIN CSTYLED */
 ATOMIC_INC_NV(8, uint8_t)
 ATOMIC_INC_NV(16, uint16_t)
 ATOMIC_INC_NV(32, uint32_t)
@@ -168,7 +155,6 @@ ATOMIC_INC_NV(uchar, uchar_t)
 ATOMIC_INC_NV(ushort, ushort_t)
 ATOMIC_INC_NV(uint, uint_t)
 ATOMIC_INC_NV(ulong, ulong_t)
-/* END CSTYLED */
 
 
 #define	ATOMIC_DEC_NV(name, type) \
@@ -177,7 +163,6 @@ ATOMIC_INC_NV(ulong, ulong_t)
 		return (__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST)); \
 	}
 
-/* BEGIN CSTYLED */
 ATOMIC_DEC_NV(8, uint8_t)
 ATOMIC_DEC_NV(16, uint16_t)
 ATOMIC_DEC_NV(32, uint32_t)
@@ -186,7 +171,6 @@ ATOMIC_DEC_NV(uchar, uchar_t)
 ATOMIC_DEC_NV(ushort, ushort_t)
 ATOMIC_DEC_NV(uint, uint_t)
 ATOMIC_DEC_NV(ulong, ulong_t)
-/* END CSTYLED */
 
 
 #define	ATOMIC_ADD_NV(name, type1, type2) \
@@ -201,7 +185,6 @@ atomic_add_ptr_nv(volatile void *target, ssize_t bits)
 	return (__atomic_add_fetch((void **)target, bits, __ATOMIC_SEQ_CST));
 }
 
-/* BEGIN CSTYLED */
 ATOMIC_ADD_NV(8, uint8_t, int8_t)
 ATOMIC_ADD_NV(16, uint16_t, int16_t)
 ATOMIC_ADD_NV(32, uint32_t, int32_t)
@@ -210,7 +193,6 @@ ATOMIC_ADD_NV(char, uchar_t, signed char)
 ATOMIC_ADD_NV(short, ushort_t, short)
 ATOMIC_ADD_NV(int, uint_t, int)
 ATOMIC_ADD_NV(long, ulong_t, long)
-/* END CSTYLED */
 
 
 #define	ATOMIC_SUB_NV(name, type1, type2) \
@@ -225,7 +207,6 @@ atomic_sub_ptr_nv(volatile void *target, ssize_t bits)
 	return (__atomic_sub_fetch((void **)target, bits, __ATOMIC_SEQ_CST));
 }
 
-/* BEGIN CSTYLED */
 ATOMIC_SUB_NV(8, uint8_t, int8_t)
 ATOMIC_SUB_NV(char, uchar_t, signed char)
 ATOMIC_SUB_NV(16, uint16_t, int16_t)
@@ -234,7 +215,6 @@ ATOMIC_SUB_NV(32, uint32_t, int32_t)
 ATOMIC_SUB_NV(int, uint_t, int)
 ATOMIC_SUB_NV(long, ulong_t, long)
 ATOMIC_SUB_NV(64, uint64_t, int64_t)
-/* END CSTYLED */
 
 
 #define	ATOMIC_OR_NV(name, type) \
@@ -243,7 +223,6 @@ ATOMIC_SUB_NV(64, uint64_t, int64_t)
 		return (__atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST)); \
 	}
 
-/* BEGIN CSTYLED */
 ATOMIC_OR_NV(8, uint8_t)
 ATOMIC_OR_NV(16, uint16_t)
 ATOMIC_OR_NV(32, uint32_t)
@@ -252,7 +231,6 @@ ATOMIC_OR_NV(uchar, uchar_t)
 ATOMIC_OR_NV(ushort, ushort_t)
 ATOMIC_OR_NV(uint, uint_t)
 ATOMIC_OR_NV(ulong, ulong_t)
-/* END CSTYLED */
 
 
 #define	ATOMIC_AND_NV(name, type) \
@@ -261,7 +239,6 @@ ATOMIC_OR_NV(ulong, ulong_t)
 		return (__atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST)); \
 	}
 
-/* BEGIN CSTYLED */
 ATOMIC_AND_NV(8, uint8_t)
 ATOMIC_AND_NV(16, uint16_t)
 ATOMIC_AND_NV(32, uint32_t)
@@ -270,7 +247,6 @@ ATOMIC_AND_NV(uchar, uchar_t)
 ATOMIC_AND_NV(ushort, ushort_t)
 ATOMIC_AND_NV(uint, uint_t)
 ATOMIC_AND_NV(ulong, ulong_t)
-/* END CSTYLED */
 
 
 /*
@@ -300,7 +276,6 @@ atomic_cas_ptr(volatile void *target, void *exp, void *des)
 	return (exp);
 }
 
-/* BEGIN CSTYLED */
 ATOMIC_CAS(8, uint8_t)
 ATOMIC_CAS(16, uint16_t)
 ATOMIC_CAS(32, uint32_t)
@@ -309,7 +284,6 @@ ATOMIC_CAS(uchar, uchar_t)
 ATOMIC_CAS(ushort, ushort_t)
 ATOMIC_CAS(uint, uint_t)
 ATOMIC_CAS(ulong, ulong_t)
-/* END CSTYLED */
 
 
 /*
@@ -322,7 +296,6 @@ ATOMIC_CAS(ulong, ulong_t)
 		return (__atomic_exchange_n(target, bits, __ATOMIC_SEQ_CST)); \
 	}
 
-/* BEGIN CSTYLED */
 ATOMIC_SWAP(8, uint8_t)
 ATOMIC_SWAP(16, uint16_t)
 ATOMIC_SWAP(32, uint32_t)
@@ -331,7 +304,6 @@ ATOMIC_SWAP(uchar, uchar_t)
 ATOMIC_SWAP(ushort, ushort_t)
 ATOMIC_SWAP(uint, uint_t)
 ATOMIC_SWAP(ulong, ulong_t)
-/* END CSTYLED */
 
 void *
 atomic_swap_ptr(volatile void *target, void *bits)

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -3281,7 +3281,6 @@ nvs_xdr_nvp_##type(XDR *xdrs, void *ptr, ...)	\
 
 #endif
 
-/* BEGIN CSTYLED */
 NVS_BUILD_XDRPROC_T(char);
 NVS_BUILD_XDRPROC_T(short);
 NVS_BUILD_XDRPROC_T(u_short);
@@ -3289,7 +3288,6 @@ NVS_BUILD_XDRPROC_T(int);
 NVS_BUILD_XDRPROC_T(u_int);
 NVS_BUILD_XDRPROC_T(longlong_t);
 NVS_BUILD_XDRPROC_T(u_longlong_t);
-/* END CSTYLED */
 
 /*
  * The format of xdr encoded nvpair is:

--- a/module/os/freebsd/spl/spl_dtrace.c
+++ b/module/os/freebsd/spl/spl_dtrace.c
@@ -31,5 +31,4 @@
 #include <sys/queue.h>
 #include <sys/sdt.h>
 
-/* CSTYLED */
 SDT_PROBE_DEFINE1(sdt, , , set__error, "int");

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -187,12 +187,10 @@ param_set_arc_max(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_max,
 	CTLTYPE_ULONG | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,
 	NULL, 0, param_set_arc_max, "LU",
 	"Maximum ARC size in bytes (LEGACY)");
-/* END CSTYLED */
 
 int
 param_set_arc_min(SYSCTL_HANDLER_ARGS)
@@ -218,12 +216,10 @@ param_set_arc_min(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_min,
 	CTLTYPE_ULONG | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,
 	NULL, 0, param_set_arc_min, "LU",
 	"Minimum ARC size in bytes (LEGACY)");
-/* END CSTYLED */
 
 extern uint_t zfs_arc_free_target;
 
@@ -252,13 +248,11 @@ param_set_arc_free_target(SYSCTL_HANDLER_ARGS)
  * NOTE: This sysctl is CTLFLAG_RW not CTLFLAG_RWTUN due to its dependency on
  * pagedaemon initialization.
  */
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_free_target,
 	CTLTYPE_UINT | CTLFLAG_RW | CTLFLAG_MPSAFE,
 	NULL, 0, param_set_arc_free_target, "IU",
 	"Desired number of free pages below which ARC triggers reclaim"
 	" (LEGACY)");
-/* END CSTYLED */
 
 int
 param_set_arc_no_grow_shift(SYSCTL_HANDLER_ARGS)
@@ -278,84 +272,64 @@ param_set_arc_no_grow_shift(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, arc_no_grow_shift,
 	CTLTYPE_INT | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,
 	NULL, 0, param_set_arc_no_grow_shift, "I",
 	"log2(fraction of ARC which must be free to allow growing) (LEGACY)");
-/* END CSTYLED */
 
 extern uint64_t l2arc_write_max;
 
-/* BEGIN CSTYLED */
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, l2arc_write_max,
 	CTLFLAG_RWTUN, &l2arc_write_max, 0,
 	"Max write bytes per interval (LEGACY)");
-/* END CSTYLED */
 
 extern uint64_t l2arc_write_boost;
 
-/* BEGIN CSTYLED */
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, l2arc_write_boost,
 	CTLFLAG_RWTUN, &l2arc_write_boost, 0,
 	"Extra write bytes during device warmup (LEGACY)");
-/* END CSTYLED */
 
 extern uint64_t l2arc_headroom;
 
-/* BEGIN CSTYLED */
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, l2arc_headroom,
 	CTLFLAG_RWTUN, &l2arc_headroom, 0,
 	"Number of max device writes to precache (LEGACY)");
-/* END CSTYLED */
 
 extern uint64_t l2arc_headroom_boost;
 
-/* BEGIN CSTYLED */
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, l2arc_headroom_boost,
 	CTLFLAG_RWTUN, &l2arc_headroom_boost, 0,
 	"Compressed l2arc_headroom multiplier (LEGACY)");
-/* END CSTYLED */
 
 extern uint64_t l2arc_feed_secs;
 
-/* BEGIN CSTYLED */
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, l2arc_feed_secs,
 	CTLFLAG_RWTUN, &l2arc_feed_secs, 0,
 	"Seconds between L2ARC writing (LEGACY)");
-/* END CSTYLED */
 
 extern uint64_t l2arc_feed_min_ms;
 
-/* BEGIN CSTYLED */
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, l2arc_feed_min_ms,
 	CTLFLAG_RWTUN, &l2arc_feed_min_ms, 0,
 	"Min feed interval in milliseconds (LEGACY)");
-/* END CSTYLED */
 
 extern int l2arc_noprefetch;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs, OID_AUTO, l2arc_noprefetch,
 	CTLFLAG_RWTUN, &l2arc_noprefetch, 0,
 	"Skip caching prefetched buffers (LEGACY)");
-/* END CSTYLED */
 
 extern int l2arc_feed_again;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs, OID_AUTO, l2arc_feed_again,
 	CTLFLAG_RWTUN, &l2arc_feed_again, 0,
 	"Turbo L2ARC warmup (LEGACY)");
-/* END CSTYLED */
 
 extern int l2arc_norw;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs, OID_AUTO, l2arc_norw,
 	CTLFLAG_RWTUN, &l2arc_norw, 0,
 	"No reads during writes (LEGACY)");
-/* END CSTYLED */
 
 static int
 param_get_arc_state_size(SYSCTL_HANDLER_ARGS)
@@ -370,7 +344,6 @@ param_get_arc_state_size(SYSCTL_HANDLER_ARGS)
 
 extern arc_state_t ARC_anon;
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, anon_size,
 	CTLTYPE_S64 | CTLFLAG_RD | CTLFLAG_MPSAFE,
 	&ARC_anon, 0, param_get_arc_state_size, "Q",
@@ -381,11 +354,9 @@ SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, anon_metadata_esize, CTLFLAG_RD,
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, anon_data_esize, CTLFLAG_RD,
 	&ARC_anon.arcs_esize[ARC_BUFC_DATA].rc_count, 0,
 	"size of evictable data in anonymous state");
-/* END CSTYLED */
 
 extern arc_state_t ARC_mru;
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, mru_size,
 	CTLTYPE_S64 | CTLFLAG_RD | CTLFLAG_MPSAFE,
 	&ARC_mru, 0, param_get_arc_state_size, "Q",
@@ -396,11 +367,9 @@ SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, mru_metadata_esize, CTLFLAG_RD,
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, mru_data_esize, CTLFLAG_RD,
 	&ARC_mru.arcs_esize[ARC_BUFC_DATA].rc_count, 0,
 	"size of evictable data in mru state");
-/* END CSTYLED */
 
 extern arc_state_t ARC_mru_ghost;
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, mru_ghost_size,
 	CTLTYPE_S64 | CTLFLAG_RD | CTLFLAG_MPSAFE,
 	&ARC_mru_ghost, 0, param_get_arc_state_size, "Q",
@@ -411,11 +380,9 @@ SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, mru_ghost_metadata_esize, CTLFLAG_RD,
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, mru_ghost_data_esize, CTLFLAG_RD,
 	&ARC_mru_ghost.arcs_esize[ARC_BUFC_DATA].rc_count, 0,
 	"size of evictable data in mru ghost state");
-/* END CSTYLED */
 
 extern arc_state_t ARC_mfu;
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, mfu_size,
 	CTLTYPE_S64 | CTLFLAG_RD | CTLFLAG_MPSAFE,
 	&ARC_mfu, 0, param_get_arc_state_size, "Q",
@@ -426,11 +393,9 @@ SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, mfu_metadata_esize, CTLFLAG_RD,
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, mfu_data_esize, CTLFLAG_RD,
 	&ARC_mfu.arcs_esize[ARC_BUFC_DATA].rc_count, 0,
 	"size of evictable data in mfu state");
-/* END CSTYLED */
 
 extern arc_state_t ARC_mfu_ghost;
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, mfu_ghost_size,
 	CTLTYPE_S64 | CTLFLAG_RD | CTLFLAG_MPSAFE,
 	&ARC_mfu_ghost, 0, param_get_arc_state_size, "Q",
@@ -441,11 +406,9 @@ SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, mfu_ghost_metadata_esize, CTLFLAG_RD,
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, mfu_ghost_data_esize, CTLFLAG_RD,
 	&ARC_mfu_ghost.arcs_esize[ARC_BUFC_DATA].rc_count, 0,
 	"size of evictable data in mfu ghost state");
-/* END CSTYLED */
 
 extern arc_state_t ARC_uncached;
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, uncached_size,
 	CTLTYPE_S64 | CTLFLAG_RD | CTLFLAG_MPSAFE,
 	&ARC_uncached, 0, param_get_arc_state_size, "Q",
@@ -456,16 +419,13 @@ SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, uncached_metadata_esize, CTLFLAG_RD,
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, uncached_data_esize, CTLFLAG_RD,
 	&ARC_uncached.arcs_esize[ARC_BUFC_DATA].rc_count, 0,
 	"size of evictable data in uncached state");
-/* END CSTYLED */
 
 extern arc_state_t ARC_l2c_only;
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, l2c_only_size,
 	CTLTYPE_S64 | CTLFLAG_RD | CTLFLAG_MPSAFE,
 	&ARC_l2c_only, 0, param_get_arc_state_size, "Q",
 	"size of l2c_only state");
-/* END CSTYLED */
 
 /* dbuf.c */
 
@@ -477,19 +437,15 @@ SYSCTL_NODE(_vfs_zfs, OID_AUTO, zfetch, CTLFLAG_RW, 0, "ZFS ZFETCH (LEGACY)");
 
 extern uint32_t	zfetch_max_distance;
 
-/* BEGIN CSTYLED */
 SYSCTL_UINT(_vfs_zfs_zfetch, OID_AUTO, max_distance,
 	CTLFLAG_RWTUN, &zfetch_max_distance, 0,
 	"Max bytes to prefetch per stream (LEGACY)");
-/* END CSTYLED */
 
 extern uint32_t	zfetch_max_idistance;
 
-/* BEGIN CSTYLED */
 SYSCTL_UINT(_vfs_zfs_zfetch, OID_AUTO, max_idistance,
 	CTLFLAG_RWTUN, &zfetch_max_idistance, 0,
 	"Max bytes to prefetch indirects for per stream (LEGACY)");
-/* END CSTYLED */
 
 /* dsl_pool.c */
 
@@ -527,12 +483,10 @@ param_set_active_allocator(SYSCTL_HANDLER_ARGS)
  */
 extern int zfs_metaslab_sm_blksz_no_log;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs_metaslab, OID_AUTO, sm_blksz_no_log,
 	CTLFLAG_RDTUN, &zfs_metaslab_sm_blksz_no_log, 0,
 	"Block size for space map in pools with log space map disabled.  "
 	"Power of 2 greater than 4096.");
-/* END CSTYLED */
 
 /*
  * When the log space map feature is enabled, we accumulate a lot of
@@ -541,12 +495,10 @@ SYSCTL_INT(_vfs_zfs_metaslab, OID_AUTO, sm_blksz_no_log,
  */
 extern int zfs_metaslab_sm_blksz_with_log;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs_metaslab, OID_AUTO, sm_blksz_with_log,
 	CTLFLAG_RDTUN, &zfs_metaslab_sm_blksz_with_log, 0,
 	"Block size for space map in pools with log space map enabled.  "
 	"Power of 2 greater than 4096.");
-/* END CSTYLED */
 
 /*
  * The in-core space map representation is more compact than its on-disk form.
@@ -556,29 +508,23 @@ SYSCTL_INT(_vfs_zfs_metaslab, OID_AUTO, sm_blksz_with_log,
  */
 extern uint_t zfs_condense_pct;
 
-/* BEGIN CSTYLED */
 SYSCTL_UINT(_vfs_zfs, OID_AUTO, condense_pct,
 	CTLFLAG_RWTUN, &zfs_condense_pct, 0,
 	"Condense on-disk spacemap when it is more than this many percents"
 	" of in-memory counterpart");
-/* END CSTYLED */
 
 extern uint_t zfs_remove_max_segment;
 
-/* BEGIN CSTYLED */
 SYSCTL_UINT(_vfs_zfs, OID_AUTO, remove_max_segment,
 	CTLFLAG_RWTUN, &zfs_remove_max_segment, 0,
 	"Largest contiguous segment ZFS will attempt to allocate when removing"
 	" a device");
-/* END CSTYLED */
 
 extern int zfs_removal_suspend_progress;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs, OID_AUTO, removal_suspend_progress,
 	CTLFLAG_RWTUN, &zfs_removal_suspend_progress, 0,
 	"Ensures certain actions can happen while in the middle of a removal");
-/* END CSTYLED */
 
 /*
  * Minimum size which forces the dynamic allocator to change
@@ -588,12 +534,10 @@ SYSCTL_INT(_vfs_zfs, OID_AUTO, removal_suspend_progress,
  */
 extern uint64_t metaslab_df_alloc_threshold;
 
-/* BEGIN CSTYLED */
 SYSCTL_QUAD(_vfs_zfs_metaslab, OID_AUTO, df_alloc_threshold,
 	CTLFLAG_RWTUN, &metaslab_df_alloc_threshold, 0,
 	"Minimum size which forces the dynamic allocator to change its"
 	" allocation strategy");
-/* END CSTYLED */
 
 /*
  * The minimum free space, in percent, which must be available
@@ -603,12 +547,10 @@ SYSCTL_QUAD(_vfs_zfs_metaslab, OID_AUTO, df_alloc_threshold,
  */
 extern uint_t metaslab_df_free_pct;
 
-/* BEGIN CSTYLED */
 SYSCTL_UINT(_vfs_zfs_metaslab, OID_AUTO, df_free_pct,
 	CTLFLAG_RWTUN, &metaslab_df_free_pct, 0,
 	"The minimum free space, in percent, which must be available in a"
 	" space map to continue allocations in a first-fit fashion");
-/* END CSTYLED */
 
 /* mmp.c */
 
@@ -631,28 +573,22 @@ param_set_multihost_interval(SYSCTL_HANDLER_ARGS)
 
 extern int zfs_ccw_retry_interval;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs, OID_AUTO, ccw_retry_interval,
 	CTLFLAG_RWTUN, &zfs_ccw_retry_interval, 0,
 	"Configuration cache file write, retry after failure, interval"
 	" (seconds)");
-/* END CSTYLED */
 
 extern uint64_t zfs_max_missing_tvds_cachefile;
 
-/* BEGIN CSTYLED */
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, max_missing_tvds_cachefile,
 	CTLFLAG_RWTUN, &zfs_max_missing_tvds_cachefile, 0,
 	"Allow importing pools with missing top-level vdevs in cache file");
-/* END CSTYLED */
 
 extern uint64_t zfs_max_missing_tvds_scan;
 
-/* BEGIN CSTYLED */
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, max_missing_tvds_scan,
 	CTLFLAG_RWTUN, &zfs_max_missing_tvds_scan, 0,
 	"Allow importing pools with missing top-level vdevs during scan");
-/* END CSTYLED */
 
 /* spa_misc.c */
 
@@ -681,11 +617,9 @@ sysctl_vfs_zfs_debug_flags(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, debugflags,
 	CTLTYPE_UINT | CTLFLAG_MPSAFE | CTLFLAG_RWTUN, NULL, 0,
 	sysctl_vfs_zfs_debug_flags, "IU", "Debug flags for ZFS testing.");
-/* END CSTYLED */
 
 int
 param_set_deadman_synctime(SYSCTL_HANDLER_ARGS)
@@ -768,10 +702,8 @@ param_set_slop_shift(SYSCTL_HANDLER_ARGS)
 
 extern int space_map_ibs;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs, OID_AUTO, space_map_ibs, CTLFLAG_RWTUN,
 	&space_map_ibs, 0, "Space map indirect block shift");
-/* END CSTYLED */
 
 
 /* vdev.c */
@@ -795,13 +727,11 @@ param_set_min_auto_ashift(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, min_auto_ashift,
 	CTLTYPE_UINT | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,
 	&zfs_vdev_min_auto_ashift, sizeof (zfs_vdev_min_auto_ashift),
 	param_set_min_auto_ashift, "IU",
 	"Min ashift used when creating new top-level vdev. (LEGACY)");
-/* END CSTYLED */
 
 int
 param_set_max_auto_ashift(SYSCTL_HANDLER_ARGS)
@@ -822,14 +752,12 @@ param_set_max_auto_ashift(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-/* BEGIN CSTYLED */
 SYSCTL_PROC(_vfs_zfs, OID_AUTO, max_auto_ashift,
 	CTLTYPE_UINT | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,
 	&zfs_vdev_max_auto_ashift, sizeof (zfs_vdev_max_auto_ashift),
 	param_set_max_auto_ashift, "IU",
 	"Max ashift used when optimizing for logical -> physical sector size on"
 	" new top-level vdevs. (LEGACY)");
-/* END CSTYLED */
 
 /*
  * Since the DTL space map of a vdev is not expected to have a lot of
@@ -837,11 +765,9 @@ SYSCTL_PROC(_vfs_zfs, OID_AUTO, max_auto_ashift,
  */
 extern int zfs_vdev_dtl_sm_blksz;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs, OID_AUTO, dtl_sm_blksz,
 	CTLFLAG_RDTUN, &zfs_vdev_dtl_sm_blksz, 0,
 	"Block size for DTL space map.  Power of 2 greater than 4096.");
-/* END CSTYLED */
 
 /*
  * vdev-wide space maps that have lots of entries written to them at
@@ -850,19 +776,15 @@ SYSCTL_INT(_vfs_zfs, OID_AUTO, dtl_sm_blksz,
  */
 extern int zfs_vdev_standard_sm_blksz;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs, OID_AUTO, standard_sm_blksz,
 	CTLFLAG_RDTUN, &zfs_vdev_standard_sm_blksz, 0,
 	"Block size for standard space map.  Power of 2 greater than 4096.");
-/* END CSTYLED */
 
 extern int vdev_validate_skip;
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs, OID_AUTO, validate_skip,
 	CTLFLAG_RDTUN, &vdev_validate_skip, 0,
 	"Enable to bypass vdev_validate().");
-/* END CSTYLED */
 
 /* vdev_mirror.c */
 
@@ -870,17 +792,13 @@ SYSCTL_INT(_vfs_zfs, OID_AUTO, validate_skip,
 
 extern uint_t zfs_vdev_max_active;
 
-/* BEGIN CSTYLED */
 SYSCTL_UINT(_vfs_zfs, OID_AUTO, top_maxinflight,
 	CTLFLAG_RWTUN, &zfs_vdev_max_active, 0,
 	"The maximum number of I/Os of all types active for each device."
 	" (LEGACY)");
-/* END CSTYLED */
 
 /* zio.c */
 
-/* BEGIN CSTYLED */
 SYSCTL_INT(_vfs_zfs_zio, OID_AUTO, exclude_metadata,
 	CTLFLAG_RDTUN, &zio_exclude_metadata, 0,
 	"Exclude metadata buffers from dumps as well");
-/* END CSTYLED */

--- a/module/os/freebsd/zfs/zio_crypt.c
+++ b/module/os/freebsd/zfs/zio_crypt.c
@@ -1823,7 +1823,6 @@ error:
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-/* CSTYLED */
 module_param(zfs_key_max_salt_uses, ulong, 0644);
 MODULE_PARM_DESC(zfs_key_max_salt_uses, "Max number of times a salt value "
 	"can be used for generating encryption keys before it is rotated");

--- a/module/os/linux/spl/spl-err.c
+++ b/module/os/linux/spl/spl-err.c
@@ -33,7 +33,6 @@
  * But we would still default to the current default of not to do that.
  */
 static unsigned int spl_panic_halt;
-/* CSTYLED */
 module_param(spl_panic_halt, uint, 0644);
 MODULE_PARM_DESC(spl_panic_halt, "Cause kernel panic on assertion failures");
 

--- a/module/os/linux/spl/spl-generic.c
+++ b/module/os/linux/spl/spl-generic.c
@@ -54,7 +54,6 @@
 unsigned long spl_hostid = 0;
 EXPORT_SYMBOL(spl_hostid);
 
-/* CSTYLED */
 module_param(spl_hostid, ulong, 0644);
 MODULE_PARM_DESC(spl_hostid, "The system hostid.");
 

--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -48,7 +48,6 @@
 #define	smp_mb__after_atomic(x) smp_mb__after_clear_bit(x)
 #endif
 
-/* BEGIN CSTYLED */
 /*
  * Cache magazines are an optimization designed to minimize the cost of
  * allocating memory.  They do this by keeping a per-cpu cache of recently
@@ -97,7 +96,6 @@ static unsigned int spl_kmem_cache_kmem_threads = 4;
 module_param(spl_kmem_cache_kmem_threads, uint, 0444);
 MODULE_PARM_DESC(spl_kmem_cache_kmem_threads,
 	"Number of spl_kmem_cache threads");
-/* END CSTYLED */
 
 /*
  * Slab allocation interfaces

--- a/module/os/linux/spl/spl-kmem.c
+++ b/module/os/linux/spl/spl-kmem.c
@@ -26,7 +26,6 @@
 #include <sys/kmem.h>
 #include <sys/vmem.h>
 
-/* BEGIN CSTYLED */
 /*
  * As a general rule kmem_alloc() allocations should be small, preferably
  * just a few pages since they must by physically contiguous.  Therefore, a
@@ -62,7 +61,6 @@ module_param(spl_kmem_alloc_max, uint, 0644);
 MODULE_PARM_DESC(spl_kmem_alloc_max,
 	"Maximum size in bytes for a kmem_alloc()");
 EXPORT_SYMBOL(spl_kmem_alloc_max);
-/* END CSTYLED */
 
 int
 kmem_debugging(void)

--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -117,9 +117,7 @@ module_param(spl_taskq_thread_bind, int, 0644);
 MODULE_PARM_DESC(spl_taskq_thread_bind, "Bind taskq thread to CPU by default");
 
 static uint_t spl_taskq_thread_timeout_ms = 5000;
-/* BEGIN CSTYLED */
 module_param(spl_taskq_thread_timeout_ms, uint, 0644);
-/* END CSTYLED */
 MODULE_PARM_DESC(spl_taskq_thread_timeout_ms,
 	"Minimum idle threads exit interval for dynamic taskqs");
 
@@ -133,9 +131,7 @@ MODULE_PARM_DESC(spl_taskq_thread_priority,
 	"Allow non-default priority for taskq threads");
 
 static uint_t spl_taskq_thread_sequential = 4;
-/* BEGIN CSTYLED */
 module_param(spl_taskq_thread_sequential, uint, 0644);
-/* END CSTYLED */
 MODULE_PARM_DESC(spl_taskq_thread_sequential,
 	"Create new taskq threads after N sequential tasks");
 

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -1346,7 +1346,6 @@ MODULE_PARM_DESC(zfs_abd_scatter_enabled,
 module_param(zfs_abd_scatter_min_size, int, 0644);
 MODULE_PARM_DESC(zfs_abd_scatter_min_size,
 	"Minimum size of scatter allocations.");
-/* CSTYLED */
 module_param(zfs_abd_scatter_max_order, uint, 0644);
 MODULE_PARM_DESC(zfs_abd_scatter_max_order,
 	"Maximum order allocation used for a scatter ABD.");

--- a/module/os/linux/zfs/zfs_debug.c
+++ b/module/os/linux/zfs/zfs_debug.c
@@ -214,7 +214,5 @@ __dprintf(boolean_t dprint, const char *file, const char *func,
 module_param(zfs_dbgmsg_enable, int, 0644);
 MODULE_PARM_DESC(zfs_dbgmsg_enable, "Enable ZFS debug message log");
 
-/* BEGIN CSTYLED */
 module_param(zfs_dbgmsg_maxsize, uint, 0644);
-/* END CSTYLED */
 MODULE_PARM_DESC(zfs_dbgmsg_maxsize, "Maximum ZFS debug log size");

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -4345,7 +4345,6 @@ EXPORT_SYMBOL(zfs_putpage);
 EXPORT_SYMBOL(zfs_dirty_inode);
 EXPORT_SYMBOL(zfs_map);
 
-/* CSTYLED */
 module_param(zfs_delete_blocks, ulong, 0644);
 MODULE_PARM_DESC(zfs_delete_blocks, "Delete files larger than N blocks async");
 #endif

--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -1967,7 +1967,6 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 EXPORT_SYMBOL(zfs_create_fs);
 EXPORT_SYMBOL(zfs_obj_to_path);
 
-/* CSTYLED */
 module_param(zfs_object_mutex_size, uint, 0644);
 MODULE_PARM_DESC(zfs_object_mutex_size, "Size of znode hold array");
 module_param(zfs_unlink_suspend_progress, int, 0644);

--- a/module/os/linux/zfs/zio_crypt.c
+++ b/module/os/linux/zfs/zio_crypt.c
@@ -2073,7 +2073,6 @@ error:
 }
 
 #if defined(_KERNEL)
-/* CSTYLED */
 module_param(zfs_key_max_salt_uses, ulong, 0644);
 MODULE_PARM_DESC(zfs_key_max_salt_uses, "Max number of times a salt value "
 	"can be used for generating encryption keys before it is rotated");

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -1143,7 +1143,6 @@ const struct file_operations zpl_dir_file_operations = {
 #endif
 };
 
-/* CSTYLED */
 module_param(zfs_fallocate_reserve_percent, uint, 0644);
 MODULE_PARM_DESC(zfs_fallocate_reserve_percent,
 	"Percentage of length to use for the available capacity check");

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -1899,7 +1899,6 @@ zvol_fini(void)
 	ida_destroy(&zvol_ida);
 }
 
-/* BEGIN CSTYLED */
 module_param(zvol_inhibit_dev, uint, 0644);
 MODULE_PARM_DESC(zvol_inhibit_dev, "Do not create zvol device nodes");
 
@@ -1908,7 +1907,7 @@ MODULE_PARM_DESC(zvol_major, "Major number for zvol device");
 
 module_param(zvol_threads, uint, 0444);
 MODULE_PARM_DESC(zvol_threads, "Number of threads to handle I/O requests. Set"
-    "to 0 to use all active CPUs");
+	"to 0 to use all active CPUs");
 
 module_param(zvol_request_sync, uint, 0644);
 MODULE_PARM_DESC(zvol_request_sync, "Synchronously handle bio requests");
@@ -1933,11 +1932,9 @@ MODULE_PARM_DESC(zvol_use_blk_mq, "Use the blk-mq API for zvols");
 
 module_param(zvol_blk_mq_blocks_per_thread, uint, 0644);
 MODULE_PARM_DESC(zvol_blk_mq_blocks_per_thread,
-    "Process volblocksize blocks per thread");
+	"Process volblocksize blocks per thread");
 
 #ifndef HAVE_BLKDEV_GET_ERESTARTSYS
 module_param(zvol_open_timeout_ms, uint, 0644);
 MODULE_PARM_DESC(zvol_open_timeout_ms, "Timeout for ZVOL open retries");
 #endif
-
-/* END CSTYLED */

--- a/module/zcommon/zfs_valstr.c
+++ b/module/zcommon/zfs_valstr.c
@@ -185,7 +185,6 @@ zfs_valstr_ ## name(int v, char *out, size_t outlen)			\
 /* String tables */
 
 /* ZIO flags: zio_flag_t, typically zio->io_flags */
-/* BEGIN CSTYLED */
 _VALSTR_BITFIELD_IMPL(zio_flag,
 	{ '.', "DA", "DONT_AGGREGATE" },
 	{ '.', "RP", "IO_REPAIR" },
@@ -221,13 +220,11 @@ _VALSTR_BITFIELD_IMPL(zio_flag,
 	{ '.', "DG", "DELEGATED" },
 	{ '.', "DC", "DIO_CHKSUM_ERR" },
 )
-/* END CSTYLED */
 
 /*
  * ZIO pipeline stage(s): enum zio_stage, typically zio->io_stage or
  *                        zio->io_pipeline.
  */
-/* BEGIN CSTYLED */
 _VALSTR_BITFIELD_IMPL(zio_stage,
 	{ 'O', "O ", "OPEN" },
 	{ 'I', "RI", "READ_BP_INIT" },
@@ -257,10 +254,8 @@ _VALSTR_BITFIELD_IMPL(zio_stage,
 	{ 'C', "DC", "DIO_CHECKSUM_VERIFY" },
 	{ 'X', "X ", "DONE" },
 )
-/* END CSTYLED */
 
 /* ZIO priority: zio_priority_t, typically zio->io_priority */
-/* BEGIN CSTYLED */
 _VALSTR_ENUM_IMPL(zio_priority,
 	"SYNC_READ",
 	"SYNC_WRITE",
@@ -274,7 +269,6 @@ _VALSTR_ENUM_IMPL(zio_priority,
 	"[NUM_QUEUEABLE]",
 	"NOW",
 )
-/* END CSTYLED */
 
 #undef _VALSTR_BITFIELD_IMPL
 #undef _VALSTR_ENUM_IMPL

--- a/module/zfs/brt.c
+++ b/module/zfs/brt.c
@@ -1473,11 +1473,9 @@ brt_unload(spa_t *spa)
 	spa->spa_brt_rangesize = 0;
 }
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_brt, , brt_zap_prefetch, INT, ZMOD_RW,
 	"Enable prefetching of BRT ZAP entries");
 ZFS_MODULE_PARAM(zfs_brt, , brt_zap_default_bs, UINT, ZMOD_RW,
 	"BRT ZAP leaf blockshift");
 ZFS_MODULE_PARAM(zfs_brt, , brt_zap_default_ibs, UINT, ZMOD_RW,
 	"BRT ZAP indirect blockshift");
-/* END CSTYLED */

--- a/module/zfs/btree.c
+++ b/module/zfs/btree.c
@@ -2208,8 +2208,6 @@ zfs_btree_verify(zfs_btree_t *tree)
 	zfs_btree_verify_poison(tree);
 }
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs, zfs_, btree_verify_intensity, UINT, ZMOD_RW,
 	"Enable btree verification. Levels above 4 require ZFS be built "
 	"with debugging");
-/* END CSTYLED */

--- a/module/zfs/ddt_zap.c
+++ b/module/zfs/ddt_zap.c
@@ -258,9 +258,7 @@ const ddt_ops_t ddt_zap_ops = {
 	ddt_zap_count,
 };
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_dedup, , ddt_zap_default_bs, UINT, ZMOD_RW,
 	"DDT ZAP leaf blockshift");
 ZFS_MODULE_PARAM(zfs_dedup, , ddt_zap_default_ibs, UINT, ZMOD_RW,
 	"DDT ZAP indirect blockshift");
-/* END CSTYLED */

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2942,10 +2942,8 @@ ZFS_MODULE_PARAM(zfs, zfs_, per_txg_dirty_frees_percent, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, dmu_offset_next_sync, INT, ZMOD_RW,
 	"Enable forcing txg sync to find holes");
 
-/* CSTYLED */
 ZFS_MODULE_PARAM(zfs, , dmu_prefetch_max, UINT, ZMOD_RW,
 	"Limit one prefetch call to this size");
 
-/* CSTYLED */
 ZFS_MODULE_PARAM(zfs, , dmu_ddt_copies, UINT, ZMOD_RW,
 	"Override copies= for dedup objects");

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -519,7 +519,5 @@ EXPORT_SYMBOL(dmu_object_next);
 EXPORT_SYMBOL(dmu_object_zapify);
 EXPORT_SYMBOL(dmu_object_free_zapified);
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs, , dmu_object_alloc_chunk_shift, UINT, ZMOD_RW,
 	"CPU-specific allocator grabs 2^N objects at once");
-/* END CSTYLED */

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -3843,4 +3843,3 @@ ZFS_MODULE_PARAM(zfs_recv, zfs_recv_, write_batch_size, UINT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs_recv, zfs_recv_, best_effort_corrective, INT, ZMOD_RW,
 	"Ignore errors during corrective receive");
-/* END CSTYLED */

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -818,6 +818,5 @@ MODULE_PARM_DESC(ignore_hole_birth,
 	"Alias for send_holes_without_birth_time");
 #endif
 
-/* CSTYLED */
 ZFS_MODULE_PARAM(zfs, , send_holes_without_birth_time, INT, ZMOD_RW,
 	"Ignore hole_birth txg for zfs send");

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -2494,6 +2494,5 @@ EXPORT_SYMBOL(dsl_dir_set_quota);
 EXPORT_SYMBOL(dsl_dir_set_reservation);
 #endif
 
-/* CSTYLED */
 ZFS_MODULE_PARAM(zfs, , zvol_enforce_quotas, INT, ZMOD_RW,
 	"Enable strict ZVOL quota enforcment");

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -5345,4 +5345,3 @@ ZFS_MODULE_PARAM(zfs, zfs_, resilver_defer_percent, UINT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs, zfs_, scrub_error_blocks_per_txg, UINT, ZMOD_RW,
 	"Error blocks to be scrubbed in one txg");
-/* END CSTYLED */

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -6226,7 +6226,6 @@ ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, unload_delay, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, unload_delay_ms, UINT, ZMOD_RW,
 	"Delay in milliseconds after metaslab was last used before unloading");
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_mg, zfs_mg_, noalloc_threshold, UINT, ZMOD_RW,
 	"Percentage of metaslab group size that should be free to make it "
 	"eligible for allocation");
@@ -6239,7 +6238,6 @@ ZFS_MODULE_PARAM(zfs_mg, zfs_mg_, fragmentation_threshold, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, fragmentation_factor_enabled, INT,
 	ZMOD_RW,
 	"Use the fragmentation metric to prefer less fragmented metaslabs");
-/* END CSTYLED */
 
 ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, fragmentation_threshold, UINT,
 	ZMOD_RW, "Fragmentation for metaslab to allow allocation");
@@ -6280,8 +6278,6 @@ ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, try_hard_before_gang, INT,
 ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, find_max_tries, UINT, ZMOD_RW,
 	"Normally only consider this many of the best metaslabs in each vdev");
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM_CALL(zfs, zfs_, active_allocator,
 	param_set_active_allocator, param_get_charp, ZMOD_RW,
 	"SPA active allocator");
-/* END CSTYLED */

--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -736,11 +736,9 @@ mmp_signal_all_threads(void)
 	mutex_exit(&spa_namespace_lock);
 }
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM_CALL(zfs_multihost, zfs_multihost_, interval,
 	param_set_multihost_interval, spl_param_get_u64, ZMOD_RW,
 	"Milliseconds between mmp writes to each leaf");
-/* END CSTYLED */
 
 ZFS_MODULE_PARAM(zfs_multihost, zfs_multihost_, fail_intervals, UINT, ZMOD_RW,
 	"Max allowed period without a successful mmp write");

--- a/module/zfs/refcount.c
+++ b/module/zfs/refcount.c
@@ -349,11 +349,9 @@ EXPORT_SYMBOL(zfs_refcount_add);
 EXPORT_SYMBOL(zfs_refcount_remove);
 EXPORT_SYMBOL(zfs_refcount_held);
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs, , reference_tracking_enable, INT, ZMOD_RW,
 	"Track reference holders to refcount_t objects");
 
 ZFS_MODULE_PARAM(zfs, , reference_history, UINT, ZMOD_RW,
 	"Maximum reference holders being tracked");
-/* END CSTYLED */
 #endif	/* ZFS_DEBUG */

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -11011,11 +11011,9 @@ EXPORT_SYMBOL(spa_event_notify);
 ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, preload_pct, UINT, ZMOD_RW,
 	"Percentage of CPUs to run a metaslab preload taskq");
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_spa, spa_, load_verify_shift, UINT, ZMOD_RW,
 	"log2 fraction of arc that can be used by inflight I/Os when "
 	"verifying pool during import");
-/* END CSTYLED */
 
 ZFS_MODULE_PARAM(zfs_spa, spa_, load_verify_metadata, INT, ZMOD_RW,
 	"Set to traverse metadata on pool import");
@@ -11032,11 +11030,9 @@ ZFS_MODULE_PARAM(zfs_zio, zio_, taskq_batch_pct, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs_zio, zio_, taskq_batch_tpq, UINT, ZMOD_RW,
 	"Number of threads per IO worker taskqueue");
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs, zfs_, max_missing_tvds, U64, ZMOD_RW,
 	"Allow importing pool with up to this number of missing top-level "
 	"vdevs (in read-only mode)");
-/* END CSTYLED */
 
 ZFS_MODULE_PARAM(zfs_livelist_condense, zfs_livelist_condense_, zthr_pause, INT,
 	ZMOD_RW, "Set the livelist condense zthr to pause");
@@ -11044,7 +11040,6 @@ ZFS_MODULE_PARAM(zfs_livelist_condense, zfs_livelist_condense_, zthr_pause, INT,
 ZFS_MODULE_PARAM(zfs_livelist_condense, zfs_livelist_condense_, sync_pause, INT,
 	ZMOD_RW, "Set the livelist condense synctask to pause");
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_livelist_condense, zfs_livelist_condense_, sync_cancel,
 	INT, ZMOD_RW,
 	"Whether livelist condensing was canceled in the synctask");
@@ -11066,7 +11061,6 @@ ZFS_MODULE_VIRTUAL_PARAM_CALL(zfs_zio, zio_, taskq_write,
 	spa_taskq_write_param_set, spa_taskq_write_param_get, ZMOD_RW,
 	"Configure IO queues for write IO");
 #endif
-/* END CSTYLED */
 
 ZFS_MODULE_PARAM(zfs_zio, zio_, taskq_write_tpq, UINT, ZMOD_RW,
 	"Number of CPUs per write issue taskq");

--- a/module/zfs/spa_checkpoint.c
+++ b/module/zfs/spa_checkpoint.c
@@ -633,8 +633,6 @@ EXPORT_SYMBOL(spa_checkpoint_get_stats);
 EXPORT_SYMBOL(spa_checkpoint_discard_thread);
 EXPORT_SYMBOL(spa_checkpoint_discard_thread_check);
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_spa, zfs_spa_, discard_memory_limit, U64, ZMOD_RW,
 	"Limit for memory used in prefetching the checkpoint space map done "
 	"on each vdev while discarding the checkpoint");
-/* END CSTYLED */

--- a/module/zfs/spa_errlog.c
+++ b/module/zfs/spa_errlog.c
@@ -1491,8 +1491,6 @@ EXPORT_SYMBOL(zep_to_zb);
 EXPORT_SYMBOL(name_to_errphys);
 #endif
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_spa, spa_, upgrade_errlog_limit, UINT, ZMOD_RW,
 	"Limit the number of errors which will be upgraded to the new "
 	"on-disk error log when enabling head_errlog");
-/* END CSTYLED */

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -1364,7 +1364,6 @@ spa_ld_log_spacemaps(spa_t *spa)
 	return (error);
 }
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs, zfs_, unflushed_max_mem_amt, U64, ZMOD_RW,
 	"Specific hard-limit in memory that ZFS allows to be used for "
 	"unflushed changes");
@@ -1383,8 +1382,8 @@ ZFS_MODULE_PARAM(zfs, zfs_, unflushed_log_block_min, U64, ZMOD_RW,
 	"log spacemap (see zfs_unflushed_log_block_max)");
 
 ZFS_MODULE_PARAM(zfs, zfs_, unflushed_log_txg_max, U64, ZMOD_RW,
-    "Hard limit (upper-bound) in the size of the space map log "
-    "in terms of dirty TXGs.");
+	"Hard limit (upper-bound) in the size of the space map log "
+	"in terms of dirty TXGs.");
 
 ZFS_MODULE_PARAM(zfs, zfs_, unflushed_log_block_pct, UINT, ZMOD_RW,
 	"Tunable used to determine the number of blocks that can be used for "
@@ -1399,7 +1398,6 @@ ZFS_MODULE_PARAM(zfs, zfs_, max_log_walking, U64, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, keep_log_spacemaps_at_export, INT, ZMOD_RW,
 	"Prevent the log spacemaps from being flushed and destroyed "
 	"during pool export/destroy");
-/* END CSTYLED */
 
 ZFS_MODULE_PARAM(zfs, zfs_, max_logsm_summary_length, U64, ZMOD_RW,
 	"Maximum number of rows allowed in the summary of the spacemap log");

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -3123,7 +3123,6 @@ ZFS_MODULE_PARAM(zfs, zfs_, ddt_data_is_special, INT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, user_indirect_is_special, INT, ZMOD_RW,
 	"Place user data indirect blocks into the special class");
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM_CALL(zfs_deadman, zfs_deadman_, failmode,
 	param_set_deadman_failmode, param_get_charp, ZMOD_RW,
 	"Failmode for deadman timer");
@@ -3139,7 +3138,6 @@ ZFS_MODULE_PARAM_CALL(zfs_deadman, zfs_deadman_, ziotime_ms,
 ZFS_MODULE_PARAM(zfs, zfs_, special_class_metadata_reserve_pct, UINT, ZMOD_RW,
 	"Small file blocks in special vdevs depends on this much "
 	"free space available");
-/* END CSTYLED */
 
 ZFS_MODULE_PARAM_CALL(zfs_spa, spa_, slop_shift, param_set_slop_shift,
 	param_get_uint, ZMOD_RW, "Reserved free space in pool");

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -6551,7 +6551,6 @@ ZFS_MODULE_PARAM(zfs, zfs_, deadman_events_per_second, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, dio_write_verify_events_per_second, UINT, ZMOD_RW,
 	"Rate Direct I/O write verify events to this many per second");
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, direct_write_verify, UINT, ZMOD_RW,
 	"Direct I/O writes will perform for checksum verification before "
 	"commiting write");
@@ -6559,7 +6558,6 @@ ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, direct_write_verify, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, checksum_events_per_second, UINT, ZMOD_RW,
 	"Rate limit checksum events to this many checksum errors per second "
 	"(do not set below ZED threshold).");
-/* END CSTYLED */
 
 ZFS_MODULE_PARAM(zfs, zfs_, scan_ignore_errors, INT, ZMOD_RW,
 	"Ignore errors during resilver/scrub");
@@ -6573,7 +6571,6 @@ ZFS_MODULE_PARAM(zfs, zfs_, nocacheflush, INT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, embedded_slog_min_ms, UINT, ZMOD_RW,
 	"Minimum number of metaslabs required to dedicate one for log blocks");
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM_CALL(zfs_vdev, zfs_vdev_, min_auto_ashift,
 	param_set_min_auto_ashift, param_get_uint, ZMOD_RW,
 	"Minimum ashift used when creating new top-level vdevs");
@@ -6582,4 +6579,3 @@ ZFS_MODULE_PARAM_CALL(zfs_vdev, zfs_vdev_, max_auto_ashift,
 	param_set_max_auto_ashift, param_get_uint, ZMOD_RW,
 	"Maximum ashift used when optimizing for logical -> physical sector "
 	"size on new top-level vdevs");
-/* END CSTYLED */

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -1897,7 +1897,6 @@ EXPORT_SYMBOL(vdev_indirect_sync_obsolete);
 EXPORT_SYMBOL(vdev_obsolete_counts_are_precise);
 EXPORT_SYMBOL(vdev_obsolete_sm_object);
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_condense, zfs_condense_, indirect_vdevs_enable, INT,
 	ZMOD_RW, "Whether to attempt condensing indirect vdev mappings");
 
@@ -1922,4 +1921,3 @@ ZFS_MODULE_PARAM(zfs_condense, zfs_condense_, indirect_commit_entry_delay_ms,
 ZFS_MODULE_PARAM(zfs_reconstruct, zfs_reconstruct_, indirect_combinations_max,
 	UINT, ZMOD_RW,
 	"Maximum number of combinations when reconstructing split segments");
-/* END CSTYLED */

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -1047,12 +1047,10 @@ ZFS_MODULE_PARAM(zfs_vdev_mirror, zfs_vdev_mirror_, rotating_inc, INT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs_vdev_mirror, zfs_vdev_mirror_, rotating_seek_inc, INT,
 	ZMOD_RW, "Rotating media load increment for seeking I/Os");
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_vdev_mirror, zfs_vdev_mirror_, rotating_seek_offset, INT,
 	ZMOD_RW,
 	"Offset in bytes from the last I/O which triggers "
 	"a reduced rotating media seek increment");
-/* END CSTYLED */
 
 ZFS_MODULE_PARAM(zfs_vdev_mirror, zfs_vdev_mirror_, non_rotating_inc, INT,
 	ZMOD_RW, "Non-rotating media load increment for non-seeking I/Os");

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -5049,7 +5049,6 @@ vdev_ops_t vdev_raidz_ops = {
 	.vdev_op_leaf = B_FALSE			/* not a leaf vdev */
 };
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_vdev, raidz_, expand_max_reflow_bytes, ULONG, ZMOD_RW,
 	"For testing, pause RAIDZ expansion after reflowing this many bytes");
 ZFS_MODULE_PARAM(zfs_vdev, raidz_, expand_max_copy_bytes, ULONG, ZMOD_RW,
@@ -5059,4 +5058,3 @@ ZFS_MODULE_PARAM(zfs_vdev, raidz_, io_aggregate_rows, ULONG, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, scrub_after_expand, INT, ZMOD_RW,
 	"For expanded RAIDZ, automatically start a pool scrub when expansion "
 	"completes");
-/* END CSTYLED */

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -2551,11 +2551,9 @@ ZFS_MODULE_PARAM(zfs_vdev, zfs_, remove_max_segment, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs_vdev, vdev_, removal_max_span, UINT, ZMOD_RW,
 	"Largest span of free chunks a remap segment can span");
 
-/* BEGIN CSTYLED */
 ZFS_MODULE_PARAM(zfs_vdev, zfs_, removal_suspend_progress, UINT, ZMOD_RW,
 	"Pause device removal after this many bytes are copied "
 	"(debug use only - causes removal to hang)");
-/* END CSTYLED */
 
 EXPORT_SYMBOL(free_from_removing_vdev);
 EXPORT_SYMBOL(spa_removal_get_stats);

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -1706,10 +1706,8 @@ zap_shrink(zap_name_t *zn, zap_leaf_t *l, dmu_tx_t *tx)
 	return (err);
 }
 
-/* CSTYLED */
 ZFS_MODULE_PARAM(zfs, , zap_iterate_prefetch, INT, ZMOD_RW,
 	"When iterating ZAP object, prefetch it");
 
-/* CSTYLED */
 ZFS_MODULE_PARAM(zfs, , zap_shrink_enabled, INT, ZMOD_RW,
 	"Enable ZAP shrinking");

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -2030,7 +2030,6 @@ EXPORT_SYMBOL(zap_cursor_serialize);
 EXPORT_SYMBOL(zap_cursor_init_serialized);
 EXPORT_SYMBOL(zap_get_stats);
 
-/* CSTYLED */
 ZFS_MODULE_PARAM(zfs, , zap_micro_max_size, INT, ZMOD_RW,
 	"Maximum micro ZAP size, before converting to a fat ZAP, in bytes");
 #endif

--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -572,7 +572,9 @@ line: while (<$filehandle>) {
 		err("comma or semicolon followed by non-blank");
 	}
 	# allow "for" statements to have empty "while" clauses
-	if (/\s[,;]/ && !/^[\t]+;$/ && !/^\s*for \([^;]*; ;[^;]*\)/) {
+	# allow macro invocations to have empty parameters
+	if (/\s[,;]/ && !/^[\t]+;$/ &&
+	    !($in_macro_call || /^\s*for \([^;]*; ;[^;]*\)/)) {
 		err("comma or semicolon preceded by blank");
 	}
 	if (/^\s*(&&|\|\|)/) {

--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -695,10 +695,13 @@ line: while (<$filehandle>) {
 			err("unary * followed by space");
 		}
 	}
-	if ($check_posix_types) {
+	if ($check_posix_types && !$in_macro_call) {
 		# try to detect old non-POSIX types.
 		# POSIX requires all non-standard typedefs to end in _t,
 		# but historically these have been used.
+		#
+		# We don't check inside macro invocations because macros have
+		# legitmate uses for these names in function generators.
 		if (/\b(unchar|ushort|uint|ulong|u_int|u_short|u_long|u_char|quad)\b/) {
 			err("non-POSIX typedef $1 used: use $old2posix{$1} instead");
 		}


### PR DESCRIPTION
### Motivation and Context

I'm doing a major uplift of tunable macros (coming soon!), and got very tired of having to turn cstyle off all the time because it really has no idea what a macro is.

### Description

Gives cstyle a modest understanding of top-level macro invocations:

- they are not function calls
- they might have missing parameters
- they might use what looks like old-style types (eg `uint`)

Then, remove a ton of `/* CSTYLED */` and `/* BEGIN CSTYLED */` escapes that aren't needed anymore.

I've tried to remain very conservative for now, because I don't want to accidentally stop checking something in non-macro parts of the code (ie most of it).

### How Has This Been Tested?

Tested during development, by removing some `CSTYLED` escapes, running `make cstyle`, then adjusting the code until those go away.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
