### PR TITLE
Select proper throttle based on class

### DIFF
--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -133,10 +133,10 @@ uint64_t metaslab_group_get_space(metaslab_group_t *);
 void metaslab_group_histogram_verify(metaslab_group_t *);
 uint64_t metaslab_group_fragmentation(metaslab_group_t *);
 void metaslab_group_histogram_remove(metaslab_group_t *, metaslab_t *);
-void metaslab_group_alloc_increment_all(spa_t *, blkptr_t *, int, int,
+void metaslab_group_alloc_increment_all(metaslab_class_t *, blkptr_t *, int,
+    int, uint64_t, const void *);
+void metaslab_group_alloc_decrement(metaslab_class_t *, uint64_t, int, int,
     uint64_t, const void *);
-void metaslab_group_alloc_decrement(spa_t *, uint64_t, int, int, uint64_t,
-    const void *);
 void metaslab_recalculate_weight_and_sort(metaslab_t *);
 void metaslab_disable(metaslab_t *);
 void metaslab_enable(metaslab_t *, boolean_t, boolean_t);

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3288,7 +3288,7 @@ zio_write_gang_block(zio_t *pio, metaslab_class_t *mc)
 		zio_gang_inherit_allocator(zio, cio);
 		if (allocated) {
 			metaslab_trace_move(&cio_list, &cio->io_alloc_list);
-			metaslab_group_alloc_increment_all(spa,
+			metaslab_group_alloc_increment_all(mc,
 			    &cio->io_bp_orig, zio->io_allocator, flags, psize,
 			    cio);
 		}
@@ -3743,7 +3743,7 @@ zio_ddt_child_write_ready(zio_t *zio)
 	if (ddt_phys_is_gang(dde->dde_phys, v)) {
 		for (int i = 0; i < BP_GET_NDVAS(zio->io_bp); i++) {
 			dva_t *d = &zio->io_bp->blk_dva[i];
-			metaslab_group_alloc_decrement(zio->io_spa,
+			metaslab_group_alloc_decrement(zio->io_metaslab_class,
 			    DVA_GET_VDEV(d), zio->io_allocator,
 			    METASLAB_ASYNC_ALLOC, zio->io_size, zio);
 		}
@@ -5418,7 +5418,7 @@ zio_dva_throttle_done(zio_t *zio)
 	ASSERT(zio->io_metaslab_class != NULL);
 	ASSERT(zio->io_metaslab_class->mc_alloc_throttle_enabled);
 
-	metaslab_group_alloc_decrement(zio->io_spa, vd->vdev_id,
+	metaslab_group_alloc_decrement(zio->io_metaslab_class, vd->vdev_id,
 	    pio->io_allocator, flags, size, tag);
 
 	if (metaslab_class_throttle_unreserve(pio->io_metaslab_class,


### PR DESCRIPTION
_Sponsored by: [Klara, Inc.; Wasabi Technology, Inc.]_

### Motivation and Context
When selecting the group to throttle on in the allocation code, we currently always take the vdev_mg of the vdev we did the allocation on. This works fine when we're doing a normal allocation in the log class, special class, or normal class, but if we're in the embedded slog class we should be using the vdev_log_mg group.

### Description
We can take the metaslab class into the allocation throttle functions instead, and then use that to decide which group we pick out of the vdev.

### How Has This Been Tested?
Ran the zfs test suite with the embedded slog enabled

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
