### PR TITLE
rpm: don't list /sbin/zgenhostid twice in %files

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -506,7 +506,6 @@ systemctl --system daemon-reload >/dev/null || true
 # Core utilities
 %{_sbindir}/*
 %{_bindir}/raidz_test
-%{_sbindir}/zgenhostid
 %{_bindir}/zvol_wait
 # Optional Python 3 scripts
 %{_bindir}/arc_summary


### PR DESCRIPTION
### Description
The location of `zgenhostid` was changed in 0ae733c7a (Install zgenhostid to sbindir, 2021-01-21).  We include all files within `sbindir`, which causes `rpmbuild` to report:

    File listed twice: /sbin/zgenhostid

Drop the redundant entry from the `%files` section.

### How Has This Been Tested?
I performed a mock build before and after, confirming that `zgenhostid` was still present in the zfs rpm and there was no longer a "File listed twice" warning for this file.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] ~~I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.~~
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).