### PR TITLE
ZTS: Increase write sizes for RAIDZ/dRAID tests

### DIFF
--- a/tests/zfs-tests/tests/functional/raidz/raidz_expand_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/raidz/raidz_expand_001_pos.ksh
@@ -200,13 +200,13 @@ log_must zpool create -f -o cachefile=none $TESTPOOL $raid ${disks[@]}
 log_must zfs set primarycache=metadata $TESTPOOL
 
 log_must zfs create $TESTPOOL/fs
-log_must fill_fs /$TESTPOOL/fs 1 512 100 1024 R
+log_must fill_fs /$TESTPOOL/fs 1 512 102400 1 R
 
 log_must zfs create -o compress=on $TESTPOOL/fs2
-log_must fill_fs /$TESTPOOL/fs2 1 512 100 1024 R
+log_must fill_fs /$TESTPOOL/fs2 1 512 102400 1 R
 
 log_must zfs create -o compress=on -o recordsize=8k $TESTPOOL/fs3
-log_must fill_fs /$TESTPOOL/fs3 1 512 100 1024 R
+log_must fill_fs /$TESTPOOL/fs3 1 512 102400 1 R
 
 log_must check_pool_status $TESTPOOL "errors" "No known data errors"
 

--- a/tests/zfs-tests/tests/functional/raidz/raidz_expand_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/raidz/raidz_expand_002_pos.ksh
@@ -78,13 +78,13 @@ log_must zpool create -f $opts $pool $raid ${disks[1..$(($nparity+1))]}
 log_must zfs set primarycache=metadata $pool
 
 log_must zfs create $pool/fs
-log_must fill_fs /$pool/fs 1 512 100 1024 R
+log_must fill_fs /$pool/fs 1 512 102400 1 R
 
 log_must zfs create -o compress=on $pool/fs2
-log_must fill_fs /$pool/fs2 1 512 100 1024 R
+log_must fill_fs /$pool/fs2 1 512 102400 1 R
 
 log_must zfs create -o compress=on -o recordsize=8k $pool/fs3
-log_must fill_fs /$pool/fs3 1 512 100 1024 R
+log_must fill_fs /$pool/fs3 1 512 102400 1 R
 
 typeset pool_size=$(get_pool_prop size $pool)
 

--- a/tests/zfs-tests/tests/functional/raidz/raidz_expand_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/raidz/raidz_expand_003_neg.ksh
@@ -92,7 +92,7 @@ log_must zpool destroy $pool
 log_must zpool create -f $opts $pool $raid ${disks[1..$(($devs-1))]}
 log_must zfs set primarycache=metadata $pool
 log_must zfs create $pool/fs
-log_must fill_fs /$pool/fs 1 512 100 1024 R
+log_must fill_fs /$pool/fs 1 512 102400 1 R
 allocated=$(zpool list -Hp -o allocated $pool)
 log_must set_tunable64 RAIDZ_EXPAND_MAX_REFLOW_BYTES $((allocated / 4))
 log_must zpool attach $pool ${raid}-0 ${disks[$devs]}

--- a/tests/zfs-tests/tests/functional/raidz/raidz_expand_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/raidz/raidz_expand_003_pos.ksh
@@ -94,10 +94,10 @@ opts="-o cachefile=none"
 log_must zpool create -f $opts $pool $raid ${disks[1..$(($nparity+1))]}
 
 log_must zfs create -o recordsize=8k $pool/fs
-log_must fill_fs /$pool/fs 1 256 100 1024 R
+log_must fill_fs /$pool/fs 1 256 102400 1 R
 
 log_must zfs create -o recordsize=128k $pool/fs2
-log_must fill_fs /$pool/fs2 1 256 100 1024 R
+log_must fill_fs /$pool/fs2 1 256 102400 1 R
 
 for disk in ${disks[$(($nparity+2))..$devs]}; do
 	log_must mkfile -n 400m /$pool/fs/file

--- a/tests/zfs-tests/tests/functional/raidz/raidz_expand_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/raidz/raidz_expand_004_pos.ksh
@@ -81,10 +81,10 @@ log_must set_tunable32 SCRUB_AFTER_EXPAND 0
 log_must zpool create -f $opts $pool $raid ${disks[1..$(($nparity+1))]}
 
 log_must zfs create -o recordsize=8k $pool/fs
-log_must fill_fs /$pool/fs 1 128 100 1024 R
+log_must fill_fs /$pool/fs 1 128 102400 1 R
 
 log_must zfs create -o recordsize=128k $pool/fs2
-log_must fill_fs /$pool/fs2 1 128 100 1024 R
+log_must fill_fs /$pool/fs2 1 128 102400 1 R
 
 for disk in ${disks[$(($nparity+2))..$devs]}; do
 	log_must zpool attach $pool ${raid}-0 $disk

--- a/tests/zfs-tests/tests/functional/raidz/raidz_expand_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/raidz/raidz_expand_005_pos.ksh
@@ -137,10 +137,10 @@ log_must zpool create -f $opts $pool $raid ${disks[1..$(($nparity+1))]}
 devices="${disks[1..$(($nparity+1))]}"
 
 log_must zfs create -o recordsize=8k $pool/fs
-log_must fill_fs /$pool/fs 1 128 100 1024 R
+log_must fill_fs /$pool/fs 1 128 102400 1 R
 
 log_must zfs create -o recordsize=128k $pool/fs2
-log_must fill_fs /$pool/fs2 1 128 100 1024 R
+log_must fill_fs /$pool/fs2 1 128 102400 1 R
 
 for disk in ${disks[$(($nparity+2))..$devs]}; do
 	# Set pause to some random value near halfway point

--- a/tests/zfs-tests/tests/functional/redundancy/redundancy_draid.ksh
+++ b/tests/zfs-tests/tests/functional/redundancy/redundancy_draid.ksh
@@ -223,13 +223,13 @@ for nparity in 1 2 3; do
 	log_must zfs set primarycache=metadata $TESTPOOL
 
 	log_must zfs create $TESTPOOL/fs
-	log_must fill_fs /$TESTPOOL/fs 1 512 100 1024 R
+	log_must fill_fs /$TESTPOOL/fs 1 512 102400 1 R
 
 	log_must zfs create -o compress=on $TESTPOOL/fs2
-	log_must fill_fs /$TESTPOOL/fs2 1 512 100 1024 R
+	log_must fill_fs /$TESTPOOL/fs2 1 512 102400 1 R
 
 	log_must zfs create -o compress=on -o recordsize=8k $TESTPOOL/fs3
-	log_must fill_fs /$TESTPOOL/fs3 1 512 100 1024 R
+	log_must fill_fs /$TESTPOOL/fs3 1 512 102400 1 R
 
 	typeset pool_size=$(get_pool_prop size $TESTPOOL)
 

--- a/tests/zfs-tests/tests/functional/redundancy/redundancy_draid_damaged1.ksh
+++ b/tests/zfs-tests/tests/functional/redundancy/redundancy_draid_damaged1.ksh
@@ -119,13 +119,13 @@ for nparity in 1 2 3; do
 	log_must zfs set primarycache=metadata $TESTPOOL
 
 	log_must zfs create $TESTPOOL/fs
-	log_must fill_fs /$TESTPOOL/fs 1 512 100 1024 R
+	log_must fill_fs /$TESTPOOL/fs 1 512 102400 1 R
 
 	log_must zfs create -o compress=on $TESTPOOL/fs2
-	log_must fill_fs /$TESTPOOL/fs2 1 512 100 1024 R
+	log_must fill_fs /$TESTPOOL/fs2 1 512 102400 1 R
 
 	log_must zfs create -o compress=on -o recordsize=8k $TESTPOOL/fs3
-	log_must fill_fs /$TESTPOOL/fs3 1 512 100 1024 R
+	log_must fill_fs /$TESTPOOL/fs3 1 512 102400 1 R
 
 	log_must zpool export $TESTPOOL
 	log_must zpool import -o cachefile=none -d $dir $TESTPOOL

--- a/tests/zfs-tests/tests/functional/redundancy/redundancy_draid_damaged2.ksh
+++ b/tests/zfs-tests/tests/functional/redundancy/redundancy_draid_damaged2.ksh
@@ -94,13 +94,13 @@ for nparity in 1 2 3; do
 	# log_must zfs set primarycache=metadata $TESTPOOL
 
 	log_must zfs create $TESTPOOL/fs
-	log_must fill_fs /$TESTPOOL/fs 1 256 10 1024 R
+	log_must fill_fs /$TESTPOOL/fs 1 256 10240 1 R
 
 	log_must zfs create -o compress=on $TESTPOOL/fs2
-	log_must fill_fs /$TESTPOOL/fs2 1 256 10 1024 R
+	log_must fill_fs /$TESTPOOL/fs2 1 256 10240 1 R
 
 	log_must zfs create -o compress=on -o recordsize=8k $TESTPOOL/fs3
-	log_must fill_fs /$TESTPOOL/fs3 1 256 10 1024 R
+	log_must fill_fs /$TESTPOOL/fs3 1 256 10240 1 R
 
 	log_must zpool export $TESTPOOL
 	log_must zpool import -o cachefile=none -d $dir $TESTPOOL

--- a/tests/zfs-tests/tests/functional/redundancy/redundancy_raidz.ksh
+++ b/tests/zfs-tests/tests/functional/redundancy/redundancy_raidz.ksh
@@ -223,13 +223,13 @@ for nparity in 1 2 3; do
 	log_must zfs set primarycache=metadata $TESTPOOL
 
 	log_must zfs create $TESTPOOL/fs
-	log_must fill_fs /$TESTPOOL/fs 1 512 100 1024 R
+	log_must fill_fs /$TESTPOOL/fs 1 512 102400 1 R
 
 	log_must zfs create -o compress=on $TESTPOOL/fs2
-	log_must fill_fs /$TESTPOOL/fs2 1 512 100 1024 R
+	log_must fill_fs /$TESTPOOL/fs2 1 512 102400 1 R
 
 	log_must zfs create -o compress=on -o recordsize=8k $TESTPOOL/fs3
-	log_must fill_fs /$TESTPOOL/fs3 1 512 100 1024 R
+	log_must fill_fs /$TESTPOOL/fs3 1 512 102400 1 R
 
 	typeset pool_size=$(get_pool_prop size $TESTPOOL)
 


### PR DESCRIPTION
Many RAIDZ/dRAID tests filled files doing millions of 100 or even 10 byte writes.  It makes very little sense since we are not micro-benchmarking syscalls or VFS layer here, while before the blocks reach the vdev layer absolute majority of the small writes will be aggregated.  In some cases I see we spend almost as much time creating the test files as actually running the tests.  And sometimes the tests even time out after that.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
