### PR TITLE
Re-order and sync `zpool status` command usage between CLI help and man page

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -521,11 +521,11 @@ get_usage(zpool_help_t idx)
 		return (gettext("\ttrim [-dw] [-r <rate>] [-c | -s] <pool> "
 		    "[<device> ...]\n"));
 	case HELP_STATUS:
-		return (gettext("\tstatus [-c script1[,script2,...]] "
-		    "[-dDegiLpPstvx] ...\n"
-		    "\t    [-j [--json-int] [--json-flat-vdevs] "
+		return (gettext("\tstatus [-DdegiLPpstvx] "
+		    "[-c script1[,script2,...]] ...\n"
+		    "\t    [-j|--json [--json-flat-vdevs] [--json-int] "
 		    "[--json-pool-key-guid]] ...\n"
-		    "\t    [--power] [-T d|u] [pool] [interval [count]]\n"));
+		    "\t    [-T d|u] [--power] [pool] [interval [count]]\n"));
 	case HELP_UPGRADE:
 		return (gettext("\tupgrade\n"
 		    "\tupgrade -v\n"
@@ -10980,28 +10980,28 @@ status_callback(zpool_handle_t *zhp, void *data)
 }
 
 /*
- * zpool status [-c [script1,script2,...]] [-dDegiLpPstvx] ...
- * 				[-j [--json-int] [--json-flat-vdevs] ...
+ * zpool status [-dDegiLpPstvx] [-c [script1,script2,...]] ...
+ * 				[-j|--json [--json-flat-vdevs] [--json-int] ...
  * 				[--json-pool-key-guid]] [--power] [-T d|u] ...
  * 				[pool] [interval [count]]
  *
  *	-c CMD	For each vdev, run command CMD
- *	-d	Display Direct I/O write verify errors
  *	-D	Display dedup status (undocumented)
+ *	-d	Display Direct I/O write verify errors
  *	-e	Display only unhealthy vdevs
  *	-g	Display guid for individual vdev name.
  *	-i	Display vdev initialization status.
  *	-j [...]	Display output in JSON format
- *	   --json-int Display numbers in inteeger format instead of string
  *	   --json-flat-vdevs Display vdevs in flat hierarchy
+ *	   --json-int Display numbers in integer format instead of string
  *	   --json-pool-key-guid Use pool GUID as key for pool objects
  *	-L	Follow links when resolving vdev path name.
- *	-p	Display values in parsable (exact) format.
  *	-P	Display full path for vdev name.
+ *	-p	Display values in parsable (exact) format.
  *	--power	Display vdev enclosure slot power status
  *	-s	Display slow IOs column.
- *	-t	Display vdev TRIM status.
  *	-T	Display a timestamp in date(1) or Unix format
+ *	-t	Display vdev TRIM status.
  *	-v	Display complete error logs
  *	-x	Display only pools with potential problems
  *

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -521,11 +521,11 @@ get_usage(zpool_help_t idx)
 		return (gettext("\ttrim [-dw] [-r <rate>] [-c | -s] <pool> "
 		    "[<device> ...]\n"));
 	case HELP_STATUS:
-		return (gettext("\tstatus [--power] [-j [--json-int, "
-		    "--json-flat-vdevs, ...\n"
-		    "\t    --json-pool-key-guid]] [-c [script1,script2,...]] "
+		return (gettext("\tstatus [-c script1[,script2,...]] "
 		    "[-dDegiLpPstvx] ...\n"
-		    "\t    [-T d|u] [pool] [interval [count]]\n"));
+		    "\t    [-j [--json-int] [--json-flat-vdevs] "
+		    "[--json-pool-key-guid]] ...\n"
+		    "\t    [--power] [-T d|u] [pool] [interval [count]]\n"));
 	case HELP_UPGRADE:
 		return (gettext("\tupgrade\n"
 		    "\tupgrade -v\n"
@@ -10980,8 +10980,10 @@ status_callback(zpool_handle_t *zhp, void *data)
 }
 
 /*
- * zpool status [-c [script1,script2,...]] [-dDegiLpPstvx] [--power] ...
- *              [-T d|u] [pool] [interval [count]]
+ * zpool status [-c [script1,script2,...]] [-dDegiLpPstvx] ...
+ * 				[-j [--json-int] [--json-flat-vdevs] ...
+ * 				[--json-pool-key-guid]] [--power] [-T d|u] ...
+ * 				[pool] [interval [count]]
  *
  *	-c CMD	For each vdev, run command CMD
  *	-d	Display Direct I/O write verify errors
@@ -10989,19 +10991,19 @@ status_callback(zpool_handle_t *zhp, void *data)
  *	-e	Display only unhealthy vdevs
  *	-g	Display guid for individual vdev name.
  *	-i	Display vdev initialization status.
+ *	-j [...]	Display output in JSON format
+ *	   --json-int Display numbers in inteeger format instead of string
+ *	   --json-flat-vdevs Display vdevs in flat hierarchy
+ *	   --json-pool-key-guid Use pool GUID as key for pool objects
  *	-L	Follow links when resolving vdev path name.
  *	-p	Display values in parsable (exact) format.
  *	-P	Display full path for vdev name.
+ *	--power	Display vdev enclosure slot power status
  *	-s	Display slow IOs column.
  *	-t	Display vdev TRIM status.
  *	-T	Display a timestamp in date(1) or Unix format
  *	-v	Display complete error logs
  *	-x	Display only pools with potential problems
- *	-j	Display output in JSON format
- *	--power	Display vdev enclosure slot power status
- *	--json-int Display numbers in inteeger format instead of string
- *	--json-flat-vdevs Display vdevs in flat hierarchy
- *	--json-pool-key-guid Use pool GUID as key for pool objects
  *
  * Describes the health status of all pools or some subset.
  */

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -37,15 +37,15 @@
 .Sh SYNOPSIS
 .Nm zpool
 .Cm status
+.Op Fl DdegiLPpstvx
 .Op Fl c Ar script1 Ns Oo , Ns Ar script2 Ns ,… Oc
-.Op Fl dDegiLpPstvx
-.Oo Fl j
-.Oo Ns Fl Fl json-int Oc
-.Oo Ns Fl Fl json-flat-vdevs Oc
-.Oo Ns Fl Fl json-pool-key-guid Oc
+.Oo Fl j|--json
+.Oo Ns Fl -json-flat-vdevs Oc
+.Oo Ns Fl -json-int Oc
+.Oo Ns Fl -json-pool-key-guid Oc
 .Oc
-.Op Fl Fl power
 .Op Fl T Ar d|u
+.Op Fl -power
 .Op Ar pool
 .Op Ar interval Op Ar count
 .
@@ -74,6 +74,14 @@ See the
 option of
 .Nm zpool Cm iostat
 for complete details.
+.It Fl D
+Display a histogram of deduplication statistics, showing the allocated
+.Pq physically present on disk
+and referenced
+.Pq logically referenced in the pool
+block counts and sizes by reference count.
+If repeated, (-DD), also shows statistics on how much of the DDT is resident
+in the ARC.
 .It Fl d
 Display the number of Direct I/O read/write checksum verify errors that have
 occurred on a top-level VDEV.
@@ -87,14 +95,6 @@ Direct I/O reads checksum verify errors can also occur if the contents of the
 buffer are being manipulated after the I/O has been issued and is in flight.
 In the case of Direct I/O read checksum verify errors, the I/O will be reissued
 through the ARC.
-.It Fl D
-Display a histogram of deduplication statistics, showing the allocated
-.Pq physically present on disk
-and referenced
-.Pq logically referenced in the pool
-block counts and sizes by reference count.
-If repeated, (-DD), also shows statistics on how much of the DDT is resident
-in the ARC.
 .It Fl e
 Only show unhealthy vdevs (not-ONLINE or with errors).
 .It Fl g
@@ -103,15 +103,15 @@ These GUIDs can be used in place of device names for the zpool
 detach/offline/remove/replace commands.
 .It Fl i
 Display vdev initialization status.
-.It Fl j , -json Oo Ns Fl Fl json-int Oc Oo Ns Fl Fl json-flat-vdevs Oc \
-Oo Ns Fl Fl json-pool-key-guid Oc
+.It Fl j , -json Oo Ns Fl -json-flat-vdevs Oc Oo Ns Fl -json-int Oc \
+Oo Ns Fl -json-pool-key-guid Oc
 Display the status for ZFS pools in JSON format.
-Specify
-.Sy --json-int
-to display numbers in integer format instead of strings.
 Specify
 .Sy --json-flat-vdevs
 to display vdevs in flat hierarchy instead of nested vdev objects.
+Specify
+.Sy --json-int
+to display numbers in integer format instead of strings.
 Specify
 .Sy --json-pool-key-guid
 to set pool GUID as key for pool objects instead of pool names.
@@ -120,14 +120,14 @@ Display real paths for vdevs resolving all symbolic links.
 This can be used to look up the current block device name regardless of the
 .Pa /dev/disk/
 path used to open it.
-.It Fl p
-Display numbers in parsable (exact) values.
 .It Fl P
 Display full paths for vdevs instead of only the last component of
 the path.
 This can be used in conjunction with the
 .Fl L
 flag.
+.It Fl p
+Display numbers in parsable (exact) values.
 .It Fl -power
 Display vdev enclosure slot power status (on or off).
 .It Fl s
@@ -140,8 +140,6 @@ This does not necessarily mean the I/O operations failed to complete, just took
 an
 unreasonably long amount of time.
 This may indicate a problem with the underlying storage.
-.It Fl t
-Display vdev TRIM status.
 .It Fl T Sy d Ns | Ns Sy u
 Display a time stamp.
 Specify
@@ -154,6 +152,8 @@ Specify
 for a printed representation of the internal representation of time.
 See
 .Xr time 1 .
+.It Fl t
+Display vdev TRIM status.
 .It Fl v
 Displays verbose data error information, printing out a complete list of all
 data errors since the last complete pool scrub.

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -37,12 +37,17 @@
 .Sh SYNOPSIS
 .Nm zpool
 .Cm status
+.Op Fl c Ar script1 Ns Oo , Ns Ar script2 Ns ,… Oc
 .Op Fl dDegiLpPstvx
-.Op Fl T Sy u Ns | Ns Sy d
-.Op Fl c Op Ar SCRIPT1 Ns Oo , Ns Ar SCRIPT2 Oc Ns …
-.Oo Ar pool Oc Ns …
+.Oo Fl j
+.Oo Ns Fl Fl json-int Oc
+.Oo Ns Fl Fl json-flat-vdevs Oc
+.Oo Ns Fl Fl json-pool-key-guid Oc
+.Oc
+.Op Fl Fl power
+.Op Fl T Ar d|u
+.Op Ar pool
 .Op Ar interval Op Ar count
-.Op Fl j Op Ar --json-int, --json-flat-vdevs, --json-pool-key-guid
 .
 .Sh DESCRIPTION
 Displays the detailed health status for the given pools.
@@ -59,9 +64,7 @@ and the estimated time to completion.
 Both of these are only approximate, because the amount of data in the pool and
 the other workloads on the system can change.
 .Bl -tag -width Ds
-.It Fl -power
-Display vdev enclosure slot power status (on or off).
-.It Fl c Op Ar SCRIPT1 Ns Oo , Ns Ar SCRIPT2 Oc Ns …
+.It Fl c Ar script1 Ns Oo , Ns Ar script2 Ns ,… Oc
 Run a script (or scripts) on each vdev and include the output as a new column
 in the
 .Nm zpool Cm status
@@ -71,17 +74,6 @@ See the
 option of
 .Nm zpool Cm iostat
 for complete details.
-.It Fl j , -json Op Ar --json-int, --json-flat-vdevs, --json-pool-key-guid
-Display the status for ZFS pools in JSON format.
-Specify
-.Sy --json-int
-to display numbers in integer format instead of strings.
-Specify
-.Sy --json-flat-vdevs
-to display vdevs in flat hierarchy instead of nested vdev objects.
-Specify
-.Sy --json-pool-key-guid
-to set pool GUID as key for pool objects instead of pool names.
 .It Fl d
 Display the number of Direct I/O read/write checksum verify errors that have
 occurred on a top-level VDEV.
@@ -111,6 +103,18 @@ These GUIDs can be used in place of device names for the zpool
 detach/offline/remove/replace commands.
 .It Fl i
 Display vdev initialization status.
+.It Fl j , -json Oo Ns Fl Fl json-int Oc Oo Ns Fl Fl json-flat-vdevs Oc \
+Oo Ns Fl Fl json-pool-key-guid Oc
+Display the status for ZFS pools in JSON format.
+Specify
+.Sy --json-int
+to display numbers in integer format instead of strings.
+Specify
+.Sy --json-flat-vdevs
+to display vdevs in flat hierarchy instead of nested vdev objects.
+Specify
+.Sy --json-pool-key-guid
+to set pool GUID as key for pool objects instead of pool names.
 .It Fl L
 Display real paths for vdevs resolving all symbolic links.
 This can be used to look up the current block device name regardless of the
@@ -124,6 +128,8 @@ the path.
 This can be used in conjunction with the
 .Fl L
 flag.
+.It Fl -power
+Display vdev enclosure slot power status (on or off).
 .It Fl s
 Display the number of leaf vdev slow I/O operations.
 This is the number of I/O operations that didn't complete in
@@ -136,18 +142,18 @@ unreasonably long amount of time.
 This may indicate a problem with the underlying storage.
 .It Fl t
 Display vdev TRIM status.
-.It Fl T Sy u Ns | Ns Sy d
+.It Fl T Sy d Ns | Ns Sy u
 Display a time stamp.
-Specify
-.Sy u
-for a printed representation of the internal representation of time.
-See
-.Xr time 1 .
 Specify
 .Sy d
 for standard date format.
 See
 .Xr date 1 .
+Specify
+.Sy u
+for a printed representation of the internal representation of time.
+See
+.Xr time 1 .
 .It Fl v
 Displays verbose data error information, printing out a complete list of all
 data errors since the last complete pool scrub.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Addresses inconsistencies in command usage syntax noted in associated Git issue.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/openzfs/zfs/issues/16004

### Description
<!--- Describe your changes in detail -->
Re-formatted and reordered the usage statement printed by `zpool status` and then modified the associated man page as well, so the synopsis and description sections match.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
New usage output:
```
[root@ironi:zfs]# zpool status -h
invalid option 'h'
usage:
	status [-c [script1[,...]] [-dDegiLpPstvx] ...
	    [-j [--json-int] [--json-flat-vdevs] [--json-pool-key-guid]] ...
	    [--power] [-T d|u] [pool] [interval [count]]
```
New man page Synopsis:
```
[root@ironi:zfs]# zpool help status |head -n10
ZPOOL-STATUS(8)               BSD System Manager's Manual               ZPOOL-STATUS(8)

NAME
     zpool-status — show detailed health status for ZFS storage pools

SYNOPSIS
     zpool status [-c script1[,script2,…]] [-dDegiLpPstvx] [-j [--json-int]
           [--json-flat-vdevs] [--json-pool-key-guid]] [--power] [-T d|u] [pool]
           [interval [count]]
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
