### PR TITLE
config: fix ZFS_LINUX_TEST_RESULT_SYMBOL with --enable-linux-builtin

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -899,7 +899,7 @@ AC_DEFUN([ZFS_LINUX_TEST_RESULT_SYMBOL], [
 					eval "$cachevar=no"
 				])
 			], [
-				eval "$cacheval=yes"
+				eval "$cachevar=yes"
 			])
 		])
 	])


### PR DESCRIPTION
### Motivation and Context

#17106 broke compiling with `--enable-linux-builtin`.

Fixes #17212.

### Description

A typo in `ZFS_LINUX_TEST_RESULT_SYMBOL` made it always return "no" when setting up for an in-kernel build, so configure ended up failing in.

Just fix the typo, oosh.

### How Has This Been Tested?

Tested locally with all combinations of `--enable-linux-builtin` and `--config-cache`.

#17212 reports success also.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
