### PR TITLE
Fix nonrot property being incorrectly unset

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1938,14 +1938,17 @@ vdev_open_children_impl(vdev_t *vd, vdev_open_children_func_t *open_func)
 			VERIFY(taskq_dispatch(tq, vdev_open_child,
 			    cvd, TQ_SLEEP) != TASKQID_INVALID);
 		}
+	}
 
+	if (tq != NULL)
+		taskq_wait(tq);
+	for (int c = 0; c < children; c++) {
+		vdev_t *cvd = vd->vdev_child[c];
 		vd->vdev_nonrot &= cvd->vdev_nonrot;
 	}
 
-	if (tq != NULL) {
-		taskq_wait(tq);
+	if (tq != NULL)
 		taskq_destroy(tq);
-	}
 }
 
 /*


### PR DESCRIPTION
 Sponsored-by: Klara, Inc.
Sponsored-by: Eshtek, Inc.

### Motivation and Context
When opening a vdev and setting the nonrot property, we used to wait for each child to be opened before examining its nonrot property. When the change was made to open vdevs asynchronously, we didn't move the nonrot check out of the main loop. As a result, the nonrot property is almost always set to false, regardless of the actual type of the underlying disks.

### Description
The fix is simply to move the nonrot check to a separate loop after the taskq has been waited for.

### How Has This Been Tested?
Ran through the test suite, which was failing the split tests with segment weighting disabled. Used zfs_dbgmsg to verify that nonrot was being set appropriately.

We should also consider augmenting the test suite to fuzz some tunables before/while running. This bug reproduces 100% of the time with segment weighting disabled, and it's almost certainly not the only bug of its type.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
