### PR TITLE
contrib: dracut: always include zfs kernel module

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -16,7 +16,7 @@ depends() {
 }
 
 installkernel() {
-	instmods -c zfs
+	hostonly='' instmods -c zfs
 }
 
 install() {


### PR DESCRIPTION
This commit fixes the issue and includes the zfs kernel module even when dracut is used in hostonly mode.

### Motivation and Context
Sometimes zfs kernel module is not included in the dracut generated initrd.
One way this can happen if zfs kernel module is not loaded at the time of initrd generation and dracut is instructed to build hostonly initrd (which is the default in some Linux distributions).

This change would also eliminate the need for the following [additional step/workaround in using zfs dracut module](https://openzfs.github.io/openzfs-docs/Getting%20Started/Fedora/Root%20on%20ZFS.html)


```
echo 'force_drivers+=" zfs "' >> /etc/dracut.conf.d/zfs.conf
```

### Description
Ignore the hostonly setting when zfs kernel module is installed.
This is a well established pattern in dracut modules - see e.g. https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/70overlayfs/module-setup.sh#L13

### How Has This Been Tested?
Run into this issue working on a dracut patch and needed to work around this bug in the dracut CI .

### How Has This Been Tested?
If dracut is configured to be in hostonly mode an zfs module is not yet loaded in the host (e.g. maybe because rootfs itself is not zfs, but some other drives that are meant to be mounted in the initramfs are zfs), than the following workaround is needed

> echo 'force_drivers+=" zfs "' >> /etc/dracut.conf.d/zfs.conf

Workarounds like this should not be required.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
