### PR TITLE
ZTS: Add bpftrace dependency to Linux VMs

### DIFF
--- a/.github/workflows/scripts/qemu-3-deps-vm.sh
+++ b/.github/workflows/scripts/qemu-3-deps-vm.sh
@@ -15,10 +15,10 @@ function archlinux() {
   echo "##[endgroup]"
 
   echo "##[group]Install Development Tools"
-  sudo pacman -Sy --noconfirm base-devel bc cpio cryptsetup dhclient dkms \
-    fakeroot fio gdb inetutils jq less linux linux-headers lsscsi nfs-utils \
-    parted pax perf python-packaging python-setuptools qemu-guest-agent ksh \
-    samba sysstat rng-tools rsync wget xxhash
+  sudo pacman -Sy --noconfirm base-devel bc bpftrace cpio cryptsetup dhclient \
+    dkms fakeroot fio gdb inetutils jq less linux linux-headers lsscsi \
+    qemu-guest-agent ksh nfs-utils parted pax perf python-packaging \
+    python-setuptools samba sysstat rng-tools rsync wget xxhash
   echo "##[endgroup]"
 }
 
@@ -32,15 +32,15 @@ function debian() {
 
   echo "##[group]Install Development Tools"
   sudo apt-get install -y \
-    acl alien attr autoconf bc cpio cryptsetup curl dbench dh-python dkms \
-    fakeroot fio gdb gdebi git ksh lcov isc-dhcp-client jq libacl1-dev \
+    acl alien attr autoconf bc bpftrace cpio cryptsetup curl dbench dh-python \
+    dkms fakeroot fio gdb gdebi git ksh lcov isc-dhcp-client jq libacl1-dev \
     libaio-dev libattr1-dev libblkid-dev libcurl4-openssl-dev libdevmapper-dev \
     libelf-dev libffi-dev libmount-dev libpam0g-dev libselinux-dev libssl-dev \
     libtool libtool-bin libudev-dev libunwind-dev linux-headers-$(uname -r) \
     lsscsi nfs-kernel-server pamtester parted python3 python3-all-dev \
     python3-cffi python3-dev python3-distlib python3-packaging \
     python3-setuptools python3-sphinx qemu-guest-agent rng-tools rpm2cpio \
-    rsync samba sysstat uuid-dev watchdog wget xfslibs-dev  xxhash zlib1g-dev
+    rsync samba sysstat uuid-dev watchdog wget xfslibs-dev xxhash zlib1g-dev
   echo "##[endgroup]"
 }
 
@@ -77,15 +77,15 @@ function rhel() {
   fi
 
   sudo dnf install -y \
-    acl attr bc bzip2 cryptsetup curl dbench dkms elfutils-libelf-devel fio \
-    gdb git jq kernel-rpm-macros ksh libacl-devel libaio-devel \
-    libargon2-devel libattr-devel libblkid-devel libcurl-devel libffi-devel \
-    ncompress libselinux-devel libtirpc-devel libtool libudev-devel \
-    libuuid-devel lsscsi mdadm nfs-utils openssl-devel pam-devel pamtester \
-    parted perf python3 python3-cffi python3-devel python3-packaging \
-    kernel-devel python3-setuptools qemu-guest-agent rng-tools rpcgen \
-    rpm-build rsync samba sysstat systemd watchdog wget xfsprogs-devel xxhash \
-    zlib-devel
+    acl attr bc bpftrace bzip2 cryptsetup curl dbench dkms \
+    elfutils-libelf-devel fio gdb git jq kernel-rpm-macros ksh libacl-devel \
+    libaio-devel libargon2-devel libattr-devel libblkid-devel libcurl-devel \
+    libffi-devel ncompress libselinux-devel libtirpc-devel libtool \
+    libudev-devel libuuid-devel lsscsi mdadm nfs-utils openssl-devel \
+    pam-devel pamtester parted perf python3 python3-cffi python3-devel \
+    python3-packaging kernel-devel python3-setuptools qemu-guest-agent \
+    rng-tools rpcgen rpm-build rsync samba sysstat systemd watchdog wget \
+    xfsprogs-devel xxhash zlib-devel
   echo "##[endgroup]"
 }
 


### PR DESCRIPTION
### Motivation and Context

Wrote a test which requires `bpftrace`.

### Description

Add a `bpftrace` dependency to the Linux VMs.

### How Has This Been Tested?

Verified that all Linux VMs install `bpftrace` by looking at the logfiles.
 
### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
