### PR TITLE
[WIP] Allocate zfs_locked_range_t memory externally from zfs_rangelock_{try,}enter()

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -49,6 +49,7 @@
 #include <sys/fs/zfs.h>
 #include <sys/zio_compress.h>
 #include <sys/zio_priority.h>
+#include <sys/zfs_rlock.h>
 #include <sys/uio.h>
 #include <sys/zfs_file.h>
 
@@ -1083,10 +1084,10 @@ uint64_t dmu_tx_get_txg(dmu_tx_t *tx);
  * {zfs,zvol,ztest}_get_done() args
  */
 typedef struct zgd {
+	zfs_locked_range_t zgd_lr;
 	struct lwb	*zgd_lwb;
 	struct blkptr	*zgd_bp;
 	dmu_buf_t	*zgd_db;
-	struct zfs_locked_range *zgd_lr;
 	void		*zgd_private;
 } zgd_t;
 

--- a/include/sys/zfs_rlock.h
+++ b/include/sys/zfs_rlock.h
@@ -69,9 +69,9 @@ typedef struct zfs_locked_range {
 void zfs_rangelock_init(zfs_rangelock_t *, zfs_rangelock_cb_t *, void *);
 void zfs_rangelock_fini(zfs_rangelock_t *);
 
-zfs_locked_range_t *zfs_rangelock_enter(zfs_rangelock_t *,
+void zfs_rangelock_enter(zfs_rangelock_t *, zfs_locked_range_t *,
     uint64_t, uint64_t, zfs_rangelock_type_t);
-zfs_locked_range_t *zfs_rangelock_tryenter(zfs_rangelock_t *,
+boolean_t zfs_rangelock_tryenter(zfs_rangelock_t *, zfs_locked_range_t *,
     uint64_t, uint64_t, zfs_rangelock_type_t);
 void zfs_rangelock_exit(zfs_locked_range_t *);
 void zfs_rangelock_reduce(zfs_locked_range_t *, uint64_t, uint64_t);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -655,7 +655,7 @@ zvol_get_done(zgd_t *zgd, int error)
 	if (zgd->zgd_db)
 		dmu_buf_rele(zgd->zgd_db, zgd);
 
-	zfs_rangelock_exit(zgd->zgd_lr);
+	zfs_rangelock_exit(&zgd->zgd_lr);
 
 	kmem_free(zgd, sizeof (zgd_t));
 }
@@ -688,7 +688,7 @@ zvol_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
 	 * we don't have to write the data twice.
 	 */
 	if (buf != NULL) { /* immediate write */
-		zgd->zgd_lr = zfs_rangelock_enter(&zv->zv_rangelock, offset,
+		zfs_rangelock_enter(&zv->zv_rangelock, &zgd->zgd_lr, offset,
 		    size, RL_READER);
 		error = dmu_read_by_dnode(zv->zv_dn, offset, size, buf,
 		    DMU_READ_NO_PREFETCH);
@@ -702,7 +702,7 @@ zvol_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
 		 */
 		size = zv->zv_volblocksize;
 		offset = P2ALIGN_TYPED(offset, size, uint64_t);
-		zgd->zgd_lr = zfs_rangelock_enter(&zv->zv_rangelock, offset,
+		zfs_rangelock_enter(&zv->zv_rangelock, &zgd->zgd_lr, offset,
 		    size, RL_READER);
 		error = dmu_buf_hold_noread_by_dnode(zv->zv_dn, offset, zgd,
 		    &db);


### PR DESCRIPTION
### Motivation and Context
The other day, a friend complained about slow `rm -r` operations on a pool that had two mirrored spinning disks. He was unlinking a large number of files, so I suggested he do a parallel rm and what should have taken a few more minutes to complete ended in seconds:

> find /path/to/subtree -name -type f | parallel -j250 rm --
> rm -r /path/to/subtree

I have long known that our VFS operations are slower than other filesystems such as ext4, and I have long attributed that to our use of range locks for scaling versus the spin locks that ext4 uses. Since scalability is more important than single threaded performance, I made no attempt to change this. Today, I had a flash of inspiration after writing a comment about this in a hacker news discussion:

https://news.ycombinator.com/item?id=42486279

It occurred to me that the uncontended case could be made faster. My initial idea was to try to make an adaptive range lock that would minimize work done in uncontended cases to approach the performance of ext4's spin locks. However, upon looking at the range lock code, I realized that the amount of work being done in the uncontended case is already somewhat minimal while significant improvement in all cases would be possible by changing how we allocate memory for `zfs_locked_range_t`.

Instead of allocating memory for `zfs_locked_range_t` as part of `zfs_rangelock_{try,}enter()`, we can allocate it externally either on the stack or as part of another structure. This is possible with trivial refactoring in all cases except `vdev_raidz_io_start()`, where slightly more extensive refactoring is needed to allocate `zfs_locked_range_t` as part of `raidz_map_t`.

I recall seeing flame graphs from close to the start of ZFSOnLinux showing significant time spent in `kmem_alloc()` when doing range locks. Doing this refactoring eliminates that entirely. This should make our VFS and zvol operations slightly faster. Some RAID-Z operations will also become slightly faster.

### Description
We do trivial refactoring to allocate `zfs_locked_range_t` either on the stack or as part of other structures in all but `vdev_raidz_io_start()`, where non-trival refactoring is needed.

### How Has This Been Tested?
I have only done build tests so far. I am letting the buildbot do runtime testing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
