### PR TITLE
AUTHORS: refresh with recent new contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -71,6 +71,7 @@ Rob Norris <rob.norris@klarasystems.com>
 Sam Lunt <samuel.j.lunt@gmail.com>
 Sanjeev Bagewadi <sanjeev.bagewadi@gmail.com>
 Sebastian Wuerl <s.wuerl@mailbox.org>
+SHENGYI HONG <aokblast@FreeBSD.org>
 Stoiko Ivanov <github@nomore.at>
 Tamas TEVESZ <ice@extreme.hu>
 WHR <msl0000023508@gmail.com>
@@ -78,8 +79,11 @@ Yanping Gao <yanping.gao@xtaotech.com>
 Youzhong Yang <youzhong@gmail.com>
 
 # Signed-off-by: overriding Author:
+Alexander Ziaee <ziaee@FreeBSD.org> <concussious@runbox.com>
 Ryan <errornointernet@envs.net> <error.nointernet@gmail.com>
 Sietse <sietse@wizdom.nu> <uglymotha@wizdom.nu>
+Phil Sutter <phil@nwl.cc> <p.github@nwl.cc>
+poscat <poscat@poscat.moe> <poscat0x04@outlook.com>
 Qiuhao Chen <chenqiuhao1997@gmail.com> <haohao0924@126.com>
 Yuxin Wang <yuxinwang9999@gmail.com> <Bi11gates9999@gmail.com>
 Zhenlei Huang <zlei@FreeBSD.org> <zlei.huang@gmail.com>
@@ -207,6 +211,7 @@ Torsten Wörtwein <twoertwein@gmail.com> <twoertwein@users.noreply.github.com>
 Tulsi Jain <tulsi.jain@delphix.com> <TulsiJain@users.noreply.github.com>
 Václav Skála <skala@vshosting.cz> <33496485+vaclavskala@users.noreply.github.com>
 Vaibhav Bhanawat <vaibhav.bhanawat@delphix.com> <88050553+vaibhav-delphix@users.noreply.github.com>
+Vandana Rungta <vrungta@amazon.com> <46906819+vandanarungta@users.noreply.github.com>
 Violet Purcell <vimproved@inventati.org> <66446404+vimproved@users.noreply.github.com>
 Vipin Kumar Verma <vipin.verma@hpe.com> <75025470+vermavipinkumar@users.noreply.github.com>
 Wolfgang Bumiller <w.bumiller@proxmox.com> <Blub@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ CONTRIBUTORS:
     Alexander Pyhalov <apyhalov@gmail.com>
     Alexander Richardson <Alexander.Richardson@cl.cam.ac.uk>
     Alexander Stetsenko <ams@nexenta.com>
+    Alexander Ziaee <ziaee@FreeBSD.org>
     Alex Braunegg <alex.braunegg@gmail.com>
     Alexey Shvetsov <alexxy@gentoo.org>
     Alexey Smirnoff <fling@member.fsf.org>
@@ -288,6 +289,7 @@ CONTRIBUTORS:
     ilovezfs <ilovezfs@icloud.com>
     InsanePrawn <Insane.Prawny@gmail.com>
     Isaac Huang <he.huang@intel.com>
+    Ivan Volosyuk <Ivan.Volosyuk@gmail.com>
     Jacek Fefliński <feflik@gmail.com>
     Jacob Adams <tookmund@gmail.com>
     Jake Howard <git@theorangeone.net>
@@ -295,6 +297,7 @@ CONTRIBUTORS:
     James H <james@kagisoft.co.uk>
     James Lee <jlee@thestaticvoid.com>
     James Pan <jiaming.pan@yahoo.com>
+    James Reilly <jreilly1821@gmail.com>
     James Wah <james@laird-wah.net>
     Jan Engelhardt <jengelh@inai.de>
     Jan Kryl <jan.kryl@nexenta.com>
@@ -306,6 +309,7 @@ CONTRIBUTORS:
     Jason Lee <jasonlee@lanl.gov>
     Jason Zaman <jasonzaman@gmail.com>
     Javen Wu <wu.javen@gmail.com>
+    Jaydeep Kshirsagar <jkshirsagar@maxlinear.com>
     Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>
     Jeff Dike <jdike@akamai.com>
     Jeremy Faulkner <gldisater@gmail.com>
@@ -313,6 +317,7 @@ CONTRIBUTORS:
     Jeremy Jones <jeremy@delphix.com>
     Jeremy Visser <jeremy.visser@gmail.com>
     Jerry Jelinek <jerry.jelinek@joyent.com>
+    Jerzy Kołosowski <jerzy@kolosowscy.pl>
     Jessica Clarke <jrtc27@jrtc27.com>
     Jinshan Xiong <jinshan.xiong@intel.com>
     Jitendra Patidar <jitendra.patidar@nutanix.com>
@@ -372,6 +377,7 @@ CONTRIBUTORS:
     Kohsuke Kawaguchi <kk@kohsuke.org>
     Konstantin Khorenko <khorenko@virtuozzo.com>
     KORN Andras <korn@elan.rulez.org>
+    kotauskas <v.toncharov@gmail.com>
     Kristof Provost <github@sigsegv.be>
     Krzysztof Piecuch <piecuch@kpiecuch.pl>
     Kyle Blatter <kyleblatter@llnl.gov>
@@ -452,6 +458,7 @@ CONTRIBUTORS:
     Mike Swanson <mikeonthecomputer@gmail.com>
     Milan Jurik <milan.jurik@xylab.cz>
     Minsoo Choo <minsoochoo0122@proton.me>
+    mnrx <mnrx@users.noreply.github.com>
     Mohamed Tawfik <m_tawfik@aucegypt.edu>
     Morgan Jones <mjones@rice.edu>
     Moritz Maxeiner <moritz@ucworks.org>
@@ -494,6 +501,7 @@ CONTRIBUTORS:
     Pawel Jakub Dawidek <pjd@FreeBSD.org>
     Pedro Giffuni <pfg@freebsd.org>
     Peng <peng.hse@xtaotech.com>
+    Peng Liu <littlenewton6@gmail.com>
     Peter Ashford <ashford@accs.com>
     Peter Dave Hello <hsu@peterdavehello.org>
     Peter Doherty <peterd@acranox.org>
@@ -503,9 +511,11 @@ CONTRIBUTORS:
     Philip Pokorny <ppokorny@penguincomputing.com>
     Philipp Riederer <pt@philipptoelke.de>
     Phil Kauffman <philip@kauffman.me>
+    Phil Sutter <phil@nwl.cc>
     Ping Huang <huangping@smartx.com>
     Piotr Kubaj <pkubaj@anongoth.pl>
     Piotr P. Stefaniak <pstef@freebsd.org>
+    poscat <poscat@poscat.moe>
     Prakash Surya <prakash.surya@delphix.com>
     Prasad Joshi <prasadjoshi124@gmail.com>
     privb0x23 <privb0x23@users.noreply.github.com>
@@ -575,6 +585,7 @@ CONTRIBUTORS:
     Shaun Tancheff <shaun@aeonazure.com>
     Shawn Bayern <sbayern@law.fsu.edu>
     Shengqi Chen <harry-chen@outlook.com>
+    SHENGYI HONG <aokblast@FreeBSD.org>
     Shen Yan <shenyanxxxy@qq.com>
     Sietse <sietse@wizdom.nu>
     Simon Guest <simon.guest@tesujimath.org>
@@ -616,7 +627,9 @@ CONTRIBUTORS:
     timor <timor.dd@googlemail.com>
     Timothy Day <tday141@gmail.com>
     Tim Schumacher <timschumi@gmx.de>
+    Tim Smith <tim@mondoo.com>
     Tino Reichardt <milky-zfs@mcmilk.de>
+    tleydxdy <shironeko.github@tesaguri.club>
     Tobin Harding <me@tobin.cc>
     Todd Seidelmann <seidelma@users.noreply.github.com>
     Tom Caputi <tcaputi@datto.com>
@@ -640,6 +653,7 @@ CONTRIBUTORS:
     Vaibhav Bhanawat <vaibhav.bhanawat@delphix.com>
     Valmiky Arquissandas <kayvlim@gmail.com>
     Val Packett <val@packett.cool>
+    Vandana Rungta <vrungta@amazon.com>
     Vince van Oosten <techhazard@codeforyouand.me>
     Violet Purcell <vimproved@inventati.org>
     Vipin Kumar Verma <vipin.verma@hpe.com>


### PR DESCRIPTION
### Motivation and Context

The reward for good work is more work. 🤝

### Description

Updating `AUTHORS` and `.mailmap` from recent commits. Usual method: run `update_authors.pl`, consider results, add mailmap entries, repeat until the water runs clear.

### How Has This Been Tested?

Repo doc change, so none/eyeballs-only.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
