### PR TITLE
ZTS: zfs_mount_all_fail leaves /var/tmp/testrootPIDNUM directory around

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_fail.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_fail.ksh
@@ -16,6 +16,7 @@
 
 #
 # Copyright (c) 2017 by Delphix. All rights reserved.
+# Copyright 2024 MNX Cloud, Inc.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -44,8 +45,9 @@ typeset fscount=10
 function setup_all
 {
 	# Create $fscount filesystems at the top level of $path
-	for ((i=0; i<$fscount; i++)); do
+	for ((i=0; i<fscount; i++)); do
 		setup_filesystem "$DISKS" "$TESTPOOL" $i "$path/$i" ctr
+		filesystems+=($i)
 	done
 
 	zfs list -r $TESTPOOL
@@ -58,6 +60,12 @@ function cleanup_all
 	export __ZFS_POOL_RESTRICT="$TESTPOOL"
 	log_must zfs $unmountall
 	unset __ZFS_POOL_RESTRICT
+	# make sure we leave $TESTPOOL mounted
+	log_must zfs mount $TESTPOOL
+
+	for fs in ${filesystems[@]}; do
+		cleanup_filesystem "$TESTPOOL" "$fs"
+	done
 
 	[[ -d ${TEST_BASE_DIR%%/}/testroot$$ ]] && \
 		rm -rf ${TEST_BASE_DIR%%/}/testroot$$
@@ -76,7 +84,7 @@ log_must zfs $unmountall
 unset __ZFS_POOL_RESTRICT
 
 # All of our filesystems should be unmounted at this point
-for ((i=0; i<$fscount; i++)); do
+for ((i=0; i<fscount; i++)); do
 	log_mustnot mounted "$TESTPOOL/$i"
 done
 
@@ -98,7 +106,7 @@ log_mustnot mounted "$TESTPOOL/0"
 unset __ZFS_POOL_RESTRICT
 
 # All other filesystems should be mounted
-for ((i=1; i<$fscount; i++)); do
+for ((i=1; i<fscount; i++)); do
 	log_must mounted "$TESTPOOL/$i"
 done
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Before we can remove test files, we need to unmount datasets used by test first.

See also: zfs_mount_all_mountpoints.ksh

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Clean up left over files from zfstest.

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

unmount datasets from test then clean up mountpoints.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
