### PR TITLE
Sorted displaying of the blocking snapshots list

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -4443,7 +4443,7 @@ zfs_do_rollback(int argc, char **argv)
 	if (cb.cb_create > 0)
 		min_txg = cb.cb_create;
 
-	if ((ret = zfs_iter_snapshots_v2(zhp, 0, rollback_check, &cb,
+	if ((ret = zfs_iter_snapshots_sorted_v2(zhp, 0, rollback_check, &cb,
 	    min_txg, 0)) != 0)
 		goto out;
 	if ((ret = zfs_iter_bookmarks_v2(zhp, 0, rollback_check, &cb)) != 0)

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -570,7 +570,7 @@ iter_dependents_cb(zfs_handle_t *zhp, void *arg)
 		err = zfs_iter_filesystems_v2(zhp, ida->flags,
 		    iter_dependents_cb, ida);
 		if (err == 0)
-			err = zfs_iter_snapshots_v2(zhp, ida->flags,
+			err = zfs_iter_snapshots_sorted_v2(zhp, ida->flags,
 			    iter_dependents_cb, ida, 0, 0);
 		ida->stack = isf.next;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When multiple snapshots prevent the destruction/rollback of the respective dataset/snapshot/volume via `zfs destroy` or `zfs rollback`, the error message does not list the blocking snapshots sorted according to their order of creation.
This causes inconvenience and can lead to confusion, and also creates a contrast with a returned message from` zfs list -t snap` function.
#12751

### Description
<!--- Describe your changes in detail -->
The `zfs_iter_snapshots_v2` functions used in these cases are replaced by `zfs_iter_snapshots_sorted_v2`

**Prepare:**
```
sudo zpool create MyPool /tmp/vdev1.img
sudo zfs create MyPool/Test
sudo zfs snap MyPool/Test@Snap1
sudo zfs snap MyPool/Test@Snap2
sudo zfs snap MyPool/Test@Snap3
sudo zfs snap MyPool/Test@Snap4
sudo zfs snap MyPool/Test@Snap5
sudo zfs snap MyPool/Test@Snap6
```

**Before:**
```
sudo zfs destroy MyPool/Test
cannot destroy 'MyPool/Test': filesystem has children
use '-r' to destroy the following datasets:
MyPool/Test@Snap4
MyPool/Test@Snap3
MyPool/Test@Snap2
MyPool/Test@Snap5
MyPool/Test@Snap1
MyPool/Test@Snap6
```

```
sudo zfs rollback MyPool/Test@Snap1
cannot rollback to 'MyPool/Test@Snap1': more recent snapshots or bookmarks exist
use '-r' to force deletion of the following snapshots and bookmarks:
MyPool/Test@Snap4
MyPool/Test@Snap3
MyPool/Test@Snap2
MyPool/Test@Snap5
MyPool/Test@Snap6
```

**After:**
```
sudo zfs destroy MyPool/Test
cannot destroy 'MyPool/Test': filesystem has children
use '-r' to destroy the following datasets:
MyPool/Test@Snap1
MyPool/Test@Snap2
MyPool/Test@Snap3
MyPool/Test@Snap4
MyPool/Test@Snap5
MyPool/Test@Snap6
```

```
sudo zfs rollback MyPool/Test@Snap1
cannot rollback to 'MyPool/Test@Snap1': more recent snapshots or bookmarks exist
use '-r' to force deletion of the following snapshots and bookmarks:
MyPool/Test@Snap2
MyPool/Test@Snap3
MyPool/Test@Snap4
MyPool/Test@Snap5
MyPool/Test@Snap6
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Run the commands in the different combinations.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
