### PR TITLE
Skip iterating over snapshots for share properties

### DIFF
--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -563,8 +563,15 @@ change_one(zfs_handle_t *zhp, void *data)
 			cn = NULL;
 		}
 
-		if (!clp->cl_alldependents)
-			ret = zfs_iter_children_v2(zhp, 0, change_one, data);
+		if (!clp->cl_alldependents) {
+			if (clp->cl_prop != ZFS_PROP_MOUNTPOINT) {
+				ret = zfs_iter_filesystems_v2(zhp, 0,
+				    change_one, data);
+			} else {
+				ret = zfs_iter_children_v2(zhp, 0, change_one,
+				    data);
+			}
+		}
 
 		/*
 		 * If we added the handle to the changelist, we will re-use it
@@ -735,6 +742,11 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 	} else if (clp->cl_alldependents) {
 		if (zfs_iter_dependents_v2(zhp, 0, B_TRUE, change_one,
 		    clp) != 0) {
+			changelist_free(clp);
+			return (NULL);
+		}
+	} else if (clp->cl_prop != ZFS_PROP_MOUNTPOINT) {
+		if (zfs_iter_filesystems_v2(zhp, 0, change_one, clp) != 0) {
 			changelist_free(clp);
 			return (NULL);
 		}


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Setting `sharenfs` and `sharesmb` properties on a dataset can become costly if there are large number of snapshots, since setting the share properties iterates over all snapshots present for a dataset. If it is the root dataset for which we are trying to set the share property, snapshots for all child datasets and their children will also be iterated.

### Description
This commit skips iterating over snapshots for share properties, instead iterate over all child dataset and their children for share properties.

There is no need to iterate over snapshots for share properties because we do not allow share properties or any other property, to be set on a snapshot itself execpt for user properties.


### How Has This Been Tested?
Accessed the snapshots over the shares created by setting the share properties for respective datasets. No difference in behavior found while accessing snapshots of dataset and child datasets shared by setting the share properties on dataset.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
