### PR TITLE
convert_wycheproof: two small fixes

### DIFF
--- a/scripts/convert_wycheproof.pl
+++ b/scripts/convert_wycheproof.pl
@@ -143,11 +143,20 @@ for my $group (@{$data->{testGroups}}) {
 		my ($id, $comment, $iv, $key, $msg, $ct, $aad, $tag, $result) =
 		    @$test{qw(tcId comment iv key msg ct aad tag result)};
 
-		# sanity check; iv, key and tag must have the length declared
-		# by the group params
+		# sanity check; iv and key must have the length declared by the
+		# group params.
 		unless (
 		    length_check($id, 'iv', $iv, $iv_size) &&
-		    length_check($id, 'key', $key, $key_size) &&
+		    length_check($id, 'key', $key, $key_size)) {
+			$skipped++;
+			next;
+		}
+
+		# sanity check; tag must have the length declared by the group
+		# param, but only for valid tests (invalid tests should be
+		# rejected, and so can't produce a tag anyway)
+		unless (
+		    $result eq 'invalid' ||
 		    length_check($id, 'tag', $tag, $tag_size)) {
 			$skipped++;
 			next;

--- a/scripts/convert_wycheproof.pl
+++ b/scripts/convert_wycheproof.pl
@@ -182,7 +182,7 @@ if ($skipped) {
 }
 if ($ntests == 0) {
 	die "E: no tests extracted, sorry!\n";
-
+}
 
 my $outfh;
 if ($outfile) {


### PR DESCRIPTION
### Motivation and Context

Fixing two bugs in `convert_wycheproof.pl` that snuck through in #17089.

### Description

One is just a dumb compile fix. The other is a sanity check fix: a test with invalid inputs will not necessary have valid outputs (specifically the tag), because it never gets that far! This doesn't occur in the Wycheproof AES-CCM and AES-GCM tests, but does in the Chacha20-Poly1305 tests (which I've been messing with off to the side).

### How Has This Been Tested?

Ran:

```
$ scripts/convert_wycheproof.pl tests/zfs-tests/tests/functional/crypto/aes_gcm_test.json  tests/zfs-tests/tests/functional/crypto/aes_gcm_test.txt
$ scripts/convert_wycheproof.pl tests/zfs-tests/tests/functional/crypto/aes_ccm_test.json  tests/zfs-tests/tests/functional/crypto/aes_ccm_test.txt
```

They both worked, and no diffs generated, so for these cases it produces the same results.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
