### PR TITLE
Fix use-afer-free regression in RAIDZ expansion

### DIFF
--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -3914,8 +3914,8 @@ raidz_reflow_read_done(zio_t *zio)
 
 	if (atomic_dec_32_nv(&rra->rra_tbd) > 0)
 		return;
-	rra->rra_tbd = rra->rra_writes;
-	for (uint64_t i = 0; i < rra->rra_writes; i++)
+	uint32_t writes = rra->rra_tbd = rra->rra_writes;
+	for (uint64_t i = 0; i < writes; i++)
 		zio_nowait(rra->rra_zio[i]);
 }
 


### PR DESCRIPTION
We should not dereference `rra` after the last `zio_nowait()` is called. It seems very unlikely, but ASAN in `ztest` managed to catch it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
