### PR TITLE
cleanup: remove var init/update

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1991,7 +1991,7 @@ dump_ddt_log(ddt_t *ddt)
 				c += strlcpy(&flagstr[c], " UNKNOWN",
 				    sizeof (flagstr) - c);
 			flagstr[1] = '[';
-			flagstr[c++] = ']';
+			flagstr[c] = ']';
 		}
 
 		uint64_t count = avl_numnodes(&ddl->ddl_tree);
@@ -8782,7 +8782,6 @@ zdb_decompress_block(abd_t *pabd, void *buf, void *lbuf, uint64_t lsize,
 	(void) buf;
 	uint64_t orig_lsize = lsize;
 	boolean_t tryzle = ((getenv("ZDB_NO_ZLE") == NULL));
-	boolean_t found = B_FALSE;
 	/*
 	 * We don't know how the data was compressed, so just try
 	 * every decompress function at every inflated blocksize.
@@ -8825,20 +8824,19 @@ zdb_decompress_block(abd_t *pabd, void *buf, void *lbuf, uint64_t lsize,
 		for (cfuncp = cfuncs; *cfuncp; cfuncp++) {
 			if (try_decompress_block(pabd, lsize, psize, flags,
 			    *cfuncp, lbuf, lbuf2)) {
-				found = B_TRUE;
+				tryzle = B_FALSE;
 				break;
 			}
 		}
 		if (*cfuncp != 0)
 			break;
 	}
-	if (!found && tryzle) {
+	if (tryzle) {
 		for (lsize = orig_lsize; lsize <= maxlsize;
 		    lsize += SPA_MINBLOCKSIZE) {
 			if (try_decompress_block(pabd, lsize, psize, flags,
 			    ZIO_COMPRESS_ZLE, lbuf, lbuf2)) {
 				*cfuncp = ZIO_COMPRESS_ZLE;
-				found = B_TRUE;
 				break;
 			}
 		}

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -110,7 +110,7 @@ zed_event_fini(struct zed_conf *zcp)
 static void
 _bump_event_queue_length(void)
 {
-	int zzlm = -1, wr;
+	int zzlm, wr;
 	char qlen_buf[12] = {0}; /* parameter is int => max "-2147483647\n" */
 	long int qlen, orig_qlen;
 

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -1974,9 +1974,8 @@ fill_dataset_info(nvlist_t *list, zfs_handle_t *zhp, boolean_t as_int)
 	}
 
 	if (type == ZFS_TYPE_SNAPSHOT) {
-		char *ds, *snap;
-		ds = snap = strdup(zfs_get_name(zhp));
-		ds = strsep(&snap, "@");
+		char *snap = strdup(zfs_get_name(zhp));
+		char *ds = strsep(&snap, "@");
 		fnvlist_add_string(list, "dataset", ds);
 		fnvlist_add_string(list, "snapshot_name", snap);
 		free(ds);
@@ -2019,8 +2018,7 @@ get_callback(zfs_handle_t *zhp, void *data)
 	nvlist_t *user_props = zfs_get_user_props(zhp);
 	zprop_list_t *pl = cbp->cb_proplist;
 	nvlist_t *propval;
-	nvlist_t *item, *d, *props;
-	item = d = props = NULL;
+	nvlist_t *item, *d = NULL, *props = NULL;
 	const char *strval;
 	const char *sourceval;
 	boolean_t received = is_recvd_column(cbp);
@@ -5879,7 +5877,7 @@ parse_fs_perm_set(fs_perm_set_t *fspset, nvlist_t *nvl)
 static inline const char *
 deleg_perm_comment(zfs_deleg_note_t note)
 {
-	const char *str = "";
+	const char *str;
 
 	/* subcommands */
 	switch (note) {

--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -379,8 +379,8 @@ process_unique_cmd_columns(vdev_cmd_data_list_t *vcdl)
 static int
 vdev_process_cmd_output(vdev_cmd_data_t *data, char *line)
 {
-	char *col = NULL;
-	char *val = line;
+	char *col;
+	char *val;
 	char *equals;
 	char **tmp;
 
@@ -397,6 +397,7 @@ vdev_process_cmd_output(vdev_cmd_data_t *data, char *line)
 		col = line;
 		val = equals + 1;
 	} else {
+		col = NULL;
 		val = line;
 	}
 

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1788,7 +1788,7 @@ zpool_do_labelclear(int argc, char **argv)
 {
 	char vdev[MAXPATHLEN];
 	char *name = NULL;
-	int c, fd = -1, ret = 0;
+	int c, fd, ret = 0;
 	nvlist_t *config;
 	pool_state_t state;
 	boolean_t inuse = B_FALSE;
@@ -6157,7 +6157,6 @@ static void
 get_interval_count_filter_guids(int *argc, char **argv, float *interval,
     unsigned long *count, iostat_cbdata_t *cb)
 {
-	char **tmpargv = argv;
 	int argc_for_interval = 0;
 
 	/* Is the last arg an interval value?  Or a guid? */
@@ -6181,7 +6180,7 @@ get_interval_count_filter_guids(int *argc, char **argv, float *interval,
 	}
 
 	/* Point to our list of possible intervals */
-	tmpargv = &argv[*argc - argc_for_interval];
+	char **tmpargv = &argv[*argc - argc_for_interval];
 
 	*argc = *argc - argc_for_interval;
 	get_interval_count(&argc_for_interval, tmpargv,
@@ -6377,7 +6376,6 @@ zpool_do_iostat(int argc, char **argv)
 	int npools;
 	float interval = 0;
 	unsigned long count = 0;
-	int winheight = 24;
 	zpool_list_t *list;
 	boolean_t verbose = B_FALSE;
 	boolean_t latency = B_FALSE, l_histo = B_FALSE, rq_histo = B_FALSE;
@@ -6673,7 +6671,7 @@ zpool_do_iostat(int argc, char **argv)
 			 * even when terminal window has its height
 			 * changed.
 			 */
-			winheight = terminal_height();
+			int winheight = terminal_height();
 			/*
 			 * Are we connected to TTY? If not, headers_once
 			 * should be true, to avoid breaking scripts.
@@ -10706,7 +10704,6 @@ status_callback_json(zpool_handle_t *zhp, void *data)
 	uint_t c;
 	vdev_stat_t *vs;
 	nvlist_t *item, *d, *load_info, *vds;
-	item = d = NULL;
 
 	/* If dedup stats were requested, also fetch dedupcached. */
 	if (cbp->cb_dedup_stats > 1)

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -574,7 +574,6 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 				nvlist_t *cnv = child[c];
 				const char *path;
 				struct stat64 statbuf;
-				int64_t size = -1LL;
 				const char *childtype;
 				int fd, err;
 
@@ -656,7 +655,7 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 				    statbuf.st_size == MAXOFFSET_T)
 					continue;
 
-				size = statbuf.st_size;
+				int64_t size = statbuf.st_size;
 
 				/*
 				 * Also make sure that devices and
@@ -1365,7 +1364,7 @@ is_grouping(const char *type, int *mindev, int *maxdev)
 static int
 draid_config_by_type(nvlist_t *nv, const char *type, uint64_t children)
 {
-	uint64_t nparity = 1;
+	uint64_t nparity;
 	uint64_t nspares = 0;
 	uint64_t ndata = UINT64_MAX;
 	uint64_t ngroups = 1;

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -919,7 +919,7 @@ ztest_parse_name_value(const char *input, ztest_shared_opts_t *zo)
 {
 	char name[32];
 	char *value;
-	int state = ZTEST_VDEV_CLASS_RND;
+	int state;
 
 	(void) strlcpy(name, input, sizeof (name));
 

--- a/lib/libspl/include/umem.h
+++ b/lib/libspl/include/umem.h
@@ -102,7 +102,7 @@ static inline void *
 umem_alloc_aligned(size_t size, size_t align, int flags)
 {
 	void *ptr = NULL;
-	int rc = EINVAL;
+	int rc;
 
 	do {
 		rc = posix_memalign(&ptr, align, size);

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -584,7 +584,7 @@ get_key_material_https(libzfs_handle_t *hdl, const char *uri,
 		goto end;
 	}
 
-	int kfd = -1;
+	int kfd;
 #ifdef O_TMPFILE
 	kfd = open(getenv("TMPDIR") ?: "/tmp",
 	    O_RDWR | O_TMPFILE | O_EXCL | O_CLOEXEC, 0600);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -896,7 +896,7 @@ int
 zpool_set_prop(zpool_handle_t *zhp, const char *propname, const char *propval)
 {
 	zfs_cmd_t zc = {"\0"};
-	int ret = -1;
+	int ret;
 	char errbuf[ERRBUFLEN];
 	nvlist_t *nvl = NULL;
 	nvlist_t *realprops;
@@ -4310,7 +4310,7 @@ zpool_set_guid(zpool_handle_t *zhp, const uint64_t *guid)
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 	nvlist_t *nvl = NULL;
 	zfs_cmd_t zc = {"\0"};
-	int error = -1;
+	int error;
 
 	if (guid != NULL) {
 		if (nvlist_alloc(&nvl, NV_UNIQUE_NAME, 0) != 0)

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -1073,8 +1073,8 @@ zvol_rename_minors(spa_t *spa, const char *oldname, const char *newname,
 int
 zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
 {
-	int fd = -1;
-	int dump_fd = -1;
+	int fd;
+	int dump_fd;
 	int err;
 	int old_umask = 0;
 	zfs_file_t *fp;

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3768,20 +3768,17 @@ out:
 	 * ZPOOL_CONFIG_MMP_HOSTID   - hostid from the active pool
 	 */
 	if (error == EREMOTEIO) {
-		const char *hostname = "<unknown>";
-		uint64_t hostid = 0;
-
 		if (mmp_label) {
 			if (nvlist_exists(mmp_label, ZPOOL_CONFIG_HOSTNAME)) {
-				hostname = fnvlist_lookup_string(mmp_label,
-				    ZPOOL_CONFIG_HOSTNAME);
+				const char *hostname = fnvlist_lookup_string(
+				    mmp_label, ZPOOL_CONFIG_HOSTNAME);
 				fnvlist_add_string(spa->spa_load_info,
 				    ZPOOL_CONFIG_MMP_HOSTNAME, hostname);
 			}
 
 			if (nvlist_exists(mmp_label, ZPOOL_CONFIG_HOSTID)) {
-				hostid = fnvlist_lookup_uint64(mmp_label,
-				    ZPOOL_CONFIG_HOSTID);
+				uint64_t hostid = fnvlist_lookup_uint64(
+				    mmp_label, ZPOOL_CONFIG_HOSTID);
 				fnvlist_add_uint64(spa->spa_load_info,
 				    ZPOOL_CONFIG_MMP_HOSTID, hostid);
 			}

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -2249,10 +2249,9 @@ vdev_raidz_asize_to_psize(vdev_t *vd, uint64_t asize, uint64_t txg)
 	vdev_raidz_t *vdrz = vd->vdev_tsd;
 	uint64_t psize;
 	uint64_t ashift = vd->vdev_top->vdev_ashift;
-	uint64_t cols = vdrz->vd_original_width;
 	uint64_t nparity = vdrz->vd_nparity;
 
-	cols = vdev_raidz_get_logical_width(vdrz, txg);
+	uint64_t cols = vdev_raidz_get_logical_width(vdrz, txg);
 
 	ASSERT0(asize % (1 << ashift));
 
@@ -2285,10 +2284,9 @@ vdev_raidz_psize_to_asize(vdev_t *vd, uint64_t psize, uint64_t txg)
 	vdev_raidz_t *vdrz = vd->vdev_tsd;
 	uint64_t asize;
 	uint64_t ashift = vd->vdev_top->vdev_ashift;
-	uint64_t cols = vdrz->vd_original_width;
 	uint64_t nparity = vdrz->vd_nparity;
 
-	cols = vdev_raidz_get_logical_width(vdrz, txg);
+	uint64_t cols = vdev_raidz_get_logical_width(vdrz, txg);
 
 	asize = ((psize - 1) >> ashift) + 1;
 	asize += nparity * ((asize + cols - nparity - 1) / (cols - nparity));

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -1304,7 +1304,7 @@ zap_increment_int(objset_t *os, uint64_t obj, uint64_t key, int64_t delta,
 int
 fzap_cursor_retrieve(zap_t *zap, zap_cursor_t *zc, zap_attribute_t *za)
 {
-	int err = ENOENT;
+	int err;
 	zap_entry_handle_t zeh;
 	zap_leaf_t *l;
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -4408,7 +4408,7 @@ int
 zio_alloc_zil(spa_t *spa, objset_t *os, uint64_t txg, blkptr_t *new_bp,
     uint64_t size, boolean_t *slog)
 {
-	int error = 1;
+	int error;
 	zio_alloc_list_t io_alloc_list;
 
 	ASSERT(txg > spa_syncing_txg(spa));

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -569,11 +569,10 @@ zfs_zstd_compress_buf(void *s_start, void *d_start, size_t s_len, size_t d_len,
 	size_t actual_abort_size = zstd_abort_size;
 	if (zstd_earlyabort_pass > 0 && zstd_level >= zstd_cutoff_level &&
 	    s_len >= actual_abort_size) {
-		int pass_len = 1;
 		abd_t sabd, dabd;
 		abd_get_from_buf_struct(&sabd, s_start, s_len);
 		abd_get_from_buf_struct(&dabd, d_start, d_len);
-		pass_len = zfs_lz4_compress(&sabd, &dabd, s_len, d_len, 0);
+		int pass_len = zfs_lz4_compress(&sabd, &dabd, s_len, d_len, 0);
 		abd_free(&dabd);
 		abd_free(&sabd);
 		if (pass_len < d_len) {

--- a/tests/zfs-tests/cmd/draid.c
+++ b/tests/zfs-tests/cmd/draid.c
@@ -204,7 +204,7 @@ write_map(const char *filename, nvlist_t *allcfgs)
 		error = errno;
 		free(buf);
 		free(tmpname);
-		return (errno);
+		return (error);
 	}
 
 	ssize_t rc, bytes = 0;

--- a/tests/zfs-tests/cmd/idmap_util.c
+++ b/tests/zfs-tests/cmd/idmap_util.c
@@ -301,7 +301,7 @@ static int
 write_idmap(pid_t pid, char *buf, size_t buf_size, idmap_type_t type)
 {
 	char path[PATH_MAX];
-	int fd = -EBADF;
+	int fd;
 	int ret;
 
 	(void) snprintf(path, sizeof (path), "/proc/%d/%cid_map",

--- a/tests/zfs-tests/cmd/mktree.c
+++ b/tests/zfs-tests/cmd/mktree.c
@@ -152,7 +152,7 @@ getfdname(char *pdir, char type, int level, int dir, int file)
 static void
 crtfile(char *pname)
 {
-	int fd = -1;
+	int fd;
 	int i, size;
 	const char *context = "0123456789ABCDF";
 	char *pbuf;

--- a/tests/zfs-tests/cmd/mmapwrite.c
+++ b/tests/zfs-tests/cmd/mmapwrite.c
@@ -59,7 +59,7 @@ static void *
 normal_writer(void *filename)
 {
 	char *file_path = filename;
-	int fd = -1;
+	int fd;
 	ssize_t write_num = 0;
 	int page_size = getpagesize();
 
@@ -93,7 +93,7 @@ normal_writer(void *filename)
 static void *
 map_writer(void *filename)
 {
-	int fd = -1;
+	int fd;
 	int ret = 0;
 	char *buf = NULL;
 	int page_size = getpagesize();


### PR DESCRIPTION
### Motivation and Context

After #17488 I spent some time messing with some static analysers. They're a real mixed bag in what they do and don't catch, and I'm not yet sure if I've learned anything new.

Still, they did all find a bunch of places where we initialise or update a variable with a value that we never use. Usually, it's an initialisation at declaration, with an assignment nearer to where we use it. None of these are bad, and dead-store optimisation will usually get rid of them anyway, but it's extra stuff to read and understand and wonder why its there, and that's no fun.

### Description

See commits.

### How Has This Been Tested?

Compile checked only (on Linux and FreeBSD). I'll be trusting CI to spot any breakages (and be astonished if it does).

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
