### PR TITLE
Fix TestGroup warning due to missing tags

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -213,6 +213,8 @@ tags = ['functional', 'snapshot']
 [tests/functional/syncfs:Linux]
 tests = ['syncfs_suspend']
 tags = ['functional', 'syncfs']
+pre =
+post =
 
 [tests/functional/tmpfile:Linux]
 tests = ['tmpfile_001_pos', 'tmpfile_002_pos', 'tmpfile_003_pos',


### PR DESCRIPTION
### Motivation and Context
```
Warning: TestGroup '/home/pcd/zfs/tests/zfs-tests/tests/functional/syncfs' not added to
this run. Auxiliary script '/home/pcd/zfs/tests/zfs-tests/tests/functional/syncfs/setup' failed
verification.
```

### Description
Add the missing tags to the runfile section for `syncfs`

### How Has This Been Tested?
Ran the test suite, verified that the group no longer gets excluded

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
