### PR TITLE
Handle interaction between gang blocks, copies, and FDT.

### DIFF
--- a/include/sys/ddt.h
+++ b/include/sys/ddt.h
@@ -352,6 +352,8 @@ extern ddt_phys_variant_t ddt_phys_select(const ddt_t *ddt,
     const ddt_entry_t *dde, const blkptr_t *bp);
 extern uint64_t ddt_phys_birth(const ddt_univ_phys_t *ddp,
     ddt_phys_variant_t v);
+extern int ddt_phys_is_gang(const ddt_univ_phys_t *ddp,
+    ddt_phys_variant_t v);
 extern int ddt_phys_dva_count(const ddt_univ_phys_t *ddp, ddt_phys_variant_t v,
     boolean_t encrypted);
 

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -857,6 +857,17 @@ ddt_phys_birth(const ddt_univ_phys_t *ddp, ddt_phys_variant_t v)
 }
 
 int
+ddt_phys_is_gang(const ddt_univ_phys_t *ddp, ddt_phys_variant_t v)
+{
+	ASSERT3U(v, <, DDT_PHYS_NONE);
+
+	const dva_t *dvas = (v == DDT_PHYS_FLAT) ?
+	    ddp->ddp_flat.ddp_dva : ddp->ddp_trad[v].ddp_dva;
+
+	return (DVA_GET_GANG(&dvas[0]));
+}
+
+int
 ddt_phys_dva_count(const ddt_univ_phys_t *ddp, ddt_phys_variant_t v,
     boolean_t encrypted)
 {

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -726,7 +726,7 @@ tests = ['large_dnode_001_pos', 'large_dnode_003_pos', 'large_dnode_004_neg',
 tags = ['functional', 'features', 'large_dnode']
 
 [tests/functional/gang_blocks]
-tests = ['gang_blocks_redundant']
+tests = ['gang_blocks_redundant', 'gang_blocks_ddt_copies']
 tags = ['functional', 'gang_blocks']
 
 [tests/functional/grow]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1561,6 +1561,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/features/large_dnode/large_dnode_009_pos.ksh \
 	functional/features/large_dnode/setup.ksh \
 	functional/gang_blocks/cleanup.ksh \
+	functional/gang_blocks/gang_blocks_ddt_copies.ksh \
 	functional/gang_blocks/gang_blocks_redundant.ksh \
 	functional/gang_blocks/setup.ksh \
 	functional/grow/grow_pool_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/gang_blocks/gang_blocks_ddt_copies.ksh
+++ b/tests/zfs-tests/tests/functional/gang_blocks/gang_blocks_ddt_copies.ksh
@@ -1,0 +1,79 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2025 by Klara Inc.
+#
+
+#
+# Description:
+# Verify that mixed gang blocks and copies interact correctly in FDT
+#
+# Strategy:
+# 1. Store a block with copies = 1 in the DDT unganged.
+# 2. Add a new entry with copies = 2 that gangs, ensure it doesn't panic
+# 3. Store a block with copies = 1 in the DDT ganged.
+# 4. Add a new entry with copies = 3 that doesn't gang, ensure that it doesn't panic.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/gang_blocks/gang_blocks.kshlib
+
+log_assert "Verify that mixed gang blocks and copies interact correctly in FDT"
+
+save_tunable DEDUP_LOG_TXG_MAX
+
+function cleanup2
+{
+	zfs destroy $TESTPOOL/fs1
+	zfs destroy $TESTPOOL/fs2
+	restore_tunable DEDUP_LOG_TXG_MAX
+	cleanup
+}
+
+preamble
+log_onexit cleanup2
+
+log_must zpool create -f -o ashift=9 -o feature@block_cloning=disabled $TESTPOOL $DISKS
+log_must zfs create -o recordsize=64k -o dedup=on $TESTPOOL/fs1
+log_must zfs create -o recordsize=64k -o dedup=on -o copies=3 $TESTPOOL/fs2
+set_tunable32 DEDUP_LOG_TXG_MAX 1
+log_must dd if=/dev/urandom of=/$TESTPOOL/fs1/f1 bs=64k count=1
+log_must sync_pool $TESTPOOL
+set_tunable32 METASLAB_FORCE_GANGING 20000
+set_tunable32 METASLAB_FORCE_GANGING_PCT 100
+log_must dd if=/$TESTPOOL/fs1/f1 of=/$TESTPOOL/fs2/f1 bs=64k count=1
+log_must sync_pool $TESTPOOL
+
+log_must rm /$TESTPOOL/fs*/f1
+log_must sync_pool $TESTPOOL
+log_must dd if=/dev/urandom of=/$TESTPOOL/fs1/f1 bs=64k count=1
+log_must sync_pool $TESTPOOL
+log_must zdb -D $TESTPOOL
+set_tunable32 METASLAB_FORCE_GANGING_PCT 0
+log_must dd if=/$TESTPOOL/fs1/f1 of=/$TESTPOOL/fs2/f1 bs=64k count=1
+log_must sync_pool $TESTPOOL
+
+log_must rm /$TESTPOOL/fs*/f1
+log_must sync_pool $TESTPOOL
+set_tunable32 METASLAB_FORCE_GANGING_PCT 50
+set_tunable32 METASLAB_FORCE_GANGING 40000
+log_must dd if=/dev/urandom of=/$TESTPOOL/f1 bs=64k count=1
+for i in `seq 1 16`; do
+	log_must cp /$TESTPOOL/f1 /$TESTPOOL/fs2/f1
+	log_must cp /$TESTPOOL/f1 /$TESTPOOL/fs1/f1
+	log_must sync_pool $TESTPOOL
+	log_must zdb -D $TESTPOOL
+done
+
+log_pass "Verify that mixed gang blocks and copies interact correctly in FDT"


### PR DESCRIPTION
This change is built on top of #17073, because the changes to add the gang_copies property interact tightly with this change, in addition to the gang blocks test group.

### Motivation and Context
See #17070. tl;dr: If you have ganging and multiple different values of the copies property while you use dedup, you can sometimes end up with BPs with a mix of gang and non-gang DVAs. That is illegal in ZFS: in debug mode, it'll trip an assertion when you're syncing the write out. In non-debug mode, it will make it to disk, but cause silent and confusing errors later when BP_IS_GANG is only partially correct.

Note that this change doesn't address cases 2 and 4 from #17070; those are trickier to deal with, and are also less problematic for users. Occasionally not getting as many copies as you asked for is a much less severe bug than silently invalid blkptrs.  It also doesn't address the nopwrite case.

### Description
This change forces updates of existing FDT entries to only add more DVAs of the same type; if there are already gang DVAs in the FDT, we require that the new allocations also be gangs. if there are non-gang DVAs in the FDT, then this allocation may not be gangs. If it would gang, we have to redo the whole write as a non-dedup write.

This change also contains a new test that covers the relevant cases. I verified that without the patch, it kernel panics when running the test.

### How Has This Been Tested?
The added test, plus manual tests/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
