### PR TITLE
Enable zero-elimination if dedup is activated

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2087,6 +2087,20 @@ zio_write_compress(zio_t *zio)
 			zio_push_transform(zio, cdata,
 			    psize, rounded, NULL);
 		}
+	} else if (zp->zp_dedup == B_TRUE) {
+		/*
+		 * Storing many references to an all zeros block in the dedup
+		 * table would be expensive, and each different size of block
+		 * would have its own checksum.
+		 * Instead, if dedup is enabled, store all zero blocks as
+		 * holes even if compression is not enabled.
+		 */
+		if (abd_cmp_zero(zio->io_abd, lsize) == 0) {
+			psize = 0;
+			compress = ZIO_COMPRESS_OFF;
+		} else {
+			psize = lsize;
+		}
 	} else {
 		ASSERT3U(psize, !=, 0);
 	}


### PR DESCRIPTION
### Motivation and Context
Optimize dedup's handling of blocks of all-zeros.

### Description
Creating high-refcount dedup entries for checksums of each record size is inefficient when the record could be recorded as a hole instead.

Normally, zero-elimination is disabled if compression is not enabled, but in the dedup case, it is expected that the write will be skipped anyway, we are just optimizing the way the write is skipped.

### How Has This Been Tested?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
