### PR TITLE
runners: Fix zfs-release RPM creation

### DIFF
--- a/.github/workflows/scripts/qemu-4-build-vm.sh
+++ b/.github/workflows/scripts/qemu-4-build-vm.sh
@@ -259,8 +259,9 @@ function rpm_build_and_install() {
 
     # ZFS release RPMs are built.  Copy them to the ~/zfs directory just to
     # keep all the RPMs in the same place.
-    cp ~/rpmbuild/RPMS/noarch/*.rpm .
-    cp ~/rpmbuild/SRPMS/*.rpm .
+    cp ~/rpmbuild/RPMS/noarch/*.rpm ~/zfs
+    cp ~/rpmbuild/SRPMS/*.rpm ~/zfs
+
     popd
     rm -fr ~/rpmbuild
     echo "##[endgroup]"


### PR DESCRIPTION
### Motivation and Context
Let `zfs-qemu-packages-packages` workflow correctly build zfs-release RPMs.

### Description
The zfs-qemu-packages workflow was incorrectly copying the built zfs-release RPMs to ~/zfsonlinux.github.com rather than ~/zfs.  This meant that the RPMs were not being correctly picked in the artifacts files.  This fixes the issue.

<!--- Describe your changes in detail -->

### How Has This Been Tested?
Ran workflow and saw zfs-release RPMs included in artifacts.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
