### PR TITLE
vdev_open: clear async remove flag after reopen

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -2041,6 +2041,7 @@ vdev_open(vdev_t *vd)
 	vd->vdev_cant_read = B_FALSE;
 	vd->vdev_cant_write = B_FALSE;
 	vd->vdev_fault_wanted = B_FALSE;
+	vd->vdev_remove_wanted = B_FALSE;
 	vd->vdev_min_asize = vdev_get_min_asize(vd);
 
 	/*


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

It's possible[*] for a vdev to be flagged for async remove after the pool has suspended. If the removed device has been returned when the pool is resumed, the `ASYNC_REMOVE` task will still run at the end of txg, and remove the device from the pool again.

[*] Maybe only theoretical. I think to happen the pool would have to suspend, then a different IO would need to return an error, and the media check fail, flagging the async remove. I haven't triggered it on stock OpenZFS. I can trip it regularly on a (not yet published) branch that chains writes and flush IOs, and so is more likely to have outstanding IO after the pool has suspended.

### Description

To fix, we clear the async remove flag at reopen, just as we did for the async fault flag in 5de3ac223.

### How Has This Been Tested?

ZTS run completed successfully.

I am not really sure how to write a test to prove this (we don't really have the tools), but I think intuitively it makes sense - it matches the existing async fault case.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
