### PR TITLE
zfs-destroy.8: Fix minor formatting typo

### DIFF
--- a/man/man8/zfs-destroy.8
+++ b/man/man8/zfs-destroy.8
@@ -157,6 +157,7 @@ Destroy
 all snapshots with this name in descendent file systems.
 .It Fl v
 Print verbose information about the deleted data.
+.El
 .Pp
 Extreme care should be taken when applying either the
 .Fl r
@@ -164,7 +165,6 @@ or the
 .Fl R
 options, as they can destroy large portions of a pool and cause unexpected
 behavior for mounted file systems in use.
-.El
 .It Xo
 .Nm zfs
 .Cm destroy


### PR DESCRIPTION
I noticed the warning in the second table was listed under the last option instead of the table. Adjust the formatting so it matches the table above to improve readability.

Tested on FreeBSD vt(4) in MANWIDTH 59 and 80, as well as `mandoc -T lint`. Thanks!