### PR TITLE
Fix pyzfs build

### DIFF
--- a/config/ax_python_devel.m4
+++ b/config/ax_python_devel.m4
@@ -72,7 +72,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 36
+#serial 37
 
 AU_ALIAS([AC_PYTHON_DEVEL], [AX_PYTHON_DEVEL])
 AC_DEFUN([AX_PYTHON_DEVEL],[
@@ -316,7 +316,7 @@ EOD`
 			PYTHON_LIBS="-L$ac_python_libdir -lpython$ac_python_version"
 		fi
 
-		if test -z "PYTHON_LIBS"; then
+		if test -z "$PYTHON_LIBS"; then
 			AC_MSG_WARN([
   Cannot determine location of your Python DSO. Please check it was installed with
   dynamic libraries enabled, or try setting PYTHON_LIBS by hand.

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -87,7 +87,19 @@
 %define __python                  %{__use_python}
 %define __python_pkg_version      %{__use_python_pkg_version}
 %endif
-%define __python_sitelib          %(%{__python} -Esc "from distutils.sysconfig import get_python_lib; print(get_python_lib())" 2>/dev/null || %{__python} -Esc "import sysconfig; print(sysconfig.get_path('purelib'))")
+%define __python_sitelib          %(%{__python} -Esc "
+import sysconfig;
+if hasattr(sysconfig, 'get_default_scheme'):
+    scheme = sysconfig.get_default_scheme()
+else:
+    scheme = sysconfig._get_default_scheme()
+if scheme == 'posix_local':
+    scheme = 'posix_prefix'
+prefix = '%{_prefix}'
+if prefix == 'NONE':
+    prefix = '%{ac_default_prefix}'
+sitedir = sysconfig.get_path('purelib', scheme, vars={'base': prefix})
+print(sitedir);" 2>/dev/null || %{__python} -Esc "from distutils import sysconfig; print(sysconfig.get_python_lib(0,0))")
 
 Name:           @PACKAGE@
 Version:        @VERSION@


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
- Attempts to fix build issue on debian/ubuntu
- #16155
- regression from #16129

### Description
For pyzfs, the evaluation of the library path is done differently at different places:

- RPM uses primarily ***`distutils.sysconfig`*** and ***`sysconfig`*** as a fallback, while
- Config uses primarily ***`sysconfig`*** and ***`distutils.sysconfig`*** as a fallback.
- Furthermore, Config also uses `posix_prefix` for the `scheme` parameter of `sysconfig.get_path()`, while RPM does not.
- The issue was introduced by https://github.com/openzfs/zfs/commit/71216b91d281e7e58f5e29ca4d4553945e080fe9 and applies to at least the following banches:
        zfs-2.2.x
        zfs-2.3.x
- Since `distutils` has been deprecated, the attempt was to update the RPM path evaluation, rather than vice versa.

### Open questions

#### Library Path does not exist on the local system

On all four tested systems (see https://github.com/openzfs/zfs/issues/16155#issuecomment-2993519234), the path that is evaluated by  `ax_python_devel.m4` does not exist on the system.

For the build process, it does not matter. As the path is relative to the build directory in `/tmp`.

However, I don't know why the RPMs are built and if that path is used during installation of pyzfs' RPM. In which case the library might be installed in a place where it is not found?

On Debian and Ubuntu, should the environment-variable `DEB_PYTHON_INSTALL_LAYOUT=deb`  be set? See [explanation](https://linux.debian.devel.narkive.com/rfXVyYSf/behavior-change-for-python-packages-built-with-cmake) and [implementation](https://sources.debian.org/patches/python3.13/3.13.5-1/sysconfig-debian-schemes.diff/#L61) fpr further details.

### How Has This Been Tested?

Since this change is build-related, the main test is the tests run here on github.

I've also tested it on my Ubuntu 24.04 installation, with python3.12 and distutils installed:

The following output was produced on that build system with the test script provided [here](https://github.com/openzfs/zfs/issues/16155#issuecomment-2993519234).
```
sysconfig.get_path.purelib                           = /usr/local/lib/python3.12/dist-packages       = ok
sysconfig.get_path.purelib.posix_prefix              = /usr/lib/python3.12/site-packages             = n/a
sysconfig.get_path.purelib.posix_local               = /usr/local/lib/python3.12/dist-packages       = ok
sysconfig.get_path.purelib.auto.base                 = /lib/python3.12/site-packages                 = n/a
sysconfig.get_path.purelib.auto.platbase             = /lib/python3.12/site-packages                 = n/a
sysconfig.get_path.include                           = /usr/include/python3.12                       = ok
distutils.sysconfig.get_python_inc                   = /usr/include/python3.12                       = ok
distutils.sysconfig.get_python_inc(plat_specific=1)  = /usr/include/python3.12                       = ok
distutils.sysconfig.get_python_lib(0,0)              = /usr/lib/python3/dist-packages                = ok
distutils.sysconfig.get_python_lib(1,0)              = /usr/lib/python3/dist-packages                = ok
distutils.sysconfig.get_python_lib()                 = /usr/lib/python3/dist-packages                = ok

Test Script Version: 1.1

hostnamectl:
Operating System: Ubuntu 24.04.2 LTS
          Kernel: Linux 5.15.167.4-microsoft-standard-WSL2+

lsb_release:
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 24.04.2 LTS
Release:        24.04
Codename:       noble

/etc/lsb-release:
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04.2 LTS"

/etc/os-release:
PRETTY_NAME="Ubuntu 24.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.2 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo

APT packages:
python3-distro
python3-distro-info

PIP packages:
distlib==0.3.9
distro==1.9.0
distro-info==1.7+build1
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
