### PR TITLE
add uncompressed_size to arc_summary

### DIFF
--- a/cmd/arc_summary
+++ b/cmd/arc_summary
@@ -559,6 +559,7 @@ def section_arc(kstats_dict):
     print()
 
     compressed_size = arc_stats['compressed_size']
+    uncompressed_size = arc_stats['uncompressed_size']
     overhead_size = arc_stats['overhead_size']
     bonus_size = arc_stats['bonus_size']
     dnode_size = arc_stats['dnode_size']
@@ -671,6 +672,8 @@ def section_arc(kstats_dict):
     print()
 
     print('ARC misc:')
+    prt_i2('Uncompressed size:', f_perc(uncompressed_size, compressed_size),
+           f_bytes(uncompressed_size))
     prt_i1('Memory throttles:', arc_stats['memory_throttle_count'])
     prt_i1('Memory direct reclaims:', arc_stats['memory_direct_count'])
     prt_i1('Memory indirect reclaims:', arc_stats['memory_indirect_count'])


### PR DESCRIPTION
Add uncompressed ARC size to statistics reported by arc_summary.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Comparing uncompressed and compressed ARC sizes is useful to understand how much ARC benefits from compression.

### Description
<!--- Describe your changes in detail -->
As above.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Minimal testing was done on a virtual machine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
