### PR TITLE
[2.2] Fix compile-time warnings caused by duplicate struct typedefs

### DIFF
--- a/include/os/linux/spl/sys/taskq.h
+++ b/include/os/linux/spl/sys/taskq.h
@@ -33,6 +33,7 @@
 #include <sys/thread.h>
 #include <sys/rwlock.h>
 #include <sys/wait.h>
+#include <sys/kstat.h>
 
 #define	TASKQ_NAMELEN		31
 

--- a/include/os/linux/zfs/sys/abd_os.h
+++ b/include/os/linux/zfs/sys/abd_os.h
@@ -30,6 +30,8 @@
 extern "C" {
 #endif
 
+struct abd;
+
 struct abd_scatter {
 	uint_t		abd_offset;
 	uint_t		abd_nents;
@@ -41,10 +43,8 @@ struct abd_linear {
 	struct scatterlist *abd_sgl; /* for LINEAR_PAGE */
 };
 
-typedef struct abd abd_t;
-
 typedef int abd_iter_page_func_t(struct page *, size_t, size_t, void *);
-int abd_iterate_page_func(abd_t *, size_t, size_t, abd_iter_page_func_t *,
+int abd_iterate_page_func(struct abd *, size_t, size_t, abd_iter_page_func_t *,
     void *);
 
 /*
@@ -52,8 +52,8 @@ int abd_iterate_page_func(abd_t *, size_t, size_t, abd_iter_page_func_t *,
  * Note: these are only needed to support vdev_classic. See comment in
  * vdev_disk.c.
  */
-unsigned int abd_bio_map_off(struct bio *, abd_t *, unsigned int, size_t);
-unsigned long abd_nr_pages_off(abd_t *, unsigned int, size_t);
+unsigned int abd_bio_map_off(struct bio *, struct abd *, unsigned int, size_t);
+unsigned long abd_nr_pages_off(struct abd *, unsigned int, size_t);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Motivation and Context

Backport #16665.

Closes #16879.

### Description

The platform specific header sys/abd_os.h shouldn't define or use abd_t, as it's defined in its non-platform specific consumer sys/abd.h. Do the same as what FreeBSD header does.

### How Has This Been Tested?

Compile checked against 6.7.12 w/ Clang/LLVM and 6.1.102 w/ GCC.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
