### PR TITLE
ZTS: allow alternate work and output dir

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -505,7 +505,6 @@ user = $SINGLETESTUSER
 timeout = 600
 post_user = root
 post =
-outputdir = /var/tmp/test_results
 EOF
 	if [ "$SINGLETEST" = "${SINGLETEST%/*}" ] ; then
 		NEWSINGLETEST=$(find "$STF_SUITE" -name "$SINGLETEST*" -print -quit)

--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -152,7 +152,7 @@ cleanup_all() {
 	else
 		TEST_LOOPBACKS=$("${LOSETUP}" -a | awk -F: '/file-vdev/ {print $1}')
 	fi
-	TEST_FILES=$(ls "${FILEDIR}"/file-vdev* /var/tmp/file-vdev* 2>/dev/null)
+	TEST_FILES=$(ls "${FILEDIR}"/file-vdev* 2>/dev/null)
 
 	msg
 	msg "--- Cleanup ---"
@@ -308,8 +308,8 @@ constrain_path() {
 		# Special case links for zfs test suite utilities
 		create_links "$CMD_DIR/tests/zfs-tests/cmd" "$ZFSTEST_FILES"
 	else
-		# Constrained path set to /var/tmp/constrained_path.*
-		SYSTEMDIR=${SYSTEMDIR:-/var/tmp/constrained_path.XXXXXX}
+		# Constrained path set to $FILEDIR/constrained_path.*
+		SYSTEMDIR=${SYSTEMDIR:-$FILEDIR/constrained_path.XXXXXX}
 		STF_PATH=$(mktemp -d "$SYSTEMDIR")
 		STF_PATH_REMOVE="yes"
 		STF_MISSING_BIN=""
@@ -492,7 +492,7 @@ if [ -n "$SINGLETEST" ]; then
 	if [ -n "$TAGS" ]; then
 		fail "-t and -T are mutually exclusive."
 	fi
-	RUNFILE_DIR="/var/tmp"
+	RUNFILE_DIR="$FILEDIR"
 	RUNFILES="zfs-tests.$$.run"
 	[ -n "$QUIET" ] && SINGLEQUIET="True" || SINGLEQUIET="False"
 

--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -718,6 +718,12 @@ if [ -e /sys/module/zfs/parameters/zfs_dbgmsg_enable ]; then
 	sudo sh -c "echo 0 >/proc/spl/kstat/zfs/dbgmsg"
 fi
 
+#
+# Set TMPDIR. Some tests run mktemp, and we want those files contained to
+# the work dir the same as any other.
+#
+export TMPDIR="$FILEDIR"
+
 msg
 msg "--- Configuration ---"
 msg "Runfiles:        $RUNFILES"
@@ -725,6 +731,7 @@ msg "STF_TOOLS:       $STF_TOOLS"
 msg "STF_SUITE:       $STF_SUITE"
 msg "STF_PATH:        $STF_PATH"
 msg "FILEDIR:         $FILEDIR"
+msg "TMPDIR:          $TMPDIR"
 msg "FILES:           $FILES"
 msg "LOOPBACKS:       $LOOPBACKS"
 msg "DISKS:           $DISKS"

--- a/tests/runfiles/bclone.run
+++ b/tests/runfiles/bclone.run
@@ -25,7 +25,6 @@ post_user = root
 post = cleanup
 failsafe_user = root
 failsafe = callbacks/zfs_failsafe
-outputdir = /var/tmp/test_results
 tags = ['bclone']
 
 [tests/functional/bclone]

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -25,7 +25,6 @@ post_user = root
 post = cleanup
 failsafe_user = root
 failsafe = callbacks/zfs_failsafe
-outputdir = /var/tmp/test_results
 tags = ['functional']
 
 [tests/functional/acl/off]

--- a/tests/runfiles/freebsd.run
+++ b/tests/runfiles/freebsd.run
@@ -19,7 +19,6 @@ post_user = root
 post = cleanup
 failsafe_user = root
 failsafe = callbacks/zfs_failsafe
-outputdir = /var/tmp/test_results
 tags = ['functional']
 
 [tests/functional/cli_root/zfs_jail:FreeBSD]

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -19,7 +19,6 @@ post_user = root
 post = cleanup
 failsafe_user = root
 failsafe = callbacks/zfs_failsafe
-outputdir = /var/tmp/test_results
 tags = ['functional']
 
 [tests/functional/acl/posix:Linux]

--- a/tests/runfiles/longevity.run
+++ b/tests/runfiles/longevity.run
@@ -17,7 +17,6 @@
 quiet = False
 user = root
 timeout = 10800
-outputdir = /var/tmp/test_results
 
 [/opt/zfs-tests/tests/longevity]
 tests = ['slop_space_test']

--- a/tests/runfiles/perf-regression.run
+++ b/tests/runfiles/perf-regression.run
@@ -21,7 +21,6 @@ user = root
 timeout = 0
 post_user = root
 post = cleanup
-outputdir = /var/tmp/test_results
 tags = ['perf']
 
 [tests/perf/regression]

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -27,7 +27,6 @@ post_user = root
 post = cleanup
 failsafe_user = root
 failsafe = callbacks/zfs_failsafe
-outputdir = /var/tmp/test_results
 tags = ['functional']
 
 [tests/functional/acl/off]

--- a/tests/runfiles/sunos.run
+++ b/tests/runfiles/sunos.run
@@ -19,7 +19,6 @@ post_user = root
 post = cleanup
 failsafe_user = root
 failsafe = callbacks/zfs_failsafe
-outputdir = /var/tmp/test_results
 tags = ['functional']
 
 [tests/functional/inuse:illumos]

--- a/tests/test-runner/bin/test-runner.py.in
+++ b/tests/test-runner/bin/test-runner.py.in
@@ -238,7 +238,15 @@ User: %s
             if os.path.isfile(cmd+'.sh') and os.access(cmd+'.sh', os.X_OK):
                 cmd += '.sh'
 
-        ret = '%s -E -u %s %s' % (SUDO, user, cmd)
+        # glibc (at least) will not pass TMPDIR through to setuid programs.
+        # if set, arrange for it to be reset before running the target cmd
+        tmpdir = os.getenv('TMPDIR')
+        if tmpdir:
+            tmpdirarg = 'env TMPDIR=%s' % tmpdir
+        else:
+            tmpdirarg = ''
+
+        ret = '%s -E -u %s %s %s' % (SUDO, user, tmpdirarg, cmd)
         return ret.split(' ')
 
     def collect_output(self, proc, debug=False):

--- a/tests/test-runner/bin/test-runner.py.in
+++ b/tests/test-runner/bin/test-runner.py.in
@@ -746,8 +746,11 @@ class TestRun(object):
 
         for opt in TestRun.props:
             if config.has_option('DEFAULT', opt):
-                setattr(self, opt, config.get('DEFAULT', opt))
-        self.outputdir = os.path.join(self.outputdir, self.timestamp)
+                if opt == 'outputdir':
+                    outputdir = config.get('DEFAULT', opt)
+                    setattr(self, opt, os.path.join(outputdir, self.timestamp))
+                else:
+                    setattr(self, opt, config.get('DEFAULT', opt))
 
         testdir = options.testdir
 
@@ -775,6 +778,11 @@ class TestRun(object):
                                 failsafe = config.get(sect, prop)
                                 setattr(testgroup, prop,
                                         os.path.join(testdir, failsafe))
+                            elif prop == 'outputdir':
+                                outputdir = config.get(sect, prop)
+                                setattr(self, opt,
+                                        os.path.join(outputdir,
+                                                     self.timestamp))
                             else:
                                 setattr(testgroup, prop,
                                         config.get(sect, prop))
@@ -793,6 +801,11 @@ class TestRun(object):
                                 failsafe = config.get(sect, prop)
                                 setattr(test, prop,
                                         os.path.join(testdir, failsafe))
+                            elif prop == 'outputdir':
+                                outputdir = config.get(sect, prop)
+                                setattr(self, opt,
+                                        os.path.join(outputdir,
+                                                     self.timestamp))
                             else:
                                 setattr(test, prop, config.get(sect, prop))
 

--- a/tests/zfs-tests/include/default.cfg.in
+++ b/tests/zfs-tests/include/default.cfg.in
@@ -184,7 +184,7 @@ Linux)
 	DEV_RDSKDIR="/dev"
 	DEV_MPATHDIR="/dev/mapper"
 
-	ZEDLET_DIR="/var/tmp/zed"
+	ZEDLET_DIR="$TEST_BASE_DIR/zed"
 	ZED_LOG="$ZEDLET_DIR/zed.log"
 	ZED_DEBUG_LOG="$ZEDLET_DIR/zed.debug.log"
 	VDEVID_CONF="$ZEDLET_DIR/vdev_id.conf"

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -915,7 +915,7 @@ function set_partition
 			log_fail "The slice, size or disk name is unspecified."
 		fi
 
-		typeset format_file=/var/tmp/format_in.$$
+		typeset format_file="$TEST_BASE_DIR"/format_in.$$
 
 		echo "partition" >$format_file
 		echo "$slicenum" >> $format_file
@@ -2404,7 +2404,7 @@ function add_user #<group_name> <user_name> <basedir>
 {
 	typeset group=$1
 	typeset user=$2
-	typeset basedir=${3:-"/var/tmp"}
+	typeset basedir=${3:-"$TEST_BASE_DIR"}
 
 	if ((${#group} == 0 || ${#user} == 0)); then
 		log_fail "group name or user name are not defined."
@@ -2434,7 +2434,7 @@ function add_user #<group_name> <user_name> <basedir>
 function del_user #<logname> <basedir>
 {
 	typeset user=$1
-	typeset basedir=${2:-"/var/tmp"}
+	typeset basedir=${2:-"$TEST_BASE_DIR"}
 
 	if ((${#user} == 0)); then
 		log_fail "login name is necessary."
@@ -3184,7 +3184,7 @@ function zed_start
 		return
 	fi
 
-	# ZEDLET_DIR=/var/tmp/zed
+	# ZEDLET_DIR=$TEST_BASE_DIR/zed
 	if [[ ! -d $ZEDLET_DIR ]]; then
 		log_must mkdir $ZEDLET_DIR
 	fi

--- a/tests/zfs-tests/tests/functional/acl/off/posixmode.ksh
+++ b/tests/zfs-tests/tests/functional/acl/off/posixmode.ksh
@@ -130,7 +130,7 @@ function test_posix_mode # base
 }
 
 # Sanity check on tmpfs first
-tmpdir=$(TMPDIR=$TEST_BASE_DIR mktemp -d)
+tmpdir=$(mktemp -d)
 log_must mount -t tmpfs tmp $tmpdir
 log_must chmod 777 $tmpdir
 

--- a/tests/zfs-tests/tests/functional/arc/dbufstats_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/arc/dbufstats_001_pos.ksh
@@ -40,8 +40,8 @@
 #    dbufstat and the dbufs kstat output
 #
 
-DBUFSTATS_FILE=$(mktemp $TEST_BASE_DIR/dbufstats.out.XXXXXX)
-DBUFS_FILE=$(mktemp $TEST_BASE_DIR/dbufs.out.XXXXXX)
+DBUFSTATS_FILE=$(mktemp -t dbufstats.out.XXXXXX)
+DBUFS_FILE=$(mktemp -t dbufs.out.XXXXXX)
 
 function cleanup
 {

--- a/tests/zfs-tests/tests/functional/arc/dbufstats_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/arc/dbufstats_002_pos.ksh
@@ -42,7 +42,7 @@
 # 8. Ensure that at least some dbufs moved to the mfu list in the ARC
 #
 
-DBUFS_FILE=$(mktemp $TEST_BASE_DIR/dbufs.out.XXXXXX)
+DBUFS_FILE=$(mktemp -t dbufs.out.XXXXXX)
 
 function cleanup
 {

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning.kshlib
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning.kshlib
@@ -48,11 +48,13 @@ function get_same_blocks
     if [ ${#KEY} -gt 0 ]; then
         KEY="--key=$KEY"
     fi
-	typeset zdbout=${TMPDIR:-$TEST_BASE_DIR}/zdbout.$$
+	typeset zdbout1=$(mktemp)
+	typeset zdbout2=$(mktemp)
 	zdb $KEY -vvvvv $1 -O $2 | \
-	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout.a
+	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout1
 	zdb $KEY -vvvvv $3 -O $4 | \
-	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout.b
-	echo $(sort -n $zdbout.a $zdbout.b | uniq -d | cut -f1 -d' ')
+	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout2
+	echo $(sort -n $zdbout1 $zdbout2 | uniq -d | cut -f1 -d' ')
+	rm -f $zdbout1 $zdbout2
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_test_race.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_test_race.ksh
@@ -38,10 +38,10 @@
 
 verify_runnable "both"
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-MNTPT=$TMPDIR/zfs_mount_test_race_mntpt
-DISK1="$TMPDIR/zfs_mount_test_race_disk1"
-DISK2="$TMPDIR/zfs_mount_test_race_disk2"
+DISKDIR=$(mktemp -d)
+MNTPT=$DISKDIR/zfs_mount_test_race_mntpt
+DISK1="$DISKDIR/zfs_mount_test_race_disk1"
+DISK2="$DISKDIR/zfs_mount_test_race_disk2"
 
 TESTPOOL1=zfs_mount_test_race_tp1
 TESTPOOL2=zfs_mount_test_race_tp2
@@ -54,11 +54,9 @@ function cleanup
 {
 	zpool destroy $TESTPOOL1
 	zpool destroy $TESTPOOL2
-	rm -rf $MNTPT
+	rm -rf $DISKDIR
 	rm -rf /$TESTPOOL1
 	rm -rf /$TESTPOOL2
-	rm -f $DISK1
-	rm -f $DISK2
 	export __ZFS_POOL_RESTRICT="$TESTPOOL1 $TESTPOOL2"
 	log_must zfs $mountall
 	unset __ZFS_POOL_RESTRICT

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_007_pos.ksh
@@ -48,8 +48,8 @@ function cleanup
 
 log_assert "Verify that 'zfs send' drills appropriate holes"
 log_onexit cleanup
-streamfile=$(mktemp $TESTDIR/file.XXXXXX)
-vdev=$(mktemp $TEST_BASE_DIR/file.XXXXXX)
+streamfile=$(mktemp)
+vdev=$(mktemp)
 
 
 function test_pool

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_rename_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_rename_001_pos.ksh
@@ -160,7 +160,7 @@ while (( i < ${#pools[*]} )); do
 	((i = i + 1))
 done
 
-VDEV_FILE=$(mktemp $TEST_BASE_DIR/tmp.XXXXXX)
+VDEV_FILE=$(mktemp)
 
 log_must mkfile -n 128M $VDEV_FILE
 log_must zpool create overflow $VDEV_FILE

--- a/tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_-c_homedir.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_-c_homedir.ksh
@@ -29,9 +29,9 @@
 #	home directory.
 #
 # STRATEGY:
-#	1. Change HOME to /var/tmp
+#	1. Change HOME to /var/tmp (TEST_BASE_DIR)
 #	2. Make a simple script that echoes a key value pair
-#	   in /var/tmp/.zpool.d
+#	   in $HOME/.zpool.d
 #	3. Make sure it can be run with -c
 #	4. Remove the script we created
 

--- a/tests/zfs-tests/tests/functional/cli_user/zpool_status/zpool_status_-c_homedir.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/zpool_status/zpool_status_-c_homedir.ksh
@@ -29,9 +29,9 @@
 #	home directory.
 #
 # STRATEGY:
-#	1. Change HOME to /var/tmp
+#	1. Change HOME to /var/tmp (TEST_BASE_DIR)
 #	2. Make a simple script that echoes a key value pair
-#	   in /var/tmp/.zpool.d
+#	   in $HOME/.zpool.d
 #	3. Make sure it can be run with -c
 #	4. Remove the script we created
 

--- a/tests/zfs-tests/tests/functional/fault/suspend_resume_single.ksh
+++ b/tests/zfs-tests/tests/functional/fault/suspend_resume_single.ksh
@@ -26,14 +26,14 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-DATAFILE="$TMPDIR/datafile"
+DATAFILE=$(mktemp)
 
 function cleanup
 {
 	zpool clear $TESTPOOL
 	destroy_pool $TESTPOOL
 	unload_scsi_debug
-	rm -f $DATA_FILE
+	rm -f $DATAFILE
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_panic.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_panic.ksh
@@ -28,7 +28,7 @@ typeset ds_name="panic"
 typeset sendfs="$POOL/$ds_name"
 typeset recvfs="$POOL2/$ds_name"
 typeset clone="$POOL/${ds_name}_clone"
-typeset stream=$(mktemp $TEST_BASE_DIR/stream.XXXX)
+typeset stream=$(mktemp -t stream.XXXX)
 
 function cleanup
 {

--- a/tests/zfs-tests/tests/functional/removal/removal_check_space.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_check_space.ksh
@@ -21,24 +21,24 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/removal/removal.kshlib
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-log_must mkfile $MINVDEVSIZE $TMPDIR/dsk1
-log_must mkfile $MINVDEVSIZE $TMPDIR/dsk2
-DISKS="$TMPDIR/dsk1 $TMPDIR/dsk2"
-REMOVEDISK=$TMPDIR/dsk1
+DISKDIR=$(mktemp -d)
+log_must mkfile $MINVDEVSIZE $DISKDIR/dsk1
+log_must mkfile $MINVDEVSIZE $DISKDIR/dsk2
+DISKS="$DISKDIR/dsk1 $DISKDIR/dsk2"
+REMOVEDISK=$DISKDIR/dsk1
 
 log_must default_setup_noexit "$DISKS"
 
 function cleanup
 {
 	default_cleanup_noexit
-	log_must rm -f $DISKS
+	log_must rm -rf $DISKDIR
 }
 log_onexit cleanup
 
 # Write a little more than half the pool.
 log_must dd if=/dev/urandom of=/$TESTDIR/$TESTFILE0 bs=$((2**20)) \
     count=$((MINVDEVSIZE / (1024 * 1024)))
-log_mustnot zpool remove $TESTPOOL $TMPDIR/dsk1
+log_mustnot zpool remove $TESTPOOL $DISKDIR/dsk1
 
 log_pass "Removal will not succeed if insufficient space."

--- a/tests/zfs-tests/tests/functional/removal/removal_multiple_indirection.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_multiple_indirection.ksh
@@ -44,18 +44,18 @@
 #    that the files contents remain the same across transfers.
 #
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-log_must mkfile $(($MINVDEVSIZE * 2)) $TMPDIR/dsk1
-log_must mkfile $(($MINVDEVSIZE * 2)) $TMPDIR/dsk2
-DISKS="$TMPDIR/dsk1 $TMPDIR/dsk2"
-REMOVEDISK=$TMPDIR/dsk1
+DISKDIR=$(mktemp -d)
+log_must mkfile $(($MINVDEVSIZE * 2)) $DISKDIR/dsk1
+log_must mkfile $(($MINVDEVSIZE * 2)) $DISKDIR/dsk2
+DISKS="$DISKDIR/dsk1 $DISKDIR/dsk2"
+REMOVEDISK=$DISKDIR/dsk1
 
 log_must default_setup_noexit "$DISKS"
 
 function cleanup
 {
 	default_cleanup_noexit
-	log_must rm -f $DISKS
+	log_must rm -rf $DISKDIR
 
 	# reset REMOVE_MAX_SEGMENT to 1M
 	set_tunable32 REMOVE_MAX_SEGMENT 1048576
@@ -71,19 +71,19 @@ FILE_CONTENTS=$(<$TESTDIR/$TESTFILE0)
 log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 
 for i in {1..10}; do
-	log_must zpool remove $TESTPOOL $TMPDIR/dsk1
+	log_must zpool remove $TESTPOOL $DISKDIR/dsk1
 	log_must wait_for_removal $TESTPOOL
-	log_mustnot vdevs_in_pool $TESTPOOL $TMPDIR/dsk1
-	log_must zpool add $TESTPOOL $TMPDIR/dsk1
+	log_mustnot vdevs_in_pool $TESTPOOL $DISKDIR/dsk1
+	log_must zpool add $TESTPOOL $DISKDIR/dsk1
 
 	log_must zinject -a
 	log_must dd if=$TESTDIR/$TESTFILE0 of=/dev/null
 	log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 
-	log_must zpool remove $TESTPOOL $TMPDIR/dsk2
+	log_must zpool remove $TESTPOOL $DISKDIR/dsk2
 	log_must wait_for_removal $TESTPOOL
-	log_mustnot vdevs_in_pool $TESTPOOL $TMPDIR/dsk2
-	log_must zpool add $TESTPOOL $TMPDIR/dsk2
+	log_mustnot vdevs_in_pool $TESTPOOL $DISKDIR/dsk2
+	log_must zpool add $TESTPOOL $DISKDIR/dsk2
 
 	log_must zinject -a
 	log_must dd if=$TESTDIR/$TESTFILE0 of=/dev/null

--- a/tests/zfs-tests/tests/functional/removal/removal_reservation.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_reservation.ksh
@@ -21,18 +21,18 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/removal/removal.kshlib
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-log_must mkfile 1g $TMPDIR/dsk1
-log_must mkfile 1g $TMPDIR/dsk2
-DISKS="$TMPDIR/dsk1 $TMPDIR/dsk2"
-REMOVEDISK=$TMPDIR/dsk1
+DISKDIR=$(mktemp -d)
+log_must mkfile 1g $DISKDIR/dsk1
+log_must mkfile 1g $DISKDIR/dsk2
+DISKS="$DISKDIR/dsk1 $DISKDIR/dsk2"
+REMOVEDISK=$DISKDIR/dsk1
 
 default_setup_noexit "$DISKS"
 
 function cleanup
 {
 	default_cleanup_noexit
-	log_must rm -f $DISKS
+	log_must rm -rf $DISKDIR
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/removal/removal_with_add.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_with_add.ksh
@@ -21,14 +21,14 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/removal/removal.kshlib
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-log_must mkfile 1g $TMPDIR/dsk1
-log_must mkfile 1g $TMPDIR/dsk2
+DISKDIR=$(mktemp -d)
+log_must mkfile 1g $DISKDIR/dsk1
+log_must mkfile 1g $DISKDIR/dsk2
 
 function cleanup
 {
 	default_cleanup_noexit
-	log_must rm -f $TMPDIR/dsk1 $TMPDIR/dsk2
+	log_must rm -rf $DISKDIR
 }
 
 default_setup_noexit "$DISKS"
@@ -36,10 +36,10 @@ log_onexit cleanup
 
 function callback
 {
-	log_mustnot zpool attach -f $TESTPOOL $TMPDIR/dsk1 $TMPDIR/dsk2
+	log_mustnot zpool attach -f $TESTPOOL $DISKDIR/dsk1 $DISKDIR/dsk2
 	log_mustnot zpool add -f $TESTPOOL \
-	    raidz $TMPDIR/dsk1 $TMPDIR/dsk2
-	log_must zpool add -f $TESTPOOL $TMPDIR/dsk1
+	    raidz $DISKDIR/dsk1 $DISKDIR/dsk2
+	log_must zpool add -f $TESTPOOL $DISKDIR/dsk1
 	return 0
 }
 

--- a/tests/zfs-tests/tests/functional/removal/removal_with_errors.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_with_errors.ksh
@@ -44,11 +44,11 @@
 # 7. Lastly verify the pool data is still intact.
 #
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-DISK0=$TMPDIR/dsk0
-DISK1=$TMPDIR/dsk1
-DISK2=$TMPDIR/dsk2
-DISK3=$TMPDIR/dsk3
+DISKDIR=$(mktemp -d)
+DISK0=$DISKDIR/dsk0
+DISK1=$DISKDIR/dsk1
+DISK2=$DISKDIR/dsk2
+DISK3=$DISKDIR/dsk3
 
 log_must truncate -s $MINVDEVSIZE $DISK0 $DISK1
 log_must truncate -s $((MINVDEVSIZE * 4)) $DISK2 $DISK3
@@ -57,7 +57,7 @@ function cleanup
 {
 	log_must zinject -c all
 	default_cleanup_noexit
-	log_must rm -f $DISK0 $DISK1 $DISK2 $DISK3
+	log_must rm -rf $DISKDIR
 }
 
 function wait_for_removing_cancel
@@ -88,7 +88,7 @@ log_must file_write -o create -f $TESTDIR/$TESTFILE1 -b $((2**20)) -c $((2**8))
 
 # Flush the ARC to minimize cache effects.
 log_must zpool export $TESTPOOL
-log_must zpool import -d $TMPDIR $TESTPOOL
+log_must zpool import -d $DISKDIR $TESTPOOL
 
 # Verify that unexpected read errors automatically cancel the removal.
 log_must zinject -d $DISK0 -e io -T all -f 100 $TESTPOOL
@@ -99,7 +99,7 @@ log_must zinject -c all
 
 # Flush the ARC to minimize cache effects.
 log_must zpool export $TESTPOOL
-log_must zpool import -d $TMPDIR $TESTPOOL
+log_must zpool import -d $DISKDIR $TESTPOOL
 
 # Verify that unexpected write errors automatically cancel the removal.
 log_must zinject -d $DISK3 -e io -T all -f 100 $TESTPOOL

--- a/tests/zfs-tests/tests/functional/removal/removal_with_faulted.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_with_faulted.ksh
@@ -63,11 +63,11 @@
 #    data is still intact.
 #
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-DISK0=$TMPDIR/dsk0
-DISK1=$TMPDIR/dsk1
-DISK2=$TMPDIR/dsk2
-DISK3=$TMPDIR/dsk3
+DISKDIR=$(mktemp -d)
+DISK0=$DISKDIR/dsk0
+DISK1=$DISKDIR/dsk1
+DISK2=$DISKDIR/dsk2
+DISK3=$DISKDIR/dsk3
 
 log_must truncate -s $MINVDEVSIZE $DISK0 $DISK1
 log_must truncate -s $((MINVDEVSIZE * 4)) $DISK2 $DISK3
@@ -75,7 +75,7 @@ log_must truncate -s $((MINVDEVSIZE * 4)) $DISK2 $DISK3
 function cleanup
 {
 	default_cleanup_noexit
-	log_must rm -f $DISK0 $DISK1 $DISK2 $DISK3
+	log_must rm -rf $DISKDIR
 }
 
 default_setup_noexit "mirror $DISK0 $DISK1 mirror $DISK2 $DISK3"

--- a/tests/zfs-tests/tests/functional/removal/removal_with_indirect.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_with_indirect.ksh
@@ -21,12 +21,11 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/removal/removal.kshlib
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-
-DISK1="$TMPDIR/dsk1"
-DISK2="$TMPDIR/dsk2"
-DISK3="$TMPDIR/dsk3"
-DISK4="$TMPDIR/dsk4"
+DISKDIR=$(mktemp -d)
+DISK1="$DISKDIR/dsk1"
+DISK2="$DISKDIR/dsk2"
+DISK3="$DISKDIR/dsk3"
+DISK4="$DISKDIR/dsk4"
 DISKS="$DISK1 $DISK2 $DISK3 $DISK4"
 
 log_must mkfile $(($MINVDEVSIZE * 2)) $DISK1
@@ -37,7 +36,7 @@ log_must mkfile $(($MINVDEVSIZE * 2)) $DISK4
 function cleanup
 {
 	default_cleanup_noexit
-	log_must rm -f $DISKS
+	log_must rm -rf $DISKDIR
 }
 
 # Build a zpool with 2 mirror vdevs

--- a/tests/zfs-tests/tests/functional/removal/removal_with_zdb.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_with_zdb.ksh
@@ -21,7 +21,7 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/removal/removal.kshlib
 
-zdbout=${TMPDIR:-$TEST_BASE_DIR}/zdbout.$$
+zdbout=$(mktemp)
 
 if is_linux; then
 	log_unsupported "ZDB fails during concurrent pool activity."

--- a/tests/zfs-tests/tests/functional/removal/remove_attach_mirror.ksh
+++ b/tests/zfs-tests/tests/functional/removal/remove_attach_mirror.ksh
@@ -34,10 +34,9 @@
 
 command -v fio > /dev/null || log_unsupported "fio missing"
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-
-DISK1="$TMPDIR/dsk1"
-DISK2="$TMPDIR/dsk2"
+DISKDIR=$(mktemp -d)
+DISK1="$DISKDIR/dsk1"
+DISK2="$DISKDIR/dsk2"
 DISKS="$DISK1 $DISK2"
 
 # fio options
@@ -58,7 +57,7 @@ log_must mkfile 4g $DISK2
 function cleanup
 {
 	default_cleanup_noexit
-	log_must rm -f $DISKS
+	log_must rm -rf $DISKDIR
 }
 
 log_must zpool create -O recordsize=4k $TESTPOOL $DISK1 $DISK2

--- a/tests/zfs-tests/tests/functional/removal/remove_expanded.ksh
+++ b/tests/zfs-tests/tests/functional/removal/remove_expanded.ksh
@@ -32,10 +32,10 @@
 #
 
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-DISK0=$TMPDIR/dsk0
-DISK1=$TMPDIR/dsk1
-DISK2=$TMPDIR/dsk2
+DISKDIR=$(mktemp -d)
+DISK0=$DISKDIR/dsk0
+DISK1=$DISKDIR/dsk1
+DISK2=$DISKDIR/dsk2
 
 log_must truncate -s $MINVDEVSIZE $DISK0
 log_must truncate -s $(($MINVDEVSIZE * 3)) $DISK1
@@ -44,7 +44,7 @@ log_must truncate -s $MINVDEVSIZE $DISK2
 function cleanup
 {
 	default_cleanup_noexit
-	log_must rm -f $DISK0 $DISK1 $DISK2
+	log_must rm -rf $DISKDIR
 }
 
 #

--- a/tests/zfs-tests/tests/functional/removal/remove_mirror.ksh
+++ b/tests/zfs-tests/tests/functional/removal/remove_mirror.ksh
@@ -21,11 +21,10 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/removal/removal.kshlib
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-
-DISK1="$TMPDIR/dsk1"
-DISK2="$TMPDIR/dsk2"
-DISK3="$TMPDIR/dsk3"
+DISKDIR=$(mktemp -d)
+DISK1="$DISKDIR/dsk1"
+DISK2="$DISKDIR/dsk2"
+DISK3="$DISKDIR/dsk3"
 DISKS="$DISK1 $DISK2 $DISK3"
 
 log_must mkfile $(($MINVDEVSIZE * 2)) $DISK1
@@ -35,7 +34,7 @@ log_must mkfile $(($MINVDEVSIZE * 2)) $DISK3
 function cleanup
 {
 	default_cleanup_noexit
-	log_must rm -f $DISKS
+	log_must rm -rf $DISKDIR
 }
 
 log_must default_setup_noexit "$DISK1 mirror $DISK2 $DISK3"

--- a/tests/zfs-tests/tests/functional/removal/remove_raidz.ksh
+++ b/tests/zfs-tests/tests/functional/removal/remove_raidz.ksh
@@ -21,28 +21,28 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/removal/removal.kshlib
 
-TMPDIR=${TMPDIR:-$TEST_BASE_DIR}
-log_must mkfile $MINVDEVSIZE $TMPDIR/dsk1
-log_must mkfile $MINVDEVSIZE $TMPDIR/dsk2
-log_must mkfile $MINVDEVSIZE $TMPDIR/dsk3
-DISKS1="$TMPDIR/dsk1"
-DISKS2="$TMPDIR/dsk2 $TMPDIR/dsk3"
+DISKDIR=$(mktemp -d)
+log_must mkfile $MINVDEVSIZE $DISKDIR/dsk1
+log_must mkfile $MINVDEVSIZE $DISKDIR/dsk2
+log_must mkfile $MINVDEVSIZE $DISKDIR/dsk3
+DISKS1="$DISKDIR/dsk1"
+DISKS2="$DISKDIR/dsk2 $DISKDIR/dsk3"
 DISKS="$DISKS1 $DISKS2"
 
 function cleanup
 {
 	default_cleanup_noexit
-	log_must rm -f $DISKS
+	log_must rm -rf $DISKDIR
 }
 
 log_must default_setup_noexit "$DISKS1 raidz $DISKS2"
 log_onexit cleanup
 
 # Attempt to remove the non raidz disk.
-log_mustnot zpool remove $TESTPOOL $TMPDIR/dsk1
+log_mustnot zpool remove $TESTPOOL $DISKDIR/dsk1
 
 # Attempt to remove one of the raidz disks.
-log_mustnot zpool remove $TESTPOOL $TMPDIR/dsk2
+log_mustnot zpool remove $TESTPOOL $DISKDIR/dsk2
 
 # Attempt to remove the raidz.
 log_mustnot zpool remove $TESTPOOL raidz1-1

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_002_pos.ksh
@@ -63,7 +63,7 @@ function cleanup
 log_assert "Verify an archive of a file system is identical to " \
     "an archive of its snapshot."
 
-SNAPSHOT_TARDIR="$(mktemp -d /tmp/zfstests_snapshot_002.XXXXXX)"
+SNAPSHOT_TARDIR="$(mktemp -t -d zfstests_snapshot_002.XXXXXX)"
 log_onexit cleanup
 
 typeset -i COUNT=21

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_006_pos.ksh
@@ -72,7 +72,7 @@ function cleanup
 log_assert "Verify that an archive of a dataset is identical to " \
    "an archive of the dataset's snapshot."
 
-SNAPSHOT_TARDIR="$(mktemp -d /tmp/zfstests_snapshot_006.XXXXXX)"
+SNAPSHOT_TARDIR="$(mktemp -t -d zfstests_snapshot_006.XXXXXX)"
 log_onexit cleanup
 
 typeset -i COUNT=21

--- a/tests/zfs-tests/tests/functional/user_namespace/user_namespace_004.ksh
+++ b/tests/zfs-tests/tests/functional/user_namespace/user_namespace_004.ksh
@@ -58,7 +58,7 @@ log_onexit user_ns_cleanup
 log_must zfs create -o zoned=on "$TESTPOOL/userns"
 
 # 1. Try to pass a non-namespace file to zfs zone.
-temp_file="$(TMPDIR=$TEST_BASE_DIR mktemp)"
+temp_file="$(mktemp)"
 log_mustnot zfs zone "$temp_file" "$TESTPOOL/userns"
 
 # 2. Try to pass a non-namespace and non-existent file to zfs zone.

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_fua.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_fua.ksh
@@ -47,8 +47,8 @@ if ! is_linux ; then
 	log_unsupported "Only linux supports dd with oflag=dsync for FUA writes"
 fi
 
-typeset datafile1="$(mktemp zvol_misc_fua1.XXXXXX)"
-typeset datafile2="$(mktemp zvol_misc_fua2.XXXXXX)"
+typeset datafile1="$(mktemp -t zvol_misc_fua1.XXXXXX)"
+typeset datafile2="$(mktemp -t zvol_misc_fua2.XXXXXX)"
 typeset zvolpath=${ZVOL_DEVDIR}/$TESTPOOL/$TESTVOL
 
 function cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_trim.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_trim.ksh
@@ -65,8 +65,8 @@ if ! is_physical_device $DISKS; then
 	log_unsupported "This directory cannot be run on raw files."
 fi
 
-typeset datafile1="$(mktemp zvol_misc_flags1.XXXXXX)"
-typeset datafile2="$(mktemp zvol_misc_flags2.XXXXXX)"
+typeset datafile1="$(mktemp -t zvol_misc_flags1.XXXXXX)"
+typeset datafile2="$(mktemp -t zvol_misc_flags2.XXXXXX)"
 typeset zvolpath=${ZVOL_DEVDIR}/$TESTPOOL/$TESTVOL
 
 function cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_stress/zvol_stress.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_stress/zvol_stress.ksh
@@ -57,7 +57,7 @@ biggest_zvol_size_possible=$(largest_volsize_from_pool $TESTPOOL)
 typeset -f each_zvol_size=$(( floor($biggest_zvol_size_possible * 0.9 / \
 	$num_zvols )))
 
-typeset tmpdir="$(mktemp -d zvol_stress_fio_state.XXXXXX)"
+typeset tmpdir="$(mktemp -t -d zvol_stress_fio_state.XXXXXX)"
 
 function create_zvols
 {

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_001_pos.ksh
@@ -41,7 +41,7 @@
 # 1. Create a pool
 # 2. Create a zvol volume
 # 3. Use zvol as swap space
-# 4. Create a file under /var/tmp
+# 4. Create a file under /var/tmp (TEST_BASE_DIR)
 #
 
 verify_runnable "global"
@@ -63,11 +63,11 @@ voldev=${ZVOL_DEVDIR}/$TESTPOOL/$TESTVOL
 log_note "Add zvol volume as swap space"
 log_must swap_setup $voldev
 
-log_note "Create a file under /var/tmp"
+log_note "Create a file under $TEST_BASE_DIR"
 log_must file_write -o create -f $TEMPFILE \
     -b $BLOCKSZ -c $NUM_WRITES -d $DATA
 
-[[ ! -f $TEMPFILE ]] && log_fail "Unable to create file under /var/tmp"
+[[ ! -f $TEMPFILE ]] && log_fail "Unable to create file under $TEST_BASE_DIR"
 
 filesize=`ls -l $TEMPFILE | awk '{print $5}'`
 tf_size=$(( BLOCKSZ * NUM_WRITES ))

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_002_pos.ksh
@@ -39,7 +39,7 @@
 #
 # STRATEGY:
 #	1. Create a new zvol and add it as swap
-#	2. Fill //var/tmp with 80% the size of the zvol
+#	2. Fill //var/tmp (TEST_BASE_DIR) with 80% the size of the zvol
 #	5. Remove the new zvol, and restore original swap devices
 #
 
@@ -54,7 +54,7 @@ function cleanup
 	fi
 }
 
-log_assert "Using a zvol as swap space, fill /var/tmp to 80%."
+log_assert "Using a zvol as swap space, fill $TEST_BASE_DIR to 80%."
 
 log_onexit cleanup
 
@@ -73,4 +73,4 @@ log_must dd if=/dev/urandom of=$TEMPFILE bs=1048576 count=$count
 log_must rm -f $TEMPFILE
 log_must swap_cleanup $swapdev
 
-log_pass "Using a zvol as swap space, fill /var/tmp to 80%."
+log_pass "Using a zvol as swap space, fill $TEST_BASE_DIR to 80%."


### PR DESCRIPTION
### Motivation and Context

I realised that part of the reason my test rig takes about 15 hours for a full ZTS run is at least in part to do with most of the tests on file vdevs, on ext4, in a VM, on a zvol. Learned a few things, some patches coming soon etc. But the best thing is to just dig out a spare NVMe drive, direct attach it to the VM, and make ZTS use that for everything.

Turns out it's awkward to mount a separate drive at `/var/tmp` because a typical Linux wants to use that for some of its housekeeping and there's a mild boot ordering issue, so fine, I'll put it somewhere else. But then it turns out that some of the path handling through `zfs-tests` and `test-runner` and the tests themselves were a bit messed up, so it wasn't possible to get everything where I wanted it.

So this PR makes it so that if you tell the test runners to use a different path, you get (mostly) get what you pay for. And now all the test work goes to `/zts` on my test rig, and a full run takes 4 hours, which is very much more manageable.

### Description

There's three separate changes here.

First, we make sure that the work dir (default `/var/tmp`) is threaded through properly. As before, it starts life as `$FILEDIR` in `zfs-tests.sh`, settable with `-d`. That becomes `$TEST_BASE_DIR` once it hits the test scripts. Some of those had `/var/tmp` hardcoded, and have been updated. There's also a small handful of setup things like the default vdevs, the `constrained_path` command dir and the generated runfile for single tests that were also hardcoded, and now go to `$FILEDIR`.

Next, we remove the explicit `outputdir` from the runfiles, and properly thread through `test-runner`'s default of `/var/tmp/test_results`. This was buggy; adding the timestamp suffix was not done consistently for all the different sources of `outputdir`, so I've fixed that up. Not that we use it, but if the code is going to exist it should probably work right.

Finally, I've made the use of `/tmp` and `$TMPDIR` a lot more consistent. In many places, individual tests create work files (including large vdev backing files) using their best guess for a good temporary dir, but it was done very inconsistently and most often ended up with files in `/tmp`, which I wanted to avoid. So I've made sure `$TMPDIR` is set to `$FILEDIR`/`$TEST_BASE_DIR`, and updated uses of `mktemp` to use it (usually simplifying the call) and uses of `$TMPDIR` to use `mktemp`.

Taken together, this brings the vast majority of the work output under the path specified by the operator in `zfs-tests.sh -d`, and I'm much happier.

Worth noting that there's still a handful of outputs to `/tmp`, which I've left for now, mostly because I ran out of day and I'd rather get this posted than leave it lying around for weeks while I find time to finish it off properly.

### How Has This Been Tested?

Two successful full ZTS runs completed pointed to an alternate work dir. The handful of tests that were modified for `mktemp`/`$TMPDIR` were run directly both on the default `/var/tmp` and an alternate dir, all passed.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
