### PR TITLE
vdev_to_nvlist_iter: ignore draid parameters when matching names

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2962,6 +2962,18 @@ vdev_to_nvlist_iter(nvlist_t *nv, nvlist_t *search, boolean_t *avail_spare,
 			*p = '\0';
 
 			/*
+			 * draid names are presented like: draid2:4d:6c:0s
+			 * We match them up to the first ':' so we can still
+			 * do the parity check below, but the other params
+			 * are ignored.
+			 */
+			if ((p = strchr(type, ':')) != NULL) {
+				if (strncmp(type, VDEV_TYPE_DRAID,
+				    strlen(VDEV_TYPE_DRAID)) == 0)
+					*p = '\0';
+			}
+
+			/*
 			 * If the types don't match then keep looking.
 			 */
 			if (strncmp(val, type, strlen(val)) != 0) {

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -444,7 +444,8 @@ tags = ['functional', 'cli_root', 'zpool_export']
 
 [tests/functional/cli_root/zpool_get]
 tests = ['zpool_get_001_pos', 'zpool_get_002_pos', 'zpool_get_003_pos',
-    'zpool_get_004_neg', 'zpool_get_005_pos', 'vdev_get_001_pos']
+    'zpool_get_004_neg', 'zpool_get_005_pos', 'vdev_get_001_pos',
+    'vdev_get_all']
 tags = ['functional', 'cli_root', 'zpool_get']
 
 [tests/functional/cli_root/zpool_history]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1103,6 +1103,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_get/cleanup.ksh \
 	functional/cli_root/zpool_get/setup.ksh \
 	functional/cli_root/zpool_get/vdev_get_001_pos.ksh \
+	functional/cli_root/zpool_get/vdev_get_all.ksh \
 	functional/cli_root/zpool_get/zpool_get_001_pos.ksh \
 	functional/cli_root/zpool_get/zpool_get_002_pos.ksh \
 	functional/cli_root/zpool_get/zpool_get_003_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/vdev_get_all.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/vdev_get_all.ksh
@@ -1,0 +1,92 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, Klara, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+#   zpool get name <pool> all-vdevs works as expected
+#
+# STRATEGY:
+#
+#   1. create various kinds of pools
+#   2. get all vdev names
+#   3. make sure we get all the names back and they look correct
+#
+
+verify_runnable "global"
+
+function cleanup {
+	zpool destroy -f $TESTPOOL1
+	[[ -e $TESTDIR ]] && rm -rf $TESTDIR/*
+}
+log_onexit cleanup
+
+log_assert "zpool get all-vdevs works as expected"
+
+# map of vdev spec -> summary form
+#
+# left side is normal args to zpool create; single number will be replaced
+# with that number test file
+#
+# right side is a summary of the vdev tree, one char per vdev
+#   !   root
+#   0-9 file number
+#   m   mirror
+#   r   raidz
+#   d   draid
+typeset -A specs=(
+    ["{0..9}"]="!0123456789"
+    ["mirror {0..9}"]="!m0123456789"
+    ["mirror 0 1 mirror 2 3 mirror 4 5 mirror 6 7"]="!m01m23m45m67"
+    ["raidz1 {0..9}"]="!r0123456789"
+    ["raidz1 {0..4} raidz1 {5..9}"]="!r01234r56789"
+    ["raidz2 {0..9}"]="!r0123456789"
+    ["raidz2 {0..4} raidz2 {5..9}"]="!r01234r56789"
+    ["raidz3 {0..9}"]="!r0123456789"
+    ["raidz3 {0..4} raidz3 {5..9}"]="!r01234r56789"
+    ["draid1 {0..9}"]="!d0123456789"
+    ["draid2 {0..9}"]="!d0123456789"
+    ["draid3 {0..9}"]="!d0123456789"
+)
+
+for spec in "${!specs[@]}" ; do
+	log_must truncate -s 100M $TESTDIR/$TESTFILE1.{0..9}
+	log_must zpool create -f $TESTPOOL1 \
+	    $(echo $spec | sed -E "s#(^| )([0-9])#\1$TESTDIR/$TESTFILE1.\2#g")
+	typeset desc=$( zpool get -Ho name name $TESTPOOL1 all-vdevs | awk '
+	    /^\//    { t = t substr($1,length($1)) ; next }
+	    /^root/  { t = t "!" last ; next }
+	    /^[a-z]/ { t = t substr($1,0,1) last ; next }
+	    END { print t }
+	')
+	log_must test "${specs[$spec]}" == "$desc"
+	cleanup
+done
+
+log_pass


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

Various tools will display draid vdev names with parameters embedded in them, but would not accept them as valid vdev names when looking them up, making it difficult to build pipelines involving draid vdevs.

```
# zpool create testpool draid2 /var/tmp/testdir1/*
# zpool get name testpool all-vdevs
NAME      PROPERTY  VALUE     SOURCE
root-0    name      testpool  -
can not find draid2:8d:10c:0s-0 in testpool: no such device in pool
can not find draid2:8d:10c:0s-0 in testpool: no such device in pool
can not find draid2:8d:10c:0s-0 in testpool: no such device in pool
/var/tmp/testdir1/testfile.0  name      /var/tmp/testdir1/testfile.0  -
/var/tmp/testdir1/testfile.1  name      /var/tmp/testdir1/testfile.1  -
/var/tmp/testdir1/testfile.2  name      /var/tmp/testdir1/testfile.2  -
/var/tmp/testdir1/testfile.3  name      /var/tmp/testdir1/testfile.3  -
/var/tmp/testdir1/testfile.4  name      /var/tmp/testdir1/testfile.4  -
/var/tmp/testdir1/testfile.5  name      /var/tmp/testdir1/testfile.5  -
/var/tmp/testdir1/testfile.6  name      /var/tmp/testdir1/testfile.6  -
/var/tmp/testdir1/testfile.7  name      /var/tmp/testdir1/testfile.7  -
/var/tmp/testdir1/testfile.8  name      /var/tmp/testdir1/testfile.8  -
/var/tmp/testdir1/testfile.9  name      /var/tmp/testdir1/testfile.9  -
```

### Description

This commit updates `vdev_to_nvlist_iter()` so that when matching vdev types it will truncate vdev types starting with `draid` at the first ':', eg `draid2:8d:10c:0s` becomes simply `draid2`.

### How Has This Been Tested?

New test is included, that exercises `zpool get name <pool> all-vdevs` to make sure it produces a row for each vdev with a plausible value. That's not a test of the matcher exactly, but is the place I found a bug, and it seems useful to at least make sure that `all-vdevs` produces something for every vdev.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
