### PR TITLE
Channel programs: add `zfs.sync.clone()`

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -4916,7 +4916,7 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 		fatal(B_FALSE, "dmu_take_snapshot(%s) = %d", snap1name, error);
 	}
 
-	error = dmu_objset_clone(clone1name, snap1name);
+	error = dsl_dataset_clone(clone1name, snap1name);
 	if (error) {
 		if (error == ENOSPC) {
 			ztest_record_enospc(FTAG);
@@ -4943,7 +4943,7 @@ ztest_dsl_dataset_promote_busy(ztest_ds_t *zd, uint64_t id)
 		fatal(B_FALSE, "dmu_open_snapshot(%s) = %d", snap3name, error);
 	}
 
-	error = dmu_objset_clone(clone2name, snap3name);
+	error = dsl_dataset_clone(clone2name, snap3name);
 	if (error) {
 		if (error == ENOSPC) {
 			ztest_record_enospc(FTAG);
@@ -6334,13 +6334,13 @@ ztest_dmu_snapshot_hold(ztest_ds_t *zd, uint64_t id)
 		fatal(B_FALSE, "dmu_objset_snapshot(%s) = %d", fullname, error);
 	}
 
-	error = dmu_objset_clone(clonename, fullname);
+	error = dsl_dataset_clone(clonename, fullname);
 	if (error) {
 		if (error == ENOSPC) {
-			ztest_record_enospc("dmu_objset_clone");
+			ztest_record_enospc("dsl_dataset_clone");
 			goto out;
 		}
-		fatal(B_FALSE, "dmu_objset_clone(%s) = %d", clonename, error);
+		fatal(B_FALSE, "dsl_dataset_clone(%s) = %d", clonename, error);
 	}
 
 	error = dsl_destroy_snapshot(fullname, B_TRUE);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -360,7 +360,6 @@ void dmu_objset_evict_dbufs(objset_t *os);
 int dmu_objset_create(const char *name, dmu_objset_type_t type, uint64_t flags,
     struct dsl_crypto_params *dcp, dmu_objset_create_sync_func_t func,
     void *arg);
-int dmu_objset_clone(const char *name, const char *origin);
 int dsl_destroy_snapshots_nvl(struct nvlist *snaps, boolean_t defer,
     struct nvlist *errlist);
 int dmu_objset_snapshot_one(const char *fsname, const char *snapname);

--- a/include/sys/dsl_dataset.h
+++ b/include/sys/dsl_dataset.h
@@ -276,6 +276,12 @@ dsl_dataset_phys(dsl_dataset_t *ds)
 	return ((dsl_dataset_phys_t *)ds->ds_dbuf->db_data);
 }
 
+typedef struct dsl_dataset_clone_arg_t {
+	const char *ddca_clone;
+	const char *ddca_origin;
+	cred_t *ddca_cred;
+} dsl_dataset_clone_arg_t;
+
 typedef struct dsl_dataset_promote_arg {
 	const char *ddpa_clonename;
 	dsl_dataset_t *ddpa_clone;
@@ -364,6 +370,9 @@ uint64_t dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 void dsl_dataset_snapshot_sync(void *arg, dmu_tx_t *tx);
 int dsl_dataset_snapshot_check(void *arg, dmu_tx_t *tx);
 int dsl_dataset_snapshot(nvlist_t *snaps, nvlist_t *props, nvlist_t *errors);
+void dsl_dataset_clone_sync(void *arg, dmu_tx_t *tx);
+int dsl_dataset_clone_check(void *arg, dmu_tx_t *tx);
+int dsl_dataset_clone(const char *clone, const char *origin);
 void dsl_dataset_promote_sync(void *arg, dmu_tx_t *tx);
 int dsl_dataset_promote_check(void *arg, dmu_tx_t *tx);
 int dsl_dataset_promote(const char *name, char *conflsnap);

--- a/man/man8/zfs-program.8
+++ b/man/man8/zfs-program.8
@@ -12,8 +12,9 @@
 .\" Copyright (c) 2016, 2019 by Delphix. All Rights Reserved.
 .\" Copyright (c) 2019, 2020 by Christian Schwarz. All Rights Reserved.
 .\" Copyright 2020 Joyent, Inc.
+.\" Copyright (c) 2025, Rob Norris <robn@despairlabs.com>
 .\"
-.Dd May 27, 2021
+.Dd June 5, 2025
 .Dt ZFS-PROGRAM 8
 .Os
 .
@@ -347,6 +348,32 @@ They are executed in "syncing context".
 .Pp
 The available sync submodule functions are as follows:
 .Bl -tag -width "xx"
+.It Fn zfs.sync.clone snapshot newdataset
+Create a new filesystem from a snapshot.
+Returns 0 if the filesystem was successfully created,
+and a nonzero error code otherwise.
+.Pp
+Note: Due to general limitations in channel programs, a filesystem created
+this way will not be mounted, regardless of the value of the
+.Sy mountpoint
+and
+.Sy canmount
+properties.
+This limitation may be removed in the future,
+so it is recommended that you set
+.Sy mountpoint Ns = Ns Sy none
+or
+.Sy canmount Ns = Ns Sy off
+or
+.Sy noauto
+to avoid surprises.
+.Pp
+.Bl -tag -compact -width "newbookmark (string)"
+.It Ar snapshot Pq string
+Name of the source snapshot to clone.
+.It Ar newdataset Pq string
+Name of the target dataset to create.
+.El
 .It Sy zfs.sync.destroy Ns Pq Ar dataset , Op Ar defer Ns = Ns Sy true Ns | Ns Sy false
 Destroy the given dataset.
 Returns 0 on successful destroy, or a nonzero error code if the dataset could
@@ -474,6 +501,7 @@ The available
 .Sy zfs.check
 functions are:
 .Bl -tag -compact -width "xx"
+.It Fn zfs.check.clone snapshot newdataset
 .It Sy zfs.check.destroy Ns Pq Ar dataset , Op Ar defer Ns = Ns Sy true Ns | Ns Sy false
 .It Fn zfs.check.promote dataset
 .It Fn zfs.check.rollback filesystem

--- a/module/zfs/zcp_synctask.c
+++ b/module/zfs/zcp_synctask.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2019, 2020 by Christian Schwarz. All rights reserved.
  * Copyright 2020 Joyent, Inc.
+ * Copyright (c) 2025, Rob Norris <robn@despairlabs.com>
  */
 
 #include <sys/lua/lua.h>
@@ -113,6 +114,48 @@ zcp_sync_task(lua_State *state, dsl_checkfunc_t *checkfunc,
 	return (err);
 }
 
+static int zcp_synctask_clone(lua_State *, boolean_t, nvlist_t *);
+static const zcp_synctask_info_t zcp_synctask_clone_info = {
+	.name = "clone",
+	.func = zcp_synctask_clone,
+	.pargs = {
+	    {.za_name = "snapshot", .za_lua_type = LUA_TSTRING },
+	    {.za_name = "newdataset", .za_lua_type = LUA_TSTRING },
+	    {NULL, 0}
+	},
+	.kwargs = {
+	    {NULL, 0}
+	},
+	.space_check = ZFS_SPACE_CHECK_NORMAL,
+	.blocks_modified = 3
+};
+static int
+zcp_synctask_clone(lua_State *state, boolean_t sync, nvlist_t *err_details)
+{
+	(void) err_details;
+	int err;
+
+	zcp_run_info_t *ri = zcp_run_info(state);
+	dsl_dataset_clone_arg_t ddca = {
+		.ddca_origin = lua_tostring(state, 1),
+		.ddca_clone = lua_tostring(state, 2),
+		.ddca_cred = ri->zri_cred,
+	};
+
+	err = zcp_sync_task(state, dsl_dataset_clone_check,
+	    dsl_dataset_clone_sync, &ddca, sync, ddca.ddca_origin);
+
+	if (err == 0)
+		/*
+		 * If the new dataset is a zvol, it will need a device
+		 * node. Put it on the list to be considered in open context.
+		 * We don't have to check the type here; if it's not a zvol,
+		 * or has volmode=none, it will be ignored.
+		 */
+		fnvlist_add_boolean(ri->zri_new_zvols, ddca.ddca_clone);
+
+	return (err);
+}
 
 static int zcp_synctask_destroy(lua_State *, boolean_t, nvlist_t *);
 static const zcp_synctask_info_t zcp_synctask_destroy_info = {
@@ -561,6 +604,7 @@ zcp_load_synctask_lib(lua_State *state, boolean_t sync)
 {
 	const zcp_synctask_info_t *zcp_synctask_funcs[] = {
 		&zcp_synctask_destroy_info,
+		&zcp_synctask_clone_info,
 		&zcp_synctask_promote_info,
 		&zcp_synctask_rollback_info,
 		&zcp_synctask_snapshot_info,

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3730,7 +3730,7 @@ zfs_ioc_clone(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl)
 	if (dataset_namecheck(origin_name, NULL, NULL) != 0)
 		return (SET_ERROR(EINVAL));
 
-	error = dmu_objset_clone(fsname, origin_name);
+	error = dsl_dataset_clone(fsname, origin_name);
 
 	/*
 	 * It would be nice to do this atomically.

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -140,7 +140,7 @@ tests = ['tst.destroy_fs', 'tst.destroy_snap', 'tst.get_count_and_limit',
     'tst.promote_multiple', 'tst.promote_simple', 'tst.rollback_mult',
     'tst.rollback_one', 'tst.set_props', 'tst.snapshot_destroy', 'tst.snapshot_neg',
     'tst.snapshot_recursive', 'tst.snapshot_rename', 'tst.snapshot_simple',
-    'tst.bookmark.create', 'tst.bookmark.copy',
+    'tst.bookmark.create', 'tst.bookmark.copy', 'tst.clone',
     'tst.terminate_by_signal'
     ]
 tags = ['functional', 'channel_program', 'synctask_core']

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -84,7 +84,7 @@ tests = ['tst.destroy_fs', 'tst.destroy_snap', 'tst.get_count_and_limit',
     'tst.promote_multiple', 'tst.promote_simple', 'tst.rollback_mult',
     'tst.rollback_one', 'tst.set_props', 'tst.snapshot_destroy',
     'tst.snapshot_neg', 'tst.snapshot_recursive', 'tst.snapshot_simple',
-    'tst.bookmark.create', 'tst.bookmark.copy']
+    'tst.bookmark.create', 'tst.bookmark.copy', 'tst.clone']
 tags = ['functional', 'channel_program', 'synctask_core']
 
 [tests/functional/cli_root/zdb]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -124,6 +124,7 @@ nobase_dist_datadir_zfs_tests_tests_DATA += \
 	functional/channel_program/lua_core/tst.timeout.zcp \
 	functional/channel_program/synctask_core/tst.bookmark.copy.zcp \
 	functional/channel_program/synctask_core/tst.bookmark.create.zcp \
+	functional/channel_program/synctask_core/tst.clone.zcp \
 	functional/channel_program/synctask_core/tst.get_index_props.out \
 	functional/channel_program/synctask_core/tst.get_index_props.zcp \
 	functional/channel_program/synctask_core/tst.get_number_props.out \
@@ -569,6 +570,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/channel_program/synctask_core/setup.ksh \
 	functional/channel_program/synctask_core/tst.bookmark.copy.ksh \
 	functional/channel_program/synctask_core/tst.bookmark.create.ksh \
+	functional/channel_program/synctask_core/tst.clone.ksh \
 	functional/channel_program/synctask_core/tst.destroy_fs.ksh \
 	functional/channel_program/synctask_core/tst.destroy_snap.ksh \
 	functional/channel_program/synctask_core/tst.get_count_and_limit.ksh \

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.clone.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.clone.ksh
@@ -1,0 +1,55 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016, 2017 by Delphix. All rights reserved.
+# Copyright (c) 2025, Rob Norris <robn@despairlabs.com>
+#
+
+. $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
+
+#
+# DESCRIPTION: Make sure basic cloning functionality works in channel programs
+#
+
+verify_runnable "global"
+
+base=$TESTPOOL/$TESTFS/base
+
+function cleanup
+{
+	destroy_dataset $base "-R"
+}
+
+log_onexit cleanup
+
+log_must zfs create $base
+
+# test filesystem cloning
+log_must zfs create $base/fs
+log_must zfs snapshot $base/fs@snap
+
+log_must_program_sync $TESTPOOL \
+    $ZCP_ROOT/synctask_core/tst.clone.zcp $base/fs@snap $base/newfs
+
+# test zvol cloning
+log_must zfs create -s -V 100G $base/vol
+log_must zfs snapshot $base/vol@snap
+
+log_must_program_sync $TESTPOOL \
+    $ZCP_ROOT/synctask_core/tst.clone.zcp $base/vol@snap $base/newvol
+
+# make sure the dev node was created
+block_device_wait $ZVOL_DEVDIR/$base/newvol
+
+log_pass "Cloning works"

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.clone.zcp
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.clone.zcp
@@ -1,0 +1,28 @@
+-- SPDX-License-Identifier: CDDL-1.0
+--
+-- This file and its contents are supplied under the terms of the
+-- Common Development and Distribution License ("CDDL"), version 1.0.
+-- You may only use this file in accordance with the terms of version
+-- 1.0 of the CDDL.
+--
+-- A full copy of the text of the CDDL should have accompanied this
+-- source.  A copy of the CDDL is also available via the Internet at
+-- http://www.illumos.org/license/CDDL.
+--
+
+--
+-- Copyright (c) 2016, 2017 by Delphix. All rights reserved.
+-- Copyright (c) 2025, Rob Norris <robn@despairlabs.com>
+--
+
+-- This program should be invoked as "zfs program <pool> <prog> <fs> <snap> <new>"
+
+args = ...
+argv = args["argv"]
+assert(zfs.sync.clone(argv[1], argv[2]) == 0)
+clones = {}
+for c in zfs.list.clones(argv[1]) do
+	table.insert(clones, c)
+end
+assert(#clones == 1)
+assert(clones[1] == argv[2])


### PR DESCRIPTION
### Motivation and Context

A popular request on the [OpenZFS Production Users](https://openzfs.org/wiki/OpenZFS_Production_Users_Meeting) call is the ability for channel programs to create clones. I was catching up on this week's call at lunch today and heard it again and, in need of a palate cleanser after far too much correctness work this week, I took a swing at it. A pleasant diversion!

### Description

Adds `zfs.sync.clone(snapshot, newdataset)`. Since clone is already implemented with a standard check/sync pair of functions, it's all really just wiring.

### How Has This Been Tested?

New tests included to test the new call, based on the existing `zfs.sync.snapshot()` tests. Since I've renamed and moved things around, I ran the `zfs_clone` tests also. All is well!

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
