### PR TITLE
Linux: Stop using NR_FILE_PAGES for ARC scaling

### DIFF
--- a/include/os/linux/kernel/linux/page_compat.h
+++ b/include/os/linux/kernel/linux/page_compat.h
@@ -4,8 +4,8 @@
 /*
  * Create our own accessor functions to follow the Linux API changes
  */
-#define	nr_file_pages() global_node_page_state(NR_FILE_PAGES)
-#define	nr_inactive_anon_pages() global_node_page_state(NR_INACTIVE_ANON)
+#define	nr_file_pages() (global_node_page_state(NR_ACTIVE_FILE) + \
+			global_node_page_state(NR_INACTIVE_FILE))
 #define	nr_inactive_file_pages() global_node_page_state(NR_INACTIVE_FILE)
 
 #endif /* _ZFS_PAGE_COMPAT_H */

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -872,7 +872,9 @@ pressure on the pagecache, yet still allows the ARC to be reclaimed down to
 .Sy zfs_arc_min
 if necessary.
 This value is specified as percent of pagecache size (as measured by
-.Sy NR_FILE_PAGES ) ,
+.Sy NR_ACTIVE_FILE
++
+.Sy NR_INACTIVE_FILE ) ,
 where that percent may exceed
 .Sy 100 .
 This


### PR DESCRIPTION
I've found that QEMU/KVM guest memory accounted as shared also included into NR_FILE_PAGES.  But it is actually a non-evictable anonymous memory.  Using it as a base for zfs_arc_pc_percent parameter makes ARC to ignore shrinker requests while page cache does not really have anything to evict, ending up in OOM killer killing the QEMU process.

Instead use of NR_ACTIVE_FILE + NR_INACTIVE_FILE should represent the part of a page cache that is actually evictable, which should be safer to use as a reference for ARC scaling.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
