### PR TITLE
ZTS: Fix zfs_send_delegation_user test

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -641,9 +641,9 @@ tests = ['zfs_list_001_pos', 'zfs_list_002_pos', 'zfs_list_003_pos',
 user =
 tags = ['functional', 'cli_user', 'zfs_list']
 
-[tests/functional/cli_root/zfs_send_delegation_user]
+[tests/functional/cli_user/zfs_send_delegation_user]
 tests = ['zfs_send_usertest']
-tags = ['functional', 'cli_root', 'zfs_send_delegation_user']
+tags = ['functional', 'cli_user', 'zfs_send_delegation_user']
 
 [tests/functional/cli_user/zpool_iostat]
 tests = ['zpool_iostat_001_neg', 'zpool_iostat_002_pos',


### PR DESCRIPTION
### Motivation and Context

```
  Warning: TestGroup '/var/tmp/tests/functional/cli_root/zfs_send_delegation_user' not added to this run. Auxiliary script '/var/tmp/tests/functional/cli_root/zfs_send_delegation_user/setup' failed verification.
```

https://github.com/openzfs/zfs/actions/runs/17686430319/job/50272200621?pr=17736

### Description

Correct the path in the common.run file.  The zfs_send_delegation_user test is installed under cli_user not cli_root.

### How Has This Been Tested?

Will be verified by the CI.  We should also consider making the verification warnings fatal when run by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)