### PR TITLE
Make new zhack test a little more reliable

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_metaslab_leak.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_metaslab_leak.ksh
@@ -64,7 +64,7 @@ log_must zpool import $TESTPOOL
 
 alloc2=$(zpool get -Hpo value alloc $TESTPOOL)
 
-[[ $((alloc * 1.02)) -gt $alloc2 ]] && [[ $alloc2 -gt $((alloc * 0.98)) ]] || \
+within_percent $alloc $alloc2 98 || 
 	log_fail "space usage changed too much: $alloc to $alloc2"
 
 log_pass "zhack metaslab leak behaved correctly"


### PR DESCRIPTION
### Motivation and Context
In #17576 , a new test was added for the new `zhack metaslab leak` subcommand. That test appears to be slightly flaky; some test runs are exhibiting failures due a decrease in space usage. The test asserts that this isn't possible, but in practice it is; regions allocated for space maps could be part of the area that is attempting to be leaked, failing to leak the first time, and then move into another region that will be leaked in the future, failing to leak them again. This isn't very likely, but it can happen, so we should make sure the test doesn't flake.

### Description
We allow the space use to go down slightly (2% of ~130MiB should be more than enough to cover all the pool metadata). Also while we're at it, we make it symmetrical.

### How Has This Been Tested?
ZFS test suite runs, checktyle verification

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
