### PR TITLE
set zfs_arc_shrinker_limit to 0 by default

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -867,14 +867,14 @@ where that percent may exceed
 This
 only operates during memory pressure/reclaim.
 .
-.It Sy zfs_arc_shrinker_limit Ns = Ns Sy 10000 Pq int
+.It Sy zfs_arc_shrinker_limit Ns = Ns Sy 0 Pq int
 This is a limit on how many pages the ARC shrinker makes available for
 eviction in response to one page allocation attempt.
 Note that in practice, the kernel's shrinker can ask us to evict
 up to about four times this for one allocation attempt.
 To reduce OOM risk, this limit is applied for kswapd reclaims only.
 .Pp
-The default limit of
+For example a value of
 .Sy 10000 Pq in practice, Em 160 MiB No per allocation attempt with 4 KiB pages
 limits the amount of time spent attempting to reclaim ARC memory to
 less than 100 ms per allocation attempt,

--- a/module/os/linux/zfs/arc_os.c
+++ b/module/os/linux/zfs/arc_os.c
@@ -63,7 +63,7 @@
  * practice, the kernel's shrinker can ask us to evict up to about 4x this
  * for one allocation attempt.
  *
- * The default limit of 10,000 (in practice, 160MB per allocation attempt
+ * For example a value of 10,000 (in practice, 160MB per allocation attempt
  * with 4K pages) limits the amount of time spent attempting to reclaim ARC
  * memory to less than 100ms per allocation attempt, even with a small
  * average compressed block size of ~8KB.
@@ -71,7 +71,7 @@
  * See also the comment in arc_shrinker_count().
  * Set to 0 to disable limit.
  */
-static int zfs_arc_shrinker_limit = 10000;
+static int zfs_arc_shrinker_limit = 0;
 
 /*
  * Relative cost of ARC eviction, AKA number of seeks needed to restore evicted


### PR DESCRIPTION
`zfs_arc_shrinker_limit` was introduced to avoid ARC collapse due to aggressive kernel reclaim. While useful, the current default (10000) is too prone to OOM especially when MGLRU-enabled kernels with default `min_ttl_ms` are used. Even when no OOM happens, it often causes too much swap usage.

This patch sets `zfs_arc_shrinker_limit=0` to not ignore kernel reclaim requests. ARC now plays better with both kernel shrinker and pagecache but, should ARC collapse happen again, MGLRU behavior can be tuned or even disabled.

Anyway, zfs should not cause OOM when ARC can be released.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above.

### Description
<!--- Describe your changes in detail -->
See above.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
