### PR TITLE
Increase meta-dnode redundancy in "some" mode

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -144,9 +144,9 @@ typedef enum dmu_object_byteswap {
 #define	DMU_OT_IS_DDT(ot) \
 	((ot) == DMU_OT_DDT_ZAP)
 
-#define	DMU_OT_IS_CRITICAL(ot) \
+#define	DMU_OT_IS_CRITICAL(ot, level) \
 	(DMU_OT_IS_METADATA(ot) && \
-	(ot) != DMU_OT_DNODE && \
+	((ot) != DMU_OT_DNODE || (level) > 0) && \
 	(ot) != DMU_OT_DIRECTORY_CONTENTS && \
 	(ot) != DMU_OT_SA)
 

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1632,7 +1632,8 @@ When set to
 ZFS stores an extra copy of only critical metadata.
 This can improve file create performance since less metadata
 needs to be written.
-If a single on-disk block is corrupt, at worst a single user file can be lost.
+If a single on-disk block is corrupt, multiple user files or directories
+can be lost.
 .Pp
 When set to
 .Sy none ,

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2358,7 +2358,7 @@ dmu_write_policy(objset_t *os, dnode_t *dn, int level, int wp, zio_prop_t *zp)
 				gang_copies++;
 			break;
 		case ZFS_REDUNDANT_METADATA_SOME:
-			if (DMU_OT_IS_CRITICAL(type)) {
+			if (DMU_OT_IS_CRITICAL(type, level)) {
 				copies++;
 				gang_copies++;
 			} else if (DMU_OT_IS_METADATA(type)) {


### PR DESCRIPTION
Loss of one indirect block of the meta dnode likely means loss of the whole dataset.  It is worse than one file that the man page promises, and in my opinion is not much better than "none" mode.

This change restores redundancy of the meta-dnode indirect blocks, while same time still corrects expectations in the man page.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
