### PR TITLE
ZTS: Reduce extra caching in pool_checkpoint

### DIFF
--- a/tests/zfs-tests/tests/functional/pool_checkpoint/checkpoint_capacity.ksh
+++ b/tests/zfs-tests/tests/functional/pool_checkpoint/checkpoint_capacity.ksh
@@ -60,14 +60,15 @@ log_must set_tunable32 SPA_ASIZE_INFLATION 4
 log_must zfs create $DISKFS
 
 log_must mkfile $FILEDISKSIZE $FILEDISK1
-log_must zpool create $NESTEDPOOL $FILEDISK1
+log_must zpool create -O primarycache=metadata $NESTEDPOOL $FILEDISK1
 
-log_must zfs create -o compression=lz4 -o recordsize=8k $NESTEDFS0
+log_must zfs create $NESTEDFS0
 log_must dd if=/dev/urandom of=$NESTEDFS0FILE bs=1M count=700
 FILE0INTRO=$(head -c 100 $NESTEDFS0FILE)
 
 log_must zpool checkpoint $NESTEDPOOL
 log_must rm $NESTEDFS0FILE
+log_must sync_pool $NESTEDPOOL
 
 #
 # only for debugging purposes

--- a/tests/zfs-tests/tests/functional/pool_checkpoint/pool_checkpoint.kshlib
+++ b/tests/zfs-tests/tests/functional/pool_checkpoint/pool_checkpoint.kshlib
@@ -139,7 +139,8 @@ function setup_nested_pool
 	log_must truncate -s $DISKSIZE $FILEDISK1
 	log_must truncate -s $DISKSIZE $FILEDISK2
 
-	log_must zpool create -O sync=disabled $NESTEDPOOL $FILEDISKS
+	log_must zpool create -O primarycache=metadata -O sync=disabled \
+	    $NESTEDPOOL $FILEDISKS
 }
 
 function setup_test_pool


### PR DESCRIPTION
Those tests are write-mostly at the nested pool.  Considering we have 3 more layers of caching underneath, we can hint ZFS how to use the memory better by setting `primarycache=metadata`.

While there, add missing `zpool sync` after `rm` in `checkpoint_capacity` before we could potentially see the freed space, would not there be a pool checkpoint.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
