### PR TITLE
Don't call dbuf_evict_one from dbuf_evict_notify for kswapd

### DIFF
--- a/include/os/freebsd/spl/sys/misc.h
+++ b/include/os/freebsd/spl/sys/misc.h
@@ -56,4 +56,9 @@ struct opensolaris_utsname {
 #define	task_io_account_read(n)
 #define	task_io_account_write(n)
 
+/*
+ * Check if the current thread is a memory reclaim thread.
+ */
+extern int current_is_reclaim_thread(void);
+
 #endif	/* _OPENSOLARIS_SYS_MISC_H_ */

--- a/include/os/linux/spl/sys/misc.h
+++ b/include/os/linux/spl/sys/misc.h
@@ -24,7 +24,13 @@
 #define	_OS_LINUX_SPL_MISC_H
 
 #include <linux/kobject.h>
+#include <linux/swap.h>
 
 extern void spl_signal_kobj_evt(struct block_device *bdev);
+
+/*
+ * Check if the current thread is a memory reclaim thread.
+ */
+extern int current_is_reclaim_thread(void);
 
 #endif

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -224,6 +224,11 @@ typedef pthread_t	kthread_t;
 #define	thread_join(t)	pthread_join((pthread_t)(t), NULL)
 
 #define	newproc(f, a, cid, pri, ctp, pid)	(ENOSYS)
+/*
+ * Check if the current thread is a memory reclaim thread.
+ * Always returns false in userspace (no memory reclaim thread).
+ */
+#define	current_is_reclaim_thread()	(0)
 
 /* in libzpool, p0 exists only to have its address taken */
 typedef struct proc {

--- a/module/os/freebsd/spl/spl_misc.c
+++ b/module/os/freebsd/spl/spl_misc.c
@@ -101,6 +101,15 @@ spl_panic(const char *file, const char *func, int line, const char *fmt, ...)
 	va_end(ap);
 }
 
+/*
+ * Check if the current thread is a memory reclaim thread.
+ * Returns true if curproc is pageproc (FreeBSD's page daemon).
+ */
+int
+current_is_reclaim_thread(void)
+{
+	return (curproc == pageproc);
+}
 
 SYSINIT(opensolaris_utsname_init, SI_SUB_TUNABLES, SI_ORDER_ANY,
     opensolaris_utsname_init, NULL);

--- a/module/os/linux/spl/spl-thread.c
+++ b/module/os/linux/spl/spl-thread.c
@@ -28,6 +28,7 @@
 #include <sys/kmem.h>
 #include <sys/tsd.h>
 #include <sys/string.h>
+#include <sys/misc.h>
 
 /*
  * Thread interfaces
@@ -197,3 +198,14 @@ issig(void)
 }
 
 EXPORT_SYMBOL(issig);
+
+/*
+ * Check if the current thread is a memory reclaim thread.
+ * Returns true if current thread is kswapd.
+ */
+int
+current_is_reclaim_thread(void)
+{
+	return (current_is_kswapd());
+}
+EXPORT_SYMBOL(current_is_reclaim_thread);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
In a high memory pressure environment using Lustre 2.15 + ZFS 2.1.7, we see a state where arc_read is holding the hash lock and waiting for a page of memory while kswapd is trying to evict a dbuf waiting on the same hash lock. 

~~This change reduces the chance of this deadlock happening by checking if the hash lock is taken before trying to evict.~~

This proposed change removes the call to dbuf_evict_one() specifically when it's running in the kswapd context. This change aims to reduce unnecessary work and hash lock contention during high memory pressure situations, while still maintaining the performance benefit of dbuf eviction in normal operational contexts.

Thread 1
```
[372109.472754] Call trace:
[372109.472759]  __switch_to+0xbc/0xfc
[372109.472763]  __schedule+0x28c/0x718
[372109.472765]  _cond_resched+0x48/0x60
[372109.472768]  shrink_page_list+0x6c/0xc70
[372109.472769]  shrink_inactive_list+0x160/0x510
[372109.472771]  shrink_lruvec+0x26c/0x300
[372109.472772]  shrink_node_memcgs+0x1c0/0x230
[372109.472773]  shrink_node+0x150/0x5e0
[372109.472775]  shrink_zones+0x98/0x220
[372109.472776]  do_try_to_free_pages+0xac/0x2e0
[372109.472778]  try_to_free_pages+0x120/0x25c
[372109.472780]  __alloc_pages_slowpath.constprop.0+0x400/0x82c
[372109.472781]  __alloc_pages_nodemask+0x2b4/0x310
[372109.472831]  abd_alloc_chunks+0x184/0x470 [zfs]
[372109.472881]  abd_alloc+0x90/0x120 [zfs]
[372109.472924]  arc_hdr_alloc_abd+0x134/0x22c [zfs]
[372109.472966]  arc_read+0x4a8/0x10a0 [zfs]
[372109.473008]  dbuf_read_impl.constprop.0+0x23c/0x3dc [zfs]
[372109.473050]  dbuf_read+0xd4/0x65c [zfs]
[372109.473092]  dmu_buf_hold_by_dnode+0xa0/0x124 [zfs]
[372109.473136]  zap_get_leaf_byblk+0x68/0x154 [zfs]
[372109.473178]  zap_deref_leaf+0xb4/0x148 [zfs]
[372109.473221]  fzap_lookup+0x80/0x1b8 [zfs]
[372109.473263]  zap_lookup_impl+0x6c/0x1c8 [zfs]
[372109.473305]  zap_lookup+0xc8/0x10c [zfs]
[372109.473314]  osd_fid_lookup+0x27c/0x4d4 [osd_zfs]
[372109.473322]  osd_object_init+0x314/0xaec [osd_zfs]
[372109.473355]  lu_object_start+0x84/0x154 [obdclass]
[372109.473385]  lu_object_find_at+0x37c/0x72c [obdclass]
[372109.473415]  lu_object_find+0x1c/0x24 [obdclass]
[372109.473423]  ofd_object_find+0x6c/0x18c [ofd]
[372109.473430]  ofd_lvbo_init+0x294/0x938 [ofd]
[372109.473481]  ldlm_lvbo_init+0x70/0x2e0 [ptlrpc]
[372109.473529]  ldlm_handle_enqueue0+0x540/0x1b24 [ptlrpc]
[372109.473577]  tgt_enqueue+0x84/0x2c0 [ptlrpc]
[372109.473624]  tgt_handle_request0+0x2b4/0x658 [ptlrpc]
[372109.473671]  tgt_request_handle+0x268/0xaac [ptlrpc]
[372109.473718]  ptlrpc_server_handle_request.isra.0+0x460/0xf20 [ptlrpc]
[372109.473765]  ptlrpc_main+0xd24/0x15bc [ptlrpc]
[372109.473768]  kthread+0x118/0x120
```

Thread 2 
```
[372073.633195] INFO: task kswapd0:188 blocked for more than 122 seconds.
[372073.634293]       Tainted: P           OE     5.10.236-228.935.amzn2.aarch64 #1
[372073.635482] echo 0 > /proc/sys/kernel/hung_task_timeout_secs disables this message.
[372073.636758] task:kswapd0         state:D stack:    0 pid:  188 ppid:     2 flags:0x00000028
[372073.638118] Call trace:
[372073.638546]  __switch_to+0xbc/0xfc
[372073.639123]  __schedule+0x28c/0x718
[372073.639712]  schedule+0x4c/0xcc
[372073.640248]  schedule_preempt_disabled+0x14/0x1c
[372073.641015]  __mutex_lock.constprop.0+0x190/0x640
[372073.641796]  __mutex_lock_slowpath+0x18/0x20
[372073.642506]  mutex_lock+0x74/0x80
[372073.643112]  arc_buf_destroy+0x84/0x178 [zfs]
[372073.643884]  dbuf_destroy+0x38/0x3dc [zfs]
[372073.644607]  dbuf_evict_one+0x168/0x188 [zfs]
[372073.645376]  dbuf_evict_notify+0xe0/0xf0 [zfs]
[372073.646153]  dbuf_rele_and_unlock+0x61c/0x708 [zfs]
[372073.646998]  dmu_buf_rele+0x44/0x58 [zfs]
[372073.647710]  sa_handle_destroy+0x7c/0x120 [zfs]
[372073.648470]  osd_object_delete+0x64/0x17c [osd_zfs]
[372073.649312]  lu_object_free.isra.0+0x88/0x1fc [obdclass]
[372073.650215]  lu_site_purge_objects+0x338/0x47c [obdclass]
[372073.651127]  lu_cache_shrink_scan+0xa0/0x18c [obdclass]
[372073.651989]  do_shrink_slab+0x194/0x394
[372073.652635]  shrink_slab+0xbc/0x13c
[372073.653234]  shrink_node_memcgs+0x1d4/0x230
[372073.653943]  shrink_node+0x150/0x5e0
[372073.654554]  balance_pgdat+0x260/0x524
[372073.655192]  kswapd+0x124/0x208
[372073.655732]  kthread+0x118/0x120
```

### Description
This change should help alleviate the blocking issue we're seeing with kswapd, as it prevents additional cache eviction work from being performed when the system is already under memory pressure. 

### How Has This Been Tested?
Tested running various IOR tests with Lustre file system and did not see any drop in performance. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
