### PR TITLE
Too many vdev probe errors should suspend pool

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -125,8 +125,8 @@ tests = ['auto_offline_001_pos', 'auto_online_001_pos', 'auto_online_002_pos',
     'auto_replace_001_pos', 'auto_replace_002_pos', 'auto_spare_001_pos',
     'auto_spare_002_pos', 'auto_spare_multiple', 'auto_spare_ashift',
     'auto_spare_shared', 'decrypt_fault', 'decompress_fault',
-    'fault_limits', 'scrub_after_resilver', 'suspend_resume_single',
-    'zpool_status_-s']
+    'fault_limits', 'scrub_after_resilver', 'suspend_on_probe_errors',
+    'suspend_resume_single', 'zpool_status_-s']
 tags = ['functional', 'fault']
 
 [tests/functional/features/large_dnode:Linux]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1532,6 +1532,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/fault/decrypt_fault.ksh \
 	functional/fault/fault_limits.ksh \
 	functional/fault/scrub_after_resilver.ksh \
+	functional/fault/suspend_on_probe_errors.ksh \
 	functional/fault/suspend_resume_single.ksh \
 	functional/fault/setup.ksh \
 	functional/fault/zpool_status_-s.ksh \

--- a/tests/zfs-tests/tests/functional/fault/suspend_on_probe_errors.ksh
+++ b/tests/zfs-tests/tests/functional/fault/suspend_on_probe_errors.ksh
@@ -1,0 +1,154 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2024, Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/blkdev.shlib
+
+#
+# DESCRIPTION: Verify that 4 disks removed from a raidz3 will suspend the pool
+#
+# STRATEGY:
+# 1. Disable ZED -- this test is focused on vdev_probe errors
+# 2. Create a raidz3 pool where 4 disks can be removed (i.e., using scsi_debug)
+# 3. Add some data to it for a resilver workload
+# 4. Replace one of the child vdevs to start a replacing vdev
+# 5. During the resilver, remove 4 disks including one from the replacing vdev
+# 6. Verify that the pool is suspended (it used to remain online)
+#
+
+DEV_SIZE_MB=1024
+
+FILE_VDEV_CNT=8
+FILE_VDEV_SIZ=256M
+
+function cleanup
+{
+	destroy_pool $TESTPOOL
+	if [[ "$(cat /sys/block/$sd/device/state)" == "offline" ]]; then
+		log_must eval "echo running > /sys/block/$sd/device/state"
+	fi
+	unload_scsi_debug
+	rm -f $DATA_FILE
+	for i in {0..$((FILE_VDEV_CNT - 1))}; do
+		log_must rm -f "$TEST_BASE_DIR/dev-$i"
+	done
+	log_must set_tunable32 SCAN_SUSPEND_PROGRESS 0
+	zed_start
+}
+
+log_onexit cleanup
+
+log_assert "VDEV probe errors for more disks than parity should suspend a pool"
+
+log_note "Stoping ZED process"
+zed_stop
+zpool events -c
+
+# Make a debug device that we can "unplug" and lose 4 drives at once
+unload_scsi_debug
+load_scsi_debug $DEV_SIZE_MB 1 1 1 '512b'
+sd=$(get_debug_device)
+
+# Create 4 partitions that match the FILE_VDEV_SIZ
+parted "/dev/${sd}" --script mklabel gpt
+parted "/dev/${sd}" --script mkpart primary 0% 25%
+parted "/dev/${sd}" --script mkpart primary 25% 50%
+parted "/dev/${sd}" --script mkpart primary 50% 75%
+parted "/dev/${sd}" --script mkpart primary 75% 100%
+block_device_wait "/dev/${sd}"
+blkdevs="/dev/${sd}1 /dev/${sd}2 /dev/${sd}3 /dev/${sd}4"
+
+# Create 8 file vdevs
+typeset -a filedevs
+for i in {0..$((FILE_VDEV_CNT - 1))}; do
+	device=$TEST_BASE_DIR/dev-$i
+	log_must truncate -s $FILE_VDEV_SIZ $device
+	# Use all but the last one for pool create
+	if [[ $i -lt "7" ]]; then
+		filedevs[${#filedevs[*]}+1]=$device
+	fi
+done
+
+# Create a raidz-3 pool that we can pull 4 disks from
+log_must zpool create -f $TESTPOOL raidz3 ${filedevs[@]} $blkdevs
+sync_pool $TESTPOOL
+
+# Add some data to the pool
+log_must zfs create $TESTPOOL/fs
+MNTPOINT="$(get_prop mountpoint $TESTPOOL/fs)"
+SECONDS=0
+log_must fill_fs $MNTPOINT 1 200 4096 10 Z
+log_note "fill_fs took $SECONDS seconds"
+sync_pool $TESTPOOL
+
+# Start a replacing vdev, but suspend the resilver
+log_must set_tunable32 SCAN_SUSPEND_PROGRESS 1
+log_must zpool replace -f $TESTPOOL /dev/${sd}4 $TEST_BASE_DIR/dev-7
+
+# Remove 4 disks all at once
+log_must eval "echo offline > /sys/block/${sd}/device/state"
+
+log_must set_tunable32 SCAN_SUSPEND_PROGRESS 0
+
+# Add some writes to drive the vdev probe errors
+log_must dd if=/dev/urandom of=$MNTPOINT/writes bs=1M count=1
+
+# Wait until sync starts, and the pool suspends
+log_note "waiting for pool to suspend"
+typeset -i tries=30
+until [[ $(cat /proc/spl/kstat/zfs/$TESTPOOL/state) == "SUSPENDED" ]] ; do
+	if ((tries-- == 0)); then
+		zpool status -s
+		log_fail "UNEXPECTED -- pool did not suspend"
+	fi
+	sleep 1
+done
+log_note $(cat /proc/spl/kstat/zfs/$TESTPOOL/state)
+
+# Put the missing disks back into service
+log_must eval "echo running > /sys/block/$sd/device/state"
+
+# Clear the vdev error states, which will reopen the vdevs and resume the pool
+log_must zpool clear $TESTPOOL
+
+# Wait until the pool resumes
+log_note "waiting for pool to resume"
+tries=30
+until [[ $(cat /proc/spl/kstat/zfs/$TESTPOOL/state) != "SUSPENDED" ]] ; do
+	if ((tries-- == 0)); then
+		log_fail "pool did not resume"
+	fi
+	sleep 1
+done
+log_must zpool wait -t resilver $TESTPOOL
+sync_pool $TESTPOOL
+
+# Make sure a pool scrub comes back clean
+log_must zpool scrub -w $TESTPOOL
+log_must zpool status -v $TESTPOOL
+log_must check_pool_status $TESTPOOL "errors" "No known data errors"
+
+log_pass "VDEV probe errors for more disks than parity should suspend a pool"


### PR DESCRIPTION
### Motivation and Context
Similar to what we saw in #16569, we need to consider that a replacing vdev should not be considered as fully contributing to the redundancy of a raidz vdev even though current IO has enough redundancy.  I have seen raidz3 pools where there were 4 missing disks (one involved in a replacing vdev) and the pool was still online and taking IO.  This case is different from #16569 in that ZED was not running so the vdev_probe() errors are driving the diagnosis here.

### Description
When a failed vdev_probe() is faulting a disk, it now checks if that disk is required, and if so it suspends the pool until the admin can return the missing disks. 

Sponsored-by: Klara, Inc. 
Sponsored-by: Wasabi Technology, Inc. 

 ### How Has This Been Tested?
Added a new test that verifies that probe errors from 4 disks on a raidz3 with a replacing vdev will suspend the pool.  Before the change the pool would not suspend.
```
  pool: testpool 
state: SUSPENDED 
status: One or more devices are faulted in response to IO failures. 
action: Make sure the affected devices are connected, then run 'zpool clear'. 
   see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-HC 
  scan: resilvered 6.47M in 00:00:03 with 8198 errors on Fri Dec 13 16:55:12 2024 
config: 
        NAME                  STATE     READ WRITE CKSUM 
        testpool              ONLINE       0     0     0 
          raidz3-0            ONLINE       0     0     0 
            /var/tmp/dev-0    ONLINE       0     0 8.16K 
            /var/tmp/dev-1    ONLINE       0     0    70 
            /var/tmp/dev-2    ONLINE       0     0    61 
            /var/tmp/dev-3    ONLINE       0     0    48 
            /var/tmp/dev-4    ONLINE       0     0    55 
            /var/tmp/dev-5    ONLINE       0     0    62 
            /var/tmp/dev-6    ONLINE       0     0 8.11K 
            sdh1              DEGRADED   195   707     0  too many errors 
            sdh2              DEGRADED   278 4.95K     0  too many errors 
            sdh3              DEGRADED   363 9.05K     0  too many errors 
            replacing-10      ONLINE       0     0 28.3K 
              sdh4            DEGRADED   453 41.5K     0  too many errors 
              /var/tmp/dev-7  ONLINE       0     0     0 
 
errors: 8168 data errors, use '-v' for a list 
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).