### PR TITLE
More aggressively assert that db_mtx protects db.db_data

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1458,9 +1458,9 @@ dbuf_read_bonus(dmu_buf_impl_t *db, dnode_t *dn)
 }
 
 static void
-dbuf_handle_indirect_hole(arc_buf_t *db_data, dnode_t *dn, blkptr_t *dbbp)
+dbuf_handle_indirect_hole(void *data, dnode_t *dn, blkptr_t *dbbp)
 {
-	blkptr_t *bps = (blkptr_t*)db_data;
+	blkptr_t *bps = data;
 	uint32_t indbs = 1ULL << dn->dn_indblkshift;
 	int n_bps = indbs >> SPA_BLKPTRSHIFT;
 
@@ -3881,7 +3881,6 @@ dbuf_hold_copy(dnode_t *dn, dmu_buf_impl_t *db)
 	}
 	memcpy(db_data->b_data, data->b_data, arc_buf_size(data));
 
-	ASSERT(MUTEX_HELD(&db->db_mtx));
 	dbuf_set_data(db, db_data);
 }
 

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1727,6 +1727,7 @@ dmu_object_cached_size(objset_t *os, uint64_t object,
 
 		err = dbuf_read(db, NULL, DB_RF_CANFAIL);
 		if (err == 0) {
+			ASSERT(MUTEX_HELD(&db->db_mtx));
 			dmu_cached_bps(dmu_objset_spa(os), db->db.db_data,
 			    nbps, l1sz, l2sz);
 		}

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1727,7 +1727,6 @@ dmu_object_cached_size(objset_t *os, uint64_t object,
 
 		err = dbuf_read(db, NULL, DB_RF_CANFAIL);
 		if (err == 0) {
-			ASSERT(MUTEX_HELD(&db->db_mtx));
 			dmu_cached_bps(dmu_objset_spa(os), db->db.db_data,
 			    nbps, l1sz, l2sz);
 		}

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -2263,8 +2263,10 @@ dmu_objset_userquota_find_data(dmu_buf_impl_t *db, dmu_tx_t *tx)
 	dbuf_dirty_record_t *dr;
 	void *data;
 
-	if (db->db_dirtycnt == 0)
+	if (db->db_dirtycnt == 0) {
+		ASSERT(MUTEX_HELD(&db->db_mtx));
 		return (db->db.db_data);  /* Nothing is changing */
+	}
 
 	dr = dbuf_find_dirty_eq(db, tx->tx_txg);
 


### PR DESCRIPTION
db.db_mtx must be held any time that db.db_data is accessed.  All of these functions do have the lock held by a parent; add assertions to ensure that it stays that way.

Also, refactor dbuf_read_bonus to make it obvious why db_rwlock isn't required.

See https://github.com/openzfs/zfs/discussions/17118

Sponsored by:	ConnectWise
Signed-off-by:	Alan Somers <asomers@gmail.com>

### Motivation and Context
Bug #16626 probably results from improper locking around db.db_data.  Any time that variable is accessed, db_mtx must be held.

### Description
As a first step to fixing that bug, add some more assertions in places that already do have the lock, but don't currently assert that they do.  This will make the problem more clear, and prevent regressions in those functions.

### How Has This Been Tested?
I ran the ZFS test suite in FreeBSD 15.0-CURRENT.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
