### PR TITLE
ZVOL: Comment platform-specific empty functions bodies on FreeBSD side

### DIFF
--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -1559,13 +1559,21 @@ zvol_os_update_volsize(zvol_state_t *zv, uint64_t volsize)
 void
 zvol_os_set_disk_ro(zvol_state_t *zv, int flags)
 {
-	// XXX? set_disk_ro(zv->zv_zso->zvo_disk, flags);
+	/*
+	 * The ro/rw ZVOL mode is switched using zvol_set_ro() function by
+	 * enabling/disabling ZVOL_RDONLY flag.  No additional FreeBSD-specific
+	 * actions are required for readonly zfs property switching.
+	 */
 }
 
 void
 zvol_os_set_capacity(zvol_state_t *zv, uint64_t capacity)
 {
-	// XXX? set_capacity(zv->zv_zso->zvo_disk, capacity);
+	/*
+	 * The ZVOL size/capacity is changed by zvol_set_volsize() function.
+	 * Leave this method empty, because all required job is doing by
+	 * zvol_os_update_volsize() platform-specific function.
+	 */
 }
 
 /*


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
Resolve some XXXs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
