### PR TITLE
Fix several typos in the man pages

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -428,7 +428,7 @@ but this may negatively impact pool space efficiency.
 .
 .It Sy zfs_vdev_direct_write_verify Ns = Ns Sy Linux 1 | FreeBSD 0 Pq uint
 If non-zero, then a Direct I/O write's checksum will be verified every
-time the write is issued and before it is commited to the block pointer.
+time the write is issued and before it is committed to the block pointer.
 In the event the checksum is not valid then the I/O operation will return EIO.
 This module parameter can be used to detect if the
 contents of the users buffer have changed in the process of doing a Direct I/O
@@ -438,7 +438,7 @@ writes.
 Each verify error causes a
 .Sy dio_verify_wr
 zevent.
-Direct Write I/O checkum verify errors can be seen with
+Direct Write I/O checksum verify errors can be seen with
 .Nm zpool Cm status Fl d .
 The default value for this is 1 on Linux, but is 0 for
 .Fx
@@ -1612,7 +1612,7 @@ _
 .
 .It Sy zfs_btree_verify_intensity Ns = Ns Sy 0 Pq uint
 Enables btree verification.
-The following settings are culminative:
+The following settings are cumulative:
 .TS
 box;
 lbz r l l .
@@ -2525,7 +2525,7 @@ generate a system-dependent value close to 6 threads per taskq.
 Set value only applies to pools imported/created after that.
 .
 .It Sy zio_taskq_write_tpq Ns = Ns Sy 16 Pq uint
-Determines the minumum number of threads per write issue taskq.
+Determines the minimum number of threads per write issue taskq.
 Higher values improve CPU utilization on high throughput,
 while lower reduce taskq locks contention on high IOPS.
 Set value only applies to pools imported/created after that.

--- a/man/man7/vdevprops.7
+++ b/man/man7/vdevprops.7
@@ -147,7 +147,7 @@ A text comment up to 8192 characters long
 .It Sy bootsize
 The amount of space to reserve for the EFI system partition
 .It Sy failfast
-If this device should propage BIO errors back to ZFS, used to disable
+If this device should propagate BIO errors back to ZFS, used to disable
 failfast.
 .It Sy path
 The path to the device for this vdev

--- a/man/man7/zpool-features.7
+++ b/man/man7/zpool-features.7
@@ -245,11 +245,11 @@ zpool_checkpoint
 .No example# Nm cat Pa /usr/share/zfs/compatibility.d/grub2-2.06
 # Features which are supported by GRUB2 versions prior to v2.12.
 #
-# GRUB is not able to detect ZFS pool if snaphsot of top level boot pool
+# GRUB is not able to detect ZFS pool if snapshot of top level boot pool
 # is created. This issue is observed with GRUB versions before v2.12 if
 # extensible_dataset feature is enabled on ZFS boot pool.
 #
-# This file lists all read-only comaptible features except
+# This file lists all read-only compatible features except
 # extensible_dataset and any other feature that depends on it.
 #
 allocation_classes

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -759,7 +759,7 @@ This option is provided for backwards compatibility with older ZFS versions.
 .It Sy ZFS_SET_PIPE_MAX
 Tells
 .Nm zfs
-to set the maximum pipe size for sends/recieves.
+to set the maximum pipe size for sends/receives.
 Disabled by default on Linux
 due to an unfixed deadlock in Linux's pipe size handling code.
 .

--- a/man/man8/zpool-initialize.8
+++ b/man/man8/zpool-initialize.8
@@ -66,7 +66,7 @@ devices if none are specified.
 If the devices are being actively initialized the command will fail.
 After being cleared
 .Nm zpool Cm initialize
-with no flags can be used to re-initialize all unallocoated regions on
+with no flags can be used to re-initialize all unallocated regions on
 the relevant target devices.
 .It Fl w , -wait
 Wait until the devices have finished initializing before returning.

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -83,7 +83,7 @@ Specify
 to set pool GUID as key for pool objects instead of pool names.
 .It Fl d
 Display the number of Direct I/O read/write checksum verify errors that have
-occured on a top-level VDEV.
+occurred on a top-level VDEV.
 See
 .Sx zfs_vdev_direct_write_verify
 in


### PR DESCRIPTION
### Motivation and Context
Ensure the man page is typo-free.

### Description
Fix the typos

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
