### PR TITLE
Add zfs_recover_ms parameter

### DIFF
--- a/include/sys/range_tree.h
+++ b/include/sys/range_tree.h
@@ -48,6 +48,13 @@ typedef enum zfs_range_seg_type {
 	ZFS_RANGE_SEG_NUM_TYPES,
 } zfs_range_seg_type_t;
 
+typedef enum zfs_range_tree_usecase {
+	ZFS_RANGE_TREE_UC_UNKNOWN,
+	ZFS_RANGE_TREE_UC_ALLOCATED_SPACE,
+	ZFS_RANGE_TREE_UC_FREE_SPACE,
+	ZFS_RANGE_TREE_UC_NUM_CASES,
+} zfs_range_tree_usecase_t;
+
 /*
  * Note: the range_tree may not be accessed concurrently; consumers
  * must provide external locking if required.
@@ -66,6 +73,7 @@ typedef struct zfs_range_tree {
 	const zfs_range_tree_ops_t *rt_ops;
 	void		*rt_arg;
 	uint64_t	rt_gap;		/* allowable inter-segment gap */
+	zfs_range_tree_usecase_t	rt_usecase;
 
 	/*
 	 * The rt_histogram maintains a histogram of ranges. Each bucket,
@@ -280,6 +288,9 @@ zfs_range_tree_t *zfs_range_tree_create_gap(const zfs_range_tree_ops_t *ops,
     uint64_t gap);
 zfs_range_tree_t *zfs_range_tree_create(const zfs_range_tree_ops_t *ops,
     zfs_range_seg_type_t type, void *arg, uint64_t start, uint64_t shift);
+zfs_range_tree_t *zfs_range_tree_create_usecase(const zfs_range_tree_ops_t *ops,
+    zfs_range_seg_type_t type, void *arg, uint64_t start, uint64_t shift,
+    zfs_range_tree_usecase_t usecase);
 void zfs_range_tree_destroy(zfs_range_tree_t *rt);
 boolean_t zfs_range_tree_contains(zfs_range_tree_t *rt, uint64_t start,
     uint64_t size);

--- a/include/sys/zfs_debug.h
+++ b/include/sys/zfs_debug.h
@@ -98,6 +98,7 @@ extern void __dprintf(boolean_t dprint, const char *file, const char *func,
 #endif /* ZFS_DEBUG */
 
 extern void zfs_panic_recover(const char *fmt, ...);
+extern void zfs_panic_recover_ms(const char *fmt, ...);
 
 extern void zfs_dbgmsg_init(void);
 extern void zfs_dbgmsg_fini(void);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -2753,8 +2753,8 @@ metaslab_init(metaslab_group_t *mg, uint64_t id, uint64_t object,
 	zfs_range_seg_type_t type =
 	    metaslab_calculate_range_tree_type(vd, ms, &start, &shift);
 
-	ms->ms_allocatable = zfs_range_tree_create(NULL, type, NULL, start,
-	    shift);
+	ms->ms_allocatable = zfs_range_tree_create_usecase(NULL, type, NULL,
+	    start, shift, ZFS_RANGE_TREE_UC_FREE_SPACE);
 	for (int t = 0; t < TXG_SIZE; t++) {
 		ms->ms_allocating[t] = zfs_range_tree_create(NULL, type,
 		    NULL, start, shift);

--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -200,15 +200,16 @@ ZFS_BTREE_FIND_IN_BUF_FUNC(zfs_range_tree_seg64_find_in_buf, zfs_range_seg64_t,
 ZFS_BTREE_FIND_IN_BUF_FUNC(zfs_range_tree_seg_gap_find_in_buf,
     zfs_range_seg_gap_t, zfs_range_tree_seg_gap_compare)
 
-zfs_range_tree_t *
-zfs_range_tree_create_gap(const zfs_range_tree_ops_t *ops,
+static zfs_range_tree_t *
+zfs_range_tree_create_impl(const zfs_range_tree_ops_t *ops,
     zfs_range_seg_type_t type, void *arg, uint64_t start, uint64_t shift,
-    uint64_t gap)
+    uint64_t gap, zfs_range_tree_usecase_t usecase)
 {
 	zfs_range_tree_t *rt = kmem_zalloc(sizeof (zfs_range_tree_t), KM_SLEEP);
 
 	ASSERT3U(shift, <, 64);
 	ASSERT3U(type, <=, ZFS_RANGE_SEG_NUM_TYPES);
+	ASSERT3U(usecase, <, ZFS_RANGE_TREE_UC_NUM_CASES);
 	size_t size;
 	int (*compare) (const void *, const void *);
 	bt_find_in_buf_f bt_find;
@@ -235,6 +236,7 @@ zfs_range_tree_create_gap(const zfs_range_tree_ops_t *ops,
 
 	rt->rt_ops = ops;
 	rt->rt_gap = gap;
+	rt->rt_usecase = usecase;
 	rt->rt_arg = arg;
 	rt->rt_type = type;
 	rt->rt_start = start;
@@ -247,10 +249,29 @@ zfs_range_tree_create_gap(const zfs_range_tree_ops_t *ops,
 }
 
 zfs_range_tree_t *
+zfs_range_tree_create_gap(const zfs_range_tree_ops_t *ops,
+    zfs_range_seg_type_t type, void *arg, uint64_t start, uint64_t shift,
+    uint64_t gap)
+{
+	return (zfs_range_tree_create_impl(ops, type, arg, start, shift, gap,
+	    ZFS_RANGE_TREE_UC_UNKNOWN));
+}
+
+zfs_range_tree_t *
 zfs_range_tree_create(const zfs_range_tree_ops_t *ops,
     zfs_range_seg_type_t type, void *arg, uint64_t start, uint64_t shift)
 {
-	return (zfs_range_tree_create_gap(ops, type, arg, start, shift, 0));
+	return (zfs_range_tree_create_impl(ops, type, arg, start, shift, 0,
+	    ZFS_RANGE_TREE_UC_UNKNOWN));
+}
+
+zfs_range_tree_t *
+zfs_range_tree_create_usecase(const zfs_range_tree_ops_t *ops,
+    zfs_range_seg_type_t type, void *arg, uint64_t start, uint64_t shift,
+    zfs_range_tree_usecase_t usecase)
+{
+	return (zfs_range_tree_create_impl(ops, type, arg, start, shift, 0,
+	    usecase));
 }
 
 void
@@ -318,14 +339,25 @@ zfs_range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
 	 * the normal code paths.
 	 */
 	if (rs != NULL) {
-		if (gap == 0) {
-			zfs_panic_recover("zfs: adding existent segment to "
-			    "range tree (offset=%llx size=%llx)",
-			    (longlong_t)start, (longlong_t)size);
-			return;
-		}
 		uint64_t rstart = zfs_rs_get_start(rs, rt);
 		uint64_t rend = zfs_rs_get_end(rs, rt);
+		if (gap == 0) {
+			zfs_panic_recover_ms("zfs: adding segment "
+			    "(offset=%llx size=%llx) overlapping with "
+			    "existing one (offset=%llx size=%llx)",
+			    (longlong_t)start, (longlong_t)size,
+			    (longlong_t)rstart, (longlong_t)(rend - rstart));
+			if (rt->rt_usecase != ZFS_RANGE_TREE_UC_ALLOCATED_SPACE)
+				return;
+			/* add non-overlapping chunks */
+			if (rstart > start)
+				range_tree_add_impl(rt, start, rstart - start,
+				   rstart - start);
+			if (rend < end)
+				range_tree_add_impl(rt, rend, end - rend,
+				   end - rend);
+			return;
+		}
 		if (rstart <= start && rend >= end) {
 			zfs_range_tree_adjust_fill(rt, rs, fill);
 			return;
@@ -450,6 +482,7 @@ zfs_range_tree_remove_impl(zfs_range_tree_t *rt, uint64_t start, uint64_t size,
 	zfs_range_seg_t *rs;
 	zfs_range_seg_max_t rsearch, rs_tmp;
 	uint64_t end = start + size;
+	uint64_t rstart, rend;
 	boolean_t left_over, right_over;
 
 	VERIFY3U(size, !=, 0);
@@ -463,11 +496,14 @@ zfs_range_tree_remove_impl(zfs_range_tree_t *rt, uint64_t start, uint64_t size,
 
 	/* Make sure we completely overlap with someone */
 	if (rs == NULL) {
-		zfs_panic_recover("zfs: removing nonexistent segment from "
+		zfs_panic_recover_ms("zfs: removing nonexistent segment from "
 		    "range tree (offset=%llx size=%llx)",
 		    (longlong_t)start, (longlong_t)size);
 		return;
 	}
+
+	rstart = zfs_rs_get_start(rs, rt);
+	rend = zfs_rs_get_end(rs, rt);
 
 	/*
 	 * Range trees with gap support must only remove complete segments
@@ -478,31 +514,47 @@ zfs_range_tree_remove_impl(zfs_range_tree_t *rt, uint64_t start, uint64_t size,
 	if (rt->rt_gap != 0) {
 		if (do_fill) {
 			if (zfs_rs_get_fill(rs, rt) == size) {
-				start = zfs_rs_get_start(rs, rt);
-				end = zfs_rs_get_end(rs, rt);
+				start = rstart;
+				end = rend;
 				size = end - start;
 			} else {
 				zfs_range_tree_adjust_fill(rt, rs, -size);
 				return;
 			}
-		} else if (zfs_rs_get_start(rs, rt) != start ||
-		    zfs_rs_get_end(rs, rt) != end) {
+		} else if (rstart != start || rend != end) {
 			zfs_panic_recover("zfs: freeing partial segment of "
 			    "gap tree (offset=%llx size=%llx) of "
 			    "(offset=%llx size=%llx)",
 			    (longlong_t)start, (longlong_t)size,
-			    (longlong_t)zfs_rs_get_start(rs, rt),
-			    (longlong_t)zfs_rs_get_end(rs, rt) -
-			    zfs_rs_get_start(rs, rt));
+			    (longlong_t)rstart,
+			    (longlong_t)(rend - rstart));
 			return;
 		}
 	}
 
-	VERIFY3U(zfs_rs_get_start(rs, rt), <=, start);
-	VERIFY3U(zfs_rs_get_end(rs, rt), >=, end);
+	if (!(rstart <= start && rend >= end)) {
+		zfs_panic_recover_ms("zfs: removing segment "
+		    "(offset=%llx size=%llx) not completely overlapped by "
+		    "existing one (offset=%llx size=%llx)",
+		    (longlong_t)start, (longlong_t)size,
+		    (longlong_t)rstart, (longlong_t)(rend - rstart));
+		if (rt->rt_usecase != ZFS_RANGE_TREE_UC_FREE_SPACE)
+			return;
+		/* perform removal of the chunks */
+		if (rstart > start)
+			range_tree_remove_impl(rt, start, rstart - start,
+			    do_fill);
+		uint64_t mstart = MAX(rstart, start);
+		uint64_t mend = MIN(rend, end);
+		range_tree_remove_impl(rt, mstart, mend - mstart, do_fill);
+		if (rend < end)
+			range_tree_remove_impl(rt, rend, end - rend,
+			    do_fill);
+		return;
+	}
 
-	left_over = (zfs_rs_get_start(rs, rt) != start);
-	right_over = (zfs_rs_get_end(rs, rt) != end);
+	left_over = (rstart != start);
+	right_over = (rend != end);
 
 	zfs_range_tree_stat_decr(rt, rs);
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -267,6 +267,8 @@ int zfs_flags = 0;
  * in leaked space, or worse.
  */
 int zfs_recover = B_FALSE;
+/* Localized to metaslab loading only */
+int zfs_recover_ms = B_FALSE;
 
 /*
  * If destroy encounters an EIO while reading metadata (e.g. indirect
@@ -1668,6 +1670,16 @@ zfs_panic_recover(const char *fmt, ...)
 
 	va_start(adx, fmt);
 	vcmn_err(zfs_recover ? CE_WARN : CE_PANIC, fmt, adx);
+	va_end(adx);
+}
+
+void
+zfs_panic_recover_ms(const char *fmt, ...)
+{
+	va_list adx;
+
+	va_start(adx, fmt);
+	vcmn_err((zfs_recover || zfs_recover_ms) ? CE_WARN : CE_PANIC, fmt, adx);
 	va_end(adx);
 }
 
@@ -3132,6 +3144,9 @@ ZFS_MODULE_PARAM(zfs, zfs_, flags, UINT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs, zfs_, recover, INT, ZMOD_RW,
 	"Set to attempt to recover from fatal errors");
+
+ZFS_MODULE_PARAM(zfs, zfs_, recover_ms, INT, ZMOD_RW,
+	"Set to attempt to recover from fatal errors during metaslab loading");
 
 ZFS_MODULE_PARAM(zfs, zfs_, free_leak_on_eio, INT, ZMOD_RW,
 	"Set to ignore IO errors during free and permanently leak the space");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context

There are production cases when loading of a metaslab leads to a ZFS panic due to unexpected entries in its spacemap (presumably). The assertions in `zfs_range_tree_add_impl()` and `zfs_range_tree_remove_impl()` fail due to overlapping or missing segments, etc.  A business would like to go ahead with such pools while the root cause is being investigated.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description

The idea is to allow loading such metaslabs with a potential space leak as a trade-off instead of a potential data loss.

We already have `zfs_recover` module parameter to mitigate various issues, including some range tree cases, and this patch adds `zfs_recover_ms` parameter to localize the recovery behavior to the metaslab loading process only.

<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
