### PR TITLE
FreeBSD: Use ashift in vdev_check_boot_reserve()

### DIFF
--- a/module/os/freebsd/zfs/vdev_label_os.c
+++ b/module/os/freebsd/zfs/vdev_label_os.c
@@ -96,7 +96,7 @@ vdev_check_boot_reserve(spa_t *spa, vdev_t *childvd)
 {
 	ASSERT(childvd->vdev_ops->vdev_op_leaf);
 
-	size_t size = SPA_MINBLOCKSIZE;
+	size_t size = 1ULL << childvd->vdev_top->vdev_ashift;
 	abd_t *abd = abd_alloc_linear(size, B_FALSE);
 
 	zio_t *pio = zio_root(spa, NULL, NULL, 0);


### PR DESCRIPTION
We should not hardcode 512-byte read size when checking for loader in the boot area before RAIDZ expansion.  Disk might be unable to handle that I/O as is, and the code zio_vdev_io_start() handling the padding asserts doing it only for top-level vdev.

### How Has This Been Tested?
Create a raidz pool with ashift > 9, try to expand it and observe the assertion panic.  Apply the patch and see it working.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
