### PR TITLE
ZIL: restore some things lost in "ZIL-crash" review (#17398)

### DIFF
--- a/include/sys/zil_impl.h
+++ b/include/sys/zil_impl.h
@@ -100,11 +100,15 @@ typedef enum {
  * holding the "zl_issuer_lock". After the lwb is issued, the zilog's
  * "zl_lock" is used to protect the lwb against concurrent access.
  */
+typedef enum {
+	LWB_FLAG_SLIM =	(1<<0),		/* log block has slim format */
+	LWB_FLAG_SLOG =	(1<<1),		/* lwb_blk is on SLOG device */
+} lwb_flag_t;
+
 typedef struct lwb {
 	zilog_t		*lwb_zilog;	/* back pointer to log struct */
 	blkptr_t	lwb_blk;	/* on disk address of this log blk */
-	boolean_t	lwb_slim;	/* log block has slim format */
-	boolean_t	lwb_slog;	/* lwb_blk is on SLOG device */
+	lwb_flag_t	lwb_flags;	/* extra info about this lwb */
 	int		lwb_error;	/* log block allocation error */
 	int		lwb_nmax;	/* max bytes in the buffer */
 	int		lwb_nused;	/* # used bytes in buffer */

--- a/include/sys/zil_impl.h
+++ b/include/sys/zil_impl.h
@@ -101,8 +101,9 @@ typedef enum {
  * "zl_lock" is used to protect the lwb against concurrent access.
  */
 typedef enum {
-	LWB_FLAG_SLIM =	(1<<0),		/* log block has slim format */
-	LWB_FLAG_SLOG =	(1<<1),		/* lwb_blk is on SLOG device */
+	LWB_FLAG_SLIM =		(1<<0),	/* log block has slim format */
+	LWB_FLAG_SLOG =		(1<<1),	/* lwb_blk is on SLOG device */
+	LWB_FLAG_CRASHED =	(1<<2),	/* lwb is on the crash list */
 } lwb_flag_t;
 
 typedef struct lwb {

--- a/include/sys/zil_impl.h
+++ b/include/sys/zil_impl.h
@@ -154,7 +154,7 @@ typedef struct zil_commit_waiter {
 	list_node_t	zcw_node;	/* linkage in lwb_t:lwb_waiter list */
 	lwb_t		*zcw_lwb;	/* back pointer to lwb when linked */
 	boolean_t	zcw_done;	/* B_TRUE when "done", else B_FALSE */
-	int		zcw_zio_error;	/* contains the zio io_error value */
+	int		zcw_error;	/* result to return from zil_commit() */
 } zil_commit_waiter_t;
 
 /*


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

I was reviewing another PR and noticed that the `lwb_flags` field wasn't there. Looking closer, and I realised that when I rebased in https://github.com/openzfs/zfs/pull/17398#issuecomment-3162260415, I did it on an older work branch that didn't have all of more recent changes from review. This PR restores those.

### Description

This was done by reading the diff between ef66c53 (the last position of #17398 before my screw-up) and master and carefully reapplying the changes.

Review comments in #17398 have more context.

Refactor/cleanup:
- add `lwb_flags`, make `lwb_slog` and `lwb_slim` be flags
- change `zil_commit_waiter_skip()` to be `zil_commit_waiter_done()` and take an error, and use it

Functional:
- add a flag `LWB_FLAG_CRASHED` to in-flight LWBs in `zil_crash()`, and use it to know to take no further action. This is mainly to avoid calling `list_next(&zl_lwb_list, lwb)` when `lwb` is on `zl_lwb_crash_list` via the same node, but being able to clearly identify an LWB as "dead" is generally useful.
- if the pool suspends during stall fallback in `zil_process_commit_list()`, stop trying, and get an error back to unassigned waiters
- don't leak the suspend cookie if the pool suspended while we were waiting for the zil to suspend

### How Has This Been Tested?

`zil` and `failmode` test tags succeeded, though none of them really exercise these fairly extreme edge cases.

This stuff was all approved in #17398 though so hopefully its not too onerous (provided I didn't screw it up again).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
