### PR TITLE
CI: run ztest on compressed zpool

### DIFF
--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -12,7 +12,8 @@ jobs:
   zloop:
     runs-on: ubuntu-24.04
     env:
-      TEST_DIR: /var/tmp/zloop
+      WORK_DIR: /mnt/zloop
+      CORE_DIR: /mnt/zloop/cores
     steps:
     - uses: actions/checkout@v4
       with:
@@ -40,38 +41,37 @@ jobs:
         sudo modprobe zfs
     - name: Tests
       run: |
-        sudo mkdir -p $TEST_DIR
-        # run for 10 minutes or at most 6 iterations for a maximum runner
-        # time of 60 minutes.
-        sudo /usr/share/zfs/zloop.sh -t 600 -I 6 -l -m 1 -- -T 120 -P 60
+        sudo truncate -s 256G /mnt/vdev
+        sudo zpool create cipool -m $WORK_DIR -O compression=on -o autotrim=on /mnt/vdev
+        sudo /usr/share/zfs/zloop.sh -t 600 -I 6 -l -m 1 -c $CORE_DIR -f $WORK_DIR -- -T 120 -P 60
     - name: Prepare artifacts
       if: failure()
       run: |
-        sudo chmod +r -R $TEST_DIR/
+        sudo chmod +r -R $WORK_DIR/
     - name: Ztest log
       if: failure()
       run: |
-        grep -B10 -A1000 'ASSERT' $TEST_DIR/*/ztest.out || tail -n 1000 $TEST_DIR/*/ztest.out
+        grep -B10 -A1000 'ASSERT' $CORE_DIR/*/ztest.out || tail -n 1000 $CORE_DIR/*/ztest.out
     - name: Gdb log
       if: failure()
       run: |
-        sed -n '/Backtraces (full)/q;p' $TEST_DIR/*/ztest.gdb
+        sed -n '/Backtraces (full)/q;p' $CORE_DIR/*/ztest.gdb
     - name: Zdb log
       if: failure()
       run: |
-        cat $TEST_DIR/*/ztest.zdb
+        cat $CORE_DIR/*/ztest.zdb
     - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Logs
         path: |
-          /var/tmp/zloop/*/
-          !/var/tmp/zloop/*/vdev/
+          /mnt/zloop/*/
+          !/mnt/zloop/cores/*/vdev/
         if-no-files-found: ignore
     - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Pool files
         path: |
-          /var/tmp/zloop/*/vdev/
+          /mnt/zloop/cores/*/vdev/
         if-no-files-found: ignore


### PR DESCRIPTION
### Motivation and Context

Keep zloop CI tests green.

### Description

When running ztest under the CI a common failure mode is for the underlying filesystem to run out of available free space.  Since the storage associated with a GitHub-hosted running is fixed, we instead create a pool and use a compressed ZFS dataset to store the ztest vdev files.  This significantly increases the available capacity since the data written by ztest is highly compressible. A compression ratio of over 40:1 is conservatively achieved using the default lz4 compression.  Autotrimming is enabled to ensure freed blocks are discarded from the backing cipool vdev file.

~Lastly, the default zloop run time is increased to an hour or up to 12 iterations, and each individual ztest run is increased to 5 minutes.~

### How Has This Been Tested?

Testing in my fork here: https://github.com/behlendorf/zfs/actions/runs/15988074405/job/45096145143

Additionally, overnight local testing of zloop showed several runs that created over 80G of vdev files.  After compression it required less than 2G on disk to these file vdevs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
