### PR TITLE
Make the vfs.zfs.vdev.raidz_impl sysctl cross-platform

### DIFF
--- a/include/os/freebsd/spl/sys/mod_os.h
+++ b/include/os/freebsd/spl/sys/mod_os.h
@@ -94,6 +94,9 @@
 #define	param_set_max_auto_ashift_args(var) \
     CTLTYPE_UINT, NULL, 0, param_set_max_auto_ashift, "IU"
 
+#define	param_set_raidz_impl_args(var) \
+    CTLTYPE_STRING, NULL, 0, param_set_raidz_impl, "A"
+
 #define	spa_taskq_read_param_set_args(var) \
     CTLTYPE_STRING, NULL, 0, spa_taskq_read_param, "A"
 

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -62,6 +62,7 @@ struct abd;
 extern uint_t zfs_vdev_queue_depth_pct;
 extern uint_t zfs_vdev_def_queue_depth;
 extern uint_t zfs_vdev_async_write_max_active;
+extern const char *zfs_vdev_raidz_impl;
 
 /*
  * Virtual device operations
@@ -645,6 +646,7 @@ extern int vdev_obsolete_counts_are_precise(vdev_t *vd, boolean_t *are_precise);
 int vdev_checkpoint_sm_object(vdev_t *vd, uint64_t *sm_obj);
 void vdev_metaslab_group_create(vdev_t *vd);
 uint64_t vdev_best_ashift(uint64_t logical, uint64_t a, uint64_t b);
+int param_set_raidz_impl(ZFS_MODULE_PARAM_ARGS);
 
 /*
  * Vdev ashift optimization tunables

--- a/include/sys/vdev_raidz.h
+++ b/include/sys/vdev_raidz.h
@@ -73,6 +73,7 @@ int vdev_raidz_math_generate(struct raidz_map *, struct raidz_row *);
 int vdev_raidz_math_reconstruct(struct raidz_map *, struct raidz_row *,
     const int *, const int *, const int);
 int vdev_raidz_impl_set(const char *);
+int vdev_raidz_impl_get(char *buffer, size_t size);
 
 typedef struct vdev_raidz_expand {
 	uint64_t vre_vdev_id;

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -680,6 +680,26 @@ param_set_deadman_failmode(SYSCTL_HANDLER_ARGS)
 }
 
 int
+param_set_raidz_impl(SYSCTL_HANDLER_ARGS)
+{
+	char *buf;
+	int rc;
+
+	buf = malloc(64, M_SOLARIS, M_NOWAIT | M_ZERO);
+	if (req->newptr == NULL)
+		vdev_raidz_impl_get(buf, 64);
+
+	rc = sysctl_handle_string(oidp, buf, 64, req);
+	if (rc || req->newptr == NULL) {
+		free(buf, M_SOLARIS);
+		return (rc);
+	}
+	rc = vdev_raidz_impl_set(buf);
+	free(buf, M_SOLARIS);
+	return (rc);
+}
+
+int
 param_set_slop_shift(SYSCTL_HANDLER_ARGS)
 {
 	int val;

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -1637,6 +1637,18 @@ param_set_max_auto_ashift(const char *buf, zfs_kernel_param_t *kp)
 	return (0);
 }
 
+const char *zfs_vdev_raidz_impl = "TODO";
+
+int
+param_set_raidz_impl(const char *val, zfs_kernel_param_t *kp)
+{
+	int error;
+
+	error = vdev_raidz_impl_set(val);
+
+	return (error);
+}
+
 ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, open_timeout_ms, UINT, ZMOD_RW,
 	"Timeout before determining that a device is missing");
 

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -6580,3 +6580,7 @@ ZFS_MODULE_PARAM_CALL(zfs_vdev, zfs_vdev_, max_auto_ashift,
 	param_set_max_auto_ashift, param_get_uint, ZMOD_RW,
 	"Maximum ashift used when optimizing for logical -> physical sector "
 	"size on new top-level vdevs");
+
+ZFS_MODULE_PARAM_CALL(zfs_vdev, zfs_vdev_, raidz_impl,
+		param_set_raidz_impl, param_get_charp, ZMOD_RW,
+		"RAIDZ implementation");


### PR DESCRIPTION
Signed-off-by:	Alan Somers <asomers@gmail.com>
Sponsored by:	ConnectWise

### Motivation and Context
It creates a `vfs.zfs.vdev.raidz_impl` sysctl on FreeBSD, so the implementation can be queried or changed.

### Description
Replace the Linux-specific `module_param_call` and `MODULE_PARM_DESC` with the portable `ZFS_MODULE_PARAM_CALL`.

### How Has This Been Tested?
Tested on FreeBSD.  Tried creating pools with every available raidz_impl testing.  On Linux, compile-tested only.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly. (the setting was already in the man page)
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
