### PR TITLE
ZTS: default to random data in fill_fs

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1085,7 +1085,7 @@ function fill_fs # destdir dirnum filenum bytes num_writes data
 	typeset -i filenum=${3:-50}
 	typeset -i bytes=${4:-8192}
 	typeset -i num_writes=${5:-10240}
-	typeset data=${6:-0}
+	typeset data=${6:-"R"}
 
 	mkdir -p $destdir/{1..$dirnum}
 	for f in $destdir/{1..$dirnum}/$TESTFILE{1..$filenum}; do

--- a/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
@@ -86,7 +86,7 @@ log_must zpool set autoreplace=on $TESTPOOL
 
 # Add some data to the pool
 log_must zfs create $TESTPOOL/fs
-log_must fill_fs /$TESTPOOL/fs 4 100 4096 512 Z
+log_must fill_fs /$TESTPOOL/fs 4 100 4096 512 R
 log_must zpool export $TESTPOOL
 
 # Record the partition UUID for later comparison

--- a/tests/zfs-tests/tests/functional/fault/auto_replace_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_replace_002_pos.ksh
@@ -119,7 +119,7 @@ log_must zpool set autoreplace=on $TESTPOOL
 
 # Add some data to the pool
 log_must zfs create $TESTPOOL/fs
-log_must fill_fs /$TESTPOOL/fs 4 100 4096 512 Z
+log_must fill_fs /$TESTPOOL/fs 4 100 4096 512 R
 log_must zpool export $TESTPOOL
 
 # Record the partition UUID for later comparison

--- a/tests/zfs-tests/tests/functional/fault/suspend_on_probe_errors.ksh
+++ b/tests/zfs-tests/tests/functional/fault/suspend_on_probe_errors.ksh
@@ -101,7 +101,7 @@ sync_pool $TESTPOOL
 log_must zfs create $TESTPOOL/fs
 MNTPOINT="$(get_prop mountpoint $TESTPOOL/fs)"
 SECONDS=0
-log_must fill_fs $MNTPOINT 1 200 4096 10 Z
+log_must fill_fs $MNTPOINT 1 200 4096 10 R
 log_note "fill_fs took $SECONDS seconds"
 sync_pool $TESTPOOL
 


### PR DESCRIPTION
### Motivation and Context

Switch to using a random fill by default for fill_fs users to restore traditional fill behavior.  This may also help reduce some of the spurious failures we've seen with these test cases.

### Description

Update the fill_fs helper function to request a random fill pattern when the "data" argument isn't specified.  This ensures the default behavior is to perform a more realistic fill of incompressible blocks.

Additionally, update a few test cases to request a random fill.

### How Has This Been Tested?

It has not.  We'll see how it does in the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
