### PR TITLE
arcstat: prevent ZeroDivisionError when L2ARC becomes empty

### DIFF
--- a/cmd/arcstat.in
+++ b/cmd/arcstat.in
@@ -735,13 +735,14 @@ def calculate():
                             v[group["percent"]] if v[group["percent"]] > 0 else 0
 
     if l2exist:
+        l2asize = cur["l2_asize"]
         v["l2hits"] = d["l2_hits"] / sint
         v["l2miss"] = d["l2_misses"] / sint
         v["l2read"] = v["l2hits"] + v["l2miss"]
         v["l2hit%"] = 100 * v["l2hits"] / v["l2read"] if v["l2read"] > 0 else 0
 
         v["l2miss%"] = 100 - v["l2hit%"] if v["l2read"] > 0 else 0
-        v["l2asize"] = cur["l2_asize"]
+        v["l2asize"] = l2asize
         v["l2size"] = cur["l2_size"]
         v["l2bytes"] = d["l2_read_bytes"] / sint
         v["l2wbytes"] = d["l2_write_bytes"] / sint
@@ -751,11 +752,11 @@ def calculate():
         v["l2mru"] = cur["l2_mru_asize"]
         v["l2data"] = cur["l2_bufc_data_asize"]
         v["l2meta"] = cur["l2_bufc_metadata_asize"]
-        v["l2pref%"] = 100 * v["l2pref"] / v["l2asize"]
-        v["l2mfu%"] = 100 * v["l2mfu"] / v["l2asize"]
-        v["l2mru%"] = 100 * v["l2mru"] / v["l2asize"]
-        v["l2data%"] = 100 * v["l2data"] / v["l2asize"]
-        v["l2meta%"] = 100 * v["l2meta"] / v["l2asize"]
+        v["l2pref%"] = 100 * v["l2pref"] / l2asize if l2asize > 0 else 0
+        v["l2mfu%"] = 100 * v["l2mfu"] / l2asize if l2asize > 0 else 0
+        v["l2mru%"] = 100 * v["l2mru"] / l2asize if l2asize > 0 else 0
+        v["l2data%"] = 100 * v["l2data"] / l2asize if l2asize > 0 else 0
+        v["l2meta%"] = 100 * v["l2meta"] / l2asize if l2asize > 0 else 0
 
     v["grow"] = 0 if cur["arc_no_grow"] else 1
     v["need"] = cur["arc_need_free"]


### PR DESCRIPTION
### Motivation and Context
Prevent a `ZeroDivisionError` in arcstat when the L2ARC exists but becomes empty during monitoring.

### Description
When monitoring L2ARC usage with arcstat, if the L2ARC device is present but its size `l2_asize` drops to zero, `arcstat` crashes with a `ZeroDivisionError` during percentage calculation:
```
$ arcstat -f time,l2size 1

Traceback (most recent call last):
  File "/bin/arcstat", line 802, in <module>
    main()
  File "/bin/arcstat", line 786, in main
    calculate()
  File "/bin/arcstat", line 754, in calculate
    v["l2pref%"] = 100 * v["l2pref"] / v["l2asize"]
                   ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
ZeroDivisionError: division by zero
```

### How Has This Been Tested?
- Manually verified that `arcstat` no longer crashes when L2ARC becomes empty during runtime.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
