### PR TITLE
Allow zero compression if dedup is enabled

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2422,6 +2422,15 @@ dmu_write_policy(objset_t *os, dnode_t *dn, int level, int wp, zio_prop_t *zp)
 		complevel = zio_complevel_select(os->os_spa, compress,
 		    complevel, complevel);
 
+		/*
+		 * Storing many references to an all zeros block in the dedup
+		 * table would be expensive.  Instead, if dedup is enabled,
+		 * store them as holes even if compression is not enabled.
+		 */
+		if (compress == ZIO_COMPRESS_OFF &&
+		    dedup_checksum != ZIO_CHECKSUM_OFF)
+			compress = ZIO_COMPRESS_EMPTY;
+
 		checksum = (dedup_checksum == ZIO_CHECKSUM_OFF) ?
 		    zio_checksum_select(dn->dn_checksum, checksum) :
 		    dedup_checksum;


### PR DESCRIPTION
Having high-refcount dedup entries for zero blocks is inefficient when they could be recorded as a holes instead.  Normally, zero compression is not done if compression is disabled to not confuse naive benchmarks.  But with dedup enabled, it is expected that the write will be skipped anyway, so we are just optimizing the way it is skipped.

This is an alternative approach to #17291, which I think is cleaner by keeping all compression decisions in the same place.  Plus it checks not for dedup enabled for specific block, but for dedup enabled on dataset in general.  Usually those are the same, except for ZIL writes, which are not dedupable now for technical reasons, but which would still benefit a lot from zero compression.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
