### PR TITLE
`zfs_cmd`: reorganise `zfs_cmd_t` to match original size

### DIFF
--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -2613,6 +2613,9 @@
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libzfs/libzfs_config.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='2816' id='514368c7'>
+      <subrange length='352' type-id='7359adad' id='b715cd6f'/>
+    </array-type-def>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='32768' id='d16c6df4'>
       <subrange length='4096' type-id='7359adad' id='bc1b5ddc'/>
     </array-type-def>
@@ -2785,7 +2788,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='zfs_share_t' type-id='feb6f2da' id='ee5cec36'/>
-    <class-decl name='zfs_cmd' size-in-bits='110080' is-struct='yes' visibility='default' id='3522cd69'>
+    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='3522cd69'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zc_name' type-id='d16c6df4' visibility='default'/>
       </data-member>
@@ -2856,40 +2859,53 @@
         <var-decl name='zc_begin_record' type-id='09fcdc01' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='106368'>
-        <var-decl name='zc_inject_record' type-id='a4301ca6' visibility='default'/>
+        <var-decl name='' type-id='ac5ab595' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109312'>
-        <var-decl name='zc_defer_destroy' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109344'>
-        <var-decl name='zc_flags' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109376'>
-        <var-decl name='zc_action_handle' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109440'>
         <var-decl name='zc_cleanup_fd' type-id='95e97e5e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109472'>
+      <data-member access='public' layout-offset-in-bits='109344'>
         <var-decl name='zc_simple' type-id='b96825af' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109480'>
+      <data-member access='public' layout-offset-in-bits='109352'>
         <var-decl name='zc_pad' type-id='d3490169' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109504'>
+      <data-member access='public' layout-offset-in-bits='109376'>
         <var-decl name='zc_sendobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109568'>
+      <data-member access='public' layout-offset-in-bits='109440'>
         <var-decl name='zc_fromobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109632'>
+      <data-member access='public' layout-offset-in-bits='109504'>
         <var-decl name='zc_createtxg' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109696'>
+      <data-member access='public' layout-offset-in-bits='109568'>
         <var-decl name='zc_stat' type-id='0371a9c7' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='110016'>
+      <data-member access='public' layout-offset-in-bits='109888'>
         <var-decl name='zc_zoneid' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='2944' is-anonymous='yes' visibility='default' id='ac5ab595'>
+      <data-member access='public'>
+        <var-decl name='zc_inject_record' type-id='a4301ca6' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='' type-id='e7f43f73' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='2944' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zc_pad1' type-id='514368c7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='zc_defer_destroy' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2848'>
+        <var-decl name='zc_flags' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2880'>
+        <var-decl name='zc_action_handle' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
     <typedef-decl name='zfs_cmd_t' type-id='3522cd69' id='a5559cdd'/>
@@ -3167,7 +3183,7 @@
     <typedef-decl name='ssize_t' type-id='41060289' id='79a0948f'/>
     <class-decl name='sigaction' size-in-bits='1216' is-struct='yes' visibility='default' id='fe391c48'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__sigaction_handler' type-id='ac5ab595' visibility='default'/>
+        <var-decl name='__sigaction_handler' type-id='ac5ab596' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='sa_mask' type-id='b9c97942' visibility='default'/>
@@ -3179,7 +3195,7 @@
         <var-decl name='sa_restorer' type-id='953b12f8' visibility='default'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='ac5ab595'>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='ac5ab596'>
       <data-member access='public'>
         <var-decl name='sa_handler' type-id='8cdd9566' visibility='default'/>
       </data-member>
@@ -3252,36 +3268,36 @@
         <var-decl name='__pad0' type-id='95e97e5e' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_sifields' type-id='ac5ab596' visibility='default'/>
+        <var-decl name='_sifields' type-id='ac5ab597' visibility='default'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='896' is-anonymous='yes' visibility='default' id='ac5ab596'>
+    <union-decl name='__anonymous_union__1' size-in-bits='896' is-anonymous='yes' visibility='default' id='ac5ab597'>
       <data-member access='public'>
         <var-decl name='_pad' type-id='47394ee0' visibility='default'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_kill' type-id='e7f43f73' visibility='default'/>
+        <var-decl name='_kill' type-id='e7f43f74' visibility='default'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_timer' type-id='e7f43f74' visibility='default'/>
+        <var-decl name='_timer' type-id='e7f43f75' visibility='default'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_rt' type-id='e7f43f75' visibility='default'/>
+        <var-decl name='_rt' type-id='e7f43f76' visibility='default'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_sigchld' type-id='e7f43f76' visibility='default'/>
+        <var-decl name='_sigchld' type-id='e7f43f77' visibility='default'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_sigfault' type-id='e7f43f77' visibility='default'/>
+        <var-decl name='_sigfault' type-id='e7f43f78' visibility='default'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_sigpoll' type-id='e7f43f78' visibility='default'/>
+        <var-decl name='_sigpoll' type-id='e7f43f79' visibility='default'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_sigsys' type-id='e7f43f79' visibility='default'/>
+        <var-decl name='_sigsys' type-id='e7f43f7a' visibility='default'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__1' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f73'>
+    <class-decl name='__anonymous_struct__1' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f74'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_pid' type-id='3629bad8' visibility='default'/>
       </data-member>
@@ -3289,7 +3305,7 @@
         <var-decl name='si_uid' type-id='cc5fcceb' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f74'>
+    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f75'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_tid' type-id='95e97e5e' visibility='default'/>
       </data-member>
@@ -3300,7 +3316,7 @@
         <var-decl name='si_sigval' type-id='eabacd01' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__3' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f75'>
+    <class-decl name='__anonymous_struct__3' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f76'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_pid' type-id='3629bad8' visibility='default'/>
       </data-member>
@@ -3311,7 +3327,7 @@
         <var-decl name='si_sigval' type-id='eabacd01' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__4' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f76'>
+    <class-decl name='__anonymous_struct__4' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f77'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_pid' type-id='3629bad8' visibility='default'/>
       </data-member>
@@ -3328,7 +3344,7 @@
         <var-decl name='si_stime' type-id='4d66c6d7' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__5' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f77'>
+    <class-decl name='__anonymous_struct__5' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f78'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_addr' type-id='eaa32e2f' visibility='default'/>
       </data-member>
@@ -3336,18 +3352,18 @@
         <var-decl name='si_addr_lsb' type-id='a2185560' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_bounds' type-id='ac5ab597' visibility='default'/>
+        <var-decl name='_bounds' type-id='ac5ab598' visibility='default'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__2' size-in-bits='128' is-anonymous='yes' visibility='default' id='ac5ab597'>
+    <union-decl name='__anonymous_union__2' size-in-bits='128' is-anonymous='yes' visibility='default' id='ac5ab598'>
       <data-member access='public'>
-        <var-decl name='_addr_bnd' type-id='e7f43f7a' visibility='default'/>
+        <var-decl name='_addr_bnd' type-id='e7f43f7b' visibility='default'/>
       </data-member>
       <data-member access='public'>
         <var-decl name='_pkey' type-id='62f1140c' visibility='default'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__6' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7a'>
+    <class-decl name='__anonymous_struct__6' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7b'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_lower' type-id='eaa32e2f' visibility='default'/>
       </data-member>
@@ -3355,7 +3371,7 @@
         <var-decl name='_upper' type-id='eaa32e2f' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__7' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f78'>
+    <class-decl name='__anonymous_struct__7' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f79'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='si_band' type-id='bd54fe1a' visibility='default'/>
       </data-member>
@@ -3363,7 +3379,7 @@
         <var-decl name='si_fd' type-id='95e97e5e' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__8' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f79'>
+    <class-decl name='__anonymous_struct__8' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7a'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_call_addr' type-id='eaa32e2f' visibility='default'/>
       </data-member>
@@ -4144,6 +4160,12 @@
       <parameter type-id='5d6479ae'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='lzc_ioctl_fd' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='7359adad'/>
+      <parameter type-id='b65f7fd1'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='lzc_snapshot' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='5ce45b60'/>
       <parameter type-id='5ce45b60'/>
@@ -4579,12 +4601,6 @@
       <parameter type-id='e75a27e9'/>
       <parameter type-id='95e97e5e'/>
       <parameter type-id='9d26089a'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='ioctl' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='7359adad'/>
       <parameter is-variadic='yes'/>
       <return type-id='95e97e5e'/>
     </function-decl>
@@ -5268,6 +5284,12 @@
       <parameter type-id='724e4de6'/>
       <parameter type-id='b59d7dce'/>
       <return type-id='79a0948f'/>
+    </function-decl>
+    <function-decl name='ioctl' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='7359adad'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='fstat64' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
@@ -7229,7 +7251,7 @@
         <var-decl name='drr_payloadlen' type-id='8f92235e' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='drr_u' type-id='ac5ab598' visibility='default'/>
+        <var-decl name='drr_u' type-id='ac5ab599' visibility='default'/>
       </data-member>
     </class-decl>
     <enum-decl name='__anonymous_enum__' is-anonymous='yes' id='08f5ca17'>
@@ -7247,7 +7269,7 @@
       <enumerator name='DRR_REDACT' value='10'/>
       <enumerator name='DRR_NUMTYPES' value='11'/>
     </enum-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' id='ac5ab598'>
+    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' id='ac5ab599'>
       <data-member access='public'>
         <var-decl name='drr_begin' type-id='09fcdc01' visibility='default'/>
       </data-member>
@@ -7594,10 +7616,10 @@
         <var-decl name='sigev_notify' type-id='95e97e5e' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_sigev_un' type-id='ac5ab599' visibility='default'/>
+        <var-decl name='_sigev_un' type-id='ac5ab59a' visibility='default'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='384' is-anonymous='yes' visibility='default' id='ac5ab599'>
+    <union-decl name='__anonymous_union__1' size-in-bits='384' is-anonymous='yes' visibility='default' id='ac5ab59a'>
       <data-member access='public'>
         <var-decl name='_pad' type-id='73b82f0f' visibility='default'/>
       </data-member>
@@ -7605,10 +7627,10 @@
         <var-decl name='_tid' type-id='3629bad8' visibility='default'/>
       </data-member>
       <data-member access='public'>
-        <var-decl name='_sigev_thread' type-id='e7f43f7b' visibility='default'/>
+        <var-decl name='_sigev_thread' type-id='e7f43f7c' visibility='default'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7b'>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f7c'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='_function' type-id='5f147c28' visibility='default'/>
       </data-member>

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -1116,13 +1116,6 @@
       <parameter type-id='95e97e5e'/>
       <return type-id='26a90f95'/>
     </function-decl>
-    <function-decl name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='e75a27e9'/>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='9d26089a'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
     <function-decl name='stat64' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='9d26089a'/>
       <parameter type-id='f1cadedf'/>
@@ -1278,6 +1271,9 @@
     </array-type-def>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='2048' id='d1617432'>
       <subrange length='256' type-id='7359adad' id='36e5b9fa'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='2816' id='514368c7'>
+      <subrange length='352' type-id='7359adad' id='b715cd6f'/>
     </array-type-def>
     <array-type-def dimensions='1' type-id='a84c031d' size-in-bits='32768' id='d16c6df4'>
       <subrange length='4096' type-id='7359adad' id='bc1b5ddc'/>
@@ -1762,7 +1758,7 @@
       <enumerator name='DRR_REDACT' value='10'/>
       <enumerator name='DRR_NUMTYPES' value='11'/>
     </enum-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='2432' is-anonymous='yes' visibility='default' id='ac5ab595'>
+    <union-decl name='__anonymous_union__1' size-in-bits='2432' is-anonymous='yes' visibility='default' id='ac5ab595'>
       <data-member access='public'>
         <var-decl name='drr_begin' type-id='09fcdc01' visibility='default'/>
       </data-member>
@@ -2153,7 +2149,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='zfs_share_t' type-id='feb6f2da' id='ee5cec36'/>
-    <class-decl name='zfs_cmd' size-in-bits='110080' is-struct='yes' visibility='default' id='3522cd69'>
+    <class-decl name='zfs_cmd' size-in-bits='109952' is-struct='yes' visibility='default' id='3522cd69'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zc_name' type-id='d16c6df4' visibility='default'/>
       </data-member>
@@ -2224,42 +2220,56 @@
         <var-decl name='zc_begin_record' type-id='09fcdc01' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='106368'>
-        <var-decl name='zc_inject_record' type-id='a4301ca6' visibility='default'/>
+        <var-decl name='' type-id='ac5ab596' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='109312'>
-        <var-decl name='zc_defer_destroy' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109344'>
-        <var-decl name='zc_flags' type-id='8f92235e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109376'>
-        <var-decl name='zc_action_handle' type-id='9c313c2d' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='109440'>
         <var-decl name='zc_cleanup_fd' type-id='95e97e5e' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109472'>
+      <data-member access='public' layout-offset-in-bits='109344'>
         <var-decl name='zc_simple' type-id='b96825af' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109480'>
+      <data-member access='public' layout-offset-in-bits='109352'>
         <var-decl name='zc_pad' type-id='d3490169' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109504'>
+      <data-member access='public' layout-offset-in-bits='109376'>
         <var-decl name='zc_sendobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109568'>
+      <data-member access='public' layout-offset-in-bits='109440'>
         <var-decl name='zc_fromobj' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109632'>
+      <data-member access='public' layout-offset-in-bits='109504'>
         <var-decl name='zc_createtxg' type-id='9c313c2d' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='109696'>
+      <data-member access='public' layout-offset-in-bits='109568'>
         <var-decl name='zc_stat' type-id='0371a9c7' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='110016'>
+      <data-member access='public' layout-offset-in-bits='109888'>
         <var-decl name='zc_zoneid' type-id='9c313c2d' visibility='default'/>
       </data-member>
     </class-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='2944' is-anonymous='yes' visibility='default' id='ac5ab596'>
+      <data-member access='public'>
+        <var-decl name='zc_inject_record' type-id='a4301ca6' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='' type-id='e7f43f72' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='2944' is-struct='yes' is-anonymous='yes' visibility='default' id='e7f43f72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='zc_pad1' type-id='514368c7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2816'>
+        <var-decl name='zc_defer_destroy' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2848'>
+        <var-decl name='zc_flags' type-id='8f92235e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2880'>
+        <var-decl name='zc_action_handle' type-id='9c313c2d' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zfs_cmd_t' type-id='3522cd69' id='a5559cdd'/>
     <class-decl name='zfs_stat' size-in-bits='320' is-struct='yes' visibility='default' id='6417f0b9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='zs_gen' type-id='9c313c2d' visibility='default'/>
@@ -2555,14 +2565,14 @@
     <qualified-type-def type-id='eaa32e2f' restrict='yes' id='1b7446cd'/>
     <pointer-type-def type-id='eaa32e2f' size-in-bits='64' id='63e171df'/>
     <pointer-type-def type-id='3522cd69' size-in-bits='64' id='b65f7fd1'/>
+    <pointer-type-def type-id='a5559cdd' size-in-bits='64' id='e4ec4540'/>
     <class-decl name='_IO_codecvt' is-struct='yes' visibility='default' is-declaration-only='yes' id='a4036571'/>
     <class-decl name='_IO_marker' is-struct='yes' visibility='default' is-declaration-only='yes' id='010ae0b9'/>
     <class-decl name='_IO_wide_data' is-struct='yes' visibility='default' is-declaration-only='yes' id='79bd3751'/>
-    <function-decl name='lzc_ioctl_fd' mangled-name='lzc_ioctl_fd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_ioctl_fd'>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='7359adad'/>
-      <parameter type-id='b65f7fd1'/>
-      <return type-id='95e97e5e'/>
+    <function-decl name='nvlist_print' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='822cd80b'/>
+      <parameter type-id='5ce45b60'/>
+      <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='nvlist_free' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='5ce45b60'/>
@@ -2778,6 +2788,13 @@
     <function-decl name='__open_missing_mode' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='48b5725f'/>
     </function-decl>
+    <function-decl name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='e75a27e9'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='9d26089a'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='__read_chk' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
       <parameter type-id='eaa32e2f'/>
@@ -2790,6 +2807,12 @@
     </function-decl>
     <function-decl name='libzfs_core_fini' mangled-name='libzfs_core_fini' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='libzfs_core_fini'>
       <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='lzc_ioctl_fd' mangled-name='lzc_ioctl_fd' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_ioctl_fd'>
+      <parameter type-id='95e97e5e' name='fd'/>
+      <parameter type-id='7359adad' name='ioc'/>
+      <parameter type-id='e4ec4540' name='zc'/>
+      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='lzc_scrub' mangled-name='lzc_scrub' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_scrub'>
       <parameter type-id='5b35941c' name='ioc'/>
@@ -3173,6 +3196,12 @@
       <parameter type-id='80f4b756' name='pool'/>
       <parameter type-id='02e25ab0' name='unit'/>
       <parameter type-id='9c313c2d' name='amount'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_ioctl_fd_os' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='7359adad'/>
+      <parameter type-id='b65f7fd1'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-type size-in-bits='64' id='c70fa2e8'>


### PR DESCRIPTION
### Motivation and Context

2aa3fbe761 extended `zinject_record_t`, and in doing so inadvertently extended `zfs_cmd_t`, which broke compatibility with userspace tools without the change.

### Description

This fixes that by using some of the unused space in `zfs_cmd_t` for the extra fields. We also add an assert to trigger a compile error if the size ever changes.

 With this commit:

```c
$ pahole -C zfs_cmd module/zfs.ko
struct zfs_cmd {
	char                       zc_name[4096];        /*     0  4096 */
	/* --- cacheline 64 boundary (4096 bytes) --- */
	uint64_t                   zc_nvlist_src;        /*  4096     8 */
	uint64_t                   zc_nvlist_src_size;   /*  4104     8 */
	uint64_t                   zc_nvlist_dst;        /*  4112     8 */
	uint64_t                   zc_nvlist_dst_size;   /*  4120     8 */
	boolean_t                  zc_nvlist_dst_filled; /*  4128     4 */
	int                        zc_pad2;              /*  4132     4 */
	uint64_t                   zc_history;           /*  4136     8 */
	char                       zc_value[8192];       /*  4144  8192 */
	/* --- cacheline 192 boundary (12288 bytes) was 48 bytes ago --- */
	char                       zc_string[256];       /* 12336   256 */
	/* --- cacheline 196 boundary (12544 bytes) was 48 bytes ago --- */
	uint64_t                   zc_guid;              /* 12592     8 */
	uint64_t                   zc_nvlist_conf;       /* 12600     8 */
	/* --- cacheline 197 boundary (12608 bytes) --- */
	uint64_t                   zc_nvlist_conf_size;  /* 12608     8 */
	uint64_t                   zc_cookie;            /* 12616     8 */
	uint64_t                   zc_objset_type;       /* 12624     8 */
	uint64_t                   zc_perm_action;       /* 12632     8 */
	uint64_t                   zc_history_len;       /* 12640     8 */
	uint64_t                   zc_history_offset;    /* 12648     8 */
	uint64_t                   zc_obj;               /* 12656     8 */
	uint64_t                   zc_iflags;            /* 12664     8 */
	/* --- cacheline 198 boundary (12672 bytes) --- */
	zfs_share_t                zc_share;             /* 12672    32 */
	dmu_objset_stats_t         zc_objset_stats;      /* 12704   288 */
	/* --- cacheline 203 boundary (12992 bytes) --- */
	struct drr_begin           zc_begin_record;      /* 12992   304 */
	/* --- cacheline 207 boundary (13248 bytes) was 48 bytes ago --- */
	union {
		zinject_record_t   zc_inject_record;     /* 13296   368 */
		struct {
			char       zc_pad1[352];         /* 13296   352 */
			/* --- cacheline 213 boundary (13632 bytes) was 16 bytes ago --- */
			uint32_t   zc_defer_destroy;     /* 13648     4 */
			uint32_t   zc_flags;             /* 13652     4 */
			uint64_t   zc_action_handle;     /* 13656     8 */
		};                                       /* 13296   368 */
	};                                               /* 13296   368 */
	/* --- cacheline 213 boundary (13632 bytes) was 32 bytes ago --- */
	int                        zc_cleanup_fd;        /* 13664     4 */
	uint8_t                    zc_simple;            /* 13668     1 */
	uint8_t                    zc_pad[3];            /* 13669     3 */
	uint64_t                   zc_sendobj;           /* 13672     8 */
	uint64_t                   zc_fromobj;           /* 13680     8 */
	uint64_t                   zc_createtxg;         /* 13688     8 */
	/* --- cacheline 214 boundary (13696 bytes) --- */
	zfs_stat_t                 zc_stat;              /* 13696    40 */
	uint64_t                   zc_zoneid;            /* 13736     8 */

	/* size: 13744, cachelines: 215, members: 32 */
	/* last cacheline: 48 bytes */
};
```

Compare with 2.2.7:

```c
$ pahole -C zfs_cmd ~/code/zfs-2.2/module/zfs.ko
struct zfs_cmd {
	char                       zc_name[4096];        /*     0  4096 */
	/* --- cacheline 64 boundary (4096 bytes) --- */
	uint64_t                   zc_nvlist_src;        /*  4096     8 */
	uint64_t                   zc_nvlist_src_size;   /*  4104     8 */
	uint64_t                   zc_nvlist_dst;        /*  4112     8 */
	uint64_t                   zc_nvlist_dst_size;   /*  4120     8 */
	boolean_t                  zc_nvlist_dst_filled; /*  4128     4 */
	int                        zc_pad2;              /*  4132     4 */
	uint64_t                   zc_history;           /*  4136     8 */
	char                       zc_value[8192];       /*  4144  8192 */
	/* --- cacheline 192 boundary (12288 bytes) was 48 bytes ago --- */
	char                       zc_string[256];       /* 12336   256 */
	/* --- cacheline 196 boundary (12544 bytes) was 48 bytes ago --- */
	uint64_t                   zc_guid;              /* 12592     8 */
	uint64_t                   zc_nvlist_conf;       /* 12600     8 */
	/* --- cacheline 197 boundary (12608 bytes) --- */
	uint64_t                   zc_nvlist_conf_size;  /* 12608     8 */
	uint64_t                   zc_cookie;            /* 12616     8 */
	uint64_t                   zc_objset_type;       /* 12624     8 */
	uint64_t                   zc_perm_action;       /* 12632     8 */
	uint64_t                   zc_history_len;       /* 12640     8 */
	uint64_t                   zc_history_offset;    /* 12648     8 */
	uint64_t                   zc_obj;               /* 12656     8 */
	uint64_t                   zc_iflags;            /* 12664     8 */
	/* --- cacheline 198 boundary (12672 bytes) --- */
	zfs_share_t                zc_share;             /* 12672    32 */
	dmu_objset_stats_t         zc_objset_stats;      /* 12704   288 */
	/* --- cacheline 203 boundary (12992 bytes) --- */
	struct drr_begin           zc_begin_record;      /* 12992   304 */
	/* --- cacheline 207 boundary (13248 bytes) was 48 bytes ago --- */
	zinject_record_t           zc_inject_record;     /* 13296   352 */
	/* --- cacheline 213 boundary (13632 bytes) was 16 bytes ago --- */
	uint32_t                   zc_defer_destroy;     /* 13648     4 */
	uint32_t                   zc_flags;             /* 13652     4 */
	uint64_t                   zc_action_handle;     /* 13656     8 */
	int                        zc_cleanup_fd;        /* 13664     4 */
	uint8_t                    zc_simple;            /* 13668     1 */
	uint8_t                    zc_pad[3];            /* 13669     3 */
	uint64_t                   zc_sendobj;           /* 13672     8 */
	uint64_t                   zc_fromobj;           /* 13680     8 */
	uint64_t                   zc_createtxg;         /* 13688     8 */
	/* --- cacheline 214 boundary (13696 bytes) --- */
	zfs_stat_t                 zc_stat;              /* 13696    40 */
	uint64_t                   zc_zoneid;            /* 13736     8 */

	/* size: 13744, cachelines: 215, members: 35 */
	/* last cacheline: 48 bytes */
};
```

Importantly, each individual field has the same alignment.

There's other ways to do this, eg by having a `zinject_record_ext_t` as a union in a different position, but it's just different ways to arrange the deckchairs.

I don't really love this, but it seems like an ok stopgap. The other options are to revert 2aa3fbe761 on master too, or push forward to convert `ZFS_IOC_INJECT` to nvlists or something equally hefty. Good things to do, and we will, when we're done with all these other things!

### How Has This Been Tested?

Just basic local testing. I've not done interop testing, but pahole suggests everything lines up nice.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
