### PR TITLE
suspend_resume_single: clear pool errors on fail

### DIFF
--- a/tests/zfs-tests/tests/functional/fault/suspend_resume_single.ksh
+++ b/tests/zfs-tests/tests/functional/fault/suspend_resume_single.ksh
@@ -30,6 +30,7 @@ DATAFILE="$TMPDIR/datafile"
 
 function cleanup
 {
+	zpool clear $TESTPOOL
 	destroy_pool $TESTPOOL
 	unload_scsi_debug
 	rm -f $DATA_FILE


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

While working on something I kept hitting this test failing. And yes, I had bugs, but it sucked that rather than failing the test the entire kernel would just hang up.

The upshot is that if the timing is unfortunate, the pool can suspend just as we're failing because it didn't suspend. If we don't resume the pool, we hang trying to destroy it.

### Description

Clear errors (resuming the pool) before trying to destroy the pool and clean up.

### How Has This Been Tested?

Used to hit it fairly often in ZTS runs, now I don't (once attendant bugs were fixed).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
