### PR TITLE
kstat: silence "maybe uninitialized" warnings

### DIFF
--- a/module/os/linux/spl/spl-kstat.c
+++ b/module/os/linux/spl/spl-kstat.c
@@ -395,7 +395,7 @@ kstat_delete_module(kstat_module_t *module)
 
 	kstat_module_t *parent = module->ksm_parent;
 
-	char *p = module->ksm_name, *frag;
+	char *p = module->ksm_name, *frag = NULL;
 	while (p != NULL && (frag = strsep(&p, "/"))) {}
 
 	remove_proc_entry(frag, parent ? parent->ksm_proc : proc_spl_kstat);
@@ -420,7 +420,7 @@ kstat_create_module(char *name)
 
 	(void) strlcpy(buf, name, KSTAT_STRLEN);
 
-	parent = NULL;
+	module = parent = NULL;
 	char *p = buf, *frag;
 	while ((frag = strsep(&p, "/")) != NULL) {
 		module = kstat_find_module(buf);
@@ -454,7 +454,6 @@ kstat_create_module(char *name)
 	}
 
 	return (module);
-
 }
 
 static int


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

Building on a customer Ubuntu 18.04 / GCC 7.4 system, it threw some warnings (== errors):

```
  CC [M]  .../zfs/module/os/linux/spl/spl-kstat.o
.../zfs/module/os/linux/spl/spl-kstat.c: In function ‘kstat_delete_module’:
.../zfs/module/os/linux/spl/spl-kstat.c:401:2: error: ‘frag’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  remove_proc_entry(frag, parent ? parent->ksm_proc : proc_spl_kstat);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../zfs/module/os/linux/spl/spl-kstat.c: In function ‘kstat_create_module’:
.../zfs/module/os/linux/spl/spl-kstat.c:456:9: error: ‘module’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  return (module);
         ^
cc1: all warnings being treated as errors
```

While these are things that technically shouldn't happen because of how the code is structured, they're easy to silence with no real loss, so why not.

### Description

Initialise the uninitialised things.

### How Has This Been Tested?

Compile checked only, on my regular dev machine and the cranky customer machine. Seems happy.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
