### PR TITLE
Fix "make install" with DESTDIR set

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -93,7 +93,7 @@ modules_install-Linux: modules_uninstall-Linux-legacy
 		$(if @KERNEL_ARCH@,ARCH=@KERNEL_ARCH@) \
 		KERNELRELEASE=@LINUX_VERSION@
 	@# Remove extraneous build products when packaging
-	if [ -n "$(DESTDIR)" ]; then \
+	if [ -n "$(DESTDIR)" ] && [ "$(DONT_DELETE_MODULES_FILES)" != "1" ]; then \
 		find $(KMODDIR) -name 'modules.*' -delete; \
 	fi
 	@# Debian ships tiny fake System.map files that are
@@ -106,7 +106,7 @@ modules_install-Linux: modules_uninstall-Linux-legacy
 	{ [ -f "$$sysmap" ] && [ $$(wc -l < "$$sysmap") -ge 100 ]; } || \
 		sysmap=$(INSTALL_MOD_PATH)/usr/lib/debug/boot/System.map-@LINUX_VERSION@; \
 	if [ -f $$sysmap ]; then \
-		depmod -ae -F $$sysmap @LINUX_VERSION@; \
+		depmod -ae -F $$sysmap @LINUX_VERSION@ -b $(INSTALL_MOD_PATH)/; \
 	fi
 
 modules_install-FreeBSD:


### PR DESCRIPTION
"DESTDIR=/path/to/target/root/ make install" may fail when installing to a root that contains an existing lib/modules structure. When run as root we may even affect the wrong kernel (the build system's one, or, if running a different version, some other directory in /lib/modules, but not the desired one installed in DESTDIR).

Add a missing reference to the INSTALL_MOD_PATH root when calling "depmod" during "make install"

Also add a switch "DONT_DELETE_MODULES_FILES=1" that skips the removal of files named "modules.*" prior to running depmod.

Signed-off-by: Christian Kohlschütter <christian@kohlschutter.com>
Closes #16994

### Motivation and Context
Fixes an important build issue when installing to DESTDIR.
see issue https://github.com/openzfs/zfs/issues/16994

### Description
In addition to the details in https://github.com/openzfs/zfs/issues/16994:

I'm sure there's a reason why the current makefile deletes files starting with "modules.*", so I'm only adding a switch that can disable that functionality when not desired.

With this change, I can now install zfs nto my target root as follows:
```
DONT_DELETE_MODULES_FILES=1 DESTDIR=/tmp/kernel-out make install
```

### How Has This Been Tested?
Tested on Alpine Linux 3.21.2 using the following zfs build instructions

```
#KERNEL_DIR=/path/to/kernel/source
#KERNEL_OUT=/path/to/target/root
./configure --prefix=/usr \
			--with-tirpc \
			--sysconfdir=/etc \
			--mandir=/usr/share/man \
			--infodir=/usr/share/info \
			--localstatedir=/var \
			--with-config=kernel \
			--with-linux="$KERNEL_DIR"
make -s -j$(nproc)
DONT_DELETE_MODULES_FILES=1 DESTDIR="$KERNEL_OUT" make install
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied. (NOTE: unrelated since it's an integration issue)
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
