### PR TITLE
simd_stat: fix undefined CONFIG_KERNEL_MODE_NEON error on armel

### DIFF
--- a/module/zcommon/simd_stat.c
+++ b/module/zcommon/simd_stat.c
@@ -132,8 +132,10 @@ simd_stat_kstat_data(char *buf, size_t size, void *data)
 #if defined(__arm__) || defined(__aarch64__)
 		off += SIMD_STAT_PRINT(simd_stat_kstat_payload,
 		    "kernel_neon", HAVE_KERNEL_NEON);
+#if defined(CONFIG_KERNEL_MODE_NEON)
 		off += SIMD_STAT_PRINT(simd_stat_kstat_payload,
 		    "kernel_mode_neon", CONFIG_KERNEL_MODE_NEON);
+#endif /* CONFIG_KERNEL_MODE_NEON */
 		off += SIMD_STAT_PRINT(simd_stat_kstat_payload,
 		    "neon", zfs_neon_available());
 		off += SIMD_STAT_PRINT(simd_stat_kstat_payload,


### PR DESCRIPTION

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently zfs 2.2.7 / 2.3.0-rc4 / master won't compile on armel.

See [debian buildd log](https://ci.debian.net/packages/z/zfs-linux/testing/armel/55265184/#S7):

```text
525s /tmp/autopkgtest-lxc.ai7b0w_k/downtmp/build.TuL/src/module/zcommon/simd_stat.c: In function ‘simd_stat_kstat_data’:
525s /tmp/autopkgtest-lxc.ai7b0w_k/downtmp/build.TuL/src/module/zcommon/simd_stat.c:136:41: error: ‘CONFIG_KERNEL_MODE_NEON’ undeclared (first use in this function)
525s   136 |                     "kernel_mode_neon", CONFIG_KERNEL_MODE_NEON);
525s       |                                         ^~~~~~~~~~~~~~~~~~~~~~~
525s /tmp/autopkgtest-lxc.ai7b0w_k/downtmp/build.TuL/src/module/zcommon/simd_stat.c:52:74: note: in definition of macro ‘SIMD_STAT_PRINT’
525s    52 |         kmem_scnprintf(s + off, MAX(4095-off, 0), "%-16s\t%1d\n", feat, (val))
525s       |                                                                          ^~~
525s /tmp/autopkgtest-lxc.ai7b0w_k/downtmp/build.TuL/src/module/zcommon/simd_stat.c:136:41: note: each undeclared identifier is reported only once for each function it appears in
525s   136 |                     "kernel_mode_neon", CONFIG_KERNEL_MODE_NEON);
525s       |                                         ^~~~~~~~~~~~~~~~~~~~~~~
525s /tmp/autopkgtest-lxc.ai7b0w_k/downtmp/build.TuL/src/module/zcommon/simd_stat.c:52:74: note: in definition of macro ‘SIMD_STAT_PRINT’
525s    52 |         kmem_scnprintf(s + off, MAX(4095-off, 0), "%-16s\t%1d\n", feat, (val))
525s       |                                                                          ^~~
525s make[4]: *** [/usr/src/linux-headers-6.11.10-common/scripts/Makefile.build:249: /tmp/autopkgtest-lxc.ai7b0w_k/downtmp/build.TuL/src/module/zcommon/simd_stat.o] Error 1
```

### Description

`CONFIG_KERNEL_MODE_NEON` depends on `CONFIG_NEON`. Neither is defined on armel. So a guard is needed to avoid compilation errors.

### How Has This Been Tested?

It now compiles. Should not affect any other functionalities.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
