### PR TITLE
ZTS: Fix two bugs in the zpool dry run tests

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_dryrun_output.ksh
@@ -161,7 +161,11 @@ for (( i=0; i < ${#tests[@]}; i+=1 )); do
 		log_fail eval "zpool add -n '$TESTPOOL' $add"
 	fi
 	if [[ "$out" != "$want" ]]; then
-		log_fail "Got:\n" "$out" "\nbut expected:\n" "$want"
+		log_note "Got:"
+		log_note "$out"
+		log_note "but expected:"
+		log_note "$want"
+		log_fail "Dry run does not display config correctly"
 	fi
 	log_must destroy_pool "$TESTPOOL"
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_dryrun_output.ksh
@@ -127,10 +127,11 @@ done
 for (( i=0; i < ${#tests[@]}; i+=1 )); do
 	tree="${tests[$i].tree}"
 	want="${tests[$i].want}"
-
-	typeset out="$(log_must eval "zpool create -n '$TESTPOOL' $tree" | \
-	    sed /^SUCCESS/d)"
-
+	typeset out
+	out="$(eval zpool create -n '$TESTPOOL' $tree)"
+	if [[ $? -ne 0 ]]; then
+		log_fail eval "zpool create -n '$TESTPOOL' $tree"
+	fi
 	if [[ "$out" != "$want" ]]; then
 		log_fail "Got:\n" "$out" "\nbut expected:\n" "$want"
 	fi

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_dryrun_output.ksh
@@ -133,7 +133,11 @@ for (( i=0; i < ${#tests[@]}; i+=1 )); do
 		log_fail eval "zpool create -n '$TESTPOOL' $tree"
 	fi
 	if [[ "$out" != "$want" ]]; then
-		log_fail "Got:\n" "$out" "\nbut expected:\n" "$want"
+		log_note "Got:"
+		log_note "$out"
+		log_note "but expected:"
+		log_note "$want"
+		log_fail "Dry run does not display config correctly"
 	fi
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_dryrun_output.ksh
@@ -146,7 +146,11 @@ for (( i=0; i < ${#tests[@]}; i+=1 )); do
 		log_fail eval "zpool split -n '$TESTPOOL' '$NEWPOOL' $devs"
 	fi
 	if [[ "$out" != "$want" ]]; then
-		log_fail "Got:\n" "$out" "\nbut expected:\n" "$want"
+		log_note "Got:"
+		log_note "$out"
+		log_note "but expected:"
+		log_note "$want"
+		log_fail "Dry run does not display config correctly"
 	fi
 	log_must destroy_pool "$TESTPOOL"
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_dryrun_output.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_dryrun_output.ksh
@@ -140,9 +140,11 @@ for (( i=0; i < ${#tests[@]}; i+=1 )); do
 
 	log_must eval zpool create "$TESTPOOL" $tree
 	log_must poolexists "$TESTPOOL"
-	typeset out="$(log_must eval "zpool split -n \
-	    '$TESTPOOL' '$NEWPOOL' $devs" | sed /^SUCCESS/d)"
-
+	typeset out
+	out="$(eval zpool split -n '$TESTPOOL' '$NEWPOOL' $devs)"
+	if [[ $? -ne 0 ]]; then
+		log_fail eval "zpool split -n '$TESTPOOL' '$NEWPOOL' $devs"
+	fi
 	if [[ "$out" != "$want" ]]; then
 		log_fail "Got:\n" "$out" "\nbut expected:\n" "$want"
 	fi


### PR DESCRIPTION
### Motivation and Context

The output changes in #17045 broke the zpool dry run tests. This PR fixes the failing tests.

### Description

Rework the tests to not depend on log output format. While here, fix a bug where "\n" was printed literally, not as a line break as intended.
 
### How Has This Been Tested?

I've run the modified tests manually forcing test failures by editing the tests accordingly.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
