### PR TITLE
contrib: dracut: always include zfs kernel module

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -16,7 +16,7 @@ depends() {
 }
 
 installkernel() {
-	instmods -c zfs
+	hostonly='' instmods -c zfs
 }
 
 install() {


### PR DESCRIPTION
This [commit](https://github.com/openzfs/zfs/compare/master...jozzsi:zfs:master) fixes the issue and includes the zfs kernel module even when dracut is used in hostonly mode.

### Motivation and Context
Sometimes zfs kernel module is not included in the dracut generated initrd.
One way this can happen if zfs kernel module is not loaded at the time of initrd generation and dracut is instructed to build hostonly initrd (which is the default in some Linux distributions).

### Description
Ignore the hostonly setting when zfs kernel module is installed.
This is a well established pattern in dracut modules - see e.g. https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/90overlayfs/module-setup.sh#L13

### How Has This Been Tested?
Run into this issue working on a dracut patch and needed to work around this bug in the dracut CI .
