### PR TITLE
optimize recv_fix_encryption_hierarchy()

### DIFF
--- a/tests/zfs-tests/tests/functional/rsend/send_encrypted_hierarchy.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_encrypted_hierarchy.ksh
@@ -61,16 +61,17 @@ log_must eval "zfs receive -d -F $POOL2 < $BACKDIR/fs-before-R"
 dstds=$(get_dst_ds $POOL/$FS $POOL2)
 log_must cmp_ds_subs $POOL/$FS $dstds
 
-log_must verify_encryption_root $POOL/$FS $POOL/$FS
-log_must verify_keylocation $POOL/$FS "prompt"
-log_must verify_origin $POOL/$FS "-"
+log_must verify_encryption_root $POOL2/$FS $POOL2/$FS
+log_must verify_keylocation $POOL2/$FS "prompt"
+log_must verify_origin $POOL2/$FS "-"
 
-log_must verify_encryption_root $POOL/clone $POOL/$FS
-log_must verify_keylocation $POOL/clone "none"
-log_must verify_origin $POOL/clone "$POOL/$FS@snap"
+log_must verify_encryption_root $POOL2/clone $POOL2/$FS
+log_must verify_keylocation $POOL2/clone "none"
+log_must verify_origin $POOL2/clone "$POOL2/$FS@snap"
 
 log_must verify_encryption_root $POOL/$FS/child $POOL/$FS
-log_must verify_keylocation $POOL/$FS/child "none"
+log_must verify_encryption_root $POOL2/$FS/child $POOL2/$FS
+log_must verify_keylocation $POOL2/$FS/child "none"
 
 # Alter the hierarchy and re-send
 log_must eval "echo $PASSPHRASE1 | zfs change-key -o keyformat=passphrase" \
@@ -92,5 +93,21 @@ log_must verify_origin $POOL/clone "-"
 
 log_must verify_encryption_root $POOL/$FS/child $POOL/$FS/child
 log_must verify_keylocation $POOL/$FS/child "prompt"
+
+log_must verify_encryption_root $POOL2 "-"
+log_must verify_encryption_root $POOL2/clone $POOL2/clone
+log_must verify_encryption_root $POOL2/$FS $POOL2/clone
+log_must verify_encryption_root $POOL2/$FS/child $POOL2/$FS/child
+
+log_must verify_keylocation $POOL2 "none"
+log_must verify_keylocation $POOL2/clone "prompt"
+log_must verify_keylocation $POOL2/$FS "none"
+log_must verify_keylocation $POOL2/$FS/child "prompt"
+
+log_must verify_origin $POOL2 "-"
+log_must verify_origin $POOL2/clone "-"
+log_must verify_origin $POOL2/$FS "$POOL2/clone@snap"
+log_must verify_origin $POOL2/$FS/child "-"
+log_must zfs list
 
 log_pass "Raw recursive sends preserve filesystem structure."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Motivation: #16317 
Closes: #16317

### Description
<!--- Describe your changes in detail -->
recv_fix_encryption_hierarchy() in its present state goes through all
stream filesystems, and for each one traverses the snapshots in order to
find one that exists locally. This happens by calling guid_to_name() for
each snapshot, which iterates through all children of the filesystem.
This results in CPU utilization of 100% for several minutes (for ~1000
filesystems on a Ryzen 4350G) for 1 thread at the end of a raw receive
(-w, regardless whether encrypted or not, dryrun or not).

Fix this by following a different logic: using the top_fs name, call
gather_nvlist() to gather the nvlists for all local filesystems. For
each one filesystem, go through the snapshots to find the corresponding
stream's filesystem (since we know the snapshots guid and can search
with it in stream_avl for the stream's fs). Then go on to fix the
encryption roots and locations as in its present state.

Avoiding guid_to_name() iteratively makes
recv_fix_encryption_hierarchy() significantly faster (from several
minutes to seconds for ~1000 filesystems on a Ryzen 4350G).

Another problem is the following: in case we have promoted a clone of
the filesystem outside the top filesystem specified in zfs send, zfs
receive does not fail but returns an error:
recv_incremental_replication() fails to find its origin and errors out
with needagain=1. This results in recv_fix_hierarchy() not being called
which may render some children of the top fs not mountable since their
encryption root was not updated. To circumvent this make
recv_incremental_replication() silently ignore this error.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
An existing test was expanded.
Perfomance testing was done locally using the script from #16317 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
