### PR TITLE
test-runner: rework output dir construction

### DIFF
--- a/tests/test-runner/bin/test-runner.py.in
+++ b/tests/test-runner/bin/test-runner.py.in
@@ -858,9 +858,10 @@ class TestRun(object):
 
     def complete_outputdirs(self):
         """
-        Collect all the pathnames for Tests, and TestGroups. Work
-        backwards one pathname component at a time, to create a unique
-        directory name in which to deposit test output. Tests will be able
+        Collect all the pathnames for Tests, and TestGroups. Strip off all
+        common leading path components, and append what remains to the top
+        "output" dir, to create a tree of output directories that match
+        the test and group names in structure. Tests will be able
         to write output files directly in the newly modified outputdir.
         TestGroups will be able to create one subdirectory per test in the
         outputdir, and are guaranteed uniqueness because a group can only
@@ -869,24 +870,30 @@ class TestRun(object):
         question for their output. Failsafe scripts will create a directory
         rooted at the outputdir of each Test for their output.
         """
-        done = False
-        components = 0
-        tmp_dict = dict(list(self.tests.items()) +
-                        list(self.testgroups.items()))
-        total = len(tmp_dict)
-        base = self.outputdir
 
-        while not done:
-            paths = []
-            components -= 1
-            for testfile in list(tmp_dict.keys()):
-                uniq = '/'.join(testfile.split('/')[components:]).lstrip('/')
-                if uniq not in paths:
-                    paths.append(uniq)
-                    tmp_dict[testfile].outputdir = os.path.join(base, uniq)
-                else:
-                    break
-            done = total == len(paths)
+        alltests = dict(list(self.tests.items()) +
+                        list(self.testgroups.items()))
+        base = os.path.join(self.outputdir, 'output')
+
+        seen = []
+
+        for path in list(alltests.keys()):
+            frag = path.split('/')
+            for i in range(0, len(frag)):
+                if len(seen) == i:
+                    seen.append({})
+                seen[i][frag[i]] = 1
+
+        cut = 0
+        for i in range(0, len(seen)):
+            if len(list(seen[i].keys())) == 1:
+                cut += 1
+            else:
+                break
+
+        for path in list(alltests.keys()):
+            uniq = path.split('/', cut)[-1]
+            alltests[path].outputdir = os.path.join(base, uniq)
 
     def setup_logging(self, options):
         """


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

Test output dirs are inconsistent. Sometimes things go under `functional/`, sometimes not, and single test mode doesn't always do the same thing as the full test suite, even though the runfile group appears the same.

### Description

The old code would compare all the test group names to work out some sort of common path, but it didn't appear to work consistently, sometimes placing output in a top-level dir, other times in one or more subdirs. (I confess, I do not quite understand what it's supposed to do).

This is a very simple rework that simply looks at all the test group paths, removes common leading components, and uses the remainder as the output directory. This should work because groups paths are unique, and means we get a output dir tree of roughly the same shape as the test groups in the runfiles and the test source dirs themselves.

### How Has This Been Tested?

Playing with running different tests and comparing output. The main comparison is a full ZTS run and comparing the output dir structure with one from a few days ago: [before](https://gist.github.com/robn/78838b5531e1fa97565eb8320bbb2ed9) [after](https://gist.github.com/robn/9dd4b88039ca393a00c4bf20c84b6815).

Simple example. The `acl` tag has some subgroups, `alloc_class` does not. Without this change:

```
/var/tmp/test_results/20250216T104228/acl/off
/var/tmp/test_results/20250216T104228/acl/posix:Linux
/var/tmp/test_results/20250216T104228/acl/posix-sa:Linux
/var/tmp/test_results/20250216T104228/functional/alloc_class
```

With:

```
/var/tmp/test_results/20250321T152726/output/acl/off
/var/tmp/test_results/20250321T152726/output/acl/posix:Linux
/var/tmp/test_results/20250321T152726/output/acl/posix-sa:Linux
/var/tmp/test_results/20250321T152726/output/alloc_class
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
