### PR TITLE
Fix the build of crypto_test on LP32 architectures

### DIFF
--- a/tests/zfs-tests/cmd/crypto_test.c
+++ b/tests/zfs-tests/cmd/crypto_test.c
@@ -863,7 +863,8 @@ test_result(const crypto_test_t *test, int encrypt_rv, uint8_t *encrypt_buf,
 		return (pass);
 
 	/* print summary of test result */
-	printf("%s[%lu]: encrypt=%s decrypt=%s\n", test->fileloc, test->id,
+	printf("%s[%ju]: encrypt=%s decrypt=%s\n", test->fileloc,
+	    (uintmax_t)test->id,
 	    encrypt_pass ? "PASS" : "FAIL",
 	    decrypt_pass ? "PASS" : "FAIL");
 


### PR DESCRIPTION
test->id is a uint64_t, not a long.

Signed-off-by:	Alan Somers <asomers@gmail.com>
Sponsored by:	ConnectWise

### Motivation and Context
OpenZFS does not currently build on FreeBSD i386

### Description
See commit message

### How Has This Been Tested?
Build tested only

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
