### PR TITLE
simd_powerpc.h: enable FPU on FreeBSD

### DIFF
--- a/include/os/freebsd/spl/sys/simd_powerpc.h
+++ b/include/os/freebsd/spl/sys/simd_powerpc.h
@@ -49,11 +49,18 @@
 
 #include <machine/pcb.h>
 #include <machine/cpu.h>
+#include <machine/fpu.h>
 
-#define	kfpu_allowed()		0
+#define	kfpu_allowed()		1
 #define	kfpu_initialize(tsk)	do {} while (0)
-#define	kfpu_begin()		do {} while (0)
-#define	kfpu_end()		do {} while (0)
+#define	kfpu_begin() {					\
+	if (__predict_false(!is_fpu_kern_thread(0)))	\
+	fpu_kern_enter(PCPU_GET(curthread), NULL, FPU_KERN_NOCTX);\
+}
+#define	kfpu_end()	{				\
+	if (__predict_false(PCPU_GET(curpcb)->pcb_flags & PCB_KERN_FPU_NOSAVE))\
+	fpu_kern_leave(PCPU_GET(curthread), NULL);	\
+}
 #define	kfpu_init()		(0)
 #define	kfpu_fini()		do {} while (0)
 


### PR DESCRIPTION
FreeBSD nowadays supports FPU in the kernel on powerpc*, so enable it.

Including machine/pcpu.h needs to be done before including sys/types.h, hence this order.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It enables ZFS to use assembly routines with SIMD.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Booting with ZFS on root on POWER9 workstation.
<!--- Include details of your testing environment, and the tests you ran to -->
FreeBSD 14.2-RELEASE on POWER9, ZFS on /.
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
