### PR TITLE
linux/atomic: fill out API for atomic pointer ops

### DIFF
--- a/include/os/linux/spl/sys/atomic.h
+++ b/include/os/linux/spl/sys/atomic.h
@@ -71,12 +71,44 @@ atomic_cas_ptr(volatile void *target,  void *cmp, void *newval)
 	return ((void *)atomic_cas_64((volatile uint64_t *)target,
 	    (uint64_t)cmp, (uint64_t)newval));
 }
+static __inline__ void *
+atomic_swap_ptr(volatile void *target, void *newval)
+{
+	return ((void *)atomic_swap_64((volatile uint64_t *)target,
+	    (uint64_t)newval));
+}
+static __inline__ void *
+atomic_load_ptr(volatile void *target)
+{
+	return ((void *)atomic_load_64((volatile uint64_t *)target));
+}
+static __inline__ void
+atomic_store_ptr(volatile void *target, void *newval)
+{
+	atomic_store_64((volatile uint64_t *)target, (uint64_t)newval);
+}
 #else /* _LP64 */
 static __inline__ void *
 atomic_cas_ptr(volatile void *target,  void *cmp, void *newval)
 {
 	return ((void *)atomic_cas_32((volatile uint32_t *)target,
 	    (uint32_t)cmp, (uint32_t)newval));
+}
+static __inline__ void *
+atomic_swap_ptr(volatile void *target, void *newval)
+{
+	return ((void *)atomic_swap_32((volatile uint32_t *)target,
+	    (uint32_t)newval));
+}
+static __inline__ void *
+atomic_load_ptr(volatile void *target)
+{
+	return ((void *)atomic_load_32((volatile uint32_t *)target));
+}
+static __inline__ void
+atomic_store_ptr(volatile void *target, void *newval)
+{
+	atomic_store_32((volatile uint32_t *)target, (uint32_t)newval);
 }
 #endif /* _LP64 */
 


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

We have them for FreeBSD and userspace, and I reached for them, and didn't get them on Linux.

### Description

Follow the existing pattern for `atomic_cas_ptr` to produce `atomic_swap_ptr`, `atomic_load_ptr` and `atomic_save_ptr`.

Worth noting that Linux doesn't have standard atomics for pointers, so we can't just wrap those, but they wouldn't be especially different to these anyway.

Asides: probably these can be global, not OS-specific, and possibly they can get some style updates (mainly `inline` vs `__inline__`), and it's probably worth thinking about 32-bit support in general. But not today!

### How Has This Been Tested?

Compile checked for master. Used on a private project to replace use of `atomic_*_64` with some messy casting, and worked just fine. The 32-bit ones, not tested at all.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
