### PR TITLE
Fix dspace underflow bug

### DIFF
--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -99,6 +99,7 @@ extern boolean_t vdev_replace_in_progress(vdev_t *vdev);
 extern void vdev_hold(vdev_t *);
 extern void vdev_rele(vdev_t *);
 
+void vdev_update_nonallocating_space(vdev_t *vd, boolean_t add);
 extern int vdev_metaslab_init(vdev_t *vd, uint64_t txg);
 extern void vdev_metaslab_fini(vdev_t *vd);
 extern void vdev_metaslab_set_size(vdev_t *);

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1515,6 +1515,24 @@ vdev_metaslab_group_create(vdev_t *vd)
 	}
 }
 
+void
+vdev_update_nonallocating_space(vdev_t *vd, boolean_t add)
+{
+	spa_t *spa = vd->vdev_spa;
+	if (vd->vdev_mg->mg_class == spa_normal_class(spa)) {
+		uint64_t raw_space = vd->vdev_stat.vs_space -
+		    metaslab_group_get_space(vd->vdev_log_mg);
+		uint64_t dspace = spa_deflate(spa) ?
+		    vdev_deflated_space(vd, raw_space) : raw_space;
+		if (add) {
+			spa->spa_nonallocating_dspace += dspace;
+		} else {
+			ASSERT3U(spa->spa_nonallocating_dspace, >=, dspace);
+			spa->spa_nonallocating_dspace -= dspace;
+		}
+	}
+}
+
 int
 vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 {
@@ -1626,8 +1644,7 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 	 */
 	if (vd->vdev_noalloc) {
 		/* track non-allocating vdev space */
-		spa->spa_nonallocating_dspace += spa_deflate(spa) ?
-		    vd->vdev_stat.vs_dspace : vd->vdev_stat.vs_space;
+		vdev_update_nonallocating_space(vd, B_TRUE);
 	} else if (!expanding) {
 		metaslab_group_activate(vd->vdev_mg);
 		if (vd->vdev_log_mg != NULL)

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -171,9 +171,6 @@ static void
 vdev_activate(vdev_t *vd)
 {
 	metaslab_group_t *mg = vd->vdev_mg;
-	spa_t *spa = vd->vdev_spa;
-	uint64_t vdev_space = spa_deflate(spa) ?
-	    vd->vdev_stat.vs_dspace : vd->vdev_stat.vs_space;
 
 	ASSERT(!vd->vdev_islog);
 	ASSERT(vd->vdev_noalloc);
@@ -181,9 +178,7 @@ vdev_activate(vdev_t *vd)
 	metaslab_group_activate(mg);
 	metaslab_group_activate(vd->vdev_log_mg);
 
-	ASSERT3U(spa->spa_nonallocating_dspace, >=, vdev_space);
-
-	spa->spa_nonallocating_dspace -= vdev_space;
+	vdev_update_nonallocating_space(vd, B_FALSE);
 
 	vd->vdev_noalloc = B_FALSE;
 }
@@ -255,8 +250,7 @@ vdev_passivate(vdev_t *vd, uint64_t *txg)
 		return (error);
 	}
 
-	spa->spa_nonallocating_dspace += spa_deflate(spa) ?
-	    vd->vdev_stat.vs_dspace : vd->vdev_stat.vs_space;
+	vdev_update_nonallocating_space(vd, B_TRUE);
 	vd->vdev_noalloc = B_TRUE;
 
 	return (0);
@@ -1369,8 +1363,6 @@ vdev_remove_complete(spa_t *spa)
 	ASSERT3P(vd->vdev_autotrim_thread, ==, NULL);
 	vdev_rebuild_stop_wait(vd);
 	ASSERT3P(vd->vdev_rebuild_thread, ==, NULL);
-	uint64_t vdev_space = spa_deflate(spa) ?
-	    vd->vdev_stat.vs_dspace : vd->vdev_stat.vs_space;
 
 	sysevent_t *ev = spa_event_create(spa, vd, NULL,
 	    ESC_ZFS_VDEV_REMOVE_DEV);
@@ -1378,11 +1370,8 @@ vdev_remove_complete(spa_t *spa)
 	zfs_dbgmsg("finishing device removal for vdev %llu in txg %llu",
 	    (u_longlong_t)vd->vdev_id, (u_longlong_t)txg);
 
-	ASSERT3U(0, !=, vdev_space);
-	ASSERT3U(spa->spa_nonallocating_dspace, >=, vdev_space);
-
 	/* the vdev is no longer part of the dspace */
-	spa->spa_nonallocating_dspace -= vdev_space;
+	vdev_update_nonallocating_space(vd, B_FALSE);
 
 	/*
 	 * Discard allocation state.


### PR DESCRIPTION
### Motivation and Context
See #17157 and #17182

### Description
When we're calculating the nonallocating space, we only include the vdev if it's part of the normal class, and we subtract out the embedded slog group space.

### How Has This Been Tested?
Passes the alloc_class_012_pos test that I initially observed the problem in.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
