### PR TITLE
Fix zdb pool/ with -k

### DIFF
--- a/tests/zfs-tests/tests/functional/pool_checkpoint/checkpoint_zdb.ksh
+++ b/tests/zfs-tests/tests/functional/pool_checkpoint/checkpoint_zdb.ksh
@@ -63,6 +63,7 @@ log_must eval "zdb $TESTPOOL | grep -q \"Checkpointed uberblock found\""
 log_mustnot eval "zdb -k $TESTPOOL | grep -q \"Checkpointed uberblock found\""
 log_mustnot eval "zdb $TESTPOOL | grep \"Dataset $FS1\""
 log_must eval "zdb -k $TESTPOOL | grep \"Dataset $CHECKPOINTED_FS1\""
+log_must eval "zdb -k $TESTPOOL/ | grep \"$TESTPOOL$BOGUS_SUFFIX\""
 
 log_must zpool export $TESTPOOL
 
@@ -70,6 +71,7 @@ log_must eval "zdb -e $TESTPOOL | grep \"Checkpointed uberblock found\""
 log_mustnot eval "zdb -k -e $TESTPOOL | grep \"Checkpointed uberblock found\""
 log_mustnot eval "zdb -e $TESTPOOL | grep \"Dataset $FS1\""
 log_must eval "zdb -k -e $TESTPOOL | grep \"Dataset $CHECKPOINTED_FS1\""
+log_must eval "zdb -k -e $TESTPOOL/ | grep \"$TESTPOOL$BOGUS_SUFFIX\""
 
 log_must zpool import $TESTPOOL
 


### PR DESCRIPTION
_Sponsored-by: Klara, Inc._


### Motivation and Context
When examining the root dataset with zdb -k, we get into a mismatched state. main() knows we are not examining the whole pool, but it strips off the trailing slash. import_checkpointed_state() then thinks we are examining the whole pool, and does not update the target path appropriately. 

### Description
The fix is to directly inform import_checkpointed_state that we are examining a filesystem, and not the whole pool.

I also added a check to the ZFS test suite to cover this case.

### How Has This Been Tested?
Ran the new test with and without the code diff; verified that it failed before and passes now.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
