### PR TITLE
Revert "Fix incorrect expected error in ztest"

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3882,7 +3882,7 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	 * If newvd is too small, it should fail with EOVERFLOW.
 	 *
 	 * If newvd is a distributed spare and it's being attached to a
-	 * dRAID which is not its parent it should fail with EINVAL.
+	 * dRAID which is not its parent it should fail with ENOTSUP.
 	 */
 	if (pvd->vdev_ops != &vdev_mirror_ops &&
 	    pvd->vdev_ops != &vdev_root_ops && (!replacing ||
@@ -3901,7 +3901,7 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	else if (ashift > oldvd->vdev_top->vdev_ashift)
 		expected_error = EDOM;
 	else if (newvd_is_dspare && pvd != vdev_draid_spare_get_parent(newvd))
-		expected_error = EINVAL;
+		expected_error = ENOTSUP;
 	else
 		expected_error = 0;
 


### PR DESCRIPTION
### Motivation and Context

Revisiting #15295.  A recent example of this failure in the CI can be found here:

https://github.com/openzfs/zfs/actions/runs/16007042925/attempts/3?pr=17501

### Description

This reverts commit 2076011e0c4c2d8ad6a59534a4784a6aa5f4f3df.  The comment which explains EINVAL should be expected for this case was wrong, not the code.  The kernel will return ENOTSUP when attaching a distributed spare to the wrong top-level dRAID vdev.  See the check for this in spa_vdev_attach().

```c
        /*
         * A dRAID spare can only replace a child of its parent dRAID vdev.
         */
        if (newvd->vdev_ops == &vdev_draid_spare_ops &&
            oldvd->vdev_top != vdev_draid_spare_get_parent(newvd)) {
                return (spa_vdev_exit(spa, newrootvd, txg, ENOTSUP));
        }
```

### How Has This Been Tested?

Locally tested.  During that testing I noticed a slightly different case which may explain the confusion here.  During one run somehow ztest ended up adding a distributed spare for a top-level dRAID device which doesn't exist.  In this case, EINVAL was returned instead ENOTSUP, however it should be impossible to manipulate a pool in to this layout.  I wasn't able to manually reproduce the issue, so more debugging will be needed.  That can be handled in a different PR.

Simplified example invalid pool config observed by ztest.  Attaching `draid1-1-0` will correctly return `EINVAL`,  the `draid1-1-0` distributed spare should not exist.

```
  pool: tank
 state: ONLINE
config:

	NAME                 STATE     READ WRITE CKSUM
	tank                 ONLINE       0     0     0
	  draid1:1d:3c:1s-0  ONLINE       0     0     0
	    /tmp/vdev1       ONLINE       0     0     0
	    /tmp/vdev2       ONLINE       0     0     0
	    /tmp/vdev3       ONLINE       0     0     0
	  draid1:1d:4c:2s-2  ONLINE       0     0     0
	    /tmp/vdev5       ONLINE       0     0     0
	    /tmp/vdev6       ONLINE       0     0     0
	    /tmp/vdev7       ONLINE       0     0     0
	    /tmp/vdev8       ONLINE       0     0     0
	spares
	  draid1-0-0         AVAIL   
	  draid1-2-0         AVAIL   
	  draid1-1-0         AVAIL   
	  draid1-2-1         AVAIL  
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
