### PR TITLE
Fix Assert in dbuf_undirty, which triggers during usage zap shrink

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2557,12 +2557,13 @@ dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 
 	/*
 	 * Due to our use of dn_nlevels below, this can only be called
-	 * in open context, unless we are operating on the MOS.
-	 * From syncing context, dn_nlevels may be different from the
-	 * dn_nlevels used when dbuf was dirtied.
+	 * in open context, unless we are operating on the MOS or it's
+	 * a special object. From syncing context, dn_nlevels may be
+	 * different from the dn_nlevels used when dbuf was dirtied.
 	 */
 	ASSERT(db->db_objset ==
 	    dmu_objset_pool(db->db_objset)->dp_meta_objset ||
+	    DMU_OBJECT_IS_SPECIAL(db->db.db_object) ||
 	    txg != spa_syncing_txg(dmu_objset_spa(db->db_objset)));
 	ASSERT(db->db_blkid != DMU_BONUS_BLKID);
 	ASSERT0(db->db_level);


### PR DESCRIPTION
Usage zap's (DMU_*USED_OBJECT) are updated in syncing context via do_userquota_cacheflush(). zap shrink triggers,
ASSERT(db->db_objset == dmu_objset_pool(db->db_objset)->dp_meta_objset
    || txg != spa_syncing_txg(dmu_objset_spa(db->db_objset)));

DMU_*USED_OBJECT are special object (DMU_OBJECT_IS_SPECIAL), gets updated in syncing context only. So, relax assert for it.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Its fixes following assert:
```
[636799.843202] VERIFY(db->db_objset == dmu_objset_pool(db->db_objset)->dp_meta_objset || txg != spa_syncing_txg(dmu_objset_spa(db->db_objset))) failed
[636799.845528] PANIC at dbuf.c:2564:dbuf_undirty()
[636799.846312] Showing stack for process 944647
...
[636799.846317] Call Trace:
[636799.846340]  dump_stack+0x6b/0x83
[636799.846352]  spl_panic+0xd3/0xfb [spl]
[636799.846586]  dbuf_undirty+0x595/0x880 [zfs]
[636799.846754]  dbuf_free_range+0x219/0x760 [zfs]
[636799.846988]  dnode_free_range+0x208/0x9b0 [zfs]
[636799.847115]  dmu_free_range+0x5b/0xf0 [zfs]
[636799.847269]  zap_shrink+0x3e5/0x9c0 [zfs]
[636799.847420]  fzap_remove+0xd0/0xe0 [zfs]
[636799.847578]  zap_remove_impl+0xdd/0x130 [zfs]
[636799.847676]  zap_remove+0x5d/0xa0 [zfs]
[636799.847773]  zap_increment+0x8f/0xc0 [zfs]
[636799.847863]  do_userquota_cacheflush+0x28a/0x4d0 [zfs]
[636799.847953]  userquota_updates_task+0x31a/0x4c0 [zfs]
[636799.848226]  taskq_thread+0x36c/0x920 [spl]
[636799.848330]  kthread+0x112/0x130
[636799.848335]  ret_from_fork+0x1f/0x30
```

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Following are repro steps.
```
$  zfs list -t all -r mytestpool
NAME             USED  AVAIL  REFER  MOUNTPOINT
mytestpool       150K   832M    24K  /mytestpool
mytestpool/ds1    24K   832M    24K  /mytestpool/ds1

$ cd /mytestpool/ds1
$ sudo chmod 0777 ../ds1
$ pwd
/mytestpool/ds1

$ pwd
/mytestpool/ds1

$ for i in $(seq 1 2000); do mkdir p-$i;done
$ for i in $(seq 1 2000); do zfs project -p $i -sr ./p-$i ;done

$ rm -fR *
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
