### PR TITLE
linux: Fix out-of-src builds

### DIFF
--- a/module/Kbuild.in
+++ b/module/Kbuild.in
@@ -494,3 +494,34 @@ UBSAN_SANITIZE_zfs/sa.o := n
 ifeq ($(CONFIG_ALTIVEC),y)
 $(obj)/zfs/vdev_raidz_math_powerpc_altivec.o : c_flags += -maltivec
 endif
+
+# The following recipes attempt to fix out of src-tree builds, where $(src) != $(obj), so that the
+# subdir %.c/%.S -> %.o targets will work as expected. The in-kernel pattern targets do not seem to
+# be working on subdirs since about ~6.10
+zobjdirs = $(dir $(zfs-objs)) $(dir $(spl-objs))                                             \
+  $(dir $(zfs-$(CONFIG_X86))) $(dir $(zfs-$(CONFIG_UML_X86))) $(dir $(zfs-$(CONFIG_ARM64)))  \
+  $(dir $(zfs-$(CONFIG_PPC64))) $(dir $(zfs-$(CONFIG_PPC)))
+
+z_cdirs = $(sort $(filter-out lua/setjmp/ $(addprefix icp/asm-aarch64/, aes/ blake3/ modes/ sha2/) \
+  $(addprefix icp/asm-x86_64/, aes/ blake3/ modes/ sha2/)                                          \
+  $(addprefix icp/asm-ppc/, aes/ blake3/ modes/ sha2/)                                             \
+  $(addprefix icp/asm-ppc64/, aes/ blake3/ modes/ sha2/), $(zobjdirs)))
+z_sdirs = $(sort $(filter lua/setjmp/ $(addprefix icp/asm-aarch64/, aes/ blake3/ modes/ sha2/)     \
+  $(addprefix icp/asm-x86_64/, aes/ blake3/ modes/ sha2/)                                          \
+  $(addprefix icp/asm-ppc/, aes/ blake3/ modes/ sha2/)                                             \
+  $(addprefix icp/asm-ppc64/, aes/ blake3/ modes/ sha2/), $(zobjdirs)))
+
+define ZKMOD_C_O_MAKE_TARGET
+$1%.o: $(src)/$1%.c FORCE
+	$$(call if_changed_rule,cc_o_c)
+	$$(call cmd,force_checksrc)
+endef
+
+define ZKMOD_S_O_MAKE_TARGET
+$1%.o: $(src)/$1%.S FORCE
+	$$(call if_changed_rule,as_o_S)
+	$$(call cmd,force_checksrc)
+endef
+
+$(foreach target,$(z_cdirs), $(eval $(call ZKMOD_C_O_MAKE_TARGET,$(target))))
+$(foreach target,$(z_sdirs), $(eval $(call ZKMOD_S_O_MAKE_TARGET,$(target))))


### PR DESCRIPTION
### Motivation and Context
The problem is described in #17321 - due to some apparent change in Kbuild, our source tree stopped building when the build was done in a separate directory, e.g.:
```sh
git clone https://github.com/openzfs/zfs zfs
cd zfs && ./autogen.sh
cd ..
mkdir zfs-build
cd zfs-build
../zfs/configure --with-linux=/usr/src/linux
make gitrev && make -C module/ modules
```

The `make -C module/ modules` command would typically fail with messages about not finding any matching targets for the `*.o` files, typically starting with `os/linux/spl/spl-atomic.o` due to its place at the top of the lexical order.

### Description
Though I am uncertain what change in Kbuild caused this, I was able to determine that the pattern targets in the Linux Kbuild system are no longer matching the `%.o` targets in subdirectories. In response to this, I added some dynamically-generated targets to the `module/Kbuild` file to fill in the missing targets and allow the build to succeed. Seems to work for me at the moment, both in-source and out-of-source builds.

I am not certain how well it works with earlier kernels (like 6.1.x branch, which probably doesn't have the Kbuild change).

If someone understands better what causes the breakage and can propose a cleaner fix here, I'm happy to implement it instead of mine. Otherwise, I'd recommend accepting this one (if it passes testing) until that mystery can be sorted out, so that things like the Arch AUR zfs-dkms-git package can work again, as well as anything else that builds like this.

### How Has This Been Tested?
I have tested the module build on 6.15.x and 6.16-rc kernels.
I have tested the module build both out-of-source and in-source builds.
I **have not** tested kernels where the out-of-source build was still working, yet - maybe someone with one of these kernels already in place can give this a whirl and approve here.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
