### PR TITLE
SIMD: Don't require definition of `HAVE_XSAVE`

### DIFF
--- a/config/toolchain-simd.m4
+++ b/config/toolchain-simd.m4
@@ -38,9 +38,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_SSE], [
 	AC_MSG_CHECKING([whether host toolchain supports SSE])
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("xorps %xmm0, %xmm1");
+			return (0);
 		}
 	]])], [
 		AC_DEFINE([HAVE_SSE], 1, [Define if host toolchain supports SSE])
@@ -57,9 +58,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_SSE2], [
 	AC_MSG_CHECKING([whether host toolchain supports SSE2])
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("pxor %xmm0, %xmm1");
+			return (0);
 		}
 	]])], [
 		AC_DEFINE([HAVE_SSE2], 1, [Define if host toolchain supports SSE2])
@@ -76,10 +78,11 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_SSE3], [
 	AC_MSG_CHECKING([whether host toolchain supports SSE3])
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([[
-		void main()
+		int main()
 		{
 			char v[16];
 			__asm__ __volatile__("lddqu %0,%%xmm0" :: "m"(v[0]));
+			return (0);
 		}
 	]])], [
 		AC_DEFINE([HAVE_SSE3], 1, [Define if host toolchain supports SSE3])
@@ -96,9 +99,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_SSSE3], [
 	AC_MSG_CHECKING([whether host toolchain supports SSSE3])
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("pshufb %xmm0,%xmm1");
+			return (0);
 		}
 	]])], [
 		AC_DEFINE([HAVE_SSSE3], 1, [Define if host toolchain supports SSSE3])
@@ -115,9 +119,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_SSE4_1], [
 	AC_MSG_CHECKING([whether host toolchain supports SSE4.1])
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("pmaxsb %xmm0,%xmm1");
+			return (0);
 		}
 	]])], [
 		AC_DEFINE([HAVE_SSE4_1], 1, [Define if host toolchain supports SSE4.1])
@@ -134,9 +139,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_SSE4_2], [
 	AC_MSG_CHECKING([whether host toolchain supports SSE4.2])
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("pcmpgtq %xmm0, %xmm1");
+			return (0);
 		}
 	]])], [
 		AC_DEFINE([HAVE_SSE4_2], 1, [Define if host toolchain supports SSE4.2])
@@ -153,10 +159,11 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX], [
 	AC_MSG_CHECKING([whether host toolchain supports AVX])
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([[
-		void main()
+		int main()
 		{
 			char v[32];
 			__asm__ __volatile__("vmovdqa %0,%%ymm0" :: "m"(v[0]));
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -174,9 +181,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX2], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("vpshufb %ymm0,%ymm1,%ymm2");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -194,9 +202,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX512F], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("vpandd %zmm0,%zmm1,%zmm2");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -214,9 +223,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX512CD], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("vplzcntd %zmm0,%zmm1");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -234,9 +244,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX512DQ], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("vandpd %zmm0,%zmm1,%zmm2");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -254,9 +265,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX512BW], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("vpshufb %zmm0,%zmm1,%zmm2");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -274,9 +286,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX512IFMA], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("vpmadd52luq %zmm0,%zmm1,%zmm2");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -294,9 +307,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX512VBMI], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("vpermb %zmm0,%zmm1,%zmm2");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -314,9 +328,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX512PF], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("vgatherpf0dps (%rsi,%zmm0,4){%k1}");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -334,9 +349,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX512ER], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("vexp2pd %zmm0,%zmm1");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -354,9 +370,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AVX512VL], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("vpabsq %zmm0,%zmm1");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -374,9 +391,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_AES], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("aesenc %xmm0, %xmm1");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -394,9 +412,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_PCLMULQDQ], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("pclmulqdq %0, %%xmm0, %%xmm1" :: "i"(0));
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -414,9 +433,10 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_MOVBE], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 			__asm__ __volatile__("movbe 0(%eax), %eax");
+			return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -434,10 +454,11 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVE], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 		  char b[4096] __attribute__ ((aligned (64)));
 		  __asm__ __volatile__("xsave %[b]\n" : : [b] "m" (*b) : "memory");
+		  return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -455,10 +476,11 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVEOPT], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 		  char b[4096] __attribute__ ((aligned (64)));
 		  __asm__ __volatile__("xsaveopt %[b]\n" : : [b] "m" (*b) : "memory");
+		  return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])
@@ -476,10 +498,11 @@ AC_DEFUN([ZFS_AC_CONFIG_TOOLCHAIN_CAN_BUILD_XSAVES], [
 
 	AC_LINK_IFELSE([AC_LANG_SOURCE([
 	[
-		void main()
+		int main()
 		{
 		  char b[4096] __attribute__ ((aligned (64)));
 		  __asm__ __volatile__("xsaves %[b]\n" : : [b] "m" (*b) : "memory");
+		  return (0);
 		}
 	]])], [
 		AC_MSG_RESULT([yes])


### PR DESCRIPTION
### Motivation and Context

Currently we fail the compilation via the #error directive if  `HAVE_XSAVE` isn't defined. This breaks i586 builds since we check the toolchains SIMD support only on i686 and onward.

Closes #13303

### Description

Remove the requirement to fix the build on i586. While here, change `void main()` to `int main()` in `toolchain-simd.m4`.

### How Has This Been Tested?

Relying on the CI.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
