### PR TITLE
linux/uio: remove "skip" offset for `UIO_ITER`

### DIFF
--- a/include/os/linux/spl/sys/uio.h
+++ b/include/os/linux/spl/sys/uio.h
@@ -174,7 +174,7 @@ zfs_uio_bvec_init(zfs_uio_t *uio, struct bio *bio, struct request *rq)
 
 static inline void
 zfs_uio_iov_iter_init(zfs_uio_t *uio, struct iov_iter *iter, offset_t offset,
-    ssize_t resid, size_t skip)
+    ssize_t resid)
 {
 	uio->uio_iter = iter;
 	uio->uio_iovcnt = iter->nr_segs;
@@ -184,7 +184,7 @@ zfs_uio_iov_iter_init(zfs_uio_t *uio, struct iov_iter *iter, offset_t offset,
 	uio->uio_fmode = 0;
 	uio->uio_extflg = 0;
 	uio->uio_resid = resid;
-	uio->uio_skip = skip;
+	uio->uio_skip = 0;
 	uio->uio_soffset = uio->uio_loffset;
 	memset(&uio->uio_dio, 0, sizeof (zfs_uio_dio_t));
 }

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -226,7 +226,7 @@ zpl_iter_read(struct kiocb *kiocb, struct iov_iter *to)
 	ssize_t count = iov_iter_count(to);
 	zfs_uio_t uio;
 
-	zfs_uio_iov_iter_init(&uio, to, kiocb->ki_pos, count, 0);
+	zfs_uio_iov_iter_init(&uio, to, kiocb->ki_pos, count);
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
@@ -276,8 +276,7 @@ zpl_iter_write(struct kiocb *kiocb, struct iov_iter *from)
 	if (ret)
 		return (ret);
 
-	zfs_uio_iov_iter_init(&uio, from, kiocb->ki_pos, count,
-	    from->iov_offset);
+	zfs_uio_iov_iter_init(&uio, from, kiocb->ki_pos, count);
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();


### PR DESCRIPTION
### Motivation and Context

torvalds/linux@f2fed441c69b9237760840a45a004730ff324faf changes the Linux loop device to (effectively) pass the iterator received from the upper filesystem down the the lower filesystem, where previously it would walk the iterator, create a new single-item iterator over each element, and call into the VFS layer for service.

This change exposed a bug in `UIO_ITER` uios, which wrap `iov_iter`: when we advance the uio, if the offset of the data inside the `iov_iter` is non-zero (the "skip"), we would try to advance the iterator ourselves. But, this is not our iterator, and we don't have to do that - the iterator internals will sort that out if it needs to.

The end result is that if we get an iterator with a first element with a non-zero offset, every time we advance we would skip that many bytes. This either lands somewhere in the middle of the iterator, getting the wrong data, or runs off the end, usually resulting in an `EFAULT` somewhere.

In the case of #17277, the iterator passed down from XFS consistently contains segments with non-zero offsets. The additional skipping runs the iterator position off the end of the available data, and results in an `EFAULT` loop in `zpl_write_iter()`.

Fixes #17277.

### Description

The bug proper is fixed by removing the unnecessary advance in `zfs_uiomove_iter()` and just let the underlying iterator sort it out. (note: the first version of this PR did _only_ this).

As it turns out, we don't even set the skip for `UIO_ITER` for read, and in the few other places we try to use it (some of the direct IO support code), we don't do anything meaningful with it, so I've removed all traces of skip handling for `UIO_ITER`.

### How Has This Been Tested?

The test case in #17277 is to create a file on a pool, use `losetup` to create a loop device over it, then format the loop device as XFS and try to mount it. Something like:

```
zpool create tank ...
truncate -s 512M /tank/img
dev=$(losetup -f /tank/img)
mkfs.xfs $dev
mount $dev /mnt
```

On kernels with the aforementioned change (eg 6.12.25), without this PR, the `mount` call hangs. With this patch, it succeeds.

I've done this same test on all release kernels back to 4.19 _without_ the upstream change but _with_ this PR, and that experiment still succeeds.

I do not have a more specific test case.

The `direct` suite appears to pass correctly, but with some tracing shows that `from->iov_offset` in `zpl_iter_write` was always zero, so if it's possible for it to be anything else in the direct IO cases, I have not tested it.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
