### PR TITLE
[WIP] Raidz Expansion: multiple devices expanding

### DIFF
--- a/cmd/raidz_test/raidz_bench.c
+++ b/cmd/raidz_test/raidz_bench.c
@@ -86,7 +86,8 @@ run_gen_bench_impl(const char *impl)
 			if (rto_opts.rto_expand) {
 				rm_bench = vdev_raidz_map_alloc_expanded(
 				    &zio_bench,
-				    rto_opts.rto_ashift, ncols+1, ncols,
+				    rto_opts.rto_ashift, 1,
+				    ncols + rto_opts.rto_expand, ncols,
 				    fn+1, rto_opts.rto_expand_offset,
 				    0, B_FALSE);
 			} else {
@@ -174,7 +175,8 @@ run_rec_bench_impl(const char *impl)
 			if (rto_opts.rto_expand) {
 				rm_bench = vdev_raidz_map_alloc_expanded(
 				    &zio_bench,
-				    BENCH_ASHIFT, ncols+1, ncols,
+				    BENCH_ASHIFT, 1,
+				    ncols + rto_opts.rto_expand, ncols,
 				    PARITY_PQR,
 				    rto_opts.rto_expand_offset, 0, B_FALSE);
 			} else {

--- a/cmd/raidz_test/raidz_test.h
+++ b/cmd/raidz_test/raidz_test.h
@@ -58,7 +58,7 @@ typedef struct raidz_test_opts {
 	size_t rto_sweep;
 	size_t rto_sweep_timeout;
 	size_t rto_benchmark;
-	size_t rto_expand;
+	uint64_t rto_expand;
 	uint64_t rto_expand_offset;
 	size_t rto_sanity;
 	size_t rto_gdb;

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -3032,6 +3032,9 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	spa_t *spa;
 	nvlist_t *nvroot;
 
+	// XXX: SKIP
+	return;
+
 	if (zo->zo_mmp_test)
 		return;
 
@@ -3093,6 +3096,9 @@ ztest_mmp_enable_disable(ztest_ds_t *zd, uint64_t id)
 	(void) zd, (void) id;
 	ztest_shared_opts_t *zo = &ztest_opts;
 	spa_t *spa = ztest_spa;
+
+	// XXX: SKIP
+	return;
 
 	if (zo->zo_mmp_test)
 		return;
@@ -3332,6 +3338,9 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 	nvlist_t *nvroot;
 	int error;
 
+	// XXX: SKIP
+	return;
+
 	if (ztest_opts.zo_mmp_test)
 		return;
 
@@ -3424,6 +3433,9 @@ ztest_vdev_class_add(ztest_ds_t *zd, uint64_t id)
 	    VDEV_ALLOC_BIAS_SPECIAL : VDEV_ALLOC_BIAS_DEDUP;
 	int error;
 
+	// XXX: SKIP
+	return;
+
 	/*
 	 * By default add a special vdev 50% of the time
 	 */
@@ -3506,6 +3518,9 @@ ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 	char *path;
 	uint64_t guid = 0;
 	int error, ignore_err = 0;
+
+	// XXX: SKIP
+	return;
 
 	if (ztest_opts.zo_mmp_test)
 		return;
@@ -3726,6 +3741,9 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	int oldvd_is_log;
 	int oldvd_is_special;
 	int error, expected_error;
+
+	// XXX: SKIP
+	return;
 
 	if (ztest_opts.zo_mmp_test)
 		return;
@@ -4075,11 +4093,13 @@ ztest_vdev_raidz_attach(ztest_ds_t *zd, uint64_t id)
 	(void) zd, (void) id;
 	ztest_shared_t *zs = ztest_shared;
 	spa_t *spa = ztest_spa;
-	uint64_t leaves, raidz_children, newsize, ashift = ztest_get_ashift();
+	uint64_t leaves, raidz_children, raidz_attach_children = 0, newsize;
+	uint64_t ashift = ztest_get_ashift();
 	kthread_t *scratch_thread = NULL;
 	vdev_t *newvd, *pvd;
-	nvlist_t *root;
-	char *newpath = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
+	nvlist_t *root = NULL;
+	nvlist_t **child = NULL;
+	char **newpath = NULL;
 	int error, expected_error = 0;
 
 	mutex_enter(&ztest_vdev_lock);
@@ -4107,6 +4127,11 @@ ztest_vdev_raidz_attach(ztest_ds_t *zd, uint64_t id)
 	ASSERT(pvd->vdev_ops == &vdev_raidz_ops);
 
 	/*
+	 * Get number of raidz childrent to attach
+	 */
+	raidz_attach_children = 2 + ztest_random(2);
+
+	/*
 	 * Get size of a child of the raidz group,
 	 * make sure device is a bit bigger
 	 */
@@ -4125,17 +4150,33 @@ ztest_vdev_raidz_attach(ztest_ds_t *zd, uint64_t id)
 
 	spa_config_exit(spa, SCL_ALL, FTAG);
 
-	/*
-	 * Path to vdev to be attached
-	 */
-	(void) snprintf(newpath, MAXPATHLEN, ztest_dev_template,
-	    ztest_opts.zo_dir, ztest_opts.zo_pool, zs->zs_vdev_next_leaf);
+	newpath = umem_alloc(raidz_attach_children * sizeof (char*),
+	    UMEM_NOFAIL);
+	child = umem_alloc(raidz_attach_children * sizeof (nvlist_t *),
+	    UMEM_NOFAIL);
+	for (int i = 0; i < raidz_attach_children; i++) {
+		/*
+		 * Path to vdev to be attached
+		 */
+		newpath[i] = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
+		(void) snprintf(newpath[i], MAXPATHLEN, ztest_dev_template,
+		    ztest_opts.zo_dir, ztest_opts.zo_pool,
+		    zs->zs_vdev_next_leaf + i);
 
-	/*
-	 * Build the nvlist describing newpath.
-	 */
-	root = make_vdev_root(newpath, NULL, NULL, newsize, ashift, NULL,
-	    0, 0, 1);
+		/*
+		 * Build the nvlist describing newpath.
+		 */
+		child[i] = make_vdev_file(newpath[i], NULL, NULL, newsize,
+		    ashift);
+	}
+
+	root = fnvlist_alloc();
+	fnvlist_add_string(root, ZPOOL_CONFIG_TYPE, VDEV_TYPE_ROOT);
+	fnvlist_add_nvlist_array(root, ZPOOL_CONFIG_CHILDREN,
+	    (const nvlist_t **)child, raidz_attach_children);
+
+	printf("==== ztest_vdev_raidz_attach():\n");
+	dump_nvlist(root, 0);
 
 	/*
 	 * 50% of the time, set raidz_expand_pause_point to cause
@@ -4143,7 +4184,7 @@ ztest_vdev_raidz_attach(ztest_ds_t *zd, uint64_t id)
 	 * then kill the test after 10 seconds so raidz_scratch_verify()
 	 * can confirm consistency when the pool is imported.
 	 */
-	if (ztest_random(2) == 0 && expected_error == 0) {
+	if (0 /*ztest_random(2) == 0 && expected_error == 0*/) {
 		raidz_expand_pause_point =
 		    ztest_random(RAIDZ_EXPAND_PAUSE_SCRATCH_POST_REFLOW_2) + 1;
 		scratch_thread = thread_create(NULL, 0, ztest_scratch_thread,
@@ -4161,7 +4202,7 @@ ztest_vdev_raidz_attach(ztest_ds_t *zd, uint64_t id)
 
 	if (error != 0 && error != expected_error) {
 		fatal(0, "raidz attach (%s %"PRIu64") returned %d, expected %d",
-		    newpath, newsize, error, expected_error);
+		    newpath[0], newsize, error, expected_error);
 	}
 
 	if (raidz_expand_pause_point) {
@@ -4178,7 +4219,13 @@ ztest_vdev_raidz_attach(ztest_ds_t *zd, uint64_t id)
 out:
 	mutex_exit(&ztest_vdev_lock);
 
-	umem_free(newpath, MAXPATHLEN);
+	for (int i = 0; i < raidz_attach_children; i++) {
+		fnvlist_free(child[i]);
+		umem_free(newpath[i], MAXPATHLEN);
+	}
+
+	umem_free(child, raidz_attach_children * sizeof (nvlist_t *));
+	umem_free(newpath, raidz_attach_children * sizeof (char*));
 }
 
 void
@@ -4189,6 +4236,9 @@ ztest_device_removal(ztest_ds_t *zd, uint64_t id)
 	vdev_t *vd;
 	uint64_t guid;
 	int error;
+
+	// XXX: SKIP
+	return;
 
 	mutex_enter(&ztest_vdev_lock);
 
@@ -4369,6 +4419,9 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 	size_t psize, newsize;
 	uint64_t top;
 	uint64_t old_class_space, new_class_space, old_ms_count, new_ms_count;
+
+	// XXX: SKIP
+	return;
 
 	mutex_enter(&ztest_checkpoint_lock);
 	mutex_enter(&ztest_vdev_lock);
@@ -6437,6 +6490,9 @@ ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 
 	path0 = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
 	pathrand = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
+
+	// XXX: SKIP
+	return;
 
 	mutex_enter(&ztest_vdev_lock);
 

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -821,6 +821,7 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_NPARITY		"nparity"
 #define	ZPOOL_CONFIG_RAIDZ_EXPANDING	"raidz_expanding"
 #define	ZPOOL_CONFIG_RAIDZ_EXPAND_TXGS	"raidz_expand_txgs"
+#define	ZPOOL_CONFIG_RAIDZ_EXPAND_VDEVS	"raidz_expand_vdevs"
 #define	ZPOOL_CONFIG_HOSTID		"hostid"
 #define	ZPOOL_CONFIG_HOSTNAME		"hostname"
 #define	ZPOOL_CONFIG_LOADED_TIME	"initial_load_time"

--- a/include/sys/vdev_raidz.h
+++ b/include/sys/vdev_raidz.h
@@ -49,7 +49,8 @@ struct kernel_param {};
 struct raidz_map *vdev_raidz_map_alloc(struct zio *, uint64_t, uint64_t,
     uint64_t);
 struct raidz_map *vdev_raidz_map_alloc_expanded(struct zio *,
-    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, boolean_t);
+    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+    boolean_t);
 void vdev_raidz_map_free(struct raidz_map *);
 void vdev_raidz_free(struct vdev_raidz *);
 void vdev_raidz_generate_parity_row(struct raidz_map *, struct raidz_row *);
@@ -83,6 +84,11 @@ typedef struct vdev_raidz_expand {
 
 	kmutex_t vre_lock;
 	kcondvar_t vre_cv;
+
+	/*
+	 * Number of children attached during current expasnion.
+	 */
+	uint64_t vre_children_attached;
 
 	/*
 	 * How much i/o is outstanding (issued and not completed).

--- a/include/sys/vdev_raidz_impl.h
+++ b/include/sys/vdev_raidz_impl.h
@@ -160,6 +160,7 @@ typedef struct raidz_map {
  */
 typedef struct reflow_node {
 	uint64_t re_txg;
+	uint64_t re_children_attached;
 	uint64_t re_logical_width;
 	avl_node_t re_link;
 } reflow_node_t;

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7526,13 +7526,17 @@ spa_vdev_new_spare_would_cause_double_spares(vdev_t *newvd, vdev_t *pvd)
  * should be performed instead of traditional healing reconstruction.  From
  * an administrators perspective these are both resilver operations.
  */
+
+/*
+ * XXX guid is raidz vdev guid in case of raidz expansion
+ */
 int
 spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
     int rebuild)
 {
 	uint64_t txg, dtl_max_txg;
 	vdev_t *rvd = spa->spa_root_vdev;
-	vdev_t *oldvd, *newvd, *newrootvd, *pvd, *tvd;
+	vdev_t *oldvd, *newvd, *newrootvd, *pvd, *tvd, *ivd, **rzcvd;
 	vdev_ops_t *pvops;
 	char *oldvdpath, *newvdpath;
 	int newvd_isspare = B_FALSE;
@@ -7576,6 +7580,12 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 
 	boolean_t raidz = oldvd->vdev_ops == &vdev_raidz_ops;
 
+#if defined(_KERNEL) && defined(__linux__)
+	printk("====== spa_vdev_attach(+)");
+#else
+	printf("====== spa_vdev_attach(+):raidz=%d\n", raidz);
+#endif
+
 	if (raidz) {
 		if (!spa_feature_is_enabled(spa, SPA_FEATURE_RAIDZ_EXPANSION))
 			return (spa_vdev_exit(spa, NULL, txg, ENOTSUP));
@@ -7584,6 +7594,9 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 		 * Can't expand a raidz while prior expand is in progress.
 		 */
 		if (spa->spa_raidz_expand != NULL) {
+#ifndef _KERNEL
+	printf("====== spa_vdev_attach(-):ZFS_ERR_RAIDZ_EXPAND_IN_PROGRESS\n");
+#endif
 			return (spa_vdev_exit(spa, NULL, txg,
 			    ZFS_ERR_RAIDZ_EXPAND_IN_PROGRESS));
 		}
@@ -7600,16 +7613,34 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 	    VDEV_ALLOC_ATTACH) != 0)
 		return (spa_vdev_exit(spa, NULL, txg, EINVAL));
 
-	if (newrootvd->vdev_children != 1)
+	if (newrootvd->vdev_children != 1 && !raidz)
 		return (spa_vdev_exit(spa, newrootvd, txg, EINVAL));
+
+#ifndef _KERNEL
+	printf("spa_vdev_attach():attach children=%ld\n",
+	    newrootvd->vdev_children);
+#endif
 
 	newvd = newrootvd->vdev_child[0];
 
-	if (!newvd->vdev_ops->vdev_op_leaf)
-		return (spa_vdev_exit(spa, newrootvd, txg, EINVAL));
+	/// XXX: free it
+	rzcvd = kmem_zalloc((1 + newrootvd->vdev_children) * sizeof (vdev_t *), KM_SLEEP);
 
-	if ((error = vdev_create(newrootvd, txg, replacing)) != 0)
+	for (int i = 0; i < newrootvd->vdev_children; i++) {
+		ivd = newrootvd->vdev_child[i];
+		rzcvd[i] = ivd;
+		if (!ivd->vdev_ops->vdev_op_leaf)
+			return (spa_vdev_exit(spa, newrootvd, txg, EINVAL));
+	}
+
+	if ((error = vdev_create(newrootvd, txg, replacing)) != 0) {
+#if defined(_KERNEL) && defined(__linux__)
+		printk("====== spa_vdev_attach():vdev_create(), err=%d", error);
+#else
+		printf("====== spa_vdev_attach():vdev_create(), err=%d\n", error);
+#endif
 		return (spa_vdev_exit(spa, newrootvd, txg, error));
+	}
 
 	/*
 	 * log, dedup and special vdevs should not be replaced by spares.
@@ -7622,9 +7653,12 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 	/*
 	 * A dRAID spare can only replace a child of its parent dRAID vdev.
 	 */
-	if (newvd->vdev_ops == &vdev_draid_spare_ops &&
-	    oldvd->vdev_top != vdev_draid_spare_get_parent(newvd)) {
-		return (spa_vdev_exit(spa, newrootvd, txg, ENOTSUP));
+	for (int i = 0; i < newrootvd->vdev_children; i++) {
+		ivd = newrootvd->vdev_child[i];
+		if (ivd->vdev_ops == &vdev_draid_spare_ops &&
+		    oldvd->vdev_top != vdev_draid_spare_get_parent(ivd)) {
+			return (spa_vdev_exit(spa, newrootvd, txg, ENOTSUP));
+		}
 	}
 
 	if (rebuild) {
@@ -7657,6 +7691,9 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 
 		pvops = &vdev_mirror_ops;
 	} else {
+		newvd = newrootvd->vdev_child[0];
+		ASSERT(newrootvd->vdev_children == 1);
+
 		/*
 		 * Active hot spares can only be replaced by inactive hot
 		 * spares.
@@ -7697,25 +7734,38 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 	/*
 	 * Make sure the new device is big enough.
 	 */
-	vdev_t *min_vdev = raidz ? oldvd->vdev_child[0] : oldvd;
-	if (newvd->vdev_asize < vdev_get_min_asize(min_vdev))
-		return (spa_vdev_exit(spa, newrootvd, txg, EOVERFLOW));
-
 	/*
 	 * The new device cannot have a higher alignment requirement
 	 * than the top-level vdev.
 	 */
-	if (newvd->vdev_ashift > oldvd->vdev_top->vdev_ashift) {
-		return (spa_vdev_exit(spa, newrootvd, txg,
-		    ZFS_ERR_ASHIFT_MISMATCH));
+	for (int i = 0; i < newrootvd->vdev_children; i++) {
+		ivd = newrootvd->vdev_child[i];
+		vdev_t *min_vdev = raidz ? oldvd->vdev_child[0] : oldvd;
+		if (ivd->vdev_asize < vdev_get_min_asize(min_vdev)) {
+#if defined(_KERNEL) && defined(__linux__)
+	printk("====== spa_vdev_attach() => EOVERFLOW, raidz=%d, %llu < %llu",
+			    raidz, ivd->vdev_asize, vdev_get_min_asize(min_vdev));
+#else
+	printf("====== spa_vdev_attach() => EOVERFLOW, raidz=%d, %lu < %lu\n",
+			    raidz, ivd->vdev_asize, vdev_get_min_asize(min_vdev));
+#endif
+			return (spa_vdev_exit(spa, newrootvd, txg, EOVERFLOW));
+		}
+
+
+		if (ivd->vdev_ashift > oldvd->vdev_top->vdev_ashift)
+			return (spa_vdev_exit(spa, newrootvd, txg, ENOTSUP));
 	}
 
 	/*
 	 * RAIDZ-expansion-specific checks.
 	 */
 	if (raidz) {
-		if (vdev_raidz_attach_check(newvd) != 0)
-			return (spa_vdev_exit(spa, newrootvd, txg, ENOTSUP));
+		for (int i = 0; i < newrootvd->vdev_children; i++) {
+			ivd = newrootvd->vdev_child[i];
+			if (vdev_raidz_attach_check(ivd) != 0)
+				return (spa_vdev_exit(spa, newrootvd, txg, ENOTSUP));
+		}
 
 		/*
 		 * Fail early if a child is not healthy or being replaced
@@ -7733,9 +7783,7 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 				    EADDRINUSE));
 			}
 		}
-	}
 
-	if (raidz) {
 		/*
 		 * Note: oldvdpath is freed by spa_strfree(),  but
 		 * kmem_asprintf() is freed by kmem_strfree(), so we have to
@@ -7781,23 +7829,28 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 	ASSERT(pvd->vdev_top->vdev_parent == rvd);
 
 	/*
-	 * Extract the new device from its root and add it to pvd.
-	 */
-	vdev_remove_child(newrootvd, newvd);
-	newvd->vdev_id = pvd->vdev_children;
-	newvd->vdev_crtxg = oldvd->vdev_crtxg;
-	vdev_add_child(pvd, newvd);
-
-	/*
 	 * Reevaluate the parent vdev state.
 	 */
 	vdev_propagate_state(pvd);
 
-	tvd = newvd->vdev_top;
-	ASSERT(pvd->vdev_top == tvd);
-	ASSERT(tvd->vdev_parent == rvd);
+	/*
+	 * Extract the new device from its root and add it to pvd.
+	 */
+	tvd = newvd; // XXX prevent warning about uninitilized variable
+	for (int i = 0; i < newrootvd->vdev_children; i++) { /// XXX it is possible that children will be changed inside the lopp
+		ivd = newrootvd->vdev_child[i];
 
-	vdev_config_dirty(tvd);
+		vdev_remove_child(newrootvd, ivd);
+		ivd->vdev_id = pvd->vdev_children;
+		ivd->vdev_crtxg = oldvd->vdev_crtxg;
+		vdev_add_child(pvd, ivd);
+
+		tvd = ivd->vdev_top;
+		ASSERT(pvd->vdev_top == tvd);
+		ASSERT(tvd->vdev_parent == rvd);
+
+		vdev_config_dirty(tvd);
+	}
 
 	/*
 	 * Set newvd's DTL to [TXG_INITIAL, dtl_max_txg) so that we account
@@ -7828,7 +7881,7 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 		dmu_tx_t *tx = dmu_tx_create_assigned(spa->spa_dsl_pool,
 		    dtl_max_txg);
 		dsl_sync_task_nowait(spa->spa_dsl_pool, vdev_raidz_attach_sync,
-		    newvd, tx);
+		    rzcvd, tx); /// XXX pass attached childrent thru void *arg
 		dmu_tx_commit(tx);
 	} else {
 		vdev_dtl_dirty(newvd, DTL_MISSING, TXG_INITIAL,
@@ -7870,15 +7923,22 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 	}
 
 	if (spa->spa_bootfs)
-		spa_event_notify(spa, newvd, NULL, ESC_ZFS_BOOTFS_VDEV_ATTACH);
+		for (int i = 0; i < newrootvd->vdev_children; i++) {
+			ivd = tvd->vdev_child[i];
+			spa_event_notify(spa, ivd, NULL, ESC_ZFS_BOOTFS_VDEV_ATTACH);
+		}
 
-	spa_event_notify(spa, newvd, NULL, ESC_ZFS_VDEV_ATTACH);
+	for (int i = 0; i < newrootvd->vdev_children; i++) {
+		newvd = tvd->vdev_child[i];
+		spa_event_notify(spa, newvd, NULL, ESC_ZFS_VDEV_ATTACH);
+	}
 
 	/*
 	 * Commit the config
 	 */
 	(void) spa_vdev_exit(spa, newrootvd, dtl_max_txg, 0);
 
+	// XXX update spa history to support multiple devices attach
 	spa_history_log_internal(spa, "vdev attach", NULL,
 	    "%s vdev=%s %s vdev=%s",
 	    replacing && newvd_isspare ? "spare in" :


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allow to attach multiple raidz children at once, by applying single reflow process for all newly attached devices in parallel.

This PR allows to attach multiple devices to raidz in same time in parallel. The zpool command is executed by the next way:
```
$ zpool attach poolname raidz1-0 /path/to/dev0 /path/to/dev1 ... /path/to/devX
```

### Description
<!--- Describe your changes in detail -->
The multiple devices raidz expnding will be completed after single reflow process iteration. The number of attached devices should be less, then raidz have initially. The older versions of ZFS with raidz expansion support will not be able to work with raidz expanded with the multiple raidz attached devices.

The multiple devices raidz expansion become possible by adding new vdev label config variable `ZPOOL_CONFIG_RAIDZ_EXPAND_VDEVS` additionally to `ZPOOL_CONFIG_RAIDZ_EXPAND_TXGS`. This variable is an array of values of devices attached per raidz expansion iteration. Updated on every reflow process completion, same as `ZPOOL_CONFIG_RAIDZ_EXPAND_TXGS` array. Both `ZPOOL_CONFIG_RAIDZ_EXPAND_TXGS` and `ZPOOL_CONFIG_RAIDZ_EXPAND_VDEVS` should have the same size and used to build raidz txg avl tree to compute raidz width dependent of bp birth txg value.

I did not found any reasons, why it would be impossible from raidz math point of view.
If you have any concerns or suggestions regarding raidz math and multiple devices raidz expanding process, please let me know.

### Notes:
- It possible to try multiple devices raidz expansion using zhack utility, zhack was modified appropriately.
- Single device raidz expansion considered as "worked" with modified raidz logic. Passed some number of ztest iterations.

### TODO:
- The appropriate ZFS feature flag need to be added.
- userspace:
    - zpool/cmd:
        - zpool attach should support multiple device paths as arguments - clean reimplementation is required
        - validate same device is not attached multiple times
        - zpool attach man page should be updated
    - ztest:
        - ztest issues need to be reproduced clearly and fixed for multiple devices raidz attaching
        - ztest logic should be refactored and retested
    - zfs-tests.sh:
        - additional tests of raidz_test tool should be added
        - multiple devices raidz attach test cases needed to be added
- kernel:
    - vdev_raidz core logic refactoring is required
    - ensure aggregation logic is compatible with multidev expansion
    - not sure that raidz_reconstruct() should not to be modified

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

No zfs-tests.sh tests scripts for now.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
