### PR TITLE
runners: Fix tarball build for zfs-qemu-packages workflow

### DIFF
--- a/.github/workflows/scripts/qemu-4-build-vm.sh
+++ b/.github/workflows/scripts/qemu-4-build-vm.sh
@@ -300,6 +300,17 @@ function deb_build_and_install() {
   echo "##[endgroup]"
 }
 
+function build_tarball {
+  if [ -n "$REPO" ] ; then
+    ./autogen.sh
+    ./configure --with-config=srpm
+    make dist
+    mkdir -p /tmp/repo/releases
+    # The tarball name is based off of 'Version' field in the META file.
+    mv *.tar.gz /tmp/repo/releases/
+  fi
+}
+
 # Debug: show kernel cmdline
 if [ -f /proc/cmdline ] ; then
   cat /proc/cmdline || true
@@ -339,6 +350,13 @@ case "$OS" in
     ;;
   fedora*)
     rpm_build_and_install "$extra"
+
+    # Historically, we've always built the release tarballs on Fedora, since
+    # there was one instance long ago where we built them on CentOS 7, and they
+    # didn't work correctly for everyone.
+    if [ -n "$TARBALL" ] ; then
+        build_tarball
+    fi
     ;;
   debian*|ubuntu*)
     deb_build_and_install "$extra"
@@ -348,16 +366,6 @@ case "$OS" in
     ;;
 esac
 
-# Optionally build tarballs.  The tarball's root directory name will be named
-# after the current tag, like 'zfs-2.3.0' or 'master'.
-if [ -n "$TARBALL" ] ; then
-  tag="$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match)"
-  git archive --format=tar.gz -o $tag.tar.gz $tag
-  if [ -n "$REPO" ] ; then
-    mkdir -p /tmp/repo/releases
-    cp $tag.tar.gz /tmp/repo/releases
-  fi
-fi
 
 # building the zfs module was ok
 echo 0 > /var/tmp/build-exitcode.txt


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Fix tarball creation in the `zfs-qemu-packages` github runner.

### Description
The initial release tarballs we built for for zfs-2.3.1 were incorrect since they did not have a `./configure` script, and their files were not in a top level `zfs-2.3.1/` directory.  This commit builds the tarballs in the same way we built them on buildbot so their contents are as expected.

### How Has This Been Tested?
Built tarball via `zfs-qemu-packages` and observed contents.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
