### PR TITLE
Make TX abort after assign safer

### DIFF
--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -1392,6 +1392,7 @@ dmu_tx_destroy(dmu_tx_t *tx)
 void
 dmu_tx_commit(dmu_tx_t *tx)
 {
+	/* This function should only be used on assigned transactions. */
 	ASSERT(tx->tx_txg != 0);
 
 	/*
@@ -1430,13 +1431,21 @@ dmu_tx_commit(dmu_tx_t *tx)
 void
 dmu_tx_abort(dmu_tx_t *tx)
 {
-	ASSERT(tx->tx_txg == 0);
+	/* This function should not be used on assigned transactions. */
+	ASSERT0(tx->tx_txg);
+
+	/* Should not be needed, but better be safe than sorry. */
+	if (tx->tx_tempreserve_cookie)
+		dsl_dir_tempreserve_clear(tx->tx_tempreserve_cookie, tx);
 
 	/*
 	 * Call any registered callbacks with an error code.
 	 */
 	if (!list_is_empty(&tx->tx_callbacks))
 		dmu_tx_do_callbacks(&tx->tx_callbacks, SET_ERROR(ECANCELED));
+
+	/* Should not be needed, but better be safe than sorry. */
+	dmu_tx_unassign(tx);
 
 	dmu_tx_destroy(tx);
 }

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1188,7 +1188,7 @@ zfs_rewrite(znode_t *zp, uint64_t off, uint64_t len, uint64_t flags,
 		error = dmu_buf_hold_array_by_dnode(dn, off, n, TRUE, FTAG,
 		    &numbufs, &dbp, DMU_READ_PREFETCH | DMU_UNCACHEDIO);
 		if (error) {
-			dmu_tx_abort(tx);
+			dmu_tx_commit(tx);
 			break;
 		}
 		for (int i = 0; i < numbufs; i++) {
@@ -1860,7 +1860,7 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 			 */
 			if (inblksz != outzp->z_blksz) {
 				error = SET_ERROR(EINVAL);
-				dmu_tx_abort(tx);
+				dmu_tx_commit(tx);
 				break;
 			}
 


### PR DESCRIPTION
It is not right, but there are few examples when TX is aborted  after being assigned in case of error.  To handle it better on production systems add extra cleanup steps.

While here, replace couple `dmu_tx_abort()` calls in simple cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
