### PR TITLE
zfs_main: allow umount only on original mountpoint

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7755,6 +7755,12 @@ unshare_unmount_path(int op, char *path, int flags, boolean_t is_manual)
 		return (1);
 	}
 
+	if (strcmp(entry.mnt_mountp, path) != 0) {
+		(void) fprintf(stderr, gettext("cannot %s '%s': not an original"
+		    " mountpoint\n"), cmdname, path);
+		return (1);
+	}
+
 	if ((zhp = zfs_open(g_zfs, entry.mnt_special,
 	    ZFS_TYPE_FILESYSTEM)) == NULL)
 		return (1);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevent silent unmount of the real mounpoint when running `zfs umount` on a binded mount.

### Description
<!--- Describe your changes in detail -->
When “zfs umount” is run on a bind mount, it silently unmounts the real dataset and leaves the bind stale. Add a check so umount only succeeds if the path matches the original mountpoint; otherwise, print an error and abort to prevent accidental unmounts.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
**Before**
```
buildroot@root:~# zpool create -O mountpoint=/mnt/tank tank nvme0n1
buildroot@root:~# mkdir -p /mnt/tank-bind
buildroot@root:~# mount --bind /mnt/tank /mnt/tank-bind
buildroot@root:~# zfs umount /mnt/tank-bind
buildroot@root:~# mount | grep tank
tank on /mnt/tank-bind type zfs (rw,relatime,xattr,noacl,casesensitive)
```
**After**
```
buildroot@root:~# zpool create -O mountpoint=/mnt/tank tank nvme0n1
buildroot@root:~# mkdir -p /mnt/tank-bind
buildroot@root:~# mount --bind /mnt/tank /mnt/tank-bind
buildroot@root:~# zfs umount /mnt/tank-bind
cannot unmount '/mnt/tank-bind': not a original mountpoint
buildroot@root:~# mount | grep tank
tank on /mnt/tank type zfs (rw,relatime,xattr,noacl,casesensitive)
tank on /mnt/tank-bind type zfs (rw,relatime,xattr,noacl,casesensitive)
buildroot@root:~# umount /mnt/tank-bind
buildroot@root:~# mount | grep tank
tank on /mnt/tank type zfs (rw,relatime,xattr,noacl,casesensitive)
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
