### PR TITLE
Fix null dereference in spa_vdev_remove_cancel_sync()

### DIFF
--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -1931,10 +1931,9 @@ spa_vdev_remove_cancel_sync(void *arg, dmu_tx_t *tx)
 		 * because we have not allocated mappings for it yet.
 		 */
 		uint64_t syncd = vdev_indirect_mapping_max_offset(vim);
-		uint64_t sm_end = msp->ms_sm->sm_start +
-		    msp->ms_sm->sm_size;
-		if (sm_end > syncd)
-			zfs_range_tree_clear(segs, syncd, sm_end - syncd);
+		uint64_t ms_end = msp->ms_start + msp->ms_size;
+		if (ms_end > syncd)
+			zfs_range_tree_clear(segs, syncd, ms_end - syncd);
 
 		zfs_range_tree_vacate(segs, free_mapped_segment_cb, vd);
 	}


### PR DESCRIPTION
We don't really need to access space map to know where the metaslab ends, while msp->ms_sm might be NULL.

Fixes #17164
Fixes #17359

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
