### PR TITLE
Multiple printf() size fixes

### DIFF
--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -454,7 +454,8 @@ print_data_handler(int id, const char *pool, zinject_record_t *record,
 
 
 	(void) printf("%3d  %-15s  %-6llu  %-6llu  %-8s  %-3d  0x%02x  %-15s  "
-	    "%6lu  %6lu\n", id, pool, (u_longlong_t)record->zi_objset,
+	    "%6" PRIu64 "  %6" PRIu64 "\n", id, pool,
+	    (u_longlong_t)record->zi_objset,
 	    (u_longlong_t)record->zi_object, type_to_name(record->zi_type),
 	    record->zi_level, record->zi_dvas, rangebuf,
 	    record->zi_match_count, record->zi_inject_count);
@@ -491,7 +492,8 @@ print_device_handler(int id, const char *pool, zinject_record_t *record,
 	    (((double)record->zi_freq) / ZI_PERCENTAGE_MAX) * 100.0f;
 
 	(void) printf("%3d  %-15s  %llx  %-5s  %-10s  %8.4f%%  "
-	    "%6lu  %6lu\n", id, pool, (u_longlong_t)record->zi_guid,
+	    "%6" PRIu64 "  %6" PRIu64 "\n", id, pool,
+	    (u_longlong_t)record->zi_guid,
 	    iotype_to_str(record->zi_iotype), err_to_str(record->zi_error),
 	    freq, record->zi_match_count, record->zi_inject_count);
 
@@ -526,7 +528,8 @@ print_delay_handler(int id, const char *pool, zinject_record_t *record,
 	    (((double)record->zi_freq) / ZI_PERCENTAGE_MAX) * 100.0f;
 
 	(void) printf("%3d  %-15s  %llx  %10llu  %5llu  %8.4f%%  "
-	    "%6lu  %6lu\n", id, pool, (u_longlong_t)record->zi_guid,
+	    "%6" PRIu64 "  %6" PRIu64 "\n", id, pool,
+	    (u_longlong_t)record->zi_guid,
 	    (u_longlong_t)NSEC2MSEC(record->zi_timer),
 	    (u_longlong_t)record->zi_nlanes,
 	    freq, record->zi_match_count, record->zi_inject_count);

--- a/tests/zfs-tests/cmd/clonefile.c
+++ b/tests/zfs-tests/cmd/clonefile.c
@@ -205,6 +205,7 @@ main(int argc, char **argv)
 
 	loff_t soff = 0, doff = 0;
 	size_t len = SSIZE_MAX;
+	unsigned long long len2;
 	if ((argc-optind) == 5) {
 		soff = strtoull(argv[optind+2], NULL, 10);
 		if (soff == ULLONG_MAX) {
@@ -220,11 +221,13 @@ main(int argc, char **argv)
 		    strcmp(argv[optind+4], "all") == 0) {
 			len = SSIZE_MAX;
 		} else {
-			len = strtoull(argv[optind+4], NULL, 10);
-			if (len == ULLONG_MAX) {
+			len2 = strtoull(argv[optind+4], NULL, 10);
+			if (len2 == ULLONG_MAX) {
 				fprintf(stderr, "invalid length");
 				return (1);
 			}
+			if (len2 < SSIZE_MAX)
+				len = (size_t)len2;
 		}
 	}
 
@@ -268,7 +271,7 @@ main(int argc, char **argv)
 		off_t dpos = lseek(dfd, 0, SEEK_CUR);
 		off_t dlen = lseek(dfd, 0, SEEK_END);
 
-		fprintf(stderr, "file offsets: src=%lu/%lu; dst=%lu/%lu\n",
+		fprintf(stderr, "file offsets: src=%jd/%jd; dst=%jd/%jd\n",
 		    spos, slen, dpos, dlen);
 	}
 
@@ -331,7 +334,7 @@ do_copyfilerange(int sfd, int dfd, loff_t soff, loff_t doff, size_t len)
 	}
 	if (copied != len) {
 		fprintf(stderr, "copy_file_range: copied less than requested: "
-		    "requested=%lu; copied=%lu\n", len, copied);
+		    "requested=%zu; copied=%zd\n", len, copied);
 		return (1);
 	}
 	return (0);

--- a/tests/zfs-tests/tests/functional/vdev_disk/page_alignment.c
+++ b/tests/zfs-tests/tests/functional/vdev_disk/page_alignment.c
@@ -421,14 +421,14 @@ run_test(const page_test_t *test, bool verbose)
 		size_t take = MIN(rem, len);
 
 		if (verbose)
-			printf("  page %d [off %lx len %lx], "
-			    "rem %lx, take %lx\n",
+			printf("  page %d [off %zx len %zx], "
+			    "rem %zx, take %zx\n",
 			    i, off, len, rem, take);
 
 		if (vdev_disk_check_alignment_cb(NULL, off, take, &s)) {
 			if (verbose)
 				printf("  ABORT: misalignment detected, "
-				    "rem %lx\n", rem);
+				    "rem %zx\n", rem);
 			return (false);
 		}
 
@@ -439,7 +439,7 @@ run_test(const page_test_t *test, bool verbose)
 
 	if (rem > 0) {
 		if (verbose)
-			printf("  ABORT: ran out of pages, rem %lx\n", rem);
+			printf("  ABORT: ran out of pages, rem %zx\n", rem);
 		return (false);
 	}
 


### PR DESCRIPTION
### Motivation and Context
When compiling on i386, multiple printf() calls incorrectly size variables

### Description
cmd/zinject/zinject.c:
- use PRIu64 when printing uint64_t
    
tests/zfs-tests/cmd/clonefile.c:
- use an unsigned long long and not size_t to store result from strtoull()
- use %jd for printing off_t, %zu for size_t, %zd for ssize_t
    
tests/zfs-tests/tests/functional/vdev_disk/page_alignment.c:
- use %zx to print size_t

### How Has This Been Tested?
Tested compiling on Linux amd64, FreeBSD amd64 and FreeBSD i386

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
