### PR TITLE
backtrace: fix off-by-one on string output

### DIFF
--- a/lib/libspl/backtrace.c
+++ b/lib/libspl/backtrace.c
@@ -38,7 +38,7 @@
  */
 #define	spl_bt_write_n(fd, s, n) \
 	do { ssize_t r __maybe_unused = write(fd, s, n); } while (0)
-#define	spl_bt_write(fd, s)		spl_bt_write_n(fd, s, sizeof (s))
+#define	spl_bt_write(fd, s)		spl_bt_write_n(fd, s, sizeof (s)-1)
 
 #if defined(HAVE_LIBUNWIND)
 #define	UNW_LOCAL_ONLY


### PR DESCRIPTION
### Motivation and Context

sizeof("foo") includes the trailing null byte, so all the output had nulls through it. Most terminals quietly ignore it, but it makes some tools misdetect file types and other annoyances.

### Description

Easy fix: subtract 1.

### How Has This Been Tested?

Stuck an assert in `zdb` and ran it. Before the commit, not the stray `00` bytes (eg right after the `0x` in the register output):

```
$ ./zdb 2>&1 | xxd
00000000: 4153 5345 5254 2061 7420 636d 642f 7a64  ASSERT at cmd/zd
00000010: 622f 7a64 622e 633a 3935 3230 3a6d 6169  b/zdb.c:9520:mai
00000020: 6e28 290a 226f 686e 6f22 203d 3d20 3020  n()."ohno" == 0
00000030: 2830 7835 3564 6533 6562 3734 6562 3520  (0x55de3eb74eb5
00000040: 3d3d 2030 290a 2020 5049 443a 2036 3931  == 0).  PID: 691
00000050: 3637 3920 2020 2043 4f4d 4d3a 207a 6462  679    COMM: zdb
00000060: 0a20 2054 4944 3a20 3639 3136 3739 2020  .  TID: 691679
00000070: 2020 4e41 4d45 3a20 7a64 620a 5265 6769    NAME: zdb.Regi
00000080: 7374 6572 733a 0a00 2020 5241 583a 2030  sters:..  RAX: 0
00000090: 7800 3030 3030 3030 3030 3030 3030 3030  x.00000000000000
000000a0: 3337 2020 5244 583a 2030 7800 3030 3030  37  RDX: 0x.0000
000000b0: 3030 3030 3030 3030 3030 3030 2020 5243  000000000000  RC
000000c0: 583a 2030 7800 3030 3030 3030 3030 3030  X: 0x.0000000000
000000d0: 3030 3030 3030 0a00 2020 5242 583a 2030  000000..  RBX: 0
000000e0: 7800 3030 3030 3030 3030 3030 3030 3030  x.00000000000000
000000f0: 3032 2020 5253 493a 2030 7800 3030 3030  02  RSI: 0x.0000
...
```

After:

```
$ ./zdb 2>&1 | xxd
00000000: 4153 5345 5254 2061 7420 636d 642f 7a64  ASSERT at cmd/zd
00000010: 622f 7a64 622e 633a 3935 3230 3a6d 6169  b/zdb.c:9520:mai
00000020: 6e28 290a 226f 686e 6f22 203d 3d20 3020  n()."ohno" == 0
00000030: 2830 7835 3633 3661 3832 6336 6562 3520  (0x5636a82c6eb5
00000040: 3d3d 2030 290a 2020 5049 443a 2037 3030  == 0).  PID: 700
00000050: 3036 3820 2020 2043 4f4d 4d3a 207a 6462  068    COMM: zdb
00000060: 0a20 2054 4944 3a20 3730 3030 3638 2020  .  TID: 700068
00000070: 2020 4e41 4d45 3a20 7a64 620a 5265 6769    NAME: zdb.Regi
00000080: 7374 6572 733a 0a20 2052 4158 3a20 3078  sters:.  RAX: 0x
00000090: 3030 3030 3030 3030 3030 3030 3030 3337  0000000000000037
000000a0: 2020 5244 583a 2030 7830 3030 3030 3030    RDX: 0x0000000
000000b0: 3030 3030 3030 3030 3020 2052 4358 3a20  000000000  RCX:
000000c0: 3078 3030 3030 3030 3030 3030 3030 3030  0x00000000000000
000000d0: 3030 0a20 2052 4258 3a20 3078 3030 3030  00.  RBX: 0x0000
000000e0: 3030 3030 3030 3030 3030 3032 2020 5253  000000000002  RS
000000f0: 493a 2030 7830 3030 3037 6666 6632 3534  I: 0x00007fff254
...
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
