### PR TITLE
Add `zpool status --lockless|--trylock`

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -7723,7 +7723,8 @@ import_checkpointed_state(char *target, nvlist_t *cfg, char **new_path)
 
 	if (cfg == NULL) {
 		zdb_set_skip_mmp(poolname);
-		error = spa_get_stats(poolname, &cfg, NULL, 0);
+		error = spa_get_stats(poolname, &cfg, NULL, 0,
+		    ZPOOL_LOCK_BEHAVIOR_DEFAULT);
 		if (error != 0) {
 			fatal("Tried to read config of pool \"%s\" but "
 			    "spa_get_stats() failed with error %d\n",

--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -118,6 +118,7 @@ pool_list_get(int argc, char **argv, zprop_list_t **proplist, zfs_type_t type,
     boolean_t literal, int *err)
 {
 	zpool_list_t *zlp;
+	int rc;
 
 	zlp = safe_malloc(sizeof (zpool_list_t));
 
@@ -137,7 +138,11 @@ pool_list_get(int argc, char **argv, zprop_list_t **proplist, zfs_type_t type,
 	zlp->zl_literal = literal;
 
 	if (argc == 0) {
-		(void) zpool_iter(g_zfs, add_pool, zlp);
+		rc = zpool_iter(g_zfs, add_pool, zlp);
+		if (rc != 0) {
+			free(zlp);
+			return (NULL);
+		}
 		zlp->zl_findall = B_TRUE;
 	} else {
 		int i;

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -264,6 +264,8 @@ _LIBZFS_H int zpool_create(libzfs_handle_t *, const char *, nvlist_t *,
     nvlist_t *, nvlist_t *);
 _LIBZFS_H int zpool_destroy(zpool_handle_t *, const char *);
 _LIBZFS_H int zpool_add(zpool_handle_t *, nvlist_t *, boolean_t check_ashift);
+_LIBZFS_H void libzfs_set_lock_behavior(libzfs_handle_t *,
+    zpool_lock_behavior_t);
 
 typedef struct splitflags {
 	/* do not split, but return the config that would be split off */

--- a/include/os/freebsd/spl/sys/mutex.h
+++ b/include/os/freebsd/spl/sys/mutex.h
@@ -72,4 +72,19 @@ typedef enum {
 #define	mutex_owned(lock)	sx_xlocked(lock)
 #define	mutex_owner(lock)	sx_xholder(lock)
 
+/*
+ * Poor-man's version of Linux kernel's down_timeout(). Try to acquire a mutex
+ * for 'ns' number of nanoseconds.  Returns 0 if mutex was acquired or ETIME
+ * if timeout occurred.
+ */
+static inline int mutex_enter_timeout(kmutex_t *mutex, uint64_t ns)
+{
+	hrtime_t end = gethrtime() + ns;
+	while (gethrtime() < end) {
+		if (mutex_tryenter(mutex))
+			return (0);	/* success */
+	}
+	return (ETIME);
+}
+
 #endif	/* _OPENSOLARIS_SYS_MUTEX_H_ */

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -866,6 +866,9 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_REBUILD_STATS	"org.openzfs:rebuild_stats"
 #define	ZPOOL_CONFIG_COMPATIBILITY	"compatibility"
 
+/* ZFS_IOC_POOL_STATS argument to for spa_namespace locking behavior */
+#define	ZPOOL_CONFIG_LOCK_BEHAVIOR	"lock_behavior"	/* not stored on disk */
+
 /*
  * The persistent vdev state is stored as separate values rather than a single
  * 'vdev_state' entry.  This is because a device can be in multiple states, such
@@ -1977,6 +1980,30 @@ enum zio_encrypt {
 	    ZFS_XA_NS_PREFIX_MATCH(LINUX_SYSTEM, name) || \
 	    ZFS_XA_NS_PREFIX_MATCH(LINUX_TRUSTED, name) || \
 	    ZFS_XA_NS_PREFIX_MATCH(LINUX_USER, name))
+
+/*
+ * Set locking behavior for zpool commands.
+ */
+typedef enum {
+	/* Wait to acquire the lock on the zpool config */
+	ZPOOL_LOCK_BEHAVIOR_WAIT = 0,
+	ZPOOL_LOCK_BEHAVIOR_DEFAULT = ZPOOL_LOCK_BEHAVIOR_WAIT,
+	/*
+	 * Return an error if it's taking an unnecessarily long time to
+	 * acquire the lock on the pool config (default 100ms)
+	 */
+	ZPOOL_LOCK_BEHAVIOR_TRYLOCK = 1,
+
+	/*
+	 * DANGER: THIS CAN CRASH YOUR SYSTEM
+	 *
+	 * If you can't acquire the pool config lock after 100ms then do a
+	 * a lockless lookup.  This should only be done in emergencies, as it
+	 * can crash the kernel module!
+	 */
+	ZPOOL_LOCK_BEHAVIOR_LOCKLESS = 2,
+	ZPOOL_LOCK_BEHAVIOR_END = 3	/* last entry marker */
+} zpool_lock_behavior_t;
 
 #ifdef	__cplusplus
 }

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -742,10 +742,13 @@ typedef enum trim_type {
 
 /* state manipulation functions */
 extern int spa_open(const char *pool, spa_t **, const void *tag);
+extern int spa_open_common_lock_behavior(const char *pool, spa_t **spapp,
+    const void *tag, nvlist_t *nvpolicy, nvlist_t **config,
+    zpool_lock_behavior_t zpool_lock_behavior);
 extern int spa_open_rewind(const char *pool, spa_t **, const void *tag,
     nvlist_t *policy, nvlist_t **config);
 extern int spa_get_stats(const char *pool, nvlist_t **config, char *altroot,
-    size_t buflen);
+    size_t buflen, zpool_lock_behavior_t zpool_lock_behavior);
 extern int spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
     nvlist_t *zplprops, struct dsl_crypto_params *dcp);
 extern int spa_import(char *pool, nvlist_t *config, nvlist_t *props,
@@ -850,10 +853,13 @@ extern kcondvar_t spa_namespace_cv;
 
 extern void spa_write_cachefile(spa_t *, boolean_t, boolean_t, boolean_t);
 extern void spa_config_load(void);
-extern int spa_all_configs(uint64_t *generation, nvlist_t **pools);
+extern int spa_all_configs(uint64_t *generation, nvlist_t **pools,
+    zpool_lock_behavior_t zpool_lock_behavior);
 extern void spa_config_set(spa_t *spa, nvlist_t *config);
 extern nvlist_t *spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg,
     int getstats);
+extern nvlist_t *spa_config_generate_lock_behavior(spa_t *spa, vdev_t *vd,
+    uint64_t txg, int getstats, zpool_lock_behavior_t zpool_lock_behavior);
 extern void spa_config_update(spa_t *spa, int what);
 extern int spa_config_parse(spa_t *spa, vdev_t **vdp, nvlist_t *nv,
     vdev_t *parent, uint_t id, int atype);
@@ -865,9 +871,11 @@ extern int spa_config_parse(spa_t *spa, vdev_t **vdp, nvlist_t *nv,
 
 /* Namespace manipulation */
 extern spa_t *spa_lookup(const char *name);
+extern spa_t *spa_lookup_lockless(const char *name);
 extern spa_t *spa_add(const char *name, nvlist_t *config, const char *altroot);
 extern void spa_remove(spa_t *spa);
 extern spa_t *spa_next(spa_t *prev);
+extern spa_t *spa_next_lockless(spa_t *prev);
 
 /* Refcount functions */
 extern void spa_open_ref(spa_t *spa, const void *tag);

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -491,6 +491,8 @@ extern void spa_set_deadman_synctime(hrtime_t ns);
 extern void spa_set_deadman_ziotime(hrtime_t ns);
 extern const char *spa_history_zone(void);
 extern const char *zfs_active_allocator;
+extern int zfs_allow_lockless_zpool_status;
+extern unsigned int spa_namespace_trylock_ms;
 extern int param_set_active_allocator_common(const char *val);
 
 #ifdef	__cplusplus

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -277,6 +277,7 @@ extern void mutex_enter(kmutex_t *mp);
 extern int mutex_enter_check_return(kmutex_t *mp);
 extern void mutex_exit(kmutex_t *mp);
 extern int mutex_tryenter(kmutex_t *mp);
+extern int mutex_enter_timeout(kmutex_t *mp, uint64_t ns);
 
 #define	NESTED_SINGLE 1
 #define	mutex_enter_nested(mp, class) mutex_enter(mp)

--- a/lib/libnvpair/libnvpair.abi
+++ b/lib/libnvpair/libnvpair.abi
@@ -2194,6 +2194,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='stack_t' type-id='380f9954' id='ac5e685f'/>
+    <typedef-decl name='unw_regnum_t' type-id='95e97e5e' id='c53620f0'/>
     <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='384a1f22'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='opaque' type-id='dc70ec0b' visibility='default'/>
@@ -2305,6 +2306,10 @@
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='b59d7dce'/>
       <return type-id='79a0948f'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='c53620f0'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='_ULx86_64_init_local' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='3946e4d1'/>

--- a/lib/libuutil/libuutil.abi
+++ b/lib/libuutil/libuutil.abi
@@ -652,6 +652,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='stack_t' type-id='380f9954' id='ac5e685f'/>
+    <typedef-decl name='unw_regnum_t' type-id='95e97e5e' id='c53620f0'/>
     <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='384a1f22'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='opaque' type-id='dc70ec0b' visibility='default'/>
@@ -762,6 +763,10 @@
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='b59d7dce'/>
       <return type-id='79a0948f'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='c53620f0'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='_ULx86_64_init_local' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='3946e4d1'/>
@@ -1011,15 +1016,8 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libspl/os/linux/getmntany.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='38b51b3c' size-in-bits='832' id='02b72c00'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
-    </array-type-def>
     <array-type-def dimensions='1' type-id='03085adc' size-in-bits='192' id='083f8d58'>
       <subrange length='3' type-id='7359adad' id='56f209d2'/>
-    </array-type-def>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
-    <array-type-def dimensions='1' type-id='80f4b756' size-in-bits='832' id='39e6f84a'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
     </array-type-def>
     <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
       <data-member access='public' layout-offset-in-bits='0'>
@@ -1130,25 +1128,6 @@
     <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
     <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
     <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
-    <class-decl name='__locale_struct' size-in-bits='1856' is-struct='yes' visibility='default' id='90cc1ce3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__locales' type-id='02b72c00' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='__ctype_b' type-id='31347b7a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='__ctype_tolower' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__ctype_toupper' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='__names' type-id='39e6f84a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__locale_t' type-id='f01e1813' id='b7ac9b5f'/>
-    <typedef-decl name='locale_t' type-id='b7ac9b5f' id='973a4f8d'/>
     <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
@@ -1157,23 +1136,12 @@
         <var-decl name='tv_nsec' type-id='03085adc' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='23de8b96' size-in-bits='64' id='38b51b3c'/>
-    <pointer-type-def type-id='90cc1ce3' size-in-bits='64' id='f01e1813'/>
-    <qualified-type-def type-id='95e97e5e' const='yes' id='2448a865'/>
-    <pointer-type-def type-id='2448a865' size-in-bits='64' id='6d60f45d'/>
-    <qualified-type-def type-id='8efea9e5' const='yes' id='3beb2af4'/>
-    <pointer-type-def type-id='3beb2af4' size-in-bits='64' id='31347b7a'/>
     <pointer-type-def type-id='0c544dc0' size-in-bits='64' id='394fc496'/>
     <pointer-type-def type-id='56fe4a37' size-in-bits='64' id='b6b61d2f'/>
     <qualified-type-def type-id='b6b61d2f' restrict='yes' id='3cad23cd'/>
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
     <qualified-type-def type-id='62f7a03d' restrict='yes' id='f1cadedf'/>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
-    <function-decl name='uselocale' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='973a4f8d'/>
-      <return type-id='973a4f8d'/>
-    </function-decl>
     <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>
       <parameter type-id='3cad23cd'/>
@@ -1185,9 +1153,8 @@
       <parameter type-id='822cd80b'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='strerror_l' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='strerror' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
-      <parameter type-id='973a4f8d'/>
       <return type-id='26a90f95'/>
     </function-decl>
     <function-decl name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -218,6 +218,7 @@
     <elf-symbol name='libzfs_run_process' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='libzfs_run_process_get_stdout' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='libzfs_run_process_get_stdout_nopath' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='libzfs_set_lock_behavior' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='list_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='list_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='list_head' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -631,7 +632,7 @@
     <elf-symbol name='sa_protocol_names' size='16' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='spa_feature_table' size='2464' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfeature_checks_disable' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='zfs_deleg_perm_tab' size='512' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_deleg_perm_tab' size='528' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_history_event_names' size='328' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_max_dataset_nesting' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_userquota_prop_prefixes' size='96' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1170,6 +1171,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='stack_t' type-id='380f9954' id='ac5e685f'/>
+    <typedef-decl name='unw_regnum_t' type-id='95e97e5e' id='c53620f0'/>
     <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='384a1f22'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='opaque' type-id='dc70ec0b' visibility='default'/>
@@ -1275,6 +1277,10 @@
     <pointer-type-def type-id='1203d35c' size-in-bits='64' id='3946e4d1'/>
     <pointer-type-def type-id='190d09ef' size-in-bits='64' id='3e0601f0'/>
     <pointer-type-def type-id='73d941c6' size-in-bits='64' id='42f5faab'/>
+    <function-decl name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='c53620f0'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
     <function-decl name='_ULx86_64_init_local' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='3946e4d1'/>
       <parameter type-id='2e408b96'/>
@@ -2062,6 +2068,15 @@
       <enumerator name='ZPROP_SRC_RECEIVED' value='32'/>
     </enum-decl>
     <typedef-decl name='zprop_source_t' type-id='5903f80e' id='a2256d42'/>
+    <enum-decl name='zpool_lock_behavior_t' naming-typedef-id='8b691302' id='cdf5aa2e'>
+      <underlying-type type-id='9cac1fee'/>
+      <enumerator name='ZPOOL_LOCK_BEHAVIOR_WAIT' value='0'/>
+      <enumerator name='ZPOOL_LOCK_BEHAVIOR_DEFAULT' value='0'/>
+      <enumerator name='ZPOOL_LOCK_BEHAVIOR_TRYLOCK' value='1'/>
+      <enumerator name='ZPOOL_LOCK_BEHAVIOR_LOCKLESS' value='2'/>
+      <enumerator name='ZPOOL_LOCK_BEHAVIOR_END' value='3'/>
+    </enum-decl>
+    <typedef-decl name='zpool_lock_behavior_t' type-id='cdf5aa2e' id='8b691302'/>
     <class-decl name='nvlist' size-in-bits='192' is-struct='yes' visibility='default' id='ac266fd9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='nvl_version' type-id='3ff5601b' visibility='default'/>
@@ -2201,7 +2216,7 @@
     <typedef-decl name='__uint32_t' type-id='f0981eeb' id='62f1140c'/>
     <typedef-decl name='__uint64_t' type-id='7359adad' id='8910171f'/>
     <typedef-decl name='size_t' type-id='7359adad' id='b59d7dce'/>
-    <class-decl name='libzfs_handle' size-in-bits='18240' is-struct='yes' visibility='default' id='c8a9d9d8'>
+    <class-decl name='libzfs_handle' size-in-bits='18304' is-struct='yes' visibility='default' id='c8a9d9d8'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='libzfs_error' type-id='95e97e5e' visibility='default'/>
       </data-member>
@@ -2258,6 +2273,9 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='18176'>
         <var-decl name='libfetch_load_error' type-id='26a90f95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='18240'>
+        <var-decl name='zpool_lock_behavior' type-id='8b691302' visibility='default'/>
       </data-member>
     </class-decl>
     <class-decl name='zfs_handle' size-in-bits='4928' is-struct='yes' visibility='default' id='f6ee4445'>
@@ -2472,6 +2490,13 @@
       <parameter type-id='9200a744'/>
       <parameter type-id='95e97e5e'/>
       <parameter type-id='c19b74c3'/>
+      <parameter type-id='d8e49ab9'/>
+      <parameter type-id='eaa32e2f'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_iter_filesystems_v2' mangled-name='zfs_iter_filesystems_v2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems_v2'>
+      <parameter type-id='9200a744'/>
+      <parameter type-id='95e97e5e'/>
       <parameter type-id='d8e49ab9'/>
       <parameter type-id='eaa32e2f'/>
       <return type-id='95e97e5e'/>
@@ -2692,7 +2717,7 @@
         <var-decl name='drr_toname' type-id='d1617432' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='3216f820'>
+    <class-decl name='zinject_record' size-in-bits='2944' is-struct='yes' visibility='default' id='3216f820'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zi_objset' type-id='9c313c2d' visibility='default'/>
       </data-member>
@@ -2744,6 +2769,12 @@
       <data-member access='public' layout-offset-in-bits='2784'>
         <var-decl name='zi_dvas' type-id='8f92235e' visibility='default'/>
       </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='zi_match_count' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2880'>
+        <var-decl name='zi_inject_count' type-id='9c313c2d' visibility='default'/>
+      </data-member>
     </class-decl>
     <typedef-decl name='zinject_record_t' type-id='3216f820' id='a4301ca6'/>
     <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='feb6f2da'>
@@ -2761,7 +2792,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='zfs_share_t' type-id='feb6f2da' id='ee5cec36'/>
-    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='3522cd69'>
+    <class-decl name='zfs_cmd' size-in-bits='110080' is-struct='yes' visibility='default' id='3522cd69'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zc_name' type-id='d16c6df4' visibility='default'/>
       </data-member>
@@ -2834,37 +2865,37 @@
       <data-member access='public' layout-offset-in-bits='106368'>
         <var-decl name='zc_inject_record' type-id='a4301ca6' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109184'>
+      <data-member access='public' layout-offset-in-bits='109312'>
         <var-decl name='zc_defer_destroy' type-id='8f92235e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109216'>
+      <data-member access='public' layout-offset-in-bits='109344'>
         <var-decl name='zc_flags' type-id='8f92235e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109248'>
+      <data-member access='public' layout-offset-in-bits='109376'>
         <var-decl name='zc_action_handle' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109312'>
+      <data-member access='public' layout-offset-in-bits='109440'>
         <var-decl name='zc_cleanup_fd' type-id='95e97e5e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109344'>
+      <data-member access='public' layout-offset-in-bits='109472'>
         <var-decl name='zc_simple' type-id='b96825af' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109352'>
+      <data-member access='public' layout-offset-in-bits='109480'>
         <var-decl name='zc_pad' type-id='d3490169' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109376'>
+      <data-member access='public' layout-offset-in-bits='109504'>
         <var-decl name='zc_sendobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109440'>
+      <data-member access='public' layout-offset-in-bits='109568'>
         <var-decl name='zc_fromobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109504'>
+      <data-member access='public' layout-offset-in-bits='109632'>
         <var-decl name='zc_createtxg' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109568'>
+      <data-member access='public' layout-offset-in-bits='109696'>
         <var-decl name='zc_stat' type-id='0371a9c7' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109888'>
+      <data-member access='public' layout-offset-in-bits='110016'>
         <var-decl name='zc_zoneid' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
@@ -2925,6 +2956,12 @@
       <parameter type-id='b65f7fd1'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='857bb57e'/>
+      <parameter type-id='3502e3ff'/>
+      <parameter type-id='95e97e5e'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='nvlist_free' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='5ce45b60'/>
       <return type-id='48b5725f'/>
@@ -2933,6 +2970,12 @@
       <parameter type-id='22cce67b'/>
       <parameter type-id='857bb57e'/>
       <parameter type-id='95e97e5e'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='5ce45b60'/>
+      <parameter type-id='80f4b756'/>
+      <parameter type-id='9c313c2d'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_lookup_nvlist' visibility='default' binding='global' size-in-bits='64'>
@@ -3030,6 +3073,12 @@
       <parameter type-id='b59d7dce'/>
       <return type-id='48b5725f'/>
     </function-decl>
+    <function-decl name='zcmd_write_src_nvlist' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='b0382bb3'/>
+      <parameter type-id='e4ec4540'/>
+      <parameter type-id='5ce45b60'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
     <function-decl name='zcmd_expand_dst_nvlist' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='b0382bb3'/>
       <parameter type-id='e4ec4540'/>
@@ -3063,9 +3112,6 @@
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libzfs/libzfs_crypto.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='38b51b3c' size-in-bits='832' id='02b72c00'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
-    </array-type-def>
     <array-type-def dimensions='1' type-id='fb7c6451' size-in-bits='256' id='64177143'>
       <subrange length='32' type-id='7359adad' id='ae5bde82'/>
     </array-type-def>
@@ -3078,10 +3124,6 @@
     <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
     <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
     <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
-    <array-type-def dimensions='1' type-id='80f4b756' size-in-bits='832' id='39e6f84a'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
-    </array-type-def>
     <array-type-def dimensions='1' type-id='95e97e5e' size-in-bits='896' id='47394ee0'>
       <subrange length='28' type-id='7359adad' id='3db583d7'/>
     </array-type-def>
@@ -3206,24 +3248,6 @@
     <typedef-decl name='__clock_t' type-id='bd54fe1a' id='4d66c6d7'/>
     <typedef-decl name='__ssize_t' type-id='bd54fe1a' id='41060289'/>
     <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
-    <class-decl name='__locale_struct' size-in-bits='1856' is-struct='yes' visibility='default' id='90cc1ce3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__locales' type-id='02b72c00' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='__ctype_b' type-id='31347b7a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='__ctype_tolower' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__ctype_toupper' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='__names' type-id='39e6f84a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__locale_t' type-id='f01e1813' id='b7ac9b5f'/>
     <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='b9c97942' visibility='default' id='2616147f'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__val' type-id='d2baa450' visibility='default'/>
@@ -3239,7 +3263,6 @@
       </data-member>
     </union-decl>
     <typedef-decl name='__sigval_t' type-id='a094b870' id='eabacd01'/>
-    <typedef-decl name='locale_t' type-id='b7ac9b5f' id='973a4f8d'/>
     <class-decl name='siginfo_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='cb681f62' visibility='default' id='d8149419'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_signo' type-id='95e97e5e' visibility='default'/>
@@ -3475,13 +3498,9 @@
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
     <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
-    <pointer-type-def type-id='23de8b96' size-in-bits='64' id='38b51b3c'/>
-    <pointer-type-def type-id='90cc1ce3' size-in-bits='64' id='f01e1813'/>
     <qualified-type-def type-id='9b23c9ad' restrict='yes' id='8c85230f'/>
     <qualified-type-def type-id='80f4b756' restrict='yes' id='9d26089a'/>
     <pointer-type-def type-id='80f4b756' size-in-bits='64' id='7d3cd834'/>
-    <qualified-type-def type-id='95e97e5e' const='yes' id='2448a865'/>
-    <pointer-type-def type-id='2448a865' size-in-bits='64' id='6d60f45d'/>
     <qualified-type-def type-id='aca3bac8' const='yes' id='2498fd78'/>
     <pointer-type-def type-id='2498fd78' size-in-bits='64' id='eed6c816'/>
     <qualified-type-def type-id='eed6c816' restrict='yes' id='a431a9da'/>
@@ -3495,6 +3514,7 @@
     <qualified-type-def type-id='8efea9e5' const='yes' id='3beb2af4'/>
     <pointer-type-def type-id='3beb2af4' size-in-bits='64' id='31347b7a'/>
     <pointer-type-def type-id='31347b7a' size-in-bits='64' id='c59e1ef0'/>
+    <pointer-type-def type-id='7a6844eb' size-in-bits='64' id='18c91f9e'/>
     <pointer-type-def type-id='1b941664' size-in-bits='64' id='7e2979d5'/>
     <qualified-type-def type-id='7e2979d5' restrict='yes' id='fc212857'/>
     <pointer-type-def type-id='fe391c48' size-in-bits='64' id='568dd84e'/>
@@ -3514,7 +3534,6 @@
     <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
     <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
     <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
     <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
       <parameter type-id='4c81de99'/>
       <parameter type-id='5d0c23fb'/>
@@ -3539,13 +3558,6 @@
     <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_to_name'>
       <parameter type-id='58603c44'/>
       <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zfs_iter_filesystems_v2' mangled-name='zfs_iter_filesystems_v2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems_v2'>
-      <parameter type-id='9200a744'/>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='d8e49ab9'/>
-      <parameter type-id='eaa32e2f'/>
-      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
       <parameter type-id='9200a744'/>
@@ -3575,12 +3587,6 @@
     <function-decl name='zfs_name_to_prop' mangled-name='zfs_name_to_prop' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_name_to_prop'>
       <parameter type-id='80f4b756'/>
       <return type-id='58603c44'/>
-    </function-decl>
-    <function-decl name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='5ce45b60'/>
-      <parameter type-id='80f4b756'/>
-      <parameter type-id='9c313c2d'/>
-      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='nvlist_add_string' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='5ce45b60'/>
@@ -3619,10 +3625,6 @@
     <function-decl name='dlerror' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='26a90f95'/>
     </function-decl>
-    <function-decl name='uselocale' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='973a4f8d'/>
-      <return type-id='973a4f8d'/>
-    </function-decl>
     <function-decl name='PKCS5_PBKDF2_HMAC_SHA1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='80f4b756'/>
       <parameter type-id='95e97e5e'/>
@@ -3631,6 +3633,14 @@
       <parameter type-id='95e97e5e'/>
       <parameter type-id='95e97e5e'/>
       <parameter type-id='cf536864'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_lock' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='18c91f9e'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_unlock' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='18c91f9e'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='regexec' visibility='default' binding='global' size-in-bits='64'>
@@ -3706,9 +3716,8 @@
       <parameter type-id='80f4b756'/>
       <return type-id='26a90f95'/>
     </function-decl>
-    <function-decl name='strerror_l' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='strerror' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
-      <parameter type-id='973a4f8d'/>
       <return type-id='26a90f95'/>
     </function-decl>
     <function-decl name='tcgetattr' visibility='default' binding='global' size-in-bits='64'>
@@ -4078,7 +4087,6 @@
     <pointer-type-def type-id='a195f4a3' size-in-bits='64' id='e80ff3ab'/>
     <qualified-type-def type-id='e80ff3ab' restrict='yes' id='8f2c7109'/>
     <pointer-type-def type-id='eae6431d' size-in-bits='64' id='0d41d328'/>
-    <pointer-type-def type-id='7a6844eb' size-in-bits='64' id='18c91f9e'/>
     <pointer-type-def type-id='dddf6ca2' size-in-bits='64' id='d915a820'/>
     <qualified-type-def type-id='d915a820' restrict='yes' id='f099ad08'/>
     <pointer-type-def type-id='5d6479ae' size-in-bits='64' id='892b4acc'/>
@@ -4335,12 +4343,6 @@
       <parameter type-id='c19b74c3'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='nvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='857bb57e'/>
-      <parameter type-id='3502e3ff'/>
-      <parameter type-id='95e97e5e'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
     <function-decl name='nvlist_size' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='5ce45b60'/>
       <parameter type-id='78c01427'/>
@@ -4528,14 +4530,6 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='pthread_mutex_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='18c91f9e'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_lock' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='18c91f9e'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_unlock' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='18c91f9e'/>
       <return type-id='95e97e5e'/>
     </function-decl>
@@ -4966,12 +4960,6 @@
       <parameter type-id='e4378506'/>
       <parameter type-id='2e45de5d'/>
       <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='zcmd_write_src_nvlist' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='b0382bb3'/>
-      <parameter type-id='e4ec4540'/>
-      <parameter type-id='5ce45b60'/>
-      <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='changelist_prefix' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='0d41d328'/>
@@ -8368,6 +8356,11 @@
       <parameter type-id='95e97e5e'/>
       <return type-id='48b5725f'/>
     </function-decl>
+    <function-decl name='setpgid' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='3629bad8'/>
+      <parameter type-id='3629bad8'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='fork' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='3629bad8'/>
     </function-decl>
@@ -8562,6 +8555,11 @@
       <parameter type-id='c0563f85' name='lines'/>
       <parameter type-id='7292109c' name='lines_cnt'/>
       <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='libzfs_set_lock_behavior' mangled-name='libzfs_set_lock_behavior' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_set_lock_behavior'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='8b691302' name='zpool_lock_behavior'/>
+      <return type-id='48b5725f'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libzfs/os/linux/libzfs_mount_os.c' language='LANG_C99'>
@@ -9532,8 +9530,8 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='module/zcommon/zfs_deleg.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='fa1870fd' size-in-bits='4096' id='59e94aca'>
-      <subrange length='32' type-id='7359adad' id='ae5bde82'/>
+    <array-type-def dimensions='1' type-id='fa1870fd' size-in-bits='4224' id='55e705e7'>
+      <subrange length='33' type-id='7359adad' id='6a5934df'/>
     </array-type-def>
     <array-type-def dimensions='1' type-id='fa1870fd' size-in-bits='infinite' id='7c00e69d'>
       <subrange length='infinite' id='031f2035'/>

--- a/lib/libzfs/libzfs_impl.h
+++ b/lib/libzfs/libzfs_impl.h
@@ -73,6 +73,8 @@ struct libzfs_handle {
 	uint64_t libzfs_max_nvlist;
 	void *libfetch;
 	char *libfetch_load_error;
+
+	zpool_lock_behavior_t zpool_lock_behavior;
 };
 
 struct zfs_handle {

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -80,14 +80,14 @@ zpool_get_all_props(zpool_handle_t *zhp)
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 
+	nvlist_t *innvl = fnvlist_alloc();
 	if (zhp->zpool_n_propnames > 0) {
-		nvlist_t *innvl = fnvlist_alloc();
 		fnvlist_add_string_array(innvl, ZPOOL_GET_PROPS_NAMES,
 		    zhp->zpool_propnames, zhp->zpool_n_propnames);
-		zcmd_write_src_nvlist(hdl, &zc, innvl);
 	}
-
-	zcmd_alloc_dst_nvlist(hdl, &zc, 0);
+	VERIFY0(nvlist_add_uint64(innvl, ZPOOL_CONFIG_LOCK_BEHAVIOR,
+	    hdl->zpool_lock_behavior));
+	zcmd_write_src_nvlist(hdl, &zc, innvl);
 
 	while (zfs_ioctl(hdl, ZFS_IOC_POOL_GET_PROPS, &zc) != 0) {
 		if (errno == ENOMEM)

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -2449,3 +2449,15 @@ zpool_prepare_and_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp,
 	rc = zpool_label_disk(hdl, zhp, name);
 	return (rc);
 }
+
+/*
+ * Set spa_namespace locking behavior for zpools.  For example you may want to
+ * error out if you can't acquire the lock, or skip the lock entirely (which
+ * can be dangerous).
+ */
+void
+libzfs_set_lock_behavior(libzfs_handle_t *hdl,
+	zpool_lock_behavior_t zpool_lock_behavior)
+{
+	hdl->zpool_lock_behavior = zpool_lock_behavior;
+}

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -651,6 +651,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='stack_t' type-id='380f9954' id='ac5e685f'/>
+    <typedef-decl name='unw_regnum_t' type-id='95e97e5e' id='c53620f0'/>
     <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='384a1f22'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='opaque' type-id='dc70ec0b' visibility='default'/>
@@ -761,6 +762,10 @@
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='b59d7dce'/>
       <return type-id='79a0948f'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='c53620f0'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='_ULx86_64_init_local' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='3946e4d1'/>
@@ -982,13 +987,6 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libspl/os/linux/getmntany.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='38b51b3c' size-in-bits='832' id='02b72c00'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
-    </array-type-def>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
-    <array-type-def dimensions='1' type-id='80f4b756' size-in-bits='832' id='39e6f84a'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
-    </array-type-def>
     <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -1092,42 +1090,12 @@
     </class-decl>
     <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
     <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
-    <class-decl name='__locale_struct' size-in-bits='1856' is-struct='yes' visibility='default' id='90cc1ce3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__locales' type-id='02b72c00' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='__ctype_b' type-id='31347b7a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='__ctype_tolower' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__ctype_toupper' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='__names' type-id='39e6f84a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__locale_t' type-id='f01e1813' id='b7ac9b5f'/>
-    <typedef-decl name='locale_t' type-id='b7ac9b5f' id='973a4f8d'/>
-    <pointer-type-def type-id='23de8b96' size-in-bits='64' id='38b51b3c'/>
-    <pointer-type-def type-id='90cc1ce3' size-in-bits='64' id='f01e1813'/>
-    <qualified-type-def type-id='95e97e5e' const='yes' id='2448a865'/>
-    <pointer-type-def type-id='2448a865' size-in-bits='64' id='6d60f45d'/>
-    <qualified-type-def type-id='8efea9e5' const='yes' id='3beb2af4'/>
-    <pointer-type-def type-id='3beb2af4' size-in-bits='64' id='31347b7a'/>
     <pointer-type-def type-id='0c544dc0' size-in-bits='64' id='394fc496'/>
     <pointer-type-def type-id='56fe4a37' size-in-bits='64' id='b6b61d2f'/>
     <qualified-type-def type-id='b6b61d2f' restrict='yes' id='3cad23cd'/>
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
     <qualified-type-def type-id='62f7a03d' restrict='yes' id='f1cadedf'/>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
-    <function-decl name='uselocale' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='973a4f8d'/>
-      <return type-id='973a4f8d'/>
-    </function-decl>
     <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>
       <parameter type-id='3cad23cd'/>
@@ -1144,9 +1112,8 @@
       <parameter type-id='80f4b756'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='strerror_l' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='strerror' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
-      <parameter type-id='973a4f8d'/>
       <return type-id='26a90f95'/>
     </function-decl>
     <function-decl name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>
@@ -2111,7 +2078,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='dmu_replay_record_t' type-id='781a52d7' id='8b8fc893'/>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='3216f820'>
+    <class-decl name='zinject_record' size-in-bits='2944' is-struct='yes' visibility='default' id='3216f820'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zi_objset' type-id='9c313c2d' visibility='default'/>
       </data-member>
@@ -2163,6 +2130,12 @@
       <data-member access='public' layout-offset-in-bits='2784'>
         <var-decl name='zi_dvas' type-id='8f92235e' visibility='default'/>
       </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='zi_match_count' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2880'>
+        <var-decl name='zi_inject_count' type-id='9c313c2d' visibility='default'/>
+      </data-member>
     </class-decl>
     <typedef-decl name='zinject_record_t' type-id='3216f820' id='a4301ca6'/>
     <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='feb6f2da'>
@@ -2180,7 +2153,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='zfs_share_t' type-id='feb6f2da' id='ee5cec36'/>
-    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='3522cd69'>
+    <class-decl name='zfs_cmd' size-in-bits='110080' is-struct='yes' visibility='default' id='3522cd69'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zc_name' type-id='d16c6df4' visibility='default'/>
       </data-member>
@@ -2253,37 +2226,37 @@
       <data-member access='public' layout-offset-in-bits='106368'>
         <var-decl name='zc_inject_record' type-id='a4301ca6' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109184'>
+      <data-member access='public' layout-offset-in-bits='109312'>
         <var-decl name='zc_defer_destroy' type-id='8f92235e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109216'>
+      <data-member access='public' layout-offset-in-bits='109344'>
         <var-decl name='zc_flags' type-id='8f92235e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109248'>
+      <data-member access='public' layout-offset-in-bits='109376'>
         <var-decl name='zc_action_handle' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109312'>
+      <data-member access='public' layout-offset-in-bits='109440'>
         <var-decl name='zc_cleanup_fd' type-id='95e97e5e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109344'>
+      <data-member access='public' layout-offset-in-bits='109472'>
         <var-decl name='zc_simple' type-id='b96825af' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109352'>
+      <data-member access='public' layout-offset-in-bits='109480'>
         <var-decl name='zc_pad' type-id='d3490169' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109376'>
+      <data-member access='public' layout-offset-in-bits='109504'>
         <var-decl name='zc_sendobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109440'>
+      <data-member access='public' layout-offset-in-bits='109568'>
         <var-decl name='zc_fromobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109504'>
+      <data-member access='public' layout-offset-in-bits='109632'>
         <var-decl name='zc_createtxg' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109568'>
+      <data-member access='public' layout-offset-in-bits='109696'>
         <var-decl name='zc_stat' type-id='0371a9c7' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109888'>
+      <data-member access='public' layout-offset-in-bits='110016'>
         <var-decl name='zc_zoneid' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>

--- a/lib/libzfsbootenv/libzfsbootenv.abi
+++ b/lib/libzfsbootenv/libzfsbootenv.abi
@@ -1,6 +1,6 @@
 <abi-corpus version='2.0' architecture='elf-amd-x86_64' soname='libzfsbootenv.so.1'>
   <elf-needed>
-    <dependency name='libzfs.so.4'/>
+    <dependency name='libzfs.so.6'/>
     <dependency name='libnvpair.so.3'/>
     <dependency name='libc.so.6'/>
   </elf-needed>

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -239,6 +239,22 @@ mutex_exit(kmutex_t *mp)
 }
 
 /*
+ * Poor-man's version of Linux kernel's down_timeout(). Try to acquire a mutex
+ * for 'ns' number of nanoseconds.  Returns 0 if mutex was acquired or ENOLCK
+ * if timeout occurred.
+ */
+int
+mutex_enter_timeout(kmutex_t *mutex, uint64_t ns)
+{
+	hrtime_t end = gethrtime() + ns;
+	while (gethrtime() < end) {
+		if (mutex_tryenter(mutex))
+			return (0);	/* success */
+	}
+	return (ENOLCK);
+}
+
+/*
  * =========================================================================
  * rwlocks
  * =========================================================================

--- a/lib/libzpool/util.c
+++ b/lib/libzpool/util.c
@@ -137,7 +137,8 @@ show_pool_stats(spa_t *spa)
 	nvlist_t *config, *nvroot;
 	const char *name;
 
-	VERIFY(spa_get_stats(spa_name(spa), &config, NULL, 0) == 0);
+	VERIFY(spa_get_stats(spa_name(spa), &config, NULL, 0,
+	    ZPOOL_LOCK_BEHAVIOR_DEFAULT) == 0);
 
 	VERIFY(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
 	    &nvroot) == 0);

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2673,8 +2673,47 @@ Defines zvol block devices behavior when
 .It Sy zvol_enforce_quotas Ns = Ns Sy 0 Ns | Ns 1 Pq uint
 Enable strict ZVOL quota enforcement.
 The strict quota enforcement may have a performance impact.
+.It Sy zfs_debug_namespace_lock_delay
+WARNING, DEBUG USE ONLY!
+If set, add an artificial
+.Sy zfs_debug_namespace_lock_delay
+milliseconds delay after taking the spa_namespace lock.
+This is used to simulate a hung pool.
+If
+.Sy zfs_debug_namespace_lock_delay
+is set to -1 then crash the kernel on the next spa_namespace lock hold.
+If set to 0 (default) then take no action.
+This option is used by test suite.
+.It Sy zfs_allow_lockless_zpool_status
+WARNING, DEBUG USE ONLY!
+Allow the use of
+.Sy zpool status --lockless
+by the user.
+.Sy zpool status --lockless
+is useful in emergency situations when you really want to see the status
+of a pool that's locked up.
+WARNING: This can crash your system if the pool configuration is being updated
+while
+.Sy zpool status --lockless
+is being run.
+Set to 1 to enable, or 0 to disable (default).
+.It Sy spa_namespace_trylock_ms
+If the user does a
+.Sy zpool status --trylock|--lockless
+then try for this many milliseconds to get the the spa_namespace lock before
+giving up.
+This is the internal lock that synchronizes changes to the pool configuration.
+Note that
+.Sy zpool status
+will try to get the lock in multiple places (like getting the pool config,
+stats, props) before returning.
+That means the total wall clock time for
+.Sy zpool status --trylock|--lockless
+could a multiple of
+.Sy spa_namespace_trylock_ms
+if the lock is already held.
+Default is 100 (milliseconds).
 .El
-.
 .Sh ZFS I/O SCHEDULER
 ZFS issues I/O operations to leaf vdevs to satisfy and complete I/O operations.
 The scheduler determines when and in what order those operations are issued.

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -38,11 +38,13 @@
 .Nm zpool
 .Cm status
 .Op Fl dDegiLpPstvx
+.Op Fl --lockless|--trylock
+.Op Fl --power
+.Op Fl j Op Ar --json-int, --json-flat-vdevs, --json-pool-key-guid
 .Op Fl T Sy u Ns | Ns Sy d
 .Op Fl c Op Ar SCRIPT1 Ns Oo , Ns Ar SCRIPT2 Oc Ns …
 .Oo Ar pool Oc Ns …
 .Op Ar interval Op Ar count
-.Op Fl j Op Ar --json-int, --json-flat-vdevs, --json-pool-key-guid
 .
 .Sh DESCRIPTION
 Displays the detailed health status for the given pools.
@@ -61,6 +63,38 @@ the other workloads on the system can change.
 .Bl -tag -width Ds
 .It Fl -power
 Display vdev enclosure slot power status (on or off).
+.It Fl -lockless
+If
+.Sy zpool status
+is unable to acquire the pool config lock (a.k.a the
+spa_namespace lock) in a reasonable amount of time, then proceed without the
+lock.
+This is useful in emergency situations when you really want to see the status
+of a pool that's locked up.
+WARNING: This can crash your system if the pool configuration is being updated
+while
+.Sy zpool status --lockless
+is being run.
+As an additional safety measure,
+.Sy --lockless
+requires the
+.Sy zfs_debug_allow_lockless_zpool
+module param be set to 1 in order to work.
+This prevents unprivileged users who have delegated access to
+.Sy zpool status
+from potentially crashing the system.
+.It Fl -trylock
+When
+.Sy zpool status
+runs, it will try to acquire the pool config lock within the
+kernel module (the spa_namespace lock).
+However, there can be times when a pool gets locked up while holding this lock,
+leading to subsequent zpool status invocations getting hung.
+The
+.Sy --trylock
+option gets around this by attempting to take the pool config lock
+for a reasonable amount of time, and then aborting if it's unable to take the
+lock.
 .It Fl c Op Ar SCRIPT1 Ns Oo , Ns Ar SCRIPT2 Oc Ns …
 Run a script (or scripts) on each vdev and include the output as a new column
 in the

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -69,6 +69,16 @@ static uint64_t spa_config_generation = 1;
  * userland pools when doing testing.
  */
 char *spa_config_path = (char *)ZPOOL_CACHE;
+
+/*
+ * WARNING, THIS CAN CRASH THE KERNEL!
+ * If enabled, allow 'zpool status --lockless'.  This is an extra safety
+ * measure the user must engage, since 'zpool status --lockless' can potentially
+ * crash the pool if run while the pool configuration is changing.  Set to 0 to
+ * disable, 1 to enable.
+ */
+int zfs_allow_lockless_zpool = 0;
+
 #ifdef _KERNEL
 static int zfs_autoimport_disable = B_TRUE;
 #endif
@@ -369,19 +379,49 @@ spa_write_cachefile(spa_t *target, boolean_t removing, boolean_t postsysevent,
  * information for all pool visible within the zone.
  */
 int
-spa_all_configs(uint64_t *generation, nvlist_t **pools)
+spa_all_configs(uint64_t *generation, nvlist_t **pools, zpool_lock_behavior_t
+    zpool_lock_behavior)
 {
+	int error = 0;
 	spa_t *spa = NULL;
+	boolean_t use_lock = B_TRUE;
+
+	/*
+	 * Sanity check: ZPOOL_LOCK_BEHAVIOR_LOCKLESS requires
+	 * zfs_allow_lockless_zpool_status = 1
+	 */
+	ASSERT(!((zpool_lock_behavior == ZPOOL_LOCK_BEHAVIOR_LOCKLESS) &&
+	    (zfs_allow_lockless_zpool_status != 1)));
 
 	if (*generation == spa_config_generation)
 		return (SET_ERROR(EEXIST));
 
-	int error = mutex_enter_interruptible(&spa_namespace_lock);
-	if (error)
-		return (SET_ERROR(EINTR));
+	if (zpool_lock_behavior == ZPOOL_LOCK_BEHAVIOR_WAIT) {
+		error = mutex_enter_interruptible(&spa_namespace_lock);
+	} else {
+		error = mutex_enter_timeout(&spa_namespace_lock,
+		    MSEC2NSEC(spa_namespace_trylock_ms));
+	}
+	if (error) {
+		if (zpool_lock_behavior == ZPOOL_LOCK_BEHAVIOR_TRYLOCK)
+			return (SET_ERROR(EAGAIN));
+		else if (zpool_lock_behavior == ZPOOL_LOCK_BEHAVIOR_LOCKLESS)
+			use_lock = B_FALSE;
+		else
+			return (SET_ERROR(EINTR));
+	}
 
 	*pools = fnvlist_alloc();
-	while ((spa = spa_next(spa)) != NULL) {
+
+	do {
+		if (use_lock)
+			spa = spa_next(spa);
+		else
+			spa = spa_next_lockless(spa);
+
+		if (spa == NULL)
+			break;
+
 		if (INGLOBALZONE(curproc) ||
 		    zone_dataset_visible(spa_name(spa), NULL)) {
 			mutex_enter(&spa->spa_props_lock);
@@ -389,9 +429,11 @@ spa_all_configs(uint64_t *generation, nvlist_t **pools)
 			    spa->spa_config);
 			mutex_exit(&spa->spa_props_lock);
 		}
-	}
+	} while (1);
 	*generation = spa_config_generation;
-	mutex_exit(&spa_namespace_lock);
+
+	if (use_lock)
+		mutex_exit(&spa_namespace_lock);
 
 	return (0);
 }
@@ -412,8 +454,9 @@ spa_config_set(spa_t *spa, nvlist_t *config)
  * We infer whether to generate a complete config or just one top-level config
  * based on whether vd is the root vdev.
  */
-nvlist_t *
-spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
+static nvlist_t *
+spa_config_generate_impl(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats,
+    zpool_lock_behavior_t zpool_lock_behavior)
 {
 	nvlist_t *config, *nvroot;
 	vdev_t *rvd = spa->spa_root_vdev;
@@ -421,15 +464,33 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 	boolean_t locked = B_FALSE;
 	uint64_t split_guid;
 	const char *pool_name;
+	boolean_t skip_locks = B_FALSE;
+
+	/*
+	 * Sanity check: ZPOOL_LOCK_BEHAVIOR_LOCKLESS requires
+	 * zfs_allow_lockless_zpool_status = 1
+	 */
+	ASSERT(!((zpool_lock_behavior == ZPOOL_LOCK_BEHAVIOR_LOCKLESS) &&
+	    (zfs_allow_lockless_zpool_status != 1)));
+
+	/* Special debug case: we've selected a pool for lockless operation */
+	if (zpool_lock_behavior == ZPOOL_LOCK_BEHAVIOR_LOCKLESS) {
+		skip_locks = B_TRUE;
+	}
 
 	if (vd == NULL) {
 		vd = rvd;
 		locked = B_TRUE;
-		spa_config_enter(spa, SCL_CONFIG | SCL_STATE, FTAG, RW_READER);
+
+		if (!skip_locks)
+			spa_config_enter(spa, SCL_CONFIG | SCL_STATE, FTAG,
+			    RW_READER);
 	}
 
-	ASSERT(spa_config_held(spa, SCL_CONFIG | SCL_STATE, RW_READER) ==
-	    (SCL_CONFIG | SCL_STATE));
+	if (!skip_locks)
+		ASSERT(spa_config_held(spa, SCL_CONFIG | SCL_STATE,
+		    RW_READER) == (SCL_CONFIG | SCL_STATE));
+
 
 	/*
 	 * If txg is -1, report the current value of spa->spa_config_txg.
@@ -552,10 +613,25 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 		kmem_free(dds, sizeof (ddt_stat_t));
 	}
 
-	if (locked)
+	if (locked && !skip_locks)
 		spa_config_exit(spa, SCL_CONFIG | SCL_STATE, FTAG);
 
 	return (config);
+}
+
+nvlist_t *
+spa_config_generate_lock_behavior(spa_t *spa, vdev_t *vd, uint64_t txg,
+    int getstats, zpool_lock_behavior_t zpool_lock_behavior)
+{
+	return (spa_config_generate_impl(spa, vd, txg, getstats,
+	    zpool_lock_behavior));
+}
+
+nvlist_t *
+spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
+{
+	return (spa_config_generate_impl(spa, vd, txg, getstats,
+	    ZPOOL_LOCK_BEHAVIOR_DEFAULT));
 }
 
 /*
@@ -637,3 +713,6 @@ ZFS_MODULE_PARAM(zfs_spa, spa_, config_path, STRING, ZMOD_RD,
 
 ZFS_MODULE_PARAM(zfs, zfs_, autoimport_disable, INT, ZMOD_RW,
 	"Disable pool import at module load");
+
+ZFS_MODULE_PARAM(zfs, zfs_, allow_lockless_zpool, INT, ZMOD_RW,
+	"DEBUG ONLY! Allow 'zpool status --lockless'");

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -559,7 +559,7 @@ tests = ['zpool_status_001_pos', 'zpool_status_002_pos',
     'zpool_status_003_pos', 'zpool_status_004_pos',
     'zpool_status_005_pos', 'zpool_status_006_pos',
     'zpool_status_007_pos', 'zpool_status_008_pos',
-    'zpool_status_features_001_pos']
+    'zpool_status_features_001_pos', 'zpool_status_lockless']
 tags = ['functional', 'cli_root', 'zpool_status']
 
 [tests/functional/cli_root/zpool_sync]

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3885,4 +3885,14 @@ function pop_coredump_pattern
 	esac
 }
 
+# Get the Unix timestamp as expressed in milliseconds.  This can be useful for
+# measuring how long something takes.  This works on both Linux and
+# FreeBSD.
+function get_unix_timestamp_in_ms
+{
+	# We can't just use 'date +%s%N' here since FreeBSD 'date' only supports
+	# one-second resolution.
+	python3 -c 'import time; print(round(time.time() * 1000))'
+}
+
 . ${STF_SUITE}/include/kstat.shlib

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -17,6 +17,7 @@ UNAME=$(uname)
 # NAME				FreeBSD tunable			Linux tunable
 cat <<%%%% |
 ADMIN_SNAPSHOT			UNSUPPORTED			zfs_admin_snapshot
+ALLOW_LOCKLESS_ZPOOL_STATUS		allow_lockless_zpool_status		zfs_allow_lockless_zpool_status
 ALLOW_REDACTED_DATASET_MOUNT	allow_redacted_dataset_mount	zfs_allow_redacted_dataset_mount
 ARC_MAX				arc.max				zfs_arc_max
 ARC_MIN				arc.min				zfs_arc_min
@@ -39,6 +40,7 @@ DEADMAN_EVENTS_PER_SECOND	deadman_events_per_second	zfs_deadman_events_per_secon
 DEADMAN_FAILMODE		deadman.failmode		zfs_deadman_failmode
 DEADMAN_SYNCTIME_MS		deadman.synctime_ms		zfs_deadman_synctime_ms
 DEADMAN_ZIOTIME_MS		deadman.ziotime_ms		zfs_deadman_ziotime_ms
+DEBUG_NAMESPACE_LOCK_DELAY	debug_namespace_lock_delay	zfs_debug_namespace_lock_delay
 DISABLE_IVSET_GUID_CHECK	disable_ivset_guid_check	zfs_disable_ivset_guid_check
 DMU_OFFSET_NEXT_SYNC		dmu_offset_next_sync		zfs_dmu_offset_next_sync
 EMBEDDED_SLOG_MIN_MS		embedded_slog_min_ms		zfs_embedded_slog_min_ms
@@ -87,6 +89,7 @@ SPA_ASIZE_INFLATION		spa.asize_inflation		spa_asize_inflation
 SPA_DISCARD_MEMORY_LIMIT	spa.discard_memory_limit	zfs_spa_discard_memory_limit
 SPA_LOAD_VERIFY_DATA		spa.load_verify_data		spa_load_verify_data
 SPA_LOAD_VERIFY_METADATA	spa.load_verify_metadata	spa_load_verify_metadata
+SPA_NAMESPACE_TRYLOCK_MS	spa.namespace_trylock_ms	spa_namespace_trylock_ms
 TRIM_EXTENT_BYTES_MIN		trim.extent_bytes_min		zfs_trim_extent_bytes_min
 TRIM_METASLAB_SKIP		trim.metaslab_skip		zfs_trim_metaslab_skip
 TRIM_TXG_BATCH			trim.txg_batch			zfs_trim_txg_batch

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1272,6 +1272,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_status/zpool_status_007_pos.ksh \
 	functional/cli_root/zpool_status/zpool_status_008_pos.ksh \
 	functional/cli_root/zpool_status/zpool_status_features_001_pos.ksh \
+	functional/cli_root/zpool_status/zpool_status_lockless.ksh \
 	functional/cli_root/zpool_sync/cleanup.ksh \
 	functional/cli_root/zpool_sync/setup.ksh \
 	functional/cli_root/zpool_sync/zpool_sync_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_lockless.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_lockless.ksh
@@ -1,0 +1,92 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify 'zpool status --lockless|--trylock' work correctly
+
+DISK=$TEST_BASE_DIR/zpool_status_lockless_vdev
+
+function cleanup
+{
+	log_must restore_tunable ALLOW_LOCKLESS_ZPOOL_STATUS
+	log_must restore_tunable DEBUG_NAMESPACE_LOCK_DELAY
+	log_must restore_tunable SPA_NAMESPACE_TRYLOCK_MS
+	log_must zpool destroy testpool2
+	log_must rm -f "$DISK"
+}
+
+log_assert "Verify 'zpool status ---lockless|--trylock'"
+
+log_onexit cleanup
+
+log_must save_tunable ALLOW_LOCKLESS_ZPOOL_STATUS
+log_must save_tunable DEBUG_NAMESPACE_LOCK_DELAY
+log_must save_tunable SPA_NAMESPACE_TRYLOCK_MS
+
+log_mustnot test -e $DISK
+log_must truncate -s 100M $DISK
+log_must zpool create testpool2 $DISK
+log_must zpool status
+log_must zpool status --trylock
+
+# This should fail since zfs_allow_lockless_zpool_status!=1
+log_mustnot zpool status --lockless
+
+# Add an artificial 1s delay after taking the spa_namespace lock
+set_tunable32 DEBUG_NAMESPACE_LOCK_DELAY 500
+zpool status &
+sleep 0.1
+
+# This should fail since the previously spawned off 'zpool status' is holding
+# the lock for at least 500ms, and --trylock only tries for 100ms.
+set_tunable32 SPA_NAMESPACE_TRYLOCK_MS 100
+log_mustnot zpool status --trylock
+wait
+
+set_tunable32 DEBUG_NAMESPACE_LOCK_DELAY 100
+zpool status &
+sleep 0.05
+
+# This should succeed since the previously spawned off 'zpool status' is holding
+# the lock for only 100ms, and --trylock tries for 300ms.
+set_tunable32 SPA_NAMESPACE_TRYLOCK_MS 300
+log_must zpool status --trylock
+wait
+
+# Now we artificially hold the lock for 500ms, and check that --lockless
+# returns in a short amount of time, and without error.
+set_tunable32 DEBUG_NAMESPACE_LOCK_DELAY 500
+set_tunable32 SPA_NAMESPACE_TRYLOCK_MS 10
+set_tunable32 ALLOW_LOCKLESS_ZPOOL_STATUS 1
+zpool status &
+sleep 0.05
+before=$(get_unix_timestamp_in_ms)
+log_must zpool status --lockless
+after=$(get_unix_timestamp_in_ms)
+d=$(($after - $before))
+wait
+log_note "'zpool status --lockless' took $d milliseconds"
+log_must test $d -le 300
+
+log_pass "zpool status --lockless|--trylock work correctly"


### PR DESCRIPTION
### Motivation and Context
Allow `zpool status` to work even when the pool is locked up.

### Description
Add the following flags to `zpool status`:
    
`--lockless`: Try for a short amount of time to get the spa_namespace lock.  If that doesn't work, then do the zpool status locklessly.  **This is dangerous and can crash your system if the pools configs are being modified while zpool status is running!** This flag requires the `zfs_allow_lockless_zpool_status` module param be set to `1` in in order to run.  `--lockless` should only be used for emergency situations.
    
`--trylock`: Try for a short amount of time to get the spa_namespace lock.  If that doesn't work then simply abort `zpool status`.
    
These commands allow users to view the `zpool status` output even when the pool gets stuck while holding the spa_namespace lock.

The amount of time `--trylock` and `--lockless` try to get the spa_namespace lock before moving on is controlled by the `spa_namespace_trylock_ms` module param.  The default is to try for 100ms.

### How Has This Been Tested?
Manually crashed the pool by calling `BUG()` while holding the spa_namespace lock .  Saw the traditional `zpool status` command hanging as before.  Saw `zpool status --trylock` successfully abort, and `zpool status --lockless` successfully return status output.  I also added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
