### PR TITLE
fix: make zfs_strerror really thread-safe and portable

### DIFF
--- a/config/user.m4
+++ b/config/user.m4
@@ -33,7 +33,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER], [
 	ZFS_AC_CONFIG_USER_MAKEDEV_IN_MKDEV
 	ZFS_AC_CONFIG_USER_ZFSEXEC
 
-	AC_CHECK_FUNCS([execvpe issetugid mlockall strerror_l strlcat strlcpy gettid])
+	AC_CHECK_FUNCS([execvpe issetugid mlockall strlcat strlcpy gettid])
 
 	AC_SUBST(RM)
 ])

--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -276,15 +276,14 @@ _LIBZUTIL_H void update_vdev_config_dev_sysfs_path(nvlist_t *nv,
  * Thread-safe strerror() for use in ZFS libraries
  */
 static inline char *zfs_strerror(int errnum) {
-	static __thread char errbuf[2048];
-	static __thread pthread_mutex_t zfs_strerror_lock =
-		PTHREAD_MUTEX_INITIALIZER;
+	static __thread char errbuf[512];
+	static pthread_mutex_t zfs_strerror_lock = PTHREAD_MUTEX_INITIALIZER;
 
-	pthread_mutex_lock(&zfs_strerror_lock);
-	strlcpy(errbuf, strerror(errnum), sizeof(errbuf));
-	pthread_mutex_unlock(&zfs_strerror_lock);
+	(void) pthread_mutex_lock(&zfs_strerror_lock);
+	(void) strlcpy(errbuf, strerror(errnum), sizeof (errbuf));
+	(void) pthread_mutex_unlock(&zfs_strerror_lock);
 
-	return errbuf;
+	return (errbuf);
 }
 
 #ifdef	__cplusplus

--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -27,7 +27,7 @@
 #define	_LIBZUTIL_H extern __attribute__((visibility("default")))
 
 #include <string.h>
-#include <locale.h>
+#include <pthread.h>
 #include <sys/nvpair.h>
 #include <sys/fs/zfs.h>
 
@@ -276,11 +276,15 @@ _LIBZUTIL_H void update_vdev_config_dev_sysfs_path(nvlist_t *nv,
  * Thread-safe strerror() for use in ZFS libraries
  */
 static inline char *zfs_strerror(int errnum) {
-#ifdef HAVE_STRERROR_L
-	return (strerror_l(errnum, uselocale(0)));
-#else
-	return (strerror(errnum));
-#endif
+	static __thread char errbuf[2048];
+	static __thread pthread_mutex_t zfs_strerror_lock =
+		PTHREAD_MUTEX_INITIALIZER;
+
+	pthread_mutex_lock(&zfs_strerror_lock);
+	strlcpy(errbuf, strerror(errnum), sizeof(errbuf));
+	pthread_mutex_unlock(&zfs_strerror_lock);
+
+	return errbuf;
 }
 
 #ifdef	__cplusplus


### PR DESCRIPTION
Fixes https://github.com/openzfs/zfs/pull/15793
Fixes https://github.com/openzfs/zfs/pull/16640
Closes https://github.com/openzfs/zfs/pull/16916

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/openzfs/zfs/pull/15793 wanted to make zfs_strerror threadsafe, unfortunately, it turned out that strerror_l() usage was wrong, and also, some libc implementations dont have strerror_l().
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
zfs_strerror() now simply calls original strerror() and copies the result to a thread-local buffer, then returns that.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Code did compile.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
