### PR TITLE
zed: prettify slack notification message

### DIFF
--- a/cmd/zed/zed.d/zed-functions.sh
+++ b/cmd/zed/zed.d/zed-functions.sh
@@ -441,8 +441,9 @@ zed_notify_slack_webhook()
         "${pathname}")"
 
     # Construct the JSON message for posting.
+    # shellcheck disable=SC2016
     #
-    msg_json="$(printf '{"text": "*%s*\\n%s"}' "${subject}" "${msg_body}" )"
+    msg_json="$(printf '{"text": "*%s*\\n```%s```"}' "${subject}" "${msg_body}" )"
 
     # Send the POST request and check for errors.
     #


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, when sending ZED notifications to slack, the message is  a bit hard to read because it is formatted as plain text:

<img width="400" alt="screenshot_2025-08-10-161817" src="https://github.com/user-attachments/assets/ee0a4d75-edde-406f-a73a-b8d07592ca90" />


With this change, the body of the message is put in a monospaced code block which is far more convenient to read already because columns are properly aligned now:

<img width="400" alt="screenshot_2025-08-10-161837" src="https://github.com/user-attachments/assets/a714a508-657e-4445-b8c2-0dc96723395c" />


### How Has This Been Tested?

Well, there is not that much to test. I've edited the respective file on my local zfs installation and been using it with this config for some time now. The slack api is well documented and code block formatting is a standard thing in webhook payloads. You can verify the result in the screenshots above.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
