### PR TITLE
linux/rw_destroy: assert no holders before destroying

### DIFF
--- a/include/os/linux/spl/sys/rwlock.h
+++ b/include/os/linux/spl/sys/rwlock.h
@@ -130,7 +130,7 @@ RW_READ_HELD(krwlock_t *rwp)
 /*
  * The Linux rwsem implementation does not require a matching destroy.
  */
-#define	rw_destroy(rwp)		((void) 0)
+#define	rw_destroy(rwp)		ASSERT(!(RW_LOCK_HELD(rwp)))
 
 /*
  * Upgrading a rwsem from a reader to a writer is not supported by the


### PR DESCRIPTION
### Motivation and Context

I had a surprising crash in a client project and traced it to an A-B-A problem, where the reused object contained a rwlock which was destroyed while it was held. That surprised me, because we usually assert if we destroy things that are still in use. But it turns out our `rw_destroy()` on Linux is a true no-op - not even an assert! So this fixes that.

### Description

Define `rw_destroy()` to `ASSERT` that there's no holds. In production, that will just become a no-op again.

### How Has This Been Tested?

ZTS passed on a debug build, which should mean there's nothing we've been silently missing. In my project, it did trip earlier than the eventual crash, so that's good too.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
