### PR TITLE
FreeBSD: Wire projects support

### DIFF
--- a/module/os/freebsd/zfs/zfs_dir.c
+++ b/module/os/freebsd/zfs/zfs_dir.c
@@ -833,7 +833,7 @@ zfs_make_xattrdir(znode_t *zp, vattr_t *vap, znode_t **xvpp, cred_t *cr)
 	if ((error = zfs_acl_ids_create(zp, IS_XATTR, vap, cr, NULL,
 	    &acl_ids, NULL)) != 0)
 		return (error);
-	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, 0)) {
+	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, zp->z_projid)) {
 		zfs_acl_ids_free(&acl_ids);
 		return (SET_ERROR(EDQUOT));
 	}

--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -768,7 +768,7 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 	if (S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode)) {
 		/*
 		 * With ZFS_PROJID flag, we can easily know whether there is
-		 * project ID stored on disk or not. See zfs_space_delta_cb().
+		 * project ID stored on disk or not. See zpl_get_file_info().
 		 */
 		if (obj_type != DMU_OT_ZNODE &&
 		    dmu_objset_projectquota_enabled(zfsvfs->z_os))

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -846,6 +846,15 @@ pre =
 post =
 tags = ['functional', 'pool_names']
 
+[tests/functional/projectquota]
+tests = ['defaultprojectquota_002_pos', 'defaultprojectquota_003_neg',
+    'defaultprojectquota_004_pos', 'defaultprojectquota_006_pos',
+    'defaultprojectquota_007_pos', 'projectquota_002_pos',
+    'projectquota_004_neg', 'projectquota_005_pos', 'projectquota_007_pos',
+    'projectquota_008_pos', 'projectquota_009_pos', 'projecttree_002_pos',
+    'projecttree_003_neg']
+tags = ['functional', 'projectquota']
+
 [tests/functional/poolversion]
 tests = ['poolversion_001_pos', 'poolversion_002_pos']
 tags = ['functional', 'poolversion']

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -175,17 +175,11 @@ tests = ['procfs_list_basic', 'procfs_list_concurrent_readers',
 tags = ['functional', 'procfs']
 
 [tests/functional/projectquota:Linux]
-tests = ['defaultprojectquota_001_pos', 'defaultprojectquota_002_pos',
-    'defaultprojectquota_003_neg', 'defaultprojectquota_004_pos',
-    'defaultprojectquota_005_pos', 'defaultprojectquota_006_pos',
-    'defaultprojectquota_007_pos',
+tests = ['defaultprojectquota_001_pos', 'defaultprojectquota_005_pos',
     'projectid_001_pos', 'projectid_002_pos', 'projectid_003_pos',
-    'projectquota_001_pos', 'projectquota_002_pos', 'projectquota_003_pos',
-    'projectquota_004_neg', 'projectquota_005_pos', 'projectquota_006_pos',
-    'projectquota_007_pos', 'projectquota_008_pos', 'projectquota_009_pos',
+    'projectquota_001_pos', 'projectquota_003_pos', 'projectquota_006_pos',
     'projectspace_001_pos', 'projectspace_002_pos', 'projectspace_003_pos',
-    'projectspace_004_pos', 'projectspace_005_pos',
-    'projecttree_001_pos', 'projecttree_002_pos', 'projecttree_003_neg']
+    'projectspace_004_pos', 'projectspace_005_pos', 'projecttree_001_pos']
 tags = ['functional', 'projectquota']
 
 [tests/functional/dos_attributes:Linux]


### PR DESCRIPTION
While FreeBSD itself does not support projects, I don't know a reason why it can't be controlled via `zfs project` and other subcommands. Most of the code is actually already there and just needs some revival and sync with Linux, plus enabling some tests not depending on the OS support.

### How Has This Been Tested?
Did some basic manual testing on FreeBSD by setting/changing/verifying projects with `zfs project`, creating files/directories and moving them here and there, also observing accounting with `zfs projectspace`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
