### PR TITLE
zcp: get_prop: fix encryptionroot and encryption

### DIFF
--- a/module/zfs/zcp_get.c
+++ b/module/zfs/zcp_get.c
@@ -378,14 +378,17 @@ get_special_prop(lua_State *state, dsl_dataset_t *ds, const char *dsname,
 		break;
 	}
 
+	case ZFS_PROP_ENCRYPTION:
 	case ZFS_PROP_KEYSTATUS:
 	case ZFS_PROP_KEYFORMAT: {
 		/* provide defaults in case no crypto obj exists */
 		setpoint[0] = '\0';
 		if (zfs_prop == ZFS_PROP_KEYSTATUS)
 			numval = ZFS_KEYSTATUS_NONE;
-		else
+		else if (zfs_prop == ZFS_PROP_KEYFORMAT)
 			numval = ZFS_KEYFORMAT_NONE;
+		else if (zfs_prop == ZFS_PROP_ENCRYPTION)
+			numval = ZIO_CRYPT_OFF;
 
 		nvlist_t *nvl, *propval;
 		nvl = fnvlist_alloc();
@@ -399,6 +402,25 @@ get_special_prop(lua_State *state, dsl_dataset_t *ds, const char *dsname,
 			if (nvlist_lookup_string(propval, ZPROP_SOURCE,
 			    &source) == 0)
 				strlcpy(setpoint, source, sizeof (setpoint));
+		}
+		nvlist_free(nvl);
+		break;
+	}
+
+	case ZFS_PROP_ENCRYPTION_ROOT: {
+		setpoint[0] = '\0';
+		numval = 0;
+
+		nvlist_t *nvl, *propval;
+		nvl = fnvlist_alloc();
+		dsl_dataset_crypt_stats(ds, nvl);
+		if (nvlist_lookup_nvlist(nvl, zfs_prop_to_name(zfs_prop),
+		    &propval) == 0) {
+			const char *dsname;
+
+			if (nvlist_lookup_string(propval, ZPROP_VALUE,
+			    &dsname) == 0)
+				strlcpy(strval, dsname, ZAP_MAXVALUELEN);
 		}
 		nvlist_free(nvl);
 		break;


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/issues/12337

### Description
It was reported that channel programs' zfs.get_prop doesn't work for
dataset properties encryption and encryptionroot.

They are handled in get_special_prop due to the need to call
dsl_dataset_crypt_stats to load those dsl props.

@grahamc already worked on a testcase for this (https://github.com/openzfs/zfs/pull/12335), we could revive and merge that PR now

### How Has This Been Tested?

Reproducer in https://github.com/openzfs/zfs/issues/12337

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
