### PR TITLE
Fix off-by-one bug in range tree code

### DIFF
--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -659,7 +659,7 @@ zfs_range_tree_find_in(zfs_range_tree_t *rt, uint64_t start, uint64_t size,
 	}
 
 	rs = zfs_btree_next(&rt->rt_root, &where, &where);
-	if (rs == NULL || zfs_rs_get_start(rs, rt) > start + size)
+	if (rs == NULL || zfs_rs_get_start(rs, rt) >= start + size)
 		return (B_FALSE);
 
 	*ostart = zfs_rs_get_start(rs, rt);


### PR DESCRIPTION
Sponsored-by: Klara, Inc.
Sponsored-by: Wasabi Technology, Inc.

### Motivation and Context
Without this fix, zfs_range_tree_find_in could return an overlap when the found range starts immediately after the searched range, with no actual overlap. For example, a tree with only a range from 10 to 14 inclusive (start 10, size 5), would return an overlap if you called `zfs_range_tree_find_in(rt, 0, 10, ...)`

### Description
Fix the bug by changing to `>=` instead of `>`.

### How Has This Been Tested?
Tested in conjunction with a new utility I've been developing that isn't quite ready for release yet.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
