### PR TITLE
Prefer embedded blocks to dedup

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1995,8 +1995,7 @@ zio_write_compress(zio_t *zio)
 			compress = ZIO_COMPRESS_OFF;
 			if (cabd != NULL)
 				abd_free(cabd);
-		} else if (!zp->zp_dedup && !zp->zp_encrypt &&
-		    psize <= BPE_PAYLOAD_SIZE &&
+		} else if (psize <= BPE_PAYLOAD_SIZE && !zp->zp_encrypt &&
 		    zp->zp_level == 0 && !DMU_OT_HAS_FILL(zp->zp_type) &&
 		    spa_feature_is_enabled(spa, SPA_FEATURE_EMBEDDED_DATA)) {
 			void *cbuf = abd_borrow_buf_copy(cabd, lsize);

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_prefetch/zpool_prefetch_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_prefetch/zpool_prefetch_001_pos.ksh
@@ -75,7 +75,7 @@ log_must zpool prefetch -t ddt $TESTPOOL
 # to generate a reasonable size DDT for testing purposes.
 
 DATASET=$TESTPOOL/ddt
-log_must zfs create -o dedup=on $DATASET
+log_must zfs create -o compression=off -o dedup=on $DATASET
 MNTPOINT=$(get_prop mountpoint $TESTPOOL/ddt)
 
 log_note "Generating dataset ..."

--- a/tests/zfs-tests/tests/functional/dedup/dedup_quota.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_quota.ksh
@@ -79,7 +79,7 @@ function do_setup
 	log_must truncate -s 5G $VDEV_GENERAL
 	# Use 'xattr=sa' to prevent selinux xattrs influencing our accounting
 	log_must zpool create -o ashift=12 -f -O xattr=sa -m $MOUNTDIR $POOL $VDEV_GENERAL
-	log_must zfs set dedup=on $POOL
+	log_must zfs set compression=off dedup=on $POOL
 	log_must set_tunable32 TXG_TIMEOUT 600
 }
 


### PR DESCRIPTION
Since embedded blocks introduction 11 years ago, their writing was blocked if dedup is enabled.  After searching through the modern code I see no reason for this restriction to exist.  Same time embedded blocks are dramatically cheaper.  Even regular write of so small blocks would likely be cheaper than deduplication, even if the last is successful, not mentioning otherwise.

### How Has This Been Tested?
After enabling dedup written a very small file and observed with `zdb` the full block pointer.  Repeated the same with the patch and observed the embedded block instead.  Now lets see what CI say about it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
