### PR TITLE
Fix stray "no" in configure output

### DIFF
--- a/config/kernel-xattr-handler.m4
+++ b/config/kernel-xattr-handler.m4
@@ -54,7 +54,6 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_XATTR_HANDLER_GET_DENTRY_INODE_FLAGS], [
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_GET_DENTRY_INODE_FLAGS], [
-	AC_MSG_RESULT(no)
 	AC_MSG_CHECKING(
 	    [whether xattr_handler->get() wants dentry and inode and flags])
 	ZFS_LINUX_TEST_RESULT([xattr_handler_get_dentry_inode_flags], [


### PR DESCRIPTION
### Motivation and Context

We don't want any extra incorrect noise in the configure output.

### Description

This is purely a cosmetic fix which removes a stray "no" from the configure output.

### How Has This Been Tested?

Before the change:

```
checking whether inode_owner_or_capable() exists... yes
checking whether super_block uses const struct xattr_handler... yes
no
checking whether xattr_handler->get() wants dentry and inode and flags... no
checking whether xattr_handler->set() wants dentry, inode, and mnt_idmap... no
```

after

```
checking whether inode_owner_or_capable() exists... yes
checking whether super_block uses const struct xattr_handler... yes
checking whether xattr_handler->get() wants dentry and inode and flags... no
checking whether xattr_handler->set() wants dentry, inode, and mnt_idmap... no
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
