### PR TITLE
Add "zpool status -vv"

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2596,7 +2596,7 @@ typedef struct status_cbdata {
 	int		cb_name_flags;
 	int		cb_namewidth;
 	boolean_t	cb_allpools;
-	boolean_t	cb_verbose;
+	int		cb_verbosity;
 	boolean_t	cb_literal;
 	boolean_t	cb_explain;
 	boolean_t	cb_first;
@@ -3328,7 +3328,7 @@ print_class_vdevs(zpool_handle_t *zhp, status_cbdata_t *cb, nvlist_t *nv,
 	nvlist_t **child;
 	boolean_t printed = B_FALSE;
 
-	assert(zhp != NULL || !cb->cb_verbose);
+	assert(zhp != NULL || cb->cb_verbosity == 0);
 
 	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN, &child,
 	    &children) != 0)
@@ -9407,7 +9407,7 @@ class_vdevs_nvlist(zpool_handle_t *zhp, status_cbdata_t *cb, nvlist_t *nv,
 	if (!cb->cb_flat_vdevs)
 		class_obj = fnvlist_alloc();
 
-	assert(zhp != NULL || !cb->cb_verbose);
+	assert(zhp != NULL || cb->cb_verbosity == 0);
 
 	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN, &child,
 	    &children) != 0)
@@ -9515,26 +9515,35 @@ static void
 errors_nvlist(zpool_handle_t *zhp, status_cbdata_t *cb, nvlist_t *item)
 {
 	uint64_t nerr;
+	int verbosity = cb->cb_verbosity;
 	nvlist_t *config = zpool_get_config(zhp, NULL);
 	if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_ERRCOUNT,
 	    &nerr) == 0) {
 		nice_num_str_nvlist(item, ZPOOL_CONFIG_ERRCOUNT, nerr,
 		    cb->cb_literal, cb->cb_json_as_int, ZFS_NICENUM_1024);
-		if (nerr != 0 && cb->cb_verbose) {
+		if (nerr != 0 && cb->cb_verbosity > 0) {
 			nvlist_t *nverrlist = NULL;
-			if (zpool_get_errlog(zhp, &nverrlist) == 0) {
+			if (zpool_get_errlog(zhp, &nverrlist, verbosity) == 0) {
 				int i = 0;
 				int count = 0;
 				size_t len = MAXPATHLEN * 2;
 				nvpair_t *elem = NULL;
+				char **errl, *pathbuf = NULL;
+				nvlist_t **errnvl;
 
 				for (nvpair_t *pair =
 				    nvlist_next_nvpair(nverrlist, NULL);
 				    pair != NULL;
 				    pair = nvlist_next_nvpair(nverrlist, pair))
 					count++;
-				char **errl = (char **)malloc(
-				    count * sizeof (char *));
+				if (cb->cb_verbosity < 2)
+					errl = (char **)malloc(
+					    count * sizeof (char *));
+				else {
+					pathbuf = safe_malloc(len);
+					errnvl = calloc(count,
+					    sizeof (nvlist_t *));
+				}
 
 				while ((elem = nvlist_next_nvpair(nverrlist,
 				    elem)) != NULL) {
@@ -9547,16 +9556,46 @@ errors_nvlist(zpool_handle_t *zhp, status_cbdata_t *cb, nvlist_t *item)
 					    ZPOOL_ERR_DATASET, &dsobj) == 0);
 					verify(nvlist_lookup_uint64(nv,
 					    ZPOOL_ERR_OBJECT, &obj) == 0);
-					errl[i] = safe_malloc(len);
-					zpool_obj_to_path(zhp, dsobj, obj,
-					    errl[i++], len);
+					if (cb->cb_verbosity < 2) {
+						errl[i] = safe_malloc(len);
+						zpool_obj_to_path(zhp, dsobj,
+						    obj, errl[i++], len);
+					} else {
+						uint64_t lvl, blkid;
+
+						errnvl[i] = fnvlist_alloc();
+						lvl = fnvlist_lookup_uint64(nv,
+						    ZPOOL_ERR_LEVEL);
+						blkid = fnvlist_lookup_uint64(
+						    nv, ZPOOL_ERR_BLKID);
+						zpool_obj_to_path(zhp, dsobj,
+						    obj, pathbuf, len);
+						fnvlist_add_string(errnvl[i],
+						    "path", pathbuf);
+						fnvlist_add_uint64(errnvl[i],
+						    "level", lvl);
+						fnvlist_add_uint64(errnvl[i++],
+						    "record", blkid);
+					}
 				}
 				nvlist_free(nverrlist);
-				fnvlist_add_string_array(item, "errlist",
-				    (const char **)errl, count);
-				for (int i = 0; i < count; ++i)
-					free(errl[i]);
-				free(errl);
+				if (cb->cb_verbosity < 2) {
+					fnvlist_add_string_array(item,
+					    "errlist", (const char **)errl,
+					    count);
+					for (int i = 0; i < count; ++i)
+						free(errl[i]);
+					free(errl);
+				} else {
+					fnvlist_add_nvlist_array(item,
+					    "errlist",
+					    (const nvlist_t **)errnvl,
+					    count);
+					for (int i = 0; i < count; ++i)
+						free(errnvl[i]);
+					free(errnvl);
+					free(pathbuf);
+				}
 			} else
 				fnvlist_add_string(item, "errlist",
 				    strerror(errno));
@@ -10233,14 +10272,14 @@ print_checkpoint_status(pool_checkpoint_stat_t *pcs)
 }
 
 static void
-print_error_log(zpool_handle_t *zhp)
+print_error_log(zpool_handle_t *zhp, int verbosity)
 {
 	nvlist_t *nverrlist = NULL;
 	nvpair_t *elem;
 	char *pathname;
 	size_t len = MAXPATHLEN * 2;
 
-	if (zpool_get_errlog(zhp, &nverrlist) != 0)
+	if (zpool_get_errlog(zhp, &nverrlist, verbosity) != 0)
 		return;
 
 	(void) printf("errors: Permanent errors have been "
@@ -10258,7 +10297,18 @@ print_error_log(zpool_handle_t *zhp)
 		verify(nvlist_lookup_uint64(nv, ZPOOL_ERR_OBJECT,
 		    &obj) == 0);
 		zpool_obj_to_path(zhp, dsobj, obj, pathname, len);
-		(void) printf("%7s %s\n", "", pathname);
+		if (verbosity > 1) {
+			uint64_t level, blkid;
+
+			verify(nvlist_lookup_uint64(nv, ZPOOL_ERR_BLKID,
+			    &blkid) == 0);
+			verify(nvlist_lookup_uint64(nv, ZPOOL_ERR_LEVEL,
+			    &level) == 0);
+			(void) printf("%7s %s L%lu record %lu\n", "", pathname,
+			    level, blkid);
+		} else {
+			(void) printf("%7s %s\n", "", pathname);
+		}
 	}
 	free(pathname);
 	nvlist_free(nverrlist);
@@ -10957,14 +11007,14 @@ status_callback(zpool_handle_t *zhp, void *data)
 			if (nerr == 0) {
 				(void) printf(gettext(
 				    "errors: No known data errors\n"));
-			} else if (!cbp->cb_verbose) {
+			} else if (0 == cbp->cb_verbosity) {
 				color_start(ANSI_RED);
 				(void) printf(gettext("errors: %llu data "
 				    "errors, use '-v' for a list\n"),
 				    (u_longlong_t)nerr);
 				color_end();
 			} else {
-				print_error_log(zhp);
+				print_error_log(zhp, cbp->cb_verbosity);
 			}
 		}
 
@@ -11091,7 +11141,7 @@ zpool_do_status(int argc, char **argv)
 			get_timestamp_arg(*optarg);
 			break;
 		case 'v':
-			cb.cb_verbose = B_TRUE;
+			cb.cb_verbosity++;
 			break;
 		case 'j':
 			cb.cb_json = B_TRUE;

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -464,7 +464,7 @@ _LIBZFS_H zpool_status_t zpool_import_status(nvlist_t *, const char **,
 _LIBZFS_H nvlist_t *zpool_get_config(zpool_handle_t *, nvlist_t **);
 _LIBZFS_H nvlist_t *zpool_get_features(zpool_handle_t *);
 _LIBZFS_H int zpool_refresh_stats(zpool_handle_t *, boolean_t *);
-_LIBZFS_H int zpool_get_errlog(zpool_handle_t *, nvlist_t **);
+_LIBZFS_H int zpool_get_errlog(zpool_handle_t *, nvlist_t **, int);
 _LIBZFS_H void zpool_add_propname(zpool_handle_t *, const char *);
 
 /*

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1720,6 +1720,8 @@ typedef enum {
 #define	ZPOOL_ERR_LIST		"error list"
 #define	ZPOOL_ERR_DATASET	"dataset"
 #define	ZPOOL_ERR_OBJECT	"object"
+#define	ZPOOL_ERR_LEVEL		"level"
+#define	ZPOOL_ERR_BLKID		"blkid"
 
 #define	HIS_MAX_RECORD_LEN	(MAXPATHLEN + MAXPATHLEN + 1)
 

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4567,7 +4567,7 @@ zpool_add_propname(zpool_handle_t *zhp, const char *propname)
  * caller.
  */
 int
-zpool_get_errlog(zpool_handle_t *zhp, nvlist_t **nverrlistp)
+zpool_get_errlog(zpool_handle_t *zhp, nvlist_t **nverrlistp, int verbosity)
 {
 	zfs_cmd_t zc = {"\0"};
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
@@ -4623,8 +4623,16 @@ zpool_get_errlog(zpool_handle_t *zhp, nvlist_t **nverrlistp)
 	for (uint64_t i = 0; i < zblen; i++) {
 		nvlist_t *nv;
 
-		/* ignoring zb_blkid and zb_level for now */
+		/* filter out duplicate records */
 		if (i > 0 && zb[i-1].zb_objset == zb[i].zb_objset &&
+		    zb[i-1].zb_object == zb[i].zb_object &&
+		    zb[i-1].zb_level == zb[i].zb_level &&
+		    zb[i-1].zb_blkid == zb[i].zb_blkid)
+			continue;
+
+		/* filter out duplicate files */
+		if (verbosity < 2 && i > 0 &&
+		    zb[i-1].zb_objset == zb[i].zb_objset &&
 		    zb[i-1].zb_object == zb[i].zb_object)
 			continue;
 
@@ -4639,6 +4647,18 @@ zpool_get_errlog(zpool_handle_t *zhp, nvlist_t **nverrlistp)
 		    zb[i].zb_object) != 0) {
 			nvlist_free(nv);
 			goto nomem;
+		}
+		if (verbosity > 1) {
+			if (nvlist_add_uint64(nv, ZPOOL_ERR_LEVEL,
+			    zb[i].zb_level) != 0) {
+				nvlist_free(nv);
+				goto nomem;
+			}
+			if (nvlist_add_uint64(nv, ZPOOL_ERR_BLKID,
+			    zb[i].zb_blkid) != 0) {
+				nvlist_free(nv);
+				goto nomem;
+			}
 		}
 		if (nvlist_add_nvlist(*nverrlistp, "ejk", nv) != 0) {
 			nvlist_free(nv);

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -27,7 +27,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd February 14, 2024
+.Dd July 1, 2025
 .Dt ZPOOL-STATUS 8
 .Os
 .
@@ -156,7 +156,9 @@ See
 Display vdev TRIM status.
 .It Fl v
 Displays verbose data error information, printing out a complete list of all
-data errors since the last complete pool scrub.
+files containing data errors since the last complete pool scrub.
+Specified twice, prints out the complete list of all corrupt records within
+each corrupt file.
 If the head_errlog feature is enabled and files containing errors have been
 removed then the respective filenames will not be reported in subsequent runs
 of this command.


### PR DESCRIPTION
Specifying the verbose flag twice will display a list of all corrupt sectors within each corrupt file, as opposed to just the name of the file.

Signed-off-by:	Alan Somers <asomers@gmail.com>
Sponsored by:	ConnectWise

### Motivation and Context
Displays the record number of every corrupt record in every corrupt file.  I find this is very useful when cleaning up the fallout from #16626.

### Description
The kernel already tracks the blkid of every corrupt record, and already transmits that information to userland.  But libzfs has always thrown it away, until now.  This PR adds a `-vv` option to `zpool status`.  When used, it will print the level and blkid of every corrupt record.  It works in combination with `-j`, too.

### How Has This Been Tested?
Manually tested on about half a dozen production datasets that had on-disk corruption as a result of #16626 , in both L0 and L1 blocks.
Manually tested on a test dataset that I intentionally corrupted.  That one had multiple corrupted records on multiple files.

Example output, in human readable mode:
```
...
errors: Permanent errors have been detected in the following files:

        /testpool/randfile.7 L0 record 3
        /testpool/randfile.7 L0 record 9
        /testpool/randfile.7 L0 record 16
        /testpool/randfile.9 L0 record 8
        /testpool/randfile.9 L0 record 15
        /testpool/randfile.10 L0 record 3
        /testpool/randfile.10 L0 record 11
        /testpool/randfile.5 L0 record 17
        /testpool/randfile.8 L0 record 11
        /testpool/randfile.8 L0 record 19
        /testpool/randfile.6 L0 record 3
        /testpool/randfile.6 L0 record 12
```
<details>
<summary>Example output, in json mode</summary>

```json
{
  "output_version": {
    "command": "zpool status",
    "vers_major": 0,
    "vers_minor": 1
  },
  "pools": {
    "testpool": {
      "name": "testpool",
      "state": "ONLINE",
      "pool_guid": "10305967396160717712",
      "txg": "1523",
      "spa_version": "5000",
      "zpl_version": "5",
      "status": "One or more devices has experienced an error resulting in data\n\tcorruption.  Applications may be affected.\n",
      "action": "Restore the file in question if possible.  Otherwise restore the\n\tentire pool from backup.\n",
      "msgid": "ZFS-8000-8A",
      "moreinfo": "https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-8A",
      "scan_stats": {
        "function": "SCRUB",
        "state": "FINISHED",
        "start_time": "Tue Jul  1 12:11:14 2025",
        "end_time": "Tue Jul  1 12:11:14 2025",
        "to_examine": "56.0M",
        "examined": "56.0M",
        "skipped": "92K",
        "processed": "0B",
        "errors": "12",
        "bytes_per_scan": "0B",
        "pass_start": "1751393474",
        "scrub_pause": "-",
        "scrub_spent_paused": "0",
        "issued_bytes_per_scan": "55.9M",
        "issued": "55.9M"
      },
      "vdevs": {
        "testpool": {
          "name": "testpool",
          "vdev_type": "root",
          "guid": "10305967396160717712",
          "class": "normal",
          "state": "ONLINE",
          "alloc_space": "56.0M",
          "total_space": "112M",
          "def_space": "112M",
          "read_errors": "0",
          "write_errors": "0",
          "checksum_errors": "0",
          "vdevs": {
            "/tmp/zfs.img": {
              "name": "/tmp/zfs.img",
              "vdev_type": "file",
              "guid": "1719526601577822810",
              "path": "/tmp/zfs.img",
              "class": "normal",
              "state": "ONLINE",
              "alloc_space": "56.0M",
              "total_space": "112M",
              "def_space": "112M",
              "rep_dev_size": "116M",
              "self_healed": "1.50K",
              "phys_space": "128M",
              "read_errors": "0",
              "write_errors": "0",
              "checksum_errors": "27",
              "slow_ios": "0"
            }
          }
        }
      },
      "error_count": "12",
      "errlist": [
        {
          "path": "/testpool/randfile.7",
          "level": 0,
          "record": 3
        },
        {
          "path": "/testpool/randfile.7",
          "level": 0,
          "record": 9
        },
        {
          "path": "/testpool/randfile.7",
          "level": 0,
          "record": 16
        },
        {
          "path": "/testpool/randfile.9",
          "level": 0,
          "record": 8
        },
        {
          "path": "/testpool/randfile.9",
          "level": 0,
          "record": 15
        },
        {
          "path": "/testpool/randfile.10",
          "level": 0,
          "record": 3
        },
        {
          "path": "/testpool/randfile.10",
          "level": 0,
          "record": 11
        },
        {
          "path": "/testpool/randfile.5",
          "level": 0,
          "record": 17
        },
        {
          "path": "/testpool/randfile.8",
          "level": 0,
          "record": 11
        },
        {
          "path": "/testpool/randfile.8",
          "level": 0,
          "record": 19
        },
        {
          "path": "/testpool/randfile.6",
          "level": 0,
          "record": 3
        },
        {
          "path": "/testpool/randfile.6",
          "level": 0,
          "record": 12
        }
      ]
    }
  }
}
```
</details>

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
