### PR TITLE
vdev_disk_close: take disk write lock before destroying it

### DIFF
--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -471,13 +471,17 @@ vdev_disk_close(vdev_t *v)
 	if (v->vdev_reopening || vd == NULL)
 		return;
 
+	rw_enter(&vd->vd_lock, RW_WRITER);
+
 	if (vd->vd_bdh != NULL)
 		vdev_blkdev_put(vd->vd_bdh, spa_mode(v->vdev_spa),
 		    zfs_vdev_holder);
 
+	v->vdev_tsd = NULL;
+
+	rw_exit(&vd->vd_lock);
 	rw_destroy(&vd->vd_lock);
 	kmem_free(vd, sizeof (vdev_disk_t));
-	v->vdev_tsd = NULL;
 }
 
 /*


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

I had a surprising crash in a client project and traced it to an A-B-A problem in vdev_disk, where the vdev could be closed and the private data, including an rwlock, destroyed while the lock was still held.

IO is issued asynchronously. If the kernel deschedules the initiating task, and then IO is scheduled, completed and goes on to call `vdev_disk_close()` and close the vdev before the initiating task runs, then the `vdev_disk_t` in `vdev_tsd` will have been destroyed, rendering the callers `vd` now invalid.

I have not been able to trigger this in stock OpenZFS, but I can easily in my client project. Since I hope to upstream that work soon, fixing this becomes important.

### Description

Take the write lock in `vdev_disk_close()`. If any read locks are outstanding, the task will sleep, and those issuing tasks will get an opportunity to release their read lock. Once cleared, `vdev_disk_close()` will gain the write lock and be able to null `vdev_tsd`.

I don't think it's possible for this to deadlock, because the read lock should always be taken in an "issue" task, while the completions will redispatch the zio to an "interrupt" task.

### How Has This Been Tested?

ZTS run completed. In my own code, this fixes my crash.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
