### PR TITLE
vdev/geom: Add raw mode access support

### DIFF
--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -59,6 +59,9 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef __FreeBSD__
+#include <sys/sysctl.h>
+#endif
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -1811,7 +1814,15 @@ zpool_find_import(libpc_handle_t *hdl, importargs_t *iarg)
 	pthread_mutex_t lock;
 	avl_tree_t *cache;
 	nvlist_t *pools = NULL;
+	int raw = 0;
+#ifdef __FreeBSD__
+	size_t size;
 
+	/* Do full directory scan if vdev raw mode is enabled. */
+	if (sysctlbyname("vfs.zfs.vdev.raw_mode", &raw, &size, NULL, 0) == -1) {
+		return (NULL);
+	}
+#endif
 	verify(iarg->poolname == NULL || iarg->guid == 0);
 	pthread_mutex_init(&lock, NULL);
 
@@ -1821,7 +1832,7 @@ zpool_find_import(libpc_handle_t *hdl, importargs_t *iarg)
 	 * entry for each discovered vdev will be returned in the cache.
 	 * It's the caller's responsibility to consume and destroy this tree.
 	 */
-	if (iarg->scan || iarg->paths != 0) {
+	if (raw || iarg->scan || iarg->paths != 0) {
 		size_t dirs = iarg->paths;
 		const char * const *dir = (const char * const *)iarg->path;
 

--- a/module/os/freebsd/zfs/vdev_geom.c
+++ b/module/os/freebsd/zfs/vdev_geom.c
@@ -80,6 +80,55 @@ SYSCTL_INT(_vfs_zfs_vdev, OID_AUTO, bio_flush_disable, CTLFLAG_RWTUN,
 static int vdev_geom_bio_delete_disable;
 SYSCTL_INT(_vfs_zfs_vdev, OID_AUTO, bio_delete_disable, CTLFLAG_RWTUN,
 	&vdev_geom_bio_delete_disable, 0, "Disable BIO_DELETE");
+/*
+ * Enable disk vdevs raw mode access.
+ * It provides ZFS ability to interact with char devices without the geom
+ * framework.  Should be used with caution, because the geom labels are
+ * completely ignored and can be overwritten.  Also, other issues with char
+ * devices IO, like large unaligned requests or error handling, previously
+ * hidden by geom, can let know about themselves on ZFS side.
+ * This sysctl is more for development/testing purposes, mean should be used
+ * carefully.
+ */
+static int vdev_raw_mode = 0;
+static int
+sysctl_vdev_raw_mode(SYSCTL_HANDLER_ARGS)
+{
+	boolean_t raw_mode = vdev_raw_mode;
+	spa_t *spa;
+	int err;
+
+	err = sysctl_handle_bool(oidp, &raw_mode, 0, req);
+	if (err != 0) {
+		return (err);
+	}
+
+	if (spa_mode_global == SPA_MODE_UNINIT) {
+		vdev_raw_mode = raw_mode;
+		return (0);
+	}
+
+	if (vdev_raw_mode != raw_mode) {
+		mutex_enter(&spa_namespace_lock);
+		/*
+		 * It is possible to switch vdev disk raw mode access only
+		 * if no zpools are imported, or set sysctl value
+		 * before ZFS kernel module loading using kenv.
+		 */
+		spa = spa_next(NULL);
+		if (spa == NULL) {
+			vdev_raw_mode = raw_mode;
+		}
+		mutex_exit(&spa_namespace_lock);
+	}
+
+	return (0);
+}
+
+SYSCTL_PROC(_vfs_zfs_vdev, OID_AUTO, raw_mode,
+    CTLTYPE_U8 | CTLFLAG_RWTUN | CTLFLAG_MPSAFE,
+    NULL, 0, sysctl_vdev_raw_mode, "CU",
+	"Enable vdev disk raw mode access");
 
 /* Declare local functions */
 static void vdev_geom_detach(struct g_consumer *cp, boolean_t open_for_read);
@@ -802,6 +851,149 @@ vdev_geom_open_by_path(vdev_t *vd, int check_guid)
 }
 
 static int
+vdev_raw_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
+    uint64_t *logical_ashift, uint64_t *physical_ashift)
+{
+	struct diocgattr_arg arg;
+	struct thread *td;
+	struct vnode *vp;
+	struct file *fp;
+	struct nameidata nd;
+	char path[MAXPATHLEN] = {0};
+	mode_t mode;
+	int flags, error;
+	uint_t sectorsize;
+	off_t stripesize = 0;
+	off_t stripeoffset = 0;
+	off_t mediasize;
+
+	flags = O_RDWR;
+	td = curthread;
+	pwd_ensure_dirs();
+
+	if ((spa_mode(vd->vdev_spa) & SPA_MODE_READ) &&
+	    (spa_mode(vd->vdev_spa) & SPA_MODE_WRITE)) {
+		mode = O_RDWR;
+	} else if (spa_mode(vd->vdev_spa) & SPA_MODE_READ) {
+		mode = O_RDONLY;
+	} else if (spa_mode(vd->vdev_spa) & SPA_MODE_WRITE) {
+		mode = O_WRONLY;
+	}
+
+	KASSERT((flags & (O_EXEC | O_PATH)) == 0,
+	    ("invalid flags: 0x%x", flags));
+	KASSERT((flags & O_ACCMODE) != O_ACCMODE,
+	    ("invalid flags: 0x%x", flags));
+	flags = FFLAGS(flags);
+
+	/*
+	 * Reopen the device if it's not currently open. Otherwise,
+	 * just update the physical size of the device.
+	 */
+	if ((fp = vd->vdev_tsd) != NULL) {
+		ASSERT(vd->vdev_reopening);
+		goto skip_open;
+	}
+
+	error = falloc_noinstall(td, &fp);
+	if (error != 0) {
+		vdev_dbgmsg(vd, "vdev_raw_open: falloc failed: [error=%d]",
+		    error);
+		return (error);
+	}
+
+	fp->f_flag = flags & FMASK;
+
+	memcpy(path, vd->vdev_path, MAXPATHLEN);
+#if __FreeBSD_version >= 1400043
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, path);
+#else
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, path, td);
+#endif
+	error = vn_open(&nd, &flags, mode, fp);
+	if (error != 0) {
+		vdev_dbgmsg(vd, "vdev_raw_open: open failed: [error=%d]",
+		    error);
+		falloc_abort(td, fp);
+		return (SET_ERROR(error));
+	}
+	NDFREE_PNBUF(&nd);
+	vp = nd.ni_vp;
+	fp->f_vnode = vp;
+	if (fp->f_ops == &badfileops) {
+		finit_vnode(fp, flags, NULL, &vnops);
+	}
+	vref(vp);
+	VOP_UNLOCK(vp);
+	if (!IS_DEVVP(vp)) {
+		vdev_dbgmsg(vd, "vdev_raw_open: vdev is not dev");
+		vrele(fp->f_vnode);
+		fdrop(fp, curthread);
+		return (SET_ERROR(EACCES));
+	}
+
+	vd->vdev_tsd = fp;
+
+skip_open:
+	error = fo_ioctl(fp, DIOCGMEDIASIZE, (caddr_t)&mediasize,
+	    td->td_ucred, td);
+	if (error) {
+		vdev_dbgmsg(vd, "vdev_raw_open: cannot get media size");
+		vrele(fp->f_vnode);
+		fdrop(fp, curthread);
+		return (SET_ERROR(EINVAL));
+	}
+
+	error = fo_ioctl(fp, DIOCGSECTORSIZE, (caddr_t)&sectorsize,
+	    td->td_ucred, td);
+	if (error) {
+		vdev_dbgmsg(vd, "vdev_raw_open: cannot get sector size");
+		vrele(fp->f_vnode);
+		fdrop(fp, curthread);
+		return (SET_ERROR(EINVAL));
+	}
+
+	*max_psize = *psize = mediasize;
+
+	error = fo_ioctl(fp, DIOCGSTRIPESIZE, (caddr_t)&stripesize,
+	    td->td_ucred, td);
+	if (error)
+		vdev_dbgmsg(vd, "vdev_raw_open: cannot get stripe size");
+
+	error = fo_ioctl(fp, DIOCGSTRIPEOFFSET, (caddr_t)&stripeoffset,
+	    td->td_ucred, td);
+	if (error)
+		vdev_dbgmsg(vd, "vdev_raw_open: cannot get stripe offset");
+
+	*logical_ashift = highbit(MAX(sectorsize, SPA_MINBLOCKSIZE)) - 1;
+	*physical_ashift = 0;
+	if (stripesize && stripesize > (1 << *logical_ashift) &&
+	    ISP2(stripesize) && stripeoffset == 0)
+		*physical_ashift = highbit(stripesize) - 1;
+
+	vd->vdev_nowritecache = B_FALSE;
+
+	vd->vdev_nonrot = B_FALSE;
+	strlcpy(arg.name, "GEOM::rotation_rate", sizeof (arg.name));
+	arg.len = sizeof (arg.value.u16);
+	error = fo_ioctl(fp, DIOCGATTR, (caddr_t)&arg, td->td_ucred, td);
+	if (error == 0 && arg.value.u16 == DISK_RR_NON_ROTATING)
+		vd->vdev_nonrot = B_TRUE;
+
+	vd->vdev_has_trim = B_FALSE;
+	strlcpy(arg.name, "GEOM::candelete", sizeof (arg.name));
+	arg.len = sizeof (arg.value.i);
+	error = fo_ioctl(fp, DIOCGATTR, (caddr_t)&arg, td->td_ucred, td);
+	if (error == 0)
+		vd->vdev_has_trim = (arg.value.i != 0);
+
+	/* unavailable on FreeBSD */
+	vd->vdev_has_securetrim = B_FALSE;
+
+	return (0);
+}
+
+static int
 vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
     uint64_t *logical_ashift, uint64_t *physical_ashift)
 {
@@ -823,6 +1015,10 @@ vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 		vd->vdev_stat.vs_aux = VDEV_AUX_BAD_LABEL;
 		return (EINVAL);
 	}
+
+	if (vdev_raw_mode)
+		return (vdev_raw_open(vd, psize, max_psize,
+		    logical_ashift, physical_ashift));
 
 	/*
 	 * Reopen the device if it's not currently open. Otherwise,
@@ -980,10 +1176,30 @@ skip_open:
 }
 
 static void
+vdev_raw_close(vdev_t *vd)
+{
+	struct file *fp;
+
+	fp = vd->vdev_tsd;
+	if (fp) {
+		vrele(fp->f_vnode);
+		fdrop(fp, curthread);
+	}
+
+	vd->vdev_delayed_close = B_FALSE;
+	vd->vdev_tsd = NULL;
+}
+
+static void
 vdev_geom_close(vdev_t *vd)
 {
 	struct g_consumer *cp;
 	boolean_t locked;
+
+	if (vdev_raw_mode) {
+		vdev_raw_close(vd);
+		return;
+	}
 
 	cp = vd->vdev_tsd;
 
@@ -1091,7 +1307,7 @@ vdev_geom_check_unmapped(zio_t *zio, struct g_consumer *cp)
 	 * If unmapped I/O is not supported by the GEOM provider,
 	 * then we can't do anything and have to copy the data.
 	 */
-	if ((cp->provider->flags & G_PF_ACCEPT_UNMAPPED) == 0)
+	if (cp && ((cp->provider->flags & G_PF_ACCEPT_UNMAPPED) == 0))
 		return (0);
 
 	/* Check the buffer chunks sizes/alignments and count pages. */
@@ -1130,8 +1346,12 @@ static void
 vdev_geom_io_start(zio_t *zio)
 {
 	vdev_t *vd;
-	struct g_consumer *cp;
+	struct g_consumer *cp = NULL;
 	struct bio *bp;
+	struct file *fp;
+	struct cdevsw *csw;
+	struct cdev *dev;
+	int ref;
 
 	vd = zio->io_vd;
 
@@ -1165,11 +1385,20 @@ vdev_geom_io_start(zio_t *zio)
 	    zio->io_type == ZIO_TYPE_TRIM ||
 	    zio->io_type == ZIO_TYPE_FLUSH);
 
-	cp = vd->vdev_tsd;
-	if (cp == NULL) {
-		zio->io_error = SET_ERROR(ENXIO);
-		zio_interrupt(zio);
-		return;
+	if (vdev_raw_mode) {
+		fp = vd->vdev_tsd;
+		if (fp == NULL) {
+			zio->io_error = SET_ERROR(ENXIO);
+			zio_interrupt(zio);
+			return;
+		}
+	} else {
+		cp = vd->vdev_tsd;
+		if (cp == NULL) {
+			zio->io_error = SET_ERROR(ENXIO);
+			zio_interrupt(zio);
+			return;
+		}
 	}
 	bp = g_alloc_bio();
 	bp->bio_caller1 = zio;
@@ -1178,7 +1407,7 @@ vdev_geom_io_start(zio_t *zio)
 	case ZIO_TYPE_WRITE:
 		zio->io_target_timestamp = zio_handle_io_delay(zio);
 		bp->bio_offset = zio->io_offset;
-		bp->bio_length = zio->io_size;
+		bp->bio_bcount = bp->bio_length = zio->io_size;
 		if (zio->io_type == ZIO_TYPE_READ)
 			bp->bio_cmd = BIO_READ;
 		else
@@ -1218,7 +1447,7 @@ vdev_geom_io_start(zio_t *zio)
 	case ZIO_TYPE_FLUSH:
 		bp->bio_cmd = BIO_FLUSH;
 		bp->bio_data = NULL;
-		bp->bio_offset = cp->provider->mediasize;
+		bp->bio_offset = cp ? cp->provider->mediasize : vd->vdev_asize;
 		bp->bio_length = 0;
 		break;
 	default:
@@ -1227,7 +1456,19 @@ vdev_geom_io_start(zio_t *zio)
 	bp->bio_done = vdev_geom_io_intr;
 	zio->io_bio = bp;
 
-	g_io_request(bp, cp);
+	if (vdev_raw_mode) {
+		csw = devvn_refthread(fp->f_vnode, &dev, &ref);
+		if (csw == NULL) {
+			zio->io_error = SET_ERROR(ENXIO);
+			zio_interrupt(zio);
+			return;
+		}
+		bp->bio_dev = dev;
+		csw->d_strategy(bp);
+		dev_relthread(dev, ref);
+	} else {
+		g_io_request(bp, cp);
+	}
 }
 
 static void


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
The vfs.zfs.vdev.raw_mode sysctl provides ability to interact directly with char devices and bypass geom/cam layers. This adds possibility to create/import zpools from nvme namespaces or cuse devices. The sysctl value could be switched only immediatly after zfs kernel module loading or if no zpools are imported.

### Description
Sometimes it is possible to get different fio performance results for nvme disks, if fio will be executed directly on nvme namespace char dev comparing with executing on nda/nvd. But it is impossible to pass nvme namespaces directly to zpool create command. This sysctl provides ability to ZFS to interact directly with char devices bypassing geom/cam layer. The sysctl can be switched only if no pools are imported.
Useful with nvme namespaces, nvdimm and cuse devices. In second case some modifications on FreeBSD side are requred. Now is possible to pass nvmeXn1/nvmeXns1 to zpool create command and zpool will be created. It could be imported in normal vdev mode later, if raw option will be disabled back. From other side, it is not possible to import exist zpool built from nda/nvd devices as nvmeXns1, the only way to do it, is to modify device tree paths in the vdevs label configs.

### How Has This Been Tested?
I teststed this sysctl it both on qemu and HW server, in both cases it is possible to get viewable zpool performance improvements comparing with geom/cam devices. I made tests runs both kyua and openzfs tests, with disks passed as nda/nvd and nvme namespaces with nda/nvd disabling (mean only nvme namespaces are viewable from user side) and did not found any notable issues, excluding some number of bus_dmamap_load_mem() failures on some tests, which produce large IO requests to nvme namespaces.
So, the vdevs raw mode could be usefull as development/testing knob.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
