### PR TITLE
zfs-list.8: Correct example number to match zfs.8 cross-reference

### DIFF
--- a/man/man8/zfs-list.8
+++ b/man/man8/zfs-list.8
@@ -176,7 +176,7 @@ or
 .Sh EXAMPLES
 .\" These are, respectively, examples 5 from zfs.8
 .\" Make sure to update them bidirectionally
-.Ss Example 1 : No Listing ZFS Datasets
+.Ss Example 5 : No Listing ZFS Datasets
 The following command lists all active file systems and volumes in the system.
 Snapshots are displayed if
 .Sy listsnaps Ns = Ns Sy on .


### PR DESCRIPTION
Closes #17281

@concussious I remember I did check `man zfs-list` before I submitted the first PR. So if that one wasn't mistaken, this one is (after checking it is indeed not one in `zfs.8`).