### PR TITLE
Don't try to get mg of hole vdev in removal

### DIFF
--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -210,7 +210,8 @@ vdev_passivate(vdev_t *vd, uint64_t *txg)
 			vdev_t *cvd = rvd->vdev_child[id];
 
 			if (cvd == vd ||
-			    cvd->vdev_ops == &vdev_indirect_ops)
+			    cvd->vdev_ops == &vdev_indirect_ops ||
+			    cvd->vdev_ops == &vdev_hole_ops)
 				continue;
 
 			metaslab_class_t *mc = cvd->vdev_mg->mg_class;

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -209,9 +209,8 @@ vdev_passivate(vdev_t *vd, uint64_t *txg)
 		for (uint64_t id = 0; id < rvd->vdev_children; id++) {
 			vdev_t *cvd = rvd->vdev_child[id];
 
-			if (cvd == vd ||
-			    cvd->vdev_ops == &vdev_indirect_ops ||
-			    cvd->vdev_ops == &vdev_hole_ops)
+			if (cvd == vd || !vdev_is_concrete(cvd) ||
+			    vdev_is_dead(cvd))
 				continue;
 
 			metaslab_class_t *mc = cvd->vdev_mg->mg_class;

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -888,7 +888,8 @@ tests = ['removal_all_vdev', 'removal_cancel', 'removal_check_space',
     'removal_with_send_recv', 'removal_with_snapshot',
     'removal_with_write', 'removal_with_zdb', 'remove_expanded',
     'remove_mirror', 'remove_mirror_sanity', 'remove_raidz',
-    'remove_indirect', 'remove_attach_mirror', 'removal_reservation']
+    'remove_indirect', 'remove_attach_mirror', 'removal_reservation',
+    'removal_with_hole']
 tags = ['functional', 'removal']
 
 [tests/functional/rename_dirs]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1853,6 +1853,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/removal/removal_with_export.ksh \
 	functional/removal/removal_with_faulted.ksh \
 	functional/removal/removal_with_ganging.ksh \
+	functional/removal/removal_with_hole.ksh \
 	functional/removal/removal_with_indirect.ksh \
 	functional/removal/removal_with_remove.ksh \
 	functional/removal/removal_with_scrub.ksh \

--- a/tests/zfs-tests/tests/functional/removal/removal_with_hole.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_with_hole.ksh
@@ -1,0 +1,34 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025 by Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/removal/removal.kshlib
+
+log_onexit default_cleanup_noexit
+DISK1="$(echo $DISKS | cut -d' ' -f1)"
+DISK2="$(echo $DISKS | cut -d' ' -f2)"
+DISK3="$(echo $DISKS | cut -d' ' -f3)"
+
+log_must zpool create $TESTPOOL $DISK1 log $DISK2
+log_must zpool add $TESTPOOL $DISK3
+log_must zpool remove $TESTPOOL $DISK2
+log_must zpool remove $TESTPOOL $DISK1
+
+log_pass "Removal with a hole as the first other device doesn't panic."


### PR DESCRIPTION
### Motivation and Context
When doing device removal, we verify that the vdev being removed isn't the last vdev in the normal class. To do that, we iterate over all the disks and checking their metaslab class until we find one in the normal group. Right now, if you have a hole vdev before the first allocatable normal class vdev, we kernel panic.

### Description
Add a check for hole vdevs to the passivate code.

### How Has This Been Tested?
Added a new test to the test suite and verified that it passes. Without the change, it fails.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
