### PR TITLE
import: add `newname` property to rename pool on next import

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -266,6 +266,7 @@ typedef enum {
 	ZPOOL_PROP_DEDUP_TABLE_QUOTA,
 	ZPOOL_PROP_DEDUPCACHED,
 	ZPOOL_PROP_LAST_SCRUBBED_TXG,
+	ZPOOL_PROP_NEWNAME,
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
@@ -865,6 +866,7 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_EXPANSION_TIME	"expansion_time"	/* not stored */
 #define	ZPOOL_CONFIG_REBUILD_STATS	"org.openzfs:rebuild_stats"
 #define	ZPOOL_CONFIG_COMPATIBILITY	"compatibility"
+#define	ZPOOL_CONFIG_NEWNAME		"org.openzfs:newname"
 
 /*
  * The persistent vdev state is stored as separate values rather than a single

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -472,6 +472,8 @@ struct spa {
 	boolean_t	spa_waiters_cancel;	/* waiters should return */
 
 	char		*spa_compatibility;	/* compatibility file(s) */
+	char		*spa_newname;		/* pool name on next import */
+
 	uint64_t	spa_dedup_table_quota;	/* property DDT maximum size */
 	uint64_t	spa_dedup_dsize;	/* cached on-disk size of DDT */
 	uint64_t	spa_dedup_class_full_txg; /* txg dedup class was full */

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -589,10 +589,12 @@ get_configs(libpc_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
 				 *	pool state
 				 *	hostid (if available)
 				 *	hostname (if available)
+				 *	new name (if available)
 				 */
 				uint64_t state, version;
 				const char *comment = NULL;
 				const char *compatibility = NULL;
+				const char *newname = NULL;
 
 				version = fnvlist_lookup_uint64(tmp,
 				    ZPOOL_CONFIG_VERSION);
@@ -634,6 +636,11 @@ get_configs(libpc_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
 					fnvlist_add_string(config,
 					    ZPOOL_CONFIG_HOSTNAME, hostname);
 				}
+
+				if (nvlist_lookup_string(tmp,
+				    ZPOOL_CONFIG_NEWNAME, &newname) == 0)
+					fnvlist_add_string(config,
+					    ZPOOL_CONFIG_NEWNAME, newname);
 
 				config_seen = B_TRUE;
 			}

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -82,6 +82,8 @@ zpool_prop_init(void)
 	zprop_register_string(ZPOOL_PROP_COMPATIBILITY, "compatibility",
 	    "off", PROP_DEFAULT, ZFS_TYPE_POOL,
 	    "<file[,file...]> | off | legacy", "COMPATIBILITY", sfeatures);
+	zprop_register_string(ZPOOL_PROP_NEWNAME, "newname", NULL,
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "<name>", "NEWNAME", sfeatures);
 
 	/* readonly number properties */
 	zprop_register_number(ZPOOL_PROP_SIZE, "size", 0, PROP_READONLY,

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -466,6 +466,9 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 	if (spa->spa_compatibility != NULL)
 		fnvlist_add_string(config, ZPOOL_CONFIG_COMPATIBILITY,
 		    spa->spa_compatibility);
+	if (spa->spa_newname != NULL)
+		fnvlist_add_string(config, ZPOOL_CONFIG_NEWNAME,
+		    spa->spa_newname);
 
 	hostid = spa_get_hostid(spa);
 	if (hostid != 0)


### PR DESCRIPTION
### Motivation and Context

Renaming a pool is possible by providing an additional argument to `zpool import`. This assumes that the operator is able to comfortably export and re-import the pool, which is generally not the case for root/boot pools.

### Description

This adds a `newname` pseudo-property to the pool. If it exists at import time, it will be used to the name the pool. This allows the operator to set the new name ahead of the next export/import cycle (eg, before rebooting).

The old method of renaming the pool is still available, and takes precedence over the property. The property itself is cleared on every successful import, regardless of the name used. This is justified as a policy of "most recent name wins", but really is just to avoid surprising renames when the property is left set and forgotten.

Because the value is needed during import, the property is stored on the label rather than in the props ZAP.

TODO:

- Consider where this is applied; might be better done entrely inside the module rather than in zpool/libzfs, because it changes the call sequence required a little.
- To that end, need to find what alternate pool-importing code does and expects (bootloaders etc)
- Understand ZFS_IMPORT_VERBATIM and make this work with it (which is possible the FreeBSD answer to the above two)
- General concept and design review.

Demo: https://asciinema.org/a/Bg8SpYXDTSsekTdRB37dX1elO

### How Has This Been Tested?

Prototype, so only light manual testing.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
