### PR TITLE
Linux 6.12 compat: Rename range_tree_* to zfs_range_tree_*

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1646,7 +1646,7 @@ dump_metaslab_stats(metaslab_t *msp)
 	    "segments", zfs_btree_numnodes(t), "maxsize", maxbuf,
 	    "freepct", free_pct);
 	(void) printf("\tIn-memory histogram:\n");
-	dump_histogram(rt->rt_histogram, RANGE_TREE_HISTOGRAM_SIZE, 0);
+	dump_histogram(rt->rt_histogram, ZFS_RANGE_TREE_HISTOGRAM_SIZE, 0);
 }
 
 static void
@@ -1769,7 +1769,8 @@ dump_metaslab_groups(spa_t *spa, boolean_t show_special)
 			(void) printf("%3llu%%\n",
 			    (u_longlong_t)mg->mg_fragmentation);
 		}
-		dump_histogram(mg->mg_histogram, RANGE_TREE_HISTOGRAM_SIZE, 0);
+		dump_histogram(mg->mg_histogram,
+		    ZFS_RANGE_TREE_HISTOGRAM_SIZE, 0);
 	}
 
 	(void) printf("\tpool %s\tfragmentation", spa_name(spa));
@@ -1778,7 +1779,7 @@ dump_metaslab_groups(spa_t *spa, boolean_t show_special)
 		(void) printf("\t%3s\n", "-");
 	else
 		(void) printf("\t%3llu%%\n", (u_longlong_t)fragmentation);
-	dump_histogram(mc->mc_histogram, RANGE_TREE_HISTOGRAM_SIZE, 0);
+	dump_histogram(mc->mc_histogram, ZFS_RANGE_TREE_HISTOGRAM_SIZE, 0);
 }
 
 static void

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -122,7 +122,7 @@ static int flagbits[256];
 
 static uint64_t max_inflight_bytes = 256 * 1024 * 1024; /* 256MB */
 static int leaked_objects = 0;
-static range_tree_t *mos_refd_objs;
+static zfs_range_tree_t *mos_refd_objs;
 static spa_t *spa;
 static objset_t *os;
 static boolean_t kernel_init_done;
@@ -325,7 +325,7 @@ typedef struct metaslab_verify {
 	/*
 	 * What's currently allocated for this metaslab.
 	 */
-	range_tree_t *mv_allocated;
+	zfs_range_tree_t *mv_allocated;
 } metaslab_verify_t;
 
 typedef void ll_iter_t(dsl_deadlist_t *ll, void *arg);
@@ -417,7 +417,7 @@ metaslab_spacemap_validation_cb(space_map_entry_t *sme, void *arg)
 	uint64_t txg = sme->sme_txg;
 
 	if (sme->sme_type == SM_ALLOC) {
-		if (range_tree_contains(mv->mv_allocated,
+		if (zfs_range_tree_contains(mv->mv_allocated,
 		    offset, size)) {
 			(void) printf("ERROR: DOUBLE ALLOC: "
 			    "%llu [%llx:%llx] "
@@ -426,11 +426,11 @@ metaslab_spacemap_validation_cb(space_map_entry_t *sme, void *arg)
 			    (u_longlong_t)size, (u_longlong_t)mv->mv_vdid,
 			    (u_longlong_t)mv->mv_msid);
 		} else {
-			range_tree_add(mv->mv_allocated,
+			zfs_range_tree_add(mv->mv_allocated,
 			    offset, size);
 		}
 	} else {
-		if (!range_tree_contains(mv->mv_allocated,
+		if (!zfs_range_tree_contains(mv->mv_allocated,
 		    offset, size)) {
 			(void) printf("ERROR: DOUBLE FREE: "
 			    "%llu [%llx:%llx] "
@@ -439,7 +439,7 @@ metaslab_spacemap_validation_cb(space_map_entry_t *sme, void *arg)
 			    (u_longlong_t)size, (u_longlong_t)mv->mv_vdid,
 			    (u_longlong_t)mv->mv_msid);
 		} else {
-			range_tree_remove(mv->mv_allocated,
+			zfs_range_tree_remove(mv->mv_allocated,
 			    offset, size);
 		}
 	}
@@ -614,11 +614,11 @@ livelist_metaslab_validate(spa_t *spa)
 			    (longlong_t)vd->vdev_ms_count);
 
 			uint64_t shift, start;
-			range_seg_type_t type =
+			zfs_range_seg_type_t type =
 			    metaslab_calculate_range_tree_type(vd, m,
 			    &start, &shift);
 			metaslab_verify_t mv;
-			mv.mv_allocated = range_tree_create(NULL,
+			mv.mv_allocated = zfs_range_tree_create(NULL,
 			    type, NULL, start, shift);
 			mv.mv_vdid = vd->vdev_id;
 			mv.mv_msid = m->ms_id;
@@ -633,8 +633,8 @@ livelist_metaslab_validate(spa_t *spa)
 			spacemap_check_ms_sm(m->ms_sm, &mv);
 			spacemap_check_sm_log(spa, &mv);
 
-			range_tree_vacate(mv.mv_allocated, NULL, NULL);
-			range_tree_destroy(mv.mv_allocated);
+			zfs_range_tree_vacate(mv.mv_allocated, NULL, NULL);
+			zfs_range_tree_destroy(mv.mv_allocated);
 			zfs_btree_clear(&mv.mv_livelist_allocs);
 			zfs_btree_destroy(&mv.mv_livelist_allocs);
 		}
@@ -1633,9 +1633,9 @@ static void
 dump_metaslab_stats(metaslab_t *msp)
 {
 	char maxbuf[32];
-	range_tree_t *rt = msp->ms_allocatable;
+	zfs_range_tree_t *rt = msp->ms_allocatable;
 	zfs_btree_t *t = &msp->ms_allocatable_by_size;
-	int free_pct = range_tree_space(rt) * 100 / msp->ms_size;
+	int free_pct = zfs_range_tree_space(rt) * 100 / msp->ms_size;
 
 	/* max sure nicenum has enough space */
 	_Static_assert(sizeof (maxbuf) >= NN_NUMBUF_SZ, "maxbuf truncated");
@@ -1668,7 +1668,7 @@ dump_metaslab(metaslab_t *msp)
 	if (dump_opt['m'] > 2 && !dump_opt['L']) {
 		mutex_enter(&msp->ms_lock);
 		VERIFY0(metaslab_load(msp));
-		range_tree_stat_verify(msp->ms_allocatable);
+		zfs_range_tree_stat_verify(msp->ms_allocatable);
 		dump_metaslab_stats(msp);
 		metaslab_unload(msp);
 		mutex_exit(&msp->ms_lock);
@@ -2292,12 +2292,12 @@ dump_dtl(vdev_t *vd, int indent)
 	    required ? "DTL-required" : "DTL-expendable");
 
 	for (int t = 0; t < DTL_TYPES; t++) {
-		range_tree_t *rt = vd->vdev_dtl[t];
-		if (range_tree_space(rt) == 0)
+		zfs_range_tree_t *rt = vd->vdev_dtl[t];
+		if (zfs_range_tree_space(rt) == 0)
 			continue;
 		(void) snprintf(prefix, sizeof (prefix), "\t%*s%s",
 		    indent + 2, "", name[t]);
-		range_tree_walk(rt, dump_dtl_seg, prefix);
+		zfs_range_tree_walk(rt, dump_dtl_seg, prefix);
 		if (dump_opt['d'] > 5 && vd->vdev_children == 0)
 			dump_spacemap(spa->spa_meta_objset,
 			    vd->vdev_dtl_sm);
@@ -6258,9 +6258,9 @@ load_unflushed_svr_segs_cb(spa_t *spa, space_map_entry_t *sme,
 		return (0);
 
 	if (sme->sme_type == SM_ALLOC)
-		range_tree_add(svr->svr_allocd_segs, offset, size);
+		zfs_range_tree_add(svr->svr_allocd_segs, offset, size);
 	else
-		range_tree_remove(svr->svr_allocd_segs, offset, size);
+		zfs_range_tree_remove(svr->svr_allocd_segs, offset, size);
 
 	return (0);
 }
@@ -6314,18 +6314,20 @@ zdb_claim_removing(spa_t *spa, zdb_cb_t *zcb)
 	vdev_t *vd = vdev_lookup_top(spa, svr->svr_vdev_id);
 	vdev_indirect_mapping_t *vim = vd->vdev_indirect_mapping;
 
-	ASSERT0(range_tree_space(svr->svr_allocd_segs));
+	ASSERT0(zfs_range_tree_space(svr->svr_allocd_segs));
 
-	range_tree_t *allocs = range_tree_create(NULL, RANGE_SEG64, NULL, 0, 0);
+	zfs_range_tree_t *allocs = zfs_range_tree_create(NULL, ZFS_RANGE_SEG64,
+	    NULL, 0, 0);
 	for (uint64_t msi = 0; msi < vd->vdev_ms_count; msi++) {
 		metaslab_t *msp = vd->vdev_ms[msi];
 
-		ASSERT0(range_tree_space(allocs));
+		ASSERT0(zfs_range_tree_space(allocs));
 		if (msp->ms_sm != NULL)
 			VERIFY0(space_map_load(msp->ms_sm, allocs, SM_ALLOC));
-		range_tree_vacate(allocs, range_tree_add, svr->svr_allocd_segs);
+		zfs_range_tree_vacate(allocs, zfs_range_tree_add,
+		    svr->svr_allocd_segs);
 	}
-	range_tree_destroy(allocs);
+	zfs_range_tree_destroy(allocs);
 
 	iterate_through_spacemap_logs(spa, load_unflushed_svr_segs_cb, svr);
 
@@ -6334,12 +6336,12 @@ zdb_claim_removing(spa_t *spa, zdb_cb_t *zcb)
 	 * because we have not allocated mappings for
 	 * it yet.
 	 */
-	range_tree_clear(svr->svr_allocd_segs,
+	zfs_range_tree_clear(svr->svr_allocd_segs,
 	    vdev_indirect_mapping_max_offset(vim),
 	    vd->vdev_asize - vdev_indirect_mapping_max_offset(vim));
 
-	zcb->zcb_removing_size += range_tree_space(svr->svr_allocd_segs);
-	range_tree_vacate(svr->svr_allocd_segs, claim_segment_cb, vd);
+	zcb->zcb_removing_size += zfs_range_tree_space(svr->svr_allocd_segs);
+	zfs_range_tree_vacate(svr->svr_allocd_segs, claim_segment_cb, vd);
 
 	spa_config_exit(spa, SCL_CONFIG, FTAG);
 }
@@ -6442,7 +6444,8 @@ checkpoint_sm_exclude_entry_cb(space_map_entry_t *sme, void *arg)
 	 * also verify that the entry is there to begin with.
 	 */
 	mutex_enter(&ms->ms_lock);
-	range_tree_remove(ms->ms_allocatable, sme->sme_offset, sme->sme_run);
+	zfs_range_tree_remove(ms->ms_allocatable, sme->sme_offset,
+	    sme->sme_run);
 	mutex_exit(&ms->ms_lock);
 
 	cseea->cseea_checkpoint_size += sme->sme_run;
@@ -6573,9 +6576,9 @@ load_unflushed_cb(spa_t *spa, space_map_entry_t *sme, uint64_t txg, void *arg)
 		return (0);
 
 	if (*uic_maptype == sme->sme_type)
-		range_tree_add(ms->ms_allocatable, offset, size);
+		zfs_range_tree_add(ms->ms_allocatable, offset, size);
 	else
-		range_tree_remove(ms->ms_allocatable, offset, size);
+		zfs_range_tree_remove(ms->ms_allocatable, offset, size);
 
 	return (0);
 }
@@ -6609,7 +6612,7 @@ load_concrete_ms_allocatable_trees(spa_t *spa, maptype_t maptype)
 			    (longlong_t)vd->vdev_ms_count);
 
 			mutex_enter(&msp->ms_lock);
-			range_tree_vacate(msp->ms_allocatable, NULL, NULL);
+			zfs_range_tree_vacate(msp->ms_allocatable, NULL, NULL);
 
 			/*
 			 * We don't want to spend the CPU manipulating the
@@ -6642,7 +6645,7 @@ load_indirect_ms_allocatable_tree(vdev_t *vd, metaslab_t *msp,
 	vdev_indirect_mapping_t *vim = vd->vdev_indirect_mapping;
 
 	mutex_enter(&msp->ms_lock);
-	range_tree_vacate(msp->ms_allocatable, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_allocatable, NULL, NULL);
 
 	/*
 	 * We don't want to spend the CPU manipulating the
@@ -6666,7 +6669,7 @@ load_indirect_ms_allocatable_tree(vdev_t *vd, metaslab_t *msp,
 		 */
 		ASSERT3U(ent_offset + ent_len, <=,
 		    msp->ms_start + msp->ms_size);
-		range_tree_add(msp->ms_allocatable, ent_offset, ent_len);
+		zfs_range_tree_add(msp->ms_allocatable, ent_offset, ent_len);
 	}
 
 	if (!msp->ms_loaded)
@@ -6812,7 +6815,7 @@ zdb_check_for_obsolete_leaks(vdev_t *vd, zdb_cb_t *zcb)
 		for (uint64_t inner_offset = 0;
 		    inner_offset < DVA_GET_ASIZE(&vimep->vimep_dst);
 		    inner_offset += 1ULL << vd->vdev_ashift) {
-			if (range_tree_contains(msp->ms_allocatable,
+			if (zfs_range_tree_contains(msp->ms_allocatable,
 			    offset + inner_offset, 1ULL << vd->vdev_ashift)) {
 				obsolete_bytes += 1ULL << vd->vdev_ashift;
 			}
@@ -6895,10 +6898,10 @@ zdb_leak_fini(spa_t *spa, zdb_cb_t *zcb)
 			 * not referenced, which is not a bug.
 			 */
 			if (vd->vdev_ops == &vdev_indirect_ops) {
-				range_tree_vacate(msp->ms_allocatable,
+				zfs_range_tree_vacate(msp->ms_allocatable,
 				    NULL, NULL);
 			} else {
-				range_tree_vacate(msp->ms_allocatable,
+				zfs_range_tree_vacate(msp->ms_allocatable,
 				    zdb_leak, vd);
 			}
 			if (msp->ms_loaded) {
@@ -7796,7 +7799,7 @@ verify_checkpoint_sm_entry_cb(space_map_entry_t *sme, void *arg)
 	 * their respective ms_allocateable trees should not contain them.
 	 */
 	mutex_enter(&ms->ms_lock);
-	range_tree_verify_not_present(ms->ms_allocatable,
+	zfs_range_tree_verify_not_present(ms->ms_allocatable,
 	    sme->sme_offset, sme->sme_run);
 	mutex_exit(&ms->ms_lock);
 
@@ -7947,8 +7950,9 @@ verify_checkpoint_ms_spacemaps(spa_t *checkpoint, spa_t *current)
 			 * This way we ensure that none of the blocks that
 			 * are part of the checkpoint were freed by mistake.
 			 */
-			range_tree_walk(ckpoint_msp->ms_allocatable,
-			    (range_tree_func_t *)range_tree_verify_not_present,
+			zfs_range_tree_walk(ckpoint_msp->ms_allocatable,
+			    (zfs_range_tree_func_t *)
+			    zfs_range_tree_verify_not_present,
 			    current_msp->ms_allocatable);
 		}
 	}
@@ -8088,7 +8092,7 @@ static void
 mos_obj_refd(uint64_t obj)
 {
 	if (obj != 0 && mos_refd_objs != NULL)
-		range_tree_add(mos_refd_objs, obj, 1);
+		zfs_range_tree_add(mos_refd_objs, obj, 1);
 }
 
 /*
@@ -8098,8 +8102,8 @@ static void
 mos_obj_refd_multiple(uint64_t obj)
 {
 	if (obj != 0 && mos_refd_objs != NULL &&
-	    !range_tree_contains(mos_refd_objs, obj, 1))
-		range_tree_add(mos_refd_objs, obj, 1);
+	    !zfs_range_tree_contains(mos_refd_objs, obj, 1))
+		zfs_range_tree_add(mos_refd_objs, obj, 1);
 }
 
 static void
@@ -8296,8 +8300,8 @@ dump_mos_leaks(spa_t *spa)
 	 */
 	uint64_t object = 0;
 	while (dmu_object_next(mos, &object, B_FALSE, 0) == 0) {
-		if (range_tree_contains(mos_refd_objs, object, 1)) {
-			range_tree_remove(mos_refd_objs, object, 1);
+		if (zfs_range_tree_contains(mos_refd_objs, object, 1)) {
+			zfs_range_tree_remove(mos_refd_objs, object, 1);
 		} else {
 			dmu_object_info_t doi;
 			const char *name;
@@ -8315,11 +8319,11 @@ dump_mos_leaks(spa_t *spa)
 			rv = 2;
 		}
 	}
-	(void) range_tree_walk(mos_refd_objs, mos_leaks_cb, NULL);
-	if (!range_tree_is_empty(mos_refd_objs))
+	(void) zfs_range_tree_walk(mos_refd_objs, mos_leaks_cb, NULL);
+	if (!zfs_range_tree_is_empty(mos_refd_objs))
 		rv = 2;
-	range_tree_vacate(mos_refd_objs, NULL, NULL);
-	range_tree_destroy(mos_refd_objs);
+	zfs_range_tree_vacate(mos_refd_objs, NULL, NULL);
+	zfs_range_tree_destroy(mos_refd_objs);
 	return (rv);
 }
 
@@ -8441,8 +8445,8 @@ dump_zpool(spa_t *spa)
 
 	if (dump_opt['d'] || dump_opt['i']) {
 		spa_feature_t f;
-		mos_refd_objs = range_tree_create(NULL, RANGE_SEG64, NULL, 0,
-		    0);
+		mos_refd_objs = zfs_range_tree_create(NULL, ZFS_RANGE_SEG64,
+		    NULL, 0, 0);
 		dump_objset(dp->dp_meta_objset);
 
 		if (dump_opt['d'] >= 3) {

--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -335,7 +335,7 @@ struct dnode {
 	/* protected by dn_mtx: */
 	kmutex_t dn_mtx;
 	list_t dn_dirty_records[TXG_SIZE];
-	struct range_tree *dn_free_ranges[TXG_SIZE];
+	struct zfs_range_tree *dn_free_ranges[TXG_SIZE];
 	uint64_t dn_allocated_txg;
 	uint64_t dn_free_txg;
 	uint64_t dn_assigned_txg;

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -139,7 +139,7 @@ void metaslab_set_selected_txg(metaslab_t *, uint64_t);
 
 extern int metaslab_debug_load;
 
-range_seg_type_t metaslab_calculate_range_tree_type(vdev_t *vdev,
+zfs_range_seg_type_t metaslab_calculate_range_tree_type(vdev_t *vdev,
     metaslab_t *msp, uint64_t *start, uint64_t *shift);
 
 #ifdef	__cplusplus

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -398,8 +398,8 @@ struct metaslab {
 	uint64_t	ms_size;
 	uint64_t	ms_fragmentation;
 
-	range_tree_t	*ms_allocating[TXG_SIZE];
-	range_tree_t	*ms_allocatable;
+	zfs_range_tree_t	*ms_allocating[TXG_SIZE];
+	zfs_range_tree_t	*ms_allocatable;
 	uint64_t	ms_allocated_this_txg;
 	uint64_t	ms_allocating_total;
 
@@ -408,10 +408,12 @@ struct metaslab {
 	 * ms_free*tree only have entries while syncing, and are empty
 	 * between syncs.
 	 */
-	range_tree_t	*ms_freeing;	/* to free this syncing txg */
-	range_tree_t	*ms_freed;	/* already freed this syncing txg */
-	range_tree_t	*ms_defer[TXG_DEFER_SIZE];
-	range_tree_t	*ms_checkpointing; /* to add to the checkpoint */
+	zfs_range_tree_t	*ms_freeing;	/* to free this syncing txg */
+	/* already freed this syncing txg */
+	zfs_range_tree_t	*ms_freed;
+	zfs_range_tree_t	*ms_defer[TXG_DEFER_SIZE];
+	/* to add to the checkpoint */
+	zfs_range_tree_t	*ms_checkpointing;
 
 	/*
 	 * The ms_trim tree is the set of allocatable segments which are
@@ -421,7 +423,7 @@ struct metaslab {
 	 * is unloaded.  Its purpose is to aggregate freed ranges to
 	 * facilitate efficient trimming.
 	 */
-	range_tree_t	*ms_trim;
+	zfs_range_tree_t	*ms_trim;
 
 	boolean_t	ms_condensing;	/* condensing? */
 	boolean_t	ms_condense_wanted;
@@ -542,8 +544,8 @@ struct metaslab {
 	 * Allocs and frees that are committed to the vdev log spacemap but
 	 * not yet to this metaslab's spacemap.
 	 */
-	range_tree_t	*ms_unflushed_allocs;
-	range_tree_t	*ms_unflushed_frees;
+	zfs_range_tree_t	*ms_unflushed_allocs;
+	zfs_range_tree_t	*ms_unflushed_frees;
 
 	/*
 	 * We have flushed entries up to but not including this TXG. In

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -200,7 +200,7 @@ struct metaslab_class {
 	uint64_t		mc_deferred;	/* total deferred frees */
 	uint64_t		mc_space;	/* total space (alloc + free) */
 	uint64_t		mc_dspace;	/* total deflated space */
-	uint64_t		mc_histogram[RANGE_TREE_HISTOGRAM_SIZE];
+	uint64_t		mc_histogram[ZFS_RANGE_TREE_HISTOGRAM_SIZE];
 
 	/*
 	 * List of all loaded metaslabs in the class, sorted in order of most
@@ -290,7 +290,7 @@ struct metaslab_group {
 	uint64_t		mg_allocations;
 	uint64_t		mg_failed_allocations;
 	uint64_t		mg_fragmentation;
-	uint64_t		mg_histogram[RANGE_TREE_HISTOGRAM_SIZE];
+	uint64_t		mg_histogram[ZFS_RANGE_TREE_HISTOGRAM_SIZE];
 
 	int			mg_ms_disabled;
 	boolean_t		mg_disabled_updating;

--- a/include/sys/range_tree.h
+++ b/include/sys/range_tree.h
@@ -37,7 +37,7 @@
 extern "C" {
 #endif
 
-#define	RANGE_TREE_HISTOGRAM_SIZE	64
+#define	ZFS_RANGE_TREE_HISTOGRAM_SIZE	64
 
 typedef struct zfs_range_tree_ops zfs_range_tree_ops_t;
 
@@ -72,34 +72,34 @@ typedef struct zfs_range_tree {
 	 * rt_histogram[i], contains the number of ranges whose size is:
 	 * 2^i <= size of range in bytes < 2^(i+1)
 	 */
-	uint64_t	rt_histogram[RANGE_TREE_HISTOGRAM_SIZE];
+	uint64_t	rt_histogram[ZFS_RANGE_TREE_HISTOGRAM_SIZE];
 } zfs_range_tree_t;
 
-typedef struct range_seg32 {
+typedef struct zfs_range_seg32 {
 	uint32_t	rs_start;	/* starting offset of this segment */
 	uint32_t	rs_end;		/* ending offset (non-inclusive) */
-} range_seg32_t;
+} zfs_range_seg32_t;
 
 /*
  * Extremely large metaslabs, vdev-wide trees, and dnode-wide trees may
  * require 64-bit integers for ranges.
  */
-typedef struct range_seg64 {
+typedef struct zfs_range_seg64 {
 	uint64_t	rs_start;	/* starting offset of this segment */
 	uint64_t	rs_end;		/* ending offset (non-inclusive) */
-} range_seg64_t;
+} zfs_range_seg64_t;
 
-typedef struct range_seg_gap {
+typedef struct zfs_range_seg_gap {
 	uint64_t	rs_start;	/* starting offset of this segment */
 	uint64_t	rs_end;		/* ending offset (non-inclusive) */
 	uint64_t	rs_fill;	/* actual fill if gap mode is on */
-} range_seg_gap_t;
+} zfs_range_seg_gap_t;
 
 /*
  * This type needs to be the largest of the range segs, since it will be stack
  * allocated and then cast the actual type to do tree operations.
  */
-typedef range_seg_gap_t range_seg_max_t;
+typedef zfs_range_seg_gap_t zfs_range_seg_max_t;
 
 /*
  * This is just for clarity of code purposes, so we can make it clear that a
@@ -122,11 +122,11 @@ zfs_rs_get_start_raw(const zfs_range_seg_t *rs, const zfs_range_tree_t *rt)
 	ASSERT3U(rt->rt_type, <=, ZFS_RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
 	case ZFS_RANGE_SEG32:
-		return (((const range_seg32_t *)rs)->rs_start);
+		return (((const zfs_range_seg32_t *)rs)->rs_start);
 	case ZFS_RANGE_SEG64:
-		return (((const range_seg64_t *)rs)->rs_start);
+		return (((const zfs_range_seg64_t *)rs)->rs_start);
 	case ZFS_RANGE_SEG_GAP:
-		return (((const range_seg_gap_t *)rs)->rs_start);
+		return (((const zfs_range_seg_gap_t *)rs)->rs_start);
 	default:
 		VERIFY(0);
 		return (0);
@@ -139,11 +139,11 @@ zfs_rs_get_end_raw(const zfs_range_seg_t *rs, const zfs_range_tree_t *rt)
 	ASSERT3U(rt->rt_type, <=, ZFS_RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
 	case ZFS_RANGE_SEG32:
-		return (((const range_seg32_t *)rs)->rs_end);
+		return (((const zfs_range_seg32_t *)rs)->rs_end);
 	case ZFS_RANGE_SEG64:
-		return (((const range_seg64_t *)rs)->rs_end);
+		return (((const zfs_range_seg64_t *)rs)->rs_end);
 	case ZFS_RANGE_SEG_GAP:
-		return (((const range_seg_gap_t *)rs)->rs_end);
+		return (((const zfs_range_seg_gap_t *)rs)->rs_end);
 	default:
 		VERIFY(0);
 		return (0);
@@ -156,15 +156,15 @@ zfs_rs_get_fill_raw(const zfs_range_seg_t *rs, const zfs_range_tree_t *rt)
 	ASSERT3U(rt->rt_type, <=, ZFS_RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
 	case ZFS_RANGE_SEG32: {
-		const range_seg32_t *r32 = (const range_seg32_t *)rs;
+		const zfs_range_seg32_t *r32 = (const zfs_range_seg32_t *)rs;
 		return (r32->rs_end - r32->rs_start);
 	}
 	case ZFS_RANGE_SEG64: {
-		const range_seg64_t *r64 = (const range_seg64_t *)rs;
+		const zfs_range_seg64_t *r64 = (const zfs_range_seg64_t *)rs;
 		return (r64->rs_end - r64->rs_start);
 	}
 	case ZFS_RANGE_SEG_GAP:
-		return (((const range_seg_gap_t *)rs)->rs_fill);
+		return (((const zfs_range_seg_gap_t *)rs)->rs_fill);
 	default:
 		VERIFY(0);
 		return (0);
@@ -197,13 +197,13 @@ zfs_rs_set_start_raw(zfs_range_seg_t *rs, zfs_range_tree_t *rt, uint64_t start)
 	switch (rt->rt_type) {
 	case ZFS_RANGE_SEG32:
 		ASSERT3U(start, <=, UINT32_MAX);
-		((range_seg32_t *)rs)->rs_start = (uint32_t)start;
+		((zfs_range_seg32_t *)rs)->rs_start = (uint32_t)start;
 		break;
 	case ZFS_RANGE_SEG64:
-		((range_seg64_t *)rs)->rs_start = start;
+		((zfs_range_seg64_t *)rs)->rs_start = start;
 		break;
 	case ZFS_RANGE_SEG_GAP:
-		((range_seg_gap_t *)rs)->rs_start = start;
+		((zfs_range_seg_gap_t *)rs)->rs_start = start;
 		break;
 	default:
 		VERIFY(0);
@@ -217,13 +217,13 @@ zfs_rs_set_end_raw(zfs_range_seg_t *rs, zfs_range_tree_t *rt, uint64_t end)
 	switch (rt->rt_type) {
 	case ZFS_RANGE_SEG32:
 		ASSERT3U(end, <=, UINT32_MAX);
-		((range_seg32_t *)rs)->rs_end = (uint32_t)end;
+		((zfs_range_seg32_t *)rs)->rs_end = (uint32_t)end;
 		break;
 	case ZFS_RANGE_SEG64:
-		((range_seg64_t *)rs)->rs_end = end;
+		((zfs_range_seg64_t *)rs)->rs_end = end;
 		break;
 	case ZFS_RANGE_SEG_GAP:
-		((range_seg_gap_t *)rs)->rs_end = end;
+		((zfs_range_seg_gap_t *)rs)->rs_end = end;
 		break;
 	default:
 		VERIFY(0);
@@ -243,7 +243,7 @@ zfs_zfs_rs_set_fill_raw(zfs_range_seg_t *rs, zfs_range_tree_t *rt,
 		    zfs_rs_get_start_raw(rs, rt));
 		break;
 	case ZFS_RANGE_SEG_GAP:
-		((range_seg_gap_t *)rs)->rs_fill = fill;
+		((zfs_range_seg_gap_t *)rs)->rs_fill = fill;
 		break;
 	default:
 		VERIFY(0);

--- a/include/sys/range_tree.h
+++ b/include/sys/range_tree.h
@@ -39,23 +39,23 @@ extern "C" {
 
 #define	RANGE_TREE_HISTOGRAM_SIZE	64
 
-typedef struct range_tree_ops range_tree_ops_t;
+typedef struct zfs_range_tree_ops zfs_range_tree_ops_t;
 
-typedef enum range_seg_type {
-	RANGE_SEG32,
-	RANGE_SEG64,
-	RANGE_SEG_GAP,
-	RANGE_SEG_NUM_TYPES,
-} range_seg_type_t;
+typedef enum zfs_range_seg_type {
+	ZFS_RANGE_SEG32,
+	ZFS_RANGE_SEG64,
+	ZFS_RANGE_SEG_GAP,
+	ZFS_RANGE_SEG_NUM_TYPES,
+} zfs_range_seg_type_t;
 
 /*
  * Note: the range_tree may not be accessed concurrently; consumers
  * must provide external locking if required.
  */
-typedef struct range_tree {
+typedef struct zfs_range_tree {
 	zfs_btree_t	rt_root;	/* offset-ordered segment b-tree */
 	uint64_t	rt_space;	/* sum of all segments in the map */
-	range_seg_type_t rt_type;	/* type of range_seg_t in use */
+	zfs_range_seg_type_t rt_type;	/* type of zfs_range_seg_t in use */
 	/*
 	 * All data that is stored in the range tree must have a start higher
 	 * than or equal to rt_start, and all sizes and offsets must be
@@ -63,7 +63,7 @@ typedef struct range_tree {
 	 */
 	uint8_t		rt_shift;
 	uint64_t	rt_start;
-	const range_tree_ops_t *rt_ops;
+	const zfs_range_tree_ops_t *rt_ops;
 	void		*rt_arg;
 	uint64_t	rt_gap;		/* allowable inter-segment gap */
 
@@ -73,7 +73,7 @@ typedef struct range_tree {
 	 * 2^i <= size of range in bytes < 2^(i+1)
 	 */
 	uint64_t	rt_histogram[RANGE_TREE_HISTOGRAM_SIZE];
-} range_tree_t;
+} zfs_range_tree_t;
 
 typedef struct range_seg32 {
 	uint32_t	rs_start;	/* starting offset of this segment */
@@ -106,26 +106,26 @@ typedef range_seg_gap_t range_seg_max_t;
  * pointer is to a range seg of some type; when we need to do the actual math,
  * we'll figure out the real type.
  */
-typedef void range_seg_t;
+typedef void zfs_range_seg_t;
 
-struct range_tree_ops {
-	void    (*rtop_create)(range_tree_t *rt, void *arg);
-	void    (*rtop_destroy)(range_tree_t *rt, void *arg);
-	void	(*rtop_add)(range_tree_t *rt, void *rs, void *arg);
-	void    (*rtop_remove)(range_tree_t *rt, void *rs, void *arg);
-	void	(*rtop_vacate)(range_tree_t *rt, void *arg);
+struct zfs_range_tree_ops {
+	void    (*rtop_create)(zfs_range_tree_t *rt, void *arg);
+	void    (*rtop_destroy)(zfs_range_tree_t *rt, void *arg);
+	void	(*rtop_add)(zfs_range_tree_t *rt, void *rs, void *arg);
+	void    (*rtop_remove)(zfs_range_tree_t *rt, void *rs, void *arg);
+	void	(*rtop_vacate)(zfs_range_tree_t *rt, void *arg);
 };
 
 static inline uint64_t
-rs_get_start_raw(const range_seg_t *rs, const range_tree_t *rt)
+zfs_rs_get_start_raw(const zfs_range_seg_t *rs, const zfs_range_tree_t *rt)
 {
-	ASSERT3U(rt->rt_type, <=, RANGE_SEG_NUM_TYPES);
+	ASSERT3U(rt->rt_type, <=, ZFS_RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
-	case RANGE_SEG32:
+	case ZFS_RANGE_SEG32:
 		return (((const range_seg32_t *)rs)->rs_start);
-	case RANGE_SEG64:
+	case ZFS_RANGE_SEG64:
 		return (((const range_seg64_t *)rs)->rs_start);
-	case RANGE_SEG_GAP:
+	case ZFS_RANGE_SEG_GAP:
 		return (((const range_seg_gap_t *)rs)->rs_start);
 	default:
 		VERIFY(0);
@@ -134,15 +134,15 @@ rs_get_start_raw(const range_seg_t *rs, const range_tree_t *rt)
 }
 
 static inline uint64_t
-rs_get_end_raw(const range_seg_t *rs, const range_tree_t *rt)
+zfs_rs_get_end_raw(const zfs_range_seg_t *rs, const zfs_range_tree_t *rt)
 {
-	ASSERT3U(rt->rt_type, <=, RANGE_SEG_NUM_TYPES);
+	ASSERT3U(rt->rt_type, <=, ZFS_RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
-	case RANGE_SEG32:
+	case ZFS_RANGE_SEG32:
 		return (((const range_seg32_t *)rs)->rs_end);
-	case RANGE_SEG64:
+	case ZFS_RANGE_SEG64:
 		return (((const range_seg64_t *)rs)->rs_end);
-	case RANGE_SEG_GAP:
+	case ZFS_RANGE_SEG_GAP:
 		return (((const range_seg_gap_t *)rs)->rs_end);
 	default:
 		VERIFY(0);
@@ -151,19 +151,19 @@ rs_get_end_raw(const range_seg_t *rs, const range_tree_t *rt)
 }
 
 static inline uint64_t
-rs_get_fill_raw(const range_seg_t *rs, const range_tree_t *rt)
+zfs_rs_get_fill_raw(const zfs_range_seg_t *rs, const zfs_range_tree_t *rt)
 {
-	ASSERT3U(rt->rt_type, <=, RANGE_SEG_NUM_TYPES);
+	ASSERT3U(rt->rt_type, <=, ZFS_RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
-	case RANGE_SEG32: {
+	case ZFS_RANGE_SEG32: {
 		const range_seg32_t *r32 = (const range_seg32_t *)rs;
 		return (r32->rs_end - r32->rs_start);
 	}
-	case RANGE_SEG64: {
+	case ZFS_RANGE_SEG64: {
 		const range_seg64_t *r64 = (const range_seg64_t *)rs;
 		return (r64->rs_end - r64->rs_start);
 	}
-	case RANGE_SEG_GAP:
+	case ZFS_RANGE_SEG_GAP:
 		return (((const range_seg_gap_t *)rs)->rs_fill);
 	default:
 		VERIFY(0);
@@ -173,36 +173,36 @@ rs_get_fill_raw(const range_seg_t *rs, const range_tree_t *rt)
 }
 
 static inline uint64_t
-rs_get_start(const range_seg_t *rs, const range_tree_t *rt)
+zfs_rs_get_start(const zfs_range_seg_t *rs, const zfs_range_tree_t *rt)
 {
-	return ((rs_get_start_raw(rs, rt) << rt->rt_shift) + rt->rt_start);
+	return ((zfs_rs_get_start_raw(rs, rt) << rt->rt_shift) + rt->rt_start);
 }
 
 static inline uint64_t
-rs_get_end(const range_seg_t *rs, const range_tree_t *rt)
+zfs_rs_get_end(const zfs_range_seg_t *rs, const zfs_range_tree_t *rt)
 {
-	return ((rs_get_end_raw(rs, rt) << rt->rt_shift) + rt->rt_start);
+	return ((zfs_rs_get_end_raw(rs, rt) << rt->rt_shift) + rt->rt_start);
 }
 
 static inline uint64_t
-rs_get_fill(const range_seg_t *rs, const range_tree_t *rt)
+zfs_rs_get_fill(const zfs_range_seg_t *rs, const zfs_range_tree_t *rt)
 {
-	return (rs_get_fill_raw(rs, rt) << rt->rt_shift);
+	return (zfs_rs_get_fill_raw(rs, rt) << rt->rt_shift);
 }
 
 static inline void
-rs_set_start_raw(range_seg_t *rs, range_tree_t *rt, uint64_t start)
+zfs_rs_set_start_raw(zfs_range_seg_t *rs, zfs_range_tree_t *rt, uint64_t start)
 {
-	ASSERT3U(rt->rt_type, <=, RANGE_SEG_NUM_TYPES);
+	ASSERT3U(rt->rt_type, <=, ZFS_RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
-	case RANGE_SEG32:
+	case ZFS_RANGE_SEG32:
 		ASSERT3U(start, <=, UINT32_MAX);
 		((range_seg32_t *)rs)->rs_start = (uint32_t)start;
 		break;
-	case RANGE_SEG64:
+	case ZFS_RANGE_SEG64:
 		((range_seg64_t *)rs)->rs_start = start;
 		break;
-	case RANGE_SEG_GAP:
+	case ZFS_RANGE_SEG_GAP:
 		((range_seg_gap_t *)rs)->rs_start = start;
 		break;
 	default:
@@ -211,18 +211,18 @@ rs_set_start_raw(range_seg_t *rs, range_tree_t *rt, uint64_t start)
 }
 
 static inline void
-rs_set_end_raw(range_seg_t *rs, range_tree_t *rt, uint64_t end)
+zfs_rs_set_end_raw(zfs_range_seg_t *rs, zfs_range_tree_t *rt, uint64_t end)
 {
-	ASSERT3U(rt->rt_type, <=, RANGE_SEG_NUM_TYPES);
+	ASSERT3U(rt->rt_type, <=, ZFS_RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
-	case RANGE_SEG32:
+	case ZFS_RANGE_SEG32:
 		ASSERT3U(end, <=, UINT32_MAX);
 		((range_seg32_t *)rs)->rs_end = (uint32_t)end;
 		break;
-	case RANGE_SEG64:
+	case ZFS_RANGE_SEG64:
 		((range_seg64_t *)rs)->rs_end = end;
 		break;
-	case RANGE_SEG_GAP:
+	case ZFS_RANGE_SEG_GAP:
 		((range_seg_gap_t *)rs)->rs_end = end;
 		break;
 	default:
@@ -231,17 +231,18 @@ rs_set_end_raw(range_seg_t *rs, range_tree_t *rt, uint64_t end)
 }
 
 static inline void
-rs_set_fill_raw(range_seg_t *rs, range_tree_t *rt, uint64_t fill)
+zfs_zfs_rs_set_fill_raw(zfs_range_seg_t *rs, zfs_range_tree_t *rt,
+    uint64_t fill)
 {
-	ASSERT3U(rt->rt_type, <=, RANGE_SEG_NUM_TYPES);
+	ASSERT3U(rt->rt_type, <=, ZFS_RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
-	case RANGE_SEG32:
+	case ZFS_RANGE_SEG32:
 		/* fall through */
-	case RANGE_SEG64:
-		ASSERT3U(fill, ==, rs_get_end_raw(rs, rt) - rs_get_start_raw(rs,
-		    rt));
+	case ZFS_RANGE_SEG64:
+		ASSERT3U(fill, ==, zfs_rs_get_end_raw(rs, rt) -
+		    zfs_rs_get_start_raw(rs, rt));
 		break;
-	case RANGE_SEG_GAP:
+	case ZFS_RANGE_SEG_GAP:
 		((range_seg_gap_t *)rs)->rs_fill = fill;
 		break;
 	default:
@@ -250,67 +251,73 @@ rs_set_fill_raw(range_seg_t *rs, range_tree_t *rt, uint64_t fill)
 }
 
 static inline void
-rs_set_start(range_seg_t *rs, range_tree_t *rt, uint64_t start)
+zfs_rs_set_start(zfs_range_seg_t *rs, zfs_range_tree_t *rt, uint64_t start)
 {
 	ASSERT3U(start, >=, rt->rt_start);
 	ASSERT(IS_P2ALIGNED(start, 1ULL << rt->rt_shift));
-	rs_set_start_raw(rs, rt, (start - rt->rt_start) >> rt->rt_shift);
+	zfs_rs_set_start_raw(rs, rt, (start - rt->rt_start) >> rt->rt_shift);
 }
 
 static inline void
-rs_set_end(range_seg_t *rs, range_tree_t *rt, uint64_t end)
+zfs_rs_set_end(zfs_range_seg_t *rs, zfs_range_tree_t *rt, uint64_t end)
 {
 	ASSERT3U(end, >=, rt->rt_start);
 	ASSERT(IS_P2ALIGNED(end, 1ULL << rt->rt_shift));
-	rs_set_end_raw(rs, rt, (end - rt->rt_start) >> rt->rt_shift);
+	zfs_rs_set_end_raw(rs, rt, (end - rt->rt_start) >> rt->rt_shift);
 }
 
 static inline void
-rs_set_fill(range_seg_t *rs, range_tree_t *rt, uint64_t fill)
+zfs_rs_set_fill(zfs_range_seg_t *rs, zfs_range_tree_t *rt, uint64_t fill)
 {
 	ASSERT(IS_P2ALIGNED(fill, 1ULL << rt->rt_shift));
-	rs_set_fill_raw(rs, rt, fill >> rt->rt_shift);
+	zfs_zfs_rs_set_fill_raw(rs, rt, fill >> rt->rt_shift);
 }
 
-typedef void range_tree_func_t(void *arg, uint64_t start, uint64_t size);
+typedef void zfs_range_tree_func_t(void *arg, uint64_t start, uint64_t size);
 
-range_tree_t *range_tree_create_gap(const range_tree_ops_t *ops,
-    range_seg_type_t type, void *arg, uint64_t start, uint64_t shift,
+zfs_range_tree_t *zfs_range_tree_create_gap(const zfs_range_tree_ops_t *ops,
+    zfs_range_seg_type_t type, void *arg, uint64_t start, uint64_t shift,
     uint64_t gap);
-range_tree_t *range_tree_create(const range_tree_ops_t *ops,
-    range_seg_type_t type, void *arg, uint64_t start, uint64_t shift);
-void range_tree_destroy(range_tree_t *rt);
-boolean_t range_tree_contains(range_tree_t *rt, uint64_t start, uint64_t size);
-range_seg_t *range_tree_find(range_tree_t *rt, uint64_t start, uint64_t size);
-boolean_t range_tree_find_in(range_tree_t *rt, uint64_t start, uint64_t size,
-    uint64_t *ostart, uint64_t *osize);
-void range_tree_verify_not_present(range_tree_t *rt,
+zfs_range_tree_t *zfs_range_tree_create(const zfs_range_tree_ops_t *ops,
+    zfs_range_seg_type_t type, void *arg, uint64_t start, uint64_t shift);
+void zfs_range_tree_destroy(zfs_range_tree_t *rt);
+boolean_t zfs_range_tree_contains(zfs_range_tree_t *rt, uint64_t start,
+    uint64_t size);
+zfs_range_seg_t *zfs_range_tree_find(zfs_range_tree_t *rt, uint64_t start,
+    uint64_t size);
+boolean_t zfs_range_tree_find_in(zfs_range_tree_t *rt, uint64_t start,
+    uint64_t size, uint64_t *ostart, uint64_t *osize);
+void zfs_range_tree_verify_not_present(zfs_range_tree_t *rt,
     uint64_t start, uint64_t size);
-void range_tree_resize_segment(range_tree_t *rt, range_seg_t *rs,
+void zfs_range_tree_resize_segment(zfs_range_tree_t *rt, zfs_range_seg_t *rs,
     uint64_t newstart, uint64_t newsize);
-uint64_t range_tree_space(range_tree_t *rt);
-uint64_t range_tree_numsegs(range_tree_t *rt);
-boolean_t range_tree_is_empty(range_tree_t *rt);
-void range_tree_swap(range_tree_t **rtsrc, range_tree_t **rtdst);
-void range_tree_stat_verify(range_tree_t *rt);
-uint64_t range_tree_min(range_tree_t *rt);
-uint64_t range_tree_max(range_tree_t *rt);
-uint64_t range_tree_span(range_tree_t *rt);
+uint64_t zfs_range_tree_space(zfs_range_tree_t *rt);
+uint64_t zfs_range_tree_numsegs(zfs_range_tree_t *rt);
+boolean_t zfs_range_tree_is_empty(zfs_range_tree_t *rt);
+void zfs_range_tree_swap(zfs_range_tree_t **rtsrc, zfs_range_tree_t **rtdst);
+void zfs_range_tree_stat_verify(zfs_range_tree_t *rt);
+uint64_t zfs_range_tree_min(zfs_range_tree_t *rt);
+uint64_t zfs_range_tree_max(zfs_range_tree_t *rt);
+uint64_t zfs_range_tree_span(zfs_range_tree_t *rt);
 
-void range_tree_add(void *arg, uint64_t start, uint64_t size);
-void range_tree_remove(void *arg, uint64_t start, uint64_t size);
-void range_tree_remove_fill(range_tree_t *rt, uint64_t start, uint64_t size);
-void range_tree_adjust_fill(range_tree_t *rt, range_seg_t *rs, int64_t delta);
-void range_tree_clear(range_tree_t *rt, uint64_t start, uint64_t size);
+void zfs_range_tree_add(void *arg, uint64_t start, uint64_t size);
+void zfs_range_tree_remove(void *arg, uint64_t start, uint64_t size);
+void zfs_range_tree_remove_fill(zfs_range_tree_t *rt, uint64_t start,
+    uint64_t size);
+void zfs_range_tree_adjust_fill(zfs_range_tree_t *rt, zfs_range_seg_t *rs,
+    int64_t delta);
+void zfs_range_tree_clear(zfs_range_tree_t *rt, uint64_t start, uint64_t size);
 
-void range_tree_vacate(range_tree_t *rt, range_tree_func_t *func, void *arg);
-void range_tree_walk(range_tree_t *rt, range_tree_func_t *func, void *arg);
-range_seg_t *range_tree_first(range_tree_t *rt);
+void zfs_range_tree_vacate(zfs_range_tree_t *rt, zfs_range_tree_func_t *func,
+    void *arg);
+void zfs_range_tree_walk(zfs_range_tree_t *rt, zfs_range_tree_func_t *func,
+    void *arg);
+zfs_range_seg_t *zfs_range_tree_first(zfs_range_tree_t *rt);
 
-void range_tree_remove_xor_add_segment(uint64_t start, uint64_t end,
-    range_tree_t *removefrom, range_tree_t *addto);
-void range_tree_remove_xor_add(range_tree_t *rt, range_tree_t *removefrom,
-    range_tree_t *addto);
+void zfs_range_tree_remove_xor_add_segment(uint64_t start, uint64_t end,
+    zfs_range_tree_t *removefrom, zfs_range_tree_t *addto);
+void zfs_range_tree_remove_xor_add(zfs_range_tree_t *rt,
+    zfs_range_tree_t *removefrom, zfs_range_tree_t *addto);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/space_map.h
+++ b/include/sys/space_map.h
@@ -207,28 +207,28 @@ boolean_t sm_entry_is_double_word(uint64_t e);
 
 typedef int (*sm_cb_t)(space_map_entry_t *sme, void *arg);
 
-int space_map_load(space_map_t *sm, range_tree_t *rt, maptype_t maptype);
-int space_map_load_length(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
-    uint64_t length);
+int space_map_load(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype);
+int space_map_load_length(space_map_t *sm, zfs_range_tree_t *rt,
+    maptype_t maptype, uint64_t length);
 int space_map_iterate(space_map_t *sm, uint64_t length,
     sm_cb_t callback, void *arg);
 int space_map_incremental_destroy(space_map_t *sm, sm_cb_t callback, void *arg,
     dmu_tx_t *tx);
 
-boolean_t space_map_histogram_verify(space_map_t *sm, range_tree_t *rt);
+boolean_t space_map_histogram_verify(space_map_t *sm, zfs_range_tree_t *rt);
 void space_map_histogram_clear(space_map_t *sm);
-void space_map_histogram_add(space_map_t *sm, range_tree_t *rt,
+void space_map_histogram_add(space_map_t *sm, zfs_range_tree_t *rt,
     dmu_tx_t *tx);
 
 uint64_t space_map_object(space_map_t *sm);
 int64_t space_map_allocated(space_map_t *sm);
 uint64_t space_map_length(space_map_t *sm);
-uint64_t space_map_entries(space_map_t *sm, range_tree_t *rt);
+uint64_t space_map_entries(space_map_t *sm, zfs_range_tree_t *rt);
 uint64_t space_map_nblocks(space_map_t *sm);
 
-void space_map_write(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
+void space_map_write(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
     uint64_t vdev_id, dmu_tx_t *tx);
-uint64_t space_map_estimate_optimal_size(space_map_t *sm, range_tree_t *rt,
+uint64_t space_map_estimate_optimal_size(space_map_t *sm, zfs_range_tree_t *rt,
     uint64_t vdev_id);
 void space_map_truncate(space_map_t *sm, int blocksize, dmu_tx_t *tx);
 uint64_t space_map_alloc(objset_t *os, int blocksize, dmu_tx_t *tx);

--- a/include/sys/space_reftree.h
+++ b/include/sys/space_reftree.h
@@ -46,8 +46,8 @@ void space_reftree_create(avl_tree_t *t);
 void space_reftree_destroy(avl_tree_t *t);
 void space_reftree_add_seg(avl_tree_t *t, uint64_t start, uint64_t end,
     int64_t refcnt);
-void space_reftree_add_map(avl_tree_t *t, range_tree_t *rt, int64_t refcnt);
-void space_reftree_generate_map(avl_tree_t *t, range_tree_t *rt,
+void space_reftree_add_map(avl_tree_t *t, zfs_range_tree_t *rt, int64_t refcnt);
+void space_reftree_generate_map(avl_tree_t *t, zfs_range_tree_t *rt,
     int64_t minref);
 
 #ifdef	__cplusplus

--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -106,12 +106,12 @@ extern void vdev_expand(vdev_t *vd, uint64_t txg);
 extern void vdev_split(vdev_t *vd);
 extern void vdev_deadman(vdev_t *vd, const char *tag);
 
-typedef void vdev_xlate_func_t(void *arg, range_seg64_t *physical_rs);
+typedef void vdev_xlate_func_t(void *arg, zfs_range_seg64_t *physical_rs);
 
-extern boolean_t vdev_xlate_is_empty(range_seg64_t *rs);
-extern void vdev_xlate(vdev_t *vd, const range_seg64_t *logical_rs,
-    range_seg64_t *physical_rs, range_seg64_t *remain_rs);
-extern void vdev_xlate_walk(vdev_t *vd, const range_seg64_t *logical_rs,
+extern boolean_t vdev_xlate_is_empty(zfs_range_seg64_t *rs);
+extern void vdev_xlate(vdev_t *vd, const zfs_range_seg64_t *logical_rs,
+    zfs_range_seg64_t *physical_rs, zfs_range_seg64_t *remain_rs);
+extern void vdev_xlate_walk(vdev_t *vd, const zfs_range_seg64_t *logical_rs,
     vdev_xlate_func_t *func, void *arg);
 
 extern void vdev_get_stats_ex(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx);

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -299,7 +299,8 @@ struct vdev {
 	kcondvar_t	vdev_initialize_cv;
 	uint64_t	vdev_initialize_offset[TXG_SIZE];
 	uint64_t	vdev_initialize_last_offset;
-	range_tree_t	*vdev_initialize_tree;	/* valid while initializing */
+	/* valid while initializing */
+	zfs_range_tree_t	*vdev_initialize_tree;
 	uint64_t	vdev_initialize_bytes_est;
 	uint64_t	vdev_initialize_bytes_done;
 	uint64_t	vdev_initialize_action_time;	/* start and end time */
@@ -375,7 +376,7 @@ struct vdev {
 	 * from multiple zio threads.
 	 */
 	kmutex_t	vdev_obsolete_lock;
-	range_tree_t	*vdev_obsolete_segments;
+	zfs_range_tree_t	*vdev_obsolete_segments;
 	space_map_t	*vdev_obsolete_sm;
 
 	/*
@@ -388,7 +389,7 @@ struct vdev {
 	/*
 	 * Leaf vdev state.
 	 */
-	range_tree_t	*vdev_dtl[DTL_TYPES]; /* dirty time logs	*/
+	zfs_range_tree_t	*vdev_dtl[DTL_TYPES]; /* dirty time logs */
 	space_map_t	*vdev_dtl_sm;	/* dirty time log space map	*/
 	txg_node_t	vdev_dtl_node;	/* per-txg dirty DTL linkage	*/
 	uint64_t	vdev_dtl_object; /* DTL object			*/

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -91,8 +91,8 @@ typedef void	vdev_remap_func_t(vdev_t *vd, uint64_t offset, uint64_t size,
  * Given a target vdev, translates the logical range "in" to the physical
  * range "res"
  */
-typedef void vdev_xlation_func_t(vdev_t *cvd, const range_seg64_t *logical,
-    range_seg64_t *physical, range_seg64_t *remain);
+typedef void vdev_xlation_func_t(vdev_t *cvd, const zfs_range_seg64_t *logical,
+    zfs_range_seg64_t *physical, zfs_range_seg64_t *remain);
 typedef uint64_t vdev_rebuild_asize_func_t(vdev_t *vd, uint64_t start,
     uint64_t size, uint64_t max_segment);
 typedef void vdev_metaslab_init_func_t(vdev_t *vd, uint64_t *startp,
@@ -616,8 +616,8 @@ extern vdev_ops_t vdev_indirect_ops;
 /*
  * Common size functions
  */
-extern void vdev_default_xlate(vdev_t *vd, const range_seg64_t *logical_rs,
-    range_seg64_t *physical_rs, range_seg64_t *remain_rs);
+extern void vdev_default_xlate(vdev_t *vd, const zfs_range_seg64_t *logical_rs,
+    zfs_range_seg64_t *physical_rs, zfs_range_seg64_t *remain_rs);
 extern uint64_t vdev_default_asize(vdev_t *vd, uint64_t psize, uint64_t txg);
 extern uint64_t vdev_default_min_asize(vdev_t *vd);
 extern uint64_t vdev_get_min_asize(vdev_t *vd);

--- a/include/sys/vdev_rebuild.h
+++ b/include/sys/vdev_rebuild.h
@@ -65,7 +65,8 @@ typedef struct vdev_rebuild_phys {
 typedef struct vdev_rebuild {
 	vdev_t		*vr_top_vdev;		/* top-level vdev to rebuild */
 	metaslab_t	*vr_scan_msp;		/* scanning disabled metaslab */
-	range_tree_t	*vr_scan_tree;		/* scan ranges (in metaslab) */
+	/* scan ranges (in metaslab) */
+	zfs_range_tree_t	*vr_scan_tree;
 	kmutex_t	vr_io_lock;		/* inflight IO lock */
 	kcondvar_t	vr_io_cv;		/* inflight IO cv */
 

--- a/include/sys/vdev_removal.h
+++ b/include/sys/vdev_removal.h
@@ -35,7 +35,7 @@ typedef struct spa_vdev_removal {
 	/* Thread performing a vdev removal. */
 	kthread_t	*svr_thread;
 	/* Segments left to copy from the current metaslab. */
-	range_tree_t	*svr_allocd_segs;
+	zfs_range_tree_t	*svr_allocd_segs;
 	kmutex_t	svr_lock;
 	kcondvar_t	svr_cv;
 	boolean_t	svr_thread_exit;
@@ -49,7 +49,7 @@ typedef struct spa_vdev_removal {
 	 * Ranges that were freed while a mapping was in flight.  This is
 	 * a subset of the ranges covered by vdev_im_new_segments.
 	 */
-	range_tree_t	*svr_frees[TXG_SIZE];
+	zfs_range_tree_t	*svr_frees[TXG_SIZE];
 
 	/*
 	 * Number of bytes which we have finished our work for

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2193,7 +2193,7 @@ dbuf_dirty_lightweight(dnode_t *dn, uint64_t blkid, dmu_tx_t *tx)
 	mutex_enter(&dn->dn_mtx);
 	int txgoff = tx->tx_txg & TXG_MASK;
 	if (dn->dn_free_ranges[txgoff] != NULL) {
-		range_tree_clear(dn->dn_free_ranges[txgoff], blkid, 1);
+		zfs_range_tree_clear(dn->dn_free_ranges[txgoff], blkid, 1);
 	}
 
 	if (dn->dn_nlevels == 1) {
@@ -2400,7 +2400,7 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 	    db->db_blkid != DMU_SPILL_BLKID) {
 		mutex_enter(&dn->dn_mtx);
 		if (dn->dn_free_ranges[txgoff] != NULL) {
-			range_tree_clear(dn->dn_free_ranges[txgoff],
+			zfs_range_tree_clear(dn->dn_free_ranges[txgoff],
 			    db->db_blkid, 1);
 		}
 		mutex_exit(&dn->dn_mtx);

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -2435,11 +2435,11 @@ done:
 	{
 		int txgoff = tx->tx_txg & TXG_MASK;
 		if (dn->dn_free_ranges[txgoff] == NULL) {
-			dn->dn_free_ranges[txgoff] = range_tree_create(NULL,
-			    RANGE_SEG64, NULL, 0, 0);
+			dn->dn_free_ranges[txgoff] = zfs_range_tree_create(NULL,
+			    ZFS_RANGE_SEG64, NULL, 0, 0);
 		}
-		range_tree_clear(dn->dn_free_ranges[txgoff], blkid, nblks);
-		range_tree_add(dn->dn_free_ranges[txgoff], blkid, nblks);
+		zfs_range_tree_clear(dn->dn_free_ranges[txgoff], blkid, nblks);
+		zfs_range_tree_add(dn->dn_free_ranges[txgoff], blkid, nblks);
 	}
 	dprintf_dnode(dn, "blkid=%llu nblks=%llu txg=%llu\n",
 	    (u_longlong_t)blkid, (u_longlong_t)nblks,
@@ -2482,7 +2482,7 @@ dnode_block_freed(dnode_t *dn, uint64_t blkid)
 	mutex_enter(&dn->dn_mtx);
 	for (i = 0; i < TXG_SIZE; i++) {
 		if (dn->dn_free_ranges[i] != NULL &&
-		    range_tree_contains(dn->dn_free_ranges[i], blkid, 1))
+		    zfs_range_tree_contains(dn->dn_free_ranges[i], blkid, 1))
 			break;
 	}
 	mutex_exit(&dn->dn_mtx);

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -660,8 +660,8 @@ dsl_early_sync_task_verify(dsl_pool_t *dp, uint64_t txg)
 
 		for (ms = txg_list_head(tl, TXG_CLEAN(txg)); ms;
 		    ms = txg_list_next(tl, ms, TXG_CLEAN(txg))) {
-			VERIFY(range_tree_is_empty(ms->ms_freeing));
-			VERIFY(range_tree_is_empty(ms->ms_checkpointing));
+			VERIFY(zfs_range_tree_is_empty(ms->ms_freeing));
+			VERIFY(zfs_range_tree_is_empty(ms->ms_checkpointing));
 		}
 	}
 

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -1602,8 +1602,8 @@ dsl_scan_should_clear(dsl_scan_t *scn)
 			 * # of extents in exts_by_addr = # in exts_by_size.
 			 * B-tree efficiency is ~75%, but can be as low as 50%.
 			 */
-			mused += zfs_btree_numnodes(&queue->q_exts_by_size) *
-			    ((sizeof (range_seg_gap_t) + sizeof (uint64_t)) *
+			mused += zfs_btree_numnodes(&queue->q_exts_by_size) * ((
+			    sizeof (zfs_range_seg_gap_t) + sizeof (uint64_t)) *
 			    3 / 2) + queue->q_sio_memused;
 		}
 		mutex_exit(&tvd->vdev_scan_io_queue_lock);
@@ -5006,7 +5006,7 @@ ext_size_destroy(zfs_range_tree_t *rt, void *arg)
 }
 
 static uint64_t
-ext_size_value(zfs_range_tree_t *rt, range_seg_gap_t *rsg)
+ext_size_value(zfs_range_tree_t *rt, zfs_range_seg_gap_t *rsg)
 {
 	(void) rt;
 	uint64_t size = rsg->rs_end - rsg->rs_start;
@@ -5021,7 +5021,7 @@ ext_size_add(zfs_range_tree_t *rt, zfs_range_seg_t *rs, void *arg)
 {
 	zfs_btree_t *size_tree = arg;
 	ASSERT3U(rt->rt_type, ==, ZFS_RANGE_SEG_GAP);
-	uint64_t v = ext_size_value(rt, (range_seg_gap_t *)rs);
+	uint64_t v = ext_size_value(rt, (zfs_range_seg_gap_t *)rs);
 	zfs_btree_add(size_tree, &v);
 }
 
@@ -5030,7 +5030,7 @@ ext_size_remove(zfs_range_tree_t *rt, zfs_range_seg_t *rs, void *arg)
 {
 	zfs_btree_t *size_tree = arg;
 	ASSERT3U(rt->rt_type, ==, ZFS_RANGE_SEG_GAP);
-	uint64_t v = ext_size_value(rt, (range_seg_gap_t *)rs);
+	uint64_t v = ext_size_value(rt, (zfs_range_seg_gap_t *)rs);
 	zfs_btree_remove(size_tree, &v);
 }
 

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -347,7 +347,8 @@ static uint64_t metaslab_weight_from_range_tree(metaslab_t *msp);
 static void metaslab_flush_update(metaslab_t *, dmu_tx_t *);
 static unsigned int metaslab_idx_func(multilist_t *, void *);
 static void metaslab_evict(metaslab_t *, uint64_t);
-static void metaslab_rt_add(range_tree_t *rt, range_seg_t *rs, void *arg);
+static void metaslab_rt_add(zfs_range_tree_t *rt, zfs_range_seg_t *rs,
+    void *arg);
 kmem_cache_t *metaslab_alloc_trace_cache;
 
 typedef struct metaslab_stats {
@@ -1379,7 +1380,7 @@ typedef struct metaslab_rt_arg {
 } metaslab_rt_arg_t;
 
 struct mssa_arg {
-	range_tree_t *rt;
+	zfs_range_tree_t *rt;
 	metaslab_rt_arg_t *mra;
 };
 
@@ -1387,16 +1388,16 @@ static void
 metaslab_size_sorted_add(void *arg, uint64_t start, uint64_t size)
 {
 	struct mssa_arg *mssap = arg;
-	range_tree_t *rt = mssap->rt;
+	zfs_range_tree_t *rt = mssap->rt;
 	metaslab_rt_arg_t *mrap = mssap->mra;
 	range_seg_max_t seg = {0};
-	rs_set_start(&seg, rt, start);
-	rs_set_end(&seg, rt, start + size);
+	zfs_rs_set_start(&seg, rt, start);
+	zfs_rs_set_end(&seg, rt, start + size);
 	metaslab_rt_add(rt, &seg, mrap);
 }
 
 static void
-metaslab_size_tree_full_load(range_tree_t *rt)
+metaslab_size_tree_full_load(zfs_range_tree_t *rt)
 {
 	metaslab_rt_arg_t *mrap = rt->rt_arg;
 	METASLABSTAT_BUMP(metaslabstat_reload_tree);
@@ -1405,7 +1406,7 @@ metaslab_size_tree_full_load(range_tree_t *rt)
 	struct mssa_arg arg = {0};
 	arg.rt = rt;
 	arg.mra = mrap;
-	range_tree_walk(rt, metaslab_size_sorted_add, &arg);
+	zfs_range_tree_walk(rt, metaslab_size_sorted_add, &arg);
 }
 
 
@@ -1417,10 +1418,11 @@ ZFS_BTREE_FIND_IN_BUF_FUNC(metaslab_rt_find_rangesize64_in_buf,
 
 /*
  * Create any block allocator specific components. The current allocators
- * rely on using both a size-ordered range_tree_t and an array of uint64_t's.
+ * rely on using both a size-ordered zfs_range_tree_t and an array of
+ * uint64_t's.
  */
 static void
-metaslab_rt_create(range_tree_t *rt, void *arg)
+metaslab_rt_create(zfs_range_tree_t *rt, void *arg)
 {
 	metaslab_rt_arg_t *mrap = arg;
 	zfs_btree_t *size_tree = mrap->mra_bt;
@@ -1429,12 +1431,12 @@ metaslab_rt_create(range_tree_t *rt, void *arg)
 	int (*compare) (const void *, const void *);
 	bt_find_in_buf_f bt_find;
 	switch (rt->rt_type) {
-	case RANGE_SEG32:
+	case ZFS_RANGE_SEG32:
 		size = sizeof (range_seg32_t);
 		compare = metaslab_rangesize32_compare;
 		bt_find = metaslab_rt_find_rangesize32_in_buf;
 		break;
-	case RANGE_SEG64:
+	case ZFS_RANGE_SEG64:
 		size = sizeof (range_seg64_t);
 		compare = metaslab_rangesize64_compare;
 		bt_find = metaslab_rt_find_rangesize64_in_buf;
@@ -1447,7 +1449,7 @@ metaslab_rt_create(range_tree_t *rt, void *arg)
 }
 
 static void
-metaslab_rt_destroy(range_tree_t *rt, void *arg)
+metaslab_rt_destroy(zfs_range_tree_t *rt, void *arg)
 {
 	(void) rt;
 	metaslab_rt_arg_t *mrap = arg;
@@ -1458,12 +1460,12 @@ metaslab_rt_destroy(range_tree_t *rt, void *arg)
 }
 
 static void
-metaslab_rt_add(range_tree_t *rt, range_seg_t *rs, void *arg)
+metaslab_rt_add(zfs_range_tree_t *rt, zfs_range_seg_t *rs, void *arg)
 {
 	metaslab_rt_arg_t *mrap = arg;
 	zfs_btree_t *size_tree = mrap->mra_bt;
 
-	if (rs_get_end(rs, rt) - rs_get_start(rs, rt) <
+	if (zfs_rs_get_end(rs, rt) - zfs_rs_get_start(rs, rt) <
 	    (1ULL << mrap->mra_floor_shift))
 		return;
 
@@ -1471,12 +1473,12 @@ metaslab_rt_add(range_tree_t *rt, range_seg_t *rs, void *arg)
 }
 
 static void
-metaslab_rt_remove(range_tree_t *rt, range_seg_t *rs, void *arg)
+metaslab_rt_remove(zfs_range_tree_t *rt, zfs_range_seg_t *rs, void *arg)
 {
 	metaslab_rt_arg_t *mrap = arg;
 	zfs_btree_t *size_tree = mrap->mra_bt;
 
-	if (rs_get_end(rs, rt) - rs_get_start(rs, rt) < (1ULL <<
+	if (zfs_rs_get_end(rs, rt) - zfs_rs_get_start(rs, rt) < (1ULL <<
 	    mrap->mra_floor_shift))
 		return;
 
@@ -1484,7 +1486,7 @@ metaslab_rt_remove(range_tree_t *rt, range_seg_t *rs, void *arg)
 }
 
 static void
-metaslab_rt_vacate(range_tree_t *rt, void *arg)
+metaslab_rt_vacate(zfs_range_tree_t *rt, void *arg)
 {
 	metaslab_rt_arg_t *mrap = arg;
 	zfs_btree_t *size_tree = mrap->mra_bt;
@@ -1494,7 +1496,7 @@ metaslab_rt_vacate(range_tree_t *rt, void *arg)
 	metaslab_rt_create(rt, arg);
 }
 
-static const range_tree_ops_t metaslab_rt_ops = {
+static const zfs_range_tree_ops_t metaslab_rt_ops = {
 	.rtop_create = metaslab_rt_create,
 	.rtop_destroy = metaslab_rt_destroy,
 	.rtop_add = metaslab_rt_add,
@@ -1515,7 +1517,7 @@ uint64_t
 metaslab_largest_allocatable(metaslab_t *msp)
 {
 	zfs_btree_t *t = &msp->ms_allocatable_by_size;
-	range_seg_t *rs;
+	zfs_range_seg_t *rs;
 
 	if (t == NULL)
 		return (0);
@@ -1526,7 +1528,7 @@ metaslab_largest_allocatable(metaslab_t *msp)
 	if (rs == NULL)
 		return (0);
 
-	return (rs_get_end(rs, msp->ms_allocatable) - rs_get_start(rs,
+	return (zfs_rs_get_end(rs, msp->ms_allocatable) - zfs_rs_get_start(rs,
 	    msp->ms_allocatable));
 }
 
@@ -1544,7 +1546,7 @@ metaslab_largest_unflushed_free(metaslab_t *msp)
 
 	if (zfs_btree_numnodes(&msp->ms_unflushed_frees_by_size) == 0)
 		metaslab_size_tree_full_load(msp->ms_unflushed_frees);
-	range_seg_t *rs = zfs_btree_last(&msp->ms_unflushed_frees_by_size,
+	zfs_range_seg_t *rs = zfs_btree_last(&msp->ms_unflushed_frees_by_size,
 	    NULL);
 	if (rs == NULL)
 		return (0);
@@ -1572,13 +1574,13 @@ metaslab_largest_unflushed_free(metaslab_t *msp)
 	 * the largest segment; there may be other usable chunks in the
 	 * largest segment, but we ignore them.
 	 */
-	uint64_t rstart = rs_get_start(rs, msp->ms_unflushed_frees);
-	uint64_t rsize = rs_get_end(rs, msp->ms_unflushed_frees) - rstart;
+	uint64_t rstart = zfs_rs_get_start(rs, msp->ms_unflushed_frees);
+	uint64_t rsize = zfs_rs_get_end(rs, msp->ms_unflushed_frees) - rstart;
 	for (int t = 0; t < TXG_DEFER_SIZE; t++) {
 		uint64_t start = 0;
 		uint64_t size = 0;
-		boolean_t found = range_tree_find_in(msp->ms_defer[t], rstart,
-		    rsize, &start, &size);
+		boolean_t found = zfs_range_tree_find_in(msp->ms_defer[t],
+		    rstart, rsize, &start, &size);
 		if (found) {
 			if (rstart == start)
 				return (0);
@@ -1588,7 +1590,7 @@ metaslab_largest_unflushed_free(metaslab_t *msp)
 
 	uint64_t start = 0;
 	uint64_t size = 0;
-	boolean_t found = range_tree_find_in(msp->ms_freed, rstart,
+	boolean_t found = zfs_range_tree_find_in(msp->ms_freed, rstart,
 	    rsize, &start, &size);
 	if (found)
 		rsize = start - rstart;
@@ -1596,15 +1598,15 @@ metaslab_largest_unflushed_free(metaslab_t *msp)
 	return (rsize);
 }
 
-static range_seg_t *
-metaslab_block_find(zfs_btree_t *t, range_tree_t *rt, uint64_t start,
+static zfs_range_seg_t *
+metaslab_block_find(zfs_btree_t *t, zfs_range_tree_t *rt, uint64_t start,
     uint64_t size, zfs_btree_index_t *where)
 {
-	range_seg_t *rs;
+	zfs_range_seg_t *rs;
 	range_seg_max_t rsearch;
 
-	rs_set_start(&rsearch, rt, start);
-	rs_set_end(&rsearch, rt, start + size);
+	zfs_rs_set_start(&rsearch, rt, start);
+	zfs_rs_set_end(&rsearch, rt, start + size);
 
 	rs = zfs_btree_find(t, &rsearch, where);
 	if (rs == NULL) {
@@ -1620,24 +1622,25 @@ metaslab_block_find(zfs_btree_t *t, range_tree_t *rt, uint64_t start,
  * for a block that matches the specified criteria.
  */
 static uint64_t
-metaslab_block_picker(range_tree_t *rt, uint64_t *cursor, uint64_t size,
+metaslab_block_picker(zfs_range_tree_t *rt, uint64_t *cursor, uint64_t size,
     uint64_t max_search)
 {
 	if (*cursor == 0)
 		*cursor = rt->rt_start;
 	zfs_btree_t *bt = &rt->rt_root;
 	zfs_btree_index_t where;
-	range_seg_t *rs = metaslab_block_find(bt, rt, *cursor, size, &where);
+	zfs_range_seg_t *rs = metaslab_block_find(bt, rt, *cursor, size,
+	    &where);
 	uint64_t first_found;
 	int count_searched = 0;
 
 	if (rs != NULL)
-		first_found = rs_get_start(rs, rt);
+		first_found = zfs_rs_get_start(rs, rt);
 
-	while (rs != NULL && (rs_get_start(rs, rt) - first_found <=
+	while (rs != NULL && (zfs_rs_get_start(rs, rt) - first_found <=
 	    max_search || count_searched < metaslab_min_search_count)) {
-		uint64_t offset = rs_get_start(rs, rt);
-		if (offset + size <= rs_get_end(rs, rt)) {
+		uint64_t offset = zfs_rs_get_start(rs, rt);
+		if (offset + size <= zfs_rs_get_end(rs, rt)) {
 			*cursor = offset + size;
 			return (offset);
 		}
@@ -1748,8 +1751,8 @@ metaslab_df_alloc(metaslab_t *msp, uint64_t size)
 	 */
 	uint64_t align = size & -size;
 	uint64_t *cursor = &msp->ms_lbas[highbit64(align) - 1];
-	range_tree_t *rt = msp->ms_allocatable;
-	uint_t free_pct = range_tree_space(rt) * 100 / msp->ms_size;
+	zfs_range_tree_t *rt = msp->ms_allocatable;
+	uint_t free_pct = zfs_range_tree_space(rt) * 100 / msp->ms_size;
 	uint64_t offset;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
@@ -1767,7 +1770,7 @@ metaslab_df_alloc(metaslab_t *msp, uint64_t size)
 	}
 
 	if (offset == -1) {
-		range_seg_t *rs;
+		zfs_range_seg_t *rs;
 		if (zfs_btree_numnodes(&msp->ms_allocatable_by_size) == 0)
 			metaslab_size_tree_full_load(msp->ms_allocatable);
 
@@ -1780,9 +1783,9 @@ metaslab_df_alloc(metaslab_t *msp, uint64_t size)
 			rs = metaslab_block_find(&msp->ms_allocatable_by_size,
 			    rt, msp->ms_start, size, &where);
 		}
-		if (rs != NULL && rs_get_start(rs, rt) + size <= rs_get_end(rs,
-		    rt)) {
-			offset = rs_get_start(rs, rt);
+		if (rs != NULL && zfs_rs_get_start(rs, rt) + size <=
+		    zfs_rs_get_end(rs, rt)) {
+			offset = zfs_rs_get_start(rs, rt);
 			*cursor = offset + size;
 		}
 	}
@@ -1802,7 +1805,7 @@ metaslab_df_alloc(metaslab_t *msp, uint64_t size)
 static uint64_t
 metaslab_cf_alloc(metaslab_t *msp, uint64_t size)
 {
-	range_tree_t *rt = msp->ms_allocatable;
+	zfs_range_tree_t *rt = msp->ms_allocatable;
 	zfs_btree_t *t = &msp->ms_allocatable_by_size;
 	uint64_t *cursor = &msp->ms_lbas[0];
 	uint64_t *cursor_end = &msp->ms_lbas[1];
@@ -1813,17 +1816,17 @@ metaslab_cf_alloc(metaslab_t *msp, uint64_t size)
 	ASSERT3U(*cursor_end, >=, *cursor);
 
 	if ((*cursor + size) > *cursor_end) {
-		range_seg_t *rs;
+		zfs_range_seg_t *rs;
 
 		if (zfs_btree_numnodes(t) == 0)
 			metaslab_size_tree_full_load(msp->ms_allocatable);
 		rs = zfs_btree_last(t, NULL);
-		if (rs == NULL || (rs_get_end(rs, rt) - rs_get_start(rs, rt)) <
-		    size)
+		if (rs == NULL || (zfs_rs_get_end(rs, rt) -
+		    zfs_rs_get_start(rs, rt)) < size)
 			return (-1ULL);
 
-		*cursor = rs_get_start(rs, rt);
-		*cursor_end = rs_get_end(rs, rt);
+		*cursor = zfs_rs_get_start(rs, rt);
+		*cursor_end = zfs_rs_get_end(rs, rt);
 	}
 
 	offset = *cursor;
@@ -1851,9 +1854,9 @@ static uint64_t
 metaslab_ndf_alloc(metaslab_t *msp, uint64_t size)
 {
 	zfs_btree_t *t = &msp->ms_allocatable->rt_root;
-	range_tree_t *rt = msp->ms_allocatable;
+	zfs_range_tree_t *rt = msp->ms_allocatable;
 	zfs_btree_index_t where;
-	range_seg_t *rs;
+	zfs_range_seg_t *rs;
 	range_seg_max_t rsearch;
 	uint64_t hbit = highbit64(size);
 	uint64_t *cursor = &msp->ms_lbas[hbit - 1];
@@ -1864,15 +1867,16 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size)
 	if (max_size < size)
 		return (-1ULL);
 
-	rs_set_start(&rsearch, rt, *cursor);
-	rs_set_end(&rsearch, rt, *cursor + size);
+	zfs_rs_set_start(&rsearch, rt, *cursor);
+	zfs_rs_set_end(&rsearch, rt, *cursor + size);
 
 	rs = zfs_btree_find(t, &rsearch, &where);
-	if (rs == NULL || (rs_get_end(rs, rt) - rs_get_start(rs, rt)) < size) {
+	if (rs == NULL || (zfs_rs_get_end(rs, rt) - zfs_rs_get_start(rs, rt)) <
+	    size) {
 		t = &msp->ms_allocatable_by_size;
 
-		rs_set_start(&rsearch, rt, 0);
-		rs_set_end(&rsearch, rt, MIN(max_size, 1ULL << (hbit +
+		zfs_rs_set_start(&rsearch, rt, 0);
+		zfs_rs_set_end(&rsearch, rt, MIN(max_size, 1ULL << (hbit +
 		    metaslab_ndf_clump_shift)));
 
 		rs = zfs_btree_find(t, &rsearch, &where);
@@ -1881,9 +1885,9 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size)
 		ASSERT(rs != NULL);
 	}
 
-	if ((rs_get_end(rs, rt) - rs_get_start(rs, rt)) >= size) {
-		*cursor = rs_get_start(rs, rt) + size;
-		return (rs_get_start(rs, rt));
+	if ((zfs_rs_get_end(rs, rt) - zfs_rs_get_start(rs, rt)) >= size) {
+		*cursor = zfs_rs_get_start(rs, rt) + size;
+		return (zfs_rs_get_start(rs, rt));
 	}
 	return (-1ULL);
 }
@@ -1973,12 +1977,12 @@ metaslab_verify_space(metaslab_t *msp, uint64_t txg)
 	ASSERT3S(space_map_allocated(msp->ms_sm), >=, 0);
 
 	ASSERT3U(space_map_allocated(msp->ms_sm), >=,
-	    range_tree_space(msp->ms_unflushed_frees));
+	    zfs_range_tree_space(msp->ms_unflushed_frees));
 
 	ASSERT3U(metaslab_allocated_space(msp), ==,
 	    space_map_allocated(msp->ms_sm) +
-	    range_tree_space(msp->ms_unflushed_allocs) -
-	    range_tree_space(msp->ms_unflushed_frees));
+	    zfs_range_tree_space(msp->ms_unflushed_allocs) -
+	    zfs_range_tree_space(msp->ms_unflushed_frees));
 
 	sm_free_space = msp->ms_size - metaslab_allocated_space(msp);
 
@@ -1988,17 +1992,19 @@ metaslab_verify_space(metaslab_t *msp, uint64_t txg)
 	 */
 	for (int t = 0; t < TXG_CONCURRENT_STATES; t++) {
 		allocating +=
-		    range_tree_space(msp->ms_allocating[(txg + t) & TXG_MASK]);
+		    zfs_range_tree_space(msp->ms_allocating[(txg + t) &
+		    TXG_MASK]);
 	}
 	ASSERT3U(allocating + msp->ms_allocated_this_txg, ==,
 	    msp->ms_allocating_total);
 
 	ASSERT3U(msp->ms_deferspace, ==,
-	    range_tree_space(msp->ms_defer[0]) +
-	    range_tree_space(msp->ms_defer[1]));
+	    zfs_range_tree_space(msp->ms_defer[0]) +
+	    zfs_range_tree_space(msp->ms_defer[1]));
 
-	msp_free_space = range_tree_space(msp->ms_allocatable) + allocating +
-	    msp->ms_deferspace + range_tree_space(msp->ms_freed);
+	msp_free_space = zfs_range_tree_space(msp->ms_allocatable) +
+	    allocating + msp->ms_deferspace +
+	    zfs_range_tree_space(msp->ms_freed);
 
 	VERIFY3U(sm_free_space, ==, msp_free_space);
 }
@@ -2019,7 +2025,7 @@ metaslab_aux_histograms_clear(metaslab_t *msp)
 
 static void
 metaslab_aux_histogram_add(uint64_t *histogram, uint64_t shift,
-    range_tree_t *rt)
+    zfs_range_tree_t *rt)
 {
 	/*
 	 * This is modeled after space_map_histogram_add(), so refer to that
@@ -2167,7 +2173,7 @@ metaslab_verify_weight_and_frag(metaslab_t *msp)
 
 	/* some extra verification for in-core tree if you can */
 	if (msp->ms_loaded) {
-		range_tree_stat_verify(msp->ms_allocatable);
+		zfs_range_tree_stat_verify(msp->ms_allocatable);
 		VERIFY(space_map_histogram_verify(msp->ms_sm,
 		    msp->ms_allocatable));
 	}
@@ -2355,8 +2361,8 @@ metaslab_load_impl(metaslab_t *msp)
 		struct mssa_arg arg = {0};
 		arg.rt = msp->ms_allocatable;
 		arg.mra = mrap;
-		range_tree_walk(msp->ms_allocatable, metaslab_size_sorted_add,
-		    &arg);
+		zfs_range_tree_walk(msp->ms_allocatable,
+		    metaslab_size_sorted_add, &arg);
 	} else {
 		/*
 		 * Add the size-sorted tree first, since we don't need to load
@@ -2370,7 +2376,7 @@ metaslab_load_impl(metaslab_t *msp)
 		 * all the space in the metaslab as free and add it to the
 		 * ms_allocatable tree.
 		 */
-		range_tree_add(msp->ms_allocatable,
+		zfs_range_tree_add(msp->ms_allocatable,
 		    msp->ms_start, msp->ms_size);
 
 		if (msp->ms_new) {
@@ -2381,8 +2387,10 @@ metaslab_load_impl(metaslab_t *msp)
 			 * expect any unflushed allocs or frees from previous
 			 * TXGs.
 			 */
-			ASSERT(range_tree_is_empty(msp->ms_unflushed_allocs));
-			ASSERT(range_tree_is_empty(msp->ms_unflushed_frees));
+			ASSERT(zfs_range_tree_is_empty(
+			    msp->ms_unflushed_allocs));
+			ASSERT(zfs_range_tree_is_empty(
+			    msp->ms_unflushed_frees));
 		}
 	}
 
@@ -2412,10 +2420,10 @@ metaslab_load_impl(metaslab_t *msp)
 	 * away so any manipulations we do below have a clear view
 	 * of what is allocated and what is free.
 	 */
-	range_tree_walk(msp->ms_unflushed_allocs,
-	    range_tree_remove, msp->ms_allocatable);
-	range_tree_walk(msp->ms_unflushed_frees,
-	    range_tree_add, msp->ms_allocatable);
+	zfs_range_tree_walk(msp->ms_unflushed_allocs,
+	    zfs_range_tree_remove, msp->ms_allocatable);
+	zfs_range_tree_walk(msp->ms_unflushed_frees,
+	    zfs_range_tree_add, msp->ms_allocatable);
 
 	ASSERT3P(msp->ms_group, !=, NULL);
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
@@ -2443,8 +2451,8 @@ metaslab_load_impl(metaslab_t *msp)
 		 * correctly doesn't contain any segments that exist
 		 * in ms_freed [see ms_synced_length].
 		 */
-		range_tree_walk(msp->ms_freed,
-		    range_tree_remove, msp->ms_allocatable);
+		zfs_range_tree_walk(msp->ms_freed,
+		    zfs_range_tree_remove, msp->ms_allocatable);
 	}
 
 	/*
@@ -2462,8 +2470,8 @@ metaslab_load_impl(metaslab_t *msp)
 	 * code path.
 	 */
 	for (int t = 0; t < TXG_DEFER_SIZE; t++) {
-		range_tree_walk(msp->ms_defer[t],
-		    range_tree_remove, msp->ms_allocatable);
+		zfs_range_tree_walk(msp->ms_defer[t],
+		    zfs_range_tree_remove, msp->ms_allocatable);
 	}
 
 	/*
@@ -2498,11 +2506,11 @@ metaslab_load_impl(metaslab_t *msp)
 	    (u_longlong_t)msp->ms_group->mg_vd->vdev_id,
 	    (u_longlong_t)msp->ms_id,
 	    (u_longlong_t)space_map_length(msp->ms_sm),
-	    (u_longlong_t)range_tree_space(msp->ms_unflushed_allocs),
-	    (u_longlong_t)range_tree_space(msp->ms_unflushed_frees),
-	    (u_longlong_t)range_tree_space(msp->ms_freed),
-	    (u_longlong_t)range_tree_space(msp->ms_defer[0]),
-	    (u_longlong_t)range_tree_space(msp->ms_defer[1]),
+	    (u_longlong_t)zfs_range_tree_space(msp->ms_unflushed_allocs),
+	    (u_longlong_t)zfs_range_tree_space(msp->ms_unflushed_frees),
+	    (u_longlong_t)zfs_range_tree_space(msp->ms_freed),
+	    (u_longlong_t)zfs_range_tree_space(msp->ms_defer[0]),
+	    (u_longlong_t)zfs_range_tree_space(msp->ms_defer[1]),
 	    (longlong_t)((load_start - msp->ms_unload_time) / 1000000),
 	    (longlong_t)((load_end - load_start) / 1000000),
 	    (u_longlong_t)msp->ms_max_size,
@@ -2584,7 +2592,7 @@ metaslab_unload(metaslab_t *msp)
 	if (!msp->ms_loaded)
 		return;
 
-	range_tree_vacate(msp->ms_allocatable, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_allocatable, NULL, NULL);
 	msp->ms_loaded = B_FALSE;
 	msp->ms_unload_time = gethrtime();
 
@@ -2640,7 +2648,7 @@ metaslab_unload(metaslab_t *msp)
  * the vdev_ms_shift - the vdev_ashift is less than 32, we can store
  * the ranges using two uint32_ts, rather than two uint64_ts.
  */
-range_seg_type_t
+zfs_range_seg_type_t
 metaslab_calculate_range_tree_type(vdev_t *vdev, metaslab_t *msp,
     uint64_t *start, uint64_t *shift)
 {
@@ -2648,11 +2656,11 @@ metaslab_calculate_range_tree_type(vdev_t *vdev, metaslab_t *msp,
 	    !zfs_metaslab_force_large_segs) {
 		*shift = vdev->vdev_ashift;
 		*start = msp->ms_start;
-		return (RANGE_SEG32);
+		return (ZFS_RANGE_SEG32);
 	} else {
 		*shift = 0;
 		*start = 0;
-		return (RANGE_SEG64);
+		return (ZFS_RANGE_SEG64);
 	}
 }
 
@@ -2738,32 +2746,33 @@ metaslab_init(metaslab_group_t *mg, uint64_t id, uint64_t object,
 	}
 
 	uint64_t shift, start;
-	range_seg_type_t type =
+	zfs_range_seg_type_t type =
 	    metaslab_calculate_range_tree_type(vd, ms, &start, &shift);
 
-	ms->ms_allocatable = range_tree_create(NULL, type, NULL, start, shift);
+	ms->ms_allocatable = zfs_range_tree_create(NULL, type, NULL, start,
+	    shift);
 	for (int t = 0; t < TXG_SIZE; t++) {
-		ms->ms_allocating[t] = range_tree_create(NULL, type,
+		ms->ms_allocating[t] = zfs_range_tree_create(NULL, type,
 		    NULL, start, shift);
 	}
-	ms->ms_freeing = range_tree_create(NULL, type, NULL, start, shift);
-	ms->ms_freed = range_tree_create(NULL, type, NULL, start, shift);
+	ms->ms_freeing = zfs_range_tree_create(NULL, type, NULL, start, shift);
+	ms->ms_freed = zfs_range_tree_create(NULL, type, NULL, start, shift);
 	for (int t = 0; t < TXG_DEFER_SIZE; t++) {
-		ms->ms_defer[t] = range_tree_create(NULL, type, NULL,
+		ms->ms_defer[t] = zfs_range_tree_create(NULL, type, NULL,
 		    start, shift);
 	}
 	ms->ms_checkpointing =
-	    range_tree_create(NULL, type, NULL, start, shift);
+	    zfs_range_tree_create(NULL, type, NULL, start, shift);
 	ms->ms_unflushed_allocs =
-	    range_tree_create(NULL, type, NULL, start, shift);
+	    zfs_range_tree_create(NULL, type, NULL, start, shift);
 
 	metaslab_rt_arg_t *mrap = kmem_zalloc(sizeof (*mrap), KM_SLEEP);
 	mrap->mra_bt = &ms->ms_unflushed_frees_by_size;
 	mrap->mra_floor_shift = metaslab_by_size_min_shift;
-	ms->ms_unflushed_frees = range_tree_create(&metaslab_rt_ops,
+	ms->ms_unflushed_frees = zfs_range_tree_create(&metaslab_rt_ops,
 	    type, mrap, start, shift);
 
-	ms->ms_trim = range_tree_create(NULL, type, NULL, start, shift);
+	ms->ms_trim = zfs_range_tree_create(NULL, type, NULL, start, shift);
 
 	metaslab_group_add(mg, ms);
 	metaslab_set_fragmentation(ms, B_FALSE);
@@ -2817,8 +2826,8 @@ metaslab_fini_flush_data(metaslab_t *msp)
 uint64_t
 metaslab_unflushed_changes_memused(metaslab_t *ms)
 {
-	return ((range_tree_numsegs(ms->ms_unflushed_allocs) +
-	    range_tree_numsegs(ms->ms_unflushed_frees)) *
+	return ((zfs_range_tree_numsegs(ms->ms_unflushed_allocs) +
+	    zfs_range_tree_numsegs(ms->ms_unflushed_frees)) *
 	    ms->ms_unflushed_allocs->rt_root.bt_elem_size);
 }
 
@@ -2851,33 +2860,33 @@ metaslab_fini(metaslab_t *msp)
 
 	metaslab_unload(msp);
 
-	range_tree_destroy(msp->ms_allocatable);
-	range_tree_destroy(msp->ms_freeing);
-	range_tree_destroy(msp->ms_freed);
+	zfs_range_tree_destroy(msp->ms_allocatable);
+	zfs_range_tree_destroy(msp->ms_freeing);
+	zfs_range_tree_destroy(msp->ms_freed);
 
 	ASSERT3U(spa->spa_unflushed_stats.sus_memused, >=,
 	    metaslab_unflushed_changes_memused(msp));
 	spa->spa_unflushed_stats.sus_memused -=
 	    metaslab_unflushed_changes_memused(msp);
-	range_tree_vacate(msp->ms_unflushed_allocs, NULL, NULL);
-	range_tree_destroy(msp->ms_unflushed_allocs);
-	range_tree_destroy(msp->ms_checkpointing);
-	range_tree_vacate(msp->ms_unflushed_frees, NULL, NULL);
-	range_tree_destroy(msp->ms_unflushed_frees);
+	zfs_range_tree_vacate(msp->ms_unflushed_allocs, NULL, NULL);
+	zfs_range_tree_destroy(msp->ms_unflushed_allocs);
+	zfs_range_tree_destroy(msp->ms_checkpointing);
+	zfs_range_tree_vacate(msp->ms_unflushed_frees, NULL, NULL);
+	zfs_range_tree_destroy(msp->ms_unflushed_frees);
 
 	for (int t = 0; t < TXG_SIZE; t++) {
-		range_tree_destroy(msp->ms_allocating[t]);
+		zfs_range_tree_destroy(msp->ms_allocating[t]);
 	}
 	for (int t = 0; t < TXG_DEFER_SIZE; t++) {
-		range_tree_destroy(msp->ms_defer[t]);
+		zfs_range_tree_destroy(msp->ms_defer[t]);
 	}
 	ASSERT0(msp->ms_deferspace);
 
 	for (int t = 0; t < TXG_SIZE; t++)
 		ASSERT(!txg_list_member(&vd->vdev_ms_list, msp, t));
 
-	range_tree_vacate(msp->ms_trim, NULL, NULL);
-	range_tree_destroy(msp->ms_trim);
+	zfs_range_tree_vacate(msp->ms_trim, NULL, NULL);
+	zfs_range_tree_destroy(msp->ms_trim);
 
 	mutex_exit(&msp->ms_lock);
 	cv_destroy(&msp->ms_load_cv);
@@ -3445,7 +3454,7 @@ metaslab_activate(metaslab_t *msp, int allocator, uint64_t activation_weight)
 	 * lock.
 	 */
 	if (msp->ms_weight == 0) {
-		ASSERT0(range_tree_space(msp->ms_allocatable));
+		ASSERT0(zfs_range_tree_space(msp->ms_allocatable));
 		return (SET_ERROR(ENOSPC));
 	}
 
@@ -3504,7 +3513,7 @@ metaslab_passivate(metaslab_t *msp, uint64_t weight)
 	 */
 	ASSERT(!WEIGHT_IS_SPACEBASED(msp->ms_weight) ||
 	    size >= SPA_MINBLOCKSIZE ||
-	    range_tree_space(msp->ms_allocatable) == 0);
+	    zfs_range_tree_space(msp->ms_allocatable) == 0);
 	ASSERT0(weight & METASLAB_ACTIVE_MASK);
 
 	ASSERT(msp->ms_activation_weight != 0);
@@ -3635,7 +3644,7 @@ metaslab_should_condense(metaslab_t *msp)
 	 * We always condense metaslabs that are empty and metaslabs for
 	 * which a condense request has been made.
 	 */
-	if (range_tree_numsegs(msp->ms_allocatable) == 0 ||
+	if (zfs_range_tree_numsegs(msp->ms_allocatable) == 0 ||
 	    msp->ms_condense_wanted)
 		return (B_TRUE);
 
@@ -3659,7 +3668,7 @@ metaslab_should_condense(metaslab_t *msp)
 static void
 metaslab_condense(metaslab_t *msp, dmu_tx_t *tx)
 {
-	range_tree_t *condense_tree;
+	zfs_range_tree_t *condense_tree;
 	space_map_t *sm = msp->ms_sm;
 	uint64_t txg = dmu_tx_get_txg(tx);
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
@@ -3711,41 +3720,41 @@ metaslab_condense(metaslab_t *msp, dmu_tx_t *tx)
 	 *    metaslab_flush_update().
 	 */
 	ASSERT3U(spa_sync_pass(spa), ==, 1);
-	ASSERT(range_tree_is_empty(msp->ms_freed)); /* since it is pass 1 */
+	ASSERT(zfs_range_tree_is_empty(msp->ms_freed)); /* since it is pass 1 */
 
 	zfs_dbgmsg("condensing: txg %llu, msp[%llu] %px, vdev id %llu, "
 	    "spa %s, smp size %llu, segments %llu, forcing condense=%s",
 	    (u_longlong_t)txg, (u_longlong_t)msp->ms_id, msp,
 	    (u_longlong_t)msp->ms_group->mg_vd->vdev_id,
 	    spa->spa_name, (u_longlong_t)space_map_length(msp->ms_sm),
-	    (u_longlong_t)range_tree_numsegs(msp->ms_allocatable),
+	    (u_longlong_t)zfs_range_tree_numsegs(msp->ms_allocatable),
 	    msp->ms_condense_wanted ? "TRUE" : "FALSE");
 
 	msp->ms_condense_wanted = B_FALSE;
 
-	range_seg_type_t type;
+	zfs_range_seg_type_t type;
 	uint64_t shift, start;
 	type = metaslab_calculate_range_tree_type(msp->ms_group->mg_vd, msp,
 	    &start, &shift);
 
-	condense_tree = range_tree_create(NULL, type, NULL, start, shift);
+	condense_tree = zfs_range_tree_create(NULL, type, NULL, start, shift);
 
 	for (int t = 0; t < TXG_DEFER_SIZE; t++) {
-		range_tree_walk(msp->ms_defer[t],
-		    range_tree_add, condense_tree);
+		zfs_range_tree_walk(msp->ms_defer[t],
+		    zfs_range_tree_add, condense_tree);
 	}
 
 	for (int t = 0; t < TXG_CONCURRENT_STATES; t++) {
-		range_tree_walk(msp->ms_allocating[(txg + t) & TXG_MASK],
-		    range_tree_add, condense_tree);
+		zfs_range_tree_walk(msp->ms_allocating[(txg + t) & TXG_MASK],
+		    zfs_range_tree_add, condense_tree);
 	}
 
 	ASSERT3U(spa->spa_unflushed_stats.sus_memused, >=,
 	    metaslab_unflushed_changes_memused(msp));
 	spa->spa_unflushed_stats.sus_memused -=
 	    metaslab_unflushed_changes_memused(msp);
-	range_tree_vacate(msp->ms_unflushed_allocs, NULL, NULL);
-	range_tree_vacate(msp->ms_unflushed_frees, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_unflushed_allocs, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_unflushed_frees, NULL, NULL);
 
 	/*
 	 * We're about to drop the metaslab's lock thus allowing other
@@ -3785,17 +3794,17 @@ metaslab_condense(metaslab_t *msp, dmu_tx_t *tx)
 	 * followed by FREES (due to space_map_write() in metaslab_sync()) for
 	 * sync pass 1.
 	 */
-	range_tree_t *tmp_tree = range_tree_create(NULL, type, NULL, start,
-	    shift);
-	range_tree_add(tmp_tree, msp->ms_start, msp->ms_size);
+	zfs_range_tree_t *tmp_tree = zfs_range_tree_create(NULL, type, NULL,
+	    start, shift);
+	zfs_range_tree_add(tmp_tree, msp->ms_start, msp->ms_size);
 	space_map_write(sm, tmp_tree, SM_ALLOC, SM_NO_VDEVID, tx);
 	space_map_write(sm, msp->ms_allocatable, SM_FREE, SM_NO_VDEVID, tx);
 	space_map_write(sm, condense_tree, SM_FREE, SM_NO_VDEVID, tx);
 
-	range_tree_vacate(condense_tree, NULL, NULL);
-	range_tree_destroy(condense_tree);
-	range_tree_vacate(tmp_tree, NULL, NULL);
-	range_tree_destroy(tmp_tree);
+	zfs_range_tree_vacate(condense_tree, NULL, NULL);
+	zfs_range_tree_destroy(condense_tree);
+	zfs_range_tree_vacate(tmp_tree, NULL, NULL);
+	zfs_range_tree_destroy(tmp_tree);
 	mutex_enter(&msp->ms_lock);
 
 	msp->ms_condensing = B_FALSE;
@@ -3808,8 +3817,8 @@ metaslab_unflushed_add(metaslab_t *msp, dmu_tx_t *tx)
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
 	ASSERT(spa_syncing_log_sm(spa) != NULL);
 	ASSERT(msp->ms_sm != NULL);
-	ASSERT(range_tree_is_empty(msp->ms_unflushed_allocs));
-	ASSERT(range_tree_is_empty(msp->ms_unflushed_frees));
+	ASSERT(zfs_range_tree_is_empty(msp->ms_unflushed_allocs));
+	ASSERT(zfs_range_tree_is_empty(msp->ms_unflushed_frees));
 
 	mutex_enter(&spa->spa_flushed_ms_lock);
 	metaslab_set_unflushed_txg(msp, spa_syncing_txg(spa), tx);
@@ -3829,8 +3838,8 @@ metaslab_unflushed_bump(metaslab_t *msp, dmu_tx_t *tx, boolean_t dirty)
 	ASSERT(msp->ms_sm != NULL);
 	ASSERT(metaslab_unflushed_txg(msp) != 0);
 	ASSERT3P(avl_find(&spa->spa_metaslabs_by_flushed, msp, NULL), ==, msp);
-	ASSERT(range_tree_is_empty(msp->ms_unflushed_allocs));
-	ASSERT(range_tree_is_empty(msp->ms_unflushed_frees));
+	ASSERT(zfs_range_tree_is_empty(msp->ms_unflushed_allocs));
+	ASSERT(zfs_range_tree_is_empty(msp->ms_unflushed_frees));
 
 	VERIFY3U(tx->tx_txg, <=, spa_final_dirty_txg(spa));
 
@@ -3950,7 +3959,7 @@ metaslab_flush(metaslab_t *msp, dmu_tx_t *tx)
 
 		space_map_histogram_clear(msp->ms_sm);
 		space_map_histogram_add(msp->ms_sm, msp->ms_allocatable, tx);
-		ASSERT(range_tree_is_empty(msp->ms_freed));
+		ASSERT(zfs_range_tree_is_empty(msp->ms_freed));
 		for (int t = 0; t < TXG_DEFER_SIZE; t++) {
 			space_map_histogram_add(msp->ms_sm,
 			    msp->ms_defer[t], tx);
@@ -3992,8 +4001,10 @@ metaslab_flush(metaslab_t *msp, dmu_tx_t *tx)
 		    spa_name(spa),
 		    (u_longlong_t)msp->ms_group->mg_vd->vdev_id,
 		    (u_longlong_t)msp->ms_id,
-		    (u_longlong_t)range_tree_space(msp->ms_unflushed_allocs),
-		    (u_longlong_t)range_tree_space(msp->ms_unflushed_frees),
+		    (u_longlong_t)zfs_range_tree_space(
+		    msp->ms_unflushed_allocs),
+		    (u_longlong_t)zfs_range_tree_space(
+		    msp->ms_unflushed_frees),
 		    (u_longlong_t)(sm_len_after - sm_len_before));
 	}
 
@@ -4001,8 +4012,8 @@ metaslab_flush(metaslab_t *msp, dmu_tx_t *tx)
 	    metaslab_unflushed_changes_memused(msp));
 	spa->spa_unflushed_stats.sus_memused -=
 	    metaslab_unflushed_changes_memused(msp);
-	range_tree_vacate(msp->ms_unflushed_allocs, NULL, NULL);
-	range_tree_vacate(msp->ms_unflushed_frees, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_unflushed_allocs, NULL, NULL);
+	zfs_range_tree_vacate(msp->ms_unflushed_frees, NULL, NULL);
 
 	metaslab_verify_space(msp, dmu_tx_get_txg(tx));
 	metaslab_verify_weight_and_frag(msp);
@@ -4027,7 +4038,7 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	vdev_t *vd = mg->mg_vd;
 	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = spa_meta_objset(spa);
-	range_tree_t *alloctree = msp->ms_allocating[txg & TXG_MASK];
+	zfs_range_tree_t *alloctree = msp->ms_allocating[txg & TXG_MASK];
 	dmu_tx_t *tx;
 
 	ASSERT(!vd->vdev_ishole);
@@ -4036,11 +4047,11 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	 * This metaslab has just been added so there's no work to do now.
 	 */
 	if (msp->ms_new) {
-		ASSERT0(range_tree_space(alloctree));
-		ASSERT0(range_tree_space(msp->ms_freeing));
-		ASSERT0(range_tree_space(msp->ms_freed));
-		ASSERT0(range_tree_space(msp->ms_checkpointing));
-		ASSERT0(range_tree_space(msp->ms_trim));
+		ASSERT0(zfs_range_tree_space(alloctree));
+		ASSERT0(zfs_range_tree_space(msp->ms_freeing));
+		ASSERT0(zfs_range_tree_space(msp->ms_freed));
+		ASSERT0(zfs_range_tree_space(msp->ms_checkpointing));
+		ASSERT0(zfs_range_tree_space(msp->ms_trim));
 		return;
 	}
 
@@ -4055,9 +4066,9 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	 * we preserve the utility of the VERIFY statements in all other
 	 * cases.
 	 */
-	if (range_tree_is_empty(alloctree) &&
-	    range_tree_is_empty(msp->ms_freeing) &&
-	    range_tree_is_empty(msp->ms_checkpointing) &&
+	if (zfs_range_tree_is_empty(alloctree) &&
+	    zfs_range_tree_is_empty(msp->ms_freeing) &&
+	    zfs_range_tree_is_empty(msp->ms_checkpointing) &&
 	    !(msp->ms_loaded && msp->ms_condense_wanted &&
 	    txg <= spa_final_dirty_txg(spa)))
 		return;
@@ -4099,12 +4110,12 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 		    msp->ms_start, msp->ms_size, vd->vdev_ashift));
 		ASSERT(msp->ms_sm != NULL);
 
-		ASSERT(range_tree_is_empty(msp->ms_unflushed_allocs));
-		ASSERT(range_tree_is_empty(msp->ms_unflushed_frees));
+		ASSERT(zfs_range_tree_is_empty(msp->ms_unflushed_allocs));
+		ASSERT(zfs_range_tree_is_empty(msp->ms_unflushed_frees));
 		ASSERT0(metaslab_allocated_space(msp));
 	}
 
-	if (!range_tree_is_empty(msp->ms_checkpointing) &&
+	if (!zfs_range_tree_is_empty(msp->ms_checkpointing) &&
 	    vd->vdev_checkpoint_sm == NULL) {
 		ASSERT(spa_has_checkpoint(spa));
 
@@ -4166,9 +4177,9 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 		    metaslab_unflushed_changes_memused(msp));
 		spa->spa_unflushed_stats.sus_memused -=
 		    metaslab_unflushed_changes_memused(msp);
-		range_tree_remove_xor_add(alloctree,
+		zfs_range_tree_remove_xor_add(alloctree,
 		    msp->ms_unflushed_frees, msp->ms_unflushed_allocs);
-		range_tree_remove_xor_add(msp->ms_freeing,
+		zfs_range_tree_remove_xor_add(msp->ms_freeing,
 		    msp->ms_unflushed_allocs, msp->ms_unflushed_frees);
 		spa->spa_unflushed_stats.sus_memused +=
 		    metaslab_unflushed_changes_memused(msp);
@@ -4182,12 +4193,12 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 		mutex_enter(&msp->ms_lock);
 	}
 
-	msp->ms_allocated_space += range_tree_space(alloctree);
+	msp->ms_allocated_space += zfs_range_tree_space(alloctree);
 	ASSERT3U(msp->ms_allocated_space, >=,
-	    range_tree_space(msp->ms_freeing));
-	msp->ms_allocated_space -= range_tree_space(msp->ms_freeing);
+	    zfs_range_tree_space(msp->ms_freeing));
+	msp->ms_allocated_space -= zfs_range_tree_space(msp->ms_freeing);
 
-	if (!range_tree_is_empty(msp->ms_checkpointing)) {
+	if (!zfs_range_tree_is_empty(msp->ms_checkpointing)) {
 		ASSERT(spa_has_checkpoint(spa));
 		ASSERT3P(vd->vdev_checkpoint_sm, !=, NULL);
 
@@ -4203,13 +4214,13 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 		mutex_enter(&msp->ms_lock);
 
 		spa->spa_checkpoint_info.sci_dspace +=
-		    range_tree_space(msp->ms_checkpointing);
+		    zfs_range_tree_space(msp->ms_checkpointing);
 		vd->vdev_stat.vs_checkpoint_space +=
-		    range_tree_space(msp->ms_checkpointing);
+		    zfs_range_tree_space(msp->ms_checkpointing);
 		ASSERT3U(vd->vdev_stat.vs_checkpoint_space, ==,
 		    -space_map_allocated(vd->vdev_checkpoint_sm));
 
-		range_tree_vacate(msp->ms_checkpointing, NULL, NULL);
+		zfs_range_tree_vacate(msp->ms_checkpointing, NULL, NULL);
 	}
 
 	if (msp->ms_loaded) {
@@ -4269,20 +4280,20 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	 * get appended to the ms_sm) so their ranges can be reused as usual.
 	 */
 	if (spa_sync_pass(spa) == 1) {
-		range_tree_swap(&msp->ms_freeing, &msp->ms_freed);
+		zfs_range_tree_swap(&msp->ms_freeing, &msp->ms_freed);
 		ASSERT0(msp->ms_allocated_this_txg);
 	} else {
-		range_tree_vacate(msp->ms_freeing,
-		    range_tree_add, msp->ms_freed);
+		zfs_range_tree_vacate(msp->ms_freeing,
+		    zfs_range_tree_add, msp->ms_freed);
 	}
-	msp->ms_allocated_this_txg += range_tree_space(alloctree);
-	range_tree_vacate(alloctree, NULL, NULL);
+	msp->ms_allocated_this_txg += zfs_range_tree_space(alloctree);
+	zfs_range_tree_vacate(alloctree, NULL, NULL);
 
-	ASSERT0(range_tree_space(msp->ms_allocating[txg & TXG_MASK]));
-	ASSERT0(range_tree_space(msp->ms_allocating[TXG_CLEAN(txg)
+	ASSERT0(zfs_range_tree_space(msp->ms_allocating[txg & TXG_MASK]));
+	ASSERT0(zfs_range_tree_space(msp->ms_allocating[TXG_CLEAN(txg)
 	    & TXG_MASK]));
-	ASSERT0(range_tree_space(msp->ms_freeing));
-	ASSERT0(range_tree_space(msp->ms_checkpointing));
+	ASSERT0(zfs_range_tree_space(msp->ms_freeing));
+	ASSERT0(zfs_range_tree_space(msp->ms_checkpointing));
 
 	mutex_exit(&msp->ms_lock);
 
@@ -4306,7 +4317,7 @@ metaslab_evict(metaslab_t *msp, uint64_t txg)
 		return;
 
 	for (int t = 1; t < TXG_CONCURRENT_STATES; t++) {
-		VERIFY0(range_tree_space(
+		VERIFY0(zfs_range_tree_space(
 		    msp->ms_allocating[(txg + t) & TXG_MASK]));
 	}
 	if (msp->ms_allocator != -1)
@@ -4326,7 +4337,7 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	metaslab_group_t *mg = msp->ms_group;
 	vdev_t *vd = mg->mg_vd;
 	spa_t *spa = vd->vdev_spa;
-	range_tree_t **defer_tree;
+	zfs_range_tree_t **defer_tree;
 	int64_t alloc_delta, defer_delta;
 	boolean_t defer_allowed = B_TRUE;
 
@@ -4340,11 +4351,11 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 
 		/* there should be no allocations nor frees at this point */
 		VERIFY0(msp->ms_allocated_this_txg);
-		VERIFY0(range_tree_space(msp->ms_freed));
+		VERIFY0(zfs_range_tree_space(msp->ms_freed));
 	}
 
-	ASSERT0(range_tree_space(msp->ms_freeing));
-	ASSERT0(range_tree_space(msp->ms_checkpointing));
+	ASSERT0(zfs_range_tree_space(msp->ms_freeing));
+	ASSERT0(zfs_range_tree_space(msp->ms_checkpointing));
 
 	defer_tree = &msp->ms_defer[txg % TXG_DEFER_SIZE];
 
@@ -4357,13 +4368,13 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 
 	defer_delta = 0;
 	alloc_delta = msp->ms_allocated_this_txg -
-	    range_tree_space(msp->ms_freed);
+	    zfs_range_tree_space(msp->ms_freed);
 
 	if (defer_allowed) {
-		defer_delta = range_tree_space(msp->ms_freed) -
-		    range_tree_space(*defer_tree);
+		defer_delta = zfs_range_tree_space(msp->ms_freed) -
+		    zfs_range_tree_space(*defer_tree);
 	} else {
-		defer_delta -= range_tree_space(*defer_tree);
+		defer_delta -= zfs_range_tree_space(*defer_tree);
 	}
 	metaslab_space_update(vd, mg->mg_class, alloc_delta + defer_delta,
 	    defer_delta, 0);
@@ -4390,13 +4401,14 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	 * frees not being trimmed.
 	 */
 	if (spa_get_autotrim(spa) == SPA_AUTOTRIM_ON) {
-		range_tree_walk(*defer_tree, range_tree_add, msp->ms_trim);
+		zfs_range_tree_walk(*defer_tree, zfs_range_tree_add,
+		    msp->ms_trim);
 		if (!defer_allowed) {
-			range_tree_walk(msp->ms_freed, range_tree_add,
+			zfs_range_tree_walk(msp->ms_freed, zfs_range_tree_add,
 			    msp->ms_trim);
 		}
 	} else {
-		range_tree_vacate(msp->ms_trim, NULL, NULL);
+		zfs_range_tree_vacate(msp->ms_trim, NULL, NULL);
 	}
 
 	/*
@@ -4405,13 +4417,13 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	 * the defer_tree -- this is safe to do because we've
 	 * just emptied out the defer_tree.
 	 */
-	range_tree_vacate(*defer_tree,
-	    msp->ms_loaded ? range_tree_add : NULL, msp->ms_allocatable);
+	zfs_range_tree_vacate(*defer_tree,
+	    msp->ms_loaded ? zfs_range_tree_add : NULL, msp->ms_allocatable);
 	if (defer_allowed) {
-		range_tree_swap(&msp->ms_freed, defer_tree);
+		zfs_range_tree_swap(&msp->ms_freed, defer_tree);
 	} else {
-		range_tree_vacate(msp->ms_freed,
-		    msp->ms_loaded ? range_tree_add : NULL,
+		zfs_range_tree_vacate(msp->ms_freed,
+		    msp->ms_loaded ? zfs_range_tree_add : NULL,
 		    msp->ms_allocatable);
 	}
 
@@ -4442,10 +4454,10 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	 */
 	metaslab_recalculate_weight_and_sort(msp);
 
-	ASSERT0(range_tree_space(msp->ms_allocating[txg & TXG_MASK]));
-	ASSERT0(range_tree_space(msp->ms_freeing));
-	ASSERT0(range_tree_space(msp->ms_freed));
-	ASSERT0(range_tree_space(msp->ms_checkpointing));
+	ASSERT0(zfs_range_tree_space(msp->ms_allocating[txg & TXG_MASK]));
+	ASSERT0(zfs_range_tree_space(msp->ms_freeing));
+	ASSERT0(zfs_range_tree_space(msp->ms_freed));
+	ASSERT0(zfs_range_tree_space(msp->ms_checkpointing));
 	msp->ms_allocating_total -= msp->ms_allocated_this_txg;
 	msp->ms_allocated_this_txg = 0;
 	mutex_exit(&msp->ms_lock);
@@ -4653,7 +4665,7 @@ static uint64_t
 metaslab_block_alloc(metaslab_t *msp, uint64_t size, uint64_t txg)
 {
 	uint64_t start;
-	range_tree_t *rt = msp->ms_allocatable;
+	zfs_range_tree_t *rt = msp->ms_allocatable;
 	metaslab_class_t *mc = msp->ms_group->mg_class;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
@@ -4668,14 +4680,15 @@ metaslab_block_alloc(metaslab_t *msp, uint64_t size, uint64_t txg)
 
 		VERIFY0(P2PHASE(start, 1ULL << vd->vdev_ashift));
 		VERIFY0(P2PHASE(size, 1ULL << vd->vdev_ashift));
-		VERIFY3U(range_tree_space(rt) - size, <=, msp->ms_size);
-		range_tree_remove(rt, start, size);
-		range_tree_clear(msp->ms_trim, start, size);
+		VERIFY3U(zfs_range_tree_space(rt) - size, <=, msp->ms_size);
+		zfs_range_tree_remove(rt, start, size);
+		zfs_range_tree_clear(msp->ms_trim, start, size);
 
-		if (range_tree_is_empty(msp->ms_allocating[txg & TXG_MASK]))
+		if (zfs_range_tree_is_empty(msp->ms_allocating[txg & TXG_MASK]))
 			vdev_dirty(mg->mg_vd, VDD_METASLAB, msp, txg);
 
-		range_tree_add(msp->ms_allocating[txg & TXG_MASK], start, size);
+		zfs_range_tree_add(msp->ms_allocating[txg & TXG_MASK], start,
+		    size);
 		msp->ms_allocating_total += size;
 
 		/* Track the last successful allocation */
@@ -5395,16 +5408,16 @@ metaslab_free_concrete(vdev_t *vd, uint64_t offset, uint64_t asize,
 	metaslab_check_free_impl(vd, offset, asize);
 
 	mutex_enter(&msp->ms_lock);
-	if (range_tree_is_empty(msp->ms_freeing) &&
-	    range_tree_is_empty(msp->ms_checkpointing)) {
+	if (zfs_range_tree_is_empty(msp->ms_freeing) &&
+	    zfs_range_tree_is_empty(msp->ms_checkpointing)) {
 		vdev_dirty(vd, VDD_METASLAB, msp, spa_syncing_txg(spa));
 	}
 
 	if (checkpoint) {
 		ASSERT(spa_has_checkpoint(spa));
-		range_tree_add(msp->ms_checkpointing, offset, asize);
+		zfs_range_tree_add(msp->ms_checkpointing, offset, asize);
 	} else {
-		range_tree_add(msp->ms_freeing, offset, asize);
+		zfs_range_tree_add(msp->ms_freeing, offset, asize);
 	}
 	mutex_exit(&msp->ms_lock);
 }
@@ -5628,18 +5641,18 @@ metaslab_unalloc_dva(spa_t *spa, const dva_t *dva, uint64_t txg)
 	msp = vd->vdev_ms[offset >> vd->vdev_ms_shift];
 
 	mutex_enter(&msp->ms_lock);
-	range_tree_remove(msp->ms_allocating[txg & TXG_MASK],
+	zfs_range_tree_remove(msp->ms_allocating[txg & TXG_MASK],
 	    offset, size);
 	msp->ms_allocating_total -= size;
 
 	VERIFY(!msp->ms_condensing);
 	VERIFY3U(offset, >=, msp->ms_start);
 	VERIFY3U(offset + size, <=, msp->ms_start + msp->ms_size);
-	VERIFY3U(range_tree_space(msp->ms_allocatable) + size, <=,
+	VERIFY3U(zfs_range_tree_space(msp->ms_allocatable) + size, <=,
 	    msp->ms_size);
 	VERIFY0(P2PHASE(offset, 1ULL << vd->vdev_ashift));
 	VERIFY0(P2PHASE(size, 1ULL << vd->vdev_ashift));
-	range_tree_add(msp->ms_allocatable, offset, size);
+	zfs_range_tree_add(msp->ms_allocatable, offset, size);
 	mutex_exit(&msp->ms_lock);
 }
 
@@ -5735,7 +5748,7 @@ metaslab_claim_concrete(vdev_t *vd, uint64_t offset, uint64_t size,
 	}
 
 	if (error == 0 &&
-	    !range_tree_contains(msp->ms_allocatable, offset, size))
+	    !zfs_range_tree_contains(msp->ms_allocatable, offset, size))
 		error = SET_ERROR(ENOENT);
 
 	if (error || txg == 0) {	/* txg == 0 indicates dry run */
@@ -5746,10 +5759,10 @@ metaslab_claim_concrete(vdev_t *vd, uint64_t offset, uint64_t size,
 	VERIFY(!msp->ms_condensing);
 	VERIFY0(P2PHASE(offset, 1ULL << vd->vdev_ashift));
 	VERIFY0(P2PHASE(size, 1ULL << vd->vdev_ashift));
-	VERIFY3U(range_tree_space(msp->ms_allocatable) - size, <=,
+	VERIFY3U(zfs_range_tree_space(msp->ms_allocatable) - size, <=,
 	    msp->ms_size);
-	range_tree_remove(msp->ms_allocatable, offset, size);
-	range_tree_clear(msp->ms_trim, offset, size);
+	zfs_range_tree_remove(msp->ms_allocatable, offset, size);
+	zfs_range_tree_clear(msp->ms_trim, offset, size);
 
 	if (spa_writeable(spa)) {	/* don't dirty if we're zdb(8) */
 		metaslab_class_t *mc = msp->ms_group->mg_class;
@@ -5761,9 +5774,9 @@ metaslab_claim_concrete(vdev_t *vd, uint64_t offset, uint64_t size,
 		}
 		multilist_sublist_unlock(mls);
 
-		if (range_tree_is_empty(msp->ms_allocating[txg & TXG_MASK]))
+		if (zfs_range_tree_is_empty(msp->ms_allocating[txg & TXG_MASK]))
 			vdev_dirty(vd, VDD_METASLAB, msp, txg);
-		range_tree_add(msp->ms_allocating[txg & TXG_MASK],
+		zfs_range_tree_add(msp->ms_allocating[txg & TXG_MASK],
 		    offset, size);
 		msp->ms_allocating_total += size;
 	}
@@ -6020,7 +6033,7 @@ metaslab_check_free_impl(vdev_t *vd, uint64_t offset, uint64_t size)
 
 	mutex_enter(&msp->ms_lock);
 	if (msp->ms_loaded) {
-		range_tree_verify_not_present(msp->ms_allocatable,
+		zfs_range_tree_verify_not_present(msp->ms_allocatable,
 		    offset, size);
 	}
 
@@ -6032,15 +6045,16 @@ metaslab_check_free_impl(vdev_t *vd, uint64_t offset, uint64_t size)
 	 * allocated and freed in the same sync pass within the same txg.
 	 * Unfortunately there are places (e.g. the ZIL) where we allocate a
 	 * segment but then we free part of it within the same txg
-	 * [see zil_sync()]. Thus, we don't call range_tree_verify() in the
+	 * [see zil_sync()]. Thus, we don't call zfs_range_tree_verify() in the
 	 * current allocating tree.
 	 */
-	range_tree_verify_not_present(msp->ms_freeing, offset, size);
-	range_tree_verify_not_present(msp->ms_checkpointing, offset, size);
-	range_tree_verify_not_present(msp->ms_freed, offset, size);
+	zfs_range_tree_verify_not_present(msp->ms_freeing, offset, size);
+	zfs_range_tree_verify_not_present(msp->ms_checkpointing, offset, size);
+	zfs_range_tree_verify_not_present(msp->ms_freed, offset, size);
 	for (int j = 0; j < TXG_DEFER_SIZE; j++)
-		range_tree_verify_not_present(msp->ms_defer[j], offset, size);
-	range_tree_verify_not_present(msp->ms_trim, offset, size);
+		zfs_range_tree_verify_not_present(msp->ms_defer[j], offset,
+		    size);
+	zfs_range_tree_verify_not_present(msp->ms_trim, offset, size);
 	mutex_exit(&msp->ms_lock);
 }
 

--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -42,11 +42,11 @@
  * splitting in response to range add/remove requests.
  *
  * A range tree starts out completely empty, with no segments in it.
- * Adding an allocation via range_tree_add to the range tree can either:
+ * Adding an allocation via zfs_range_tree_add to the range tree can either:
  * 1) create a new extent
  * 2) extend an adjacent extent
  * 3) merge two adjacent extents
- * Conversely, removing an allocation via range_tree_remove can:
+ * Conversely, removing an allocation via zfs_range_tree_remove can:
  * 1) completely remove an extent
  * 2) shorten an extent (if the allocation was near one of its ends)
  * 3) split an extent into two extents, in effect punching a hole
@@ -54,16 +54,16 @@
  * A range tree is also capable of 'bridging' gaps when adding
  * allocations. This is useful for cases when close proximity of
  * allocations is an important detail that needs to be represented
- * in the range tree. See range_tree_set_gap(). The default behavior
+ * in the range tree. See zfs_range_tree_set_gap(). The default behavior
  * is not to bridge gaps (i.e. the maximum allowed gap size is 0).
  *
- * In order to traverse a range tree, use either the range_tree_walk()
- * or range_tree_vacate() functions.
+ * In order to traverse a range tree, use either the zfs_range_tree_walk()
+ * or zfs_range_tree_vacate() functions.
  *
  * To obtain more accurate information on individual segment
  * operations that the range tree performs "under the hood", you can
- * specify a set of callbacks by passing a range_tree_ops_t structure
- * to the range_tree_create function. Any callbacks that are non-NULL
+ * specify a set of callbacks by passing a zfs_range_tree_ops_t structure
+ * to the zfs_range_tree_create function. Any callbacks that are non-NULL
  * are then called at the appropriate times.
  *
  * The range tree code also supports a special variant of range trees
@@ -76,18 +76,18 @@
  */
 
 static inline void
-rs_copy(range_seg_t *src, range_seg_t *dest, range_tree_t *rt)
+zfs_rs_copy(zfs_range_seg_t *src, zfs_range_seg_t *dest, zfs_range_tree_t *rt)
 {
-	ASSERT3U(rt->rt_type, <, RANGE_SEG_NUM_TYPES);
+	ASSERT3U(rt->rt_type, <, ZFS_RANGE_SEG_NUM_TYPES);
 	size_t size = 0;
 	switch (rt->rt_type) {
-	case RANGE_SEG32:
+	case ZFS_RANGE_SEG32:
 		size = sizeof (range_seg32_t);
 		break;
-	case RANGE_SEG64:
+	case ZFS_RANGE_SEG64:
 		size = sizeof (range_seg64_t);
 		break;
-	case RANGE_SEG_GAP:
+	case ZFS_RANGE_SEG_GAP:
 		size = sizeof (range_seg_gap_t);
 		break;
 	default:
@@ -97,16 +97,17 @@ rs_copy(range_seg_t *src, range_seg_t *dest, range_tree_t *rt)
 }
 
 void
-range_tree_stat_verify(range_tree_t *rt)
+zfs_range_tree_stat_verify(zfs_range_tree_t *rt)
 {
-	range_seg_t *rs;
+	zfs_range_seg_t *rs;
 	zfs_btree_index_t where;
 	uint64_t hist[RANGE_TREE_HISTOGRAM_SIZE] = { 0 };
 	int i;
 
 	for (rs = zfs_btree_first(&rt->rt_root, &where); rs != NULL;
 	    rs = zfs_btree_next(&rt->rt_root, &where, &where)) {
-		uint64_t size = rs_get_end(rs, rt) - rs_get_start(rs, rt);
+		uint64_t size = zfs_rs_get_end(rs, rt) -
+		    zfs_rs_get_start(rs, rt);
 		int idx	= highbit64(size) - 1;
 
 		hist[idx]++;
@@ -124,9 +125,9 @@ range_tree_stat_verify(range_tree_t *rt)
 }
 
 static void
-range_tree_stat_incr(range_tree_t *rt, range_seg_t *rs)
+zfs_range_tree_stat_incr(zfs_range_tree_t *rt, zfs_range_seg_t *rs)
 {
-	uint64_t size = rs_get_end(rs, rt) - rs_get_start(rs, rt);
+	uint64_t size = zfs_rs_get_end(rs, rt) - zfs_rs_get_start(rs, rt);
 	int idx = highbit64(size) - 1;
 
 	ASSERT(size != 0);
@@ -138,9 +139,9 @@ range_tree_stat_incr(range_tree_t *rt, range_seg_t *rs)
 }
 
 static void
-range_tree_stat_decr(range_tree_t *rt, range_seg_t *rs)
+zfs_range_tree_stat_decr(zfs_range_tree_t *rt, zfs_range_seg_t *rs)
 {
-	uint64_t size = rs_get_end(rs, rt) - rs_get_start(rs, rt);
+	uint64_t size = zfs_rs_get_end(rs, rt) - zfs_rs_get_start(rs, rt);
 	int idx = highbit64(size) - 1;
 
 	ASSERT(size != 0);
@@ -153,7 +154,7 @@ range_tree_stat_decr(range_tree_t *rt, range_seg_t *rs)
 
 __attribute__((always_inline)) inline
 static int
-range_tree_seg32_compare(const void *x1, const void *x2)
+zfs_range_tree_seg32_compare(const void *x1, const void *x2)
 {
 	const range_seg32_t *r1 = x1;
 	const range_seg32_t *r2 = x2;
@@ -166,7 +167,7 @@ range_tree_seg32_compare(const void *x1, const void *x2)
 
 __attribute__((always_inline)) inline
 static int
-range_tree_seg64_compare(const void *x1, const void *x2)
+zfs_range_tree_seg64_compare(const void *x1, const void *x2)
 {
 	const range_seg64_t *r1 = x1;
 	const range_seg64_t *r2 = x2;
@@ -179,7 +180,7 @@ range_tree_seg64_compare(const void *x1, const void *x2)
 
 __attribute__((always_inline)) inline
 static int
-range_tree_seg_gap_compare(const void *x1, const void *x2)
+zfs_range_tree_seg_gap_compare(const void *x1, const void *x2)
 {
 	const range_seg_gap_t *r1 = x1;
 	const range_seg_gap_t *r2 = x2;
@@ -190,41 +191,42 @@ range_tree_seg_gap_compare(const void *x1, const void *x2)
 	return ((r1->rs_start >= r2->rs_end) - (r1->rs_end <= r2->rs_start));
 }
 
-ZFS_BTREE_FIND_IN_BUF_FUNC(range_tree_seg32_find_in_buf, range_seg32_t,
-    range_tree_seg32_compare)
+ZFS_BTREE_FIND_IN_BUF_FUNC(zfs_range_tree_seg32_find_in_buf, range_seg32_t,
+    zfs_range_tree_seg32_compare)
 
-ZFS_BTREE_FIND_IN_BUF_FUNC(range_tree_seg64_find_in_buf, range_seg64_t,
-    range_tree_seg64_compare)
+ZFS_BTREE_FIND_IN_BUF_FUNC(zfs_range_tree_seg64_find_in_buf, range_seg64_t,
+    zfs_range_tree_seg64_compare)
 
-ZFS_BTREE_FIND_IN_BUF_FUNC(range_tree_seg_gap_find_in_buf, range_seg_gap_t,
-    range_tree_seg_gap_compare)
+ZFS_BTREE_FIND_IN_BUF_FUNC(zfs_range_tree_seg_gap_find_in_buf, range_seg_gap_t,
+    zfs_range_tree_seg_gap_compare)
 
-range_tree_t *
-range_tree_create_gap(const range_tree_ops_t *ops, range_seg_type_t type,
-    void *arg, uint64_t start, uint64_t shift, uint64_t gap)
+zfs_range_tree_t *
+zfs_range_tree_create_gap(const zfs_range_tree_ops_t *ops,
+    zfs_range_seg_type_t type, void *arg, uint64_t start, uint64_t shift,
+    uint64_t gap)
 {
-	range_tree_t *rt = kmem_zalloc(sizeof (range_tree_t), KM_SLEEP);
+	zfs_range_tree_t *rt = kmem_zalloc(sizeof (zfs_range_tree_t), KM_SLEEP);
 
 	ASSERT3U(shift, <, 64);
-	ASSERT3U(type, <=, RANGE_SEG_NUM_TYPES);
+	ASSERT3U(type, <=, ZFS_RANGE_SEG_NUM_TYPES);
 	size_t size;
 	int (*compare) (const void *, const void *);
 	bt_find_in_buf_f bt_find;
 	switch (type) {
-	case RANGE_SEG32:
+	case ZFS_RANGE_SEG32:
 		size = sizeof (range_seg32_t);
-		compare = range_tree_seg32_compare;
-		bt_find = range_tree_seg32_find_in_buf;
+		compare = zfs_range_tree_seg32_compare;
+		bt_find = zfs_range_tree_seg32_find_in_buf;
 		break;
-	case RANGE_SEG64:
+	case ZFS_RANGE_SEG64:
 		size = sizeof (range_seg64_t);
-		compare = range_tree_seg64_compare;
-		bt_find = range_tree_seg64_find_in_buf;
+		compare = zfs_range_tree_seg64_compare;
+		bt_find = zfs_range_tree_seg64_find_in_buf;
 		break;
-	case RANGE_SEG_GAP:
+	case ZFS_RANGE_SEG_GAP:
 		size = sizeof (range_seg_gap_t);
-		compare = range_tree_seg_gap_compare;
-		bt_find = range_tree_seg_gap_find_in_buf;
+		compare = zfs_range_tree_seg_gap_compare;
+		bt_find = zfs_range_tree_seg_gap_find_in_buf;
 		break;
 	default:
 		panic("Invalid range seg type %d", type);
@@ -244,15 +246,15 @@ range_tree_create_gap(const range_tree_ops_t *ops, range_seg_type_t type,
 	return (rt);
 }
 
-range_tree_t *
-range_tree_create(const range_tree_ops_t *ops, range_seg_type_t type,
-    void *arg, uint64_t start, uint64_t shift)
+zfs_range_tree_t *
+zfs_range_tree_create(const zfs_range_tree_ops_t *ops,
+    zfs_range_seg_type_t type, void *arg, uint64_t start, uint64_t shift)
 {
-	return (range_tree_create_gap(ops, type, arg, start, shift, 0));
+	return (zfs_range_tree_create_gap(ops, type, arg, start, shift, 0));
 }
 
 void
-range_tree_destroy(range_tree_t *rt)
+zfs_range_tree_destroy(zfs_range_tree_t *rt)
 {
 	VERIFY0(rt->rt_space);
 
@@ -264,35 +266,36 @@ range_tree_destroy(range_tree_t *rt)
 }
 
 void
-range_tree_adjust_fill(range_tree_t *rt, range_seg_t *rs, int64_t delta)
+zfs_range_tree_adjust_fill(zfs_range_tree_t *rt, zfs_range_seg_t *rs,
+    int64_t delta)
 {
-	if (delta < 0 && delta * -1 >= rs_get_fill(rs, rt)) {
+	if (delta < 0 && delta * -1 >= zfs_rs_get_fill(rs, rt)) {
 		zfs_panic_recover("zfs: attempting to decrease fill to or "
 		    "below 0; probable double remove in segment [%llx:%llx]",
-		    (longlong_t)rs_get_start(rs, rt),
-		    (longlong_t)rs_get_end(rs, rt));
+		    (longlong_t)zfs_rs_get_start(rs, rt),
+		    (longlong_t)zfs_rs_get_end(rs, rt));
 	}
-	if (rs_get_fill(rs, rt) + delta > rs_get_end(rs, rt) -
-	    rs_get_start(rs, rt)) {
+	if (zfs_rs_get_fill(rs, rt) + delta > zfs_rs_get_end(rs, rt) -
+	    zfs_rs_get_start(rs, rt)) {
 		zfs_panic_recover("zfs: attempting to increase fill beyond "
 		    "max; probable double add in segment [%llx:%llx]",
-		    (longlong_t)rs_get_start(rs, rt),
-		    (longlong_t)rs_get_end(rs, rt));
+		    (longlong_t)zfs_rs_get_start(rs, rt),
+		    (longlong_t)zfs_rs_get_end(rs, rt));
 	}
 
 	if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
 		rt->rt_ops->rtop_remove(rt, rs, rt->rt_arg);
-	rs_set_fill(rs, rt, rs_get_fill(rs, rt) + delta);
+	zfs_rs_set_fill(rs, rt, zfs_rs_get_fill(rs, rt) + delta);
 	if (rt->rt_ops != NULL && rt->rt_ops->rtop_add != NULL)
 		rt->rt_ops->rtop_add(rt, rs, rt->rt_arg);
 }
 
 static void
-range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
+zfs_range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
 {
-	range_tree_t *rt = arg;
+	zfs_range_tree_t *rt = arg;
 	zfs_btree_index_t where;
-	range_seg_t *rs_before, *rs_after, *rs;
+	zfs_range_seg_t *rs_before, *rs_after, *rs;
 	range_seg_max_t tmp, rsearch;
 	uint64_t end = start + size, gap = rt->rt_gap;
 	uint64_t bridge_size = 0;
@@ -302,8 +305,8 @@ range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
 	ASSERT3U(fill, <=, size);
 	ASSERT3U(start + size, >, start);
 
-	rs_set_start(&rsearch, rt, start);
-	rs_set_end(&rsearch, rt, end);
+	zfs_rs_set_start(&rsearch, rt, start);
+	zfs_rs_set_end(&rsearch, rt, end);
 	rs = zfs_btree_find(&rt->rt_root, &rsearch, &where);
 
 	/*
@@ -321,26 +324,26 @@ range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
 			    (longlong_t)start, (longlong_t)size);
 			return;
 		}
-		uint64_t rstart = rs_get_start(rs, rt);
-		uint64_t rend = rs_get_end(rs, rt);
+		uint64_t rstart = zfs_rs_get_start(rs, rt);
+		uint64_t rend = zfs_rs_get_end(rs, rt);
 		if (rstart <= start && rend >= end) {
-			range_tree_adjust_fill(rt, rs, fill);
+			zfs_range_tree_adjust_fill(rt, rs, fill);
 			return;
 		}
 
 		if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
 			rt->rt_ops->rtop_remove(rt, rs, rt->rt_arg);
 
-		range_tree_stat_decr(rt, rs);
+		zfs_range_tree_stat_decr(rt, rs);
 		rt->rt_space -= rend - rstart;
 
-		fill += rs_get_fill(rs, rt);
+		fill += zfs_rs_get_fill(rs, rt);
 		start = MIN(start, rstart);
 		end = MAX(end, rend);
 		size = end - start;
 
 		zfs_btree_remove(&rt->rt_root, rs);
-		range_tree_add_impl(rt, start, size, fill);
+		zfs_range_tree_add_impl(rt, start, size, fill);
 		return;
 	}
 
@@ -355,15 +358,15 @@ range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
 	rs_before = zfs_btree_prev(&rt->rt_root, &where, &where_before);
 	rs_after = zfs_btree_next(&rt->rt_root, &where, &where_after);
 
-	merge_before = (rs_before != NULL && rs_get_end(rs_before, rt) >=
+	merge_before = (rs_before != NULL && zfs_rs_get_end(rs_before, rt) >=
 	    start - gap);
-	merge_after = (rs_after != NULL && rs_get_start(rs_after, rt) <= end +
-	    gap);
+	merge_after = (rs_after != NULL && zfs_rs_get_start(rs_after, rt) <=
+	    end + gap);
 
 	if (merge_before && gap != 0)
-		bridge_size += start - rs_get_end(rs_before, rt);
+		bridge_size += start - zfs_rs_get_end(rs_before, rt);
 	if (merge_after && gap != 0)
-		bridge_size += rs_get_start(rs_after, rt) - end;
+		bridge_size += zfs_rs_get_start(rs_after, rt) - end;
 
 	if (merge_before && merge_after) {
 		if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL) {
@@ -371,13 +374,13 @@ range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
 			rt->rt_ops->rtop_remove(rt, rs_after, rt->rt_arg);
 		}
 
-		range_tree_stat_decr(rt, rs_before);
-		range_tree_stat_decr(rt, rs_after);
+		zfs_range_tree_stat_decr(rt, rs_before);
+		zfs_range_tree_stat_decr(rt, rs_after);
 
-		rs_copy(rs_after, &tmp, rt);
-		uint64_t before_start = rs_get_start_raw(rs_before, rt);
-		uint64_t before_fill = rs_get_fill(rs_before, rt);
-		uint64_t after_fill = rs_get_fill(rs_after, rt);
+		zfs_rs_copy(rs_after, &tmp, rt);
+		uint64_t before_start = zfs_rs_get_start_raw(rs_before, rt);
+		uint64_t before_fill = zfs_rs_get_fill(rs_before, rt);
+		uint64_t after_fill = zfs_rs_get_fill(rs_after, rt);
 		zfs_btree_remove_idx(&rt->rt_root, &where_before);
 
 		/*
@@ -386,76 +389,76 @@ range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
 		 */
 		rs_after = zfs_btree_find(&rt->rt_root, &tmp, &where_after);
 		ASSERT3P(rs_after, !=, NULL);
-		rs_set_start_raw(rs_after, rt, before_start);
-		rs_set_fill(rs_after, rt, after_fill + before_fill + fill);
+		zfs_rs_set_start_raw(rs_after, rt, before_start);
+		zfs_rs_set_fill(rs_after, rt, after_fill + before_fill + fill);
 		rs = rs_after;
 	} else if (merge_before) {
 		if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
 			rt->rt_ops->rtop_remove(rt, rs_before, rt->rt_arg);
 
-		range_tree_stat_decr(rt, rs_before);
+		zfs_range_tree_stat_decr(rt, rs_before);
 
-		uint64_t before_fill = rs_get_fill(rs_before, rt);
-		rs_set_end(rs_before, rt, end);
-		rs_set_fill(rs_before, rt, before_fill + fill);
+		uint64_t before_fill = zfs_rs_get_fill(rs_before, rt);
+		zfs_rs_set_end(rs_before, rt, end);
+		zfs_rs_set_fill(rs_before, rt, before_fill + fill);
 		rs = rs_before;
 	} else if (merge_after) {
 		if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
 			rt->rt_ops->rtop_remove(rt, rs_after, rt->rt_arg);
 
-		range_tree_stat_decr(rt, rs_after);
+		zfs_range_tree_stat_decr(rt, rs_after);
 
-		uint64_t after_fill = rs_get_fill(rs_after, rt);
-		rs_set_start(rs_after, rt, start);
-		rs_set_fill(rs_after, rt, after_fill + fill);
+		uint64_t after_fill = zfs_rs_get_fill(rs_after, rt);
+		zfs_rs_set_start(rs_after, rt, start);
+		zfs_rs_set_fill(rs_after, rt, after_fill + fill);
 		rs = rs_after;
 	} else {
 		rs = &tmp;
 
-		rs_set_start(rs, rt, start);
-		rs_set_end(rs, rt, end);
-		rs_set_fill(rs, rt, fill);
+		zfs_rs_set_start(rs, rt, start);
+		zfs_rs_set_end(rs, rt, end);
+		zfs_rs_set_fill(rs, rt, fill);
 		zfs_btree_add_idx(&rt->rt_root, rs, &where);
 	}
 
 	if (gap != 0) {
-		ASSERT3U(rs_get_fill(rs, rt), <=, rs_get_end(rs, rt) -
-		    rs_get_start(rs, rt));
+		ASSERT3U(zfs_rs_get_fill(rs, rt), <=, zfs_rs_get_end(rs, rt) -
+		    zfs_rs_get_start(rs, rt));
 	} else {
-		ASSERT3U(rs_get_fill(rs, rt), ==, rs_get_end(rs, rt) -
-		    rs_get_start(rs, rt));
+		ASSERT3U(zfs_rs_get_fill(rs, rt), ==, zfs_rs_get_end(rs, rt) -
+		    zfs_rs_get_start(rs, rt));
 	}
 
 	if (rt->rt_ops != NULL && rt->rt_ops->rtop_add != NULL)
 		rt->rt_ops->rtop_add(rt, rs, rt->rt_arg);
 
-	range_tree_stat_incr(rt, rs);
+	zfs_range_tree_stat_incr(rt, rs);
 	rt->rt_space += size + bridge_size;
 }
 
 void
-range_tree_add(void *arg, uint64_t start, uint64_t size)
+zfs_range_tree_add(void *arg, uint64_t start, uint64_t size)
 {
-	range_tree_add_impl(arg, start, size, size);
+	zfs_range_tree_add_impl(arg, start, size, size);
 }
 
 static void
-range_tree_remove_impl(range_tree_t *rt, uint64_t start, uint64_t size,
+zfs_range_tree_remove_impl(zfs_range_tree_t *rt, uint64_t start, uint64_t size,
     boolean_t do_fill)
 {
 	zfs_btree_index_t where;
-	range_seg_t *rs;
+	zfs_range_seg_t *rs;
 	range_seg_max_t rsearch, rs_tmp;
 	uint64_t end = start + size;
 	boolean_t left_over, right_over;
 
 	VERIFY3U(size, !=, 0);
 	VERIFY3U(size, <=, rt->rt_space);
-	if (rt->rt_type == RANGE_SEG64)
+	if (rt->rt_type == ZFS_RANGE_SEG64)
 		ASSERT3U(start + size, >, start);
 
-	rs_set_start(&rsearch, rt, start);
-	rs_set_end(&rsearch, rt, end);
+	zfs_rs_set_start(&rsearch, rt, start);
+	zfs_rs_set_end(&rsearch, rt, end);
 	rs = zfs_btree_find(&rt->rt_root, &rsearch, &where);
 
 	/* Make sure we completely overlap with someone */
@@ -474,49 +477,49 @@ range_tree_remove_impl(range_tree_t *rt, uint64_t start, uint64_t size,
 	 */
 	if (rt->rt_gap != 0) {
 		if (do_fill) {
-			if (rs_get_fill(rs, rt) == size) {
-				start = rs_get_start(rs, rt);
-				end = rs_get_end(rs, rt);
+			if (zfs_rs_get_fill(rs, rt) == size) {
+				start = zfs_rs_get_start(rs, rt);
+				end = zfs_rs_get_end(rs, rt);
 				size = end - start;
 			} else {
-				range_tree_adjust_fill(rt, rs, -size);
+				zfs_range_tree_adjust_fill(rt, rs, -size);
 				return;
 			}
-		} else if (rs_get_start(rs, rt) != start ||
-		    rs_get_end(rs, rt) != end) {
+		} else if (zfs_rs_get_start(rs, rt) != start ||
+		    zfs_rs_get_end(rs, rt) != end) {
 			zfs_panic_recover("zfs: freeing partial segment of "
 			    "gap tree (offset=%llx size=%llx) of "
 			    "(offset=%llx size=%llx)",
 			    (longlong_t)start, (longlong_t)size,
-			    (longlong_t)rs_get_start(rs, rt),
-			    (longlong_t)rs_get_end(rs, rt) - rs_get_start(rs,
-			    rt));
+			    (longlong_t)zfs_rs_get_start(rs, rt),
+			    (longlong_t)zfs_rs_get_end(rs, rt) -
+			    zfs_rs_get_start(rs, rt));
 			return;
 		}
 	}
 
-	VERIFY3U(rs_get_start(rs, rt), <=, start);
-	VERIFY3U(rs_get_end(rs, rt), >=, end);
+	VERIFY3U(zfs_rs_get_start(rs, rt), <=, start);
+	VERIFY3U(zfs_rs_get_end(rs, rt), >=, end);
 
-	left_over = (rs_get_start(rs, rt) != start);
-	right_over = (rs_get_end(rs, rt) != end);
+	left_over = (zfs_rs_get_start(rs, rt) != start);
+	right_over = (zfs_rs_get_end(rs, rt) != end);
 
-	range_tree_stat_decr(rt, rs);
+	zfs_range_tree_stat_decr(rt, rs);
 
 	if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
 		rt->rt_ops->rtop_remove(rt, rs, rt->rt_arg);
 
 	if (left_over && right_over) {
 		range_seg_max_t newseg;
-		rs_set_start(&newseg, rt, end);
-		rs_set_end_raw(&newseg, rt, rs_get_end_raw(rs, rt));
-		rs_set_fill(&newseg, rt, rs_get_end(rs, rt) - end);
-		range_tree_stat_incr(rt, &newseg);
+		zfs_rs_set_start(&newseg, rt, end);
+		zfs_rs_set_end_raw(&newseg, rt, zfs_rs_get_end_raw(rs, rt));
+		zfs_rs_set_fill(&newseg, rt, zfs_rs_get_end(rs, rt) - end);
+		zfs_range_tree_stat_incr(rt, &newseg);
 
 		// This modifies the buffer already inside the range tree
-		rs_set_end(rs, rt, start);
+		zfs_rs_set_end(rs, rt, start);
 
-		rs_copy(rs, &rs_tmp, rt);
+		zfs_rs_copy(rs, &rs_tmp, rt);
 		if (zfs_btree_next(&rt->rt_root, &where, &where) != NULL)
 			zfs_btree_add_idx(&rt->rt_root, &newseg, &where);
 		else
@@ -526,12 +529,12 @@ range_tree_remove_impl(range_tree_t *rt, uint64_t start, uint64_t size,
 			rt->rt_ops->rtop_add(rt, &newseg, rt->rt_arg);
 	} else if (left_over) {
 		// This modifies the buffer already inside the range tree
-		rs_set_end(rs, rt, start);
-		rs_copy(rs, &rs_tmp, rt);
+		zfs_rs_set_end(rs, rt, start);
+		zfs_rs_copy(rs, &rs_tmp, rt);
 	} else if (right_over) {
 		// This modifies the buffer already inside the range tree
-		rs_set_start(rs, rt, end);
-		rs_copy(rs, &rs_tmp, rt);
+		zfs_rs_set_start(rs, rt, end);
+		zfs_rs_copy(rs, &rs_tmp, rt);
 	} else {
 		zfs_btree_remove_idx(&rt->rt_root, &where);
 		rs = NULL;
@@ -543,9 +546,9 @@ range_tree_remove_impl(range_tree_t *rt, uint64_t start, uint64_t size,
 		 * the size, since we do not support removing partial segments
 		 * of range trees with gaps.
 		 */
-		rs_set_fill_raw(rs, rt, rs_get_end_raw(rs, rt) -
-		    rs_get_start_raw(rs, rt));
-		range_tree_stat_incr(rt, &rs_tmp);
+		zfs_zfs_rs_set_fill_raw(rs, rt, zfs_rs_get_end_raw(rs, rt) -
+		    zfs_rs_get_start_raw(rs, rt));
+		zfs_range_tree_stat_incr(rt, &rs_tmp);
 
 		if (rt->rt_ops != NULL && rt->rt_ops->rtop_add != NULL)
 			rt->rt_ops->rtop_add(rt, &rs_tmp, rt->rt_arg);
@@ -555,76 +558,78 @@ range_tree_remove_impl(range_tree_t *rt, uint64_t start, uint64_t size,
 }
 
 void
-range_tree_remove(void *arg, uint64_t start, uint64_t size)
+zfs_range_tree_remove(void *arg, uint64_t start, uint64_t size)
 {
-	range_tree_remove_impl(arg, start, size, B_FALSE);
+	zfs_range_tree_remove_impl(arg, start, size, B_FALSE);
 }
 
 void
-range_tree_remove_fill(range_tree_t *rt, uint64_t start, uint64_t size)
+zfs_range_tree_remove_fill(zfs_range_tree_t *rt, uint64_t start, uint64_t size)
 {
-	range_tree_remove_impl(rt, start, size, B_TRUE);
+	zfs_range_tree_remove_impl(rt, start, size, B_TRUE);
 }
 
 void
-range_tree_resize_segment(range_tree_t *rt, range_seg_t *rs,
+zfs_range_tree_resize_segment(zfs_range_tree_t *rt, zfs_range_seg_t *rs,
     uint64_t newstart, uint64_t newsize)
 {
-	int64_t delta = newsize - (rs_get_end(rs, rt) - rs_get_start(rs, rt));
+	int64_t delta = newsize - (zfs_rs_get_end(rs, rt) -
+	    zfs_rs_get_start(rs, rt));
 
-	range_tree_stat_decr(rt, rs);
+	zfs_range_tree_stat_decr(rt, rs);
 	if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
 		rt->rt_ops->rtop_remove(rt, rs, rt->rt_arg);
 
-	rs_set_start(rs, rt, newstart);
-	rs_set_end(rs, rt, newstart + newsize);
+	zfs_rs_set_start(rs, rt, newstart);
+	zfs_rs_set_end(rs, rt, newstart + newsize);
 
-	range_tree_stat_incr(rt, rs);
+	zfs_range_tree_stat_incr(rt, rs);
 	if (rt->rt_ops != NULL && rt->rt_ops->rtop_add != NULL)
 		rt->rt_ops->rtop_add(rt, rs, rt->rt_arg);
 
 	rt->rt_space += delta;
 }
 
-static range_seg_t *
-range_tree_find_impl(range_tree_t *rt, uint64_t start, uint64_t size)
+static zfs_range_seg_t *
+zfs_range_tree_find_impl(zfs_range_tree_t *rt, uint64_t start, uint64_t size)
 {
 	range_seg_max_t rsearch;
 	uint64_t end = start + size;
 
 	VERIFY(size != 0);
 
-	rs_set_start(&rsearch, rt, start);
-	rs_set_end(&rsearch, rt, end);
+	zfs_rs_set_start(&rsearch, rt, start);
+	zfs_rs_set_end(&rsearch, rt, end);
 	return (zfs_btree_find(&rt->rt_root, &rsearch, NULL));
 }
 
-range_seg_t *
-range_tree_find(range_tree_t *rt, uint64_t start, uint64_t size)
+zfs_range_seg_t *
+zfs_range_tree_find(zfs_range_tree_t *rt, uint64_t start, uint64_t size)
 {
-	if (rt->rt_type == RANGE_SEG64)
+	if (rt->rt_type == ZFS_RANGE_SEG64)
 		ASSERT3U(start + size, >, start);
 
-	range_seg_t *rs = range_tree_find_impl(rt, start, size);
-	if (rs != NULL && rs_get_start(rs, rt) <= start &&
-	    rs_get_end(rs, rt) >= start + size) {
+	zfs_range_seg_t *rs = zfs_range_tree_find_impl(rt, start, size);
+	if (rs != NULL && zfs_rs_get_start(rs, rt) <= start &&
+	    zfs_rs_get_end(rs, rt) >= start + size) {
 		return (rs);
 	}
 	return (NULL);
 }
 
 void
-range_tree_verify_not_present(range_tree_t *rt, uint64_t off, uint64_t size)
+zfs_range_tree_verify_not_present(zfs_range_tree_t *rt, uint64_t off,
+    uint64_t size)
 {
-	range_seg_t *rs = range_tree_find(rt, off, size);
+	zfs_range_seg_t *rs = zfs_range_tree_find(rt, off, size);
 	if (rs != NULL)
 		panic("segment already in tree; rs=%p", (void *)rs);
 }
 
 boolean_t
-range_tree_contains(range_tree_t *rt, uint64_t start, uint64_t size)
+zfs_range_tree_contains(zfs_range_tree_t *rt, uint64_t start, uint64_t size)
 {
-	return (range_tree_find(rt, start, size) != NULL);
+	return (zfs_range_tree_find(rt, start, size) != NULL);
 }
 
 /*
@@ -633,31 +638,32 @@ range_tree_contains(range_tree_t *rt, uint64_t start, uint64_t size)
  * isn't.
  */
 boolean_t
-range_tree_find_in(range_tree_t *rt, uint64_t start, uint64_t size,
+zfs_range_tree_find_in(zfs_range_tree_t *rt, uint64_t start, uint64_t size,
     uint64_t *ostart, uint64_t *osize)
 {
-	if (rt->rt_type == RANGE_SEG64)
+	if (rt->rt_type == ZFS_RANGE_SEG64)
 		ASSERT3U(start + size, >, start);
 
 	range_seg_max_t rsearch;
-	rs_set_start(&rsearch, rt, start);
-	rs_set_end_raw(&rsearch, rt, rs_get_start_raw(&rsearch, rt) + 1);
+	zfs_rs_set_start(&rsearch, rt, start);
+	zfs_rs_set_end_raw(&rsearch, rt, zfs_rs_get_start_raw(&rsearch, rt) +
+	    1);
 
 	zfs_btree_index_t where;
-	range_seg_t *rs = zfs_btree_find(&rt->rt_root, &rsearch, &where);
+	zfs_range_seg_t *rs = zfs_btree_find(&rt->rt_root, &rsearch, &where);
 	if (rs != NULL) {
 		*ostart = start;
-		*osize = MIN(size, rs_get_end(rs, rt) - start);
+		*osize = MIN(size, zfs_rs_get_end(rs, rt) - start);
 		return (B_TRUE);
 	}
 
 	rs = zfs_btree_next(&rt->rt_root, &where, &where);
-	if (rs == NULL || rs_get_start(rs, rt) > start + size)
+	if (rs == NULL || zfs_rs_get_start(rs, rt) > start + size)
 		return (B_FALSE);
 
-	*ostart = rs_get_start(rs, rt);
-	*osize = MIN(start + size, rs_get_end(rs, rt)) -
-	    rs_get_start(rs, rt);
+	*ostart = zfs_rs_get_start(rs, rt);
+	*osize = MIN(start + size, zfs_rs_get_end(rs, rt)) -
+	    zfs_rs_get_start(rs, rt);
 	return (B_TRUE);
 }
 
@@ -666,29 +672,29 @@ range_tree_find_in(range_tree_t *rt, uint64_t start, uint64_t size,
  * it is currently in the tree.
  */
 void
-range_tree_clear(range_tree_t *rt, uint64_t start, uint64_t size)
+zfs_range_tree_clear(zfs_range_tree_t *rt, uint64_t start, uint64_t size)
 {
-	range_seg_t *rs;
+	zfs_range_seg_t *rs;
 
 	if (size == 0)
 		return;
 
-	if (rt->rt_type == RANGE_SEG64)
+	if (rt->rt_type == ZFS_RANGE_SEG64)
 		ASSERT3U(start + size, >, start);
 
-	while ((rs = range_tree_find_impl(rt, start, size)) != NULL) {
-		uint64_t free_start = MAX(rs_get_start(rs, rt), start);
-		uint64_t free_end = MIN(rs_get_end(rs, rt), start + size);
-		range_tree_remove(rt, free_start, free_end - free_start);
+	while ((rs = zfs_range_tree_find_impl(rt, start, size)) != NULL) {
+		uint64_t free_start = MAX(zfs_rs_get_start(rs, rt), start);
+		uint64_t free_end = MIN(zfs_rs_get_end(rs, rt), start + size);
+		zfs_range_tree_remove(rt, free_start, free_end - free_start);
 	}
 }
 
 void
-range_tree_swap(range_tree_t **rtsrc, range_tree_t **rtdst)
+zfs_range_tree_swap(zfs_range_tree_t **rtsrc, zfs_range_tree_t **rtdst)
 {
-	range_tree_t *rt;
+	zfs_range_tree_t *rt;
 
-	ASSERT0(range_tree_space(*rtdst));
+	ASSERT0(zfs_range_tree_space(*rtdst));
 	ASSERT0(zfs_btree_numnodes(&(*rtdst)->rt_root));
 
 	rt = *rtsrc;
@@ -697,19 +703,20 @@ range_tree_swap(range_tree_t **rtsrc, range_tree_t **rtdst)
 }
 
 void
-range_tree_vacate(range_tree_t *rt, range_tree_func_t *func, void *arg)
+zfs_range_tree_vacate(zfs_range_tree_t *rt, zfs_range_tree_func_t *func,
+    void *arg)
 {
 	if (rt->rt_ops != NULL && rt->rt_ops->rtop_vacate != NULL)
 		rt->rt_ops->rtop_vacate(rt, rt->rt_arg);
 
 	if (func != NULL) {
-		range_seg_t *rs;
+		zfs_range_seg_t *rs;
 		zfs_btree_index_t *cookie = NULL;
 
 		while ((rs = zfs_btree_destroy_nodes(&rt->rt_root, &cookie)) !=
 		    NULL) {
-			func(arg, rs_get_start(rs, rt), rs_get_end(rs, rt) -
-			    rs_get_start(rs, rt));
+			func(arg, zfs_rs_get_start(rs, rt),
+			    zfs_rs_get_end(rs, rt) - zfs_rs_get_start(rs, rt));
 		}
 	} else {
 		zfs_btree_clear(&rt->rt_root);
@@ -720,39 +727,40 @@ range_tree_vacate(range_tree_t *rt, range_tree_func_t *func, void *arg)
 }
 
 void
-range_tree_walk(range_tree_t *rt, range_tree_func_t *func, void *arg)
+zfs_range_tree_walk(zfs_range_tree_t *rt, zfs_range_tree_func_t *func,
+    void *arg)
 {
 	zfs_btree_index_t where;
-	for (range_seg_t *rs = zfs_btree_first(&rt->rt_root, &where);
+	for (zfs_range_seg_t *rs = zfs_btree_first(&rt->rt_root, &where);
 	    rs != NULL; rs = zfs_btree_next(&rt->rt_root, &where, &where)) {
-		func(arg, rs_get_start(rs, rt), rs_get_end(rs, rt) -
-		    rs_get_start(rs, rt));
+		func(arg, zfs_rs_get_start(rs, rt), zfs_rs_get_end(rs, rt) -
+		    zfs_rs_get_start(rs, rt));
 	}
 }
 
-range_seg_t *
-range_tree_first(range_tree_t *rt)
+zfs_range_seg_t *
+zfs_range_tree_first(zfs_range_tree_t *rt)
 {
 	return (zfs_btree_first(&rt->rt_root, NULL));
 }
 
 uint64_t
-range_tree_space(range_tree_t *rt)
+zfs_range_tree_space(zfs_range_tree_t *rt)
 {
 	return (rt->rt_space);
 }
 
 uint64_t
-range_tree_numsegs(range_tree_t *rt)
+zfs_range_tree_numsegs(zfs_range_tree_t *rt)
 {
 	return ((rt == NULL) ? 0 : zfs_btree_numnodes(&rt->rt_root));
 }
 
 boolean_t
-range_tree_is_empty(range_tree_t *rt)
+zfs_range_tree_is_empty(zfs_range_tree_t *rt)
 {
 	ASSERT(rt != NULL);
-	return (range_tree_space(rt) == 0);
+	return (zfs_range_tree_space(rt) == 0);
 }
 
 /*
@@ -760,46 +768,46 @@ range_tree_is_empty(range_tree_t *rt)
  * from removefrom. Add non-overlapping leftovers to addto.
  */
 void
-range_tree_remove_xor_add_segment(uint64_t start, uint64_t end,
-    range_tree_t *removefrom, range_tree_t *addto)
+zfs_range_tree_remove_xor_add_segment(uint64_t start, uint64_t end,
+    zfs_range_tree_t *removefrom, zfs_range_tree_t *addto)
 {
 	zfs_btree_index_t where;
 	range_seg_max_t starting_rs;
-	rs_set_start(&starting_rs, removefrom, start);
-	rs_set_end_raw(&starting_rs, removefrom, rs_get_start_raw(&starting_rs,
-	    removefrom) + 1);
+	zfs_rs_set_start(&starting_rs, removefrom, start);
+	zfs_rs_set_end_raw(&starting_rs, removefrom,
+	    zfs_rs_get_start_raw(&starting_rs, removefrom) + 1);
 
-	range_seg_t *curr = zfs_btree_find(&removefrom->rt_root,
+	zfs_range_seg_t *curr = zfs_btree_find(&removefrom->rt_root,
 	    &starting_rs, &where);
 
 	if (curr == NULL)
 		curr = zfs_btree_next(&removefrom->rt_root, &where, &where);
 
-	range_seg_t *next;
+	zfs_range_seg_t *next;
 	for (; curr != NULL; curr = next) {
 		if (start == end)
 			return;
 		VERIFY3U(start, <, end);
 
 		/* there is no overlap */
-		if (end <= rs_get_start(curr, removefrom)) {
-			range_tree_add(addto, start, end - start);
+		if (end <= zfs_rs_get_start(curr, removefrom)) {
+			zfs_range_tree_add(addto, start, end - start);
 			return;
 		}
 
-		uint64_t overlap_start = MAX(rs_get_start(curr, removefrom),
+		uint64_t overlap_start = MAX(zfs_rs_get_start(curr, removefrom),
 		    start);
-		uint64_t overlap_end = MIN(rs_get_end(curr, removefrom),
+		uint64_t overlap_end = MIN(zfs_rs_get_end(curr, removefrom),
 		    end);
 		uint64_t overlap_size = overlap_end - overlap_start;
 		ASSERT3S(overlap_size, >, 0);
 		range_seg_max_t rs;
-		rs_copy(curr, &rs, removefrom);
+		zfs_rs_copy(curr, &rs, removefrom);
 
-		range_tree_remove(removefrom, overlap_start, overlap_size);
+		zfs_range_tree_remove(removefrom, overlap_start, overlap_size);
 
 		if (start < overlap_start)
-			range_tree_add(addto, start, overlap_start - start);
+			zfs_range_tree_add(addto, start, overlap_start - start);
 
 		start = overlap_end;
 		next = zfs_btree_find(&removefrom->rt_root, &rs, &where);
@@ -814,7 +822,7 @@ range_tree_remove_xor_add_segment(uint64_t start, uint64_t end,
 		 * area to process.
 		 */
 		if (next != NULL) {
-			ASSERT(start == end || start == rs_get_end(&rs,
+			ASSERT(start == end || start == zfs_rs_get_end(&rs,
 			    removefrom));
 		}
 
@@ -824,7 +832,7 @@ range_tree_remove_xor_add_segment(uint64_t start, uint64_t end,
 
 	if (start != end) {
 		VERIFY3U(start, <, end);
-		range_tree_add(addto, start, end - start);
+		zfs_range_tree_add(addto, start, end - start);
 	} else {
 		VERIFY3U(start, ==, end);
 	}
@@ -835,33 +843,33 @@ range_tree_remove_xor_add_segment(uint64_t start, uint64_t end,
  * from removefrom. Otherwise, add it to addto.
  */
 void
-range_tree_remove_xor_add(range_tree_t *rt, range_tree_t *removefrom,
-    range_tree_t *addto)
+zfs_range_tree_remove_xor_add(zfs_range_tree_t *rt,
+    zfs_range_tree_t *removefrom, zfs_range_tree_t *addto)
 {
 	zfs_btree_index_t where;
-	for (range_seg_t *rs = zfs_btree_first(&rt->rt_root, &where); rs;
+	for (zfs_range_seg_t *rs = zfs_btree_first(&rt->rt_root, &where); rs;
 	    rs = zfs_btree_next(&rt->rt_root, &where, &where)) {
-		range_tree_remove_xor_add_segment(rs_get_start(rs, rt),
-		    rs_get_end(rs, rt), removefrom, addto);
+		zfs_range_tree_remove_xor_add_segment(zfs_rs_get_start(rs, rt),
+		    zfs_rs_get_end(rs, rt), removefrom, addto);
 	}
 }
 
 uint64_t
-range_tree_min(range_tree_t *rt)
+zfs_range_tree_min(zfs_range_tree_t *rt)
 {
-	range_seg_t *rs = zfs_btree_first(&rt->rt_root, NULL);
-	return (rs != NULL ? rs_get_start(rs, rt) : 0);
+	zfs_range_seg_t *rs = zfs_btree_first(&rt->rt_root, NULL);
+	return (rs != NULL ? zfs_rs_get_start(rs, rt) : 0);
 }
 
 uint64_t
-range_tree_max(range_tree_t *rt)
+zfs_range_tree_max(zfs_range_tree_t *rt)
 {
-	range_seg_t *rs = zfs_btree_last(&rt->rt_root, NULL);
-	return (rs != NULL ? rs_get_end(rs, rt) : 0);
+	zfs_range_seg_t *rs = zfs_btree_last(&rt->rt_root, NULL);
+	return (rs != NULL ? zfs_rs_get_end(rs, rt) : 0);
 }
 
 uint64_t
-range_tree_span(range_tree_t *rt)
+zfs_range_tree_span(zfs_range_tree_t *rt)
 {
-	return (range_tree_max(rt) - range_tree_min(rt));
+	return (zfs_range_tree_max(rt) - zfs_range_tree_min(rt));
 }

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -9869,7 +9869,7 @@ vdev_indirect_state_sync_verify(vdev_t *vd)
 	 * happen in syncing context, the obsolete segments
 	 * tree must be empty when we start syncing.
 	 */
-	ASSERT0(range_tree_space(vd->vdev_obsolete_segments));
+	ASSERT0(zfs_range_tree_space(vd->vdev_obsolete_segments));
 }
 
 /*

--- a/module/zfs/spa_checkpoint.c
+++ b/module/zfs/spa_checkpoint.c
@@ -235,9 +235,9 @@ spa_checkpoint_discard_sync_callback(space_map_entry_t *sme, void *arg)
 	 * potentially save ourselves from future headaches.
 	 */
 	mutex_enter(&ms->ms_lock);
-	if (range_tree_is_empty(ms->ms_freeing))
+	if (zfs_range_tree_is_empty(ms->ms_freeing))
 		vdev_dirty(vd, VDD_METASLAB, ms, sdc->sdc_txg);
-	range_tree_add(ms->ms_freeing, sme->sme_offset, sme->sme_run);
+	zfs_range_tree_add(ms->ms_freeing, sme->sme_offset, sme->sme_run);
 	mutex_exit(&ms->ms_lock);
 
 	ASSERT3U(vd->vdev_spa->spa_checkpoint_info.sci_dspace, >=,

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -1108,11 +1108,11 @@ spa_ld_log_sm_cb(space_map_entry_t *sme, void *arg)
 
 	switch (sme->sme_type) {
 	case SM_ALLOC:
-		range_tree_remove_xor_add_segment(offset, offset + size,
+		zfs_range_tree_remove_xor_add_segment(offset, offset + size,
 		    ms->ms_unflushed_frees, ms->ms_unflushed_allocs);
 		break;
 	case SM_FREE:
-		range_tree_remove_xor_add_segment(offset, offset + size,
+		zfs_range_tree_remove_xor_add_segment(offset, offset + size,
 		    ms->ms_unflushed_allocs, ms->ms_unflushed_frees);
 		break;
 	default:
@@ -1251,14 +1251,14 @@ out:
 	    m != NULL; m = AVL_NEXT(&spa->spa_metaslabs_by_flushed, m)) {
 		mutex_enter(&m->ms_lock);
 		m->ms_allocated_space = space_map_allocated(m->ms_sm) +
-		    range_tree_space(m->ms_unflushed_allocs) -
-		    range_tree_space(m->ms_unflushed_frees);
+		    zfs_range_tree_space(m->ms_unflushed_allocs) -
+		    zfs_range_tree_space(m->ms_unflushed_frees);
 
 		vdev_t *vd = m->ms_group->mg_vd;
 		metaslab_space_update(vd, m->ms_group->mg_class,
-		    range_tree_space(m->ms_unflushed_allocs), 0, 0);
+		    zfs_range_tree_space(m->ms_unflushed_allocs), 0, 0);
 		metaslab_space_update(vd, m->ms_group->mg_class,
-		    -range_tree_space(m->ms_unflushed_frees), 0, 0);
+		    -zfs_range_tree_space(m->ms_unflushed_frees), 0, 0);
 
 		ASSERT0(m->ms_weight & METASLAB_ACTIVE_MASK);
 		metaslab_recalculate_weight_and_sort(m);
@@ -1317,8 +1317,8 @@ spa_ld_unflushed_txgs(vdev_t *vd)
 
 		ms->ms_unflushed_txg = entry.msp_unflushed_txg;
 		ms->ms_unflushed_dirty = B_FALSE;
-		ASSERT(range_tree_is_empty(ms->ms_unflushed_allocs));
-		ASSERT(range_tree_is_empty(ms->ms_unflushed_frees));
+		ASSERT(zfs_range_tree_is_empty(ms->ms_unflushed_allocs));
+		ASSERT(zfs_range_tree_is_empty(ms->ms_unflushed_frees));
 		if (ms->ms_unflushed_txg != 0) {
 			mutex_enter(&spa->spa_flushed_ms_lock);
 			avl_add(&spa->spa_metaslabs_by_flushed, ms);

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -497,7 +497,7 @@ space_map_histogram_add(space_map_t *sm, zfs_range_tree_t *rt, dmu_tx_t *tx)
 	 * map only cares about allocatable blocks (minimum of sm_shift) we
 	 * can safely ignore all ranges in the range tree smaller than sm_shift.
 	 */
-	for (int i = sm->sm_shift; i < RANGE_TREE_HISTOGRAM_SIZE; i++) {
+	for (int i = sm->sm_shift; i < ZFS_RANGE_TREE_HISTOGRAM_SIZE; i++) {
 
 		/*
 		 * Since the largest histogram bucket in the space map is
@@ -1050,7 +1050,7 @@ space_map_estimate_optimal_size(space_map_t *sm, zfs_range_tree_t *rt,
 			size += histogram[idx] * entry_size;
 
 		if (!spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_V2)) {
-			for (; idx < RANGE_TREE_HISTOGRAM_SIZE; idx++) {
+			for (; idx < ZFS_RANGE_TREE_HISTOGRAM_SIZE; idx++) {
 				ASSERT3U(idx, >=, single_entry_max_bucket);
 				entries_for_seg =
 				    1ULL << (idx - single_entry_max_bucket);
@@ -1067,7 +1067,7 @@ space_map_estimate_optimal_size(space_map_t *sm, zfs_range_tree_t *rt,
 	for (; idx <= double_entry_max_bucket; idx++)
 		size += histogram[idx] * 2 * sizeof (uint64_t);
 
-	for (; idx < RANGE_TREE_HISTOGRAM_SIZE; idx++) {
+	for (; idx < ZFS_RANGE_TREE_HISTOGRAM_SIZE; idx++) {
 		ASSERT3U(idx, >=, double_entry_max_bucket);
 		entries_for_seg = 1ULL << (idx - double_entry_max_bucket);
 		size += histogram[idx] *

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -393,7 +393,7 @@ space_map_incremental_destroy(space_map_t *sm, sm_cb_t callback, void *arg,
 
 typedef struct space_map_load_arg {
 	space_map_t	*smla_sm;
-	range_tree_t	*smla_rt;
+	zfs_range_tree_t	*smla_rt;
 	maptype_t	smla_type;
 } space_map_load_arg_t;
 
@@ -402,11 +402,13 @@ space_map_load_callback(space_map_entry_t *sme, void *arg)
 {
 	space_map_load_arg_t *smla = arg;
 	if (sme->sme_type == smla->smla_type) {
-		VERIFY3U(range_tree_space(smla->smla_rt) + sme->sme_run, <=,
+		VERIFY3U(zfs_range_tree_space(smla->smla_rt) + sme->sme_run, <=,
 		    smla->smla_sm->sm_size);
-		range_tree_add(smla->smla_rt, sme->sme_offset, sme->sme_run);
+		zfs_range_tree_add(smla->smla_rt, sme->sme_offset,
+		    sme->sme_run);
 	} else {
-		range_tree_remove(smla->smla_rt, sme->sme_offset, sme->sme_run);
+		zfs_range_tree_remove(smla->smla_rt, sme->sme_offset,
+		    sme->sme_run);
 	}
 
 	return (0);
@@ -417,15 +419,15 @@ space_map_load_callback(space_map_entry_t *sme, void *arg)
  * read the first 'length' bytes of the spacemap.
  */
 int
-space_map_load_length(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
+space_map_load_length(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
     uint64_t length)
 {
 	space_map_load_arg_t smla;
 
-	VERIFY0(range_tree_space(rt));
+	VERIFY0(zfs_range_tree_space(rt));
 
 	if (maptype == SM_FREE)
-		range_tree_add(rt, sm->sm_start, sm->sm_size);
+		zfs_range_tree_add(rt, sm->sm_start, sm->sm_size);
 
 	smla.smla_rt = rt;
 	smla.smla_sm = sm;
@@ -434,7 +436,7 @@ space_map_load_length(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
 	    space_map_load_callback, &smla);
 
 	if (err != 0)
-		range_tree_vacate(rt, NULL, NULL);
+		zfs_range_tree_vacate(rt, NULL, NULL);
 
 	return (err);
 }
@@ -444,7 +446,7 @@ space_map_load_length(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
  * are added to the range tree, other segment types are removed.
  */
 int
-space_map_load(space_map_t *sm, range_tree_t *rt, maptype_t maptype)
+space_map_load(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype)
 {
 	return (space_map_load_length(sm, rt, maptype, space_map_length(sm)));
 }
@@ -460,7 +462,7 @@ space_map_histogram_clear(space_map_t *sm)
 }
 
 boolean_t
-space_map_histogram_verify(space_map_t *sm, range_tree_t *rt)
+space_map_histogram_verify(space_map_t *sm, zfs_range_tree_t *rt)
 {
 	/*
 	 * Verify that the in-core range tree does not have any
@@ -474,7 +476,7 @@ space_map_histogram_verify(space_map_t *sm, range_tree_t *rt)
 }
 
 void
-space_map_histogram_add(space_map_t *sm, range_tree_t *rt, dmu_tx_t *tx)
+space_map_histogram_add(space_map_t *sm, zfs_range_tree_t *rt, dmu_tx_t *tx)
 {
 	int idx = 0;
 
@@ -667,7 +669,7 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
  * take effect.
  */
 static void
-space_map_write_impl(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
+space_map_write_impl(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
     uint64_t vdev_id, dmu_tx_t *tx)
 {
 	spa_t *spa = tx->tx_pool->dp_spa;
@@ -700,12 +702,12 @@ space_map_write_impl(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
 
 	zfs_btree_t *t = &rt->rt_root;
 	zfs_btree_index_t where;
-	for (range_seg_t *rs = zfs_btree_first(t, &where); rs != NULL;
+	for (zfs_range_seg_t *rs = zfs_btree_first(t, &where); rs != NULL;
 	    rs = zfs_btree_next(t, &where, &where)) {
-		uint64_t offset = (rs_get_start(rs, rt) - sm->sm_start) >>
+		uint64_t offset = (zfs_rs_get_start(rs, rt) - sm->sm_start) >>
 		    sm->sm_shift;
-		uint64_t length = (rs_get_end(rs, rt) - rs_get_start(rs, rt)) >>
-		    sm->sm_shift;
+		uint64_t length = (zfs_rs_get_end(rs, rt) -
+		    zfs_rs_get_start(rs, rt)) >> sm->sm_shift;
 		uint8_t words = 1;
 
 		/*
@@ -730,8 +732,9 @@ space_map_write_impl(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
 		    random_in_range(100) == 0)))
 			words = 2;
 
-		space_map_write_seg(sm, rs_get_start(rs, rt), rs_get_end(rs,
-		    rt), maptype, vdev_id, words, &db, FTAG, tx);
+		space_map_write_seg(sm, zfs_rs_get_start(rs, rt),
+		    zfs_rs_get_end(rs, rt), maptype, vdev_id, words, &db,
+		    FTAG, tx);
 	}
 
 	dmu_buf_rele(db, FTAG);
@@ -753,7 +756,7 @@ space_map_write_impl(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
  * for synchronizing writes to the space map.
  */
 void
-space_map_write(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
+space_map_write(space_map_t *sm, zfs_range_tree_t *rt, maptype_t maptype,
     uint64_t vdev_id, dmu_tx_t *tx)
 {
 	ASSERT(dsl_pool_sync_context(dmu_objset_pool(sm->sm_os)));
@@ -768,18 +771,18 @@ space_map_write(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
 	 */
 	sm->sm_phys->smp_object = sm->sm_object;
 
-	if (range_tree_is_empty(rt)) {
+	if (zfs_range_tree_is_empty(rt)) {
 		VERIFY3U(sm->sm_object, ==, sm->sm_phys->smp_object);
 		return;
 	}
 
 	if (maptype == SM_ALLOC)
-		sm->sm_phys->smp_alloc += range_tree_space(rt);
+		sm->sm_phys->smp_alloc += zfs_range_tree_space(rt);
 	else
-		sm->sm_phys->smp_alloc -= range_tree_space(rt);
+		sm->sm_phys->smp_alloc -= zfs_range_tree_space(rt);
 
 	uint64_t nodes = zfs_btree_numnodes(&rt->rt_root);
-	uint64_t rt_space = range_tree_space(rt);
+	uint64_t rt_space = zfs_range_tree_space(rt);
 
 	space_map_write_impl(sm, rt, maptype, vdev_id, tx);
 
@@ -788,7 +791,7 @@ space_map_write(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
 	 * while we were in the middle of writing it out.
 	 */
 	VERIFY3U(nodes, ==, zfs_btree_numnodes(&rt->rt_root));
-	VERIFY3U(range_tree_space(rt), ==, rt_space);
+	VERIFY3U(zfs_range_tree_space(rt), ==, rt_space);
 }
 
 static int
@@ -960,7 +963,7 @@ space_map_free(space_map_t *sm, dmu_tx_t *tx)
  * the given space map.
  */
 uint64_t
-space_map_estimate_optimal_size(space_map_t *sm, range_tree_t *rt,
+space_map_estimate_optimal_size(space_map_t *sm, zfs_range_tree_t *rt,
     uint64_t vdev_id)
 {
 	spa_t *spa = dmu_objset_spa(sm->sm_os);

--- a/module/zfs/space_reftree.c
+++ b/module/zfs/space_reftree.c
@@ -107,14 +107,14 @@ space_reftree_add_seg(avl_tree_t *t, uint64_t start, uint64_t end,
  * Convert (or add) a range tree into a reference tree.
  */
 void
-space_reftree_add_map(avl_tree_t *t, range_tree_t *rt, int64_t refcnt)
+space_reftree_add_map(avl_tree_t *t, zfs_range_tree_t *rt, int64_t refcnt)
 {
 	zfs_btree_index_t where;
 
-	for (range_seg_t *rs = zfs_btree_first(&rt->rt_root, &where); rs; rs =
-	    zfs_btree_next(&rt->rt_root, &where, &where)) {
-		space_reftree_add_seg(t, rs_get_start(rs, rt), rs_get_end(rs,
-		    rt),  refcnt);
+	for (zfs_range_seg_t *rs = zfs_btree_first(&rt->rt_root, &where); rs;
+	    rs = zfs_btree_next(&rt->rt_root, &where, &where)) {
+		space_reftree_add_seg(t, zfs_rs_get_start(rs, rt),
+		    zfs_rs_get_end(rs, rt),  refcnt);
 	}
 }
 
@@ -123,13 +123,13 @@ space_reftree_add_map(avl_tree_t *t, range_tree_t *rt, int64_t refcnt)
  * all members of the reference tree for which refcnt >= minref.
  */
 void
-space_reftree_generate_map(avl_tree_t *t, range_tree_t *rt, int64_t minref)
+space_reftree_generate_map(avl_tree_t *t, zfs_range_tree_t *rt, int64_t minref)
 {
 	uint64_t start = -1ULL;
 	int64_t refcnt = 0;
 	space_ref_t *sr;
 
-	range_tree_vacate(rt, NULL, NULL);
+	zfs_range_tree_vacate(rt, NULL, NULL);
 
 	for (sr = avl_first(t); sr != NULL; sr = AVL_NEXT(t, sr)) {
 		refcnt += sr->sr_refcnt;
@@ -142,7 +142,8 @@ space_reftree_generate_map(avl_tree_t *t, range_tree_t *rt, int64_t minref)
 				uint64_t end = sr->sr_offset;
 				ASSERT(start <= end);
 				if (end > start)
-					range_tree_add(rt, start, end - start);
+					zfs_range_tree_add(rt, start, end -
+					    start);
 				start = -1ULL;
 			}
 		}

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -294,8 +294,8 @@ vdev_get_mg(vdev_t *vd, metaslab_class_t *mc)
 }
 
 void
-vdev_default_xlate(vdev_t *vd, const range_seg64_t *logical_rs,
-    range_seg64_t *physical_rs, range_seg64_t *remain_rs)
+vdev_default_xlate(vdev_t *vd, const zfs_range_seg64_t *logical_rs,
+    zfs_range_seg64_t *physical_rs, zfs_range_seg64_t *remain_rs)
 {
 	(void) vd, (void) remain_rs;
 
@@ -1677,7 +1677,7 @@ vdev_metaslab_fini(vdev_t *vd)
 		vd->vdev_ms = NULL;
 		vd->vdev_ms_count = 0;
 
-		for (int i = 0; i < RANGE_TREE_HISTOGRAM_SIZE; i++) {
+		for (int i = 0; i < ZFS_RANGE_TREE_HISTOGRAM_SIZE; i++) {
 			ASSERT0(mg->mg_histogram[i]);
 			if (vd->vdev_log_mg != NULL)
 				ASSERT0(vd->vdev_log_mg->mg_histogram[i]);
@@ -5689,7 +5689,7 @@ vdev_clear_resilver_deferred(vdev_t *vd, dmu_tx_t *tx)
 }
 
 boolean_t
-vdev_xlate_is_empty(range_seg64_t *rs)
+vdev_xlate_is_empty(zfs_range_seg64_t *rs)
 {
 	return (rs->rs_start == rs->rs_end);
 }
@@ -5703,8 +5703,8 @@ vdev_xlate_is_empty(range_seg64_t *rs)
  * specific translation function to do the real conversion.
  */
 void
-vdev_xlate(vdev_t *vd, const range_seg64_t *logical_rs,
-    range_seg64_t *physical_rs, range_seg64_t *remain_rs)
+vdev_xlate(vdev_t *vd, const zfs_range_seg64_t *logical_rs,
+    zfs_range_seg64_t *physical_rs, zfs_range_seg64_t *remain_rs)
 {
 	/*
 	 * Walk up the vdev tree
@@ -5736,7 +5736,7 @@ vdev_xlate(vdev_t *vd, const range_seg64_t *logical_rs,
 	 * range into its physical and any remaining components by calling
 	 * the vdev specific translate function.
 	 */
-	range_seg64_t intermediate = { 0 };
+	zfs_range_seg64_t intermediate = { 0 };
 	pvd->vdev_ops->vdev_op_xlate(vd, physical_rs, &intermediate, remain_rs);
 
 	physical_rs->rs_start = intermediate.rs_start;
@@ -5744,12 +5744,12 @@ vdev_xlate(vdev_t *vd, const range_seg64_t *logical_rs,
 }
 
 void
-vdev_xlate_walk(vdev_t *vd, const range_seg64_t *logical_rs,
+vdev_xlate_walk(vdev_t *vd, const zfs_range_seg64_t *logical_rs,
     vdev_xlate_func_t *func, void *arg)
 {
-	range_seg64_t iter_rs = *logical_rs;
-	range_seg64_t physical_rs;
-	range_seg64_t remain_rs;
+	zfs_range_seg64_t iter_rs = *logical_rs;
+	zfs_range_seg64_t physical_rs;
+	zfs_range_seg64_t remain_rs;
 
 	while (!vdev_xlate_is_empty(&iter_rs)) {
 

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -1823,7 +1823,7 @@ static void
 vdev_draid_io_verify(vdev_t *vd, raidz_row_t *rr, int col)
 {
 #ifdef ZFS_DEBUG
-	range_seg64_t logical_rs, physical_rs, remain_rs;
+	zfs_range_seg64_t logical_rs, physical_rs, remain_rs;
 	logical_rs.rs_start = rr->rr_offset;
 	logical_rs.rs_end = logical_rs.rs_start +
 	    vdev_draid_asize(vd, rr->rr_size, 0);
@@ -2080,8 +2080,8 @@ vdev_draid_state_change(vdev_t *vd, int faulted, int degraded)
 }
 
 static void
-vdev_draid_xlate(vdev_t *cvd, const range_seg64_t *logical_rs,
-    range_seg64_t *physical_rs, range_seg64_t *remain_rs)
+vdev_draid_xlate(vdev_t *cvd, const zfs_range_seg64_t *logical_rs,
+    zfs_range_seg64_t *physical_rs, zfs_range_seg64_t *remain_rs)
 {
 	vdev_t *raidvd = cvd->vdev_parent;
 	ASSERT(raidvd->vdev_ops == &vdev_draid_ops);

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -333,7 +333,7 @@ vdev_indirect_mark_obsolete(vdev_t *vd, uint64_t offset, uint64_t size)
 
 	if (spa_feature_is_enabled(spa, SPA_FEATURE_OBSOLETE_COUNTS)) {
 		mutex_enter(&vd->vdev_obsolete_lock);
-		range_tree_add(vd->vdev_obsolete_segments, offset, size);
+		zfs_range_tree_add(vd->vdev_obsolete_segments, offset, size);
 		mutex_exit(&vd->vdev_obsolete_lock);
 		vdev_dirty(vd, 0, NULL, spa_syncing_txg(spa));
 	}
@@ -816,7 +816,7 @@ vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 	vdev_indirect_config_t *vic __maybe_unused = &vd->vdev_indirect_config;
 
 	ASSERT3U(vic->vic_mapping_object, !=, 0);
-	ASSERT(range_tree_space(vd->vdev_obsolete_segments) > 0);
+	ASSERT(zfs_range_tree_space(vd->vdev_obsolete_segments) > 0);
 	ASSERT(vd->vdev_removing || vd->vdev_ops == &vdev_indirect_ops);
 	ASSERT(spa_feature_is_enabled(spa, SPA_FEATURE_OBSOLETE_COUNTS));
 
@@ -845,7 +845,7 @@ vdev_indirect_sync_obsolete(vdev_t *vd, dmu_tx_t *tx)
 
 	space_map_write(vd->vdev_obsolete_sm,
 	    vd->vdev_obsolete_segments, SM_ALLOC, SM_NO_VDEVID, tx);
-	range_tree_vacate(vd->vdev_obsolete_segments, NULL, NULL);
+	zfs_range_tree_vacate(vd->vdev_obsolete_segments, NULL, NULL);
 }
 
 int

--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -359,7 +359,7 @@ vdev_initialize_ranges(vdev_t *vd, abd_t *data)
 }
 
 static void
-vdev_initialize_xlate_last_rs_end(void *arg, range_seg64_t *physical_rs)
+vdev_initialize_xlate_last_rs_end(void *arg, zfs_range_seg64_t *physical_rs)
 {
 	uint64_t *last_rs_end = (uint64_t *)arg;
 
@@ -368,7 +368,7 @@ vdev_initialize_xlate_last_rs_end(void *arg, range_seg64_t *physical_rs)
 }
 
 static void
-vdev_initialize_xlate_progress(void *arg, range_seg64_t *physical_rs)
+vdev_initialize_xlate_progress(void *arg, zfs_range_seg64_t *physical_rs)
 {
 	vdev_t *vd = (vdev_t *)arg;
 
@@ -407,7 +407,7 @@ vdev_initialize_calculate_progress(vdev_t *vd)
 		 * on our vdev. We use this to determine if we are
 		 * in the middle of this metaslab range.
 		 */
-		range_seg64_t logical_rs, physical_rs, remain_rs;
+		zfs_range_seg64_t logical_rs, physical_rs, remain_rs;
 		logical_rs.rs_start = msp->ms_start;
 		logical_rs.rs_end = msp->ms_start + msp->ms_size;
 
@@ -481,7 +481,7 @@ vdev_initialize_load(vdev_t *vd)
 }
 
 static void
-vdev_initialize_xlate_range_add(void *arg, range_seg64_t *physical_rs)
+vdev_initialize_xlate_range_add(void *arg, zfs_range_seg64_t *physical_rs)
 {
 	vdev_t *vd = arg;
 
@@ -516,7 +516,7 @@ static void
 vdev_initialize_range_add(void *arg, uint64_t start, uint64_t size)
 {
 	vdev_t *vd = arg;
-	range_seg64_t logical_rs;
+	zfs_range_seg64_t logical_rs;
 	logical_rs.rs_start = start;
 	logical_rs.rs_end = start + size;
 

--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -330,13 +330,14 @@ vdev_initialize_block_free(abd_t *data)
 static int
 vdev_initialize_ranges(vdev_t *vd, abd_t *data)
 {
-	range_tree_t *rt = vd->vdev_initialize_tree;
+	zfs_range_tree_t *rt = vd->vdev_initialize_tree;
 	zfs_btree_t *bt = &rt->rt_root;
 	zfs_btree_index_t where;
 
-	for (range_seg_t *rs = zfs_btree_first(bt, &where); rs != NULL;
+	for (zfs_range_seg_t *rs = zfs_btree_first(bt, &where); rs != NULL;
 	    rs = zfs_btree_next(bt, &where, &where)) {
-		uint64_t size = rs_get_end(rs, rt) - rs_get_start(rs, rt);
+		uint64_t size = zfs_rs_get_end(rs, rt) -
+		    zfs_rs_get_start(rs, rt);
 
 		/* Split range into legally-sized physical chunks */
 		uint64_t writes_required =
@@ -346,7 +347,7 @@ vdev_initialize_ranges(vdev_t *vd, abd_t *data)
 			int error;
 
 			error = vdev_initialize_write(vd,
-			    VDEV_LABEL_START_SIZE + rs_get_start(rs, rt) +
+			    VDEV_LABEL_START_SIZE + zfs_rs_get_start(rs, rt) +
 			    (w * zfs_initialize_chunk_size),
 			    MIN(size - (w * zfs_initialize_chunk_size),
 			    zfs_initialize_chunk_size), data);
@@ -440,13 +441,13 @@ vdev_initialize_calculate_progress(vdev_t *vd)
 		VERIFY0(metaslab_load(msp));
 
 		zfs_btree_index_t where;
-		range_tree_t *rt = msp->ms_allocatable;
-		for (range_seg_t *rs =
+		zfs_range_tree_t *rt = msp->ms_allocatable;
+		for (zfs_range_seg_t *rs =
 		    zfs_btree_first(&rt->rt_root, &where); rs;
 		    rs = zfs_btree_next(&rt->rt_root, &where,
 		    &where)) {
-			logical_rs.rs_start = rs_get_start(rs, rt);
-			logical_rs.rs_end = rs_get_end(rs, rt);
+			logical_rs.rs_start = zfs_rs_get_start(rs, rt);
+			logical_rs.rs_end = zfs_rs_get_end(rs, rt);
 
 			vdev_xlate_walk(vd, &logical_rs,
 			    vdev_initialize_xlate_progress, vd);
@@ -503,7 +504,7 @@ vdev_initialize_xlate_range_add(void *arg, range_seg64_t *physical_rs)
 
 	ASSERT3U(physical_rs->rs_end, >, physical_rs->rs_start);
 
-	range_tree_add(vd->vdev_initialize_tree, physical_rs->rs_start,
+	zfs_range_tree_add(vd->vdev_initialize_tree, physical_rs->rs_start,
 	    physical_rs->rs_end - physical_rs->rs_start);
 }
 
@@ -539,8 +540,8 @@ vdev_initialize_thread(void *arg)
 
 	abd_t *deadbeef = vdev_initialize_block_alloc();
 
-	vd->vdev_initialize_tree = range_tree_create(NULL, RANGE_SEG64, NULL,
-	    0, 0);
+	vd->vdev_initialize_tree = zfs_range_tree_create(NULL, ZFS_RANGE_SEG64,
+	    NULL, 0, 0);
 
 	for (uint64_t i = 0; !vd->vdev_detached &&
 	    i < vd->vdev_top->vdev_ms_count; i++) {
@@ -563,15 +564,15 @@ vdev_initialize_thread(void *arg)
 			unload_when_done = B_TRUE;
 		VERIFY0(metaslab_load(msp));
 
-		range_tree_walk(msp->ms_allocatable, vdev_initialize_range_add,
-		    vd);
+		zfs_range_tree_walk(msp->ms_allocatable,
+		    vdev_initialize_range_add, vd);
 		mutex_exit(&msp->ms_lock);
 
 		error = vdev_initialize_ranges(vd, deadbeef);
 		metaslab_enable(msp, B_TRUE, unload_when_done);
 		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 
-		range_tree_vacate(vd->vdev_initialize_tree, NULL, NULL);
+		zfs_range_tree_vacate(vd->vdev_initialize_tree, NULL, NULL);
 		if (error != 0)
 			break;
 	}
@@ -584,7 +585,7 @@ vdev_initialize_thread(void *arg)
 	}
 	mutex_exit(&vd->vdev_initialize_io_lock);
 
-	range_tree_destroy(vd->vdev_initialize_tree);
+	zfs_range_tree_destroy(vd->vdev_initialize_tree);
 	vdev_initialize_block_free(deadbeef);
 	vd->vdev_initialize_tree = NULL;
 

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -643,7 +643,8 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 			 * will be combined with adjacent allocated segments
 			 * as a single mapping.
 			 */
-			for (int i = 0; i < RANGE_TREE_HISTOGRAM_SIZE; i++) {
+			for (int i = 0; i < ZFS_RANGE_TREE_HISTOGRAM_SIZE;
+			    i++) {
 				if (i + 1 < highbit64(vdev_removal_max_span)
 				    - 1) {
 					to_alloc +=

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -2305,7 +2305,7 @@ vdev_raidz_io_verify(zio_t *zio, raidz_map_t *rm, raidz_row_t *rr, int col)
 {
 	(void) rm;
 #ifdef ZFS_DEBUG
-	range_seg64_t logical_rs, physical_rs, remain_rs;
+	zfs_range_seg64_t logical_rs, physical_rs, remain_rs;
 	logical_rs.rs_start = rr->rr_offset;
 	logical_rs.rs_end = logical_rs.rs_start +
 	    vdev_raidz_asize(zio->io_vd, rr->rr_size,
@@ -3650,8 +3650,8 @@ vdev_raidz_need_resilver(vdev_t *vd, const dva_t *dva, size_t psize,
 }
 
 static void
-vdev_raidz_xlate(vdev_t *cvd, const range_seg64_t *logical_rs,
-    range_seg64_t *physical_rs, range_seg64_t *remain_rs)
+vdev_raidz_xlate(vdev_t *cvd, const zfs_range_seg64_t *logical_rs,
+    zfs_range_seg64_t *physical_rs, zfs_range_seg64_t *remain_rs)
 {
 	(void) remain_rs;
 

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -1143,7 +1143,7 @@ spa_vdev_copy_segment(vdev_t *vd, zfs_range_tree_t *segs,
 		 * the allocation at the end of a segment, thus avoiding
 		 * additional split blocks.
 		 */
-		range_seg_max_t search;
+		zfs_range_seg_max_t search;
 		zfs_btree_index_t where;
 		zfs_rs_set_start(&search, segs, start + maxalloc);
 		zfs_rs_set_end(&search, segs, start + maxalloc);

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -645,7 +645,7 @@ done:
 }
 
 static void
-vdev_trim_xlate_last_rs_end(void *arg, range_seg64_t *physical_rs)
+vdev_trim_xlate_last_rs_end(void *arg, zfs_range_seg64_t *physical_rs)
 {
 	uint64_t *last_rs_end = (uint64_t *)arg;
 
@@ -654,7 +654,7 @@ vdev_trim_xlate_last_rs_end(void *arg, range_seg64_t *physical_rs)
 }
 
 static void
-vdev_trim_xlate_progress(void *arg, range_seg64_t *physical_rs)
+vdev_trim_xlate_progress(void *arg, zfs_range_seg64_t *physical_rs)
 {
 	vdev_t *vd = (vdev_t *)arg;
 
@@ -696,7 +696,7 @@ vdev_trim_calculate_progress(vdev_t *vd)
 		 * on our vdev. We use this to determine if we are
 		 * in the middle of this metaslab range.
 		 */
-		range_seg64_t logical_rs, physical_rs, remain_rs;
+		zfs_range_seg64_t logical_rs, physical_rs, remain_rs;
 		logical_rs.rs_start = msp->ms_start;
 		logical_rs.rs_end = msp->ms_start + msp->ms_size;
 
@@ -807,7 +807,7 @@ vdev_trim_load(vdev_t *vd)
 }
 
 static void
-vdev_trim_xlate_range_add(void *arg, range_seg64_t *physical_rs)
+vdev_trim_xlate_range_add(void *arg, zfs_range_seg64_t *physical_rs)
 {
 	trim_args_t *ta = arg;
 	vdev_t *vd = ta->trim_vdev;
@@ -845,7 +845,7 @@ vdev_trim_range_add(void *arg, uint64_t start, uint64_t size)
 {
 	trim_args_t *ta = arg;
 	vdev_t *vd = ta->trim_vdev;
-	range_seg64_t logical_rs;
+	zfs_range_seg64_t logical_rs;
 	logical_rs.rs_start = start;
 	logical_rs.rs_end = start + size;
 
@@ -1588,7 +1588,7 @@ vdev_trim_l2arc_thread(void *arg)
 	spa_t		*spa = vd->vdev_spa;
 	l2arc_dev_t	*dev = l2arc_vdev_get(vd);
 	trim_args_t	ta = {0};
-	range_seg64_t 	physical_rs;
+	zfs_range_seg64_t 	physical_rs;
 
 	ASSERT(vdev_is_concrete(vd));
 	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
@@ -1722,7 +1722,7 @@ int
 vdev_trim_simple(vdev_t *vd, uint64_t start, uint64_t size)
 {
 	trim_args_t ta = {0};
-	range_seg64_t physical_rs;
+	zfs_range_seg64_t physical_rs;
 	int error;
 	physical_rs.rs_start = start;
 	physical_rs.rs_end = start + size;


### PR DESCRIPTION
Linux 6.12 has conflicting range_tree_{find,destroy,clear} symbols.

### Motivation and Context
Linux 6.12 introduced conflicting symbols which cause issues when compiling zfs with ```--enable-linux-builtin```
See #16932 for context.
The change fix compilation in this configuration.

### Description
The change is basically:
```find . -type f -exec sed -i 's/range_tree_/zfs_range_tree_/g' {} +```
... and manually fixing lines > 80 characters to get checkstyle pass.

### How Has This Been Tested?
No functional changes, linux kernel 6.12 with ZFS builtin compiled successfully.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
