### PR TITLE
Fix inode eviction and sync writeback deadlock on Linux

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -2491,7 +2491,7 @@ ztest_get_done(zgd_t *zgd, int error)
 }
 
 static int
-ztest_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
+ztest_get_data(void *arg, void *arg2, lr_write_t *lr, char *buf,
     struct lwb *lwb, zio_t *zio)
 {
 	(void) arg2;

--- a/include/os/freebsd/zfs/sys/zfs_znode_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_znode_impl.h
@@ -103,7 +103,7 @@ typedef struct zfs_soft_state {
 #define	VTOZ(VP)	((struct znode *)(VP)->v_data)
 #define	VTOZ_SMR(VP)	((znode_t *)vn_load_v_data_smr(VP))
 #define	ITOZ(VP)	((struct znode *)(VP)->v_data)
-#define	zhold(zp)	vhold(ZTOV((zp)))
+#define	zhold(zp)	vref(ZTOV((zp)))
 #define	zrele(zp)	vrele(ZTOV((zp)))
 
 #define	ZTOZSB(zp) ((zp)->z_zfsvfs)

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -457,6 +457,7 @@ typedef enum {
 } itx_wr_state_t;
 
 typedef void (*zil_callback_t)(void *data, int err);
+typedef void (*itx_zrele_t)(void *);
 
 typedef struct itx {
 	list_node_t	itx_node;	/* linkage on zl_itx_list */
@@ -467,7 +468,8 @@ typedef struct itx {
 	void		*itx_callback_data; /* User data for the callback */
 	size_t		itx_size;	/* allocated itx structure size */
 	uint64_t	itx_oid;	/* object id */
-	uint64_t	itx_gen;	/* gen number for zfs_get_data */
+	void		*itx_znode;	/* znode for zfs_get_data */
+	itx_zrele_t	itx_zrele;	/* cleanup for itx_znode */
 	lr_t		itx_lr;		/* common part of log record */
 	uint8_t		itx_lr_data[];	/* type-specific part of lr_xx_t */
 } itx_t;
@@ -605,7 +607,7 @@ typedef int zil_parse_blk_func_t(zilog_t *zilog, const blkptr_t *bp, void *arg,
 typedef int zil_parse_lr_func_t(zilog_t *zilog, const lr_t *lr, void *arg,
     uint64_t txg);
 typedef int zil_replay_func_t(void *arg1, void *arg2, boolean_t byteswap);
-typedef int zil_get_data_t(void *arg, uint64_t arg2, lr_write_t *lr, char *dbuf,
+typedef int zil_get_data_t(void *arg, void *arg2, lr_write_t *lr, char *dbuf,
     struct lwb *lwb, zio_t *zio);
 
 extern int zil_parse(zilog_t *zilog, zil_parse_blk_func_t *parse_blk_func,

--- a/include/sys/zvol_impl.h
+++ b/include/sys/zvol_impl.h
@@ -115,7 +115,7 @@ void zvol_log_truncate(zvol_state_t *zv, dmu_tx_t *tx, uint64_t off,
     uint64_t len);
 void zvol_log_write(zvol_state_t *zv, dmu_tx_t *tx, uint64_t offset,
     uint64_t size, boolean_t commit);
-int zvol_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
+int zvol_get_data(void *arg, void *arg2, lr_write_t *lr, char *buf,
     struct lwb *lwb, zio_t *zio);
 int zvol_init_impl(void);
 void zvol_fini_impl(void);

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -1641,6 +1641,29 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 	znode_t	*zp;
 	dsl_dir_t *dd;
 
+	ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
+
+	if (!unmounting) {
+		/*
+		 * We purge the parent filesystem's vfsp as the parent
+		 * filesystem and all of its snapshots have their vnode's
+		 * v_vfsp set to the parent's filesystem's vfsp.  Note,
+		 * 'z_parent' is self referential for non-snapshots.
+		 */
+#ifdef FREEBSD_NAMECACHE
+		cache_purgevfs(zfsvfs->z_parent->z_vfs);
+#endif
+	}
+
+	/*
+	 * Close the zil. NB: Can't close the zil while zfs_inactive
+	 * threads are blocked as zil_close can call zfs_inactive.
+	 */
+	if (zfsvfs->z_log) {
+		zil_close(zfsvfs->z_log);
+		zfsvfs->z_log = NULL;
+	}
+
 	/*
 	 * If someone has not already unmounted this file system,
 	 * drain the zrele_taskq to ensure all active references to the
@@ -1666,28 +1689,6 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 			if (++round > 1 && !unmounting)
 				break;
 		}
-	}
-	ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
-
-	if (!unmounting) {
-		/*
-		 * We purge the parent filesystem's vfsp as the parent
-		 * filesystem and all of its snapshots have their vnode's
-		 * v_vfsp set to the parent's filesystem's vfsp.  Note,
-		 * 'z_parent' is self referential for non-snapshots.
-		 */
-#ifdef FREEBSD_NAMECACHE
-		cache_purgevfs(zfsvfs->z_parent->z_vfs);
-#endif
-	}
-
-	/*
-	 * Close the zil. NB: Can't close the zil while zfs_inactive
-	 * threads are blocked as zil_close can call zfs_inactive.
-	 */
-	if (zfsvfs->z_log) {
-		zil_close(zfsvfs->z_log);
-		zfsvfs->z_log = NULL;
 	}
 
 	ZFS_TEARDOWN_INACTIVE_ENTER_WRITE(zfsvfs);

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -1641,6 +1641,29 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 	znode_t	*zp;
 	dsl_dir_t *dd;
 
+	ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
+
+	if (!unmounting) {
+		/*
+		 * We purge the parent filesystem's vfsp as the parent
+		 * filesystem and all of its snapshots have their vnode's
+		 * v_vfsp set to the parent's filesystem's vfsp.  Note,
+		 * 'z_parent' is self referential for non-snapshots.
+		 */
+#ifdef FREEBSD_NAMECACHE
+		cache_purgevfs(zfsvfs->z_parent->z_vfs);
+#endif
+	}
+
+	/*
+	 * Close the zil. NB: Can't close the zil while zfs_inactive
+	 * threads are blocked as zil_close can call zfs_inactive.
+	 */
+	if (zfsvfs->z_log) {
+		zil_close(zfsvfs->z_log);
+		zfsvfs->z_log = NULL;
+	}
+
 	/*
 	 * If someone has not already unmounted this file system,
 	 * drain the zrele_taskq to ensure all active references to the
@@ -1666,28 +1689,6 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 			if (++round > 1 && !unmounting)
 				break;
 		}
-	}
-	ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
-
-	if (!unmounting) {
-		/*
-		 * We purge the parent filesystem's vfsp as the parent
-		 * filesystem and all of its snapshots have their vnode's
-		 * v_vfsp set to the parent's filesystem's vfsp.  Note,
-		 * 'z_parent' is self referential for non-snapshots.
-		 */
-#ifdef FREEBSD_NAMECACHE
-		cache_purgevfs(zfsvfs->z_parent->z_vfs);
-#endif
-	}
-
-	/*
-	 * Close the zil. NB: Can't close the zil while zfs_inactive
-	 * threads are blocked as zil_close can call zfs_inactive.
-	 */
-	if (zfsvfs->z_log) {
-		zil_close(zfsvfs->z_log);
-		zfsvfs->z_log = NULL;
 	}
 
 	ZFS_TEARDOWN_INACTIVE_ENTER_WRITE(zfsvfs);
@@ -1789,23 +1790,40 @@ zfs_umount(vfs_t *vfsp, int fflag)
 			return (ret);
 	}
 
+	ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
+	if (zfsvfs->z_log != NULL) {
+		zil_close(zfsvfs->z_log);
+		zfsvfs->z_log = NULL;
+	}
 	if (fflag & MS_FORCE) {
 		/*
 		 * Mark file system as unmounted before calling
 		 * vflush(FORCECLOSE). This way we ensure no future vnops
 		 * will be called and risk operating on DOOMED vnodes.
 		 */
-		ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
 		zfsvfs->z_unmounted = B_TRUE;
-		ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
+	}
+	ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
+
+	if (zfsvfs->z_os != NULL) {
+		taskq_wait_outstanding(dsl_pool_zrele_taskq(
+		    dmu_objset_pool(zfsvfs->z_os)), 0);
 	}
 
 	/*
 	 * Flush all the files.
 	 */
 	ret = vflush(vfsp, 0, (fflag & MS_FORCE) ? FORCECLOSE : 0, td);
-	if (ret != 0)
+	if (ret != 0) {
+		ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
+		ASSERT0P(zfsvfs->z_log);
+		if (zfsvfs->z_os != NULL) {
+			zfsvfs->z_log = zil_open(zfsvfs->z_os, zfs_get_data,
+			    &zfsvfs->z_kstat.dk_zil_sums);
+		}
+		ZFS_TEARDOWN_EXIT(zfsvfs, FTAG);
 		return (ret);
+	}
 	while (taskqueue_cancel(zfsvfs_taskq->tq_queue,
 	    &zfsvfs->z_unlinked_drain_task, NULL) != 0)
 		taskqueue_drain(zfsvfs_taskq->tq_queue,

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1207,6 +1207,28 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 
 	zfs_unlinked_drain_stop_wait(zfsvfs);
 
+	ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
+
+	if (!unmounting) {
+		/*
+		 * We purge the parent filesystem's super block as the
+		 * parent filesystem and all of its snapshots have their
+		 * inode's super block set to the parent's filesystem's
+		 * super block.  Note,  'z_parent' is self referential
+		 * for non-snapshots.
+		 */
+		shrink_dcache_sb(zfsvfs->z_parent->z_sb);
+	}
+
+	/*
+	 * Close the zil. NB: Can't close the zil while zfs_inactive
+	 * threads are blocked as zil_close can call zfs_inactive.
+	 */
+	if (zfsvfs->z_log) {
+		zil_close(zfsvfs->z_log);
+		zfsvfs->z_log = NULL;
+	}
+
 	/*
 	 * If someone has not already unmounted this file system,
 	 * drain the zrele_taskq to ensure all active references to the
@@ -1232,28 +1254,6 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 			if (++round > 1 && !unmounting)
 				break;
 		}
-	}
-
-	ZFS_TEARDOWN_ENTER_WRITE(zfsvfs, FTAG);
-
-	if (!unmounting) {
-		/*
-		 * We purge the parent filesystem's super block as the
-		 * parent filesystem and all of its snapshots have their
-		 * inode's super block set to the parent's filesystem's
-		 * super block.  Note,  'z_parent' is self referential
-		 * for non-snapshots.
-		 */
-		shrink_dcache_sb(zfsvfs->z_parent->z_sb);
-	}
-
-	/*
-	 * Close the zil. NB: Can't close the zil while zfs_inactive
-	 * threads are blocked as zil_close can call zfs_inactive.
-	 */
-	if (zfsvfs->z_log) {
-		zil_close(zfsvfs->z_log);
-		zfsvfs->z_log = NULL;
 	}
 
 	rw_enter(&zfsvfs->z_teardown_inactive_lock, RW_WRITER);

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1373,45 +1373,27 @@ static void zfs_get_done(zgd_t *zgd, int error);
  * Get data to generate a TX_WRITE intent log record.
  */
 int
-zfs_get_data(void *arg, uint64_t gen, lr_write_t *lr, char *buf,
+zfs_get_data(void *arg, void *arg2, lr_write_t *lr, char *buf,
     struct lwb *lwb, zio_t *zio)
 {
 	zfsvfs_t *zfsvfs = arg;
 	objset_t *os = zfsvfs->z_os;
-	znode_t *zp;
+	znode_t *zp = arg2;
 	uint64_t object = lr->lr_foid;
 	uint64_t offset = lr->lr_offset;
 	uint64_t size = lr->lr_length;
 	zgd_t *zgd;
 	int error = 0;
-	uint64_t zp_gen;
 
+	ASSERT3P(zp, !=, NULL);
 	ASSERT3P(lwb, !=, NULL);
 	ASSERT3U(size, !=, 0);
 
-	/*
-	 * Nothing to do if the file has been removed
-	 */
-	if (zfs_zget(zfsvfs, object, &zp) != 0)
+	if (zp->z_unlinked)
 		return (SET_ERROR(ENOENT));
-	if (zp->z_unlinked) {
-		/*
-		 * Release the vnode asynchronously as we currently have the
-		 * txg stopped from syncing.
-		 */
-		zfs_zrele_async(zp);
-		return (SET_ERROR(ENOENT));
-	}
-	/* check if generation number matches */
-	if (sa_lookup(zp->z_sa_hdl, SA_ZPL_GEN(zfsvfs), &zp_gen,
-	    sizeof (zp_gen)) != 0) {
-		zfs_zrele_async(zp);
-		return (SET_ERROR(EIO));
-	}
-	if (zp_gen != gen) {
-		zfs_zrele_async(zp);
-		return (SET_ERROR(ENOENT));
-	}
+
+	/* Hold zp ref for ourselves */
+	zhold(zp);
 
 	zgd = kmem_zalloc(sizeof (zgd_t), KM_SLEEP);
 	zgd->zgd_lwb = lwb;

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1366,45 +1366,27 @@ static void zfs_get_done(zgd_t *zgd, int error);
  * Get data to generate a TX_WRITE intent log record.
  */
 int
-zfs_get_data(void *arg, uint64_t gen, lr_write_t *lr, char *buf,
+zfs_get_data(void *arg, void *arg2, lr_write_t *lr, char *buf,
     struct lwb *lwb, zio_t *zio)
 {
 	zfsvfs_t *zfsvfs = arg;
 	objset_t *os = zfsvfs->z_os;
-	znode_t *zp;
+	znode_t *zp = arg2;
 	uint64_t object = lr->lr_foid;
 	uint64_t offset = lr->lr_offset;
 	uint64_t size = lr->lr_length;
 	zgd_t *zgd;
 	int error = 0;
-	uint64_t zp_gen;
 
+	ASSERT3P(zp, !=, NULL);
 	ASSERT3P(lwb, !=, NULL);
 	ASSERT3U(size, !=, 0);
 
-	/*
-	 * Nothing to do if the file has been removed
-	 */
-	if (zfs_zget(zfsvfs, object, &zp) != 0)
+	if (zp->z_unlinked)
 		return (SET_ERROR(ENOENT));
-	if (zp->z_unlinked) {
-		/*
-		 * Release the vnode asynchronously as we currently have the
-		 * txg stopped from syncing.
-		 */
-		zfs_zrele_async(zp);
-		return (SET_ERROR(ENOENT));
-	}
-	/* check if generation number matches */
-	if (sa_lookup(zp->z_sa_hdl, SA_ZPL_GEN(zfsvfs), &zp_gen,
-	    sizeof (zp_gen)) != 0) {
-		zfs_zrele_async(zp);
-		return (SET_ERROR(EIO));
-	}
-	if (zp_gen != gen) {
-		zfs_zrele_async(zp);
-		return (SET_ERROR(ENOENT));
-	}
+
+	/* Hold zp ref for ourselves */
+	zhold(zp);
 
 	zgd = kmem_zalloc(sizeof (zgd_t), KM_SLEEP);
 	zgd->zgd_lwb = lwb;

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -2469,7 +2469,7 @@ zil_lwb_commit(zilog_t *zilog, lwb_t *lwb, itx_t *itx)
 			 * writing completion before the vdev cache flushing.
 			 */
 			error = zilog->zl_get_data(itx->itx_private,
-			    itx->itx_gen, lrwb, dbuf, lwb,
+			    itx->itx_znode, lrwb, dbuf, lwb,
 			    lwb->lwb_child_zio);
 			if (dbuf != NULL && error == 0) {
 				/* Zero any padding bytes in the last block. */
@@ -2562,6 +2562,8 @@ zil_itx_create(uint64_t txtype, size_t olrsize)
 	itx->itx_callback = NULL;
 	itx->itx_callback_data = NULL;
 	itx->itx_size = itxsize;
+	itx->itx_znode = NULL;
+	itx->itx_zrele = NULL;
 
 	return (itx);
 }
@@ -2577,6 +2579,7 @@ zil_itx_clone(itx_t *oitx)
 	memcpy(itx, oitx, oitx->itx_size);
 	itx->itx_callback = NULL;
 	itx->itx_callback_data = NULL;
+	itx->itx_zrele = NULL;
 	return (itx);
 }
 
@@ -2591,6 +2594,11 @@ zil_itx_destroy(itx_t *itx, int err)
 
 	if (itx->itx_callback != NULL)
 		itx->itx_callback(itx->itx_callback_data, err);
+
+	if (itx->itx_zrele) {
+		ASSERT3P(itx->itx_znode, !=, NULL);
+		itx->itx_zrele(itx->itx_znode);
+	}
 
 	zio_data_buf_free(itx, itx->itx_size);
 }

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1036,7 +1036,7 @@ zvol_get_done(zgd_t *zgd, int error)
  * Get data to generate a TX_WRITE intent log record.
  */
 int
-zvol_get_data(void *arg, uint64_t arg2, lr_write_t *lr, char *buf,
+zvol_get_data(void *arg, void *arg2, lr_write_t *lr, char *buf,
     struct lwb *lwb, zio_t *zio)
 {
 	zvol_state_t *zv = arg;


### PR DESCRIPTION
If inode eviction and sync writeback happen on the same inode at the same time, inode eviction will set I_FREEING and wait for sync writeback, and sync writeback may eventually calls zfs_get_data and loop in zfs_zget forever because igrab cannot succeed with I_FREEING, thus causing deadlock.

To fix this, we take a hold on znode in itx. This make sure the inode won't get evicted until sync writeback is done.

Signed-off-by: Chunwei Chen <david.chen@nutanix.com>
Fixes #7964
Fixes #9430

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
