### PR TITLE
ZTS: Remove non-standard awk hex numbers usage

### DIFF
--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -556,27 +556,15 @@ function list_file_blocks # input_file
 	# 512B blocks for ease of use with dd.
 	#
 	typeset level vdev path offset length
-	if awk -n '' 2>/dev/null; then
-		# gawk needs -n to decode hex
-		AWK='awk -n'
-	else
-		AWK='awk'
-	fi
 	sync_all_pools true
-	zdb -dddddd $ds $objnum | $AWK -v pad=$((4<<20)) -v bs=512 '
+	zdb -dddddd $ds $objnum | awk '
 	    /^$/ { looking = 0 }
 	    looking {
 	        level = $2
 	        field = 3
 	        while (split($field, dva, ":") == 3) {
-	            # top level vdev id
-	            vdev = int(dva[1])
-	            # offset + 4M label/boot pad in 512B blocks
-	            offset = (int("0x"dva[2]) + pad) / bs
-		    # length in 512B blocks
-		    len = int("0x"dva[3]) / bs
 
-	            print level, vdev, offset, len
+	            print level, int(dva[1]), "0x"dva[2], "0x"dva[3]
 
 	            ++field
 	        }
@@ -585,7 +573,8 @@ function list_file_blocks # input_file
 	' | \
 	while read level vdev offset length; do
 		for path in ${VDEV_MAP[$vdev][@]}; do
-			echo "$level $path $offset $length"
+			echo "$level $path $(( ($offset + (4<<20)) / 512 ))" \
+			    "$(( $length / 512 ))"
 		done
 	done 2>/dev/null
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_status.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_status.ksh
@@ -103,20 +103,15 @@ log_must zpool export $TESTPOOL1
 log_must set_tunable64 METASLAB_DEBUG_LOAD 1
 log_note "Starting zpool import in background at" $(date +'%H:%M:%S')
 zpool import -d $DEVICE_DIR -f $guid &
-pid=$!
 
 #
 # capture progress until import is finished
 #
-log_note waiting for pid $pid to exit
 kstat import_progress
-while [[ -d /proc/"$pid" ]]; do
+while [[ -n $(jobs) ]]; do
 	line=$(kstat import_progress | grep -v pool_guid)
 	if [[ -n $line ]]; then
 		echo $line
-	fi
-	if [[ -f /$TESTPOOL1/fs/00 ]]; then
-		break;
 	fi
 	sleep 0.0001
 done

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_panic.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_panic.ksh
@@ -39,7 +39,7 @@ function cleanup
 log_onexit cleanup
 
 log_must zfs create -o recsize=8k $sendfs
-log_must dd if=/dev/urandom of=/$sendfs/file bs=1024k count=2048
+log_must dd if=/dev/urandom of=/$sendfs/file bs=1024k count=1024
 log_must zfs snapshot $sendfs@init
 log_must zfs clone $sendfs@init $clone
 log_must stride_dd -i /dev/urandom -o /$clone/file -b 8192 -s 2 -c 7226


### PR DESCRIPTION
FreeBSD recently removed non-standard hex numbers support from awk. Neither it supports -n argument, enabling it in gawk.  Instead of depending on those rewrite `list_file_blocks()` function to handle the hex math in shell instead of awk.

Fixes #11141

### How Has This Been Tested?
Called the function manually and saw it returning some numbers instead of constant 4MB offset and zero length.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
