### PR TITLE
[2.2.8 backport] config: fix dequeue_signal check for kernels <4.20

### DIFF
--- a/config/kernel-kthread.m4
+++ b/config/kernel-kthread.m4
@@ -17,14 +17,21 @@ AC_DEFUN([ZFS_AC_KERNEL_KTHREAD_COMPLETE_AND_EXIT], [
 
 AC_DEFUN([ZFS_AC_KERNEL_KTHREAD_DEQUEUE_SIGNAL], [
 	dnl #
-	dnl # 5.17 API: enum pid_type * as new 4th dequeue_signal() argument,
-	dnl # 5768d8906bc23d512b1a736c1e198aa833a6daa4 ("signal: Requeue signals in the appropriate queue")
+	dnl # prehistory:
+	dnl #     int dequeue_signal(struct task_struct *task, sigset_t *mask,
+	dnl #         siginfo_t *info)
 	dnl #
-	dnl # int dequeue_signal(struct task_struct *task, sigset_t *mask, kernel_siginfo_t *info);
-	dnl # int dequeue_signal(struct task_struct *task, sigset_t *mask, kernel_siginfo_t *info, enum pid_type *type);
+	dnl # 4.20: kernel_siginfo_t introduced, replaces siginfo_t
+	dnl #     int dequeue_signal(struct task_struct *task, sigset_t *mask,
+	dnl           kernel_siginfo_t *info)
 	dnl #
-	dnl # 6.12 API: first arg struct_task* removed
-	dnl # int dequeue_signal(sigset_t *mask, kernel_siginfo_t *info, enum pid_type *type);
+	dnl # 5.17: enum pid_type introduced as 4th arg
+	dnl #     int dequeue_signal(struct task_struct *task, sigset_t *mask,
+	dnl #         kernel_siginfo_t *info, enum pid_type *type)
+	dnl #
+	dnl # 6.12: first arg struct_task* removed
+	dnl #     int dequeue_signal(sigset_t *mask, kernel_siginfo_t *info,
+	dnl #         enum pid_type *type)
 	dnl #
 	AC_MSG_CHECKING([whether dequeue_signal() takes 4 arguments])
 	ZFS_LINUX_TEST_RESULT([kthread_dequeue_signal_4arg], [
@@ -33,11 +40,11 @@ AC_DEFUN([ZFS_AC_KERNEL_KTHREAD_DEQUEUE_SIGNAL], [
 		    [dequeue_signal() takes 4 arguments])
 	], [
 		AC_MSG_RESULT(no)
-		AC_MSG_CHECKING([whether dequeue_signal() a task argument])
-		ZFS_LINUX_TEST_RESULT([kthread_dequeue_signal_3arg_task], [
+		AC_MSG_CHECKING([whether 3-arg dequeue_signal() takes a type argument])
+		ZFS_LINUX_TEST_RESULT([kthread_dequeue_signal_3arg_type], [
 			AC_MSG_RESULT(yes)
-			AC_DEFINE(HAVE_DEQUEUE_SIGNAL_3ARG_TASK, 1,
-			    [dequeue_signal() takes a task argument])
+			AC_DEFINE(HAVE_DEQUEUE_SIGNAL_3ARG_TYPE, 1,
+			    [3-arg dequeue_signal() takes a type argument])
 		], [
 			AC_MSG_RESULT(no)
 		])
@@ -56,17 +63,6 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_KTHREAD_COMPLETE_AND_EXIT], [
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_SRC_KTHREAD_DEQUEUE_SIGNAL], [
-	ZFS_LINUX_TEST_SRC([kthread_dequeue_signal_3arg_task], [
-		#include <linux/sched/signal.h>
-	], [
-		struct task_struct *task = NULL;
-		sigset_t *mask = NULL;
-		kernel_siginfo_t *info = NULL;
-		int error __attribute__ ((unused));
-
-		error = dequeue_signal(task, mask, info);
-	])
-
 	ZFS_LINUX_TEST_SRC([kthread_dequeue_signal_4arg], [
 		#include <linux/sched/signal.h>
 	], [
@@ -77,6 +73,17 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_KTHREAD_DEQUEUE_SIGNAL], [
 		int error __attribute__ ((unused));
 
 		error = dequeue_signal(task, mask, info, type);
+	])
+
+	ZFS_LINUX_TEST_SRC([kthread_dequeue_signal_3arg_type], [
+		#include <linux/sched/signal.h>
+	], [
+		sigset_t *mask = NULL;
+		kernel_siginfo_t *info = NULL;
+		enum pid_type *type = NULL;
+		int error __attribute__ ((unused));
+
+		error = dequeue_signal(mask, info, type);
 	])
 ])
 

--- a/module/os/linux/spl/spl-thread.c
+++ b/module/os/linux/spl/spl-thread.c
@@ -171,11 +171,11 @@ issig(void)
 #if defined(HAVE_DEQUEUE_SIGNAL_4ARG)
 	enum pid_type __type;
 	if (dequeue_signal(current, &set, &__info, &__type) != 0) {
-#elif defined(HAVE_DEQUEUE_SIGNAL_3ARG_TASK)
-	if (dequeue_signal(current, &set, &__info) != 0) {
-#else
+#elif defined(HAVE_DEQUEUE_SIGNAL_3ARG_TYPE)
 	enum pid_type __type;
 	if (dequeue_signal(&set, &__info, &__type) != 0) {
+#else
+	if (dequeue_signal(current, &set, &__info) != 0) {
 #endif
 		spin_unlock_irq(&current->sighand->siglock);
 		kernel_signal_stop();


### PR DESCRIPTION
### Motivation and Context

Issue #16858.  Resolve Linux 4.19 kernel build failure.

### Description

Before 4.20, kernel_siginfo_t was just called siginfo_t. This was causing the kthread_dequeue_signal_3arg_task check, which uses kernel_siginfo_t, to fail on older kernels.

In d6b8c17f1, we started checking for the "new" three-arg dequeue_signal() by testing for the "old" version. Because that test is explicitly using kernel_siginfo_t, it would fail, leading to the build trying to use the new three-arg version, which would then not comile.

This commit fixes that by avoiding checking for the old 3-arg dequeue_signal entirely. Instead, we check for the new one, as well as the 4-arg form, and we use the old form as a fallback. This way, we never have to test for it explicitly, and once we're building HAVE_SIGINFO will make sure we get the right kernel_siginfo_t for it, so everything works out nice.

### How Has This Been Tested?

Clean cherry pick from master.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)