### PR TITLE
CI: Add CentOS Stream 9/10 to the FULL_OS runner list

### DIFF
--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -5,16 +5,6 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      include_stream9:
-        type: boolean
-        required: false
-        default: false
-        description: 'Test on CentOS 9 stream'
-      include_stream10:
-        type: boolean
-        required: false
-        default: false
-        description: 'Test on CentOS 10 stream'
       fedora_kernel_ver:
         type: string
         required: false
@@ -39,7 +29,7 @@ jobs:
       - name: Generate OS config and CI type
         id: os
         run: |
-          FULL_OS='["almalinux8", "almalinux9", "almalinux10", "debian11", "debian12", "fedora41", "fedora42", "freebsd13-5r", "freebsd14-3s", "freebsd15-0c", "ubuntu22", "ubuntu24"]'
+          FULL_OS='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "fedora41", "fedora42", "freebsd13-5r", "freebsd14-3s", "freebsd15-0c", "ubuntu22", "ubuntu24"]'
           QUICK_OS='["almalinux8", "almalinux9", "almalinux10", "debian12", "fedora42", "freebsd14-3s", "ubuntu24"]'
           # determine CI type when running on PR
           ci_type="full"
@@ -61,14 +51,6 @@ jobs:
           else
               # Normal case
               os_json=$(echo ${os_selection} | jq -c)
-          fi
-
-          # Add optional runners
-          if [ "${{ github.event.inputs.include_stream9 }}" == 'true' ]; then
-            os_json=$(echo $os_json | jq -c '. += ["centos-stream9"]')
-          fi
-          if [ "${{ github.event.inputs.include_stream10 }}" == 'true' ]; then
-            os_json=$(echo $os_json | jq -c '. += ["centos-stream10"]')
           fi
 
           echo $os_json


### PR DESCRIPTION
### Motivation and Context

Testing on CentOS Stream provides several months advance notice of changes coming to the RHEL kernel.  This should help OpenZFS be proactive instead of reactive to new RHEL minor versions.

### Description

I partially reverted the changes in #16904 which made CentOS Stream 9 an optional runner, and added CentOS Stream 10 to the FULL_OS runner list.

### How Has This Been Tested?

As this is a change to the CI itself, I'd like the CI run on this PR to serve as the testing.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
