### PR TITLE
rpm: dkms: Include other kernel-devel packages for spec requirements

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -30,9 +30,9 @@ Requires(preun): dkms >= 2.2.0.3
 Requires:       gcc, make, perl, diffutils
 Requires(post): gcc, make, perl, diffutils
 %if 0%{?rhel}%{?fedora}%{?mageia}%{?suse_version}%{?openEuler}
-Requires:       kernel-devel >= @ZFS_META_KVER_MIN@, kernel-devel <= @ZFS_META_KVER_MAX@.999
-Requires(post): kernel-devel >= @ZFS_META_KVER_MIN@, kernel-devel <= @ZFS_META_KVER_MAX@.999
-Conflicts:      kernel-devel < @ZFS_META_KVER_MIN@, kernel-devel > @ZFS_META_KVER_MAX@.999
+Requires:       (kernel-devel >= @ZFS_META_KVER_MIN@ or kernel-longterm-devel >= @ZFS_META_KVER_MIN@ or kernel-16k-devel >= @ZFS_META_KVER_MIN@) and (kernel-devel <= @ZFS_META_KVER_MAX@.999 or kernel-longterm-devel <= @ZFS_META_KVER_MAX@.999 or kernel-16k-devel <= @ZFS_META_KVER_MAX@.999)
+Requires(post): (kernel-devel >= @ZFS_META_KVER_MIN@ or kernel-longterm-devel >= @ZFS_META_KVER_MIN@ or kernel-16k-devel >= @ZFS_META_KVER_MIN@) and (kernel-devel <= @ZFS_META_KVER_MAX@.999 or kernel-longterm-devel <= @ZFS_META_KVER_MAX@.999 or kernel-16k-devel <= @ZFS_META_KVER_MAX@.999)
+Conflicts:      (kernel-devel >= @ZFS_META_KVER_MIN@ or kernel-longterm-devel >= @ZFS_META_KVER_MIN@ or kernel-16k-devel >= @ZFS_META_KVER_MIN@) and (kernel-devel <= @ZFS_META_KVER_MAX@.999 or kernel-longterm-devel <= @ZFS_META_KVER_MAX@.999 or kernel-16k-devel <= @ZFS_META_KVER_MAX@.999)
 Obsoletes:      spl-dkms <= %{version}
 %endif
 Provides:       %{module}-kmod = %{version}


### PR DESCRIPTION
### Motivation and Context
- Fedora users who use LTS kernels depend on a different kernel-devel package (kernel-longterm-devel).
- Similarly, Fedora Asahi Linux users use kernel-16k-devel instead of kernel-devel
- Update spec requirements to include both kernel-devel packages to support these set-ups.
- Should address #16742 and #16429

### Description
- Replace `Requires`, `Requires(post)`, and `Conflicts` with boolean operators according to https://rpm-software-management.github.io/rpm/manual/boolean_dependencies.html

### How Has This Been Tested?
- Can't seem to build the zfs-dkms rpm packages according to this documentation: https://openzfs.github.io/openzfs-docs/Developer%20Resources/Custom%20Packages.html#dkms , seem to only get src packages instead.
- Do Fedora 41 builds build the kmod variant instead of the dkms module?

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
