### PR TITLE
zfs_vnops_os.c: Add support for _PC_HAS_HIDDENSYSTEM

### DIFF
--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -5428,6 +5428,11 @@ zfs_freebsd_pathconf(struct vop_pathconf_args *ap)
 			return (0);
 		}
 		return (EINVAL);
+#ifdef _PC_HAS_HIDDENSYSTEM
+	case _PC_HAS_HIDDENSYSTEM:
+		*ap->a_retval = 1;
+		return (0);
+#endif
 	default:
 		return (vop_stdpathconf(ap));
 	}


### PR DESCRIPTION

Add support for the FreeBSD _PC_HAS_HIDDENSYSTEM pathconf name


### Motivation and Context
The pathconf name _PC_HAS_HIDDENSYSTEM was recently added to FreeBSD to
indicate that a file supports the UF_HIDDEN and UF_SYSTEM va_flags.
Without this patch, pathconf will erroneously return 0 to indicate no support.

### Description
When zfs_freebsd_pathconf() is called with the name _PC_HAS_HIDDENSYSTEM,
the code returns 1 to indicate support in the switch statement.

### How Has This Been Tested?
This was tested in an up-to-date FreeBSD system, using the chflags(1) command
to set/clear the flags. It was also tested using a trivial program that calls
enabled = pathconf(argv[1], _PC_HAS_HIDDENSYSTEM);
where argv[1] was a pathname for a file on a ZFS volume.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
