### PR TITLE
kstat: allow multi-level module names

### DIFF
--- a/include/os/linux/spl/sys/kstat.h
+++ b/include/os/linux/spl/sys/kstat.h
@@ -21,6 +21,10 @@
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  */
+/*
+ * Copyright (c) 2024-2025, Klara, Inc.
+ * Copyright (c) 2024-2025, Syneto
+ */
 
 #ifndef _SPL_KSTAT_H
 #define	_SPL_KSTAT_H
@@ -90,6 +94,8 @@ typedef struct kstat_module {
 	struct list_head ksm_module_list;	/* module linkage */
 	struct list_head ksm_kstat_list;	/* list of kstat entries */
 	struct proc_dir_entry *ksm_proc;	/* proc entry */
+	struct kstat_module *ksm_parent;	/* parent module in hierarchy */
+	uint_t ksm_nchildren;			/* number of child modules */
 } kstat_module_t;
 
 typedef struct kstat_raw_ops {

--- a/module/os/freebsd/spl/spl_kstat.c
+++ b/module/os/freebsd/spl/spl_kstat.c
@@ -28,6 +28,10 @@
  * [1] https://illumos.org/man/1M/kstat
  * [2] https://illumos.org/man/9f/kstat_create
  */
+/*
+ * Copyright (c) 2024-2025, Klara, Inc.
+ * Copyright (c) 2024-2025, Syneto
+ */
 
 #include <sys/types.h>
 #include <sys/param.h>
@@ -288,7 +292,7 @@ __kstat_create(const char *module, int instance, const char *name,
 	char buf[KSTAT_STRLEN];
 	struct sysctl_oid *root;
 	kstat_t *ksp;
-	char *pool;
+	char *p, *frag;
 
 	KASSERT(instance == 0, ("instance=%d", instance));
 	if ((ks_type == KSTAT_TYPE_INTR) || (ks_type == KSTAT_TYPE_IO))
@@ -346,74 +350,54 @@ __kstat_create(const char *module, int instance, const char *name,
 	else
 		ksp->ks_data = kmem_zalloc(ksp->ks_data_size, KM_SLEEP);
 
-	/*
-	 * Some kstats use a module name like "zfs/poolname" to distinguish a
-	 * set of kstats belonging to a specific pool.  Split on '/' to add an
-	 * extra node for the pool name if needed.
-	 */
+	sysctl_ctx_init(&ksp->ks_sysctl_ctx);
+
 	(void) strlcpy(buf, module, KSTAT_STRLEN);
-	module = buf;
-	pool = strchr(module, '/');
-	if (pool != NULL)
-		*pool++ = '\0';
 
 	/*
-	 * Create sysctl tree for those statistics:
-	 *
-	 *	kstat.<module>[.<pool>].<class>.<name>
+	 * Walk over the module name, splitting on '/', and create the
+	 * intermediate nodes.
 	 */
-	sysctl_ctx_init(&ksp->ks_sysctl_ctx);
-	root = SYSCTL_ADD_NODE(&ksp->ks_sysctl_ctx,
-	    SYSCTL_STATIC_CHILDREN(_kstat), OID_AUTO, module, CTLFLAG_RW, 0,
-	    "");
-	if (root == NULL) {
-		printf("%s: Cannot create kstat.%s tree!\n", __func__, module);
-		sysctl_ctx_free(&ksp->ks_sysctl_ctx);
-		free(ksp, M_KSTAT);
-		return (NULL);
-	}
-	if (pool != NULL) {
-		root = SYSCTL_ADD_NODE(&ksp->ks_sysctl_ctx,
-		    SYSCTL_CHILDREN(root), OID_AUTO, pool, CTLFLAG_RW, 0, "");
+	root = NULL;
+	p = buf;
+	while ((frag = strsep(&p, "/")) != NULL) {
+		root = SYSCTL_ADD_NODE(&ksp->ks_sysctl_ctx, root ?
+		    SYSCTL_CHILDREN(root) : SYSCTL_STATIC_CHILDREN(_kstat),
+		    OID_AUTO, frag, CTLFLAG_RW, 0, "");
 		if (root == NULL) {
-			printf("%s: Cannot create kstat.%s.%s tree!\n",
-			    __func__, module, pool);
+			printf("%s: Cannot create kstat.%s tree!\n",
+			    __func__, buf);
 			sysctl_ctx_free(&ksp->ks_sysctl_ctx);
 			free(ksp, M_KSTAT);
 			return (NULL);
 		}
+		if (p != NULL)
+			p[-1] = '.';
 	}
+
 	root = SYSCTL_ADD_NODE(&ksp->ks_sysctl_ctx, SYSCTL_CHILDREN(root),
 	    OID_AUTO, class, CTLFLAG_RW, 0, "");
 	if (root == NULL) {
-		if (pool != NULL)
-			printf("%s: Cannot create kstat.%s.%s.%s tree!\n",
-			    __func__, module, pool, class);
-		else
-			printf("%s: Cannot create kstat.%s.%s tree!\n",
-			    __func__, module, class);
+		printf("%s: Cannot create kstat.%s.%s tree!\n",
+		    __func__, buf, class);
 		sysctl_ctx_free(&ksp->ks_sysctl_ctx);
 		free(ksp, M_KSTAT);
 		return (NULL);
 	}
+
 	if (ksp->ks_type == KSTAT_TYPE_NAMED) {
 		root = SYSCTL_ADD_NODE(&ksp->ks_sysctl_ctx,
 		    SYSCTL_CHILDREN(root),
 		    OID_AUTO, name, CTLFLAG_RW, 0, "");
 		if (root == NULL) {
-			if (pool != NULL)
-				printf("%s: Cannot create kstat.%s.%s.%s.%s "
-				    "tree!\n", __func__, module, pool, class,
-				    name);
-			else
-				printf("%s: Cannot create kstat.%s.%s.%s "
-				    "tree!\n", __func__, module, class, name);
+			printf("%s: Cannot create kstat.%s.%s.%s tree!\n",
+			    __func__, buf, class, name);
 			sysctl_ctx_free(&ksp->ks_sysctl_ctx);
 			free(ksp, M_KSTAT);
 			return (NULL);
 		}
-
 	}
+
 	ksp->ks_sysctl_root = root;
 
 	return (ksp);
@@ -437,7 +421,26 @@ kstat_install_named(kstat_t *ksp)
 		if (ksent->data_type != 0) {
 			typelast = ksent->data_type;
 			namelast = ksent->name;
+
+			/*
+			 * If a sysctl with this name already exists on this on
+			 * this root, first remove it by deleting it from its
+			 * old context, and then destroying it.
+			 */
+			struct sysctl_oid *oid = NULL;
+			SYSCTL_FOREACH(oid,
+			    SYSCTL_CHILDREN(ksp->ks_sysctl_root)) {
+				if (strcmp(oid->oid_name, namelast) == 0) {
+					kstat_t *oldksp =
+					    (kstat_t *)oid->oid_arg1;
+					sysctl_ctx_entry_del(
+					    &oldksp->ks_sysctl_ctx, oid);
+					sysctl_remove_oid(oid, 1, 0);
+					break;
+				}
+			}
 		}
+
 		switch (typelast) {
 		case KSTAT_DATA_CHAR:
 			/* Not Implemented */


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Syneto]_

### Motivation and Context

In #16200 I added support for multi-level kstat nodes so that I could more easily add per-vdev queue stats. I intend to come back to that PR, but I have separately wanted this support in another project, so I've lifted it out.

In general, this gives us an easy way to create a richer tree of stats, by building on the simple one-level support we have for `zfs/<pool>`. With this, we could avoid the mess we have for `objset-0xXX` dataset stats.

### Description

Both Linux and FreeBSD implementations of `kstat_create()` have support for creating a single sub-level stat base, by splitting on a single `/` char and creating an additional intermediate node. This PR extends that support by turning that into a loop, such that each `/` creates a new intermediate node.

"Intermediate node" here means an extra `SYSCTL_ADD_NODE()` on FreeBSD, or an extra `proc_mkdir()` on Linux.

There's extra teardown code needed on Linux to remove the intermediate directories when the last concrete kstat object is removed. FreeBSD doesn't have this problem (I think), at least because the intermediate nodes don't seem to "exist" except as a hook point for other kstats to hang off. I can and will do more here if asked, but this is the same situation as the previous code has, so its kinda half each way.

There's one extra commit here. Previously, if you tried to create a second kstat with the same module & name as an existing one, it would be ignored. This changes it so the old one is removed and the new one added. This also came from #16200 because during import, we create a `vdev_t` for each drive (which create kstat nodes) and then as we transition to a trusted config, we create another `vdev_t` before destroying the old one, which creates another set of kstats to replace the first ones.

That behaviour is of course specific to that PR, but it does raise the question of what should happen if we try to create a kstat a second time. "Keep the first" was mostly an accident of the implementation, and never happened in normal operation anyway. The other options are to take the second, or reject it until explicitly removed. This commit is making a choice, but I don't want to hold this PR up on it if there's strong opinions. I'm happy to drop it for now, or move it to another PR, or discuss it when I get back to #16200. I think it's pretty benign as-is, and obviously something we can change down the track if its not working for us.

### How Has This Been Tested?

There's no actual stats changes here, so this should be an effective no-op change (only once round the loop is the same as an `if (...)`. That's not much fun though, so I've made a demo commit robn/zfs@e18264f that moves the existing `zfs/<poolname>` stats to `zfs/pool/<poolname>` and `zfs/<poolname>/objset-<id>` to `zfs/pool/<poolname>/dataset/<id>`.

On Linux, that gives us:

```
    # find /proc/spl/kstat/zfs/pool
    /proc/spl/kstat/zfs/pool
    /proc/spl/kstat/zfs/pool/tank
    /proc/spl/kstat/zfs/pool/tank/guid
    /proc/spl/kstat/zfs/pool/tank/state
    /proc/spl/kstat/zfs/pool/tank/dataset
    /proc/spl/kstat/zfs/pool/tank/dataset/0x36
    /proc/spl/kstat/zfs/pool/tank/iostats
    /proc/spl/kstat/zfs/pool/tank/dmu_tx_assign
    /proc/spl/kstat/zfs/pool/tank/ddt_stats_edonr
    /proc/spl/kstat/zfs/pool/tank/ddt_stats_skein
    /proc/spl/kstat/zfs/pool/tank/ddt_stats_blake3
    /proc/spl/kstat/zfs/pool/tank/ddt_stats_sha256
    /proc/spl/kstat/zfs/pool/tank/ddt_stats_sha512

    # cat /proc/spl/kstat/zfs/pool/tank/state
    ONLINE

    # head /proc/spl/kstat/zfs/pool/tank/dataset/0x36
    151 1 0x01 27 7600 23955484523 216194931914
    name                            type data
    dataset_name                    7    tank
    writes                          4    0
    nwritten                        4    0
    reads                           4    0
    nread                           4    0
    nunlinks                        4    0
    nunlinked                       4    0
    zil_commit_count                4    0
    ...
```

and on FreeBSD:

```
    # sysctl -a kstat.zfs.pool | head
    kstat.zfs.pool.tank.dataset.dataset.0x36.zil_itx_metaslab_slog_alloc: 0
    kstat.zfs.pool.tank.dataset.dataset.0x36.zil_itx_metaslab_slog_write: 0
    kstat.zfs.pool.tank.dataset.dataset.0x36.zil_itx_metaslab_slog_bytes: 0
    kstat.zfs.pool.tank.dataset.dataset.0x36.zil_itx_metaslab_slog_count: 0
    kstat.zfs.pool.tank.dataset.dataset.0x36.zil_itx_metaslab_normal_alloc: 0
    kstat.zfs.pool.tank.dataset.dataset.0x36.zil_itx_metaslab_normal_write: 0
    kstat.zfs.pool.tank.dataset.dataset.0x36.zil_itx_metaslab_normal_bytes: 0
    kstat.zfs.pool.tank.dataset.dataset.0x36.zil_itx_metaslab_normal_count: 0
    kstat.zfs.pool.tank.dataset.dataset.0x36.zil_itx_needcopy_bytes: 0
    kstat.zfs.pool.tank.dataset.dataset.0x36.zil_itx_needcopy_count: 0

    # sysctl kstat.zfs.pool.tank.misc.state
    kstat.zfs.pool.tank.misc.state: ONLINE

    # sysctl kstat.zfs.pool.tank.dataset.dataset.0x36.dataset_name
    kstat.zfs.pool.tank.dataset.dataset.0x36.dataset_name: tank
```

Note the extra `misc` and `dataset` nodes are part of the existing implementation; I'm not here to remake the world just yet.

Meanwhile, my own ZTS run is progressing nicely. I'm not expecting any issues, though we never do so who knows :sweat_smile:.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
