### PR TITLE
FreeBSD: Use new SYSCTL_SIZEOF()

### DIFF
--- a/module/os/freebsd/zfs/zfs_znode_os.c
+++ b/module/os/freebsd/zfs/zfs_znode_os.c
@@ -67,8 +67,12 @@
 #include "zfs_comutil.h"
 
 /* Used by fstat(1). */
+#ifdef SYSCTL_SIZEOF
+SYSCTL_SIZEOF(znode, znode_t);
+#else
 SYSCTL_INT(_debug_sizeof, OID_AUTO, znode, CTLFLAG_RD,
 	SYSCTL_NULL_INT_PTR, sizeof (znode_t), "sizeof(znode_t)");
+#endif
 
 /*
  * Define ZNODE_STATS to turn on statistic gathering. By default, it is only


### PR DESCRIPTION
`SYSCTL_SIZEOF()` has been introduced in FreeBSD by commit "sysctl(9): Ease exporting struct sizes; Discourage doing that" (713abc9880aa) in branch 'main', and is the preferred way to create leaves under the `debug.sizeof` sysctl node.

This is simply a FreeBSD-specific code update to use it, where available, with backward compatibility (which is needed as long as `stable/13` is supported, so April 30, 2026 in theory).