### PR TITLE
Fixed zfs_notify_email for programs like sendmail by including a separating empty line between email header and body

### DIFF
--- a/cmd/zed/zed.d/zed-functions.sh
+++ b/cmd/zed/zed.d/zed-functions.sh
@@ -283,6 +283,11 @@ zed_notify_email()
         if [ "${ZED_EMAIL_OPTS%@SUBJECT@*}" = "${ZED_EMAIL_OPTS}" ] ; then
             # inject subject header
             printf "Subject: %s\n" "${subject}"
+            # The following empty line is needed to separate the header from the
+            # body of the message. Otherwise programs like sendmail will skip
+            # everything up to the first empty line (or wont send an email at
+            # all) and will still exit with exit code 0
+            printf "\n"
         fi
         # output message
         cat "${pathname}"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
<!--- Provide a general summary of your changes in the Title above -->
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
There were missing first lines in emails send by `sendmail` or the email wasn't sent at all.
This happened with all programs that require the `Subject` field to be part of the message piped to stdin.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: #10123
Fixes: #16656

### Description
<!--- Describe your changes in detail -->
In the case that the `Subject:` field is part of the of the message piped to stdin of the email program, zed_notify_email will now output an additional (required) empty line between the message header (i.e. `Subject:...`) and the body.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Tested by running `zpool offline -f test <target>` which then sent an email (which was not the case before).
- Also ran `zpool scrub test` Which now includes the first line of the message which was missing before
<!--- Include details of your testing environment, and the tests you ran to -->
- Using `msmtp` as mail program
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

### Important Additional Notes
Currently the 'ZFS Test Suite' was not run since deemed not necessary for this fix; Will be performed if seen as required by the openzfs team!
The same goes for added a test to cover the changes.

If there is anything more needed please let me know and I will come back to this as soon as possible.
