### PR TITLE
zio: rename `io_reexecute` as `io_post`; use it for the direct IO checksum error flag

### DIFF
--- a/include/os/linux/zfs/sys/trace_common.h
+++ b/include/os/linux/zfs/sys/trace_common.h
@@ -45,7 +45,7 @@
 		__field(zio_flag_t,		zio_orig_flags)		\
 		__field(enum zio_stage,		zio_orig_stage)		\
 		__field(enum zio_stage,		zio_orig_pipeline)	\
-		__field(uint8_t,		zio_reexecute)		\
+		__field(uint8_t,		zio_post)		\
 		__field(uint64_t,		zio_txg)		\
 		__field(int,			zio_error)		\
 		__field(uint64_t,		zio_ena)		\
@@ -74,7 +74,7 @@
 		__entry->zio_orig_flags		= zio->io_orig_flags;	    \
 		__entry->zio_orig_stage		= zio->io_orig_stage;	    \
 		__entry->zio_orig_pipeline	= zio->io_orig_pipeline;    \
-		__entry->zio_reexecute		= zio->io_reexecute;	    \
+		__entry->zio_post		= zio->io_post;		    \
 		__entry->zio_txg		= zio->io_txg;		    \
 		__entry->zio_error		= zio->io_error;	    \
 		__entry->zio_ena		= zio->io_ena;		    \
@@ -92,7 +92,7 @@
 	"zio { type %u prio %u size %llu orig_size %llu "		\
 	"offset %llu timestamp %llu delta %llu delay %llu "		\
 	"flags 0x%llx stage 0x%x pipeline 0x%x orig_flags 0x%llx "	\
-	"orig_stage 0x%x orig_pipeline 0x%x reexecute %u "		\
+	"orig_stage 0x%x orig_pipeline 0x%x post %u "			\
 	"txg %llu error %d ena %llu prop { checksum %u compress %u "	\
 	"type %u level %u copies %u dedup %u dedup_verify %u nopwrite %u } }"
 
@@ -102,7 +102,7 @@
 	__entry->zio_timestamp, __entry->zio_delta, __entry->zio_delay,	\
 	__entry->zio_flags, __entry->zio_stage, __entry->zio_pipeline,	\
 	__entry->zio_orig_flags, __entry->zio_orig_stage,		\
-	__entry->zio_orig_pipeline, __entry->zio_reexecute,		\
+	__entry->zio_orig_pipeline, __entry->zio_post,			\
 	__entry->zio_txg, __entry->zio_error, __entry->zio_ena,		\
 	__entry->zp_checksum, __entry->zp_compress, __entry->zp_type,	\
 	__entry->zp_level, __entry->zp_copies, __entry->zp_dedup,	\

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -418,14 +418,15 @@ typedef struct zio_transform {
 typedef zio_t *zio_pipe_stage_t(zio_t *zio);
 
 /*
- * The io_reexecute flags are distinct from io_flags because the child must
- * be able to propagate them to the parent.  The normal io_flags are local
- * to the zio, not protected by any lock, and not modifiable by children;
- * the reexecute flags are protected by io_lock, modifiable by children,
- * and always propagated -- even when ZIO_FLAG_DONT_PROPAGATE is set.
+ * The io_post flags describe additional actions that a parent IO should
+ * consider or perform on behalf of a child. They are distinct from io_flags
+ * because the child must be able to propagate them to the parent. The normal
+ * io_flags are local to the zio, not protected by any lock, and not modifiable
+ * by children; the reexecute flags are protected by io_lock, modifiable by
+ * children, and always propagated -- even when ZIO_FLAG_DONT_PROPAGATE is set.
  */
-#define	ZIO_REEXECUTE_NOW	0x01
-#define	ZIO_REEXECUTE_SUSPEND	0x02
+#define	ZIO_POST_REEXECUTE	(1 << 0)
+#define	ZIO_POST_SUSPEND	(1 << 1)
 
 /*
  * The io_trim flags are used to specify the type of TRIM to perform.  They
@@ -461,7 +462,7 @@ struct zio {
 	enum zio_child	io_child_type;
 	enum trim_flag	io_trim_flags;
 	zio_priority_t	io_priority;
-	uint8_t		io_reexecute;
+	uint8_t		io_post;
 	uint8_t		io_state[ZIO_WAIT_TYPES];
 	uint64_t	io_txg;
 	spa_t		*io_spa;

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -226,8 +226,7 @@ typedef uint64_t zio_flag_t;
 #define	ZIO_FLAG_NOPWRITE	(1ULL << 29)
 #define	ZIO_FLAG_REEXECUTED	(1ULL << 30)
 #define	ZIO_FLAG_DELEGATED	(1ULL << 31)
-#define	ZIO_FLAG_DIO_CHKSUM_ERR	(1ULL << 32)
-#define	ZIO_FLAG_PREALLOCATED	(1ULL << 33)
+#define	ZIO_FLAG_PREALLOCATED	(1ULL << 32)
 
 #define	ZIO_ALLOCATOR_NONE	(-1)
 #define	ZIO_HAS_ALLOCATOR(zio)	((zio)->io_allocator != ZIO_ALLOCATOR_NONE)
@@ -427,6 +426,7 @@ typedef zio_t *zio_pipe_stage_t(zio_t *zio);
  */
 #define	ZIO_POST_REEXECUTE	(1 << 0)
 #define	ZIO_POST_SUSPEND	(1 << 1)
+#define	ZIO_POST_DIO_CHKSUM_ERR	(1 << 2)
 
 /*
  * The io_trim flags are used to specify the type of TRIM to perform.  They

--- a/module/zcommon/zfs_valstr.c
+++ b/module/zcommon/zfs_valstr.c
@@ -221,7 +221,6 @@ _VALSTR_BITFIELD_IMPL(zio_flag,
 	{ '.', "NP", "NOPWRITE" },
 	{ '.', "EX", "REEXECUTED" },
 	{ '.', "DG", "DELEGATED" },
-	{ '.', "DC", "DIO_CHKSUM_ERR" },
 	{ '.', "PA", "PREALLOCATED" },
 )
 

--- a/module/zfs/dmu_direct.c
+++ b/module/zfs/dmu_direct.c
@@ -104,7 +104,7 @@ dmu_write_direct_done(zio_t *zio)
 	dmu_sync_done(zio, NULL, zio->io_private);
 
 	if (zio->io_error != 0) {
-		if (zio->io_flags & ZIO_FLAG_DIO_CHKSUM_ERR)
+		if (zio->io_post & ZIO_POST_DIO_CHKSUM_ERR)
 			ASSERT3U(zio->io_error, ==, EIO);
 
 		/*

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -1842,7 +1842,7 @@ vdev_indirect_io_done(zio_t *zio)
 	 */
 	if (zio->io_flags & ZIO_FLAG_DIO_READ && ret == ECKSUM) {
 		zio->io_error = ret;
-		zio->io_flags |= ZIO_FLAG_DIO_CHKSUM_ERR;
+		zio->io_post |= ZIO_POST_DIO_CHKSUM_ERR;
 		zio_dio_chksum_verify_error_report(zio);
 		ret = 0;
 	}

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -779,7 +779,7 @@ vdev_mirror_io_done(zio_t *zio)
 	 * being written out during self healing.
 	 */
 	if ((zio->io_flags & ZIO_FLAG_DIO_READ) &&
-	    (zio->io_flags & ZIO_FLAG_DIO_CHKSUM_ERR)) {
+	    (zio->io_post & ZIO_POST_DIO_CHKSUM_ERR)) {
 		zio_dio_chksum_verify_error_report(zio);
 		zio->io_error = vdev_mirror_worst_error(mm);
 		ASSERT3U(zio->io_error, ==, ECKSUM);

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -2691,7 +2691,7 @@ raidz_checksum_verify(zio_t *zio)
 	 */
 	if (zio->io_flags & ZIO_FLAG_DIO_READ && ret == ECKSUM) {
 		zio->io_error = ret;
-		zio->io_flags |= ZIO_FLAG_DIO_CHKSUM_ERR;
+		zio->io_post |= ZIO_POST_DIO_CHKSUM_ERR;
 		zio_dio_chksum_verify_error_report(zio);
 		zio_checksum_verified(zio);
 		return (0);
@@ -3048,7 +3048,7 @@ raidz_reconstruct(zio_t *zio, int *ltgts, int ntgts, int nparity)
 
 	/* Check for success */
 	if (raidz_checksum_verify(zio) == 0) {
-		if (zio->io_flags & ZIO_FLAG_DIO_CHKSUM_ERR)
+		if (zio->io_post & ZIO_POST_DIO_CHKSUM_ERR)
 			return (0);
 
 		/* Reconstruction succeeded - report errors */
@@ -3514,7 +3514,7 @@ vdev_raidz_io_done(zio_t *zio)
 		}
 
 		if (raidz_checksum_verify(zio) == 0) {
-			if (zio->io_flags & ZIO_FLAG_DIO_CHKSUM_ERR)
+			if (zio->io_post & ZIO_POST_DIO_CHKSUM_ERR)
 				goto done;
 
 			for (int i = 0; i < rm->rm_nrows; i++) {


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

I spent two days this week debugging a very strange assertion trip in a fairly complicated thing I’m working on. Most of the details of it aren’t relevant to this, but the heart of the problem came from following (perhaps naively) a pattern that already existed, and which I think might be wrong.

I needed a vdev IO to signal to its parent that something had happened that required additional work to be done. I followed the approach taken with `ZIO_FLAG_DIO_CHKSUM_ERR`: in `zio_notify_parent()`, if the flag is set on the child, set it on the parent, and propagate it up the tree for something else to handle as appropriate.

In my case, the IO timing was different, and `zio_notify_parent()` could be doing `pio->io_flags |= ZIO_FLAG_MYFLAG` at the same time as `metaslab_class_throttle_reserve()` was doing `zio->io_flags |= ZIO_FLAG_IO_ALLOCATING`. So I was seeing what seemed impossible: successful returns from `metaslab_class_throttle_reserve() `without `ZIO_FLAG_IO_ALLOCATING` set.

(That I missed it for a long while is a whole different story, partly dealt with in #17508, but largely unrelated).

Obviously, I was in the right, as `zio_notify_parent()` has `pio->io_lock` at the time, but sticking a lock acquisition in `metaslab_class_throttle_reserve`() seemed like a fairly dangerous move, but also, I’ve never really felt great about modifying `io_flags` after the zio had been issued, because so many of those flags feel “structural” in nature to me (in another language, I feel like many of them would be variants on a parametric type). So I started looking around for other ways to propagate a signal up the tree.

Eventually, I realised we already had this: `io_reexecute`. It is already propagated up to its parent, and its purpose is to inform the pipeline of something unusual or exceptional that has happen that requires further action as the tree is being completed. It just happens that the two existing actions happen to be about reexecuting the zio.

Framed like that, it’s easy to see that `ZIO_FLAG_DIO_CHKSUM_ERR` can also be that: there was a special kind of event that happened, which something else up-tree needs to take some action on. And, as it happens, it’s exactly the same shape I need in my own project. So, it seemed like remodeling `io_reexecute` to be a more general “information for my parents” mechanism would be a reasonable approach.

(If you squint slightly differently, you can also imagine it as an extension of `io_error`).

And then I read the comment about `io_reexecute`:

```c
/*
 * The io_reexecute flags are distinct from io_flags because the child must
 * be able to propagate them to the parent.  The normal io_flags are local
 * to the zio, not protected by any lock, and not modifiable by children;
 * the reexecute flags are protected by io_lock, modifiable by children,
 * and always propagated -- even when ZIO_FLAG_DONT_PROPAGATE is set.
 */
```

That is, no lock is required for an IO being processed to modify its own `io_flags`, and a child definitely shouldn’t even be attempting it. If it’s true that that’s a proper invariant, then `metaslab_class_throttle_reserve()` was in the right, and propagating `ZIO_FLAG_DIO_CHKSUM_ERR` has never been truly safe, except perhaps by convenient timing.

### Description

Two commits. First, rename `io_reexecute` to `io_post`, `ZIO_REEXECUTE_*` to `ZIO_POST_*`, etc, and second to make `ZIO_FLAG_DIO_CHKSUM_ERR` be `ZIO_POST_DIO_CHKSUM_ERR`. Apart from the renaming, the only change is to remove the explicit propagation of that flag in `zio_notify_parent()`, since its now handled by propagating `io_post`.

The “truthy” `io_reexecute` checks here and there if been changed to explicitly consider the reexecute flags only, since that’s what they used to mean.

On the name,  “post” is something like “post-IO actions”, or, if you like, “fix it in post”. I considered `io_info`,  `io_extra`, `io_action`, `io_todo` and (maybe my true favourite) `io_encore`. If you’ve got a better suggestion I will be quite happy to change it, but it has to at least mean something :)

### How Has This Been Tested?

Compiled checked on both platforms, full test run completed on Linux.

I would not expect any differences really, since it’s little more than a rename.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).