### PR TITLE
vdev_id: symlinks creation for multipath disk partitions

### DIFF
--- a/udev/vdev_id
+++ b/udev/vdev_id
@@ -288,13 +288,20 @@ sas_handler() {
 		# we have to append the -part suffix directly in the
 		# helper.
 		if [ "$DEVTYPE" != "partition" ] ; then
-			# Match p[number], remove the 'p' and prepend "-part"
-			PART=$(echo "$DM_NAME" |
-				awk 'match($0,/p[0-9]+$/) {print "-part"substr($0,RSTART+1,RLENGTH-1)}')
+                        # WWNs end with number -> p<partition>, alphabet -> <partition>
+                        # '3' + (WWN length 16) = 17
+                        PART=${DM_NAME:17}
+                        if [[ $PART = "p"*  ]]; then
+                                # Match p[number], remove the 'p' and prepend "-part"
+                                PART=$(echo "$DM_NAME" |
+                                    awk 'match($0,/p[0-9]+$/) {print "-part"substr($0,RSTART+1,RLENGTH-1)}')
+                        elif [[ $PART != "" ]]; then
+                                PART="-part"${PART}
+                        fi
 		fi
 
 		# Strip off partition information.
-		DM_NAME=$(echo "$DM_NAME" | sed 's/p[0-9][0-9]*$//')
+                DM_NAME=${DM_NAME:0:17}
 		if [ -z "$DM_NAME" ] ; then
 			return
 		fi
@@ -305,10 +312,20 @@ sas_handler() {
 		# If our DEVNAME is something like /dev/dm-177, then we may be
 		# able to get our DMDEV from it.
 		DMDEV=$(echo $DEVNAME | sed 's;/dev/;;g')
+                if [ -n "$DMDEV"  ]; then
+                        DEV=$(ls /sys/block/$DMDEV/slaves)
+                        for elm in "${DEV[@]}"; do
+                                if [[ $elm == "dm-"* ]]; then
+                                        DMDEV=$elm
+                                        break
+                                fi
+                        done
+                fi
+
 		if [ ! -e /sys/block/$DMDEV/slaves/* ] ; then
 			# It's not there, try looking in /dev/mapper
 			DMDEV=$(ls -l --full-time /dev/mapper | grep $DM_NAME |
-			awk '{gsub("../", " "); print $NF}')
+			awk '{gsub("../", " "); print $NF}' | head -n 1)
 		fi
 
 		# Use sysfs pointers in /sys/block/dm-X/slaves because using
@@ -520,13 +537,20 @@ scsi_handler() {
 		# we have to append the -part suffix directly in the
 		# helper.
 		if [ "$DEVTYPE" != "partition" ] ; then
-			# Match p[number], remove the 'p' and prepend "-part"
-			PART=$(echo "$DM_NAME" |
-			    awk 'match($0,/p[0-9]+$/) {print "-part"substr($0,RSTART+1,RLENGTH-1)}')
+                        # WWNs end with number -> p<partition>, alphabet -> <partition>
+                        # '3' + (WWN length 16) = 17
+                        PART=${DM_NAME:17}
+                        if [[ $PART = "p"*  ]]; then
+                                # Match p[number], remove the 'p' and prepend "-part"
+                                PART=$(echo "$DM_NAME" |
+                                    awk 'match($0,/p[0-9]+$/) {print "-part"substr($0,RSTART+1,RLENGTH-1)}')
+                        elif [[ $PART != "" ]]; then
+                                PART="-part"${PART}
+                        fi
 		fi
 
 		# Strip off partition information.
-		DM_NAME=$(echo "$DM_NAME" | sed 's/p[0-9][0-9]*$//')
+                DM_NAME=${DM_NAME:0:17}
 		if [ -z "$DM_NAME" ] ; then
 			return
 		fi


### PR DESCRIPTION
It has been observed that the symlinks are not being created for the disk partitions on multipath enabled systems. This fix addresses the issue.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It has been observed that the symlinks are not being created for the disk partitions on multipath enabled systems.
Before change:
```
# ll /dev/disk/by-vdev/enc1-20*
lrwxrwxrwx 1 root root 12 May 12 06:41 /dev/disk/by-vdev/enc1-20 -> ../../dm-113
```
After change:
```
# ll /dev/disk/by-vdev/enc1-20*
lrwxrwxrwx 1 root root 12 May 12 06:49 /dev/disk/by-vdev/enc1-20 -> ../../dm-113
lrwxrwxrwx 1 root root 12 May 12 06:49 /dev/disk/by-vdev/enc1-20-part1 -> ../../dm-157
```
### Description
It appears that the issue is there in the vdev_id tool/script, which seems to assume partitioned multipath device names to end with 'p'[n]. However, in some cases, the devices have only the number (e.g., 1) appended as a suffix. As per linux convention If the disk WWN ends in digit, then p is appended. If name ends in letter, no p is appended. The device member ending with p1 has a total length of 17 + 2 (p1), some members have a length of 17 + 1 (1). 

Examples:
```
35000c500ca0182b7 
35000c500ca0182b7p1 
35000c500ca9ed76f 
35000c500ca9ed76f1
```
This fix addresses the above issues accordingly.
<!--- Describe your changes in detail -->

### How Has This Been Tested?
I have tested this manually in some of our multipath enabled systems.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
