### PR TITLE
nvlist: Add nvlist_snprintf() and zfs_dbgmsg_nvlist()

### DIFF
--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -267,6 +267,8 @@ _SYS_NVPAIR_H int nvlist_lookup_double(const nvlist_t *, const char *,
     double *);
 #endif
 
+_SYS_NVPAIR_H int nvlist_snprintf(char *, size_t, nvlist_t *, int);
+
 _SYS_NVPAIR_H int nvlist_lookup_nvpair(nvlist_t *, const char *, nvpair_t **);
 _SYS_NVPAIR_H int nvlist_lookup_nvpair_embedded_index(nvlist_t *, const char *,
     nvpair_t **, int *, const char **);

--- a/include/sys/zfs_debug.h
+++ b/include/sys/zfs_debug.h
@@ -39,6 +39,8 @@ extern "C" {
 #define	FALSE 0
 #endif
 
+#include <sys/nvpair.h>
+
 extern int zfs_flags;
 extern int zfs_recover;
 extern int zfs_free_leak_on_eio;
@@ -103,6 +105,24 @@ extern void zfs_panic_recover(const char *fmt, ...);
 
 extern void zfs_dbgmsg_init(void);
 extern void zfs_dbgmsg_fini(void);
+
+/*
+ * When printing an nvlist, print one beginning line with the file/func/line
+ * number and the text "nvlist <var name>:" followed by all the nvlist lines
+ * without the file/fun/line number.  This makes the nvlist lines easy to read.
+ */
+#define	zfs_dbgmsg_nvlist(nv) \
+	if (zfs_dbgmsg_enable) { \
+		zfs_dbgmsg("nvlist "#nv":"); \
+		__zfs_dbgmsg_nvlist(nv); \
+	}
+
+#define	zfs_dbgmsg(...) \
+	if (zfs_dbgmsg_enable) \
+		__dprintf(B_FALSE, __FILE__, __func__, __LINE__, __VA_ARGS__)
+
+
+extern void __zfs_dbgmsg_nvlist(nvlist_t *nv);
 
 #ifndef _KERNEL
 extern int dprintf_find_string(const char *string);

--- a/lib/libnvpair/libnvpair.abi
+++ b/lib/libnvpair/libnvpair.abi
@@ -196,6 +196,7 @@
     <elf-symbol name='nvlist_remove_all' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nvlist_remove_nvpair' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nvlist_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='nvlist_snprintf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nvlist_unpack' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nvlist_xalloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='nvlist_xdup' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -967,6 +968,13 @@
     <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
     <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
     <class-decl name='re_dfa_t' is-struct='yes' visibility='default' is-declaration-only='yes' id='b48d2441'/>
+    <function-decl name='nvlist_snprintf' mangled-name='nvlist_snprintf' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_snprintf'>
+      <parameter type-id='26a90f95'/>
+      <parameter type-id='b59d7dce'/>
+      <parameter type-id='5ce45b60'/>
+      <parameter type-id='95e97e5e'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='nvlist_next_nvpair' mangled-name='nvlist_next_nvpair' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvlist_next_nvpair'>
       <parameter type-id='5ce45b60'/>
       <parameter type-id='dace003f'/>
@@ -1126,18 +1134,17 @@
       <parameter type-id='7408d286'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='dcgettext' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='80f4b756'/>
-      <parameter type-id='80f4b756'/>
-      <parameter type-id='95e97e5e'/>
-      <return type-id='26a90f95'/>
-    </function-decl>
     <function-decl name='regexec' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='a431a9da'/>
       <parameter type-id='9d26089a'/>
       <parameter type-id='b59d7dce'/>
       <parameter type-id='fc212857'/>
       <parameter type-id='95e97e5e'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='fputs' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='9d26089a'/>
+      <parameter type-id='e75a27e9'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='malloc' visibility='default' binding='global' size-in-bits='64'>
@@ -1177,12 +1184,6 @@
       <parameter type-id='e75a27e9'/>
       <parameter type-id='95e97e5e'/>
       <parameter type-id='9d26089a'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='__printf_chk' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='80f4b756'/>
       <parameter is-variadic='yes'/>
       <return type-id='95e97e5e'/>
     </function-decl>
@@ -1398,11 +1399,6 @@
       <parameter type-id='b0c1ff8d' name='pctl'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='dump_nvlist' mangled-name='dump_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dump_nvlist'>
-      <parameter type-id='5ce45b60' name='list'/>
-      <parameter type-id='95e97e5e' name='indent'/>
-      <return type-id='48b5725f'/>
-    </function-decl>
     <function-decl name='nvpair_value_match_regex' mangled-name='nvpair_value_match_regex' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='nvpair_value_match_regex'>
       <parameter type-id='3fa542f0' name='nvp'/>
       <parameter type-id='95e97e5e' name='ai'/>
@@ -1417,6 +1413,11 @@
       <parameter type-id='80f4b756' name='value'/>
       <parameter type-id='7d3cd834' name='ep'/>
       <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='dump_nvlist' mangled-name='dump_nvlist' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='dump_nvlist'>
+      <parameter type-id='5ce45b60' name='list'/>
+      <parameter type-id='95e97e5e' name='indent'/>
+      <return type-id='48b5725f'/>
     </function-decl>
     <function-type size-in-bits='64' id='9f88f76e'>
       <parameter type-id='196db161'/>
@@ -2194,6 +2195,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='stack_t' type-id='380f9954' id='ac5e685f'/>
+    <typedef-decl name='unw_regnum_t' type-id='95e97e5e' id='c53620f0'/>
     <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='384a1f22'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='opaque' type-id='dc70ec0b' visibility='default'/>
@@ -2305,6 +2307,10 @@
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='b59d7dce'/>
       <return type-id='79a0948f'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='c53620f0'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='_ULx86_64_init_local' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='3946e4d1'/>

--- a/lib/libnvpair/libnvpair.c
+++ b/lib/libnvpair/libnvpair.c
@@ -783,160 +783,6 @@ nvlist_prt(nvlist_t *nvl, nvlist_prtctl_t pctl)
 	nvlist_print_with_indent(nvl, pctl);
 }
 
-#define	NVP(elem, type, vtype, ptype, format) { \
-	vtype	value; \
-\
-	(void) nvpair_value_##type(elem, &value); \
-	(void) printf("%*s%s: " format "\n", indent, "", \
-	    nvpair_name(elem), (ptype)value); \
-}
-
-#define	NVPA(elem, type, vtype, ptype, format) { \
-	uint_t	i, count; \
-	vtype	*value;  \
-\
-	(void) nvpair_value_##type(elem, &value, &count); \
-	for (i = 0; i < count; i++) { \
-		(void) printf("%*s%s[%d]: " format "\n", indent, "", \
-		    nvpair_name(elem), i, (ptype)value[i]); \
-	} \
-}
-
-/*
- * Similar to nvlist_print() but handles arrays slightly differently.
- */
-void
-dump_nvlist(nvlist_t *list, int indent)
-{
-	nvpair_t	*elem = NULL;
-	boolean_t	bool_value;
-	nvlist_t	*nvlist_value;
-	nvlist_t	**nvlist_array_value;
-	uint_t		i, count;
-
-	if (list == NULL) {
-		return;
-	}
-
-	while ((elem = nvlist_next_nvpair(list, elem)) != NULL) {
-		switch (nvpair_type(elem)) {
-		case DATA_TYPE_BOOLEAN:
-			(void) printf("%*s%s\n", indent, "", nvpair_name(elem));
-			break;
-
-		case DATA_TYPE_BOOLEAN_VALUE:
-			(void) nvpair_value_boolean_value(elem, &bool_value);
-			(void) printf("%*s%s: %s\n", indent, "",
-			    nvpair_name(elem), bool_value ? "true" : "false");
-			break;
-
-		case DATA_TYPE_BYTE:
-			NVP(elem, byte, uchar_t, int, "%u");
-			break;
-
-		case DATA_TYPE_INT8:
-			NVP(elem, int8, int8_t, int, "%d");
-			break;
-
-		case DATA_TYPE_UINT8:
-			NVP(elem, uint8, uint8_t, int, "%u");
-			break;
-
-		case DATA_TYPE_INT16:
-			NVP(elem, int16, int16_t, int, "%d");
-			break;
-
-		case DATA_TYPE_UINT16:
-			NVP(elem, uint16, uint16_t, int, "%u");
-			break;
-
-		case DATA_TYPE_INT32:
-			NVP(elem, int32, int32_t, long, "%ld");
-			break;
-
-		case DATA_TYPE_UINT32:
-			NVP(elem, uint32, uint32_t, ulong_t, "%lu");
-			break;
-
-		case DATA_TYPE_INT64:
-			NVP(elem, int64, int64_t, longlong_t, "%lld");
-			break;
-
-		case DATA_TYPE_UINT64:
-			NVP(elem, uint64, uint64_t, u_longlong_t, "%llu");
-			break;
-
-		case DATA_TYPE_STRING:
-			NVP(elem, string, const char *, const char *, "'%s'");
-			break;
-
-		case DATA_TYPE_BYTE_ARRAY:
-			NVPA(elem, byte_array, uchar_t, int, "%u");
-			break;
-
-		case DATA_TYPE_INT8_ARRAY:
-			NVPA(elem, int8_array, int8_t, int, "%d");
-			break;
-
-		case DATA_TYPE_UINT8_ARRAY:
-			NVPA(elem, uint8_array, uint8_t, int, "%u");
-			break;
-
-		case DATA_TYPE_INT16_ARRAY:
-			NVPA(elem, int16_array, int16_t, int, "%d");
-			break;
-
-		case DATA_TYPE_UINT16_ARRAY:
-			NVPA(elem, uint16_array, uint16_t, int, "%u");
-			break;
-
-		case DATA_TYPE_INT32_ARRAY:
-			NVPA(elem, int32_array, int32_t, long, "%ld");
-			break;
-
-		case DATA_TYPE_UINT32_ARRAY:
-			NVPA(elem, uint32_array, uint32_t, ulong_t, "%lu");
-			break;
-
-		case DATA_TYPE_INT64_ARRAY:
-			NVPA(elem, int64_array, int64_t, longlong_t, "%lld");
-			break;
-
-		case DATA_TYPE_UINT64_ARRAY:
-			NVPA(elem, uint64_array, uint64_t, u_longlong_t,
-			    "%llu");
-			break;
-
-		case DATA_TYPE_STRING_ARRAY:
-			NVPA(elem, string_array, const char *, const char *,
-			    "'%s'");
-			break;
-
-		case DATA_TYPE_NVLIST:
-			(void) nvpair_value_nvlist(elem, &nvlist_value);
-			(void) printf("%*s%s:\n", indent, "",
-			    nvpair_name(elem));
-			dump_nvlist(nvlist_value, indent + 4);
-			break;
-
-		case DATA_TYPE_NVLIST_ARRAY:
-			(void) nvpair_value_nvlist_array(elem,
-			    &nvlist_array_value, &count);
-			for (i = 0; i < count; i++) {
-				(void) printf("%*s%s[%u]:\n", indent, "",
-				    nvpair_name(elem), i);
-				dump_nvlist(nvlist_array_value[i], indent + 4);
-			}
-			break;
-
-		default:
-			(void) printf(dgettext(TEXT_DOMAIN, "bad config type "
-			    "%d for %s\n"), nvpair_type(elem),
-			    nvpair_name(elem));
-		}
-	}
-}
-
 /*
  * ======================================================================
  * |									|
@@ -1290,4 +1136,31 @@ int
 nvpair_value_match(nvpair_t *nvp, int ai, const char *value, const char **ep)
 {
 	return (nvpair_value_match_regex(nvp, ai, value, NULL, ep));
+}
+
+/*
+ * Similar to nvlist_print() but handles arrays slightly differently.
+ */
+void
+dump_nvlist(nvlist_t *list, int indent)
+{
+	int len;
+	char *buf;
+
+	len = nvlist_snprintf(NULL, 0, list, indent);
+	len++;	/* Add null terminator */
+
+	buf = malloc(len);
+	if (buf == NULL)
+		return;
+
+	(void) nvlist_snprintf(buf, len, list, indent);
+
+	/*
+	 * fputs does not have limitations on the size of the buffer being
+	 * printed (unlike printf).
+	 */
+	fputs(buf, stdout);
+
+	free(buf);
 }

--- a/lib/libuutil/libuutil.abi
+++ b/lib/libuutil/libuutil.abi
@@ -652,6 +652,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='stack_t' type-id='380f9954' id='ac5e685f'/>
+    <typedef-decl name='unw_regnum_t' type-id='95e97e5e' id='c53620f0'/>
     <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='384a1f22'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='opaque' type-id='dc70ec0b' visibility='default'/>
@@ -762,6 +763,10 @@
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='b59d7dce'/>
       <return type-id='79a0948f'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='c53620f0'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='_ULx86_64_init_local' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='3946e4d1'/>
@@ -1011,15 +1016,8 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libspl/os/linux/getmntany.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='38b51b3c' size-in-bits='832' id='02b72c00'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
-    </array-type-def>
     <array-type-def dimensions='1' type-id='03085adc' size-in-bits='192' id='083f8d58'>
       <subrange length='3' type-id='7359adad' id='56f209d2'/>
-    </array-type-def>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
-    <array-type-def dimensions='1' type-id='80f4b756' size-in-bits='832' id='39e6f84a'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
     </array-type-def>
     <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
       <data-member access='public' layout-offset-in-bits='0'>
@@ -1130,25 +1128,6 @@
     <typedef-decl name='__blksize_t' type-id='bd54fe1a' id='d3f10a7f'/>
     <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
     <typedef-decl name='__syscall_slong_t' type-id='bd54fe1a' id='03085adc'/>
-    <class-decl name='__locale_struct' size-in-bits='1856' is-struct='yes' visibility='default' id='90cc1ce3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__locales' type-id='02b72c00' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='__ctype_b' type-id='31347b7a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='__ctype_tolower' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__ctype_toupper' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='__names' type-id='39e6f84a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__locale_t' type-id='f01e1813' id='b7ac9b5f'/>
-    <typedef-decl name='locale_t' type-id='b7ac9b5f' id='973a4f8d'/>
     <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' id='a9c79a1f'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='tv_sec' type-id='65eda9c0' visibility='default'/>
@@ -1157,23 +1136,12 @@
         <var-decl name='tv_nsec' type-id='03085adc' visibility='default'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='23de8b96' size-in-bits='64' id='38b51b3c'/>
-    <pointer-type-def type-id='90cc1ce3' size-in-bits='64' id='f01e1813'/>
-    <qualified-type-def type-id='95e97e5e' const='yes' id='2448a865'/>
-    <pointer-type-def type-id='2448a865' size-in-bits='64' id='6d60f45d'/>
-    <qualified-type-def type-id='8efea9e5' const='yes' id='3beb2af4'/>
-    <pointer-type-def type-id='3beb2af4' size-in-bits='64' id='31347b7a'/>
     <pointer-type-def type-id='0c544dc0' size-in-bits='64' id='394fc496'/>
     <pointer-type-def type-id='56fe4a37' size-in-bits='64' id='b6b61d2f'/>
     <qualified-type-def type-id='b6b61d2f' restrict='yes' id='3cad23cd'/>
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
     <qualified-type-def type-id='62f7a03d' restrict='yes' id='f1cadedf'/>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
-    <function-decl name='uselocale' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='973a4f8d'/>
-      <return type-id='973a4f8d'/>
-    </function-decl>
     <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>
       <parameter type-id='3cad23cd'/>
@@ -1185,9 +1153,8 @@
       <parameter type-id='822cd80b'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='strerror_l' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='strerror' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
-      <parameter type-id='973a4f8d'/>
       <return type-id='26a90f95'/>
     </function-decl>
     <function-decl name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -631,7 +631,7 @@
     <elf-symbol name='sa_protocol_names' size='16' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='spa_feature_table' size='2464' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfeature_checks_disable' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='zfs_deleg_perm_tab' size='512' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_deleg_perm_tab' size='528' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_history_event_names' size='328' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_max_dataset_nesting' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_userquota_prop_prefixes' size='96' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1170,6 +1170,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='stack_t' type-id='380f9954' id='ac5e685f'/>
+    <typedef-decl name='unw_regnum_t' type-id='95e97e5e' id='c53620f0'/>
     <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='384a1f22'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='opaque' type-id='dc70ec0b' visibility='default'/>
@@ -1275,6 +1276,10 @@
     <pointer-type-def type-id='1203d35c' size-in-bits='64' id='3946e4d1'/>
     <pointer-type-def type-id='190d09ef' size-in-bits='64' id='3e0601f0'/>
     <pointer-type-def type-id='73d941c6' size-in-bits='64' id='42f5faab'/>
+    <function-decl name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='c53620f0'/>
+      <return type-id='80f4b756'/>
+    </function-decl>
     <function-decl name='_ULx86_64_init_local' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='3946e4d1'/>
       <parameter type-id='2e408b96'/>
@@ -2476,6 +2481,13 @@
       <parameter type-id='eaa32e2f'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='zfs_iter_filesystems_v2' mangled-name='zfs_iter_filesystems_v2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems_v2'>
+      <parameter type-id='9200a744'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='d8e49ab9'/>
+      <parameter type-id='eaa32e2f'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='zfs_iter_mounted' mangled-name='zfs_iter_mounted' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_mounted'>
       <parameter type-id='9200a744'/>
       <parameter type-id='d8e49ab9'/>
@@ -2692,7 +2704,7 @@
         <var-decl name='drr_toname' type-id='d1617432' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='3216f820'>
+    <class-decl name='zinject_record' size-in-bits='2944' is-struct='yes' visibility='default' id='3216f820'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zi_objset' type-id='9c313c2d' visibility='default'/>
       </data-member>
@@ -2744,6 +2756,12 @@
       <data-member access='public' layout-offset-in-bits='2784'>
         <var-decl name='zi_dvas' type-id='8f92235e' visibility='default'/>
       </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='zi_match_count' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2880'>
+        <var-decl name='zi_inject_count' type-id='9c313c2d' visibility='default'/>
+      </data-member>
     </class-decl>
     <typedef-decl name='zinject_record_t' type-id='3216f820' id='a4301ca6'/>
     <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='feb6f2da'>
@@ -2761,7 +2779,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='zfs_share_t' type-id='feb6f2da' id='ee5cec36'/>
-    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='3522cd69'>
+    <class-decl name='zfs_cmd' size-in-bits='110080' is-struct='yes' visibility='default' id='3522cd69'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zc_name' type-id='d16c6df4' visibility='default'/>
       </data-member>
@@ -2834,37 +2852,37 @@
       <data-member access='public' layout-offset-in-bits='106368'>
         <var-decl name='zc_inject_record' type-id='a4301ca6' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109184'>
+      <data-member access='public' layout-offset-in-bits='109312'>
         <var-decl name='zc_defer_destroy' type-id='8f92235e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109216'>
+      <data-member access='public' layout-offset-in-bits='109344'>
         <var-decl name='zc_flags' type-id='8f92235e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109248'>
+      <data-member access='public' layout-offset-in-bits='109376'>
         <var-decl name='zc_action_handle' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109312'>
+      <data-member access='public' layout-offset-in-bits='109440'>
         <var-decl name='zc_cleanup_fd' type-id='95e97e5e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109344'>
+      <data-member access='public' layout-offset-in-bits='109472'>
         <var-decl name='zc_simple' type-id='b96825af' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109352'>
+      <data-member access='public' layout-offset-in-bits='109480'>
         <var-decl name='zc_pad' type-id='d3490169' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109376'>
+      <data-member access='public' layout-offset-in-bits='109504'>
         <var-decl name='zc_sendobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109440'>
+      <data-member access='public' layout-offset-in-bits='109568'>
         <var-decl name='zc_fromobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109504'>
+      <data-member access='public' layout-offset-in-bits='109632'>
         <var-decl name='zc_createtxg' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109568'>
+      <data-member access='public' layout-offset-in-bits='109696'>
         <var-decl name='zc_stat' type-id='0371a9c7' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109888'>
+      <data-member access='public' layout-offset-in-bits='110016'>
         <var-decl name='zc_zoneid' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
@@ -3063,9 +3081,6 @@
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libzfs/libzfs_crypto.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='38b51b3c' size-in-bits='832' id='02b72c00'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
-    </array-type-def>
     <array-type-def dimensions='1' type-id='fb7c6451' size-in-bits='256' id='64177143'>
       <subrange length='32' type-id='7359adad' id='ae5bde82'/>
     </array-type-def>
@@ -3078,10 +3093,6 @@
     <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
     <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
     <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
-    <array-type-def dimensions='1' type-id='80f4b756' size-in-bits='832' id='39e6f84a'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
-    </array-type-def>
     <array-type-def dimensions='1' type-id='95e97e5e' size-in-bits='896' id='47394ee0'>
       <subrange length='28' type-id='7359adad' id='3db583d7'/>
     </array-type-def>
@@ -3206,24 +3217,6 @@
     <typedef-decl name='__clock_t' type-id='bd54fe1a' id='4d66c6d7'/>
     <typedef-decl name='__ssize_t' type-id='bd54fe1a' id='41060289'/>
     <typedef-decl name='FILE' type-id='ec1ed955' id='aa12d1ba'/>
-    <class-decl name='__locale_struct' size-in-bits='1856' is-struct='yes' visibility='default' id='90cc1ce3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__locales' type-id='02b72c00' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='__ctype_b' type-id='31347b7a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='__ctype_tolower' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__ctype_toupper' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='__names' type-id='39e6f84a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__locale_t' type-id='f01e1813' id='b7ac9b5f'/>
     <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='b9c97942' visibility='default' id='2616147f'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='__val' type-id='d2baa450' visibility='default'/>
@@ -3239,7 +3232,6 @@
       </data-member>
     </union-decl>
     <typedef-decl name='__sigval_t' type-id='a094b870' id='eabacd01'/>
-    <typedef-decl name='locale_t' type-id='b7ac9b5f' id='973a4f8d'/>
     <class-decl name='siginfo_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='cb681f62' visibility='default' id='d8149419'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_signo' type-id='95e97e5e' visibility='default'/>
@@ -3475,13 +3467,9 @@
     <pointer-type-def type-id='bb4788fa' size-in-bits='64' id='cecf4ea7'/>
     <pointer-type-def type-id='010ae0b9' size-in-bits='64' id='e4c6fa61'/>
     <pointer-type-def type-id='79bd3751' size-in-bits='64' id='c65a1f29'/>
-    <pointer-type-def type-id='23de8b96' size-in-bits='64' id='38b51b3c'/>
-    <pointer-type-def type-id='90cc1ce3' size-in-bits='64' id='f01e1813'/>
     <qualified-type-def type-id='9b23c9ad' restrict='yes' id='8c85230f'/>
     <qualified-type-def type-id='80f4b756' restrict='yes' id='9d26089a'/>
     <pointer-type-def type-id='80f4b756' size-in-bits='64' id='7d3cd834'/>
-    <qualified-type-def type-id='95e97e5e' const='yes' id='2448a865'/>
-    <pointer-type-def type-id='2448a865' size-in-bits='64' id='6d60f45d'/>
     <qualified-type-def type-id='aca3bac8' const='yes' id='2498fd78'/>
     <pointer-type-def type-id='2498fd78' size-in-bits='64' id='eed6c816'/>
     <qualified-type-def type-id='eed6c816' restrict='yes' id='a431a9da'/>
@@ -3495,6 +3483,7 @@
     <qualified-type-def type-id='8efea9e5' const='yes' id='3beb2af4'/>
     <pointer-type-def type-id='3beb2af4' size-in-bits='64' id='31347b7a'/>
     <pointer-type-def type-id='31347b7a' size-in-bits='64' id='c59e1ef0'/>
+    <pointer-type-def type-id='7a6844eb' size-in-bits='64' id='18c91f9e'/>
     <pointer-type-def type-id='1b941664' size-in-bits='64' id='7e2979d5'/>
     <qualified-type-def type-id='7e2979d5' restrict='yes' id='fc212857'/>
     <pointer-type-def type-id='fe391c48' size-in-bits='64' id='568dd84e'/>
@@ -3514,7 +3503,6 @@
     <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
     <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
     <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
     <function-decl name='zpool_get_prop_int' mangled-name='zpool_get_prop_int' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_prop_int'>
       <parameter type-id='4c81de99'/>
       <parameter type-id='5d0c23fb'/>
@@ -3539,13 +3527,6 @@
     <function-decl name='zfs_prop_to_name' mangled-name='zfs_prop_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_to_name'>
       <parameter type-id='58603c44'/>
       <return type-id='80f4b756'/>
-    </function-decl>
-    <function-decl name='zfs_iter_filesystems_v2' mangled-name='zfs_iter_filesystems_v2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_filesystems_v2'>
-      <parameter type-id='9200a744'/>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='d8e49ab9'/>
-      <parameter type-id='eaa32e2f'/>
-      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_parent_name' mangled-name='zfs_parent_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_parent_name'>
       <parameter type-id='9200a744'/>
@@ -3619,10 +3600,6 @@
     <function-decl name='dlerror' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='26a90f95'/>
     </function-decl>
-    <function-decl name='uselocale' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='973a4f8d'/>
-      <return type-id='973a4f8d'/>
-    </function-decl>
     <function-decl name='PKCS5_PBKDF2_HMAC_SHA1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='80f4b756'/>
       <parameter type-id='95e97e5e'/>
@@ -3631,6 +3608,14 @@
       <parameter type-id='95e97e5e'/>
       <parameter type-id='95e97e5e'/>
       <parameter type-id='cf536864'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_lock' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='18c91f9e'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='pthread_mutex_unlock' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='18c91f9e'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='regexec' visibility='default' binding='global' size-in-bits='64'>
@@ -3706,9 +3691,8 @@
       <parameter type-id='80f4b756'/>
       <return type-id='26a90f95'/>
     </function-decl>
-    <function-decl name='strerror_l' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='strerror' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
-      <parameter type-id='973a4f8d'/>
       <return type-id='26a90f95'/>
     </function-decl>
     <function-decl name='tcgetattr' visibility='default' binding='global' size-in-bits='64'>
@@ -4078,7 +4062,6 @@
     <pointer-type-def type-id='a195f4a3' size-in-bits='64' id='e80ff3ab'/>
     <qualified-type-def type-id='e80ff3ab' restrict='yes' id='8f2c7109'/>
     <pointer-type-def type-id='eae6431d' size-in-bits='64' id='0d41d328'/>
-    <pointer-type-def type-id='7a6844eb' size-in-bits='64' id='18c91f9e'/>
     <pointer-type-def type-id='dddf6ca2' size-in-bits='64' id='d915a820'/>
     <qualified-type-def type-id='d915a820' restrict='yes' id='f099ad08'/>
     <pointer-type-def type-id='5d6479ae' size-in-bits='64' id='892b4acc'/>
@@ -4528,14 +4511,6 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='pthread_mutex_destroy' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='18c91f9e'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_lock' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='18c91f9e'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='pthread_mutex_unlock' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='18c91f9e'/>
       <return type-id='95e97e5e'/>
     </function-decl>
@@ -8368,6 +8343,11 @@
       <parameter type-id='95e97e5e'/>
       <return type-id='48b5725f'/>
     </function-decl>
+    <function-decl name='setpgid' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='3629bad8'/>
+      <parameter type-id='3629bad8'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='fork' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='3629bad8'/>
     </function-decl>
@@ -9532,8 +9512,8 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='module/zcommon/zfs_deleg.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='fa1870fd' size-in-bits='4096' id='59e94aca'>
-      <subrange length='32' type-id='7359adad' id='ae5bde82'/>
+    <array-type-def dimensions='1' type-id='fa1870fd' size-in-bits='4224' id='55e705e7'>
+      <subrange length='33' type-id='7359adad' id='6a5934df'/>
     </array-type-def>
     <array-type-def dimensions='1' type-id='fa1870fd' size-in-bits='infinite' id='7c00e69d'>
       <subrange length='infinite' id='031f2035'/>

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -651,6 +651,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='stack_t' type-id='380f9954' id='ac5e685f'/>
+    <typedef-decl name='unw_regnum_t' type-id='95e97e5e' id='c53620f0'/>
     <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='384a1f22'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='opaque' type-id='dc70ec0b' visibility='default'/>
@@ -761,6 +762,10 @@
       <parameter type-id='eaa32e2f'/>
       <parameter type-id='b59d7dce'/>
       <return type-id='79a0948f'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='c53620f0'/>
+      <return type-id='80f4b756'/>
     </function-decl>
     <function-decl name='_ULx86_64_init_local' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='3946e4d1'/>
@@ -982,13 +987,6 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libspl/os/linux/getmntany.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='38b51b3c' size-in-bits='832' id='02b72c00'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
-    </array-type-def>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
-    <array-type-def dimensions='1' type-id='80f4b756' size-in-bits='832' id='39e6f84a'>
-      <subrange length='13' type-id='7359adad' id='487fded1'/>
-    </array-type-def>
     <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -1092,42 +1090,12 @@
     </class-decl>
     <typedef-decl name='__ino64_t' type-id='7359adad' id='71288a47'/>
     <typedef-decl name='__blkcnt64_t' type-id='bd54fe1a' id='4e711bf1'/>
-    <class-decl name='__locale_struct' size-in-bits='1856' is-struct='yes' visibility='default' id='90cc1ce3'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__locales' type-id='02b72c00' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='__ctype_b' type-id='31347b7a' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='__ctype_tolower' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__ctype_toupper' type-id='6d60f45d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='__names' type-id='39e6f84a' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__locale_t' type-id='f01e1813' id='b7ac9b5f'/>
-    <typedef-decl name='locale_t' type-id='b7ac9b5f' id='973a4f8d'/>
-    <pointer-type-def type-id='23de8b96' size-in-bits='64' id='38b51b3c'/>
-    <pointer-type-def type-id='90cc1ce3' size-in-bits='64' id='f01e1813'/>
-    <qualified-type-def type-id='95e97e5e' const='yes' id='2448a865'/>
-    <pointer-type-def type-id='2448a865' size-in-bits='64' id='6d60f45d'/>
-    <qualified-type-def type-id='8efea9e5' const='yes' id='3beb2af4'/>
-    <pointer-type-def type-id='3beb2af4' size-in-bits='64' id='31347b7a'/>
     <pointer-type-def type-id='0c544dc0' size-in-bits='64' id='394fc496'/>
     <pointer-type-def type-id='56fe4a37' size-in-bits='64' id='b6b61d2f'/>
     <qualified-type-def type-id='b6b61d2f' restrict='yes' id='3cad23cd'/>
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
     <qualified-type-def type-id='62f7a03d' restrict='yes' id='f1cadedf'/>
-    <class-decl name='__locale_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='23de8b96'/>
-    <function-decl name='uselocale' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='973a4f8d'/>
-      <return type-id='973a4f8d'/>
-    </function-decl>
     <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>
       <parameter type-id='3cad23cd'/>
@@ -1144,9 +1112,8 @@
       <parameter type-id='80f4b756'/>
       <return type-id='95e97e5e'/>
     </function-decl>
-    <function-decl name='strerror_l' visibility='default' binding='global' size-in-bits='64'>
+    <function-decl name='strerror' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
-      <parameter type-id='973a4f8d'/>
       <return type-id='26a90f95'/>
     </function-decl>
     <function-decl name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>
@@ -2111,7 +2078,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='dmu_replay_record_t' type-id='781a52d7' id='8b8fc893'/>
-    <class-decl name='zinject_record' size-in-bits='2816' is-struct='yes' visibility='default' id='3216f820'>
+    <class-decl name='zinject_record' size-in-bits='2944' is-struct='yes' visibility='default' id='3216f820'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zi_objset' type-id='9c313c2d' visibility='default'/>
       </data-member>
@@ -2163,6 +2130,12 @@
       <data-member access='public' layout-offset-in-bits='2784'>
         <var-decl name='zi_dvas' type-id='8f92235e' visibility='default'/>
       </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='zi_match_count' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2880'>
+        <var-decl name='zi_inject_count' type-id='9c313c2d' visibility='default'/>
+      </data-member>
     </class-decl>
     <typedef-decl name='zinject_record_t' type-id='3216f820' id='a4301ca6'/>
     <class-decl name='zfs_share' size-in-bits='256' is-struct='yes' visibility='default' id='feb6f2da'>
@@ -2180,7 +2153,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='zfs_share_t' type-id='feb6f2da' id='ee5cec36'/>
-    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='3522cd69'>
+    <class-decl name='zfs_cmd' size-in-bits='110080' is-struct='yes' visibility='default' id='3522cd69'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zc_name' type-id='d16c6df4' visibility='default'/>
       </data-member>
@@ -2253,37 +2226,37 @@
       <data-member access='public' layout-offset-in-bits='106368'>
         <var-decl name='zc_inject_record' type-id='a4301ca6' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109184'>
+      <data-member access='public' layout-offset-in-bits='109312'>
         <var-decl name='zc_defer_destroy' type-id='8f92235e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109216'>
+      <data-member access='public' layout-offset-in-bits='109344'>
         <var-decl name='zc_flags' type-id='8f92235e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109248'>
+      <data-member access='public' layout-offset-in-bits='109376'>
         <var-decl name='zc_action_handle' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109312'>
+      <data-member access='public' layout-offset-in-bits='109440'>
         <var-decl name='zc_cleanup_fd' type-id='95e97e5e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109344'>
+      <data-member access='public' layout-offset-in-bits='109472'>
         <var-decl name='zc_simple' type-id='b96825af' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109352'>
+      <data-member access='public' layout-offset-in-bits='109480'>
         <var-decl name='zc_pad' type-id='d3490169' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109376'>
+      <data-member access='public' layout-offset-in-bits='109504'>
         <var-decl name='zc_sendobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109440'>
+      <data-member access='public' layout-offset-in-bits='109568'>
         <var-decl name='zc_fromobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109504'>
+      <data-member access='public' layout-offset-in-bits='109632'>
         <var-decl name='zc_createtxg' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109568'>
+      <data-member access='public' layout-offset-in-bits='109696'>
         <var-decl name='zc_stat' type-id='0371a9c7' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109888'>
+      <data-member access='public' layout-offset-in-bits='110016'>
         <var-decl name='zc_zoneid' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>

--- a/lib/libzfsbootenv/libzfsbootenv.abi
+++ b/lib/libzfsbootenv/libzfsbootenv.abi
@@ -1,6 +1,6 @@
 <abi-corpus version='2.0' architecture='elf-amd-x86_64' soname='libzfsbootenv.so.1'>
   <elf-needed>
-    <dependency name='libzfs.so.4'/>
+    <dependency name='libzfs.so.6'/>
     <dependency name='libnvpair.so.3'/>
     <dependency name='libc.so.6'/>
   </elf-needed>

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -178,6 +178,7 @@ nodist_libzpool_la_SOURCES = \
 	module/zfs/zfeature.c \
 	module/zfs/zfs_byteswap.c \
 	module/zfs/zfs_chksum.c \
+	module/zfs/zfs_debug_common.c \
 	module/zfs/zfs_fm.c \
 	module/zfs/zfs_fuid.c \
 	module/zfs/zfs_ratelimit.c \

--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -413,6 +413,7 @@ ZFS_OBJS := \
 	zfeature.o \
 	zfs_byteswap.o \
 	zfs_chksum.o \
+	zfs_debug_common.o \
 	zfs_fm.o \
 	zfs_fuid.o \
 	zfs_impl.o \

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -3681,6 +3681,240 @@ nvs_xdr(nvstream_t *nvs, nvlist_t *nvl, char *buf, size_t *buflen)
 	return (err);
 }
 
+#define	NVP(buf, size, len, buf_end, elem, type, vtype, ptype, format) { \
+	vtype	value; \
+	int rc; \
+\
+	(void) nvpair_value_##type(elem, &value); \
+	rc = snprintf(buf, size, "%*s%s: " format "\n", indent, "", \
+	nvpair_name(elem), (ptype)value); \
+	if (rc < 0) \
+		return (rc); \
+	size = MAX((int)size - rc, 0); \
+	buf = size == 0 ? NULL : buf_end - size; \
+	len += rc; \
+}
+
+#define	NVPA(buf, size, len, buf_end, elem, type, vtype, ptype, format) \
+{ \
+	uint_t	i, count; \
+	vtype	*value;  \
+	int rc; \
+\
+	(void) nvpair_value_##type(elem, &value, &count); \
+	for (i = 0; i < count; i++) { \
+		rc = snprintf(buf, size, "%*s%s[%d]: " format "\n", indent, \
+		"", nvpair_name(elem), i, (ptype)value[i]); \
+		if (rc < 0) \
+			return (rc); \
+		size = MAX((int)size - rc, 0); \
+		buf = size == 0 ? NULL : buf_end - size; \
+		len += rc; \
+	} \
+}
+
+/*
+ * snprintf() version of dump_nvlist()
+ *
+ * Works just like snprintf(), but with an nvlist and indent count as args.
+ *
+ * Output is similar to nvlist_print() but handles arrays slightly differently.
+ *
+ * Return value matches C99 snprintf() return value conventions.
+ */
+int
+nvlist_snprintf(char *buf, size_t size, nvlist_t *list, int indent)
+{
+	nvpair_t	*elem = NULL;
+	boolean_t	bool_value;
+	nvlist_t	*nvlist_value;
+	nvlist_t	**nvlist_array_value;
+	uint_t		i, count;
+	int len = 0;
+	int rc;
+	char *buf_end = &buf[size];
+
+	if (list == NULL)
+		return (0);
+
+	while ((elem = nvlist_next_nvpair(list, elem)) != NULL) {
+		switch (nvpair_type(elem)) {
+		case DATA_TYPE_BOOLEAN:
+			rc = snprintf(buf, size, "%*s%s\n", indent, "",
+			    nvpair_name(elem));
+			if (rc < 0)
+				return (rc);
+			size = MAX((int)size - rc, 0);
+			buf = size == 0 ? NULL : buf_end - size;
+			len += rc;
+			break;
+
+		case DATA_TYPE_BOOLEAN_VALUE:
+			(void) nvpair_value_boolean_value(elem, &bool_value);
+			rc = snprintf(buf, size, "%*s%s: %s\n", indent, "",
+			    nvpair_name(elem), bool_value ? "true" : "false");
+			if (rc < 0)
+				return (rc);
+			size = MAX((int)size - rc, 0);
+			buf = size == 0 ? NULL : buf_end - size;
+			len += rc;
+			break;
+
+		case DATA_TYPE_BYTE:
+			NVP(buf, size, len, buf_end, elem, byte, uchar_t, int,
+			    "%u");
+			break;
+
+		case DATA_TYPE_INT8:
+			NVP(buf, size, len, buf_end, elem, int8, int8_t, int,
+			    "%d");
+			break;
+
+		case DATA_TYPE_UINT8:
+			NVP(buf, size, len, buf_end, elem, uint8, uint8_t, int,
+			    "%u");
+			break;
+
+		case DATA_TYPE_INT16:
+			NVP(buf, size, len, buf_end, elem, int16, int16_t, int,
+			    "%d");
+			break;
+
+		case DATA_TYPE_UINT16:
+			NVP(buf, size, len, buf_end, elem, uint16, uint16_t,
+			    int, "%u");
+			break;
+
+		case DATA_TYPE_INT32:
+			NVP(buf, size, len, buf_end, elem, int32, int32_t,
+			    long, "%ld");
+			break;
+
+		case DATA_TYPE_UINT32:
+			NVP(buf, size, len, buf_end, elem, uint32, uint32_t,
+			    ulong_t, "%lu");
+			break;
+
+		case DATA_TYPE_INT64:
+			NVP(buf, size, len, buf_end, elem, int64, int64_t,
+			    longlong_t, "%lld");
+			break;
+
+		case DATA_TYPE_UINT64:
+			NVP(buf, size, len, buf_end, elem, uint64, uint64_t,
+			    u_longlong_t, "%llu");
+			break;
+
+		case DATA_TYPE_STRING:
+			NVP(buf, size, len, buf_end, elem, string, const char *,
+			    const char *, "'%s'");
+			break;
+
+		case DATA_TYPE_BYTE_ARRAY:
+			NVPA(buf, size, len, buf_end, elem, byte_array, uchar_t,
+			    int, "%u");
+			break;
+
+		case DATA_TYPE_INT8_ARRAY:
+			NVPA(buf, size, len, buf_end, elem, int8_array, int8_t,
+			    int, "%d");
+			break;
+
+		case DATA_TYPE_UINT8_ARRAY:
+			NVPA(buf, size, len, buf_end, elem, uint8_array,
+			    uint8_t, int, "%u");
+			break;
+
+		case DATA_TYPE_INT16_ARRAY:
+			NVPA(buf, size, len, buf_end, elem, int16_array,
+			    int16_t, int, "%d");
+			break;
+
+		case DATA_TYPE_UINT16_ARRAY:
+			NVPA(buf, size, len, buf_end, elem, uint16_array,
+			    uint16_t, int, "%u");
+			break;
+
+		case DATA_TYPE_INT32_ARRAY:
+			NVPA(buf, size, len, buf_end, elem, int32_array,
+			    int32_t, long, "%ld");
+			break;
+
+		case DATA_TYPE_UINT32_ARRAY:
+			NVPA(buf, size, len, buf_end, elem, uint32_array,
+			    uint32_t, ulong_t, "%lu");
+			break;
+
+		case DATA_TYPE_INT64_ARRAY:
+			NVPA(buf, size, len, buf_end, elem, int64_array,
+			    int64_t, longlong_t, "%lld");
+			break;
+
+		case DATA_TYPE_UINT64_ARRAY:
+			NVPA(buf, size, len, buf_end, elem, uint64_array,
+			    uint64_t, u_longlong_t, "%llu");
+			break;
+
+		case DATA_TYPE_STRING_ARRAY:
+			NVPA(buf, size, len, buf_end, elem, string_array,
+			    const char *, const char *, "'%s'");
+			break;
+
+		case DATA_TYPE_NVLIST:
+			(void) nvpair_value_nvlist(elem, &nvlist_value);
+
+			rc = snprintf(buf, size, "%*s%s:\n", indent, "",
+			    nvpair_name(elem));
+			if (rc < 0)
+				return (rc);
+			size = MAX((int)size - rc, 0);
+			buf = size == 0 ? NULL : buf_end - size;
+			len += rc;
+
+			rc = nvlist_snprintf(buf, size, nvlist_value,
+			    indent + 4);
+			if (rc < 0)
+				return (rc);
+			size = MAX((int)size - rc, 0);
+			buf = size == 0 ? NULL : buf_end - size;
+			len += rc;
+			break;
+
+		case DATA_TYPE_NVLIST_ARRAY:
+			(void) nvpair_value_nvlist_array(elem,
+			    &nvlist_array_value, &count);
+			for (i = 0; i < count; i++) {
+				rc = snprintf(buf, size, "%*s%s[%u]:\n",
+				    indent, "", nvpair_name(elem), i);
+				if (rc < 0)
+					return (rc);
+				size = MAX((int)size - rc, 0);
+				buf = size == 0 ? NULL : buf_end - size;
+				len += rc;
+
+				rc = nvlist_snprintf(buf, size,
+				    nvlist_array_value[i], indent + 4);
+				if (rc < 0)
+					return (rc);
+				size = MAX((int)size - rc, 0);
+				buf = size == 0 ? NULL : buf_end - size;
+				len += rc;
+			}
+			break;
+
+		default:
+			rc = snprintf(buf, size, "bad config type %d for %s\n",
+			    nvpair_type(elem), nvpair_name(elem));
+			if (rc < 0)
+				return (rc);
+			size = MAX((int)size - rc, 0);
+			buf = size == 0 ? NULL : buf_end - size;
+			len += rc;
+		}
+	}
+	return (len);
+}
+
 EXPORT_SYMBOL(nv_alloc_init);
 EXPORT_SYMBOL(nv_alloc_reset);
 EXPORT_SYMBOL(nv_alloc_fini);
@@ -3765,6 +3999,8 @@ EXPORT_SYMBOL(nvlist_lookup_pairs);
 
 EXPORT_SYMBOL(nvlist_lookup_nvpair);
 EXPORT_SYMBOL(nvlist_exists);
+
+EXPORT_SYMBOL(nvlist_snprintf);
 
 /* processing nvpair */
 EXPORT_SYMBOL(nvpair_name);

--- a/module/zfs/zfs_debug_common.c
+++ b/module/zfs/zfs_debug_common.c
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2025 by Lawrence Livermore National Security, LLC.
+ */
+/*
+ * This file contains zfs_dbgmsg() specific functions that are not OS or
+ * userspace specific.
+ */
+#if !defined(_KERNEL)
+#include <string.h>
+#endif
+
+#include <sys/zfs_context.h>
+#include <sys/zfs_debug.h>
+#include <sys/nvpair.h>
+
+/*
+ * Given a multi-line string, print out one of the lines and return a pointer
+ * to the next line. Lines are demarcated by '\n'.  Note: this modifies the
+ * input string (buf[]).
+ *
+ * This function is meant to be used in a loop like:
+ * 	while (buf != NULL)
+ * 		buf = kernel_print_one_line(buf);
+ *
+ * This function is useful for printing large, multi-line text buffers.
+ *
+ * Returns the pointer to the beginning of the next line in buf[], or NULL
+ * if it's the last line, or nothing more to print.
+ */
+static char *
+zfs_dbgmsg_one_line(char *buf)
+{
+	char *nl;
+	if (!buf)
+		return (NULL);
+
+	nl = strchr(buf, '\n');
+	if (nl == NULL) {
+		__zfs_dbgmsg(buf);
+		return (NULL); /* done */
+	}
+	*nl = '\0';
+	__zfs_dbgmsg(buf);
+
+	return (nl + 1);
+}
+
+/*
+ * Dump an nvlist tree to dbgmsg.
+ *
+ * This is the zfs_dbgmsg version of userspace's dump_nvlist() from libnvpair.
+ */
+void
+__zfs_dbgmsg_nvlist(nvlist_t *nv)
+{
+	int len;
+	char *buf;
+
+	len = nvlist_snprintf(NULL, 0, nv, 4);
+	len++; /* Add null terminator */
+
+	buf = vmem_alloc(len, KM_SLEEP);
+	if (buf == NULL)
+		return;
+
+	(void) nvlist_snprintf(buf, len, nv, 4);
+
+	while (buf != NULL)
+		buf = zfs_dbgmsg_one_line(buf);
+
+	vmem_free(buf, len);
+}
+
+#ifdef _KERNEL
+EXPORT_SYMBOL(__zfs_dbgmsg_nvlist);
+#endif


### PR DESCRIPTION
### Motivation and Context
Over the years I've wanted an easy way to print an nvlist in kernel space.

### Description
Add `nvlist_snprintf()` to print a nvlist to a buffer.  This is basically the `snprintf()` version of `dump_nvlist()`.  Along with that, add a `zfs_dbgmsg_nvlist()` to print out an nvlist to dbgmsg.  This will aid in debugging.

### How Has This Been Tested?
Manually tested

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
