### PR TITLE
ZTS: Polish online_offline tests

### DIFF
--- a/tests/zfs-tests/tests/functional/online_offline/online_offline_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/online_offline/online_offline_001_pos.ksh
@@ -50,16 +50,17 @@ DISKLIST=$(get_disklist $TESTPOOL)
 
 function cleanup
 {
+	kill $killpid >/dev/null 2>&1
+
 	#
 	# Ensure we don't leave disks in the offline state
 	#
 	for disk in $DISKLIST; do
 		log_must zpool online $TESTPOOL $disk
 		log_must check_state $TESTPOOL $disk "online"
-
 	done
+	log_must zpool wait -t resilver $TESTPOOL
 
-	kill $killpid >/dev/null 2>&1
 	[[ -e $TESTDIR ]] && log_must rm -rf $TESTDIR/*
 }
 
@@ -77,8 +78,7 @@ for disk in $DISKLIST; do
 	log_must zpool online $TESTPOOL $disk
 	log_must check_state $TESTPOOL $disk "online"
 
-	# Delay for resilver to complete
-	sleep 3
+	log_must zpool wait -t resilver $TESTPOOL
 done
 
 log_must kill $killpid

--- a/tests/zfs-tests/tests/functional/online_offline/online_offline_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/online_offline/online_offline_002_neg.ksh
@@ -51,6 +51,8 @@ DISKLIST=$(get_disklist $TESTPOOL)
 
 function cleanup
 {
+	kill $killpid >/dev/null 2>&1
+
 	#
 	# Ensure we don't leave disks in the offline state
 	#
@@ -58,8 +60,8 @@ function cleanup
 		log_must zpool online $TESTPOOL $disk
 		log_must check_state $TESTPOOL $disk "online"
 	done
+	log_must zpool wait -t resilver $TESTPOOL
 
-	kill $killpid >/dev/null 2>&1
 	[[ -e $TESTDIR ]] && log_must rm -rf $TESTDIR/*
 }
 

--- a/tests/zfs-tests/tests/functional/online_offline/online_offline_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/online_offline/online_offline_003_neg.ksh
@@ -49,7 +49,6 @@ function cleanup
 		destroy_pool $TESTPOOL1
 	fi
 
-	kill $killpid >/dev/null 2>&1
 	[[ -e $TESTDIR ]] && log_must rm -rf $TESTDIR/*
 }
 
@@ -59,7 +58,7 @@ log_onexit cleanup
 
 specials_list=""
 for i in 0 1 2; do
-	mkfile $MINVDEVSIZE $TESTDIR/$TESTFILE1.$i
+	log_must mkfile $MINVDEVSIZE $TESTDIR/$TESTFILE1.$i
 	specials_list="$specials_list $TESTDIR/$TESTFILE1.$i"
 done
 disk=($specials_list)
@@ -68,15 +67,9 @@ create_pool $TESTPOOL1 $specials_list
 log_must zfs create $TESTPOOL1/$TESTFS1
 log_must zfs set mountpoint=$TESTDIR1 $TESTPOOL1/$TESTFS1
 
-file_trunc -f $((64 * 1024 * 1024)) -b 8192 -c 0 -r $TESTDIR/$TESTFILE1 &
-typeset killpid="$! "
-
 for i in 0 1 2; do
 	log_mustnot zpool offline $TESTPOOL1 ${disk[$i]}
 	check_state $TESTPOOL1 ${disk[$i]} "online"
 done
-
-log_must kill $killpid
-sync_all_pools
 
 log_pass


### PR DESCRIPTION
 - Kill workload first for faster cleanup.
 - Use `zpool wait` for resilver instead of `sleep`.
 - Remove irrelevant workload from `online_offline_003_neg`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
