### PR TITLE
zdb: better handling for corrupt block pointers

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2592,18 +2592,6 @@ print_indirect(spa_t *spa, blkptr_t *bp, const zbookmark_phys_t *zb,
 	int l;
 
 	offset = (u_longlong_t)blkid2offset(dnp, bp, zb);
-	if (!BP_IS_EMBEDDED(bp)) {
-		if (BP_GET_TYPE(bp) != dnp->dn_type) {
-			(void) fprintf(stderr, "%16llx: Block pointer type "
-			    "(%llu) does not match dnode type (%hhu)\n",
-			    offset, BP_GET_TYPE(bp), dnp->dn_type);
-		}
-		if (BP_GET_LEVEL(bp) != zb->zb_level) {
-			(void) fprintf(stderr, "%16llx: Block pointer level "
-			    "(%llu) does not match bookmark level (%ld)\n",
-			    offset, BP_GET_LEVEL(bp), zb->zb_level);
-		}
-	}
 
 	(void) printf("%16llx ", offset);
 
@@ -2620,7 +2608,21 @@ print_indirect(spa_t *spa, blkptr_t *bp, const zbookmark_phys_t *zb,
 	snprintf_blkptr_compact(blkbuf, sizeof (blkbuf), bp, B_FALSE);
 	if (dump_opt['Z'] && BP_GET_COMPRESS(bp) == ZIO_COMPRESS_ZSTD)
 		snprintf_zstd_header(spa, blkbuf, sizeof (blkbuf), bp);
-	(void) printf("%s\n", blkbuf);
+	(void) printf("%s", blkbuf);
+
+	if (!BP_IS_EMBEDDED(bp)) {
+		if (BP_GET_TYPE(bp) != dnp->dn_type) {
+			(void) printf(" (ERROR: Block pointer type "
+			    "(%llu) does not match dnode type (%hhu))",
+			    BP_GET_TYPE(bp), dnp->dn_type);
+		}
+		if (BP_GET_LEVEL(bp) != zb->zb_level) {
+			(void) printf(" (ERROR: Block pointer level "
+			    "(%llu) does not match bookmark level (%ld))",
+			    BP_GET_LEVEL(bp), zb->zb_level);
+		}
+	}
+	(void) printf("\n");
 
 	return (offset);
 }
@@ -2667,7 +2669,7 @@ visit_indirect(spa_t *spa, const dnode_phys_t *dnp,
 		}
 		if (!err) {
 			if (fill != BP_GET_FILL(bp)) {
-				(void) fprintf(stderr, "%16llx: Block pointer "
+				(void) printf("%16llx: Block pointer "
 				    "fill (%llu) does not match calculated "
 				    "value (%lu)\n", offset, BP_GET_FILL(bp),
 				    fill);

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -833,7 +833,7 @@ usage(void)
 	(void) fprintf(stderr, "Specify an option more than once (e.g. -bb) "
 	    "to make only that option verbose\n");
 	(void) fprintf(stderr, "Default is to dump everything non-verbosely\n");
-	zdb_exit(1);
+	zdb_exit(2);
 }
 
 static void
@@ -9666,7 +9666,7 @@ main(int argc, char **argv)
 		} else if (objset_str && !zdb_numeric(objset_str + 1) &&
 		    dump_opt['N']) {
 			printf("Supply a numeric objset ID with -N\n");
-			error = 1;
+			error = 2;
 			goto fini;
 		}
 	} else {

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -429,6 +429,7 @@ metaslab_spacemap_validation_cb(space_map_entry_t *sme, void *arg)
 			    (u_longlong_t)txg, (u_longlong_t)offset,
 			    (u_longlong_t)size, (u_longlong_t)mv->mv_vdid,
 			    (u_longlong_t)mv->mv_msid);
+			corruption_found = B_TRUE;
 		} else {
 			zfs_range_tree_add(mv->mv_allocated,
 			    offset, size);
@@ -530,6 +531,7 @@ mv_populate_livelist_allocs(metaslab_verify_t *mv, sublivelist_verify_t *sv)
 			    (u_longlong_t)DVA_GET_VDEV(&svb->svb_dva),
 			    (u_longlong_t)DVA_GET_OFFSET(&svb->svb_dva),
 			    (u_longlong_t)DVA_GET_ASIZE(&svb->svb_dva));
+			corruption_found = B_TRUE;
 			continue;
 		}
 

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -15,7 +15,7 @@
 .\" Copyright (c) 2017 Lawrence Livermore National Security, LLC.
 .\" Copyright (c) 2017 Intel Corporation.
 .\"
-.Dd October 27, 2024
+.Dd April 23, 2025
 .Dt ZDB 8
 .Os
 .
@@ -531,6 +531,18 @@ option, with more occurrences enabling more verbosity.
 If no options are specified, all information about the named pool will be
 displayed at default verbosity.
 .
+.Sh EXIT STATUS
+The
+.Nm
+utility exits
+.Sy 0
+on success,
+.Sy 1
+if a fatal error occurs,
+.Sy 2
+if invalid command line options were specified, or
+.Sy 3
+if on-disk corruption was detected, but was not fatal.
 .Sh EXAMPLES
 .Ss Example 1 : No Display the configuration of imported pool Ar rpool
 .Bd -literal


### PR DESCRIPTION
When dumping indirect blocks, attempt to print corrupt block pointers rather than abort the program.

Sponsored by:	ConnectWise
Signed-off-by:	Alan Somers <asomers@gmail.com>

### Motivation and Context

When trying to print a file's indirect blocks with "zfs -vvbbbb", if that file contains corrupt block pointers zdb will fail assertions and crash.

### Description
Remove three assertions, replacing them with warnings printed to stderr.  The rest of zdb does not require those block pointers to be intact.

### How Has This Been Tested?
Tested with a dataset that had become corrupted, similarly to #17077 .

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
