### PR TITLE
Remove duplicate dedup_legacy_create test in common.run

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -677,8 +677,8 @@ post =
 tags = ['functional', 'deadman']
 
 [tests/functional/dedup]
-tests = ['dedup_legacy_create', 'dedup_fdt_create', 'dedup_fdt_import',
-    'dedup_legacy_create', 'dedup_legacy_import', 'dedup_legacy_fdt_upgrade',
+tests = ['dedup_fdt_create', 'dedup_fdt_import', 'dedup_legacy_create',
+    'dedup_legacy_import', 'dedup_legacy_fdt_upgrade',
     'dedup_legacy_fdt_mixed', 'dedup_quota']
 pre =
 post =


### PR DESCRIPTION
### Motivation and Context

`common.run` lists `tests/functional/dedup/dedup_legacy_create` twice for unknown reasons:

https://github.com/openzfs/zfs/blob/50cbb14641b32215c87825ab158f726541707888/tests/runfiles/common.run#L679-L682

This is detected by my experimental tooling that runs ZTS in parallel distributed to local VMs. It reports a warning if it observes the same test outcome twice. Turns out in this case the test is in the runfile twice.

I'm not 100% sure it should appear only once, but it seems odd that it's there twice. @allanjude is this a typo from c7ada64bb664d5fab73f255099da5e170e7c82e5?

### Description

Remove the duplicate test

### How Has This Been Tested?

Ran the `common.run` suite

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).