### PR TITLE
Fix a crash when attempting to read a block pointer with no valid DVAs

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -670,7 +670,6 @@ typedef struct blkptr {
 			    (u_longlong_t)DVA_GET_ASIZE(dva),		\
 			    ws);					\
 		}							\
-		ASSERT3S(copies, >, 0);					\
 		if (BP_IS_ENCRYPTED(bp)) {				\
 			len += func(buf + len, size - len,		\
 			    "salt=%llx iv=%llx:%llx%c",			\
@@ -679,10 +678,6 @@ typedef struct blkptr {
 			    (u_longlong_t)BP_GET_IV2(bp),		\
 			    ws);					\
 		}							\
-		if (BP_IS_GANG(bp) &&					\
-		    DVA_GET_ASIZE(&bp->blk_dva[2]) <=			\
-		    DVA_GET_ASIZE(&bp->blk_dva[1]) / 2)			\
-			copies--;					\
 		len += func(buf + len, size - len,			\
 		    "[L%llu %s] %s %s %s %s %s %s %s%c"			\
 		    "size=%llxL/%llxP birth=%lluL/%lluP fill=%llu%c"	\


### PR DESCRIPTION
### Motivation and Context
Somehow ZFS wrote to my pool a block pointer that is neither embedded nor a hole, yet contains no DVAs with a non-zero asize.  That should be impossible, but it happened.  This PR will cause ZFS to return `ECKSUM` when attempting to read from that block pointer, rather than crashing.  This PR will also fix zdb so it can display such block pointers.  Finally, I believe that this PR will prevent such block pointers from being written to disk in the first place, by triggering a panic in `zfs_blkptr_verify` in the write path.

### Description
* Modify `zfs_blkptr_verify` to ensure that every block pointer is either embedded, hole, or has at least one valid DVA.
* Modify zdb to display such block pointers rather than failing an assertion.  They will displayed with no DVA shown.

### How Has This Been Tested?
Tested on FreeBSD 15.0-CURRENT by trying to read from a suitably corrupted dataset.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
