### PR TITLE
ZTS: Fix zpool_status_features_001_pos local test

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -59,6 +59,7 @@ export INSTALL_UDEV_RULE_DIR=$(udevruledir)
 export INSTALL_MOUNT_HELPER_DIR=$(mounthelperdir)
 export INSTALL_SYSCONF_DIR=$(sysconfdir)
 export INSTALL_PYTHON_DIR=$(pythonsitedir)
+export INSTALL_PKGDATA_DIR=$(pkgdatadir)
 
 export KMOD_SPL=$(abs_top_builddir)/module/spl.ko
 export KMOD_ZFS=$(abs_top_builddir)/module/zfs.ko

--- a/scripts/zfs-helpers.sh
+++ b/scripts/zfs-helpers.sh
@@ -163,6 +163,7 @@ if [ "${INSTALL}" = "yes" ]; then
 		install "$UDEV_RULE_DIR/$rule" "$INSTALL_UDEV_RULE_DIR/$rule"
 	done
 	install "$ZPOOL_SCRIPT_DIR"              "$INSTALL_SYSCONF_DIR/zfs/zpool.d"
+	install "$ZPOOL_COMPAT_DIR"              "$INSTALL_PKGDATA_DIR/compatibility.d"
 	install "$CONTRIB_DIR/pyzfs/libzfs_core" "$INSTALL_PYTHON_DIR/libzfs_core"
 	# Ideally we would install these in the configured ${libdir}, which is
 	# by default "/usr/local/lib and unfortunately not included in the
@@ -179,6 +180,7 @@ else
 	remove "$INSTALL_UDEV_RULE_DIR/69-vdev.rules"
 	remove "$INSTALL_UDEV_RULE_DIR/90-zfs.rules"
 	remove "$INSTALL_SYSCONF_DIR/zfs/zpool.d"
+	remove "$INSTALL_PKGDATA_DIR/compatibility.d"
 	remove "$INSTALL_PYTHON_DIR/libzfs_core"
 	remove "/lib/libzfs_core.so"
 	remove "/lib/libnvpair.so"


### PR DESCRIPTION

### Motivation and Context
Allow `zpool_status_features_001_pos` test to run from a local workspace.

### Description
Update `zfs-helpers.sh -i` to install the compatibility.d/ file symlinks. These are need to run the `zpool_status_features_001_pos` test from a local workspace (as opposed to running ZTS from a formal 'make install' or install from RPMs, which are unaffected).


### How Has This Been Tested?
Successfully ran `zpool_status_features_001_pos` from a ZFS git repo dir.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
