### PR TITLE
ZTS: Remove TXG_TIMEOUT from dedup_quota test

### DIFF
--- a/tests/zfs-tests/tests/functional/dedup/dedup_quota.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_quota.ksh
@@ -50,8 +50,6 @@ VDEV_GENERAL="$TEST_BASE_DIR/vdevfile.general.$$"
 VDEV_DEDUP="$TEST_BASE_DIR/vdevfile.dedup.$$"
 POOL="dedup_pool"
 
-save_tunable TXG_TIMEOUT
-
 # we set the dedup log txg interval to 1, to get a log flush every txg,
 # effectively disabling the log. without this it's hard to predict when and
 # where things appear on-disk
@@ -66,7 +64,6 @@ function cleanup
 		destroy_pool $POOL
 	fi
 	log_must rm -fd $VDEV_GENERAL $VDEV_DEDUP $MOUNTDIR
-	log_must restore_tunable TXG_TIMEOUT
 	log_must restore_tunable DEDUP_LOG_TXG_MAX
 	log_must restore_tunable DEDUP_LOG_FLUSH_ENTRIES_MIN
 }
@@ -84,7 +81,6 @@ function do_setup
 	# Use 'xattr=sa' to prevent selinux xattrs influencing our accounting
 	log_must zpool create -o ashift=12 -f -O xattr=sa -m $MOUNTDIR $POOL $VDEV_GENERAL
 	log_must zfs set compression=off dedup=on $POOL
-	log_must set_tunable32 TXG_TIMEOUT 600
 }
 
 function dedup_table_size


### PR DESCRIPTION
It seems `fio` in `ddt_dedup_vdev_limit` overwhelms the system with the amount of dirty data caused by DDT updates within one TXG due to tiny 1KB records used, while I see no reason for this test to extend the TXGs beyond default.

### How Has This Been Tested?
Run full CI sweep in personal repository without any errors from dedup_quota.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
