### PR TITLE
ZTS: Print warning if running ZTS user_run test locally

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2881,6 +2881,28 @@ function user_run
 	log_note "user: $user"
 	log_note "cmd: $*"
 
+	if ! sudo -Eu $user test -x $PATH ; then
+		log_note "-------------------------------------------------"
+		log_note "Warning: $user doesn't have permissions on $PATH"
+		log_note ""
+		log_note "This usually happens when you're running ZTS locally"
+		log_note "from inside the ZFS source dir, and are attempting to"
+		log_note "run a test that calls user_run.  The ephemeral user"
+		log_note "($user) that ZTS is creating does not have permission"
+		log_note "to traverse to $PATH, or the binaries in $PATH are"
+		log_note "not the right permissions."
+		log_note ""
+		log_note "To get around this, copy your ZFS source directory"
+		log_note "to a world-accessible location (like /tmp), and "
+		log_note "change the permissions on your ZFS source dir "
+		log_note "to allow access."
+		log_note ""
+		log_note "Also, verify that /dev/zfs is RW for others:"
+		log_note ""
+		log_note "    sudo chmod o+rw /dev/zfs"
+		log_note "-------------------------------------------------"
+	fi
+
 	typeset out=$TEST_BASE_DIR/out
 	typeset err=$TEST_BASE_DIR/err
 


### PR DESCRIPTION

### Motivation and Context
Print warning when doing `user_run` ZTS tests in a local git repo

### Description
Print a warning if you're attempting to run a ZTS test that calls `user_run`, and the ephemeral test user doesn't have permissions to access the test binaries. `user_run` is used to run commands as a different user.

This can happen if you're running ZTS from a local git repo.  In that case the ephemeral test user (say, 'testuser1') may need access to the ZTS binaries in:
```
/home/<your_username>/zfs/tests/zfs-tests/bin/
```
... but 'testuser1' doesn't have permission to enter your home dir:
```
/home/<your_username>
```
The warning will help alert users to what is going on.  This is not an issue is ZTS is actually installed on the system (via 'make install' or from packages).


### How Has This Been Tested?
Tested locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
