### PR TITLE
Unified allocation throttling

### DIFF
--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -64,6 +64,8 @@ extern uint64_t zfs_wrlog_data_max;
 extern uint_t zfs_dirty_data_max_percent;
 extern uint_t zfs_dirty_data_max_max_percent;
 extern uint_t zfs_delay_min_dirty_percent;
+extern uint_t zfs_vdev_async_write_active_min_dirty_percent;
+extern uint_t zfs_vdev_async_write_active_max_dirty_percent;
 extern uint64_t zfs_delay_scale;
 
 /* These macros are for indexing into the zfs_all_blkstats_t. */

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -75,18 +75,13 @@ uint64_t metaslab_largest_allocatable(metaslab_t *);
 /*
  * metaslab alloc flags
  */
-#define	METASLAB_HINTBP_FAVOR		0x0
-#define	METASLAB_HINTBP_AVOID		0x1
+#define	METASLAB_ZIL			0x1
 #define	METASLAB_GANG_HEADER		0x2
 #define	METASLAB_GANG_CHILD		0x4
 #define	METASLAB_ASYNC_ALLOC		0x8
-#define	METASLAB_DONT_THROTTLE		0x10
-#define	METASLAB_MUST_RESERVE		0x20
-#define	METASLAB_ZIL			0x80
 
-int metaslab_alloc(spa_t *, metaslab_class_t *, uint64_t,
-    blkptr_t *, int, uint64_t, blkptr_t *, int, zio_alloc_list_t *, zio_t *,
-	int);
+int metaslab_alloc(spa_t *, metaslab_class_t *, uint64_t, blkptr_t *, int,
+    uint64_t, blkptr_t *, int, zio_alloc_list_t *, int, const void *);
 int metaslab_alloc_dva(spa_t *, metaslab_class_t *, uint64_t,
     dva_t *, int, dva_t *, uint64_t, int, zio_alloc_list_t *, int);
 void metaslab_free(spa_t *, const blkptr_t *, uint64_t, boolean_t);
@@ -103,15 +98,17 @@ void metaslab_stat_fini(void);
 void metaslab_trace_init(zio_alloc_list_t *);
 void metaslab_trace_fini(zio_alloc_list_t *);
 
-metaslab_class_t *metaslab_class_create(spa_t *, const metaslab_ops_t *);
+metaslab_class_t *metaslab_class_create(spa_t *, const metaslab_ops_t *,
+    boolean_t);
 void metaslab_class_destroy(metaslab_class_t *);
-int metaslab_class_validate(metaslab_class_t *);
+void metaslab_class_validate(metaslab_class_t *);
+void metaslab_class_balance(metaslab_class_t *mc, boolean_t onsync);
 void metaslab_class_histogram_verify(metaslab_class_t *);
 uint64_t metaslab_class_fragmentation(metaslab_class_t *);
 uint64_t metaslab_class_expandable_space(metaslab_class_t *);
-boolean_t metaslab_class_throttle_reserve(metaslab_class_t *, int, int,
-    zio_t *, int);
-void metaslab_class_throttle_unreserve(metaslab_class_t *, int, int, zio_t *);
+boolean_t metaslab_class_throttle_reserve(metaslab_class_t *, int, zio_t *,
+    boolean_t, boolean_t *);
+boolean_t metaslab_class_throttle_unreserve(metaslab_class_t *, int, zio_t *);
 void metaslab_class_evict_old(metaslab_class_t *, uint64_t);
 uint64_t metaslab_class_get_alloc(metaslab_class_t *);
 uint64_t metaslab_class_get_space(metaslab_class_t *);
@@ -130,9 +127,8 @@ uint64_t metaslab_group_get_space(metaslab_group_t *);
 void metaslab_group_histogram_verify(metaslab_group_t *);
 uint64_t metaslab_group_fragmentation(metaslab_group_t *);
 void metaslab_group_histogram_remove(metaslab_group_t *, metaslab_t *);
-void metaslab_group_alloc_decrement(spa_t *, uint64_t, const void *, int, int,
-    boolean_t);
-void metaslab_group_alloc_verify(spa_t *, const blkptr_t *, const void *, int);
+void metaslab_group_alloc_decrement(spa_t *, uint64_t, int, int, uint64_t,
+    const void *);
 void metaslab_recalculate_weight_and_sort(metaslab_t *);
 void metaslab_disable(metaslab_t *);
 void metaslab_enable(metaslab_t *, boolean_t, boolean_t);

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -141,23 +141,24 @@ typedef enum trace_alloc_type {
  * Per-allocator data structure.
  */
 typedef struct metaslab_class_allocator {
+	kmutex_t		mca_lock;
+	avl_tree_t		mca_tree;
+
 	metaslab_group_t	*mca_rotor;
 	uint64_t		mca_aliquot;
 
 	/*
 	 * The allocation throttle works on a reservation system. Whenever
 	 * an asynchronous zio wants to perform an allocation it must
-	 * first reserve the number of blocks that it wants to allocate.
+	 * first reserve the number of bytes that it wants to allocate.
 	 * If there aren't sufficient slots available for the pending zio
 	 * then that I/O is throttled until more slots free up. The current
-	 * number of reserved allocations is maintained by the mca_alloc_slots
-	 * refcount. The mca_alloc_max_slots value determines the maximum
-	 * number of allocations that the system allows. Gang blocks are
-	 * allowed to reserve slots even if we've reached the maximum
-	 * number of allocations allowed.
+	 * size of reserved allocations is maintained by mca_reserved.
+	 * The maximum total size of reserved allocations is determined by
+	 * mc_alloc_max in the metaslab_class_t.  Gang blocks are allowed
+	 * to reserve for their headers even if we've reached the maximum.
 	 */
-	uint64_t		mca_alloc_max_slots;
-	zfs_refcount_t		mca_alloc_slots;
+	uint64_t		mca_reserved;
 } ____cacheline_aligned metaslab_class_allocator_t;
 
 /*
@@ -190,10 +191,10 @@ struct metaslab_class {
 	 */
 	uint64_t		mc_groups;
 
-	/*
-	 * Toggle to enable/disable the allocation throttle.
-	 */
+	boolean_t		mc_is_log;
 	boolean_t		mc_alloc_throttle_enabled;
+	uint64_t		mc_alloc_io_size;
+	uint64_t		mc_alloc_max;
 
 	uint64_t		mc_alloc_groups; /* # of allocatable groups */
 
@@ -216,11 +217,10 @@ struct metaslab_class {
  * Per-allocator data structure.
  */
 typedef struct metaslab_group_allocator {
-	uint64_t	mga_cur_max_alloc_queue_depth;
-	zfs_refcount_t	mga_alloc_queue_depth;
+	zfs_refcount_t	mga_queue_depth;
 	metaslab_t	*mga_primary;
 	metaslab_t	*mga_secondary;
-} metaslab_group_allocator_t;
+} ____cacheline_aligned metaslab_group_allocator_t;
 
 /*
  * Metaslab groups encapsulate all the allocatable regions (i.e. metaslabs)
@@ -235,6 +235,7 @@ struct metaslab_group {
 	kmutex_t		mg_lock;
 	avl_tree_t		mg_metaslab_tree;
 	uint64_t		mg_aliquot;
+	uint64_t		mg_queue_target;
 	boolean_t		mg_allocatable;		/* can we allocate? */
 	uint64_t		mg_ms_ready;
 
@@ -246,39 +247,11 @@ struct metaslab_group {
 	 */
 	boolean_t		mg_initialized;
 
-	uint64_t		mg_free_capacity;	/* percentage free */
-	int64_t			mg_bias;
 	int64_t			mg_activation_count;
 	metaslab_class_t	*mg_class;
 	vdev_t			*mg_vd;
 	metaslab_group_t	*mg_prev;
 	metaslab_group_t	*mg_next;
-
-	/*
-	 * In order for the allocation throttle to function properly, we cannot
-	 * have too many IOs going to each disk by default; the throttle
-	 * operates by allocating more work to disks that finish quickly, so
-	 * allocating larger chunks to each disk reduces its effectiveness.
-	 * However, if the number of IOs going to each allocator is too small,
-	 * we will not perform proper aggregation at the vdev_queue layer,
-	 * also resulting in decreased performance. Therefore, we will use a
-	 * ramp-up strategy.
-	 *
-	 * Each allocator in each metaslab group has a current queue depth
-	 * (mg_alloc_queue_depth[allocator]) and a current max queue depth
-	 * (mga_cur_max_alloc_queue_depth[allocator]), and each metaslab group
-	 * has an absolute max queue depth (mg_max_alloc_queue_depth).  We
-	 * add IOs to an allocator until the mg_alloc_queue_depth for that
-	 * allocator hits the cur_max. Every time an IO completes for a given
-	 * allocator on a given metaslab group, we increment its cur_max until
-	 * it reaches mg_max_alloc_queue_depth. The cur_max resets every txg to
-	 * help protect against disks that decrease in performance over time.
-	 *
-	 * It's possible for an allocator to handle more allocations than
-	 * its max. This can occur when gang blocks are required or when other
-	 * groups are unable to handle their share of allocations.
-	 */
-	uint64_t		mg_max_alloc_queue_depth;
 
 	/*
 	 * A metalab group that can no longer allocate the minimum block
@@ -288,8 +261,6 @@ struct metaslab_group {
 	 */
 	boolean_t		mg_no_free_space;
 
-	uint64_t		mg_allocations;
-	uint64_t		mg_failed_allocations;
 	uint64_t		mg_fragmentation;
 	uint64_t		mg_histogram[ZFS_RANGE_TREE_HISTOGRAM_SIZE];
 
@@ -508,7 +479,7 @@ struct metaslab {
 	 */
 	hrtime_t	ms_load_time;	/* time last loaded */
 	hrtime_t	ms_unload_time;	/* time last unloaded */
-	hrtime_t	ms_selected_time; /* time last allocated from */
+	uint64_t	ms_selected_time; /* time last allocated from (secs) */
 
 	uint64_t	ms_alloc_txg;	/* last successful alloc (debug only) */
 	uint64_t	ms_max_size;	/* maximum allocatable size	*/

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -59,11 +59,6 @@
 extern "C" {
 #endif
 
-typedef struct spa_alloc {
-	kmutex_t	spaa_lock;
-	avl_tree_t	spaa_tree;
-} ____cacheline_aligned spa_alloc_t;
-
 typedef struct spa_allocs_use {
 	kmutex_t	sau_lock;
 	uint_t		sau_rotor;
@@ -273,12 +268,6 @@ struct spa {
 	uint64_t	spa_last_synced_guid;	/* last synced guid */
 	list_t		spa_config_dirty_list;	/* vdevs with dirty config */
 	list_t		spa_state_dirty_list;	/* vdevs with dirty state */
-	/*
-	 * spa_allocs is an array, whose lengths is stored in spa_alloc_count.
-	 * There is one tree and one lock for each allocator, to help improve
-	 * allocation performance in write-heavy workloads.
-	 */
-	spa_alloc_t	*spa_allocs;
 	spa_allocs_use_t *spa_allocs_use;
 	int		spa_alloc_count;
 	int		spa_active_allocator;	/* selectable allocator */

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -60,10 +60,6 @@ extern "C" {
 typedef struct vdev_queue vdev_queue_t;
 struct abd;
 
-extern uint_t zfs_vdev_queue_depth_pct;
-extern uint_t zfs_vdev_def_queue_depth;
-extern uint_t zfs_vdev_async_write_max_active;
-
 /*
  * Virtual device operations
  */

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -245,16 +245,26 @@ For L2ARC devices less than 1 GiB, the amount of data
 evicts is significant compared to the amount of restored L2ARC data.
 In this case, do not write log blocks in L2ARC in order not to waste space.
 .
-.It Sy metaslab_aliquot Ns = Ns Sy 1048576 Ns B Po 1 MiB Pc Pq u64
-Metaslab granularity, in bytes.
+.It Sy metaslab_aliquot Ns = Ns Sy 2097152 Ns B Po 2 MiB Pc Pq u64
+Metaslab group's per child vdev allocation granularity, in bytes.
 This is roughly similar to what would be referred to as the "stripe size"
 in traditional RAID arrays.
-In normal operation, ZFS will try to write this amount of data to each disk
-before moving on to the next top-level vdev.
+In normal operation, ZFS will try to write this amount of data to each child
+of a top-level vdev before moving on to the next top-level vdev.
 .
 .It Sy metaslab_bias_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
-Enable metaslab group biasing based on their vdevs' over- or under-utilization
-relative to the pool.
+Enable metaslab groups biasing based on their over- or under-utilization
+relative to the metaslab class average.
+If disabled, each metaslab group will receive allocations proportional to its
+capacity.
+.
+.It Sy metaslab_perf_bias Ns = Ns Sy 1 Ns | Ns 0 Ns | Ns 2 Pq int
+Controls metaslab groups biasing based on their write performance.
+Setting to 0 makes all metaslab groups receive fixed amounts of allocations.
+Setting to 2 allows faster metaslab groups to allocate more.
+Setting to 1 equals to 2 if the pool is write-bound or 0 otherwise.
+That is, if the pool is limited by write throughput, then allocate more from
+faster metaslab groups, but if not, try to evenly distribute the allocations.
 .
 .It Sy metaslab_force_ganging Ns = Ns Sy 16777217 Ns B Po 16 MiB + 1 B Pc Pq u64
 Make some blocks above a certain size be gang blocks.
@@ -1527,23 +1537,6 @@ This enforced wait ensures the HDD services the interactive I/O
 within a reasonable amount of time.
 .No See Sx ZFS I/O SCHEDULER .
 .
-.It Sy zfs_vdev_queue_depth_pct Ns = Ns Sy 1000 Ns % Pq uint
-Maximum number of queued allocations per top-level vdev expressed as
-a percentage of
-.Sy zfs_vdev_async_write_max_active ,
-which allows the system to detect devices that are more capable
-of handling allocations and to allocate more blocks to those devices.
-This allows for dynamic allocation distribution when devices are imbalanced,
-as fuller devices will tend to be slower than empty devices.
-.Pp
-Also see
-.Sy zio_dva_throttle_enabled .
-.
-.It Sy zfs_vdev_def_queue_depth Ns = Ns Sy 32 Pq uint
-Default queue depth for each vdev IO allocator.
-Higher values allow for better coalescing of sequential writes before sending
-them to the disk, but can increase transaction commit times.
-.
 .It Sy zfs_vdev_failfast_mask Ns = Ns Sy 1 Pq uint
 Defines if the driver should retire on a given error type.
 The following options may be bitwise-ored together:
@@ -2488,10 +2481,7 @@ Slow I/O counters can be seen with
 .
 .It Sy zio_dva_throttle_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Throttle block allocations in the I/O pipeline.
-This allows for dynamic allocation distribution when devices are imbalanced.
-When enabled, the maximum number of pending allocations per top-level vdev
-is limited by
-.Sy zfs_vdev_queue_depth_pct .
+This allows for dynamic allocation distribution based on device performance.
 .
 .It Sy zfs_xattr_compat Ns = Ns 0 Ns | Ns 1 Pq int
 Control the naming scheme used when setting new xattrs in the user namespace.

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1686,11 +1686,11 @@ spa_activate(spa_t *spa, spa_mode_t mode)
 	spa->spa_mode = mode;
 	spa->spa_read_spacemaps = spa_mode_readable_spacemaps;
 
-	spa->spa_normal_class = metaslab_class_create(spa, msp);
-	spa->spa_log_class = metaslab_class_create(spa, msp);
-	spa->spa_embedded_log_class = metaslab_class_create(spa, msp);
-	spa->spa_special_class = metaslab_class_create(spa, msp);
-	spa->spa_dedup_class = metaslab_class_create(spa, msp);
+	spa->spa_normal_class = metaslab_class_create(spa, msp, B_FALSE);
+	spa->spa_log_class = metaslab_class_create(spa, msp, B_TRUE);
+	spa->spa_embedded_log_class = metaslab_class_create(spa, msp, B_TRUE);
+	spa->spa_special_class = metaslab_class_create(spa, msp, B_FALSE);
+	spa->spa_dedup_class = metaslab_class_create(spa, msp, B_FALSE);
 
 	/* Try to create a covering process */
 	mutex_enter(&spa->spa_proc_lock);
@@ -9883,60 +9883,9 @@ spa_sync_adjust_vdev_max_queue_depth(spa_t *spa)
 {
 	ASSERT(spa_writeable(spa));
 
-	vdev_t *rvd = spa->spa_root_vdev;
-	uint32_t max_queue_depth = zfs_vdev_async_write_max_active *
-	    zfs_vdev_queue_depth_pct / 100;
-	metaslab_class_t *normal = spa_normal_class(spa);
-	metaslab_class_t *special = spa_special_class(spa);
-	metaslab_class_t *dedup = spa_dedup_class(spa);
-
-	uint64_t slots_per_allocator = 0;
-	for (int c = 0; c < rvd->vdev_children; c++) {
-		vdev_t *tvd = rvd->vdev_child[c];
-
-		metaslab_group_t *mg = tvd->vdev_mg;
-		if (mg == NULL || !metaslab_group_initialized(mg))
-			continue;
-
-		metaslab_class_t *mc = mg->mg_class;
-		if (mc != normal && mc != special && mc != dedup)
-			continue;
-
-		/*
-		 * It is safe to do a lock-free check here because only async
-		 * allocations look at mg_max_alloc_queue_depth, and async
-		 * allocations all happen from spa_sync().
-		 */
-		for (int i = 0; i < mg->mg_allocators; i++) {
-			ASSERT0(zfs_refcount_count(
-			    &(mg->mg_allocator[i].mga_alloc_queue_depth)));
-		}
-		mg->mg_max_alloc_queue_depth = max_queue_depth;
-
-		for (int i = 0; i < mg->mg_allocators; i++) {
-			mg->mg_allocator[i].mga_cur_max_alloc_queue_depth =
-			    zfs_vdev_def_queue_depth;
-		}
-		slots_per_allocator += zfs_vdev_def_queue_depth;
-	}
-
-	for (int i = 0; i < spa->spa_alloc_count; i++) {
-		ASSERT0(zfs_refcount_count(&normal->mc_allocator[i].
-		    mca_alloc_slots));
-		ASSERT0(zfs_refcount_count(&special->mc_allocator[i].
-		    mca_alloc_slots));
-		ASSERT0(zfs_refcount_count(&dedup->mc_allocator[i].
-		    mca_alloc_slots));
-		normal->mc_allocator[i].mca_alloc_max_slots =
-		    slots_per_allocator;
-		special->mc_allocator[i].mca_alloc_max_slots =
-		    slots_per_allocator;
-		dedup->mc_allocator[i].mca_alloc_max_slots =
-		    slots_per_allocator;
-	}
-	normal->mc_alloc_throttle_enabled = zio_dva_throttle_enabled;
-	special->mc_alloc_throttle_enabled = zio_dva_throttle_enabled;
-	dedup->mc_alloc_throttle_enabled = zio_dva_throttle_enabled;
+	metaslab_class_balance(spa_normal_class(spa), B_TRUE);
+	metaslab_class_balance(spa_special_class(spa), B_TRUE);
+	metaslab_class_balance(spa_dedup_class(spa), B_TRUE);
 }
 
 static void
@@ -10156,12 +10105,6 @@ spa_sync(spa_t *spa, uint64_t txg)
 	spa->spa_syncing_txg = txg;
 	spa->spa_sync_pass = 0;
 
-	for (int i = 0; i < spa->spa_alloc_count; i++) {
-		mutex_enter(&spa->spa_allocs[i].spaa_lock);
-		VERIFY0(avl_numnodes(&spa->spa_allocs[i].spaa_tree));
-		mutex_exit(&spa->spa_allocs[i].spaa_lock);
-	}
-
 	/*
 	 * If there are any pending vdev state changes, convert them
 	 * into config changes that go out with this transaction group.
@@ -10273,12 +10216,6 @@ spa_sync(spa_t *spa, uint64_t txg)
 	}
 
 	dsl_pool_sync_done(dp, txg);
-
-	for (int i = 0; i < spa->spa_alloc_count; i++) {
-		mutex_enter(&spa->spa_allocs[i].spaa_lock);
-		VERIFY0(avl_numnodes(&spa->spa_allocs[i].spaa_tree));
-		mutex_exit(&spa->spa_allocs[i].spaa_lock);
-	}
 
 	/*
 	 * Update usable space statistics.

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -149,7 +149,7 @@ static uint_t zfs_vdev_sync_write_max_active = 10;
 static uint_t zfs_vdev_async_read_min_active = 1;
 /*  */ uint_t zfs_vdev_async_read_max_active = 3;
 static uint_t zfs_vdev_async_write_min_active = 2;
-/*  */ uint_t zfs_vdev_async_write_max_active = 10;
+static uint_t zfs_vdev_async_write_max_active = 10;
 static uint_t zfs_vdev_scrub_min_active = 1;
 static uint_t zfs_vdev_scrub_max_active = 3;
 static uint_t zfs_vdev_removal_min_active = 1;
@@ -203,31 +203,6 @@ static uint_t zfs_vdev_aggregation_limit = 1 << 20;
 static uint_t zfs_vdev_aggregation_limit_non_rotating = SPA_OLD_MAXBLOCKSIZE;
 static uint_t zfs_vdev_read_gap_limit = 32 << 10;
 static uint_t zfs_vdev_write_gap_limit = 4 << 10;
-
-/*
- * Define the queue depth percentage for each top-level. This percentage is
- * used in conjunction with zfs_vdev_async_max_active to determine how many
- * allocations a specific top-level vdev should handle. Once the queue depth
- * reaches zfs_vdev_queue_depth_pct * zfs_vdev_async_write_max_active / 100
- * then allocator will stop allocating blocks on that top-level device.
- * The default kernel setting is 1000% which will yield 100 allocations per
- * device. For userland testing, the default setting is 300% which equates
- * to 30 allocations per device.
- */
-#ifdef _KERNEL
-uint_t zfs_vdev_queue_depth_pct = 1000;
-#else
-uint_t zfs_vdev_queue_depth_pct = 300;
-#endif
-
-/*
- * When performing allocations for a given metaslab, we want to make sure that
- * there are enough IOs to aggregate together to improve throughput. We want to
- * ensure that there are at least 128k worth of IOs that can be aggregated, and
- * we assume that the average allocation size is 4k, so we need the queue depth
- * to be 32 per allocator to get good aggregation of sequential writes.
- */
-uint_t zfs_vdev_def_queue_depth = 32;
 
 static int
 vdev_queue_offset_compare(const void *x1, const void *x2)
@@ -1168,9 +1143,3 @@ ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, nia_credit, UINT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, nia_delay, UINT, ZMOD_RW,
 	"Number of non-interactive I/Os before _max_active");
-
-ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, queue_depth_pct, UINT, ZMOD_RW,
-	"Queue depth percentage for each top-level vdev");
-
-ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, def_queue_depth, UINT, ZMOD_RW,
-	"Default queue depth for each allocator");

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -1172,10 +1172,10 @@ spa_vdev_copy_segment(vdev_t *vd, zfs_range_tree_t *segs,
 	if (mc->mc_groups == 0)
 		mc = spa_normal_class(spa);
 	int error = metaslab_alloc_dva(spa, mc, size, &dst, 0, NULL, txg,
-	    METASLAB_DONT_THROTTLE, zal, 0);
+	    0, zal, 0);
 	if (error == ENOSPC && mc != spa_normal_class(spa)) {
 		error = metaslab_alloc_dva(spa, spa_normal_class(spa), size,
-		    &dst, 0, NULL, txg, METASLAB_DONT_THROTTLE, zal, 0);
+		    &dst, 0, NULL, txg, 0, zal, 0);
 	}
 	if (error != 0)
 		return (error);


### PR DESCRIPTION
### Motivation and Context
Existing allocation throttling had a goal to improve write speed by allocating more data to vdevs that are able to write it faster. But in the process it completely broke the original mechanism, designed to balance vdev space usage.  With severe vdev space use imbalance it is possible that some with higher use start growing fragmentation sooner than others and after getting full will stop any writes at all.  Also after vdev addition it might take a very long time for pool to restore the balance, since the new vdev does not have any real preference, unless the old one is already much slower due to fragmentation.  Also the old throttling was request-based, which was unpredictable with block sizes varying from 512B to 16MB, neither it made much sense in case of I/O aggregation, when its 32-100 requests could be aggregated into few, leaving device underutilized, submitting fewer and/or shorter requests, or in opposite try to queue up to 1.6GB of writes per device.

### Description
This change presents a completely new throttling algorithm. Unlike the request-based old one, this one measures allocation queue in bytes.  It makes possible to integrate with the reworked allocation quota (aliquot) mechanism, which is also byte-based.  Unlike the original code, balancing the vdevs amounts of free space, this one balances their free/used space fractions.  It should result in a lower and more uniform fragmentation in a long run.

This algorithm still allows to improve write speed by allocating more data to faster vdevs, but does it in more controllable way. On top of space-based allocation quota, it also calculates minimum queue depth that vdev is allowed to maintain, and respectively the amount of extra allocations it can receive if it appear faster. That amount is based on vdev's capacity and space usage, but also applied only when the pool is busy.  This way the code can choose between faster writes when needed and better vdev balance when not, with the choice gradually reducing together with the free space.

This change also makes allocation queues per-class, allowing them to throttle independently and in parallel.  Allocations that are bounced between classes due to allocation errors will be able to properly throttle in the new class.  Allocations that should not be throttled (ZIL, gang, copies) are not, but may still follow the rotor and allocation quota mechanism of the class without disrupting it.

### How Has This Been Tested?
## Test 1: 2 SSDs with 128GB and 256GB capacity written at full speed

![image](https://github.com/user-attachments/assets/2ba6a7a6-87ad-43d8-8dc9-5264e7266648)

Up to ~25% of space usage of the smaller one the SSDs are writing at about the same maximum speed.  After that smaller device is gradually getting throttled to balance space usage.  To the full space usage devices come with only few percent difference.  Since users are typically discouraged to run at full capacity to reduce fragmentation, the performance at the beginning is more important than at the end.

## Test 2: 2 SSDs with 128GB and 256GB capacity written at slower speed

![image](https://github.com/user-attachments/assets/3eb8a7b5-0e2d-49e8-8d93-93c905d719e6)

Since we do not need more speed, the vdevs are keeping almost perfect space usage balance.

## Test 3: SSD and HDD vdevs of the same capacity, but very different performance, written at full speed

![image](https://github.com/user-attachments/assets/f0111ba7-bc94-4543-9c71-197ecd1fb017)

While empty, the SSD is allowed to write 2.5 times faster than the HDD.  With its space usage increase to ~50% the SSD is getting throttled to the HDD speed and after that even slower.  To the full space usage devices come with only few percent difference.

## Test 4: SSD and HDD vdevs of the same capacity, but very different performance, written at slower speed

![image](https://github.com/user-attachments/assets/60854d8b-7b99-4b89-afa6-1bdae47408a6)

Since we do not need more speed, the SSD is throttled to the HDD speed, but instead they are keeping almost perfect space usage balance.

## Test 5: Second vdev addition

![image](https://github.com/user-attachments/assets/2831d783-0fde-4743-b613-28776715b7b2)

First the pool of one vdev is filled almost up to capacity.  After that second vdev is added and the data is overwritten couple times.  Single data overwrite is enough to re-balance the vdevs, even with some overshot, probably due to big sizes of TXG relative to device sizes used in the test and ZFS delayed frees.

## Test 6: Parallel sequential write to 12x 5-wide RAIDZ1 of HDDs

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
block | old | new
-- | -- | --
16K | 3076MiB/s | 3621MiB/s
128K | 3773MiB/s | 4638MiB/s
1M | 4434MiB/s | 4541MiB/s
16M | 4105MiB/s | 4145MiB/s

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
