### PR TITLE
arc: resolve several unlikely arc header races

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5769,6 +5769,18 @@ arc_read_done(zio_t *zio)
 		arc_hdr_verify(hdr, zio->io_bp);
 	} else {
 		arc_hdr_set_flags(hdr, ARC_FLAG_IO_ERROR);
+		/*
+		 * hdr in the arc_anon state must not have L2 header.
+		 * Destroy it so that arc_release()'s anon fast path
+		 * wouldn't trip over a dangling L2 hdr.
+		 */
+		if (HDR_HAS_L2HDR(hdr)) {
+			mutex_enter(&hdr->b_l2hdr.b_dev->l2ad_mtx);
+			/* Recheck to prevent race with l2arc_evict(). */
+			if (HDR_HAS_L2HDR(hdr))
+				arc_hdr_l2hdr_destroy(hdr);
+			mutex_exit(&hdr->b_l2hdr.b_dev->l2ad_mtx);
+		}
 		if (hdr->b_l1hdr.b_state != arc_anon)
 			arc_change_state(arc_anon, hdr);
 		if (HDR_IN_HASH_TABLE(hdr))
@@ -5780,6 +5792,36 @@ arc_read_done(zio_t *zio)
 
 	if (hash_lock != NULL)
 		mutex_exit(hash_lock);
+
+	/*
+	 * Wake pure waiters (no done cb) first, so a waiter blocked under
+	 * db_mtx (e.g. dbuf_read_done()->arc_release()) isn't gated behind
+	 * a done callback that needs that lock.
+	 */
+	arc_callback_t *prev;
+	for (acb = callback_list; acb != NULL; acb = prev) {
+		prev = acb->acb_prev;
+
+		if (acb->acb_wait && acb->acb_done == NULL) {
+			arc_callback_t *next = acb->acb_next;
+
+			/* acb is freed by waiter, remove it from the list. */
+			if (next != NULL)
+				next->acb_prev = prev;
+			if (prev != NULL)
+				prev->acb_next = next;
+			if (callback_list == acb)
+				callback_list = prev;
+
+			mutex_enter(&acb->acb_wait_lock);
+			acb->acb_wait_error = zio->io_error;
+			acb->acb_wait = B_FALSE;
+			acb->acb_prev = NULL;
+			acb->acb_next = NULL;
+			cv_signal(&acb->acb_wait_cv);
+			mutex_exit(&acb->acb_wait_lock);
+		}
+	}
 
 	/* execute each callback and free its structure */
 	while ((acb = callback_list) != NULL) {
@@ -6023,7 +6065,6 @@ top:
 				hdr->b_l1hdr.b_acb->acb_prev = acb;
 				hdr->b_l1hdr.b_acb = acb;
 			}
-			mutex_exit(hash_lock);
 
 			ARCSTAT_BUMP(arcstat_iohits);
 			ARCSTAT_CONDSTAT(!(*arc_flags & ARC_FLAG_PREFETCH),
@@ -6031,6 +6072,7 @@ top:
 
 			if (*arc_flags & ARC_FLAG_WAIT) {
 				mutex_enter(&acb->acb_wait_lock);
+				mutex_exit(hash_lock);
 				while (acb->acb_wait) {
 					cv_wait(&acb->acb_wait_cv,
 					    &acb->acb_wait_lock);
@@ -6040,7 +6082,10 @@ top:
 				mutex_destroy(&acb->acb_wait_lock);
 				cv_destroy(&acb->acb_wait_cv);
 				kmem_free(acb, sizeof (arc_callback_t));
+			} else {
+				mutex_exit(hash_lock);
 			}
+
 			goto out;
 		}
 
@@ -6203,8 +6248,8 @@ top:
 				acb->acb_next = hdr->b_l1hdr.b_acb;
 				hdr->b_l1hdr.b_acb->acb_prev = acb;
 				hdr->b_l1hdr.b_acb = acb;
-				mutex_exit(hash_lock);
 				mutex_enter(&acb->acb_wait_lock);
+				mutex_exit(hash_lock);
 				while (acb->acb_wait) {
 					cv_wait(&acb->acb_wait_cv,
 					    &acb->acb_wait_lock);
@@ -6624,6 +6669,7 @@ void
 arc_release(arc_buf_t *buf, const void *tag)
 {
 	arc_buf_hdr_t *hdr = buf->b_hdr;
+	kmutex_t *hash_lock = HDR_LOCK(hdr);
 
 	/*
 	 * It would be nice to assert that if its DMU metadata (level >
@@ -6632,6 +6678,45 @@ arc_release(arc_buf_t *buf, const void *tag)
 	 */
 
 	ASSERT(HDR_HAS_L1HDR(hdr));
+
+	/*
+	 * Wait for any other IO for this hdr, as additional buf(s) could be
+	 * about to be added by arc_read_done(), in which case we would not
+	 * want to transition hdr to arc_anon.  This is a rare case, so take
+	 * the hash_lock only if it's true and re-check it under the lock.
+	 */
+	while (HDR_IO_IN_PROGRESS(hdr)) {
+		mutex_enter(hash_lock);
+
+		if (HDR_IO_IN_PROGRESS(hdr)) {
+			arc_callback_t *acb;
+
+			acb = kmem_zalloc(sizeof (*acb), KM_SLEEP);
+			acb->acb_wait = B_TRUE;
+			mutex_init(&acb->acb_wait_lock, NULL, MUTEX_DEFAULT,
+			    NULL);
+			cv_init(&acb->acb_wait_cv, NULL, CV_DEFAULT, NULL);
+
+			VERIFY3P(hdr->b_l1hdr.b_acb, !=, NULL);
+			acb->acb_zio_head = hdr->b_l1hdr.b_acb->acb_zio_head;
+			acb->acb_next = hdr->b_l1hdr.b_acb;
+			hdr->b_l1hdr.b_acb->acb_prev = acb;
+			hdr->b_l1hdr.b_acb = acb;
+
+			mutex_enter(&acb->acb_wait_lock);
+			mutex_exit(hash_lock);
+
+			while (acb->acb_wait)
+				cv_wait(&acb->acb_wait_cv, &acb->acb_wait_lock);
+
+			mutex_exit(&acb->acb_wait_lock);
+			mutex_destroy(&acb->acb_wait_lock);
+			cv_destroy(&acb->acb_wait_cv);
+			kmem_free(acb, sizeof (*acb));
+		} else {
+			mutex_exit(hash_lock);
+		}
+	}
 
 	/*
 	 * We don't grab the hash lock prior to this check, because if
@@ -6660,7 +6745,6 @@ arc_release(arc_buf_t *buf, const void *tag)
 		return;
 	}
 
-	kmutex_t *hash_lock = HDR_LOCK(hdr);
 	mutex_enter(hash_lock);
 
 	/*


### PR DESCRIPTION
### Motivation and Context

https://www.illumos.org/issues/14003 and #13479.  I was only able to identify the one reported instance of this in our tracker, but this race definitely looks possible and should be fixed.

Edit: Updated to address the same original Illumos issue and close a few additional races.

A race between an outstanding ARC read and arc_release() can move an ARC header to the arc_anon state after the arc_anon check in arc_release().  Wait for all in-progress I/O to complete before processing the header.

Additionally, wake pure waiters before executing the completion callbacks.  This ensure that a waiter blocked under db_mtx
(e.g. dbuf_read_done()->arc_release()) isn't gated behind a done callback that needs that lock.

Lastly, immediately destroy any L2 header when an ARC read fails so arc_release()'s anonymous-state fast path can't encounter a dangling L2 header.

While structured differently this change resolves the same issue which was reported as Illumos 14003.

### Description

From the illumos issue:

> It's a race condition; the dtrace just widens the window (by inserting delays at the appropriate point). My theory is that zfs send is reading a blkptr that has a hdr in l1arc, but with no cached raw buffer, so it issues a zio_read for that data, then drops the hash_lock to wait (the prefetch code can do that, too, although it uses nowait()). At the same time, a different thread issues a dbuf_hold() for the same blkptr, and finds a dbuf pointing to an arc_buf with the same header in the dbuf cache. before the send's read completes, that same thread calls arc_release() (e.g. via dbuf_dirty() when adding or removing ZAP entries for objects in a directory). Since arc_release() only checks for existing buffers, and not outstanding i/o that may add a buffer later, it moves the hdr to state arc_anon. When the send's read finishes and send destroys the buffer, there are now two buffers (each with its own reference) on the hdr, which trips the verify.

### How Has This Been Tested?

A reproducer was written which leveraged a new dtrace probe that allowed to race to be more easily triggered.  It was still difficult to hit, but at least possible.  Additional testing notes can be found at https://www.illumos.org/issues/14003#note-29.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
