### PR TITLE
Fix typos in zpool_do_scrub() error messages

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -8481,19 +8481,19 @@ zpool_do_scrub(int argc, char **argv)
 
 	if (is_pause && is_stop) {
 		(void) fprintf(stderr, gettext("invalid option "
-		    "combination :-s and -p are mutually exclusive\n"));
+		    "combination: -s and -p are mutually exclusive\n"));
 		usage(B_FALSE);
 	} else if (is_pause && is_txg_continue) {
 		(void) fprintf(stderr, gettext("invalid option "
-		    "combination :-p and -C are mutually exclusive\n"));
+		    "combination: -p and -C are mutually exclusive\n"));
 		usage(B_FALSE);
 	} else if (is_stop && is_txg_continue) {
 		(void) fprintf(stderr, gettext("invalid option "
-		    "combination :-s and -C are mutually exclusive\n"));
+		    "combination: -s and -C are mutually exclusive\n"));
 		usage(B_FALSE);
 	} else if (is_error_scrub && is_txg_continue) {
 		(void) fprintf(stderr, gettext("invalid option "
-		    "combination :-e and -C are mutually exclusive\n"));
+		    "combination: -e and -C are mutually exclusive\n"));
 		usage(B_FALSE);
 	} else {
 		if (is_error_scrub)


### PR DESCRIPTION
Sponsored-by: Wasabi Technology, Inc.
Sponsored-by: Klara, Inc.



### Motivation and Context
This changes fixes some typos in the error messages in `zpool_do_scrub()`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
