### PR TITLE
Introduce zfs rewrite subcommand

### DIFF
--- a/contrib/debian/openzfs-zfsutils.install
+++ b/contrib/debian/openzfs-zfsutils.install
@@ -73,6 +73,7 @@ usr/share/man/man8/zfs-recv.8
 usr/share/man/man8/zfs-redact.8
 usr/share/man/man8/zfs-release.8
 usr/share/man/man8/zfs-rename.8
+usr/share/man/man8/zfs-rewrite.8
 usr/share/man/man8/zfs-rollback.8
 usr/share/man/man8/zfs-send.8
 usr/share/man/man8/zfs-set.8

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1620,6 +1620,15 @@ typedef enum zfs_ioc {
 
 #endif
 
+typedef struct zfs_rewrite_args {
+	uint64_t	off;
+	uint64_t	len;
+	uint64_t	flags;
+	uint64_t	arg;
+} zfs_rewrite_args_t;
+
+#define	ZFS_IOC_REWRITE		_IOW(0x83, 3, zfs_rewrite_args_t)
+
 /*
  * ZFS-specific error codes used for returning descriptive errors
  * to the userland through zfs ioctls.

--- a/include/sys/zfs_vnops.h
+++ b/include/sys/zfs_vnops.h
@@ -40,6 +40,7 @@ extern int zfs_clone_range(znode_t *, uint64_t *, znode_t *, uint64_t *,
     uint64_t *, cred_t *);
 extern int zfs_clone_range_replay(znode_t *, uint64_t, uint64_t, uint64_t,
     const blkptr_t *, size_t);
+extern int zfs_rewrite(znode_t *, uint64_t, uint64_t, uint64_t, uint64_t);
 
 extern int zfs_getsecattr(znode_t *, vsecattr_t *, int, cred_t *);
 extern int zfs_setsecattr(znode_t *, vsecattr_t *, int, cred_t *);

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -50,6 +50,7 @@ dist_man_MANS = \
 	%D%/man8/zfs-redact.8 \
 	%D%/man8/zfs-release.8 \
 	%D%/man8/zfs-rename.8 \
+	%D%/man8/zfs-rewrite.8 \
 	%D%/man8/zfs-rollback.8 \
 	%D%/man8/zfs-send.8 \
 	%D%/man8/zfs-set.8 \

--- a/man/man8/zfs-rewrite.8
+++ b/man/man8/zfs-rewrite.8
@@ -1,0 +1,76 @@
+.\" SPDX-License-Identifier: CDDL-1.0
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or https://opensource.org/licenses/CDDL-1.0.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\" Copyright (c) 2025 iXsystems, Inc.
+.\"
+.Dd May 6, 2025
+.Dt ZFS-REWRITE 8
+.Os
+.
+.Sh NAME
+.Nm zfs-rewrite
+.Nd rewrite specified files without modification
+.Sh SYNOPSIS
+.Nm zfs
+.Cm rewrite
+.Oo Fl rvx Ns Oc
+.Op Fl l Ar length
+.Op Fl o Ar offset
+.Ar file Ns | Ns Ar directory Ns …
+.
+.Sh DESCRIPTION
+Rewrite blocks of specified
+.Ar file
+as is without modification at a new location and possibly with new
+properties, such as checksum, compression, dedup, copies, etc,
+as if they were atomically read and written back.
+.Bl -tag -width "-r"
+.It Fl l Ar length
+Rewrite at most this number of bytes.
+.It Fl o Ar offset
+Start at this offset in bytes.
+.It Fl r
+Recurse into directories.
+.It Fl v
+Print names of all successfully rewritten files.
+.It Fl x
+Don't cross file system mount points when recursing.
+.El
+.Sh NOTES
+Rewrite of cloned blocks and blocks that are part of any snapshots,
+same as some property changes may increase pool space usage.
+Holes that were never written or were previously zero-compressed are
+not rewritten and will remain holes even if compression is disabled.
+.Pp
+Rewritten blocks will be seen as modified in next snapshot and as such
+included into the incremental
+.Nm zfs Cm send
+stream.
+.Pp
+If a
+.Fl l
+or
+.Fl o
+value request a rewrite to regions past the end of the file, then those
+regions are silently ignored, and no error is reported.
+.
+.Sh SEE ALSO
+.Xr zfsprops 7

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -37,7 +37,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd May 12, 2022
+.Dd April 18, 2025
 .Dt ZFS 8
 .Os
 .
@@ -297,6 +297,12 @@ removing the ability to access the dataset.
 .It Xr zfs-program 8
 Execute ZFS administrative operations
 programmatically via a Lua script-language channel program.
+.El
+.
+.Ss Data rewrite
+.Bl -tag -width ""
+.It Xr zfs-rewrite 8
+Rewrite specified files without modification.
 .El
 .
 .Ss Jails

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -305,6 +305,18 @@ zfs_ioctl(vnode_t *vp, ulong_t com, intptr_t data, int flag, cred_t *cred,
 		*(offset_t *)data = off;
 		return (0);
 	}
+	case ZFS_IOC_REWRITE: {
+		zfs_rewrite_args_t *args = (zfs_rewrite_args_t *)data;
+		if ((flag & FWRITE) == 0)
+			return (SET_ERROR(EBADF));
+		error = vn_lock(vp, LK_SHARED);
+		if (error)
+			return (error);
+		error = zfs_rewrite(VTOZ(vp), args->off, args->len,
+		    args->flags, args->arg);
+		VOP_UNLOCK(vp);
+		return (error);
+	}
 	}
 	return (SET_ERROR(ENOTTY));
 }

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1050,6 +1050,143 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 	return (0);
 }
 
+/*
+ * Rewrite a range of file as-is without modification.
+ *
+ *	IN:	zp	- znode of file to be rewritten.
+ *		off	- Offset of the range to rewrite.
+ *		len	- Length of the range to rewrite.
+ *		flags	- Random rewrite parameters.
+ *		arg	- flags-specific argument.
+ *
+ *	RETURN:	0 if success
+ *		error code if failure
+ */
+int
+zfs_rewrite(znode_t *zp, uint64_t off, uint64_t len, uint64_t flags,
+    uint64_t arg)
+{
+	int error;
+
+	if (flags != 0 || arg != 0)
+		return (SET_ERROR(EINVAL));
+
+	zfsvfs_t *zfsvfs = ZTOZSB(zp);
+	if ((error = zfs_enter_verify_zp(zfsvfs, zp, FTAG)) != 0)
+		return (error);
+
+	if (zfs_is_readonly(zfsvfs)) {
+		zfs_exit(zfsvfs, FTAG);
+		return (SET_ERROR(EROFS));
+	}
+
+	if (off >= zp->z_size) {
+		zfs_exit(zfsvfs, FTAG);
+		return (0);
+	}
+	if (len == 0 || len > zp->z_size - off)
+		len = zp->z_size - off;
+
+	/* Flush any mmap()'d data to disk */
+	if (zn_has_cached_data(zp, off, off + len - 1))
+		zn_flush_cached_data(zp, B_TRUE);
+
+	zfs_locked_range_t *lr;
+	lr = zfs_rangelock_enter(&zp->z_rangelock, off, len, RL_WRITER);
+
+	const uint64_t uid = KUID_TO_SUID(ZTOUID(zp));
+	const uint64_t gid = KGID_TO_SGID(ZTOGID(zp));
+	const uint64_t projid = zp->z_projid;
+
+	dmu_buf_impl_t *db = (dmu_buf_impl_t *)sa_get_db(zp->z_sa_hdl);
+	DB_DNODE_ENTER(db);
+	dnode_t *dn = DB_DNODE(db);
+
+	uint64_t n, noff = off, nr = 0, nw = 0;
+	while (len > 0) {
+		/*
+		 * Rewrite only actual data, skipping any holes.  This might
+		 * be inaccurate for dirty files, but we don't really care.
+		 */
+		if (noff == off) {
+			/* Find next data in the file. */
+			error = dnode_next_offset(dn, 0, &noff, 1, 1, 0);
+			if (error || noff >= off + len) {
+				if (error == ESRCH)	/* No more data. */
+					error = 0;
+				break;
+			}
+			ASSERT3U(noff, >=, off);
+			len -= noff - off;
+			off = noff;
+
+			/* Find where the data end. */
+			error = dnode_next_offset(dn, DNODE_FIND_HOLE, &noff,
+			    1, 1, 0);
+			if (error != 0)
+				noff = off + len;
+		}
+		ASSERT3U(noff, >, off);
+
+		if (zfs_id_overblockquota(zfsvfs, DMU_USERUSED_OBJECT, uid) ||
+		    zfs_id_overblockquota(zfsvfs, DMU_GROUPUSED_OBJECT, gid) ||
+		    (projid != ZFS_DEFAULT_PROJID &&
+		    zfs_id_overblockquota(zfsvfs, DMU_PROJECTUSED_OBJECT,
+		    projid))) {
+			error = SET_ERROR(EDQUOT);
+			break;
+		}
+
+		n = MIN(MIN(len, noff - off),
+		    DMU_MAX_ACCESS / 2 - P2PHASE(off, zp->z_blksz));
+
+		dmu_tx_t *tx = dmu_tx_create(zfsvfs->z_os);
+		dmu_tx_hold_write_by_dnode(tx, dn, off, n);
+		error = dmu_tx_assign(tx, DMU_TX_WAIT);
+		if (error) {
+			dmu_tx_abort(tx);
+			break;
+		}
+
+		/* Mark all dbufs within range as dirty to trigger rewrite. */
+		dmu_buf_t **dbp;
+		int numbufs;
+		error = dmu_buf_hold_array_by_dnode(dn, off, n, TRUE, FTAG,
+		    &numbufs, &dbp, DMU_READ_PREFETCH);
+		if (error) {
+			dmu_tx_abort(tx);
+			break;
+		}
+		for (int i = 0; i < numbufs; i++) {
+			nr += dbp[i]->db_size;
+			if (dmu_buf_is_dirty(dbp[i], tx))
+				continue;
+			nw += dbp[i]->db_size;
+			dmu_buf_will_dirty(dbp[i], tx);
+		}
+		dmu_buf_rele_array(dbp, numbufs, FTAG);
+
+		dmu_tx_commit(tx);
+
+		len -= n;
+		off += n;
+
+		if (issig()) {
+			error = SET_ERROR(EINTR);
+			break;
+		}
+	}
+
+	DB_DNODE_EXIT(db);
+
+	dataset_kstats_update_read_kstats(&zfsvfs->z_kstat, nr);
+	dataset_kstats_update_write_kstats(&zfsvfs->z_kstat, nw);
+
+	zfs_rangelock_exit(lr);
+	zfs_exit(zfsvfs, FTAG);
+	return (error);
+}
+
 int
 zfs_getsecattr(znode_t *zp, vsecattr_t *vsecp, int flag, cred_t *cr)
 {

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -306,6 +306,10 @@ tags = ['functional', 'cli_root', 'zfs_rename']
 tests = ['zfs_reservation_001_pos', 'zfs_reservation_002_pos']
 tags = ['functional', 'cli_root', 'zfs_reservation']
 
+[tests/functional/cli_root/zfs_rewrite]
+tests = ['zfs_rewrite']
+tags = ['functional', 'cli_root', 'zfs_rewrite']
+
 [tests/functional/cli_root/zfs_rollback]
 tests = ['zfs_rollback_001_pos', 'zfs_rollback_002_pos',
     'zfs_rollback_003_neg', 'zfs_rollback_004_neg']

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -194,6 +194,10 @@ tags = ['functional', 'cli_root', 'zfs_rename']
 tests = ['zfs_reservation_001_pos', 'zfs_reservation_002_pos']
 tags = ['functional', 'cli_root', 'zfs_reservation']
 
+[tests/functional/cli_root/zfs_rewrite]
+tests = ['zfs_rewrite']
+tags = ['functional', 'cli_root', 'zfs_rewrite']
+
 [tests/functional/cli_root/zfs_rollback]
 tests = ['zfs_rollback_003_neg', 'zfs_rollback_004_neg']
 tags = ['functional', 'cli_root', 'zfs_rollback']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -862,6 +862,9 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_reservation/setup.ksh \
 	functional/cli_root/zfs_reservation/zfs_reservation_001_pos.ksh \
 	functional/cli_root/zfs_reservation/zfs_reservation_002_pos.ksh \
+	functional/cli_root/zfs_rewrite/cleanup.ksh \
+	functional/cli_root/zfs_rewrite/setup.ksh \
+	functional/cli_root/zfs_rewrite/zfs_rewrite.ksh \
 	functional/cli_root/zfs_rollback/cleanup.ksh \
 	functional/cli_root/zfs_rollback/setup.ksh \
 	functional/cli_root/zfs_rollback/zfs_rollback_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rewrite/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rewrite/cleanup.ksh
@@ -1,0 +1,26 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rewrite/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rewrite/setup.ksh
@@ -1,0 +1,28 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+
+default_setup $DISK

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rewrite/zfs_rewrite.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rewrite/zfs_rewrite.ksh
@@ -1,0 +1,104 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025, iXsystems, Inc.
+#
+
+# DESCRIPTION:
+#	Verify zfs rewrite rewrites specified files blocks.
+#
+# STRATEGY:
+#	1. Create two files, one of which is in a directory.
+#	2. Save the checksums and block pointers.
+#	3. Rewrite part of the files.
+#	4. Verify checksums are the same.
+#	5. Verify block pointers of the rewritten part have changed.
+#	6. Rewrite all the files.
+#	7. Verify checksums are the same.
+#	8. Verify all block pointers have changed.
+
+. $STF_SUITE/include/libtest.shlib
+
+typeset tmp=$(mktemp)
+typeset bps=$(mktemp)
+typeset bps1=$(mktemp)
+typeset bps2=$(mktemp)
+
+function cleanup
+{
+	rm -rf $tmp $bps $bps1 $bps2 $TESTDIR/*
+}
+
+log_assert "zfs rewrite rewrites specified files blocks"
+
+log_onexit cleanup
+
+log_must zfs set recordsize=128k $TESTPOOL/$TESTFS
+
+log_must mkdir $TESTDIR/dir
+log_must dd if=/dev/urandom of=$TESTDIR/file1 bs=128k count=8
+log_must dd if=$TESTDIR/file1 of=$TESTDIR/dir/file2 bs=128k
+log_must sync_pool $TESTPOOL
+typeset orig_hash1=$(xxh128digest $TESTDIR/file1)
+typeset orig_hash2=$(xxh128digest $TESTDIR/dir/file2)
+
+log_must [ "$orig_hash1" = "$orig_hash2" ]
+log_must eval "zdb -Ovv $TESTPOOL/$TESTFS file1 > $tmp"
+log_must eval "awk '/ L0 / { print l++ \" \" \$3 }' < $tmp > $bps1"
+log_must eval "zdb -Ovv $TESTPOOL/$TESTFS dir/file2 > $tmp"
+log_must eval "awk '/ L0 / { print l++ \" \" \$3 }' < $tmp > $bps2"
+
+log_must zfs rewrite -o 327680 -l 262144 -r -x $TESTDIR/file1 $TESTDIR/dir/file2
+log_must sync_pool $TESTPOOL
+typeset new_hash1=$(xxh128digest $TESTDIR/file1)
+typeset new_hash2=$(xxh128digest $TESTDIR/dir/file2)
+log_must [ "$orig_hash1" = "$new_hash1" ]
+log_must [ "$orig_hash2" = "$new_hash2" ]
+
+log_must eval "zdb -Ovv $TESTPOOL/$TESTFS file1 > $tmp"
+log_must eval "awk '/ L0 / { print l++ \" \" \$3 }' < $tmp > $bps"
+typeset same=$(echo $(sort -n $bps $bps1 | uniq -d | cut -f1 -d' '))
+log_must [ "$same" = "0 1 5 6 7" ]
+log_must eval "zdb -Ovv $TESTPOOL/$TESTFS dir/file2 > $tmp"
+log_must eval "awk '/ L0 / { print l++ \" \" \$3 }' < $tmp > $bps"
+typeset same=$(echo $(sort -n $bps $bps2 | uniq -d | cut -f1 -d' '))
+log_must [ "$same" = "0 1 5 6 7" ]
+
+log_must zfs rewrite -r $TESTDIR/file1 $TESTDIR/dir/file2
+log_must sync_pool $TESTPOOL
+typeset new_hash1=$(xxh128digest $TESTDIR/file1)
+typeset new_hash2=$(xxh128digest $TESTDIR/dir/file2)
+log_must [ "$orig_hash1" = "$new_hash1" ]
+log_must [ "$orig_hash2" = "$new_hash2" ]
+
+log_must eval "zdb -Ovv $TESTPOOL/$TESTFS file1 > $tmp"
+log_must eval "awk '/ L0 / { print l++ \" \" \$3 }' < $tmp > $bps"
+typeset same=$(echo $(sort -n $bps $bps1 | uniq -d | cut -f1 -d' '))
+log_must [ -z "$same" ]
+log_must eval "zdb -Ovv $TESTPOOL/$TESTFS dir/file2 > $tmp"
+log_must eval "awk '/ L0 / { print l++ \" \" \$3 }' < $tmp > $bps"
+typeset same=$(echo $(sort -n $bps $bps2 | uniq -d | cut -f1 -d' '))
+log_must [ -z "$same" ]
+
+log_pass


### PR DESCRIPTION
### Motivation and Context
For years users were asking for an ability to re-balance pool after vdev addition, de-fragment randomly written files, change some properties for already written files, etc.  The closest option would be to either copy and rename a file or send/receive/rename the dataset.  Unfortunately all of those options have some downsides.

### Description
This change introduces new `zfs rewrite` subcommand, that allows to rewrite content of specified file(s) as-is without modifications, but at a different location, compression, checksum, dedup, copies and other parameter values.  It is faster than read plus write, since it does not require data copying to user-space. It is also faster for sync=always datasets, since without data modification it does not require ZIL writing.  Also since it is protected by normal range range locks, it can be done under any other load.  Also it does not affect file's modification time or other properties.

### How Has This Been Tested?
Manually tested it on FreeBSD.  Linux-specific code is not yet tested.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
