### PR TITLE
zfs_main: fix alignment on props usage output

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -500,7 +500,7 @@ usage_prop_cb(int prop, void *cb)
 {
 	FILE *fp = cb;
 
-	(void) fprintf(fp, "\t%-15s ", zfs_prop_to_name(prop));
+	(void) fprintf(fp, "\t%-22s ", zfs_prop_to_name(prop));
 
 	if (zfs_prop_readonly(prop))
 		(void) fprintf(fp, " NO    ");
@@ -561,40 +561,40 @@ usage(boolean_t requested)
 		(void) fprintf(fp, "%s",
 		    gettext("\nThe following properties are supported:\n"));
 
-		(void) fprintf(fp, "\n\t%-14s %s  %s   %s\n\n",
+		(void) fprintf(fp, "\n\t%-21s %s  %s   %s\n\n",
 		    "PROPERTY", "EDIT", "INHERIT", "VALUES");
 
 		/* Iterate over all properties */
 		(void) zprop_iter(usage_prop_cb, fp, B_FALSE, B_TRUE,
 		    ZFS_TYPE_DATASET);
 
-		(void) fprintf(fp, "\t%-15s ", "userused@...");
+		(void) fprintf(fp, "\t%-22s ", "userused@...");
 		(void) fprintf(fp, " NO       NO   <size>\n");
-		(void) fprintf(fp, "\t%-15s ", "groupused@...");
+		(void) fprintf(fp, "\t%-22s ", "groupused@...");
 		(void) fprintf(fp, " NO       NO   <size>\n");
-		(void) fprintf(fp, "\t%-15s ", "projectused@...");
+		(void) fprintf(fp, "\t%-22s ", "projectused@...");
 		(void) fprintf(fp, " NO       NO   <size>\n");
-		(void) fprintf(fp, "\t%-15s ", "userobjused@...");
+		(void) fprintf(fp, "\t%-22s ", "userobjused@...");
 		(void) fprintf(fp, " NO       NO   <size>\n");
-		(void) fprintf(fp, "\t%-15s ", "groupobjused@...");
+		(void) fprintf(fp, "\t%-22s ", "groupobjused@...");
 		(void) fprintf(fp, " NO       NO   <size>\n");
-		(void) fprintf(fp, "\t%-15s ", "projectobjused@...");
+		(void) fprintf(fp, "\t%-22s ", "projectobjused@...");
 		(void) fprintf(fp, " NO       NO   <size>\n");
-		(void) fprintf(fp, "\t%-15s ", "userquota@...");
+		(void) fprintf(fp, "\t%-22s ", "userquota@...");
 		(void) fprintf(fp, "YES       NO   <size> | none\n");
-		(void) fprintf(fp, "\t%-15s ", "groupquota@...");
+		(void) fprintf(fp, "\t%-22s ", "groupquota@...");
 		(void) fprintf(fp, "YES       NO   <size> | none\n");
-		(void) fprintf(fp, "\t%-15s ", "projectquota@...");
+		(void) fprintf(fp, "\t%-22s ", "projectquota@...");
 		(void) fprintf(fp, "YES       NO   <size> | none\n");
-		(void) fprintf(fp, "\t%-15s ", "userobjquota@...");
+		(void) fprintf(fp, "\t%-22s ", "userobjquota@...");
 		(void) fprintf(fp, "YES       NO   <size> | none\n");
-		(void) fprintf(fp, "\t%-15s ", "groupobjquota@...");
+		(void) fprintf(fp, "\t%-22s ", "groupobjquota@...");
 		(void) fprintf(fp, "YES       NO   <size> | none\n");
-		(void) fprintf(fp, "\t%-15s ", "projectobjquota@...");
+		(void) fprintf(fp, "\t%-22s ", "projectobjquota@...");
 		(void) fprintf(fp, "YES       NO   <size> | none\n");
-		(void) fprintf(fp, "\t%-15s ", "written@<snap>");
+		(void) fprintf(fp, "\t%-22s ", "written@<snap>");
 		(void) fprintf(fp, " NO       NO   <size>\n");
-		(void) fprintf(fp, "\t%-15s ", "written#<bookmark>");
+		(void) fprintf(fp, "\t%-22s ", "written#<bookmark>");
 		(void) fprintf(fp, " NO       NO   <size>\n");
 
 		(void) fprintf(fp, gettext("\nSizes are specified in bytes "


### PR DESCRIPTION
### Motivation and Context

Just playing with some ideas for alternate property display, and this stuck out as a very easy thing to tidy up.

### Description

Make the property name column wider, so the columns align nicely.

### How Has This Been Tested?

Just looking at it.

```
$ zfs get
...
	PROPERTY       EDIT  INHERIT   VALUES
...
	defer_destroy    NO       NO   yes | no
	encryptionroot   NO       NO   <filesystem | volume>
	filesystem_count  NO       NO   <count>
	guid             NO       NO   <uint64>
	keystatus        NO       NO   none | unavailable | available
	logicalreferenced  NO       NO   <size>
	logicalused      NO       NO   <size>
	mounted          NO       NO   yes | no
	objsetid         NO       NO   <uint64>
	origin           NO       NO   <snapshot>
	receive_resume_token  NO       NO   <string token>
	redact_snaps     NO       NO   <snapshot>[,...]
	refcompressratio  NO       NO   <1.00x or higher if compressed>
	referenced       NO       NO   <size>
	snapshot_count   NO       NO   <count>
	snapshots_changed  NO       NO   <date>
	type             NO       NO   filesystem | volume | snapshot | bookmark
	used             NO       NO   <size>
	usedbychildren   NO       NO   <size>
...
```

```
$ ./zfs get
...
	PROPERTY              EDIT  INHERIT   VALUES
...
	defer_destroy           NO       NO   yes | no
	encryptionroot          NO       NO   <filesystem | volume>
	filesystem_count        NO       NO   <count>
	guid                    NO       NO   <uint64>
	keystatus               NO       NO   none | unavailable | available
	logicalreferenced       NO       NO   <size>
	logicalused             NO       NO   <size>
	mounted                 NO       NO   yes | no
	objsetid                NO       NO   <uint64>
	origin                  NO       NO   <snapshot>
	receive_resume_token    NO       NO   <string token>
	redact_snaps            NO       NO   <snapshot>[,...]
	refcompressratio        NO       NO   <1.00x or higher if compressed>
	referenced              NO       NO   <size>
	snapshot_count          NO       NO   <count>
	snapshots_changed       NO       NO   <date>
	type                    NO       NO   filesystem | volume | snapshot | bookmark
	used                    NO       NO   <size>
	usedbychildren          NO       NO   <size>
...
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
