### PR TITLE
zpl: handle suspend from two remaining calls to `txg_wait_synced()`

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1805,9 +1805,17 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 			 * fallback, or wait for the next TXG and check again.
 			 */
 			if (error == EAGAIN && zfs_bclone_wait_dirty) {
-				txg_wait_synced(dmu_objset_pool(inos),
-				    last_synced_txg + 1);
-				continue;
+				txg_wait_flag_t wait_flags =
+				    spa_get_failmode(dmu_objset_spa(inos)) ==
+				    ZIO_FAILURE_MODE_CONTINUE ?
+				    TXG_WAIT_SUSPEND : 0;
+				error = txg_wait_synced_flags(
+				    dmu_objset_pool(inos), last_synced_txg + 1,
+				    wait_flags);
+				if (error == 0)
+					continue;
+				ASSERT3U(error, ==, ESHUTDOWN);
+				error = SET_ERROR(EIO);
 			}
 
 			break;


### PR DESCRIPTION
### Motivation and Context

Following #17355, there's two remaining ZPL ops that use `txg_wait_synced()` directly. This converts them to allow suspend.

(This came from review on #17398, but not really related).

### Description

Convert the two call sites to `txg_wait_synced_flags()`, setting `TXG_WAIT_SUSPEND` when `failmode=continue`, and handling a suspend (`ESHUTDOWN`) by returning `EIO`.

(Aside: this particular pattern of checking `spa_failmode`, choosing the right suspend flags and making the call could probably be a macro, but I couldn't think of a great name right now, and I can live with it for two calls. It's probably ok to wait for the moment, at least until a similar question in #17398 is resolved, and until an update to #11082 is posted, as I know @ihoro has some "convert the errors" ideas in there).

### How Has This Been Tested?

Compile checked on Linux and FreeBSD. Will rely on CI tests to make sure I haven't broken anything. Nothing tests these codepaths directly though.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
