### PR TITLE
Avoid unnecessary transform operations during prefetch

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6031,6 +6031,7 @@ top:
 		acb->acb_compressed = compressed_read;
 		acb->acb_encrypted = encrypted_read;
 		acb->acb_noauth = noauth_read;
+		acb->acb_nobuf = no_buf;
 		acb->acb_zb = *zb;
 
 		ASSERT3P(hdr->b_l1hdr.b_acb, ==, NULL);


### PR DESCRIPTION
This change will prevent prefetch to perform unnecessary transform operations on ARC buffer.


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In current ZFS, the read performance with prefetch enabled was getting affected because of the extra and unnecessary operations happening on ARC buffer. While the flag to avoid the ARC buffer was set in prefetch path, it was not getting assigned when actual zio is getting data from Disk to ARC.
This change will reduce the CPU utilization and boost the performance.
Closes https://github.com/openzfs/zfs/issues/17008

### Description
<!--- Describe your changes in detail -->
This change is mainly focused on utilizing the existing flag to avoid the unnecessary operations (buffer allocation and transform operations) in prefetch.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
This change was tested on following system:
Type | Version/Name
-- | --
Distribution Name | Ubuntu
Distribution Version | 23.10
Kernel Version | 6.5.0-44-generic
Architecture | Intel(R) Xeon(R) Gold 6342 CPU
OpenZFS Version | 2.2.6

Parameter | Info
-- | --
Benchmarking Tool | IOR
Zpool Drives | 6 NVME 1 TB Each
Zpool Configuration | RAID0
Zpool Recordsize | 128k
ZFS Primarycache | all
ZFS compression | on (lz4)
ZFS encryption | off
ZFS checksum | on
ZFS zfs_compressed_arc_enabled | 1

<!--EndFragment-->
</body>
</html>
<!--EndFragment-->
</body>
</html>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
