### PR TITLE
include/libzutil.h: fix misuse of strerror_l()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -65,7 +65,7 @@ Michael Gmelin <grembo@FreeBSD.org>
 Olivier Mazouffre <olivier.mazouffre@ims-bordeaux.fr>
 Piotr Kubaj <pkubaj@anongoth.pl>
 Quentin Zdanis <zdanisq@gmail.com>
-Roberto Ricci <ricci@disroot.org>
+Roberto Ricci <io@r-ricci.it> <ricci@disroot.org>
 Rob Norris <robn@despairlabs.com>
 Rob Norris <rob.norris@klarasystems.com>
 Sam Lunt <samuel.j.lunt@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -534,7 +534,7 @@ CONTRIBUTORS:
     rilysh <nightquick@proton.me>
     Robert Evans <evansr@google.com>
     Robert Novak <sailnfool@gmail.com>
-    Roberto Ricci <ricci@disroot.org>
+    Roberto Ricci <io@r-ricci.it>
     Rob Norris <robn@despairlabs.com>
     Rob Wing <rew@FreeBSD.org>
     Rohan Puri <rohan.puri15@gmail.com>

--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -277,7 +277,16 @@ _LIBZUTIL_H void update_vdev_config_dev_sysfs_path(nvlist_t *nv,
  */
 static inline char *zfs_strerror(int errnum) {
 #ifdef HAVE_STRERROR_L
-	return (strerror_l(errnum, uselocale(0)));
+	locale_t l = uselocale(0);
+
+	/*
+	 * the behavior is undefined if the second argument
+	 * to strerror_l() is LC_GLOBAL_LOCALE.
+	 */
+	if (l == LC_GLOBAL_LOCALE)
+		return (strerror(errnum));
+	else
+		return (strerror_l(errnum, l));
 #else
 	return (strerror(errnum));
 #endif


### PR DESCRIPTION
According to the POSIX man pages:

"The behavior is undefined if the locale argument to strerror_l() is the special locale object LC_GLOBAL_LOCALE or is not a valid locale object handle."

Since uselocale() could return LC_GLOBAL_LOCALE, the value must be checked before passing it to strerror_l().

This fixes a segmentation fault on systems with the musl libc.

### How Has This Been Tested?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
