### PR TITLE
config: cache results of kernel checks

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -463,6 +463,11 @@ AC_DEFUN([ZFS_AC_KERNEL], [
 	AC_SUBST(LINUX)
 	AC_SUBST(LINUX_OBJ)
 	AC_SUBST(LINUX_VERSION)
+
+	dnl # create a relatively unique numeric checksum based on the kernel
+	dnl # version and path. this is included in the cache key below,
+	dnl # allowing different cached values for different kernels
+	_zfs_linux_cache_checksum=$(echo ${kernelsrc} {$kernelbuild} ${kernsrcver} | cksum | cut -f1 -d' ')
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_VERSION_WARNING], [
@@ -810,14 +815,18 @@ dnl # must never depend on the results of previous tests.  Each test
 dnl # needs to be entirely independent.
 dnl #
 AC_DEFUN([ZFS_LINUX_TEST_SRC], [
-	ZFS_LINUX_CONFTEST_C([ZFS_LINUX_TEST_PROGRAM([[$2]], [[$3]],
-	    [["Dual BSD/GPL"]])], [$1])
-	ZFS_LINUX_CONFTEST_MAKEFILE([$1], [yes], [$4])
+	cachevar="zfs_cv_kernel_[$1]_$_zfs_linux_cache_checksum"
+	eval "cacheval=\$$cachevar"
+	AS_IF([test "x$cacheval" = "x"], [
+		ZFS_LINUX_CONFTEST_C([ZFS_LINUX_TEST_PROGRAM([[$2]], [[$3]],
+		    [["Dual BSD/GPL"]])], [$1])
+		ZFS_LINUX_CONFTEST_MAKEFILE([$1], [yes], [$4])
 
-	AS_IF([ test -n "$5" ], [
-		ZFS_LINUX_CONFTEST_C([ZFS_LINUX_TEST_PROGRAM(
-		    [[$2]], [[$3]], [[$5]])], [$1_license])
-		ZFS_LINUX_CONFTEST_MAKEFILE([$1_license], [yes], [$4])
+		AS_IF([ test -n "$5" ], [
+			ZFS_LINUX_CONFTEST_C([ZFS_LINUX_TEST_PROGRAM(
+			    [[$2]], [[$3]], [[$5]])], [$1_license])
+			ZFS_LINUX_CONFTEST_MAKEFILE([$1_license], [yes], [$4])
+		])
 	])
 ])
 
@@ -829,14 +838,23 @@ dnl # $2 - run on success (valid .ko generated)
 dnl # $3 - run on failure (unable to compile)
 dnl #
 AC_DEFUN([ZFS_LINUX_TEST_RESULT], [
-	AS_IF([test -d build/$1], [
-		AS_IF([test -f build/$1/$1.ko], [$2], [$3])
-	], [
-		AC_MSG_ERROR([
+	cachevar="zfs_cv_kernel_[$1]_$_zfs_linux_cache_checksum"
+	AC_CACHE_VAL([$cachevar], [
+		AS_IF([test -d build/$1], [
+			AS_IF([test -f build/$1/$1.ko], [
+				eval "$cachevar=yes"
+			], [
+				eval "$cachevar=no"
+			])
+		], [
+			AC_MSG_ERROR([
 	*** No matching source for the "$1" test, check that
 	*** both the test source and result macros refer to the same name.
+			])
 		])
 	])
+	eval "cacheval=\$$cachevar"
+	AS_IF([test "x$cacheval" = "xyes"], [$2], [$3])
 ])
 
 dnl #
@@ -865,15 +883,24 @@ dnl # verify symbol exports, unless --enable-linux-builtin was provided to
 dnl # configure.
 dnl #
 AC_DEFUN([ZFS_LINUX_TEST_RESULT_SYMBOL], [
-	AS_IF([ ! test -f build/$1/$1.ko], [
-		$5
-	], [
-		AS_IF([test "x$enable_linux_builtin" != "xyes"], [
-			ZFS_CHECK_SYMBOL_EXPORT([$2], [$3], [$4], [$5])
+	cachevar="zfs_cv_kernel_[$1]_$_zfs_linux_cache_checksum"
+	AC_CACHE_VAL([$cachevar], [
+		AS_IF([ ! test -f build/$1/$1.ko], [
+			eval "$cachevar=no"
 		], [
-			$4
+			AS_IF([test "x$enable_linux_builtin" != "xyes"], [
+				ZFS_CHECK_SYMBOL_EXPORT([$2], [$3], [
+					eval "$cachevar=yes"
+				], [
+					eval "$cachevar=no"
+				])
+			], [
+				eval "$cacheval=yes"
+			])
 		])
 	])
+	eval "cacheval=\$$cachevar"
+	AS_IF([test "x$cacheval" = "xyes"], [$4], [$5])
 ])
 
 dnl #


### PR DESCRIPTION
### Motivation and Context

Kernel checks are the heaviest part of the configure checks. This allows the results to be cached through the normal autoconf cache.

Since we don't want to reuse cached values for different kernels, but don't want to discard the entire cache on every kernel, we instead add a short checksum to kernel config cache keys, based on the version and path, so the cache can hold results for multiple different kernels.

### Description

In `ZFS_AC_KERNEL`, once we've done the kernel detection, we create a simple checksum out of `kernelsrc`, `kernelbuild` and `kernsrcver`.

In `ZFS_LINUX_TEST_SRC`, if the output cache key exists (regardless of value), we skip creating the test source at all, since we don't want to build it.

Then the test module build runs as normal, if there's anything left that wasn't cached already.

In `ZFS_LINUX_TEST_RESULT` and `ZFS_LINUX_TEST_RESULT_SYMBOL`, if the cache key doesn't exist, we run the test and set the cache var from it. Then, based on the cached value, we run the "yes" or "no" commands.

### How Has This Been Tested?

By hand, trying combinations of `--config-cache` and different kernels, then building.

Without `--config-cache`, works as normal.

With `--config-cache`, works as normal, and all sorts of interesting kernel things in the cache. Just one:

```
$ grep zfs_cv_kernel_type_intptr_t config.cache
zfs_cv_kernel_type_intptr_t_2133237685=${zfs_cv_kernel_type_intptr_t_2133237685=no}
```

Running again with `--config-cache`, same result just faster.

Building against a different kernel, again, slow on the first run, fast on the next. And then, two items in the cache:

```
$ grep zfs_cv_kernel_type_intptr_t config.cache
zfs_cv_kernel_type_intptr_t_2133237685=${zfs_cv_kernel_type_intptr_t_2133237685=no}
zfs_cv_kernel_type_intptr_t_3448135993=${zfs_cv_kernel_type_intptr_t_3448135993=no}
```

And finally, the real win for me is on a potato riscv board I've been messing with this weekend:

```
$ time ./configure --config-cache
configure: creating cache config.cache
checking for gawk... no
checking for mawk... mawk
checking metadata... git describe
checking build system type... riscv64-unknown-linux-gnu
checking host system type... riscv64-unknown-linux-gnu
checking target system type... riscv64-unknown-linux-gnu
...
config.status: executing depfiles commands
config.status: executing libtool commands
config.status: executing po-directories commands

real	3m32.698s
user	9m45.988s
sys	0m59.956s

$ time ./configure --config-cache
configure: loading cache config.cache
checking for gawk... (cached) mawk
checking metadata... git describe
checking build system type... (cached) riscv64-unknown-linux-gnu
checking host system type... (cached) riscv64-unknown-linux-gnu
checking target system type... (cached) riscv64-unknown-linux-gnu
...
config.status: executing depfiles commands
config.status: executing libtool commands
config.status: executing po-directories commands

real	1m21.683s
user	2m18.199s
sys	0m19.924s
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
