### PR TITLE
runners: Add option to install custom kernel on Fedora

### DIFF
--- a/.github/workflows/scripts/qemu-3-deps.sh
+++ b/.github/workflows/scripts/qemu-3-deps.sh
@@ -3,12 +3,25 @@
 #    script on it.
 #
 # $1: OS name (like 'fedora41')
+# $2: (optional) Experimental kernel version to install on fedora,
+#     like "6.14".
 ######################################################################
 
 .github/workflows/scripts/qemu-wait-for-vm.sh vm0
+
+# SPECIAL CASE:
+#
+# If the user passed in an experimental kernel version to test on Fedora,
+# we need to update the kernel version in zfs's META file to allow the
+# build to happen.  We update our local copy of META here, since we know
+# it will be rsync'd up in the next step.
+if [ -n "${2:-}" ] ; then
+  sed -i -E 's/Linux-Maximum: .+/Linux-Maximum: 99.99/g' META
+fi
+
 scp .github/workflows/scripts/qemu-3-deps-vm.sh zfs@vm0:qemu-3-deps-vm.sh
 PID=`pidof /usr/bin/qemu-system-x86_64`
-ssh zfs@vm0 '$HOME/qemu-3-deps-vm.sh' $1
+ssh zfs@vm0 '$HOME/qemu-3-deps-vm.sh' "$@"
 # wait for poweroff to succeed
 tail --pid=$PID -f /dev/null
 sleep 5 # avoid this: "error: Domain is already active"

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: false
         description: 'Test on CentOS 10 stream'
+      fedora_kernel_ver:
+        type: string
+        required: false
+        default: ""
+        description: "(optional) Experimental kernel version to install on Fedora (like '6.14' or '6.13.3-0.rc3')"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -48,7 +53,15 @@ jobs:
           else
             os_selection="$FULL_OS"
           fi
-          os_json=$(echo ${os_selection} | jq -c)
+
+          if [ ${{ github.event.inputs.fedora_kernel_ver }} != "" ] ; then
+              # They specified a custom kernel version for Fedora.  Use only
+              # Fedora runners.
+              os_json=$(echo ${os_selection} | jq -c '[.[] | select(startswith("fedora"))]')
+          else
+              # Normal case
+              os_json=$(echo ${os_selection} | jq -c)
+          fi
 
           # Add optional runners
           if [ "${{ github.event.inputs.include_stream9 }}" == 'true' ]; then
@@ -92,7 +105,7 @@ jobs:
 
     - name: Install dependencies
       timeout-minutes: 20
-      run: .github/workflows/scripts/qemu-3-deps.sh ${{ matrix.os }}
+      run: .github/workflows/scripts/qemu-3-deps.sh ${{ matrix.os }} ${{ github.event.inputs.fedora_kernel_ver }}
 
     - name: Build modules
       timeout-minutes: 30


### PR DESCRIPTION
### Motivation and Context
Easily test ZFS against new kernels on github runners.

### Description
Allow installing a custom kernel version from the Fedora experimental kernel repos onto the github runners.  This is useful for testing if ZFS works against a newer kernel.

Fedora has a number of repos with experimental kernel packages. This PR allows installs from kernels in these repos:

@kernel-vanilla/stable
@kernel-vanilla/mainline
(https://fedoraproject.org/wiki/Kernel_Vanilla_Repositories)

You will need to manually kick of a github runner to test with a custom kernel version.  To do that, go to the github actions tab under 'zfs-qemu' and click the drop-down for 'run workflow'.  In there you will see a text box to specify the version (like '6.14').  The scripts will do their best to match the version to the newest matching version that the repos support (since they're may be multiple nightly versions of, say, '6.14').  A full list of kernel versions can be seen in the dependency stage output if you kick off a manual run.


![image](https://github.com/user-attachments/assets/30cec874-4979-4b0a-a835-c92c27df1c6c)

### How Has This Been Tested?
Tested with 6.14rc7 kernel.  Saw test suite complete successfully.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
