### PR TITLE
Refresh db_buf pointer after lock and conditional wait.

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1539,6 +1539,7 @@ dbuf_read_verify_dnode_crypt(dmu_buf_impl_t *db, dnode_t *dn, uint32_t flags)
 		return (0);
 
 	mutex_enter(&dndb->db_mtx);
+	dnbuf = dndb->db_buf;
 
 	/*
 	 * Since dnode buffer is modified by sync process, there can be only
@@ -1556,6 +1557,7 @@ dbuf_read_verify_dnode_crypt(dmu_buf_impl_t *db, dnode_t *dn, uint32_t flags)
 		if (dr == NULL || dr->dt.dl.dr_data != dnbuf)
 			break;
 		cv_wait(&dndb->db_changed, &dndb->db_mtx);
+		dnbuf = dndb->db_buf;
 	};
 
 	SET_BOOKMARK(&zb, dmu_objset_id(os),


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Try to solve the encrypted zfs send issue. This is purely theoretical change, I wasn't been able to reproduce the issue myself, but looking at the code this have come to mind.
#

### Description
<!--- Describe your changes in detail -->
I'm not very familiar with the zfs code base, but I think there is a logic issue in the code.
db_buf can reference can be changed by the code holdiing dndb->db_mtx mutex and waiting on mutex can take a while, so the reference can become stale.

### How Has This Been Tested?
Show pass the test suite test without an issue I would imagine.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
