### PR TITLE
Update pin_user_pages() calls for Direct I/O

### DIFF
--- a/config/kernel-vfs-iov_iter.m4
+++ b/config/kernel-vfs-iov_iter.m4
@@ -21,6 +21,20 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_VFS_IOV_ITER], [
 		__attribute__((unused)) enum iter_type i = iov_iter_type(&iter);
 	])
 
+	ZFS_LINUX_TEST_SRC([iov_iter_get_pages2], [
+		#include <linux/uio.h>
+	],[
+		struct iov_iter iter = { 0 };
+		struct page **pages = NULL;
+		size_t maxsize = 4096;
+		unsigned maxpages = 1;
+		size_t start;
+		size_t ret __attribute__ ((unused));
+
+		ret = iov_iter_get_pages2(&iter, pages, maxsize, maxpages,
+		    &start);
+	])
+
 	ZFS_LINUX_TEST_SRC([iter_is_ubuf], [
 		#include <linux/uio.h>
 	],[
@@ -60,6 +74,19 @@ AC_DEFUN([ZFS_AC_KERNEL_VFS_IOV_ITER], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_IOV_ITER_TYPE, 1,
 		    [iov_iter_type() is available])
+	],[
+		AC_MSG_RESULT(no)
+	])
+
+
+	dnl #
+	dnl # Kernel 6.0 changed iov_iter_get_pages() to iov_iter_get_pages2().
+	dnl #
+	AC_MSG_CHECKING([whether iov_iter_get_pages2() is available])
+	ZFS_LINUX_TEST_RESULT([iov_iter_get_pages2], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_IOV_ITER_GET_PAGES2, 1,
+		    [iov_iter_get_pages2() is available])
 	],[
 		AC_MSG_RESULT(no)
 	])

--- a/include/os/linux/spl/sys/uio.h
+++ b/include/os/linux/spl/sys/uio.h
@@ -63,6 +63,7 @@ typedef enum zfs_uio_seg {
 typedef struct {
 	struct page	**pages;	/* Mapped pages */
 	long 		npages;		/* Number of mapped pages */
+	boolean_t	pinned;		/* Whether FOLL_PIN was used */
 } zfs_uio_dio_t;
 
 typedef struct zfs_uio {
@@ -197,6 +198,15 @@ zfs_uio_iov_iter_init(zfs_uio_t *uio, struct iov_iter *iter, offset_t offset,
 #define	zfs_uio_iov_iter_type(iter)	iov_iter_type((iter))
 #else
 #define	zfs_uio_iov_iter_type(iter)	(iter)->type
+#endif
+
+#if defined(HAVE_ITER_IS_UBUF)
+#define	zfs_user_backed_iov_iter(iter)	\
+	(iter_is_ubuf((iter)) || \
+	(zfs_uio_iov_iter_type((iter)) == ITER_IOVEC))
+#else
+#define	zfs_user_backed_iov_iter(iter) \
+	(zfs_uio_iov_iter_type((iter)) == ITER_IOVEC)
 #endif
 
 #endif /* SPL_UIO_H */

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -103,7 +103,7 @@ tests = ['devices_001_pos', 'devices_002_neg', 'devices_003_pos']
 tags = ['functional', 'devices']
 
 [tests/functional/direct:Linux]
-tests = ['dio_write_verify']
+tests = ['dio_loopback_dev', 'dio_write_verify']
 tags = ['functional', 'direct']
 
 [tests/functional/events:Linux]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1476,6 +1476,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/direct/dio_dedup.ksh \
 	functional/direct/dio_encryption.ksh \
 	functional/direct/dio_grow_block.ksh \
+	functional/direct/dio_loopback_dev.ksh \
 	functional/direct/dio_max_recordsize.ksh \
 	functional/direct/dio_mixed.ksh \
 	functional/direct/dio_mmap.ksh \

--- a/tests/zfs-tests/tests/functional/direct/dio_loopback_dev.ksh
+++ b/tests/zfs-tests/tests/functional/direct/dio_loopback_dev.ksh
@@ -1,0 +1,78 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025 by Triad National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/direct/dio.cfg
+. $STF_SUITE/tests/functional/direct/dio.kshlib
+
+#
+# DESCRIPTION:
+# 	Verify Direct I/O reads work with loopback devices using direct=always.
+#
+# STRATEGY:
+#	1. Create raidz zpool.
+#	2. Create dataset with the direct dataset property set to always.
+#	3. Create an empty file in dataset and setup loop device on it.
+#	4. Read from loopback device.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	if [[ -n $lofidev ]]; then
+		losetup -d $lofidev
+	fi
+	dio_cleanup
+}
+
+log_assert "Verify loopback devices with Direct I/O."
+
+if ! is_linux; then
+	log_unsupported "This is just a check for Linux Direct I/O"
+fi
+
+log_onexit cleanup
+
+# Create zpool
+log_must truncate -s $MINVDEVSIZE $DIO_VDEVS
+log_must create_pool $TESTPOOL1 "raidz" $DIO_VDEVS
+
+# Creating dataset with direct=always
+log_must eval "zfs create -o direct=always $TESTPOOL1/$TESTFS1"
+mntpt=$(get_prop mountpoint $TESTPOOL1/$TESTFS1)
+
+# Getting a loopback device
+lofidev=$(losetup -f)
+
+# Create loopback device
+log_must truncate -s 1M "$mntpt/temp_file"
+log_must losetup $lofidev "$mntpt/temp_file"
+
+# Read from looback device to make sure Direct I/O works with loopback device
+log_must dd if=$lofidev of=/dev/null count=1 bs=4k
+
+log_pass "Verified loopback devices for Direct I/O." 


### PR DESCRIPTION
Originally #16856 updated Linux Direct I/O requests to use the new pin_user_pages API. However, it was an oversight that this PR only handled iov_iter's of type ITER_IOVEC and ITER_UBUF. Other iov_iter types may try and use the pin_user_pages API if it is available. This can lead to panics as the iov_iter is not being iterated over correctly in zfs_uio_pin_user_pages().

Unfortunately, generic iov_iter API's that call pin_user_page_fast() are protected as GPL only. Rather than update zfs_uio_pin_user_pages() to account for all iov_iter types, we can simply just call zfs_uio_get_dio_page_iov_iter() if the iov_iter type is not ITER_IOVEC or ITER_UBUF. zfs_uio_get_dio_page_iov_iter() calls the iov_iter_get_pages() calls that can handle any iov_iter type.

In the future it might be worth using the exposed iov_iter iterator functions that are included in the header iov_iter.h since v6.7. These functions allow for any iov_iter type to be iterated over and advanced while applying a step function during iteration. This could possibly be leveraged in zfs_uio_pin_user_pages().

A new ZFS test case was added to test that a ITER_BVEC is handled correctly using this new code path. This test case was provided though issue #16956.

Signed-off-by: Brian Atkinson <batkinson@lanl.gov>
Closes #16956

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Updated when to use `pin_user_pages_unlocked()` based on the `iov_iter` type.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->00
It resolves a kernel panic that can occur in `zfs_uio_pin_user_pages()` when trying to iterate over a `struct iov_iter` t    hat is not a `ITER_IOVEC` or `ITER_UBUF`.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #16956.

### Description
<!--- Describe your changes in detail -->
Updated the check in `zfs_uio_get_dio_pages_alloc()` to only call ` zfs_uio_pin_user_pages()` if the `iov_iter` type is `ITER_IOVEC` or `ITER_UBUF`. These two types are the only `iov_iter` types taken into account for iterating in `zfs_uio_pin_user_pages()`. While we could manually code in other `iov_iter` types to iterate over them, that seems ripe for error in the future if the kernel introduces another `struct iov_iter` type in the future. Added `boolean_t` variable called `pinned` to `zfs_uio_dio_t` to signal whether `pin_user_pages_unlocked()` was used for pages for Direct I/O. 

Due to this update, I did have to add back the check for `iov_iter_get_pages2()` in the config checks. This will still need to used in kernels >= v6.0 if we need to call `zfs_uio_get_dio_pages_iov_iter()`.

A ZTS test case `dio_loopback_dev` was added that uses the test that caused a kernel panic in #16956.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested by running the direct ZTS tests on:

1. 4.18.0-240.15.1.el8_3.x86_64 -> pin_user_pages_unlocked() not available, iter_is_ubuf() not available
2. 4.18.0-553.6.1.el8.x86_64 -> pin_user_pages_unlocked() available, iter_is_ubuf() not available
3. 6.5.12-100.fc37.x86_64 -> pin_user_pages_unlocked() available, iter_is_ubuf() available
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
