### PR TITLE
ZTS: Remove fixed sleeps from slog_006_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/slog/slog_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_006_pos.ksh
@@ -61,8 +61,7 @@ do
 			tdev=$(random_get $LDEV2)
 			log_must zpool replace $TESTPOOL $sdev $tdev
 			log_must display_status $TESTPOOL
-			# sleep 15 to make sure replacement completely.
-			log_must sleep 15
+			log_must zpool wait $TESTPOOL
 			log_must verify_slog_device \
 				$TESTPOOL $tdev 'ONLINE' $logtype
 


### PR DESCRIPTION
Replace `sleep 15` with `zpool wait`, which should take much less than the 15 seconds.  And considering it is called 16 times, this should save us up to 4 minutes total.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
