### PR TITLE
`AUTHORS`/`mailmap` update (with `update_authors.pl` improvements)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -80,11 +80,13 @@ Youzhong Yang <youzhong@gmail.com>
 
 # Signed-off-by: overriding Author:
 Alexander Ziaee <ziaee@FreeBSD.org> <concussious@runbox.com>
-Ryan <errornointernet@envs.net> <error.nointernet@gmail.com>
-Sietse <sietse@wizdom.nu> <uglymotha@wizdom.nu>
+Felix Schmidt <felixschmidt20@aol.com> <f.sch.prototype@gmail.com>
+Olivier Certner <olce@FreeBSD.org> <olce.freebsd@certner.fr>
 Phil Sutter <phil@nwl.cc> <p.github@nwl.cc>
 poscat <poscat@poscat.moe> <poscat0x04@outlook.com>
 Qiuhao Chen <chenqiuhao1997@gmail.com> <haohao0924@126.com>
+Ryan <errornointernet@envs.net> <error.nointernet@gmail.com>
+Sietse <sietse@wizdom.nu> <uglymotha@wizdom.nu>
 Yuxin Wang <yuxinwang9999@gmail.com> <Bi11gates9999@gmail.com>
 Zhenlei Huang <zlei@FreeBSD.org> <zlei.huang@gmail.com>
 
@@ -101,6 +103,7 @@ Tulsi Jain <tulsi.jain@delphix.com> <tulsi.jain@Tulsi-Jains-MacBook-Pro.local>
 # Mappings from Github no-reply addresses
 ajs124 <git@ajs124.de> <ajs124@users.noreply.github.com>
 Alek Pinchuk <apinchuk@axcient.com> <alek-p@users.noreply.github.com>
+Aleksandr Liber <aleksandr.liber@perforce.com> <61714074+AleksandrLiber@users.noreply.github.com>
 Alexander Lobakin <alobakin@pm.me> <solbjorn@users.noreply.github.com>
 Alexey Smirnoff <fling@member.fsf.org> <fling-@users.noreply.github.com>
 Allen Holl <allen.m.holl@gmail.com> <65494904+allen-4@users.noreply.github.com>
@@ -137,6 +140,7 @@ Fedor Uporov <fuporov.vstack@gmail.com> <60701163+fuporovvStack@users.noreply.gi
 Felix Dörre <felix@dogcraft.de> <felixdoerre@users.noreply.github.com>
 Felix Neumärker <xdch47@posteo.de> <34678034+xdch47@users.noreply.github.com>
 Finix Yan <yancw@info2soft.com> <Finix1979@users.noreply.github.com>
+Friedrich Weber <f.weber@proxmox.com> <56110206+frwbr@users.noreply.github.com>
 Gaurav Kumar <gauravk.18@gmail.com> <gaurkuma@users.noreply.github.com>
 George Gaydarov <git@gg7.io> <gg7@users.noreply.github.com>
 Georgy Yakovlev <gyakovlev@gentoo.org> <168902+gyakovlev@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ CONTRIBUTORS:
     Alejandro Colomar <Colomar.6.4.3@GMail.com>
     Alejandro R. Sedeño <asedeno@mit.edu>
     Alek Pinchuk <alek@nexenta.com>
+    Aleksandr Liber <aleksandr.liber@perforce.com>
     Aleksa Sarai <cyphar@cyphar.com>
     Alexander Eremin <a.eremin@nexenta.com>
     Alexander Lobakin <alobakin@pm.me>
@@ -81,6 +82,7 @@ CONTRIBUTORS:
     Arne Jansen <arne@die-jansens.de>
     Aron Xu <happyaron.xu@gmail.com>
     Arshad Hussain <arshad.hussain@aeoncomputing.com>
+    Artem <artem.vlasenko@ossrevival.org>
     Arun KV <arun.kv@datacore.com>
     Arvind Sankar <nivedita@alum.mit.edu>
     Attila Fülöp <attila@fueloep.org>
@@ -227,10 +229,12 @@ CONTRIBUTORS:
     Fedor Uporov <fuporov.vstack@gmail.com>
     Felix Dörre <felix@dogcraft.de>
     Felix Neumärker <xdch47@posteo.de>
+    Felix Schmidt <felixschmidt20@aol.com>
     Feng Sun <loyou85@gmail.com>
     Finix Yan <yancw@info2soft.com>
     Francesco Mazzoli <f@mazzo.li>
     Frederik Wessels <wessels147@gmail.com>
+    Friedrich Weber <f.weber@proxmox.com>
     Frédéric Vanniere <f.vanniere@planet-work.com>
     Gabriel A. Devenyi <gdevenyi@gmail.com>
     Garrett D'Amore <garrett@nexenta.com>
@@ -484,7 +488,7 @@ CONTRIBUTORS:
     Olaf Faaland <faaland1@llnl.gov>
     Oleg Drokin <green@linuxhacker.ru>
     Oleg Stepura <oleg@stepura.com>
-    Olivier Certner <olce.freebsd@certner.fr>
+    Olivier Certner <olce@FreeBSD.org>
     Olivier Mazouffre <olivier.mazouffre@ims-bordeaux.fr>
     omni <omni+vagant@hack.org>
     Orivej Desh <orivej@gmx.fr>
@@ -522,6 +526,7 @@ CONTRIBUTORS:
     P.SCH <p88@yahoo.com>
     Qiuhao Chen <chenqiuhao1997@gmail.com>
     Quartz <yyhran@163.com>
+    Quentin Thébault <quentin.thebault@defenso.fr>
     Quentin Zdanis <zdanisq@gmail.com>
     Rafael Kitover <rkitover@gmail.com>
     RageLtMan <sempervictus@users.noreply.github.com>
@@ -573,6 +578,7 @@ CONTRIBUTORS:
     Scot W. Stevenson <scot.stevenson@gmail.com>
     Sean Eric Fagan <sef@ixsystems.com>
     Sebastian Gottschall <s.gottschall@dd-wrt.com>
+    Sebastian Pauka <me@spauka.se>
     Sebastian Wuerl <s.wuerl@mailbox.org>
     Sebastien Roy <seb@delphix.com>
     Sen Haerens <sen@senhaerens.be>
@@ -589,6 +595,7 @@ CONTRIBUTORS:
     Shen Yan <shenyanxxxy@qq.com>
     Sietse <sietse@wizdom.nu>
     Simon Guest <simon.guest@tesujimath.org>
+    Simon Howard <fraggle@soulsphere.org>
     Simon Klinkert <simon.klinkert@gmail.com>
     Sowrabha Gopal <sowrabha.gopal@delphix.com>
     Spencer Kinny <spencerkinny1995@gmail.com>
@@ -610,6 +617,7 @@ CONTRIBUTORS:
     Stéphane Lesimple <speed47_github@speed47.net>
     Suman Chakravartula <schakrava@gmail.com>
     Sydney Vanda <sydney.m.vanda@intel.com>
+    Syed Shahrukh Hussain <syed.shahrukh@ossrevival.org>
     Sören Tempel <soeren+git@soeren-tempel.net>
     Tamas TEVESZ <ice@extreme.hu>
     Teodor Spæren <teodor_spaeren@riseup.net>

--- a/scripts/update_authors.pl
+++ b/scripts/update_authors.pl
@@ -59,6 +59,17 @@
 # the display version. We use this slug to update two maps, one of email->name,
 # the other of name->email.
 #
+# Where possible, we also consider Signed-off-by: trailers in the commit
+# message, and if they match the commit author, enter them into the maps also.
+# Because a commit can contain multiple signoffs, we only track one if either
+# the name or the email address match the commit author (by slug). This is
+# mostly aimed at letting an explicit signoff override a generated name or
+# email on the same commit (usually a Github noreply), while avoiding every
+# signoff ever being treated as a possible canonical ident for some other
+# committer. (Also note that this behaviour only works for signoffs that can be
+# extracted with git-interpret-trailers, which misses many seen in the OpenZFS
+# git history, for various reasons).
+#
 # Once collected, we then walk all the emails we've seen and get all the names
 # associated with every instance. Then for each of those names, we get all the
 # emails associated, and so on until we've seen all the connected names and
@@ -118,31 +129,42 @@ for my $line (do { local (@ARGV) = ('AUTHORS'); <> }) {
 	}
 }
 
-# Next, we load all the commit authors. and form name<->email mappings, keyed
-# on slug. Note that this format is getting the .mailmap-converted form. This
-# lets us control the input to some extent by making changes there.
+# Next, we load all the commit authors and signoff pairs, and form name<->email
+# mappings, keyed on slug. Note that this format is getting the
+# .mailmap-converted form. This lets us control the input to some extent by
+# making changes there.
 my %git_names;
 my %git_emails;
 
-for my $line (reverse qx(git log --pretty=tformat:'%aN:::%aE')) {
+for my $line (reverse qx(git log --pretty=tformat:'%aN:::%aE:::%(trailers:key=signed-off-by,valueonly,separator=:::)')) {
 	chomp $line;
-	my ($name, $email) = $line =~ m/^(.*):::(.*)/;
+	my ($name, $email, @signoffs) = split ':::', $line;
 	next unless $name && $email;
 
 	my $semail = email_slug($email);
 	my $sname = name_slug($name);
 
+	# Track the committer name and email.
 	$git_names{$semail}{$sname} = 1;
 	$git_emails{$sname}{$semail} = 1;
 
-	# Update the "best looking" display value, but only if we don't already
-	# have something from the AUTHORS file. If we do, we must not change it.
-	if (!$authors_name{email_slug($email)}) {
-		update_display_email($email);
-	}
+	# Consider if these are the best we've ever seen.
+	update_display_name($name);
+	update_display_email($email);
 
-	if (!$authors_email{name_slug($name)}) {
-		update_display_name($name);
+	# Check signoffs. any that have a matching name or email as the
+	# committer (by slug), also track them.
+	for my $signoff (@signoffs) {
+		my ($soname, $soemail) = $signoff =~ m/^([^<]+)\s+<(.+)>$/;
+		next unless $soname && $soemail;
+		my $ssoname = name_slug($soname);
+		my $ssoemail = email_slug($soemail);
+		if (($semail eq $ssoemail) ^ ($sname eq $ssoname)) {
+		    $git_names{$ssoemail}{$ssoname} = 1;
+		    $git_emails{$ssoname}{$ssoemail} = 1;
+		    update_display_name($soname);
+		    update_display_email($soemail);
+		}
 	}
 }
 
@@ -194,7 +216,6 @@ for my $committer (@committers) {
 
 # Now output the new AUTHORS file
 open my $fh, '>', 'AUTHORS' or die "E: couldn't open AUTHORS for write: $!\n";
-#my $fh = \*STDOUT;
 say $fh join("\n", @authors_header, "");
 for my $name (sort keys %authors_email) {
 	my $cname = $display_name{$name};
@@ -233,9 +254,18 @@ sub email_slug {
 	return lc $email;
 }
 
+# As we accumulate new names and addresses, record the "best looking" version
+# of each. Once we decide to add a committer to AUTHORS, we'll take the best
+# version of their name and address from here.
+#
+# Note that we don't record them if they're already in AUTHORS (that is, in
+# %authors_name or %authors_email) because that file already contains the
+# "best" version, by definition. So we return immediately if we've seen it
+# there already.
 sub update_display_name {
 	my ($name) = @_;
 	my $sname = name_slug($name);
+	return if $authors_email{$sname};
 
 	# For names, "more specific" means "has more non-lower-case characters"
 	# (in ASCII), guessing that if a person has gone to some effort to
@@ -252,9 +282,11 @@ sub update_display_name {
 sub update_display_email {
 	my ($email) = @_;
 	my $semail = email_slug($email);
+	return if $authors_name{$semail};
 
 	# Like names, we prefer uppercase when possible. We also remove any
 	# leading "plus address" for Github noreply addresses.
+
 	$email =~ s/^[^\+]*\+//g if $email =~ m/\.noreply\.github\.com$/;
 
 	my $cemail = $display_email{$semail};


### PR DESCRIPTION
### Motivation and Context

> Jason: You're not gonna die on the planet, Guy.
> Guy: I'm not? Then what's my last name?
> Jason: It's, uh, uh - I don't know.
> Guy: Nobody knows! Do you know why? Because my character isn't important enough for a last name, because I'm gonna die five minutes in!
> Gwen: Guy, you have a last name!
> Guy: DO I? DO I? For all you know, I'm "Crewman Number Six"!
> 
> – Galaxy Quest, 1999

New contributors, new credits! Hello and welcome!

### Description

The important part is the `AUTHORS` and `mailmap` updates. Includes @OlCe2's requested update from [#17309](https://github.com/openzfs/zfs/pull/17309#issuecomment-2858740171).

`update_authors.pl` gets some improvements, to consider `Signed-of-by:` trailers in name matching, and to output suggestions for `mailmap`.

### How Has This Been Tested?

Run program, tweak, repeat.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
