### PR TITLE
Add missing AC_MSG_RESULT

### DIFF
--- a/config/kernel-mkdir.m4
+++ b/config/kernel-mkdir.m4
@@ -84,6 +84,8 @@ AC_DEFUN([ZFS_AC_KERNEL_MKDIR], [
 		AC_DEFINE(HAVE_IOPS_MKDIR_DENTRY, 1,
 		    [iops->mkdir() returns struct dentry*])
 	],[
+		AC_MSG_RESULT(no)
+
 		dnl #
 		dnl # 6.3 API change
 		dnl # mkdir() takes struct mnt_idmap * as the first arg


### PR DESCRIPTION
### Motivation and Context

A quick fix for some incorrect formatting output from configure.

### Description

Output the result of the "iops->mkdir() returns struct dentry*" check to cleanup the configure output.

Before:

```
checking whether iops->mkdir() returns struct dentry*... checking whether iops->mkdir() takes struct mnt_idmap*... yes
```

After

```
checking whether iops->mkdir() returns struct dentry*... no
checking whether iops->mkdir() takes struct mnt_idmap*... yes
```

### How Has This Been Tested?

Visually inspected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
