### PR TITLE
RPM: Hold back incompatible kernel packages on Fedora

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -29,10 +29,16 @@ Requires(post): dkms >= 2.2.0.3
 Requires(preun): dkms >= 2.2.0.3
 Requires:       gcc, make, perl, diffutils
 Requires(post): gcc, make, perl, diffutils
+
+# Hold back kernel upgrades if kernel is not supported by ZFS
 %if 0%{?rhel}%{?fedora}%{?mageia}%{?suse_version}%{?openEuler}
 Requires:       kernel-devel >= @ZFS_META_KVER_MIN@, kernel-devel <= @ZFS_META_KVER_MAX@.999
 Requires(post): kernel-devel >= @ZFS_META_KVER_MIN@, kernel-devel <= @ZFS_META_KVER_MAX@.999
 Conflicts:      kernel-devel < @ZFS_META_KVER_MIN@, kernel-devel > @ZFS_META_KVER_MAX@.999
+Requires:       kernel-uname-r >= @ZFS_META_KVER_MIN@, kernel-uname-r <= @ZFS_META_KVER_MAX@.999
+Requires(post): kernel-uname-r >= @ZFS_META_KVER_MIN@, kernel-uname-r <= @ZFS_META_KVER_MAX@.999
+Conflicts:      kernel-uname-r < @ZFS_META_KVER_MIN@, kernel-uname-r > @ZFS_META_KVER_MAX@.999
+
 Obsoletes:      spl-dkms <= %{version}
 %endif
 Provides:       %{module}-kmod = %{version}


### PR DESCRIPTION
### Motivation and Context
Closes: #17265


### Description
A user reported that when your upgrade your kernel packages on Fedora with ZFS installed, only the kernel-devel package gets held back to the ZFS-supported version, but not the other kernel packages. So if ZFS only supports the 6.13 kernel, Fedora will still happily upgrade the kernel RPMs to 6.14, but hold back kernel-devel at 6.13, for example.
This commit includes version checks for the 'kernel' dependency, typically provided by the 'kernel-core' package.

Original-patch-by: @jkool702

### How Has This Been Tested?
I tested this on Fedora 41:

1. Downgrade kernel packages from 6.13 -> 6.11
2. Install zfs-2.3.0 (supports up to 6.12 kernel)
3. Remove ZFS repo so it doesn't update past zfs-2.3.0
4. Ran `dnf update` and verified it only held back kernel-devel, and not the other kernel packages.
5. Added this commit to zfs-2.3.0 source and rebuilt dkms packages
6. Installed new modified zfs-2.3.0 packages.
7. Ran a `dnf update` and saw it hold back everything:
```
$ sudo dnf update
Updating and loading repositories:
Repositories loaded.
Problem 1: installed package zfs-dkms-2.3.0-1_g80884de7e.fc41.noarch conflicts with kernel-modules-core > 6.12.999 provided by kernel-modules-core-6.13.12-200.fc41.x86_64 from updates
  - cannot install the best update candidate for package kernel-modules-core-6.11.11-300.fc41.x86_64
  - problem with installed package
 Problem 2: installed package zfs-dkms-2.3.0-1_g80884de7e.fc41.noarch conflicts with kernel > 6.12.999 provided by kernel-core-6.13.12-200.fc41.x86_64 from updates
  - installed package zfs-dkms-2.3.0-1_g80884de7e.fc41.noarch conflicts with kernel-core > 6.12.999 provided by kernel-core-6.13.12-200.fc41.x86_64 from updates
  - installed package zfs-2.3.0-1_g80884de7e.fc41.x86_64 requires zfs-kmod = 2.3.0, but none of the providers can be installed
  - cannot install the best update candidate for package kernel-core-6.11.11-300.fc41.x86_64
  - problem with installed package
 Problem 3: installed package zfs-2.3.0-1_g80884de7e.fc41.x86_64 requires zfs-kmod = 2.3.0, but none of the providers can be installed
  - installed package zfs-dkms-2.3.0-1_g80884de7e.fc41.noarch conflicts with kernel > 6.12.999 provided by kernel-core-6.13.12-200.fc41.x86_64 from updates
  - installed package zfs-dkms-2.3.0-1_g80884de7e.fc41.noarch conflicts with kernel-core > 6.12.999 provided by kernel-core-6.13.12-200.fc41.x86_64 from updates
  - installed package zfs-dracut-2.3.0-1_g80884de7e.fc41.noarch requires zfs >= 2.3.0, but none of the providers can be installed
  - cannot install the best update candidate for package kernel-core-6.11.4-301.fc41.x86_64
  - problem with installed package
 Problem 4: installed package zfs-2.3.0-1_g80884de7e.fc41.x86_64 requires zfs-kmod = 2.3.0, but none of the providers can be installed
  - installed package zfs-dkms-2.3.0-1_g80884de7e.fc41.noarch conflicts with kernel-devel > 6.12.999 provided by kernel-devel-6.13.12-200.fc41.x86_64 from updates
  - installed package zfs-test-2.3.0-1_g80884de7e.fc41.x86_64 requires zfs(x86-64) = 2.3.0-1_g80884de7e.fc41, but none of the providers can be installed
  - cannot install the best update candidate for package kernel-devel-6.11.4-301.fc41.x86_64
  - problem with installed package

Package                                                                 Arch             Version                                                                  Repository                                    Size
Skipping packages with conflicts:
 kernel-core                                                            x86_64           6.13.12-200.fc41                                                         updates                                   75.3 MiB
 kernel-devel                                                           x86_64           6.13.12-200.fc41                                                         updates                                   77.8 MiB
 kernel-modules-core                                                    x86_64           6.13.12-200.fc41                                                         updates                                   37.8 MiB

Nothing to do.
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
