### PR TITLE
ZTS: Fix 256MB file leak in zed_cksum_reported

### DIFF
--- a/tests/zfs-tests/tests/functional/events/zed_cksum_reported.ksh
+++ b/tests/zfs-tests/tests/functional/events/zed_cksum_reported.ksh
@@ -55,7 +55,7 @@ function cleanup
 	if poolexists $POOL ; then
 		destroy_pool $POOL
 	fi
-	log_must rm -fd $VDEV $MOUNTDIR
+	log_must rm -fd $VDEV $VDEV1 $MOUNTDIR
 }
 log_onexit cleanup
 


### PR DESCRIPTION
Aside of using some disk space, I suppose it could stay in page cache.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
