### PR TITLE
ZTS: Fix replacement/resilver_restart_001 on FreeBSD

### DIFF
--- a/tests/zfs-tests/tests/functional/replacement/resilver_restart_001.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/resilver_restart_001.ksh
@@ -154,7 +154,7 @@ do
 	log_must zpool events -c
 
 	# limit scanning time
-	log_must set_tunable32 RESILVER_MIN_TIME_MS 50
+	log_must set_tunable32 RESILVER_MIN_TIME_MS 20
 
 	# initiate a resilver and suspend the scan as soon as possible
 	log_must zpool replace $TESTPOOL1 $VDEV_REPLACE


### PR DESCRIPTION
### Motivation and Context

Details on the issue can be seen here #16822

Increasing the data files from 16M to 32M fixes the replacement/resilver_restart_001 test.

Closes: #16822

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
