### PR TITLE
Added fix for zpool get state segfaults with two or more vdevs (#15972).

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -12747,11 +12747,13 @@ found:
 
 			if (strcmp(argv[1], "root") == 0)
 				vdev = strdup("root-0");
-			else
-				vdev = strdup(argv[1]);
 
 			/* ... and the rest are vdev names */
-			cb.cb_vdevs.cb_names = &vdev;
+			if (vdev == NULL)
+				cb.cb_vdevs.cb_names = argv + 1;
+			else
+				cb.cb_vdevs.cb_names = &vdev;
+
 			cb.cb_vdevs.cb_names_count = argc - 1;
 			cb.cb_type = ZFS_TYPE_VDEV;
 			argc = 1; /* One pool to process */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context

This change fixes the zpool get state command segfault issue if you pass
two or vdevs to ```zpool get state <pool_name> <vdev1> <vdev2>```.
https://github.com/openzfs/zfs/issues/15972

### Description
The problem was identified in handling of the zpool get state command
line arguments. A pointer vdev was used to point to the argv[1], and
its address set to cb.cb_vdevs.cb_names(pointer to array of strings)
so any increment to cb_names resulted in a segfault. Fix covers a
special case of root parameter at argv[1] and remaining cases are
handled by passing in the argv + 1, which allows cb_names iteration
of next command line arguments (vdevs).

### How Has This Been Tested?
zpool get state is a command so the testing was done manualy using
command line arguments.
There are there types of arguments for 
```zpool get state <poolname>``` 
1. ```all-vdevs```
2. ```root```
3. ```<vdev1> <vdev2>```

The third type of argument resulted in segfault without the fix.
With the fix all three types of arguments are handled properly.
```
./zpool get state zpool root
NAME    PROPERTY  VALUE  SOURCE
root-0  state     ONLINE  -

```

```
./zpool get state zpool all-vdevs
NAME    PROPERTY  VALUE  SOURCE
root-0  state     ONLINE  -
/tmp/1.img  state     ONLINE  -
/tmp/2.img  state     ONLINE  -
```

```
./zpool get state zpool /tmp/1.img /tmp/2.img
NAME        PROPERTY  VALUE  SOURCE
/tmp/1.img  state     ONLINE  -
/tmp/2.img  state     ONLINE  -

```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).