### PR TITLE
zed: Print return code on failed zpool_prepare_disk

### DIFF
--- a/cmd/zed/agents/zfs_mod.c
+++ b/cmd/zed/agents/zfs_mod.c
@@ -214,6 +214,7 @@ zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 	vdev_stat_t *vs;
 	char **lines = NULL;
 	int lines_cnt = 0;
+	int rc;
 
 	/*
 	 * Get the persistent path, typically under the '/dev/disk/by-id' or
@@ -405,17 +406,17 @@ zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 	}
 
 	nvlist_lookup_string(vdev, "new_devid", &new_devid);
-
 	if (is_mpath_wholedisk) {
 		/* Don't label device mapper or multipath disks. */
 		zed_log_msg(LOG_INFO,
 		    "  it's a multipath wholedisk, don't label");
-		if (zpool_prepare_disk(zhp, vdev, "autoreplace", &lines,
-		    &lines_cnt) != 0) {
+		rc = zpool_prepare_disk(zhp, vdev, "autoreplace", &lines,
+		    &lines_cnt);
+		if (rc != 0) {
 			zed_log_msg(LOG_INFO,
 			    "  zpool_prepare_disk: could not "
-			    "prepare '%s' (%s)", fullpath,
-			    libzfs_error_description(g_zfshdl));
+			    "prepare '%s' (%s), path '%s', rc = %d", fullpath,
+			    libzfs_error_description(g_zfshdl), path, rc);
 			if (lines_cnt > 0) {
 				zed_log_msg(LOG_INFO,
 				    "  zfs_prepare_disk output:");
@@ -446,12 +447,13 @@ zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 		 * If this is a request to label a whole disk, then attempt to
 		 * write out the label.
 		 */
-		if (zpool_prepare_and_label_disk(g_zfshdl, zhp, leafname,
-		    vdev, "autoreplace", &lines, &lines_cnt) != 0) {
+		rc = zpool_prepare_and_label_disk(g_zfshdl, zhp, leafname,
+		    vdev, "autoreplace", &lines, &lines_cnt);
+		if (rc != 0) {
 			zed_log_msg(LOG_WARNING,
 			    "  zpool_prepare_and_label_disk: could not "
-			    "label '%s' (%s)", leafname,
-			    libzfs_error_description(g_zfshdl));
+			    "label '%s' (%s), rc = %d", leafname,
+			    libzfs_error_description(g_zfshdl), rc);
 			if (lines_cnt > 0) {
 				zed_log_msg(LOG_INFO,
 				"  zfs_prepare_disk output:");


### PR DESCRIPTION
### Motivation and Context
Better `zed` error logging

### Description
We had a case where we were autoreplacing a disk and `zpool_prepare_disk` failed for some reason, and ZED didn't log the return code.  This commit logs the code.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
