### PR TITLE
Fix memory leaks in pool properties handling

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -85,6 +85,7 @@ zpool_get_all_props(zpool_handle_t *zhp)
 		fnvlist_add_string_array(innvl, ZPOOL_GET_PROPS_NAMES,
 		    zhp->zpool_propnames, zhp->zpool_n_propnames);
 		zcmd_write_src_nvlist(hdl, &zc, innvl);
+		fnvlist_free(innvl);
 	}
 
 	zcmd_alloc_dst_nvlist(hdl, &zc, 0);
@@ -332,7 +333,7 @@ zpool_get_prop(zpool_handle_t *zhp, zpool_prop_t prop, char *buf,
 	 */
 	if (prop == ZPOOL_PROP_DEDUPCACHED) {
 		zpool_add_propname(zhp, ZPOOL_DEDUPCACHED_PROP_NAME);
-		(void) zpool_get_all_props(zhp);
+		(void) zpool_props_refresh(zhp);
 	}
 
 	if (zhp->zpool_props == NULL && zpool_get_all_props(zhp) &&


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #17207 

### Description
<!--- Describe your changes in detail -->
A temporary nvlist was not freed in zpool_get_all_props().  In zpool_get_prop() zpool_props_refresh() is used instead of zpool_get_all_props(), as it turned out that zpool_props might already have been initialized.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Running `valgrind --leak-check=full zpool get dedupcached <pool>` does not report lost blocks anymore.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
