### PR TITLE
Clarify and restrict dmu_tx_assign() errors

### DIFF
--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1450,6 +1450,8 @@ dsl_dir_tempreserve_space(dsl_dir_t *dd, uint64_t lsize, uint64_t asize,
 			    MSEC2NSEC(10), MSEC2NSEC(10));
 			err = SET_ERROR(ERESTART);
 		}
+
+		ASSERT3U(err, ==, ERESTART);
 	}
 
 	if (err == 0) {


### PR DESCRIPTION
### Motivation and Context

`ztest` could ASSERT in `ztest_tx_assign()` when an IO error was encountered.  This occurs because it only checks for `ERESTART` and `ENOSPC`.  It does not consider either the over quota or IO error cases.  Let's fix that.

Rather than attempting to enumerate each possible error code all `tx->tx_err`'s are converted to EIO.  I couldn't find any cases where the additional detail was actually useful to the caller, so I opted to simply the interface.  The intent is to make it easier for callers to reason about each possible error and handle it appropriately. 

### Description

There are three possible cases where `dmu_tx_assign()` may encounter a fatal error.  When there is a true lack of free space (ENOSPC), when there is a lack of quota space (EDQUOT), or when data required to perform the transaction cannot be read from disk (EIO).  See the `dmu_tx_check_ioerr()` function for additional details on the motivation for checking for I/O errors early.

Prior to this `change dmu_tx_assign()` would return the contents of `tx->tx_err` which covered a wide range of possible error codes (EIO, ECKSUM, ESRCH, etc).  In practice, none of the callers could do anything useful with this level of detail and simply returned the error.

Therefore, this change converts all `tx->tx_err` errors to EIO, adds ASSERTs to `dmu_tx_assign()` to cover the only possible errors, and clarifies the function comment to include EIO as a possible fatal error.

### How Has This Been Tested?

Locally compiled.  It still need a full run through the test suite by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
