### PR TITLE
zvol: Enable zvol threading functionality on FreeBSD

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3386,17 +3386,21 @@ function set_tunable_impl
 
 function save_tunable
 {
-	[[ ! -d $TEST_BASE_DIR ]] && return 1
-	[[ -e $TEST_BASE_DIR/tunable-$1 ]] && return 2
-	echo "$(get_tunable """$1""")" > "$TEST_BASE_DIR"/tunable-"$1"
+	if tunable_exists $1 ; then
+		[[ ! -d $TEST_BASE_DIR ]] && return 1
+		[[ -e $TEST_BASE_DIR/tunable-$1 ]] && return 2
+		echo "$(get_tunable """$1""")" > "$TEST_BASE_DIR"/tunable-"$1"
+	fi
 }
 
 function restore_tunable
 {
-	[[ ! -e $TEST_BASE_DIR/tunable-$1 ]] && return 1
-	val="$(cat $TEST_BASE_DIR/tunable-"""$1""")"
-	set_tunable64 "$1" "$val"
-	rm $TEST_BASE_DIR/tunable-$1
+	if tunable_exists $1 ; then
+		[[ ! -e $TEST_BASE_DIR/tunable-$1 ]] && return 1
+		val="$(cat $TEST_BASE_DIR/tunable-"""$1""")"
+		set_tunable64 "$1" "$val"
+		rm $TEST_BASE_DIR/tunable-$1
+	fi
 }
 
 #

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -102,6 +102,7 @@ VDEV_VALIDATE_SKIP		vdev.validate_skip		vdev_validate_skip
 VOL_INHIBIT_DEV			UNSUPPORTED			zvol_inhibit_dev
 VOL_MODE			vol.mode			zvol_volmode
 VOL_RECURSIVE			vol.recursive			UNSUPPORTED
+VOL_REQUEST_SYNC		zvol_request_sync		zvol_request_sync
 VOL_USE_BLK_MQ			UNSUPPORTED			zvol_use_blk_mq
 BCLONE_ENABLED			bclone_enabled			zfs_bclone_enabled
 BCLONE_WAIT_DIRTY		bclone_wait_dirty		zfs_bclone_wait_dirty

--- a/tests/zfs-tests/tests/functional/zvol/zvol_common.shlib
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_common.shlib
@@ -140,3 +140,11 @@ function set_blk_mq
 		log_must set_tunable32 VOL_USE_BLK_MQ $1
 	fi
 }
+
+# enable/disable zvol sync mode
+#
+# $1: 1 = enable, 0 = disable
+function set_zvol_sync
+{
+	log_must set_tunable32 VOL_REQUEST_SYNC $1
+}


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Add zvol IO taskqs support on FreeBSD side. Make zvol threadpool creation/destruction logic and zvol module parameters shared for both Linux and FreeBSD.

### Description
Make zvol I/O requests processing asynchronous on FreeBSD side in some cases. Clone zvol threading logic and required module parameters from Linux side. Make zvol threadpool creation/destruction logic shared for both Linux and FreeBSD.
The IO requests are processed asynchronously in next cases:
- volmode=geom: if IO request passed thru zvol_geom_worker thread.
- volmode=cdev: if IO request passed thru struct cdevsw .d_strategy routine, mean is AIO request.

In all other cases the IO requests are processed synchronously.


### How Has This Been Tested?
The [zvol_request_sync](https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Module%20Parameters.html#zvol-request-sync) module parameter manipulation was added to tests/functional/zvol/zvol_stress/zvol_stress.ksh testcase for both Linux and FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
