### PR TITLE
scrub: generate scrub_finish event

### DIFF
--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -235,6 +235,9 @@ static uint_t zfs_resilver_defer_percent = 10;
 #define	DSL_SCAN_IS_SCRUB(scn)		\
 	((scn)->scn_phys.scn_func == POOL_SCAN_SCRUB)
 
+#define	DSL_SCAN_IS_RESILVER(scn) \
+	((scn)->scn_phys.scn_func == POOL_SCAN_RESILVER)
+
 /*
  * Enable/disable the processing of the free_bpobj object.
  */
@@ -1169,7 +1172,7 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 			vdev_dtl_reassess(spa->spa_root_vdev, tx->tx_txg,
 			    scn->scn_phys.scn_max_txg, B_TRUE, B_FALSE);
 
-			if (scn->scn_phys.scn_min_txg) {
+			if (DSL_SCAN_IS_RESILVER(scn)) {
 				nvlist_t *aux = fnvlist_alloc();
 				fnvlist_add_string(aux, ZFS_EV_RESILVER_TYPE,
 				    "healing");

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1091,6 +1091,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_events/zpool_events_errors.ksh \
 	functional/cli_root/zpool_events/zpool_events_follow.ksh \
 	functional/cli_root/zpool_events/zpool_events_poolname.ksh \
+	functional/cli_root/zpool_events/zpool_events_scrub_txg_continue_from_last.ksh \
 	functional/cli_root/zpool_expand/cleanup.ksh \
 	functional/cli_root/zpool_expand/setup.ksh \
 	functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_scrub_txg_continue_from_last.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_scrub_txg_continue_from_last.ksh
@@ -1,0 +1,71 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+# Copyright (c) 2025, Klara Inc.
+#
+# This software was developed by
+# Mariusz Zaborski <oshogbo@FreeBSD.org>
+# under sponsorship from Wasabi Technology, Inc. and Klara Inc.
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_events/zpool_events.kshlib
+
+#
+# DESCRIPTION:
+#      Verify that using “zpool scrub -C” correctly generates events.
+#
+# STRATEGY:
+#      1. Run an initial “zpool scrub” on the test pool to generate a txg.
+#      2. Clear existing pool events.
+#      3. Run “zpool scrub -C” to scrub from the last txg.
+#      4. Capture the event log and confirm it contains both “scrub_start” and
+#         “scrub_finish” entries.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	rm -f $EVENTS_FILE
+}
+
+EVENTS_FILE="$TESTDIR/zpool_events.$$"
+log_onexit cleanup
+
+log_assert "Verify scrub -C events."
+
+# Run an initial “zpool scrub”
+log_must zpool scrub -w $TESTPOOL
+
+# Clear existing pool events.
+log_must zpool events -c
+
+# Generate new scrub events.
+log_must zpool scrub -Cw $TESTPOOL
+
+# Verify events.
+log_must eval "zpool events -H > $EVENTS_FILE"
+log_must grep "scrub_start" $EVENTS_FILE
+log_must grep "scrub_finish" $EVENTS_FILE
+
+log_pass "Verified scrub -C generate correct events."


### PR DESCRIPTION
### Motivation and Context
#17317

### Description
The `scn_min_txg` can now be used not only with resilver. Instead of checking `scn_min_txg` to determine whether it’s a resilver or a scrub, simply check which function is defined. Thanks to this change, a scrub_finish event is generated when performing a scrub from the saved txg.

Sponsored-by: Klara, Inc.
Sponsored-by: Wasabi Technology, Inc.

### How Has This Been Tested?
Implemented new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
