### PR TITLE
Add templated zfs-mount@.service

### DIFF
--- a/contrib/debian/openzfs-zfsutils.install
+++ b/contrib/debian/openzfs-zfsutils.install
@@ -8,6 +8,7 @@ lib/systemd/system/zfs-import-scan.service
 lib/systemd/system/zfs-import.target
 lib/systemd/system/zfs-load-key.service
 lib/systemd/system/zfs-mount.service
+lib/systemd/system/zfs-mount@.service
 lib/systemd/system/zfs-scrub-monthly@.timer
 lib/systemd/system/zfs-scrub-weekly@.timer
 lib/systemd/system/zfs-scrub@.service

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -56,6 +56,7 @@ systemdunit_DATA = \
 	%D%/systemd/system/zfs-import-scan.service \
 	%D%/systemd/system/zfs-import.target \
 	%D%/systemd/system/zfs-mount.service \
+	%D%/systemd/system/zfs-mount@.service \
 	%D%/systemd/system/zfs-scrub-monthly@.timer \
 	%D%/systemd/system/zfs-scrub-weekly@.timer \
 	%D%/systemd/system/zfs-scrub@.service \

--- a/etc/systemd/system/zfs-mount@.service.in
+++ b/etc/systemd/system/zfs-mount@.service.in
@@ -1,0 +1,26 @@
+[Unit]
+Description=Mount ZFS filesystem %I
+Documentation=man:zfs(8)
+DefaultDependencies=no
+After=systemd-udev-settle.service
+After=zfs-import.target
+After=zfs-mount.service
+After=systemd-remount-fs.service
+Before=local-fs.target
+ConditionPathIsDirectory=/sys/module/zfs
+
+# This merely tells the service manager
+# that unmounting everything undoes the
+# effect of this service. No extra logic
+# is ran as a result of these settings.
+Conflicts=umount.target
+Before=umount.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-@initconfdir@/zfs
+ExecStart=@sbindir@/zfs mount -R %I
+
+[Install]
+WantedBy=zfs.target

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -376,7 +376,7 @@ support for unlocking datasets on user login.
 
 %if 0%{?_systemd}
     %define systemd --enable-systemd --with-systemdunitdir=%{_unitdir} --with-systemdpresetdir=%{_presetdir} --with-systemdmodulesloaddir=%{_modulesloaddir} --with-systemdgeneratordir=%{_systemdgeneratordir} --disable-sysvinit
-    %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target zfs-import.target zfs-volume-wait.service zfs-volumes.target
+    %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-mount@.service zfs-share.service zfs-zed.service zfs.target zfs-import.target zfs-volume-wait.service zfs-volumes.target
 %else
     %define systemd --enable-sysvinit --disable-systemd
 %endif


### PR DESCRIPTION
Runs `zfs mount -R <dataset>` at boot, after `zfs mount -a`. Intended to replace `mountpoint=legacy` in certain mount setups.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a pool has multiple ZFS root filesystems (`canmount=noauto mountpoint=/`) (or some other dual-booting setup that utilizes ZFS across multiple systems), and those in turn each have child datasets (e.g., `canmount=on mountpoint=/var/lib/mysql`), then problems arise as `zfs-mount.service` will execute `zfs mount -a`, attempting to mount multiple datasets to the same location.

The typical solution is to set `mountpoint=legacy` and set a mount entry in `/etc/fstab`. This is cumbersome and easy to mess up.

Instead, introduce a `zfs-mount@.service` which runs `zfs mount -R <dataset>`, to be used in conjunction with `canmount=noauto mountpoint=/path/...`

### Description
`zfs-mount@.service` is essentially identical to `zfs-mount.service`, with the following two changes:

1. It is ordered `After=zfs-mount.service`, yielding an intuitive precedence order.
2. It executes `zfs mount -R <dataset>` instead of `zfs mount -a`.

The build/install files have been adjusted to install `zfs-mount@.service` where appropriate.

As far as I can tell, the documentation does not directly mention `zfs-mount.service`, so I have not added or modified any documentation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I have tested it on a personal machine. Being essentially identical to `zfs-mount.service`, I would not expect there to be any issues with the implementation. Being a template unit, it will never be enabled by default, so `50-zfs.preset` was left unmodified (I did verify that template units without a `DefaultInstance=` setting do not need to be disabled explicitly)

The `dracut` and `initramfs-tools` modules both do not use `zfs-mount.service`, so they are left unmodified. `zfs-mount-generator` adds a `Before=zfs-mount.service` ordering, and with `zfs-mount@.service` being `After=zfs-mount.service`, a consistent ordering is preserved here too.

Beyond this, I did not see any test files that directly deal with systemd services, so nothing was modified there. No core ZFS code was modified.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
