### PR TITLE
ZTS: Add raidz/raidz_001_neg exception

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -251,6 +251,7 @@ maybe = {
     'pam/setup': ['SKIP', "pamtester might be not available"],
     'pool_checkpoint/checkpoint_discard_busy': ['FAIL', 11946],
     'projectquota/setup': ['SKIP', exec_reason],
+    'raidz/raidz_001_neg': ['FAIL', known_reason],
     'raidz/raidz_002_pos': ['FAIL', known_reason],
     'raidz/raidz_expand_001_pos': ['FAIL', 16421],
     'redundancy/redundancy_draid_spare1': ['FAIL', known_reason],


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/17681632795/job/50256936279

### Description

Add `raidz/raidz_001_neg` to the FreeBSD maybe exception list for the moment.  The failure appears to only be reproducible under the CI on the FreeBSD stable/15 builder.  See the comments in issue #17722 for additional details.

We should attempt to revert this patch when there is an updated FreeBSD stable/15 image available for the CI.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)
