### PR TITLE
Linux 6.14 compat

### DIFF
--- a/config/kernel-automount.m4
+++ b/config/kernel-automount.m4
@@ -5,7 +5,7 @@ dnl # solution to handling automounts.  Prior to this cifs/nfs clients
 dnl # which required automount support would abuse the follow_link()
 dnl # operation on directories for this purpose.
 dnl #
-AC_DEFUN([ZFS_AC_KERNEL_SRC_AUTOMOUNT], [
+AC_DEFUN([ZFS_AC_KERNEL_SRC_D_AUTOMOUNT], [
 	ZFS_LINUX_TEST_SRC([dentry_operations_d_automount], [
 		#include <linux/dcache.h>
 		static struct vfsmount *d_automount(struct path *p) { return NULL; }
@@ -15,11 +15,48 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_AUTOMOUNT], [
 	])
 ])
 
-AC_DEFUN([ZFS_AC_KERNEL_AUTOMOUNT], [
+AC_DEFUN([ZFS_AC_KERNEL_D_AUTOMOUNT], [
 	AC_MSG_CHECKING([whether dops->d_automount() exists])
 	ZFS_LINUX_TEST_RESULT([dentry_operations_d_automount], [
 		AC_MSG_RESULT(yes)
 	],[
 		ZFS_LINUX_TEST_ERROR([dops->d_automount()])
 	])
+])
+
+dnl #
+dnl # 6.14 API change
+dnl # dops->d_revalidate now has four args.
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_D_REVALIDATE_4ARGS], [
+	ZFS_LINUX_TEST_SRC([dentry_operations_d_revalidate_4args], [
+		#include <linux/dcache.h>
+		static int d_revalidate(struct inode *dir,
+		    const struct qstr *name, struct dentry *dentry,
+		    unsigned int fl) { return 0; }
+		struct dentry_operations dops __attribute__ ((unused)) = {
+			.d_revalidate = d_revalidate,
+		};
+	])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_D_REVALIDATE_4ARGS], [
+	AC_MSG_CHECKING([whether dops->d_revalidate() takes 4 args])
+	ZFS_LINUX_TEST_RESULT([dentry_operations_d_revalidate_4args], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_D_REVALIDATE_4ARGS, 1,
+		    [dops->d_revalidate() takes 4 args])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_SRC_AUTOMOUNT], [
+	ZFS_AC_KERNEL_SRC_D_AUTOMOUNT
+	ZFS_AC_KERNEL_SRC_D_REVALIDATE_4ARGS
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_AUTOMOUNT], [
+	ZFS_AC_KERNEL_D_AUTOMOUNT
+	ZFS_AC_KERNEL_D_REVALIDATE_4ARGS
 ])

--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -189,8 +189,14 @@ zpl_snapdir_automount(struct path *path)
  * as of the 3.18 kernel revaliding the mountpoint dentry will result in
  * the snapshot being immediately unmounted.
  */
+#ifdef HAVE_D_REVALIDATE_4ARGS
+static int
+zpl_snapdir_revalidate(struct inode *dir, const struct qstr *name,
+    struct dentry *dentry, unsigned int flags)
+#else
 static int
 zpl_snapdir_revalidate(struct dentry *dentry, unsigned int flags)
+#endif
 {
 	return (!!dentry->d_inode);
 }

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -202,7 +202,16 @@ static int zvol_blk_mq_alloc_tag_set(zvol_state_t *zv)
 	 * We need BLK_MQ_F_BLOCKING here since we do blocking calls in
 	 * zvol_request_impl()
 	 */
-	zso->tag_set.flags = BLK_MQ_F_SHOULD_MERGE | BLK_MQ_F_BLOCKING;
+	zso->tag_set.flags = BLK_MQ_F_BLOCKING;
+
+#ifdef BLK_MQ_F_SHOULD_MERGE
+	/*
+	 * Linux 6.14 removed BLK_MQ_F_SHOULD_MERGE and made it implicit.
+	 * For older kernels, we set it.
+	 */
+	zso->tag_set.flags |= BLK_MQ_F_SHOULD_MERGE;
+#endif
+
 	zso->tag_set.driver_data = zv;
 
 	return (blk_mq_alloc_tag_set(&zso->tag_set));


### PR DESCRIPTION
### Motivation and Context

> Everyday I talk to my machines
> More sense than talking to human beings
> It's pretty in the land of the free
> Where things ain't quite what they seem
> 
> – Everyday Formula, Regurgitator, 1997.

It's your regularly-scheduled updates for [Linux 6.14-rc1](https://lore.kernel.org/lkml/CAHk-=wicYNCkEgH06w0mpR+GJhJ_ywe0BLTTFXBAj1+y0dqe4Q@mail.gmail.com/T/#u).

### Description

See commit messages. Only two changes, both quite simple.

### How Has This Been Tested?

Compiled and simple sanity check completed on 6.14-rc1 and 6.1.124. I'll do a full ZTS run on 6.14-rc1 in the next couple of days.

Note that there are still unconfirmed reports of flakiness on 6.12 and 6.13 (#16831). I can't see how this would make anything worse though.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
