### PR TITLE
Add Makefile dependencies for scripts/zfs-tests.sh -c

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -79,7 +79,7 @@ CLEANFILES += %D%/common.sh
 	-$(AM_V_at)echo "$$SCRIPTS_EXTRA_ENVIRONMENT" >>$@
 
 ALL_LOCAL += scripts-all-local
-scripts-all-local: %D%/common.sh
+scripts-all-local: %D%/common.sh $(PROGRAMS) $(SCRIPTS) $(DATA)
 	-SCRIPT_COMMON=$< $(srcdir)/%D%/zfs-tests.sh -c
 
 CLEAN_LOCAL += scripts-clean-local


### PR DESCRIPTION
This updates the Makefile to be more correct for parallel make.

Adding explicit dependencies forces make to build all outputs before running the script to populate `tests/zfs-tests/bin`. 

Really this target only needs to depend on targets used by `tests/zfs-tests/include/commands.cfg`, but waiting for primary automake targets is easier and more straightforward.

Without this, parallel make might install symlinks before all outputs are built. This is problematic when also doing `sudo make install` afterward as that step repeats this step causing some files to end up owned by root. That ultimately confuses ZTS into adding non-root test users to the root group causing test breakage.

Fixes #16030

### Motivation and Context

Using `make -j32` causes flakiness when also doing `sudo make install` before running ZTS.

See the debugging quest at #16030 for the full story, but also the Makefile should be correct for parallel builds.

### Description

Adds the automake targets `PROGRAMS`, `DATA`, and `SCRIPTS` to `scripts-all-local` to force this step to run after all of the primary targets are built.

### How Has This Been Tested?

Ran `make -j32` after `make distclean` and observed that `scripts/zfs-tests.sh -c` ran after primary targets as expected.

### Types of changes

This is a Makefile-only change.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
