### PR TITLE
Release topology restrictions on special/dedup vdevs

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -876,6 +876,18 @@ check_replication(nvlist_t *config, nvlist_t *newroot)
 				    (u_longlong_t)mirror->zprl_children);
 				ret = -1;
 			}
+		} else if (is_raidz_draid(current, new)) {
+			if (current->zprl_parity != new->zprl_parity) {
+				vdev_error(gettext(
+				    "mismatched replication level: pool and "
+				    "new vdev with different redundancy, %s "
+				    "and %s vdevs, %llu vs. %llu\n"),
+				    current->zprl_type,
+				    new->zprl_type,
+				    (u_longlong_t)current->zprl_parity,
+				    (u_longlong_t)new->zprl_parity);
+				ret = -1;
+			}
 		} else if (strcmp(current->zprl_type, new->zprl_type) != 0) {
 			vdev_error(gettext(
 			    "mismatched replication level: pool uses %s "
@@ -1581,13 +1593,12 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 				is_dedup = is_spare = B_FALSE;
 			}
 
-			if (is_log || is_special || is_dedup) {
+			if (is_log) {
 				if (strcmp(type, VDEV_TYPE_MIRROR) != 0) {
 					(void) fprintf(stderr,
 					    gettext("invalid vdev "
-					    "specification: unsupported '%s' "
-					    "device: %s\n"), is_log ? "log" :
-					    "special", type);
+					    "specification: unsupported 'log' "
+					    "device: %s\n"), type);
 					goto spec_out;
 				}
 				nlogs++;

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_002_neg.ksh
@@ -41,9 +41,4 @@ log_mustnot zpool create $TESTPOOL $ZPOOL_DISKS special mirror \
 log_mustnot display_status $TESTPOOL
 log_mustnot zpool destroy -f $TESTPOOL
 
-log_mustnot zpool create $TESTPOOL raidz $ZPOOL_DISKS special raidz \
-    $CLASS_DISK0 $CLASS_DISK1 $CLASS_DISK2
-log_mustnot display_status $TESTPOOL
-log_mustnot zpool destroy -f $TESTPOOL
-
 log_pass $claim

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_003_pos.ksh
@@ -32,7 +32,7 @@ log_onexit cleanup
 
 log_must disk_setup
 
-for type in "" "mirror" "raidz"
+for type in "" "mirror" "raidz" "draid"
 do
 	log_must zpool create $TESTPOOL $type $ZPOOL_DISKS
 
@@ -47,6 +47,12 @@ do
 		    $CLASS_DISK0 $CLASS_DISK1
 		log_must zpool iostat -H $TESTPOOL $CLASS_DISK0
 		log_must zpool iostat -H $TESTPOOL $CLASS_DISK1
+	elif [ "$type" = "draid" ]; then
+		log_must zpool add $TESTPOOL special raidz \
+		    $CLASS_DISK0 $CLASS_DISK1 $CLASS_DISK2
+		log_must zpool iostat -H $TESTPOOL $CLASS_DISK0
+		log_must zpool iostat -H $TESTPOOL $CLASS_DISK1
+		log_must zpool iostat -H $TESTPOOL $CLASS_DISK2
 	else
 		log_must zpool add $TESTPOOL special $CLASS_DISK0
 		log_must zpool iostat -H $TESTPOOL $CLASS_DISK0

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_004_pos.ksh
@@ -37,7 +37,7 @@ typeset ac_value
 typeset stype=""
 typeset sdisks=""
 
-for type in "" "mirror" "raidz"
+for type in "" "mirror" "raidz" "draid"
 do
 	if [ "$type" = "mirror" ]; then
 		stype="mirror"
@@ -45,6 +45,9 @@ do
 	elif [ "$type" = "raidz" ]; then
 		stype="mirror"
 		sdisks="${CLASS_DISK0} ${CLASS_DISK1}"
+	elif [ "$type" = "draid" ]; then
+		stype="raidz"
+		sdisks="${CLASS_DISK0} ${CLASS_DISK1} ${CLASS_DISK2}"
 	else
 		stype=""
 		sdisks="${CLASS_DISK0}"

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_009_pos.ksh
@@ -36,7 +36,7 @@ typeset stype=""
 typeset sdisks=""
 typeset props=""
 
-for type in "" "mirror" "raidz"
+for type in "" "mirror" "raidz" "draid"
 do
 	if [ "$type" = "mirror" ]; then
 		stype="mirror"
@@ -45,6 +45,9 @@ do
 	elif [ "$type" = "raidz" ]; then
 		stype="mirror"
 		sdisks="${CLASS_DISK0} ${CLASS_DISK1}"
+	elif [ "$type" = "draid" ]; then
+		stype="raidz"
+		sdisks="${CLASS_DISK0} ${CLASS_DISK1} ${CLASS_DISK2}"
 	else
 		stype=""
 		sdisks="${CLASS_DISK0}"


### PR DESCRIPTION
Special vdevs were originally designed as a small blocks storage for dRAID, for which role RAIDZ/dRAID topologies are not good. But it is more often used as SSD storage for metadata and hot data of HDD pools.  In these use cases narrow RAIDZ of SSDs might be fine, so we should not introduce unnecessary restrictions, and ZFS internally does not care.

Similar applies to dedup vdevs.  Original DDT used 4KB blocks, for which anything but mirror was a terrible storage.  But new FDT implementation uses 32KB blocks by default, which are much less demanding even including compression, and which could be increased even higher now, if needed.

### How Has This Been Tested?
Successfully create several pools with raidz and draid special and dedup vdevs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
