### PR TITLE
tunables: general code cleanup

### DIFF
--- a/include/os/freebsd/spl/sys/ccompile.h
+++ b/include/os/freebsd/spl/sys/ccompile.h
@@ -43,10 +43,7 @@ extern "C" {
 #endif
 
 #define	EXPORT_SYMBOL(x)
-#define	module_param(a, b, c)
-#define	module_param_call(a, b, c, d, e)
-#define	module_param_named(a, b, c, d)
-#define	MODULE_PARM_DESC(a, b)
+
 #define	asm __asm
 #ifdef ZFS_DEBUG
 #undef NDEBUG

--- a/include/os/linux/kernel/linux/mod_compat.h
+++ b/include/os/linux/kernel/linux/mod_compat.h
@@ -107,15 +107,15 @@ enum scope_prefix_types {
 #define	spl_param_ops_ulong param_ops_ulong
 #define	spl_param_ops_ULONG param_ops_ulong
 
+#define	spl_param_set_u64 param_set_ullong
+#define	spl_param_get_u64 param_get_ullong
+#define	spl_param_ops_u64 param_ops_ullong
+#define	spl_param_ops_U64 param_ops_ullong
+
 #define	spl_param_set_charp param_set_charp
 #define	spl_param_get_charp param_get_charp
 #define	spl_param_ops_charp param_ops_charp
 #define	spl_param_ops_STRING param_ops_charp
-
-extern int spl_param_set_u64(const char *val, zfs_kernel_param_t *kp);
-extern int spl_param_get_u64(char *buffer, zfs_kernel_param_t *kp);
-extern const struct kernel_param_ops spl_param_ops_u64;
-#define	spl_param_ops_U64 spl_param_ops_u64
 
 /*
  * Declare a module parameter / sysctl node

--- a/include/os/linux/kernel/linux/mod_compat.h
+++ b/include/os/linux/kernel/linux/mod_compat.h
@@ -79,43 +79,23 @@ enum scope_prefix_types {
 };
 
 /*
- * While we define our own u64 types, there is no reason to reimplement the
- * existing Linux kernel types, so we use the preprocessor to remap our
- * "custom" implementations to the kernel ones. This is done because the CPP
- * does not allow us to write conditional definitions. The fourth definition
- * exists because the CPP will not allow us to replace things like INT with int
- * before string concatenation.
+ * Our uint64 params are called U64 in part because we had them before Linux
+ * provided ULLONG param ops. Now it does, and we use them, but we retain the
+ * U64 name to keep many existing tunables working without issue.
  */
+#define	spl_param_set_u64	param_set_ullong
+#define	spl_param_get_u64	param_get_ullong
+#define	spl_param_ops_U64	param_ops_ullong
 
-#define	spl_param_set_int param_set_int
-#define	spl_param_get_int param_get_int
-#define	spl_param_ops_int param_ops_int
-#define	spl_param_ops_INT param_ops_int
-
-#define	spl_param_set_long param_set_long
-#define	spl_param_get_long param_get_long
-#define	spl_param_ops_long param_ops_long
-#define	spl_param_ops_LONG param_ops_long
-
-#define	spl_param_set_uint param_set_uint
-#define	spl_param_get_uint param_get_uint
-#define	spl_param_ops_uint param_ops_uint
-#define	spl_param_ops_UINT param_ops_uint
-
-#define	spl_param_set_ulong param_set_ulong
-#define	spl_param_get_ulong param_get_ulong
-#define	spl_param_ops_ulong param_ops_ulong
-#define	spl_param_ops_ULONG param_ops_ulong
-
-#define	spl_param_set_u64 param_set_ullong
-#define	spl_param_get_u64 param_get_ullong
-#define	spl_param_ops_u64 param_ops_ullong
-#define	spl_param_ops_U64 param_ops_ullong
-
-#define	spl_param_set_charp param_set_charp
-#define	spl_param_get_charp param_get_charp
-#define	spl_param_ops_charp param_ops_charp
-#define	spl_param_ops_STRING param_ops_charp
+/*
+ * We keep our own names for param ops to make expanding them in
+ * ZFS_MODULE_PARAM easy.
+ */
+#define	spl_param_ops_INT	param_ops_int
+#define	spl_param_ops_LONG	param_ops_long
+#define	spl_param_ops_UINT	param_ops_uint
+#define	spl_param_ops_ULONG	param_ops_ulong
+#define	spl_param_ops_STRING	param_ops_charp
 
 /*
  * Declare a module parameter / sysctl node

--- a/include/os/linux/kernel/linux/mod_compat.h
+++ b/include/os/linux/kernel/linux/mod_compat.h
@@ -79,7 +79,7 @@ enum scope_prefix_types {
 };
 
 /*
- * While we define our own s64/u64 types, there is no reason to reimplement the
+ * While we define our own u64 types, there is no reason to reimplement the
  * existing Linux kernel types, so we use the preprocessor to remap our
  * "custom" implementations to the kernel ones. This is done because the CPP
  * does not allow us to write conditional definitions. The fourth definition
@@ -111,11 +111,6 @@ enum scope_prefix_types {
 #define	spl_param_get_charp param_get_charp
 #define	spl_param_ops_charp param_ops_charp
 #define	spl_param_ops_STRING param_ops_charp
-
-int spl_param_set_s64(const char *val, zfs_kernel_param_t *kp);
-extern int spl_param_get_s64(char *buffer, zfs_kernel_param_t *kp);
-extern const struct kernel_param_ops spl_param_ops_s64;
-#define	spl_param_ops_S64 spl_param_ops_s64
 
 extern int spl_param_set_u64(const char *val, zfs_kernel_param_t *kp);
 extern int spl_param_get_u64(char *buffer, zfs_kernel_param_t *kp);

--- a/include/os/linux/kernel/linux/mod_compat.h
+++ b/include/os/linux/kernel/linux/mod_compat.h
@@ -31,15 +31,6 @@
 #include <linux/module.h>
 #include <linux/moduleparam.h>
 
-/*
- * Despite constifying struct kernel_param_ops, some older kernels define a
- * `__check_old_set_param()` function in their headers that checks for a
- * non-constified `->set()`. This has long been fixed in Linux mainline, but
- * since we support older kernels, we workaround it by using a preprocessor
- * definition to disable it.
- */
-#define	__check_old_set_param(_) (0)
-
 typedef const struct kernel_param zfs_kernel_param_t;
 
 #define	ZMOD_RW 0644

--- a/module/icp/algs/aes/aes_impl.c
+++ b/module/icp/algs/aes/aes_impl.c
@@ -420,8 +420,6 @@ icp_aes_impl_get(char *buffer, zfs_kernel_param_t *kp)
 	char *fmt;
 	const uint32_t impl = AES_IMPL_READ(icp_aes_impl);
 
-	ASSERT(aes_impl_initialized);
-
 	/* list mandatory options */
 	for (i = 0; i < ARRAY_SIZE(aes_impl_opts); i++) {
 		fmt = (impl == aes_impl_opts[i].sel) ? "[%s] " : "%s ";

--- a/module/icp/algs/modes/gcm.c
+++ b/module/icp/algs/modes/gcm.c
@@ -948,8 +948,6 @@ icp_gcm_impl_get(char *buffer, zfs_kernel_param_t *kp)
 	char *fmt;
 	const uint32_t impl = GCM_IMPL_READ(icp_gcm_impl);
 
-	ASSERT(gcm_impl_initialized);
-
 	/* list mandatory options */
 	for (i = 0; i < ARRAY_SIZE(gcm_impl_opts); i++) {
 #ifdef CAN_USE_GCM_ASM

--- a/module/os/freebsd/zfs/zio_crypt.c
+++ b/module/os/freebsd/zfs/zio_crypt.c
@@ -1822,9 +1822,3 @@ error:
 
 	return (SET_ERROR(ret));
 }
-
-#if defined(_KERNEL) && defined(HAVE_SPL)
-module_param(zfs_key_max_salt_uses, ulong, 0644);
-MODULE_PARM_DESC(zfs_key_max_salt_uses, "Max number of times a salt value "
-	"can be used for generating encryption keys before it is rotated");
-#endif

--- a/module/os/linux/spl/spl-generic.c
+++ b/module/os/linux/spl/spl-generic.c
@@ -575,7 +575,6 @@ EXPORT_SYMBOL(spl_param_get_##type);					\
 EXPORT_SYMBOL(spl_param_set_##type);					\
 EXPORT_SYMBOL(spl_param_ops_##type);
 
-define_spl_param(s64, "%lld")
 define_spl_param(u64, "%llu")
 
 /*

--- a/module/os/linux/spl/spl-generic.c
+++ b/module/os/linux/spl/spl-generic.c
@@ -555,28 +555,6 @@ ddi_copyin(const void *from, void *to, size_t len, int flags)
 }
 EXPORT_SYMBOL(ddi_copyin);
 
-#define	define_spl_param(type, fmt)					\
-int									\
-spl_param_get_##type(char *buf, zfs_kernel_param_t *kp)			\
-{									\
-	return (scnprintf(buf, PAGE_SIZE, fmt "\n",			\
-	    *(type *)kp->arg));						\
-}									\
-int									\
-spl_param_set_##type(const char *buf, zfs_kernel_param_t *kp)		\
-{									\
-	return (kstrto##type(buf, 0, (type *)kp->arg));			\
-}									\
-const struct kernel_param_ops spl_param_ops_##type = {			\
-	.set = spl_param_set_##type,					\
-	.get = spl_param_get_##type,					\
-};									\
-EXPORT_SYMBOL(spl_param_get_##type);					\
-EXPORT_SYMBOL(spl_param_set_##type);					\
-EXPORT_SYMBOL(spl_param_ops_##type);
-
-define_spl_param(u64, "%llu")
-
 /*
  * Post a uevent to userspace whenever a new vdev adds to the pool. It is
  * necessary to sync blkid information with udev, which zed daemon uses

--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -37,6 +37,7 @@
 #include <sys/atomic.h>
 #include <sys/kstat.h>
 #include <linux/cpuhotplug.h>
+#include <linux/mod_compat.h>
 
 /* Linux 6.2 renamed timer_delete_sync(); point it at its old name for those. */
 #ifndef HAVE_TIMER_DELETE_SYNC
@@ -1651,18 +1652,8 @@ spl_taskq_kstat_fini(void)
 
 static unsigned int spl_taskq_kick = 0;
 
-/*
- * 2.6.36 API Change
- * module_param_cb is introduced to take kernel_param_ops and
- * module_param_call is marked as obsolete. Also set and get operations
- * were changed to take a 'const struct kernel_param *'.
- */
 static int
-#ifdef module_param_cb
-param_set_taskq_kick(const char *val, const struct kernel_param *kp)
-#else
-param_set_taskq_kick(const char *val, struct kernel_param *kp)
-#endif
+param_set_taskq_kick(const char *val, zfs_kernel_param_t *kp)
 {
 	int ret;
 	taskq_t *tq = NULL;
@@ -1692,16 +1683,8 @@ param_set_taskq_kick(const char *val, struct kernel_param *kp)
 	return (ret);
 }
 
-#ifdef module_param_cb
-static const struct kernel_param_ops param_ops_taskq_kick = {
-	.set = param_set_taskq_kick,
-	.get = param_get_uint,
-};
-module_param_cb(spl_taskq_kick, &param_ops_taskq_kick, &spl_taskq_kick, 0644);
-#else
 module_param_call(spl_taskq_kick, param_set_taskq_kick, param_get_uint,
 	&spl_taskq_kick, 0644);
-#endif
 MODULE_PARM_DESC(spl_taskq_kick,
 	"Write nonzero to kick stuck taskqs to spawn more threads");
 

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -614,7 +614,7 @@ static inline uint_t
 vdev_bio_max_segs(struct block_device *bdev)
 {
 	/*
-	 * Smallest of the device max segs and the tuneable max segs. Minimum
+	 * Smallest of the device max segs and the tunable max segs. Minimum
 	 * 4, so there's room to finish split pages if they come up.
 	 */
 	const uint_t dev_max_segs = queue_max_segments(bdev_get_queue(bdev));

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -385,8 +385,8 @@ static int zfs_arc_overflow_shift = 8;
 /* log2(fraction of arc to reclaim) */
 uint_t arc_shrink_shift = 7;
 
-/* percent of pagecache to reclaim arc to */
 #ifdef _KERNEL
+/* percent of pagecache to reclaim arc to */
 uint_t zfs_arc_pc_percent = 0;
 #endif
 
@@ -11202,8 +11202,10 @@ ZFS_MODULE_PARAM_CALL(zfs_arc, zfs_arc_, grow_retry, param_set_arc_int,
 ZFS_MODULE_PARAM_CALL(zfs_arc, zfs_arc_, shrink_shift, param_set_arc_int,
 	param_get_uint, ZMOD_RW, "log2(fraction of ARC to reclaim)");
 
+#ifdef _KERNEL
 ZFS_MODULE_PARAM(zfs_arc, zfs_arc_, pc_percent, UINT, ZMOD_RW,
 	"Percent of pagecache to reclaim ARC to");
+#endif
 
 ZFS_MODULE_PARAM(zfs_arc, zfs_arc_, average_blocksize, UINT, ZMOD_RD,
 	"Target average block size");

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -153,7 +153,7 @@
  * storage object (ie ZAP) as normal. OpenZFS will try hard to flush enough to
  * keep up with the rate of change on dedup entries, but not so much that it
  * would impact overall throughput, and not using too much memory. See the
- * zfs_dedup_log_* tuneables in zfs(4) for more details.
+ * zfs_dedup_log_* tunables in zfs(4) for more details.
  *
  * ## Repair IO
  *

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2373,7 +2373,7 @@ dmu_write_policy(objset_t *os, dnode_t *dn, int level, int wp, zio_prop_t *zp)
 
 		if (dmu_ddt_copies > 0) {
 			/*
-			 * If this tuneable is set, and this is a write for a
+			 * If this tunable is set, and this is a write for a
 			 * dedup entry store (zap or log), then we treat it
 			 * something like ZFS_REDUNDANT_METADATA_MOST on a
 			 * regular dataset: this many copies, and one more for

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -1368,7 +1368,8 @@ fm_fini(void)
 		fm_ksp = NULL;
 	}
 }
-#endif /* _KERNEL */
 
 ZFS_MODULE_PARAM(zfs_zevent, zfs_zevent_, len_max, UINT, ZMOD_RW,
 	"Max event queue length");
+
+#endif /* _KERNEL */

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -635,5 +635,7 @@ ZFS_MODULE_PARAM(zfs_spa, spa_, config_path, STRING, ZMOD_RD,
 	"SPA config file (/etc/zfs/zpool.cache)");
 #endif
 
+#ifdef _KERNEL
 ZFS_MODULE_PARAM(zfs, zfs_, autoimport_disable, INT, ZMOD_RW,
 	"Disable pool import at module load");
+#endif

--- a/module/zfs/vdev_raidz_math.c
+++ b/module/zfs/vdev_raidz_math.c
@@ -643,8 +643,6 @@ vdev_raidz_impl_get(char *buffer, size_t size)
 	char *fmt;
 	const uint32_t impl = RAIDZ_IMPL_READ(zfs_vdev_raidz_impl);
 
-	ASSERT(raidz_math_initialized);
-
 	/* list mandatory options */
 	for (i = 0; i < ARRAY_SIZE(math_impl_opts) - 2; i++) {
 		fmt = (impl == math_impl_opts[i].sel) ? "[%s] " : "%s ";

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -607,7 +607,7 @@ zfs_log_rename_whiteout(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
  * called as soon as the write is on stable storage (be it via a DMU sync or a
  * ZIL commit).
  */
-static int64_t zfs_immediate_write_sz = 32768;
+static uint_t zfs_immediate_write_sz = 32768;
 
 void
 zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
@@ -936,5 +936,5 @@ zfs_log_clone_range(zilog_t *zilog, dmu_tx_t *tx, int txtype, znode_t *zp,
 	}
 }
 
-ZFS_MODULE_PARAM(zfs, zfs_, immediate_write_sz, S64, ZMOD_RW,
+ZFS_MODULE_PARAM(zfs, zfs_, immediate_write_sz, UINT, ZMOD_RW,
 	"Largest data block to write to zil");


### PR DESCRIPTION
### Motivation and Context

Our tunables/module parameters infrastructure has accumulated a lot of cruft over time, making it pretty difficult to work with. I've been working quietly over the last year on a general uplift. The first thing to do though is make a run at the obvious things, which is this PR: a goodie bag of miscellaneous tunable-related cleanups.

This PR is just the internal code cleanup. See #17375 and #17376 for the user-visible changes (removing old tunables proper).

### Description

See the individual commits. Commit summaries:

* zfs_log: make `zfs_immediate_write_sz` uint
* tunables: don't assert initialisation in impl getters
* tunables: ensure tunable and variable have same define gate
* tunables: remove FreeBSD compat macros for Linux module params
* tunables: remove direct use of `module_param_cb`
* tunables: remove support for s64 tunables
* tunables: use Linux ullong param ops for u64
* tunables: remove unused param get/set aliases
* tunables: remove `__check_old_set_param` workaround

### How Has This Been Tested?

Compile checked on Linux and FreeBSD.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).