### PR TITLE
Update FreeBSD CI images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,16 +5,16 @@ env:
 build_task:
   matrix:
     freebsd_instance:
-      image_family: freebsd-12-4
+      image_family: freebsd-13-5
     freebsd_instance:
-      image_family: freebsd-13-2
+      image_family: freebsd-14-2
     freebsd_instance:
-      image_family: freebsd-14-0-snap
+      image_family: freebsd-15-0-snap
   prepare_script:
-    - pkg install -y autoconf automake libtool gettext-runtime gmake ksh93 py39-packaging py39-cffi py39-sysctl
+    - pkg install -y autoconf automake libtool gettext-runtime gmake ksh93 py311-packaging py311-cffi py311-sysctl
   configure_script:
     - env MAKE=gmake ./autogen.sh
-    - env MAKE=gmake ./configure --with-config="user" --with-python=3.9
+    - env MAKE=gmake ./configure --with-config="user" --with-python=3.11
   build_script:
     - gmake -j `sysctl -n kern.smp.cpus`
   install_script:


### PR DESCRIPTION
* FreeBSD 12 is EoL.  Drop it.
* Use the latest FreeBSD 13 and 14 versions.
* Add FreeBSD 15.0-CURRENT.
* Use the current python version.

Sponsored by:	ConnectWise
Signed-off-by:	Alan Somers <asomers@gmail.com>

### Motivation and Context
Maintenance: test on the latest FreeBSD versions instead of old ones.

### Description
Update FreeBSD and Python versions used in CI.

### How Has This Been Tested?

None.  This change affects CI only.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
