### PR TITLE
`libzfs_core`: add `ZFS_IOC_TRACE` envvar to enable ioctl tracing

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -4911,7 +4911,7 @@ zfs_smb_acl_mgmt(libzfs_handle_t *hdl, char *dataset, char *path,
 	default:
 		return (-1);
 	}
-	error = ioctl(hdl->libzfs_fd, ZFS_IOC_SMB_ACL, &zc);
+	error = lzc_ioctl_fd(hdl->libzfs_fd, ZFS_IOC_SMB_ACL, &zc);
 	nvlist_free(nvlist);
 	return (error);
 }

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -785,6 +785,12 @@ zpool_standard_error_fmt(libzfs_handle_t *hdl, int error, const char *fmt, ...)
 	return (-1);
 }
 
+int
+zfs_ioctl(libzfs_handle_t *hdl, int request, zfs_cmd_t *zc)
+{
+	return (lzc_ioctl_fd(hdl->libzfs_fd, request, zc));
+}
+
 /*
  * Display an out of memory error message and abort the current program.
  */

--- a/lib/libzfs/os/freebsd/libzfs_compat.c
+++ b/lib/libzfs/os/freebsd/libzfs_compat.c
@@ -218,12 +218,6 @@ libzfs_error_init(int error)
 	return (errbuf);
 }
 
-int
-zfs_ioctl(libzfs_handle_t *hdl, int request, zfs_cmd_t *zc)
-{
-	return (lzc_ioctl_fd(hdl->libzfs_fd, request, zc));
-}
-
 /*
  * Verify the required ZFS_DEV device is available and optionally attempt
  * to load the ZFS modules.  Under normal circumstances the modules

--- a/lib/libzfs/os/linux/libzfs_util_os.c
+++ b/lib/libzfs/os/linux/libzfs_util_os.c
@@ -53,12 +53,6 @@
 
 #define	ZDIFF_SHARESDIR		"/.zfs/shares/"
 
-int
-zfs_ioctl(libzfs_handle_t *hdl, int request, zfs_cmd_t *zc)
-{
-	return (ioctl(hdl->libzfs_fd, request, zc));
-}
-
 const char *
 libzfs_error_init(int error)
 {

--- a/lib/libzfs_core/Makefile.am
+++ b/lib/libzfs_core/Makefile.am
@@ -1,18 +1,21 @@
 libzfs_core_la_CFLAGS  = $(AM_CFLAGS) $(LIBRARY_CFLAGS)
 libzfs_core_la_CFLAGS += -fvisibility=hidden
 
+libzfs_core_la_CPPFLAGS  = $(AM_CPPFLAGS)
+libzfs_core_la_CPPFLAGS += -I$(srcdir)/%D%
+
 lib_LTLIBRARIES += libzfs_core.la
 CPPCHECKTARGETS += libzfs_core.la
 
 libzfs_core_la_SOURCES = \
-	%D%/libzfs_core.c
+	%D%/libzfs_core.c \
+	%D%/libzfs_core_impl.h
 
 if BUILD_LINUX
 libzfs_core_la_SOURCES += \
 	%D%/os/linux/libzfs_core_ioctl.c
 endif
 
-libzfs_core_la_CPPFLAGS  = $(AM_CPPFLAGS)
 if BUILD_FREEBSD
 libzfs_core_la_CPPFLAGS += -Iinclude/os/freebsd/zfs
 

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -102,6 +102,8 @@ static int g_fd = -1;
 static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
 static int g_refcount;
 
+static int g_ioc_trace = 0;
+
 #ifdef ZFS_DEBUG
 static zfs_ioc_t fail_ioc_cmd = ZFS_IOC_LAST;
 static zfs_errno_t fail_ioc_err;
@@ -154,6 +156,10 @@ libzfs_core_init(void)
 #ifdef ZFS_DEBUG
 	libzfs_core_debug_ioc();
 #endif
+
+	if (getenv("ZFS_IOC_TRACE"))
+		g_ioc_trace = 1;
+
 	(void) pthread_mutex_unlock(&g_lock);
 	return (0);
 }
@@ -176,7 +182,37 @@ libzfs_core_fini(void)
 int
 lzc_ioctl_fd(int fd, unsigned long ioc, zfs_cmd_t *zc)
 {
-	return (lzc_ioctl_fd_os(fd, ioc, zc));
+	if (!g_ioc_trace)
+		return (lzc_ioctl_fd_os(fd, ioc, zc));
+
+	nvlist_t *nvl;
+
+	fprintf(stderr, "=== lzc_ioctl: call: ioc=0x%lx name=%s\n",
+	    ioc, zc->zc_name[0] ? zc->zc_name : "[none]");
+	if (zc->zc_nvlist_src) {
+		nvl = fnvlist_unpack(
+		    (void *)(uintptr_t)zc->zc_nvlist_src,
+		    zc->zc_nvlist_src_size);
+		nvlist_print(stderr, nvl);
+		fnvlist_free(nvl);
+	}
+
+	int rc = lzc_ioctl_fd_os(fd, ioc, zc);
+	int err = errno;
+
+	fprintf(stderr, "=== lzc_ioctl: result: ioc=0x%lx name=%s "
+	    "rc=%d errno=%d\n", ioc, zc->zc_name[0] ? zc->zc_name : "[none]",
+	    rc, (rc < 0 ? err : 0));
+	if (rc >= 0 && zc->zc_nvlist_dst) {
+		nvl = fnvlist_unpack(
+		    (void *)(uintptr_t)zc->zc_nvlist_dst,
+		    zc->zc_nvlist_dst_size);
+		nvlist_print(stderr, nvl);
+		fnvlist_free(nvl);
+	}
+
+	errno = err;
+	return (rc);
 }
 
 static int

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -96,6 +96,8 @@
 #define	BIG_PIPE_SIZE (64 * 1024) /* From sys/pipe.h */
 #endif
 
+#include "libzfs_core_impl.h"
+
 static int g_fd = -1;
 static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
 static int g_refcount;
@@ -169,6 +171,12 @@ libzfs_core_fini(void)
 		g_fd = -1;
 	}
 	(void) pthread_mutex_unlock(&g_lock);
+}
+
+int
+lzc_ioctl_fd(int fd, unsigned long ioc, zfs_cmd_t *zc)
+{
+	return (lzc_ioctl_fd_os(fd, ioc, zc));
 }
 
 static int

--- a/lib/libzfs_core/libzfs_core_impl.h
+++ b/lib/libzfs_core/libzfs_core_impl.h
@@ -19,14 +19,18 @@
  *
  * CDDL HEADER END
  */
-#include <sys/types.h>
-#include <sys/param.h>
-#include <sys/zfs_ioctl.h>
-#include <libzfs_core.h>
-#include "libzfs_core_impl.h"
 
-int
-lzc_ioctl_fd_os(int fd, unsigned long request, zfs_cmd_t *zc)
-{
-	return (ioctl(fd, request, zc));
-}
+/*
+ * Copyright (c) 2012, 2020 by Delphix. All rights reserved.
+ * Copyright 2017 RackTop Systems.
+ * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+ * Copyright (c) 2019 Datto Inc.
+ */
+
+#ifndef	_LIBZFS_CORE_IMPL_H
+#define	_LIBZFS_CORE_IMPL_H
+
+struct zfs_cmd;
+int lzc_ioctl_fd_os(int, unsigned long, struct zfs_cmd *);
+
+#endif	/* _LIBZFS_CORE_IMPL_H */

--- a/lib/libzfs_core/os/freebsd/libzfs_core_ioctl.c
+++ b/lib/libzfs_core/os/freebsd/libzfs_core_ioctl.c
@@ -26,6 +26,7 @@
 #include <os/freebsd/zfs/sys/zfs_ioctl_compat.h>
 #include <err.h>
 #include <libzfs_core.h>
+#include "libzfs_core_impl.h"
 
 int zfs_ioctl_version = ZFS_IOCVER_UNDEF;
 
@@ -101,7 +102,7 @@ zcmd_ioctl_compat(int fd, int request, zfs_cmd_t *zc, const int cflag)
  * error is returned zc_nvlist_dst_size won't be updated.
  */
 int
-lzc_ioctl_fd(int fd, unsigned long request, zfs_cmd_t *zc)
+lzc_ioctl_fd_os(int fd, unsigned long request, zfs_cmd_t *zc)
 {
 	size_t oldsize;
 	int ret, cflag = ZFS_CMD_COMPAT_NONE;


### PR DESCRIPTION
### Motivation and Context

Understanding how the command line tools and the kernel module coordinate is tricky to understand sometimes, and while system tracing tools can show you the raw `ioctl()` calls, they usually have no idea about nvlists.

So, this adds a simple tracing facility that will dump `ioctl()` calls and returns.

### Description

First two commits are some light reorganisation to make `lzc_ioctl_fd()` a single chokepoint where all calls come through, and which then call any platform-specific code.

Top commit is the meat: if the`ZFS_IOC_TRACE` environment variable is set, then `lzc_ioctl_fd()` will put info about the call and return onto STDERR, with the source and dest nvlists if applicable.

Note that I'm only dumping nvlist contents, not trying to deal with all of `zfs_cmd_t`. Not that that wouldn't be useful, it's just not what I needed right now. Easily added later.

Some examples. `zfs get` receives results in nvlists:

```
$ env ZFS_IOC_TRACE=1 ./zfs get recordsize crayon/var
=== lzc_ioctl: call: ioc=0x5a12 name=crayon/var
=== lzc_ioctl: result: ioc=0x5a12 name=crayon/var errno=0
nvlist version: 0
	mountpoint = (embedded nvlist)
	nvlist version: 0
		value = /var
		source = crayon/var
	(end mountpoint)

	canmount = (embedded nvlist)
	nvlist version: 0
		value = 0x0
		source = crayon/var
	(end canmount)

...
	useraccounting = (embedded nvlist)
	nvlist version: 0
		value = 0x1
	(end useraccounting)

=== lzc_ioctl: call: ioc=0x5a05 name=crayon
=== lzc_ioctl: result: ioc=0x5a05 name=crayon errno=0
nvlist version: 0
	version = 0x1388
	name = crayon
	state = 0x0
	txg = 0x581489
	pool_guid = 0xeb8f8068290104ad
...
		com.klarasystems:fast_dedup = 0x0
		org.zfsonlinux:longname = 0x0
		com.klarasystems:large_microzap = 0x0
	(end feature_stats)

NAME        PROPERTY    VALUE    SOURCE
crayon/var  recordsize  128K     default
=== lzc_ioctl: call: ioc=0x5a3f name=[none]
nvlist version: 0
	message = zfs get recordsize crayon/var
=== lzc_ioctl: result: ioc=0x5a3f name=[none] errno=1
```

`zpool wait` has a request nvlist:

```
$ env ZFS_IOC_TRACE=1 ./zpool wait crayon
=== lzc_ioctl: call: ioc=0x5a05 name=crayon
=== lzc_ioctl: result: ioc=0x5a05 name=crayon errno=84
=== lzc_ioctl: call: ioc=0x5a53 name=crayon
nvlist version: 0
	wait_activity = 0
=== lzc_ioctl: result: ioc=0x5a53 name=crayon errno=84
```

Some have no nvlists, but you still get an idea of what's going on:

```
$ env ZFS_IOC_TRACE=1 ./zpool list crayon
=== lzc_ioctl: call: ioc=0x5a05 name=crayon
=== lzc_ioctl: result: ioc=0x5a05 name=crayon errno=84
=== lzc_ioctl: call: ioc=0x5a27 name=crayon
=== lzc_ioctl: result: ioc=0x5a27 name=crayon errno=84
NAME     SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
crayon   444G   393G  51.2G        -         -    79%    88%  1.00x    ONLINE  -
=== lzc_ioctl: call: ioc=0x5a3f name=[none]
nvlist version: 0
	message = zpool list crayon
=== lzc_ioctl: result: ioc=0x5a3f name=[none] errno=1
```

### How Has This Been Tested?

By hand, as above, on both Linux and FreeBSD. I'll let the buildbots make sure nothing is broken, but I don't expect anything weird because if the envvar isn't set, it should just be the fast path.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
