### PR TITLE
require rollback permission when force receive

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2188,6 +2188,9 @@ If there is an error during healing, the healing receive is not
 terminated instead it moves on to the next record.
 .El
 .
+.It Sy zfs_recv_force_needs_perm Ns = Ns Sy 0 Pq int
+When not zero, force receive (zfs recv -F) requires rollback permission.
+.
 .It Sy zfs_override_estimate_recordsize Ns = Ns Sy 0 Ns | Ns 1 Pq uint
 Setting this variable overrides the default logic for estimating block
 sizes when doing a

--- a/man/man8/zfs-allow.8
+++ b/man/man8/zfs-allow.8
@@ -207,7 +207,7 @@ load-key	subcommand	Allows loading and unloading of encryption key (see \fBzfs l
 change-key	subcommand	Allows changing an encryption key via \fBzfs change-key\fR.
 mount	subcommand	Allows mounting/umounting ZFS datasets
 promote	subcommand	Must also have the \fBmount\fR and \fBpromote\fR ability in the origin file system
-receive	subcommand	Must also have the \fBmount\fR and \fBcreate\fR ability
+receive	subcommand	Must also have the \fBmount\fR and \fBcreate\fR ability; must also have the \fBrollback\fR ability if \fBzfs receive -F\fR (force receive) is used and \fBzfs_recv_force_needs_perm\fR is set to 1.
 release	subcommand	Allows releasing a user hold which might destroy the snapshot
 rename	subcommand	Must also have the \fBmount\fR and \fBcreate\fR ability in the new parent
 rollback	subcommand	Must also have the \fBmount\fR ability


### PR DESCRIPTION
Force receive (zfs receive -F) can rollback or destroy snapshots and file systems that do not exist on the sending side (see zfs-receive man page). This means an user having the receive permission can effectively delete data on receiving side, even if such user does not have explicit rollback or destroy permissions.

This patch add the rollback permission requirement for force receive. To avoid changing current default behavior, a new tunable `zfs_recv_force_needs_perm` is introduced. When set to 0 (default) the new permission check is disabled. When set to 1 rollback permission requirement is enabled.

Fixes https://github.com/openzfs/zfs/issues/16943

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
