### PR TITLE
cleanup: remove obsolete things from linux/kmem

### DIFF
--- a/include/os/linux/spl/sys/kmem.h
+++ b/include/os/linux/spl/sys/kmem.h
@@ -61,7 +61,7 @@ void *spl_kvmalloc(size_t size, gfp_t flags);
 /*
  * Convert a KM_* flags mask to its Linux GFP_* counterpart.  The conversion
  * function is context aware which means that KM_SLEEP allocations can be
- * safely used in syncing contexts which have set PF_FSTRANS.
+ * safely used in syncing contexts which have set SPL_FSTRANS.
  */
 static inline gfp_t
 kmem_flags_convert(int flags)
@@ -91,25 +91,11 @@ typedef struct {
 } fstrans_cookie_t;
 
 /*
- * Introduced in Linux 3.9, however this cannot be solely relied on before
- * Linux 3.18 as it doesn't turn off __GFP_FS as it should.
+ * SPL_FSTRANS is the set of flags that indicate that the task is in a
+ * filesystem or IO codepath, and so any allocation must not call back into
+ * those codepaths (eg to swap).
  */
-#ifdef PF_MEMALLOC_NOIO
-#define	__SPL_PF_MEMALLOC_NOIO (PF_MEMALLOC_NOIO)
-#else
-#define	__SPL_PF_MEMALLOC_NOIO (0)
-#endif
-
-/*
- * PF_FSTRANS is removed from Linux 4.12
- */
-#ifdef PF_FSTRANS
-#define	__SPL_PF_FSTRANS (PF_FSTRANS)
-#else
-#define	__SPL_PF_FSTRANS (0)
-#endif
-
-#define	SPL_FSTRANS (__SPL_PF_FSTRANS|__SPL_PF_MEMALLOC_NOIO)
+#define	SPL_FSTRANS (PF_MEMALLOC_NOIO)
 
 static inline fstrans_cookie_t
 spl_fstrans_mark(void)
@@ -139,16 +125,6 @@ static inline int
 spl_fstrans_check(void)
 {
 	return (current->flags & SPL_FSTRANS);
-}
-
-/*
- * specifically used to check PF_FSTRANS flag, cannot be relied on for
- * checking spl_fstrans_mark().
- */
-static inline int
-__spl_pf_fstrans_check(void)
-{
-	return (current->flags & __SPL_PF_FSTRANS);
 }
 
 /*

--- a/include/os/linux/spl/sys/kmem.h
+++ b/include/os/linux/spl/sys/kmem.h
@@ -127,21 +127,8 @@ spl_fstrans_check(void)
 	return (current->flags & SPL_FSTRANS);
 }
 
-#ifdef HAVE_ATOMIC64_T
-#define	kmem_alloc_used_add(size)	atomic64_add(size, &kmem_alloc_used)
-#define	kmem_alloc_used_sub(size)	atomic64_sub(size, &kmem_alloc_used)
-#define	kmem_alloc_used_read()		atomic64_read(&kmem_alloc_used)
-#define	kmem_alloc_used_set(size)	atomic64_set(&kmem_alloc_used, size)
 extern atomic64_t kmem_alloc_used;
-extern unsigned long long kmem_alloc_max;
-#else  /* HAVE_ATOMIC64_T */
-#define	kmem_alloc_used_add(size)	atomic_add(size, &kmem_alloc_used)
-#define	kmem_alloc_used_sub(size)	atomic_sub(size, &kmem_alloc_used)
-#define	kmem_alloc_used_read()		atomic_read(&kmem_alloc_used)
-#define	kmem_alloc_used_set(size)	atomic_set(&kmem_alloc_used, size)
-extern atomic_t kmem_alloc_used;
-extern unsigned long long kmem_alloc_max;
-#endif /* HAVE_ATOMIC64_T */
+extern uint64_t kmem_alloc_max;
 
 extern unsigned int spl_kmem_alloc_warn;
 extern unsigned int spl_kmem_alloc_max;

--- a/include/os/linux/spl/sys/kmem.h
+++ b/include/os/linux/spl/sys/kmem.h
@@ -127,18 +127,6 @@ spl_fstrans_check(void)
 	return (current->flags & SPL_FSTRANS);
 }
 
-/*
- * Kernel compatibility for GFP flags
- */
-/* < 4.13 */
-#ifndef __GFP_RETRY_MAYFAIL
-#define	__GFP_RETRY_MAYFAIL	__GFP_REPEAT
-#endif
-/* < 4.4 */
-#ifndef __GFP_RECLAIM
-#define	__GFP_RECLAIM		__GFP_WAIT
-#endif
-
 #ifdef HAVE_ATOMIC64_T
 #define	kmem_alloc_used_add(size)	atomic64_add(size, &kmem_alloc_used)
 #define	kmem_alloc_used_sub(size)	atomic64_sub(size, &kmem_alloc_used)

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -766,7 +766,6 @@ typedef int fstrans_cookie_t;
 
 extern fstrans_cookie_t spl_fstrans_mark(void);
 extern void spl_fstrans_unmark(fstrans_cookie_t);
-extern int __spl_pf_fstrans_check(void);
 extern int kmem_cache_reap_active(void);
 
 

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -1025,12 +1025,6 @@ spl_fstrans_unmark(fstrans_cookie_t cookie)
 }
 
 int
-__spl_pf_fstrans_check(void)
-{
-	return (0);
-}
-
-int
 kmem_cache_reap_active(void)
 {
 	return (0);

--- a/module/os/linux/spl/spl-proc.c
+++ b/module/os/linux/spl/spl-proc.c
@@ -82,11 +82,7 @@ proc_domemused(CONST_CTL_TABLE *table, int write,
 	if (write) {
 		*ppos += *lenp;
 	} else {
-#ifdef HAVE_ATOMIC64_T
 		val = atomic64_read((atomic64_t *)table->data);
-#else
-		val = atomic_read((atomic_t *)table->data);
-#endif /* HAVE_ATOMIC64_T */
 		rc = proc_doulongvec_minmax(&dummy, write, buffer, lenp, ppos);
 	}
 
@@ -315,18 +311,14 @@ static struct ctl_table spl_kmem_table[] = {
 	{
 		.procname	= "kmem_used",
 		.data		= &kmem_alloc_used,
-#ifdef HAVE_ATOMIC64_T
 		.maxlen		= sizeof (atomic64_t),
-#else
-		.maxlen		= sizeof (atomic_t),
-#endif /* HAVE_ATOMIC64_T */
 		.mode		= 0444,
 		.proc_handler	= &proc_domemused,
 	},
 	{
 		.procname	= "kmem_max",
 		.data		= &kmem_alloc_max,
-		.maxlen		= sizeof (unsigned long),
+		.maxlen		= sizeof (uint64_t),
 		.extra1		= &table_min,
 		.extra2		= &table_max,
 		.mode		= 0444,

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -256,10 +256,6 @@ abd_unmark_zfs_page(struct page *page)
 
 #ifndef CONFIG_HIGHMEM
 
-#ifndef __GFP_RECLAIM
-#define	__GFP_RECLAIM		__GFP_WAIT
-#endif
-
 /*
  * The goal is to minimize fragmentation by preferentially populating ABDs
  * with higher order compound pages from a single zone.  Allocation size is


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context

One of the static analysers I was messing with complained about not being able to work out what to do with `PF_FSTRANS`. Turns out there's a few old bits in `kmem.h`, so I got rid of them.

### Description

See commits!

### How Has This Been Tested?

Compiled on 4.19, 5.4, 5.15, 6.1, 6.8, 6.12, with and without `--enable-debug-kmem`.

Ran 6.12 + `--enable-debug-kmem` and made sure the debug options look plausible:

```
quiz# sysctl -a | grep kmem
kernel.spl.kmem.kmem_max = 8221778
kernel.spl.kmem.kmem_used = 8141504
kernel.spl.kmem.slab_kvmem_alloc = 11768384
kernel.spl.kmem.slab_kvmem_max = 12816960
kernel.spl.kmem.slab_kvmem_total = 16492416
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
