### PR TITLE
zinject: add "probe" device injection type

### DIFF
--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -251,6 +251,7 @@ static const char *const iotypestrtable[ZINJECT_IOTYPES] = {
 	[ZINJECT_IOTYPE_FLUSH]	= "flush",
 	[ZINJECT_IOTYPE_TRIM]	= "trim",
 	[ZINJECT_IOTYPE_ALL]	= "all",
+	[ZINJECT_IOTYPE_PROBE]	= "probe",
 };
 
 static zinject_iotype_t

--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -471,7 +471,8 @@ typedef enum zinject_iotype {
 	ZINJECT_IOTYPE_TRIM	= ZIO_TYPE_TRIM,
 	ZINJECT_IOTYPE_ALL	= ZIO_TYPES,
 	/* Room for future expansion for ZIO_TYPE_* */
-	ZINJECT_IOTYPES		= 16,
+	ZINJECT_IOTYPE_PROBE	= 16,
+	ZINJECT_IOTYPES,
 } zinject_iotype_t;
 
 typedef struct zfs_share {

--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -456,6 +456,24 @@ typedef enum zinject_type {
 	ZINJECT_DELAY_EXPORT,
 } zinject_type_t;
 
+typedef enum zinject_iotype {
+	/*
+	 * Compatibility: zi_iotype used to be set to ZIO_TYPE_, so make sure
+	 * the corresponding ZINJECT_IOTYPE_ matches. Note that existing here
+	 * does not mean that injections are possible for all these types.
+	 */
+	ZINJECT_IOTYPE_NULL	= ZIO_TYPE_NULL,
+	ZINJECT_IOTYPE_READ	= ZIO_TYPE_READ,
+	ZINJECT_IOTYPE_WRITE	= ZIO_TYPE_WRITE,
+	ZINJECT_IOTYPE_FREE	= ZIO_TYPE_FREE,
+	ZINJECT_IOTYPE_CLAIM	= ZIO_TYPE_CLAIM,
+	ZINJECT_IOTYPE_FLUSH	= ZIO_TYPE_FLUSH,
+	ZINJECT_IOTYPE_TRIM	= ZIO_TYPE_TRIM,
+	ZINJECT_IOTYPE_ALL	= ZIO_TYPES,
+	/* Room for future expansion for ZIO_TYPE_* */
+	ZINJECT_IOTYPES		= 16,
+} zinject_iotype_t;
+
 typedef struct zfs_share {
 	uint64_t	z_exportdata;
 	uint64_t	z_sharedata;

--- a/man/man8/zinject.8
+++ b/man/man8/zinject.8
@@ -19,11 +19,11 @@
 .\" CDDL HEADER END
 .\"
 .\" Copyright 2013 Darik Horn <dajhorn@vanadac.com>. All rights reserved.
-.\" Copyright (c) 2024, Klara Inc.
+.\" Copyright (c) 2024, 2025, Klara, Inc.
 .\"
 .\" lint-ok: WARNING: sections out of conventional order: Sh SYNOPSIS
 .\"
-.Dd December 2, 2024
+.Dd January 14, 2025
 .Dt ZINJECT 8
 .Os
 .
@@ -265,15 +265,16 @@ will be translated to the appropriate blkid range according to the
 object's properties.
 .It Fl s Ar seconds
 Run for this many seconds before reporting failure.
-.It Fl T Ar failure
-Set the failure type to one of
-.Sy all ,
-.Sy flush ,
-.Sy claim ,
-.Sy free ,
-.Sy read ,
-or
-.Sy write .
+.It Fl T Ar type
+Inject the error into I/O of this type.
+.Bl -tag -compact -width "read, write, flush, claim, free"
+.It Sy read , Sy write , Sy flush , Sy claim , Sy free
+Fundamental I/O types
+.It Sy all
+All fundamental I/O types
+.It Sy probe
+Device probe I/O
+.El
 .It Fl t Ar mos_type
 Set this to
 .Bl -tag -compact -width "spacemap"

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -159,7 +159,7 @@ tests = ['json_sanity']
 tags = ['functional', 'cli_root', 'json']
 
 [tests/functional/cli_root/zinject]
-tests = ['zinject_args', 'zinject_counts']
+tests = ['zinject_args', 'zinject_counts', 'zinject_probe']
 pre =
 post =
 tags = ['functional', 'cli_root', 'zinject']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -616,6 +616,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/json/json_sanity.ksh \
 	functional/cli_root/zinject/zinject_args.ksh \
 	functional/cli_root/zinject/zinject_counts.ksh \
+	functional/cli_root/zinject/zinject_probe.ksh \
 	functional/cli_root/zdb/zdb_002_pos.ksh \
 	functional/cli_root/zdb/zdb_003_pos.ksh \
 	functional/cli_root/zdb/zdb_004_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zinject/zinject_probe.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zinject/zinject_probe.ksh
@@ -1,0 +1,75 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+log_assert "Check zinject can correctly inject a probe failure."
+
+DISK1=${DISKS%% *}
+
+function cleanup
+{
+	log_pos zinject -c all
+	log_pos zpool clear $TESTPOOL
+	log_pos zpool destroy -f $TESTPOOL
+	log_pos restore_tunable TXG_TIMEOUT
+}
+
+log_onexit cleanup
+
+log_must zpool create $TESTPOOL $DISK1
+
+# set the txg timeout a long way out, to try and avoid the pool syncing
+# between error injection and writing
+save_tunable TXG_TIMEOUT
+log_must set_tunable32 TXG_TIMEOUT 600
+
+# force a sync now
+log_must zpool sync -f
+
+# write stuff. this should go into memory, not written yet
+log_must dd if=/dev/urandom of=/$TESTPOOL/file bs=1M count=1
+
+# inject faults
+log_must zinject -d $DISK1 -e io -T probe $TESTPOOL
+log_must zinject -d $DISK1 -e io -T write $TESTPOOL
+
+# force the sync now. backgrounded, because the pool will suspend and we don't
+# want to block.
+log_pos zpool sync &
+
+log_note "waiting for pool to suspend"
+typeset -i tries=30
+until [[ $(kstat_pool $TESTPOOL state) == "SUSPENDED" ]] ; do
+	if ((tries-- == 0)); then
+		log_fail "pool didn't suspend"
+	fi
+	sleep 1
+done
+
+log_pass "zinject can correctly inject a probe failure."


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

`zinject` can't create the scenario of a drive faulting after a failed write. The write failure can be injected, which triggers a probe, but probe IO always goes to the label regions, which are explicitly excluded from device injections. So the probe succeeds, and the write is retried, triggering another probe, over and over, forever.

This adds a new `probe` pseudo-IO-type for device injection, which allows a probe failure to be simulated.

### Description

First, we extend the device injection type to allow more than just the "fundamental" IO types. `zi_iotype` was always large enough, there just wasn't a way to do more than the regular `ZIO_TYPE_*` values. Now it has its own values, `ZINJECT_IOTYPE_*` for injection IO types. For compatibility, the existing IO types are placed at the start so their numeric values match. `all` still matches all fundamental types, so this change should be UI and ABI-compatible.

Then, we add a new type, `ZINJECT_IOTYPE_PROBE`. This matches any and all ZIOs with the `ZIO_FLAG_PROBE` flag set, regardless of type or location on disk (including in the labels). The normal `_READ` and `_WRITE` injections won't match these, to preserve the existing behaviour.

Taken together, this we can simulate a device fault on write with:

```
$ zinject -d $<devcie> -e io -T write <pool>
$ zinject -d $<device> -e io -T probe <pool>
```

And indeed, this is exactly what the included test does.

### How Has This Been Tested?

New test included.

All `zinject`-using tests have passed with this change in place.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

(Wow! Clean sweep!)