### PR TITLE
zpool: allow relative vdev paths

### DIFF
--- a/lib/libzutil/zutil_device_path.c
+++ b/lib/libzutil/zutil_device_path.c
@@ -57,6 +57,7 @@ int
 zfs_resolve_shortname(const char *name, char *path, size_t len)
 {
 	const char *env = getenv("ZPOOL_IMPORT_PATH");
+	char resolved_path[PATH_MAX];
 
 	if (env) {
 		for (;;) {
@@ -85,6 +86,20 @@ zfs_resolve_shortname(const char *name, char *path, size_t len)
 		}
 	}
 
+	/*
+	 * The user can pass a relative path like ./file1 for the vdev. The path
+	 * must contain a directory prefix like './file1' or '../file1'.  Simply
+	 * passing 'file1' is not allowed, as it may match a block device name.
+	 */
+	if ((strncmp(name, "./", 2) == 0 || strncmp(name, "../", 3) == 0) &&
+	    realpath(name, resolved_path) != NULL) {
+		if (access(resolved_path, F_OK) == 0) {
+			if (strlen(resolved_path) + 1 <= len) {
+				if (strlcpy(path, resolved_path, len) < len)
+					return (0); /* success */
+			}
+		}
+	}
 	return (errno = ENOENT);
 }
 


### PR DESCRIPTION
### Motivation and Context
Allow relative paths in `zpool create`.

### Description
`zpool create` won't let you use relative paths to disks.  This is annoying when you want to do:
```
zpool create tank ./diskfile
```
But have to do..
```
zpool create tank `pwd`/diskfile
```
This fixes it.

### How Has This Been Tested?
Manually tested

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
