### PR TITLE
Always perform bounds-checking in metaslab_free_concrete

### DIFF
--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -5405,12 +5405,13 @@ metaslab_free_concrete(vdev_t *vd, uint64_t offset, uint64_t asize,
 {
 	metaslab_t *msp;
 	spa_t *spa = vd->vdev_spa;
+	int m = offset >> vd->vdev_ms_shift;
 
 	ASSERT(vdev_is_concrete(vd));
 	ASSERT3U(spa_config_held(spa, SCL_ALL, RW_READER), !=, 0);
-	ASSERT3U(offset >> vd->vdev_ms_shift, <, vd->vdev_ms_count);
+	VERIFY3U(m, <, vd->vdev_ms_count);
 
-	msp = vd->vdev_ms[offset >> vd->vdev_ms_shift];
+	msp = vd->vdev_ms[m];
 
 	VERIFY(!msp->ms_condensing);
 	VERIFY3U(offset, >=, msp->ms_start);


### PR DESCRIPTION
The vd->vdev_ms access can overflow due to on-disk corruption, not just due to programming bugs.  So it makes sense to check its boundaries even in production builds.

Sponsored by:	ConnectWise
Signed-off-by:	Alan Somers <asomers@gmail.com>

### Motivation and Context
Prevents an out-of-bounds memory access due to on-disk corruption.  The out of bounds access usually results in a page fault, but its effects are unpredictable.  Better to cleanly panic instead.  The original corruption was probably caused by the same underlying cause as #16626, combined with inadequate sanity checking of the block pointers.

### Description
Changes in existing ASSERT into a VERIFY

### How Has This Been Tested?
Ran the ZFS test suite on FreeBSD

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
