### PR TITLE
Add CodeQL check to detect cause of issue #12014

### DIFF
--- a/.github/codeql-cpp.yml
+++ b/.github/codeql-cpp.yml
@@ -2,3 +2,4 @@ name: "Custom CodeQL Analysis"
 
 queries:
   - uses: ./.github/codeql/custom-queries/cpp/deprecatedFunctionUsage.ql
+  - uses: ./.github/codeql/custom-queries/cpp/dslDatasetHoldReleMismatch.ql

--- a/.github/codeql/custom-queries/cpp/dslDatasetHoldReleMismatch.ql
+++ b/.github/codeql/custom-queries/cpp/dslDatasetHoldReleMismatch.ql
@@ -1,0 +1,34 @@
+/**
+ * @name Detect mismatched dsl_dataset_hold/_rele pairs
+ * @description Flags instances of issue #12014 where
+ *   - a dataset held with dsl_dataset_hold_obj() ends up in dsl_dataset_rele_flags(), or
+ *   - a dataset held with dsl_dataset_hold_obj_flags() ends up in dsl_dataset_rele().
+ * @kind problem
+ * @severity error
+ * @tags correctness
+ * @id cpp/dslDatasetHoldReleMismatch
+ */
+
+import cpp
+
+from Variable ds, Call holdCall, Call releCall, string message
+where
+    ds.getType().toString() = "dsl_dataset_t *" and
+    holdCall.getASuccessor*() = releCall and
+    (
+        (holdCall.getTarget().getName() = "dsl_dataset_hold_obj_flags" and
+         holdCall.getArgument(4).(AddressOfExpr).getOperand().(VariableAccess).getTarget() = ds and
+         releCall.getTarget().getName() = "dsl_dataset_rele" and
+         releCall.getArgument(0).(VariableAccess).getTarget() = ds and
+         message = "Held with dsl_dataset_hold_obj_flags but released with dsl_dataset_rele")
+        or
+        (holdCall.getTarget().getName() = "dsl_dataset_hold_obj" and
+         holdCall.getArgument(3).(AddressOfExpr).getOperand().(VariableAccess).getTarget() = ds and
+         releCall.getTarget().getName() = "dsl_dataset_rele_flags" and
+         releCall.getArgument(0).(VariableAccess).getTarget() = ds and
+         message = "Held with dsl_dataset_hold_obj but released with dsl_dataset_rele_flags")
+    )
+select releCall,
+       "Mismatched release: held with $@ but released with " + releCall.getTarget().getName() + " for dataset $@",
+       holdCall, holdCall.getTarget().getName(),
+       ds, ds.toString()


### PR DESCRIPTION
### Motivation and Context
This is a simple check that would detect instances of the cause of issue #12014.

### Description
This check is currently limited to checking mismatches that occur in the same stack frame. It does not detect across stack frames.

I had originally intended not to send this in favor of developing a more comprehensive check and sending the patch for that, but @behlendorf asked for it in #17340, so I am opening a PR with what I currently have. Note that I had made an initial attempt at making the more comprehensive check on the weekend, but I am not well versed in the CodeQL language, so it will take a while to implement. 

### How Has This Been Tested?
I verified it identified the issue on ryao/zfs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
