### PR TITLE
Add tunables to control inode & dentry reclaim behaviour

### DIFF
--- a/config/kernel-dentry-operations.m4
+++ b/config/kernel-dentry-operations.m4
@@ -46,12 +46,37 @@ AC_DEFUN([ZFS_AC_KERNEL_D_SET_D_OP], [
 	])
 ])
 
+dnl #
+dnl # 6.17 API change
+dnl # sb->s_d_op removed; set_default_d_op(sb, dop) added
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_SET_DEFAULT_D_OP], [
+	ZFS_LINUX_TEST_SRC([set_default_d_op], [
+		#include <linux/dcache.h>
+	], [
+		set_default_d_op(NULL, NULL);
+	])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_SET_DEFAULT_D_OP], [
+	AC_MSG_CHECKING([whether set_default_d_op() is available])
+	ZFS_LINUX_TEST_RESULT([set_default_d_op], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_SET_DEFAULT_D_OP, 1,
+		    [Define if set_default_d_op() is available])
+	], [
+		AC_MSG_RESULT(no)
+	])
+])
+
 AC_DEFUN([ZFS_AC_KERNEL_SRC_DENTRY], [
         ZFS_AC_KERNEL_SRC_D_OBTAIN_ALIAS
         ZFS_AC_KERNEL_SRC_D_SET_D_OP
+        ZFS_AC_KERNEL_SRC_SET_DEFAULT_D_OP
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_DENTRY], [
         ZFS_AC_KERNEL_D_OBTAIN_ALIAS
         ZFS_AC_KERNEL_D_SET_D_OP
+        ZFS_AC_KERNEL_SET_DEFAULT_D_OP
 ])

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -55,6 +55,7 @@ extern const struct file_operations zpl_dir_file_operations;
 extern void zpl_prune_sb(uint64_t nr_to_scan, void *arg);
 
 extern const struct super_operations zpl_super_operations;
+extern const struct dentry_operations zpl_dentry_operations;
 extern const struct export_operations zpl_export_operations;
 extern struct file_system_type zpl_fs_type;
 

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2604,6 +2604,28 @@ frequently evicted and reloaded.
 .Pp
 This parameter is only available on Linux.
 .
+.It Sy zfs_delete_dentry Ns = Ns Sy 0 Ns | Ns 1 Pq int
+Sets whether the kernel should free a dentry structure when it is no longer
+required, or hold it in the dentry cache.
+Intended for testing/debugging.
+.
+Since a dentry structure holds an inode reference, a cached dentry can "pin"
+an inode in memory indefinitely, along with associated OpenZFS structures (See
+.Sy zfs_delete_inode ) .
+.Pp
+The default value of
+.Sy 0
+instructs the kernel to cache entries and their associated inodes when they
+are no longer directly referenced.
+They will be reclaimed as part of the kernel's normal cache management
+processes.
+Setting it to
+.Sy 1
+will instruct the kernel to release directory entries and their inodes as soon
+as they are no longer referenced by the filesystem.
+.Pp
+This parameter is only available on Linux.
+.
 .It Sy zio_taskq_batch_pct Ns = Ns Sy 80 Ns % Pq uint
 Percentage of online CPUs which will run a worker thread for I/O.
 These workers are responsible for I/O work such as compression, encryption,

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1556,6 +1556,12 @@ zfs_domount(struct super_block *sb, zfs_mnt_t *zm, int silent)
 	sb->s_xattr = zpl_xattr_handlers;
 	sb->s_export_op = &zpl_export_operations;
 
+#ifdef HAVE_SET_DEFAULT_D_OP
+	set_default_d_op(sb, &zpl_dentry_operations);
+#else
+	sb->s_d_op = &zpl_dentry_operations;
+#endif
+
 	/* Set features for file system. */
 	zfs_set_fuid_feature(zfsvfs);
 


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Fastmail Pty Ltd]_

### Motivation and Context

This PR came out of customer investigation into the memory reclaim issues in 2.3.0 that were eventually identified as a regression and resolved by #17487.

That change is undoubtedly correct, ie, when the kernel comes asking for memory, we need to give back what we can. We were tackling it from the other side, trying to release things earlier if both the kernel and OpenZFS agree that they won't be needed again.

This PR adds the scaffolding and a pair of tunables for the kernel's inode and dentry reclaim queries. In both cases, the kernel asks the filesystem "I don't need these any more, should I free them or cache them?". We didn't implement these queries at all at all; this PR adds them, with tunables to control simple "always" and "never" responses, with the defaults set to "always" to keep the traditional behaviour.

The intent at this point is to have a couple of extra hooks available for debugging related issues at customer sites (with somewhat finer control that `echo 3 > drop_caches`, the brute force way to achieve same), but also some shapes to allow experimentation with cache control policy (eg #17159).

### Description

- Implement `super_operations.drop_inode()`, called by the kernel when it wants to drop the last inode reference. The return decides if it should destroy the inode immediately, or put it on the `s_inodes` list in the superblock. The tunable `zfs_delete_inode` decides if the kernel's `generic_delete_inode()` or `generic_drop_inode()` policy functions are called, which signal either an immediate destroy, or (default) cache if the file still exists on disk.

- Implement `dentry_operations.d_delete()`, called by the kernel when it wants to drop the last dentry reference. The return decides if it should destroy the dentry immediately, or return it to the dentry cache. The `zfs_delete_dentry` tunable directly decides this; the default of `0` returns it to the cache. Worth noting that while we don't interact directly with the dentry cache, every active dentry holds an inode reference, which does pin the inode as above.

### How Has This Been Tested?

Compiled back to 4.19, ZTS run on 6.1.x completed.

I ran both of these "on" (destroy everything immediately) as a daily driver for a month. Mostly unnoticeable on my under-loaded laptop, but at least, nothing crashed or broke.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
