### PR TITLE
Export correct symbols for Lustre Direct I/O

### DIFF
--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -1340,6 +1340,8 @@ abd_bio_map_off(struct bio *bio, abd_t *abd,
 	return (io_size);
 }
 
+EXPORT_SYMBOL(abd_alloc_from_pages);
+
 /* Tunable Parameters */
 module_param(zfs_abd_scatter_enabled, int, 0644);
 MODULE_PARM_DESC(zfs_abd_scatter_enabled,

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -1210,3 +1210,5 @@ abd_raidz_rec_iterate(abd_t **cabds, abd_t **tabds,
 	}
 	abd_exit_critical(flags);
 }
+
+EXPORT_SYMBOL(abd_free);

--- a/module/zfs/dmu_direct.c
+++ b/module/zfs/dmu_direct.c
@@ -393,5 +393,5 @@ dmu_write_uio_direct(dnode_t *dn, zfs_uio_t *uio, uint64_t size, dmu_tx_t *tx)
 }
 #endif /* _KERNEL */
 
-EXPORT_SYMBOL(dmu_read_uio_direct);
-EXPORT_SYMBOL(dmu_write_uio_direct);
+EXPORT_SYMBOL(dmu_read_abd);
+EXPORT_SYMBOL(dmu_write_abd);


### PR DESCRIPTION
Originally the Lustre ZFS OSD code was going to use zfs_uio_t structs for supporting Direct I/O with ZFS. However, this has changed to using abd_t structs instead. This exports the proper symbols that will be used by the Lustre ZFS OSD code.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Updated exported symbols that will be used by Lustre.
<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These symbols need to be exported so support for ZFS Direct I/O can be added to the OSD ZFS code.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Exported the following symbols:
1. dmu_read_abd()
2. dmu_write_abd()
3. abd_alloc_from_pages()
4. abd_free()
These are needed as Lustre will be using `abd_t`'s to issue Direct I/O.

I also stopped exporting the following symbols:
1. dmu_read_uio_direct()
2. dmu_write_uio_direct()
These no longer needed to be exported.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Built ZFS after updating the exports.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
