### PR TITLE
cmd: force zarcstat/zarc_summary recreation at install

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -109,8 +109,8 @@ arc_summary: %D%/arc_summary
 	$(AM_V_at)cp $< $@
 
 cmd-rename-install-exec-hook:
-	$(LN_S) arcstat $(DESTDIR)$(bindir)/zarcstat
-	$(LN_S) arc_summary $(DESTDIR)$(bindir)/zarcsummary
+	$(LN_S) -f arcstat $(DESTDIR)$(bindir)/zarcstat
+	$(LN_S) -f arc_summary $(DESTDIR)$(bindir)/zarcsummary
 INSTALL_EXEC_HOOKS += cmd-rename-install-exec-hook
 endif
 


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

After #17695, `make install` over an existing install will fail:

```
ln -s arcstat /home/robn/code/quiz/system/work/usr/local/bin/zarcstat
ln: failed to create symbolic link '/home/robn/code/quiz/system/work/usr/local/bin/zarcstat': File exists
```

### Description

Pass `-f` to `ln` to force the symlink to be recreated.

### How Has This Been Tested?

Didn't work, now does :shrug: 

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
