### PR TITLE
zfsprops(7): attempt to clarify the keylocation description

### DIFF
--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -39,7 +39,7 @@
 .\" Copyright (c) 2019, Kjeld Schouten-Lebbing
 .\" Copyright (c) 2022 Hewlett Packard Enterprise Development LP.
 .\"
-.Dd August 6, 2025
+.Dd September 13, 2025
 .Dt ZFSPROPS 7
 .Os
 .
@@ -1192,18 +1192,26 @@ keylocation can be with either
 .Nm zfs Cm set
 or
 .Nm zfs Cm change-key .
+.Pp
 If
 .Sy prompt
-is selected ZFS will ask for the key at the command prompt when it is required
-to access the encrypted data (see
+is selected, ZFS will expect the key to be provided when it is required to
+access the encrypted data (see
 .Nm zfs Cm load-key
 for details).
-This setting will also allow the key to be passed in via the standard input
-stream,
-but users should be careful not to place keys which should be kept secret on
-the command line.
-If a file URI is selected, the key will be loaded from the
+If stdin is a TTY, then ZFS will ask for the key to be provided.
+Otherwise, stdin is expected to be the key to use and will be processed as such.
+Users should be careful not to place keys which should be kept secret on the
+command line, as most operating systems may expose command line arguments to
+other processes.
+If the
+.Dq raw
+.Sy keyformat
+was used, then the key must be provided via stdin.
+.Pp
+If a file URL is selected, the key will be loaded from the
 specified absolute file path.
+.Pp
 If an HTTPS or HTTP URL is selected, it will be GETted using
 .Xr fetch 3 ,
 libcurl, or nothing, depending on compile-time configuration and run-time


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In trying to scope out how I might be able to incorporate a TPM into a new pool design, it wasn't very clear how I might be able to fit the pieces together to minimize the amount of hacking I might need to do on ZFS itself.  The biggest source of confusion for me, personally, was the description of keylocation (and that "prompt" is maybe not the best name; something like 'adhoc' would have probably been vague enough for me to realize immediately that it wasn't just an interactive thing, prompting is only half of the actual behavior. 'adhoc' is also not a great name so I'm not even proposing anything there).  The end result is that I think all of the pieces are there for me to have something wrap `zfs load-key` that derives a key from the TPM and passes it along with keylocation=prompt, but it seems worth restructuring the description a bit to make it more obvious that this would work.

### Description
<!--- Describe your changes in detail -->
The current description is somewhat difficult to parse through, and in some cases is a little unclear as to the behavior.

Split it into a paragraphs based on the three distinct behaviors you may get: prompt, file URL, HTTP(S) URL.  The descriptions of the file and HTTP(s) behavior seems fine, but prompt is a little vague- expand on it and make it clear that the behavior is actively based on whether the inquisitor of key-data is provided with a tty for stdin or not.

Also clarify *why* one shouldn't "place keys which should be kept secret on the command line" and note that you *have* to supply the key via stdin if it's a raw key, just to be sure.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I read it again after a shallow dive into libzfs_crypto to confirm the behavior.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
