### PR TITLE
zpool/zfs: Add '-a|--all' option to scrub, trim, initialize.

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -34,7 +34,7 @@
  * Copyright (c) 2019, loli10K <ezomori.nozomu@gmail.com>
  * Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
  * Copyright (c) 2021, 2023, Klara Inc.
- * Copyright [2021] Hewlett Packard Enterprise Development LP
+ * Copyright (c) 2021, 2025 Hewlett Packard Enterprise Development LP.
  */
 
 #include <assert.h>
@@ -510,16 +510,16 @@ get_usage(zpool_help_t idx)
 	case HELP_REOPEN:
 		return (gettext("\treopen [-n] <pool>\n"));
 	case HELP_INITIALIZE:
-		return (gettext("\tinitialize [-c | -s | -u] [-w] <pool> "
+		return (gettext("\tinitialize [-c | -s | -u] [-w] <-a | pool> "
 		    "[<device> ...]\n"));
 	case HELP_SCRUB:
-		return (gettext("\tscrub [-e | -s | -p | -C] [-w] "
+		return (gettext("\tscrub [-e | -s | -p | -C] [-w] <-a | pool> "
 		    "<pool> ...\n"));
 	case HELP_RESILVER:
 		return (gettext("\tresilver <pool> ...\n"));
 	case HELP_TRIM:
-		return (gettext("\ttrim [-dw] [-r <rate>] [-c | -s] <pool> "
-		    "[<device> ...]\n"));
+		return (gettext("\ttrim [-dw] [-r <rate>] [-c | -s] "
+		    "<-a | pool> [<device> ...]\n"));
 	case HELP_STATUS:
 		return (gettext("\tstatus [-DdegiLPpstvx] "
 		    "[-c script1[,script2,...]] ...\n"
@@ -557,33 +557,6 @@ get_usage(zpool_help_t idx)
 		return (gettext("\tddtprune -d|-p <amount> <pool>\n"));
 	default:
 		__builtin_unreachable();
-	}
-}
-
-static void
-zpool_collect_leaves(zpool_handle_t *zhp, nvlist_t *nvroot, nvlist_t *res)
-{
-	uint_t children = 0;
-	nvlist_t **child;
-	uint_t i;
-
-	(void) nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
-	    &child, &children);
-
-	if (children == 0) {
-		char *path = zpool_vdev_name(g_zfs, zhp, nvroot,
-		    VDEV_NAME_PATH);
-
-		if (strcmp(path, VDEV_TYPE_INDIRECT) != 0 &&
-		    strcmp(path, VDEV_TYPE_HOLE) != 0)
-			fnvlist_add_boolean(res, path);
-
-		free(path);
-		return;
-	}
-
-	for (i = 0; i < children; i++) {
-		zpool_collect_leaves(zhp, child[i], res);
 	}
 }
 
@@ -794,25 +767,29 @@ zpool_do_initialize(int argc, char **argv)
 	int c;
 	char *poolname;
 	zpool_handle_t *zhp;
-	nvlist_t *vdevs;
 	int err = 0;
 	boolean_t wait = B_FALSE;
+	boolean_t initialize_all = B_FALSE;
 
 	struct option long_options[] = {
 		{"cancel",	no_argument,		NULL, 'c'},
 		{"suspend",	no_argument,		NULL, 's'},
 		{"uninit",	no_argument,		NULL, 'u'},
 		{"wait",	no_argument,		NULL, 'w'},
+		{"all", 	no_argument,		NULL, 'a'},
 		{0, 0, 0, 0}
 	};
 
 	pool_initialize_func_t cmd_type = POOL_INITIALIZE_START;
-	while ((c = getopt_long(argc, argv, "csuw", long_options,
+	while ((c = getopt_long(argc, argv, "acsuw", long_options,
 	    NULL)) != -1) {
 		switch (c) {
+		case 'a':
+			initialize_all = B_TRUE;
+			break;
 		case 'c':
-			if (cmd_type != POOL_INITIALIZE_START &&
-			    cmd_type != POOL_INITIALIZE_CANCEL) {
+			if ((cmd_type != POOL_INITIALIZE_START &&
+			    cmd_type != POOL_INITIALIZE_CANCEL)) {
 				(void) fprintf(stderr, gettext("-c cannot be "
 				    "combined with other options\n"));
 				usage(B_FALSE);
@@ -820,8 +797,8 @@ zpool_do_initialize(int argc, char **argv)
 			cmd_type = POOL_INITIALIZE_CANCEL;
 			break;
 		case 's':
-			if (cmd_type != POOL_INITIALIZE_START &&
-			    cmd_type != POOL_INITIALIZE_SUSPEND) {
+			if ((cmd_type != POOL_INITIALIZE_START &&
+			    cmd_type != POOL_INITIALIZE_SUSPEND)) {
 				(void) fprintf(stderr, gettext("-s cannot be "
 				    "combined with other options\n"));
 				usage(B_FALSE);
@@ -856,6 +833,17 @@ zpool_do_initialize(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
+	initialize_cbdata_t cbdata = {
+		.wait = wait,
+		.cmd_type = cmd_type
+	};
+
+	if (initialize_all && argc > 0) {
+		(void) fprintf(stderr, gettext("-a cannot be combined with "
+		    "individual zpools or vdevs\n"));
+		usage(B_FALSE);
+	}
+
 	if (argc < 1) {
 		(void) fprintf(stderr, gettext("missing pool name argument\n"));
 		usage(B_FALSE);
@@ -868,30 +856,35 @@ zpool_do_initialize(int argc, char **argv)
 		usage(B_FALSE);
 	}
 
-	poolname = argv[0];
-	zhp = zpool_open(g_zfs, poolname);
-	if (zhp == NULL)
-		return (-1);
-
-	vdevs = fnvlist_alloc();
-	if (argc == 1) {
-		/* no individual leaf vdevs specified, so add them all */
-		nvlist_t *config = zpool_get_config(zhp, NULL);
-		nvlist_t *nvroot = fnvlist_lookup_nvlist(config,
-		    ZPOOL_CONFIG_VDEV_TREE);
-		zpool_collect_leaves(zhp, nvroot, vdevs);
+	if (argc == 0 && initialize_all) {
+		/* Initilize each pool recursively */
+		err = for_each_pool(argc, argv, B_TRUE, NULL, ZFS_TYPE_POOL,
+		    B_FALSE, zpool_initialize_one, &cbdata);
+		return (err);
+	} else if (argc == 1) {
+		/* no individual leaf vdevs specified, initialize the pool */
+		poolname = argv[0];
+		zhp = zpool_open(g_zfs, poolname);
+		if (zhp == NULL)
+			return (-1);
+		err = zpool_initialize_one(zhp, &cbdata);
 	} else {
+		/* individual leaf vdevs specified, initialize them */
+		poolname = argv[0];
+		zhp = zpool_open(g_zfs, poolname);
+		if (zhp == NULL)
+			return (-1);
+		nvlist_t *vdevs = fnvlist_alloc();
 		for (int i = 1; i < argc; i++) {
 			fnvlist_add_boolean(vdevs, argv[i]);
 		}
+		if (wait)
+			err = zpool_initialize_wait(zhp, cmd_type, vdevs);
+		else
+			err = zpool_initialize(zhp, cmd_type, vdevs);
+		fnvlist_free(vdevs);
 	}
 
-	if (wait)
-		err = zpool_initialize_wait(zhp, cmd_type, vdevs);
-	else
-		err = zpool_initialize(zhp, cmd_type, vdevs);
-
-	fnvlist_free(vdevs);
 	zpool_close(zhp);
 
 	return (err);
@@ -8454,10 +8447,14 @@ zpool_do_scrub(int argc, char **argv)
 	boolean_t is_pause = B_FALSE;
 	boolean_t is_stop = B_FALSE;
 	boolean_t is_txg_continue = B_FALSE;
+	boolean_t scrub_all = B_FALSE;
 
 	/* check options */
-	while ((c = getopt(argc, argv, "spweC")) != -1) {
+	while ((c = getopt(argc, argv, "aspweC")) != -1) {
 		switch (c) {
+		case 'a':
+			scrub_all = B_TRUE;
+			break;
 		case 'e':
 			is_error_scrub = B_TRUE;
 			break;
@@ -8521,7 +8518,7 @@ zpool_do_scrub(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-	if (argc < 1) {
+	if (argc < 1 && !scrub_all) {
 		(void) fprintf(stderr, gettext("missing pool name argument\n"));
 		usage(B_FALSE);
 	}
@@ -8593,6 +8590,7 @@ zpool_do_trim(int argc, char **argv)
 		{"rate",	required_argument,	NULL,	'r'},
 		{"suspend",	no_argument,		NULL,	's'},
 		{"wait",	no_argument,		NULL,	'w'},
+		{"all",		no_argument,		NULL,	'a'},
 		{0, 0, 0, 0}
 	};
 
@@ -8600,11 +8598,16 @@ zpool_do_trim(int argc, char **argv)
 	uint64_t rate = 0;
 	boolean_t secure = B_FALSE;
 	boolean_t wait = B_FALSE;
+	boolean_t trimall = B_FALSE;
+	int error;
 
 	int c;
-	while ((c = getopt_long(argc, argv, "cdr:sw", long_options, NULL))
+	while ((c = getopt_long(argc, argv, "acdr:sw", long_options, NULL))
 	    != -1) {
 		switch (c) {
+		case 'a':
+			trimall = B_TRUE;
+			break;
 		case 'c':
 			if (cmd_type != POOL_TRIM_START &&
 			    cmd_type != POOL_TRIM_CANCEL) {
@@ -8663,7 +8666,18 @@ zpool_do_trim(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-	if (argc < 1) {
+	trimflags_t trim_flags = {
+		.secure = secure,
+		.rate = rate,
+		.wait = wait,
+	};
+
+	trim_cbdata_t cbdata = {
+		.trim_flags = trim_flags,
+		.cmd_type = cmd_type
+	};
+
+		if (argc < 1 && !trimall) {
 		(void) fprintf(stderr, gettext("missing pool name argument\n"));
 		usage(B_FALSE);
 		return (-1);
@@ -8671,40 +8685,45 @@ zpool_do_trim(int argc, char **argv)
 
 	if (wait && (cmd_type != POOL_TRIM_START)) {
 		(void) fprintf(stderr, gettext("-w cannot be used with -c or "
-		    "-s\n"));
+		    "-s options\n"));
 		usage(B_FALSE);
 	}
 
-	char *poolname = argv[0];
-	zpool_handle_t *zhp = zpool_open(g_zfs, poolname);
-	if (zhp == NULL)
-		return (-1);
+	if (trimall && argc > 0) {
+		(void) fprintf(stderr, gettext("-a cannot be combined with "
+		    "individual zpools or vdevs\n"));
+		usage(B_FALSE);
+	}
 
-	trimflags_t trim_flags = {
-		.secure = secure,
-		.rate = rate,
-		.wait = wait,
-	};
-
-	nvlist_t *vdevs = fnvlist_alloc();
-	if (argc == 1) {
+	if (argc == 0 && trimall) {
+		cbdata.trim_flags.fullpool = B_TRUE;
+		/* Trim each pool recursively */
+		error = for_each_pool(argc, argv, B_TRUE, NULL, ZFS_TYPE_POOL,
+		    B_FALSE, zpool_trim_one, &cbdata);
+	} else if (argc == 1) {
+		char *poolname = argv[0];
+		zpool_handle_t *zhp = zpool_open(g_zfs, poolname);
+		if (zhp == NULL)
+			return (-1);
 		/* no individual leaf vdevs specified, so add them all */
-		nvlist_t *config = zpool_get_config(zhp, NULL);
-		nvlist_t *nvroot = fnvlist_lookup_nvlist(config,
-		    ZPOOL_CONFIG_VDEV_TREE);
-		zpool_collect_leaves(zhp, nvroot, vdevs);
-		trim_flags.fullpool = B_TRUE;
+		error = zpool_trim_one(zhp, &cbdata);
+		zpool_close(zhp);
 	} else {
-		trim_flags.fullpool = B_FALSE;
+		char *poolname = argv[0];
+		zpool_handle_t *zhp = zpool_open(g_zfs, poolname);
+		if (zhp == NULL)
+			return (-1);
+		/* leaf vdevs specified, trim only those */
+		cbdata.trim_flags.fullpool = B_FALSE;
+		nvlist_t *vdevs = fnvlist_alloc();
 		for (int i = 1; i < argc; i++) {
 			fnvlist_add_boolean(vdevs, argv[i]);
 		}
+		error = zpool_trim(zhp, cbdata.cmd_type, vdevs,
+		    &cbdata.trim_flags);
+		fnvlist_free(vdevs);
+		zpool_close(zhp);
 	}
-
-	int error = zpool_trim(zhp, cmd_type, vdevs, &trim_flags);
-
-	fnvlist_free(vdevs);
-	zpool_close(zhp);
 
 	return (error);
 }

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -30,6 +30,7 @@
  * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
  * Copyright (c) 2019 Datto Inc.
  * Copyright (c) 2021, Colm Buckley <colm@tuatha.org>
+ * Copyright (c) 2025 Hewlett Packard Enterprise Development LP.
  */
 
 #ifndef	_LIBZFS_H
@@ -288,10 +289,20 @@ typedef struct trimflags {
 	uint64_t rate;
 } trimflags_t;
 
+typedef struct trim_cbdata {
+    trimflags_t trim_flags;
+    pool_trim_func_t cmd_type;
+} trim_cbdata_t;
+
+typedef struct initialize_cbdata {
+	boolean_t wait;
+	pool_initialize_func_t cmd_type;
+} initialize_cbdata_t;
 /*
  * Functions to manipulate pool and vdev state
  */
 _LIBZFS_H int zpool_scan(zpool_handle_t *, pool_scan_func_t, pool_scrub_cmd_t);
+_LIBZFS_H int zpool_initialize_one(zpool_handle_t *, void *);
 _LIBZFS_H int zpool_initialize(zpool_handle_t *, pool_initialize_func_t,
     nvlist_t *);
 _LIBZFS_H int zpool_initialize_wait(zpool_handle_t *, pool_initialize_func_t,
@@ -304,7 +315,9 @@ _LIBZFS_H int zpool_reguid(zpool_handle_t *);
 _LIBZFS_H int zpool_set_guid(zpool_handle_t *, const uint64_t *);
 _LIBZFS_H int zpool_reopen_one(zpool_handle_t *, void *);
 
+_LIBZFS_H void zpool_collect_leaves(zpool_handle_t *, nvlist_t *, nvlist_t *);
 _LIBZFS_H int zpool_sync_one(zpool_handle_t *, void *);
+_LIBZFS_H int zpool_trim_one(zpool_handle_t *, void *);
 
 _LIBZFS_H int zpool_ddt_prune(zpool_handle_t *, zpool_ddt_prune_unit_t,
     uint64_t);

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -479,6 +479,7 @@
     <elf-symbol name='zpool_clear' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_clear_label' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_close' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_collect_leaves' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_collect_unsup_feat' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_ddt_prune' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -528,6 +529,7 @@
     <elf-symbol name='zpool_import_status' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_in_use' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_initialize' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_initialize_one' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_initialize_wait' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_is_draid_spare' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_iter' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -577,6 +579,7 @@
     <elf-symbol name='zpool_state_to_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_sync_one' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_trim' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_trim_one' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_upgrade' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_vdev_attach' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_vdev_clear' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1450,8 +1453,103 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libspl/os/linux/getmntany.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='d315442e' size-in-bits='16' id='811205dc'>
+      <subrange length='1' type-id='7359adad' id='52f813b4'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='d3130597' size-in-bits='768' id='f63f23b9'>
+      <subrange length='12' type-id='7359adad' id='84827bdc'/>
+    </array-type-def>
+    <typedef-decl name='__u16' type-id='8efea9e5' id='d315442e'/>
+    <typedef-decl name='__s32' type-id='95e97e5e' id='3158a266'/>
+    <typedef-decl name='__u32' type-id='f0981eeb' id='3f1a6b60'/>
+    <typedef-decl name='__s64' type-id='1eb56b1e' id='49659421'/>
+    <typedef-decl name='__u64' type-id='3a47d82b' id='d3130597'/>
+    <class-decl name='statx_timestamp' size-in-bits='128' is-struct='yes' visibility='default' id='94101016'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='49659421' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_nsec' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__reserved' type-id='3158a266' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='statx' size-in-bits='2048' is-struct='yes' visibility='default' id='720b04c5'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='stx_mask' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='stx_blksize' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='stx_attributes' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stx_nlink' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='stx_uid' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='stx_gid' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='stx_mode' type-id='d315442e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='240'>
+        <var-decl name='__spare0' type-id='811205dc' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='stx_ino' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='stx_size' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='stx_blocks' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='stx_attributes_mask' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='stx_atime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='stx_btime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='stx_ctime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='stx_mtime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='stx_rdev_major' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='stx_rdev_minor' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='stx_dev_major' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='stx_dev_minor' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='stx_mnt_id' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='__spare2' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='__spare3' type-id='f63f23b9' visibility='default'/>
+      </data-member>
+    </class-decl>
     <pointer-type-def type-id='56fe4a37' size-in-bits='64' id='b6b61d2f'/>
     <qualified-type-def type-id='b6b61d2f' restrict='yes' id='3cad23cd'/>
+    <pointer-type-def type-id='720b04c5' size-in-bits='64' id='936b8e35'/>
+    <qualified-type-def type-id='936b8e35' restrict='yes' id='31d265b7'/>
     <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>
       <parameter type-id='3cad23cd'/>
@@ -1461,6 +1559,14 @@
     </function-decl>
     <function-decl name='feof' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='822cd80b'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='statx' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='9d26089a'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='f0981eeb'/>
+      <parameter type-id='31d265b7'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
@@ -4135,13 +4241,6 @@
       <parameter type-id='58603c44'/>
       <return type-id='9c313c2d'/>
     </function-decl>
-    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
-      <parameter type-id='4c81de99'/>
-      <parameter type-id='80f4b756'/>
-      <parameter type-id='26a90f95'/>
-      <parameter type-id='b59d7dce'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
     <function-decl name='zfs_iter_snapshots_v2' mangled-name='zfs_iter_snapshots_v2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_iter_snapshots_v2'>
       <parameter type-id='9200a744'/>
       <parameter type-id='95e97e5e'/>
@@ -6629,6 +6728,13 @@
       <parameter type-id='e4378506' name='plp'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='zpool_prop_get_feature' mangled-name='zpool_prop_get_feature' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_prop_get_feature'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='80f4b756' name='propname'/>
+      <parameter type-id='26a90f95' name='buf'/>
+      <parameter type-id='b59d7dce' name='len'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='zpool_get_state' mangled-name='zpool_get_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_state'>
       <parameter type-id='4c81de99' name='zhp'/>
       <return type-id='95e97e5e'/>
@@ -6710,6 +6816,11 @@
       <parameter type-id='95e97e5e' name='flags'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='zpool_initialize_one' mangled-name='zpool_initialize_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize_one'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='eaa32e2f' name='data'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='zpool_initialize' mangled-name='zpool_initialize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_initialize'>
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='7063e1ab' name='cmd_type'/>
@@ -6720,6 +6831,17 @@
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='7063e1ab' name='cmd_type'/>
       <parameter type-id='5ce45b60' name='vds'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_collect_leaves' mangled-name='zpool_collect_leaves' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_collect_leaves'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='5ce45b60' name='nvroot'/>
+      <parameter type-id='5ce45b60' name='res'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='zpool_trim_one' mangled-name='zpool_trim_one' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim_one'>
+      <parameter type-id='4c81de99' name='zhp'/>
+      <parameter type-id='eaa32e2f' name='data'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zpool_trim' mangled-name='zpool_trim' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_trim'>

--- a/man/man8/zpool-initialize.8
+++ b/man/man8/zpool-initialize.8
@@ -26,6 +26,7 @@
 .\" Copyright (c) 2018 George Melikov. All Rights Reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+.\" Copyright (c) 2025 Hewlett Packard Enterprise Development LP.
 .\"
 .Dd May 27, 2021
 .Dt ZPOOL-INITIALIZE 8
@@ -39,7 +40,7 @@
 .Cm initialize
 .Op Fl c Ns | Ns Fl s | Ns Fl u
 .Op Fl w
-.Ar pool
+.Fl a Ns | Ns Ar pool
 .Oo Ar device Oc Ns …
 .
 .Sh DESCRIPTION
@@ -71,6 +72,10 @@ with no flags can be used to re-initialize all unallocated regions on
 the relevant target devices.
 .It Fl w , -wait
 Wait until the devices have finished initializing before returning.
+.It Fl a , -all
+Begin, cancel, suspend initializing on
+all
+pools.
 .El
 .
 .Sh SEE ALSO

--- a/man/man8/zpool-scrub.8
+++ b/man/man8/zpool-scrub.8
@@ -26,6 +26,7 @@
 .\" Copyright (c) 2018, 2021 George Melikov. All Rights Reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+.\" Copyright (c) 2025 Hewlett Packard Enterprise Development LP.
 .\"
 .Dd November 18, 2024
 .Dt ZPOOL-SCRUB 8
@@ -39,7 +40,7 @@
 .Cm scrub
 .Op Ns Fl e | Ns Fl p | Fl s Ns | Fl C Ns
 .Op Fl w
-.Ar pool Ns …
+.Fl a Ns | Ns Ar pool Ns …
 .
 .Sh DESCRIPTION
 Begins a scrub or resumes a paused scrub.
@@ -118,6 +119,10 @@ resilvering, nor can it be run when a regular scrub is paused.
 Continue scrub from last saved txg (see zpool
 .Sy last_scrubbed_txg
 property).
+.It Fl a , -all
+Begin, pause, stop scrub on
+all
+pools.
 .El
 .Sh EXAMPLES
 .Ss Example 1

--- a/man/man8/zpool-trim.8
+++ b/man/man8/zpool-trim.8
@@ -26,6 +26,7 @@
 .\" Copyright (c) 2018 George Melikov. All Rights Reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+.\" Copyright (c) 2025 Hewlett Packard Enterprise Development LP.
 .\"
 .Dd May 27, 2021
 .Dt ZPOOL-TRIM 8
@@ -40,7 +41,7 @@
 .Op Fl dw
 .Op Fl r Ar rate
 .Op Fl c Ns | Ns Fl s
-.Ar pool
+.Fl a Ns | Ns Ar pool
 .Oo Ar device Ns Oc Ns …
 .
 .Sh DESCRIPTION
@@ -84,6 +85,10 @@ Trimming can then be resumed by running
 with no flags on the relevant target devices.
 .It Fl w , -wait
 Wait until the devices are done being trimmed before returning.
+.It Fl a , -all
+Perform TRIM operation on
+all
+pools.
 .El
 .Sh PERIODIC TRIM
 On machines using systemd, trim timers can be enabled on a per-pool basis.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_001_neg.ksh
@@ -28,6 +28,7 @@
 
 #
 # Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2025 Hewlett Packard Enterprise Development LP.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -46,7 +47,7 @@
 verify_runnable "global"
 
 set -A args "" "-?" "blah blah" "-%" "--?" "-*" "-=" \
-    "-a" "-b" "-c" "-d" "-e" "-f" "-g" "-h" "-i" "-j" "-k" "-l" \
+    "-b" "-c" "-d" "-e" "-f" "-g" "-h" "-i" "-j" "-k" "-l" \
     "-m" "-n" "-o" "-p" "-q" "-r" "-s" "-t" "-u" "-v" "-w" "-x" "-y" "-z" \
     "-A" "-B" "-C" "-D" "-E" "-F" "-G" "-H" "-I" "-J" "-K" "-L" \
     "-M" "-N" "-O" "-P" "-Q" "-R" "-S" "-T" "-U" "-V" "-W" "-X" "-W" "-Z"


### PR DESCRIPTION
Add support for the '-a | --all' option to perform trim, scrub, and initialize operations on all pools.

Previously, specifying a pool name was mandatory for these operations. With this enhancement, users can now execute these operations across all pools at once, without needing to manually iterate over each pool from the command line.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It would be helpful to have the ability to initiate these operations (scrub, trim, initialize) on multiple pools simultaneously.
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Add support for commands like zpool scrub -a, zpool trim -a, and zpool initialize -a to run the respective operation on all pools present in the system. This enhancement allows users to perform these tasks across all pools with a single command, improving efficiency and convenience.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested this manually.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
