### PR TITLE
Scrub recent data

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -512,8 +512,8 @@ get_usage(zpool_help_t idx)
 		return (gettext("\tinitialize [-c | -s | -u] [-w] <-a | <pool> "
 		    "[<device> ...]>\n"));
 	case HELP_SCRUB:
-		return (gettext("\tscrub [-e | -s | -p | -C | -E | -S] [-w] "
-		    "<-a | <pool> [<pool> ...]>\n"));
+		return (gettext("\tscrub [-e | -s | -p | -C | -E | -S | -R] "
+		    "[-w] <-a | <pool> [<pool> ...]>\n"));
 	case HELP_RESILVER:
 		return (gettext("\tresilver <pool> ...\n"));
 	case HELP_TRIM:
@@ -8523,7 +8523,7 @@ struct zpool_scrub_option {
 };
 
 /*
- * zpool scrub [-e | -s | -p | -C | -E | -S] [-w] [-a | <pool> ...]
+ * zpool scrub [-e | -s | -p | -C | -E | -S | -R] [-w] [-a | <pool> ...]
  *
  *	-a	Scrub all pools.
  *	-e	Only scrub blocks in the error log.
@@ -8531,6 +8531,7 @@ struct zpool_scrub_option {
  *	-S	Start date of scrub.
  *	-s	Stop.  Stops any in-progress scrub.
  *	-p	Pause. Pause in-progress scrub.
+ *	-R	Scrub only recent data.
  *	-w	Wait.  Blocks until scrub has completed.
  *	-C	Scrub from last saved txg.
  */
@@ -8549,11 +8550,12 @@ zpool_do_scrub(int argc, char **argv)
 	struct zpool_scrub_option is_error_scrub = {'e', B_FALSE};
 	struct zpool_scrub_option is_pause = {'p', B_FALSE};
 	struct zpool_scrub_option is_stop = {'s', B_FALSE};
+	struct zpool_scrub_option is_recent = {'R', B_FALSE};
 	struct zpool_scrub_option is_txg_continue = {'C', B_FALSE};
 	struct zpool_scrub_option scrub_all = {'a', B_FALSE};
 
 	/* check options */
-	while ((c = getopt(argc, argv, "aspweCE:S:")) != -1) {
+	while ((c = getopt(argc, argv, "aspweCE:S:R")) != -1) {
 		switch (c) {
 		case 'a':
 			scrub_all.enabled = B_TRUE;
@@ -8577,6 +8579,9 @@ zpool_do_scrub(int argc, char **argv)
 		case 'p':
 			is_pause.enabled = B_TRUE;
 			break;
+		case 'R':
+			is_recent.enabled = B_TRUE;
+			break;
 		case 'w':
 			wait.enabled = B_TRUE;
 			break;
@@ -8597,9 +8602,13 @@ zpool_do_scrub(int argc, char **argv)
 		{&is_stop, &is_pause},
 		{&is_stop, &is_txg_continue},
 		{&is_stop, &is_error_scrub},
+		{&is_stop, &is_recent},
 		{&is_pause, &is_txg_continue},
 		{&is_pause, &is_error_scrub},
+		{&is_pause, &is_recent},
 		{&is_error_scrub, &is_txg_continue},
+		{&is_error_scrub, &is_recent},
+		{&is_recent, &is_txg_continue},
 	};
 
 	for (int i = 0; i < sizeof (scrub_exclusive_options) /
@@ -8624,6 +8633,8 @@ zpool_do_scrub(int argc, char **argv)
 		cb.cb_type = POOL_SCAN_NONE;
 	} else if (is_txg_continue.enabled) {
 		cb.cb_scrub_cmd = POOL_SCRUB_FROM_LAST_TXG;
+	} else if (is_recent.enabled) {
+		cb.cb_scrub_cmd = POOL_SCRUB_RECENT;
 	} else {
 		cb.cb_scrub_cmd = POOL_SCRUB_NORMAL;
 	}

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -8517,6 +8517,11 @@ date_string_to_sec(const char *timestr, boolean_t rounding)
 	return (mktime(&tm) + adjustment);
 }
 
+struct zpool_scrub_option {
+	char name;
+	boolean_t enabled;
+};
+
 /*
  * zpool scrub [-e | -s | -p | -C | -E | -S] [-w] [-a | <pool> ...]
  *
@@ -8534,27 +8539,27 @@ zpool_do_scrub(int argc, char **argv)
 {
 	int c;
 	scrub_cbdata_t cb;
-	boolean_t wait = B_FALSE;
 	int error;
 
 	cb.cb_type = POOL_SCAN_SCRUB;
 	cb.cb_scrub_cmd = POOL_SCRUB_NORMAL;
 	cb.cb_date_start = cb.cb_date_end = 0;
 
-	boolean_t is_error_scrub = B_FALSE;
-	boolean_t is_pause = B_FALSE;
-	boolean_t is_stop = B_FALSE;
-	boolean_t is_txg_continue = B_FALSE;
-	boolean_t scrub_all = B_FALSE;
+	struct zpool_scrub_option wait = {'w', B_FALSE};
+	struct zpool_scrub_option is_error_scrub = {'e', B_FALSE};
+	struct zpool_scrub_option is_pause = {'p', B_FALSE};
+	struct zpool_scrub_option is_stop = {'s', B_FALSE};
+	struct zpool_scrub_option is_txg_continue = {'C', B_FALSE};
+	struct zpool_scrub_option scrub_all = {'a', B_FALSE};
 
 	/* check options */
 	while ((c = getopt(argc, argv, "aspweCE:S:")) != -1) {
 		switch (c) {
 		case 'a':
-			scrub_all = B_TRUE;
+			scrub_all.enabled = B_TRUE;
 			break;
 		case 'e':
-			is_error_scrub = B_TRUE;
+			is_error_scrub.enabled = B_TRUE;
 			break;
 		case 'E':
 			/*
@@ -8564,19 +8569,19 @@ zpool_do_scrub(int argc, char **argv)
 			cb.cb_date_end = date_string_to_sec(optarg, B_TRUE);
 			break;
 		case 's':
-			is_stop = B_TRUE;
+			is_stop.enabled = B_TRUE;
 			break;
 		case 'S':
 			cb.cb_date_start = date_string_to_sec(optarg, B_FALSE);
 			break;
 		case 'p':
-			is_pause = B_TRUE;
+			is_pause.enabled = B_TRUE;
 			break;
 		case 'w':
-			wait = B_TRUE;
+			wait.enabled = B_TRUE;
 			break;
 		case 'C':
-			is_txg_continue = B_TRUE;
+			is_txg_continue.enabled = B_TRUE;
 			break;
 		case '?':
 			(void) fprintf(stderr, gettext("invalid option '%c'\n"),
@@ -8585,35 +8590,40 @@ zpool_do_scrub(int argc, char **argv)
 		}
 	}
 
-	if (is_pause && is_stop) {
-		(void) fprintf(stderr, gettext("invalid option "
-		    "combination: -s and -p are mutually exclusive\n"));
-		usage(B_FALSE);
-	} else if (is_pause && is_txg_continue) {
-		(void) fprintf(stderr, gettext("invalid option "
-		    "combination: -p and -C are mutually exclusive\n"));
-		usage(B_FALSE);
-	} else if (is_stop && is_txg_continue) {
-		(void) fprintf(stderr, gettext("invalid option "
-		    "combination: -s and -C are mutually exclusive\n"));
-		usage(B_FALSE);
-	} else if (is_error_scrub && is_txg_continue) {
-		(void) fprintf(stderr, gettext("invalid option "
-		    "combination: -e and -C are mutually exclusive\n"));
-		usage(B_FALSE);
-	} else {
-		if (is_error_scrub)
-			cb.cb_type = POOL_SCAN_ERRORSCRUB;
+	struct {
+		struct zpool_scrub_option *op1;
+		struct zpool_scrub_option *op2;
+	} scrub_exclusive_options[] = {
+		{&is_stop, &is_pause},
+		{&is_stop, &is_txg_continue},
+		{&is_pause, &is_txg_continue},
+		{&is_error_scrub, &is_txg_continue},
+	};
 
-		if (is_pause) {
-			cb.cb_scrub_cmd = POOL_SCRUB_PAUSE;
-		} else if (is_stop) {
-			cb.cb_type = POOL_SCAN_NONE;
-		} else if (is_txg_continue) {
-			cb.cb_scrub_cmd = POOL_SCRUB_FROM_LAST_TXG;
-		} else {
-			cb.cb_scrub_cmd = POOL_SCRUB_NORMAL;
+	for (int i = 0; i < sizeof (scrub_exclusive_options) /
+	    sizeof (scrub_exclusive_options[0]); i++) {
+		if (scrub_exclusive_options[i].op1->enabled &&
+		    scrub_exclusive_options[i].op2->enabled) {
+			(void) fprintf(stderr, gettext("invalid option "
+			    "combination: -%c and -%c are mutually "
+			    "exclusive\n"),
+			    scrub_exclusive_options[i].op1->name,
+			    scrub_exclusive_options[i].op2->name);
+			usage(B_FALSE);
 		}
+	}
+
+	if (is_error_scrub.enabled)
+		cb.cb_type = POOL_SCAN_ERRORSCRUB;
+
+	if (is_pause.enabled) {
+		cb.cb_scrub_cmd = POOL_SCRUB_PAUSE;
+	} else if (is_stop.enabled) {
+		cb.cb_type = POOL_SCAN_NONE;
+	} else if (is_txg_continue.enabled) {
+		cb.cb_scrub_cmd = POOL_SCRUB_FROM_LAST_TXG;
+	} else {
+		cb.cb_scrub_cmd = POOL_SCRUB_NORMAL;
 	}
 
 	if ((cb.cb_date_start != 0 || cb.cb_date_end != 0) &&
@@ -8629,7 +8639,7 @@ zpool_do_scrub(int argc, char **argv)
 		usage(B_FALSE);
 	}
 
-	if (wait && (cb.cb_type == POOL_SCAN_NONE ||
+	if (wait.enabled && (cb.cb_type == POOL_SCAN_NONE ||
 	    cb.cb_scrub_cmd == POOL_SCRUB_PAUSE)) {
 		(void) fprintf(stderr, gettext("invalid option combination: "
 		    "-w cannot be used with -p or -s\n"));
@@ -8639,7 +8649,7 @@ zpool_do_scrub(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-	if (argc < 1 && !scrub_all) {
+	if (argc < 1 && !scrub_all.enabled) {
 		(void) fprintf(stderr, gettext("missing pool name argument\n"));
 		usage(B_FALSE);
 	}
@@ -8647,7 +8657,7 @@ zpool_do_scrub(int argc, char **argv)
 	error = for_each_pool(argc, argv, B_TRUE, NULL, ZFS_TYPE_POOL,
 	    B_FALSE, scrub_callback, &cb);
 
-	if (wait && !error) {
+	if (wait.enabled && !error) {
 		zpool_wait_activity_t act = ZPOOL_WAIT_SCRUB;
 		error = for_each_pool(argc, argv, B_TRUE, NULL, ZFS_TYPE_POOL,
 		    B_FALSE, wait_callback, &act);

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -8596,7 +8596,9 @@ zpool_do_scrub(int argc, char **argv)
 	} scrub_exclusive_options[] = {
 		{&is_stop, &is_pause},
 		{&is_stop, &is_txg_continue},
+		{&is_stop, &is_error_scrub},
 		{&is_pause, &is_txg_continue},
+		{&is_pause, &is_error_scrub},
 		{&is_error_scrub, &is_txg_continue},
 	};
 

--- a/include/os/freebsd/spl/sys/mod.h
+++ b/include/os/freebsd/spl/sys/mod.h
@@ -86,6 +86,15 @@
 #define	param_set_deadman_ziotime_args(var) \
     CTLTYPE_U64, NULL, 0, param_set_deadman_ziotime, "QU"
 
+#define	scrub_param_set_recent_time_args(var) \
+    CTLTYPE_U64, NULL, 0, scrub_param_set_recent_time, "QU"
+
+#define	scrub_param_set_recent_time_hours_args(var) \
+    CTLTYPE_U64, NULL, 0, scrub_param_set_recent_time_hours, "QU"
+
+#define	scrub_param_set_recent_time_days_args(var) \
+    CTLTYPE_U64, NULL, 0, scrub_param_set_recent_time_days, "QU"
+
 #define	param_set_multihost_interval_args(var) \
     CTLTYPE_U64, NULL, 0, param_set_multihost_interval, "QU"
 

--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -45,6 +45,9 @@ struct dsl_pool;
 struct dmu_tx;
 
 extern int zfs_scan_suspend_progress;
+extern uint64_t zfs_scrub_recent_time;
+extern uint64_t zfs_scrub_recent_time_hours;
+extern uint64_t zfs_scrub_recent_time_days;
 
 /*
  * All members of this structure must be uint64_t, for byteswap
@@ -221,6 +224,10 @@ boolean_t dsl_errorscrub_is_paused(const dsl_scan_t *scn);
 void dsl_scan_freed(spa_t *spa, const blkptr_t *bp);
 void dsl_scan_io_queue_destroy(dsl_scan_io_queue_t *queue);
 void dsl_scan_io_queue_vdev_xfer(vdev_t *svd, vdev_t *tvd);
+
+int scrub_param_set_recent_time(ZFS_MODULE_PARAM_ARGS);
+int scrub_param_set_recent_time_hours(ZFS_MODULE_PARAM_ARGS);
+int scrub_param_set_recent_time_days(ZFS_MODULE_PARAM_ARGS);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -45,6 +45,7 @@ struct dsl_pool;
 struct dmu_tx;
 
 extern int zfs_scan_suspend_progress;
+extern int zfs_scrub_after_resume;
 extern uint64_t zfs_scrub_recent_time;
 extern uint64_t zfs_scrub_recent_time_hours;
 extern uint64_t zfs_scrub_recent_time_days;

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1223,6 +1223,7 @@ typedef enum pool_scrub_cmd {
 	POOL_SCRUB_NORMAL = 0,
 	POOL_SCRUB_PAUSE,
 	POOL_SCRUB_FROM_LAST_TXG,
+	POOL_SCRUB_RECENT,
 	POOL_SCRUB_FLAGS_END
 } pool_scrub_cmd_t;
 

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -851,6 +851,7 @@ extern void spa_l2cache_drop(spa_t *spa);
 extern int spa_scan(spa_t *spa, pool_scan_func_t func);
 extern int spa_scan_range(spa_t *spa, pool_scan_func_t func, uint64_t txgstart,
     uint64_t txgend);
+extern int spa_scan_recent(spa_t *spa);
 extern int spa_scan_stop(spa_t *spa);
 extern int spa_scrub_pause_resume(spa_t *spa, pool_scrub_cmd_t flag);
 

--- a/include/zfs_crrd.h
+++ b/include/zfs_crrd.h
@@ -71,5 +71,6 @@ void rrd_add(rrd_t *rrd, hrtime_t time, uint64_t txg);
 
 void dbrrd_add(dbrrd_t *db, hrtime_t time, uint64_t txg);
 uint64_t dbrrd_query(dbrrd_t *r, hrtime_t tv, dbrrd_rounding_t rouding);
+hrtime_t dbrrd_tail_time(dbrrd_t *r);
 
 #endif

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -6486,7 +6486,8 @@
       <enumerator name='POOL_SCRUB_NORMAL' value='0'/>
       <enumerator name='POOL_SCRUB_PAUSE' value='1'/>
       <enumerator name='POOL_SCRUB_FROM_LAST_TXG' value='2'/>
-      <enumerator name='POOL_SCRUB_FLAGS_END' value='3'/>
+      <enumerator name='POOL_SCRUB_RECENT' value='3'/>
+      <enumerator name='POOL_SCRUB_FLAGS_END' value='4'/>
     </enum-decl>
     <typedef-decl name='pool_scrub_cmd_t' type-id='a1474cbd' id='b51cf3c2'/>
     <enum-decl name='zpool_errata' id='d9abbf54'>

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2126,6 +2126,16 @@ to 3600 and
 .Sy zfs_scrub_recent_time_days
 to 0.
 .
+.It Sy zfs_scrub_after_resume Ns = Ns Sy 1 Ns | Ns 0 Pq int
+When a
+.Nm zpool Cm clear
+command resumes a pool that was suspended, automatically start a scrub of the
+most recently written data
+.Pq see Sy zfs_scrub_recent_time .
+Set to
+.Sy 0
+to disable this behavior.
+.
 .It Sy zfs_nocacheflush Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Disable cache flush operations on disks when writing.
 Setting this will cause pool corruption on power loss

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2108,6 +2108,24 @@ simply doing a metadata crawl of the pool instead.
 .It Sy zfs_no_scrub_prefetch Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Set to disable block prefetching for scrubs.
 .
+.It Sy zfs_scrub_recent_time Ns = Ns Sy 14400 Pq uint
+.It Sy zfs_scrub_recent_time_hours Ns = Ns Sy 4 Pq uint
+.It Sy zfs_scrub_recent_time_days Ns = Ns Sy 0 Pq uint
+Set the time interval that defines which data is considered most recent.
+The interval is measured relative to the last known TXG in the TXG database.
+.Pp
+This setting can be specified using one of three properties: seconds, hours,
+or days.
+These properties are provided for user convenience.
+Each represents the same value, expressed in different units of time.
+For example, setting the
+.Sy zfs_scrub_recent_time_hours
+property to 1 will automatically set the
+.Sy zfs_scrub_recent_time
+to 3600 and
+.Sy zfs_scrub_recent_time_days
+to 0.
+.
 .It Sy zfs_nocacheflush Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Disable cache flush operations on disks when writing.
 Setting this will cause pool corruption on power loss

--- a/man/man8/zpool-clear.8
+++ b/man/man8/zpool-clear.8
@@ -55,6 +55,13 @@ enabled which have been suspended cannot be resumed when there is evidence
 that the pool was imported by another host.
 The same checks performed during an import will be applied before the clear
 proceeds.
+.Pp
+When a suspended pool is resumed, a scrub of the most recently written data is
+automatically started.
+This scrub can be disabled with the
+.Sy zfs_scrub_after_resume
+module parameter; see
+.Xr zfs 4 .
 .Bl -tag -width Ds
 .It Fl -power
 Power on the devices's slot in the storage enclosure and wait for the device

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -269,6 +269,64 @@ param_set_arc_no_grow_shift(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
+/* dsl_scan.c */
+
+static void
+scrub_set_recent_time(uint64_t sec)
+{
+	zfs_scrub_recent_time = sec;
+	zfs_scrub_recent_time_hours = sec / 3600;
+	zfs_scrub_recent_time_days = sec / 86400;
+}
+
+int
+scrub_param_set_recent_time(SYSCTL_HANDLER_ARGS)
+{
+	uint64_t val;
+	int err;
+
+	val = zfs_scrub_recent_time;
+	err = sysctl_handle_64(oidp, &val, 0, req);
+	if (err != 0 || req->newptr == NULL)
+		return (err);
+
+	scrub_set_recent_time(val);
+
+	return (0);
+}
+
+int
+scrub_param_set_recent_time_hours(SYSCTL_HANDLER_ARGS)
+{
+	uint64_t val;
+	int err;
+
+	val = zfs_scrub_recent_time_hours;
+	err = sysctl_handle_64(oidp, &val, 0, req);
+	if (err != 0 || req->newptr == NULL)
+		return (err);
+
+	scrub_set_recent_time(val * 3600);
+
+	return (0);
+}
+
+int
+scrub_param_set_recent_time_days(SYSCTL_HANDLER_ARGS)
+{
+	uint64_t val;
+	int err;
+
+	val = zfs_scrub_recent_time_days;
+	err = sysctl_handle_64(oidp, &val, 0, req);
+	if (err != 0 || req->newptr == NULL)
+		return (err);
+
+	scrub_set_recent_time(val * 86400);
+
+	return (0);
+}
+
 /* metaslab.c */
 
 int
@@ -447,7 +505,6 @@ param_set_slop_shift(SYSCTL_HANDLER_ARGS)
 /* spacemap.c */
 
 extern int space_map_ibs;
-
 SYSCTL_INT(_vfs_zfs, OID_AUTO, space_map_ibs, CTLFLAG_RWTUN,
 	&space_map_ibs, 0, "Space map indirect block shift");
 

--- a/module/os/linux/zfs/spa_misc_os.c
+++ b/module/os/linux/zfs/spa_misc_os.c
@@ -114,8 +114,64 @@ param_set_active_allocator(const char *val, zfs_kernel_param_t *kp)
 	error = -param_set_active_allocator_common(val);
 	if (error == 0)
 		error = param_set_charp(val, kp);
+	error = spl_param_set_u64(val, kp);
+	if (error < 0)
+		return (SET_ERROR(error));
 
 	return (error);
+}
+
+static void
+scrub_set_recent_time(uint64_t sec)
+{
+	zfs_scrub_recent_time = sec;
+	zfs_scrub_recent_time_hours = sec / 3600;
+	zfs_scrub_recent_time_days = sec / 86400;
+}
+
+int
+scrub_param_set_recent_time(const char *buf, zfs_kernel_param_t *kp)
+{
+	uint64_t val;
+	int error;
+
+	error = kstrtoull(buf, 0, &val);
+	if (error)
+		return (SET_ERROR(error));
+
+	scrub_set_recent_time(val);
+
+	return (0);
+}
+
+int
+scrub_param_set_recent_time_hours(const char *buf, zfs_kernel_param_t *kp)
+{
+	uint64_t val;
+	int error;
+
+	error = kstrtoull(buf, 0, &val);
+	if (error)
+		return (SET_ERROR(error));
+
+	scrub_set_recent_time(val * 3600);
+
+	return (0);
+}
+
+int
+scrub_param_set_recent_time_days(const char *buf, zfs_kernel_param_t *kp)
+{
+	uint64_t val;
+	int error;
+
+	error = kstrtoull(buf, 0, &val);
+	if (error)
+		return (SET_ERROR(error));
+
+	scrub_set_recent_time(val * 86400);
+
+	return (0);
 }
 
 const char *

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -258,6 +258,12 @@ uint64_t zfs_scrub_recent_time = 14400;
 uint64_t zfs_scrub_recent_time_hours = 4;
 uint64_t zfs_scrub_recent_time_days = 0;
 
+/*
+ * Automatically scrub recent data when 'zpool clear' resumes a pool that
+ * was suspended.
+ */
+int zfs_scrub_after_resume = 1;
+
 /* the order has to match pool_scan_type */
 static scan_cb_t *scan_funcs[POOL_SCAN_FUNCS] = {
 	NULL,
@@ -5412,3 +5418,6 @@ ZFS_MODULE_PARAM_CALL(zfs, zfs_, scrub_recent_time_days,
 	"Defines the time window for recent scrub in days. "
 	"Adjusting this value will also update the seconds and hours "
 	"equivalents");
+
+ZFS_MODULE_PARAM(zfs, zfs_, scrub_after_resume, INT, ZMOD_RW,
+	"Scrub recent data when 'zpool clear' resumes a suspended pool");

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -250,6 +250,14 @@ static int zfs_free_bpobj_enabled = 1;
 /* Error blocks to be scrubbed in one txg. */
 static uint_t zfs_scrub_error_blocks_per_txg = 1 << 12;
 
+/*
+ * The number of TXGs should be scrubbed while scrubbing recent data.
+ * Default: 4 hours.
+ */
+uint64_t zfs_scrub_recent_time = 14400;
+uint64_t zfs_scrub_recent_time_hours = 4;
+uint64_t zfs_scrub_recent_time_days = 0;
+
 /* the order has to match pool_scan_type */
 static scan_cb_t *scan_funcs[POOL_SCAN_FUNCS] = {
 	NULL,
@@ -5387,3 +5395,20 @@ ZFS_MODULE_PARAM(zfs, zfs_, resilver_defer_percent, UINT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs, zfs_, scrub_error_blocks_per_txg, UINT, ZMOD_RW,
 	"Error blocks to be scrubbed in one txg");
+
+ZFS_MODULE_PARAM_CALL(zfs, zfs_, scrub_recent_time, scrub_param_set_recent_time,
+	spl_param_get_u64, ZMOD_RW,
+	"Defines the time window for recent scrub in seconds. "
+	"Adjusting this value will also update the hours and days equivalents");
+
+ZFS_MODULE_PARAM_CALL(zfs, zfs_, scrub_recent_time_hours,
+	scrub_param_set_recent_time_hours, spl_param_get_u64, ZMOD_RW,
+	"Defines the time window for recent scrub in hours. "
+	"Adjusting this value will also update the seconds and days "
+	"equivalents");
+
+ZFS_MODULE_PARAM_CALL(zfs, zfs_, scrub_recent_time_days,
+	scrub_param_set_recent_time_days, spl_param_get_u64, ZMOD_RW,
+	"Defines the time window for recent scrub in days. "
+	"Adjusting this value will also update the seconds and hours "
+	"equivalents");

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -9727,6 +9727,23 @@ spa_scan_range(spa_t *spa, pool_scan_func_t func, uint64_t txgstart,
 	return (dsl_scan(spa->spa_dsl_pool, func, txgstart, txgend));
 }
 
+int
+spa_scan_recent(spa_t *spa)
+{
+	uint64_t txg_start = 0;
+	hrtime_t lasttime;
+
+	mutex_enter(&spa->spa_txg_log_time_lock);
+	lasttime = dbrrd_tail_time(&spa->spa_txg_log_time);
+	if (lasttime > zfs_scrub_recent_time) {
+		txg_start = dbrrd_query(&spa->spa_txg_log_time,
+		    lasttime - zfs_scrub_recent_time, DBRRD_FLOOR);
+	}
+	mutex_exit(&spa->spa_txg_log_time_lock);
+
+	return (spa_scan_range(spa, POOL_SCAN_SCRUB, txg_start, 0));
+}
+
 /*
  * ==========================================================================
  * SPA async task processing
@@ -11780,6 +11797,7 @@ EXPORT_SYMBOL(spa_l2cache_drop);
 /* scanning */
 EXPORT_SYMBOL(spa_scan);
 EXPORT_SYMBOL(spa_scan_range);
+EXPORT_SYMBOL(spa_scan_recent);
 EXPORT_SYMBOL(spa_scan_stop);
 
 /* spa syncing */

--- a/module/zfs/zfs_crrd.c
+++ b/module/zfs/zfs_crrd.c
@@ -226,3 +226,22 @@ dbrrd_query(dbrrd_t *r, hrtime_t tv, dbrrd_rounding_t rounding)
 
 	return (data == NULL ? 0 : data->rrdd_txg);
 }
+
+hrtime_t
+dbrrd_tail_time(dbrrd_t *r)
+{
+	const rrd_data_t *data, *dd, *dy;
+
+	data = rrd_tail_entry(&r->dbr_minutes);
+	dd = rrd_tail_entry(&r->dbr_days);
+	dy = rrd_tail_entry(&r->dbr_months);
+
+	if (data == NULL || (dd != NULL && data->rrdd_time < dd->rrdd_time)) {
+		data = dd;
+	}
+	if (data == NULL || (dy != NULL && data->rrdd_time < dy->rrdd_time)) {
+		data = dy;
+	}
+
+	return (data == NULL ? 0 : data->rrdd_time);
+}

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1975,19 +1975,7 @@ zfs_ioc_pool_scrub(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 		error = spa_scan_range(spa, scan_type,
 		    spa_get_last_scrubbed_txg(spa), 0);
 	} else if (scan_cmd == POOL_SCRUB_RECENT) {
-		uint64_t txg_start;
-		hrtime_t lasttime;
-
-		txg_start = 0;
-		mutex_enter(&spa->spa_txg_log_time_lock);
-		lasttime = dbrrd_tail_time(&spa->spa_txg_log_time);
-		if (lasttime > zfs_scrub_recent_time) {
-			txg_start = dbrrd_query(&spa->spa_txg_log_time,
-			    lasttime - zfs_scrub_recent_time, DBRRD_FLOOR);
-		}
-		mutex_exit(&spa->spa_txg_log_time_lock);
-
-		error = spa_scan_range(spa, scan_type, txg_start, 0);
+		error = spa_scan_recent(spa);
 	} else {
 		uint64_t txg_start, txg_end;
 
@@ -6413,6 +6401,7 @@ zfs_ioc_clear(zfs_cmd_t *zc)
 	spa_t *spa;
 	vdev_t *vd;
 	int error;
+	boolean_t resume_scrub;
 
 	/*
 	 * On zpool clear we also fix up missing slogs
@@ -6467,6 +6456,7 @@ zfs_ioc_clear(zfs_cmd_t *zc)
 		return (SET_ERROR(EREMOTEIO));
 	}
 
+	resume_scrub = spa_suspended(spa);
 	spa_vdev_state_enter(spa, SCL_NONE);
 
 	if (zc->zc_guid == 0) {
@@ -6491,6 +6481,13 @@ zfs_ioc_clear(zfs_cmd_t *zc)
 	 */
 	if (zio_resume(spa) != 0)
 		error = SET_ERROR(EIO);
+
+	/*
+	 * If we successfully resumed a previously suspended pool, scrub the
+	 * recently written data.
+	 */
+	if (error == 0 && resume_scrub && zfs_scrub_after_resume)
+		(void) spa_scan_recent(spa);
 
 	spa_close(spa, FTAG);
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1974,6 +1974,20 @@ zfs_ioc_pool_scrub(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 	} else if (scan_cmd == POOL_SCRUB_FROM_LAST_TXG) {
 		error = spa_scan_range(spa, scan_type,
 		    spa_get_last_scrubbed_txg(spa), 0);
+	} else if (scan_cmd == POOL_SCRUB_RECENT) {
+		uint64_t txg_start;
+		hrtime_t lasttime;
+
+		txg_start = 0;
+		mutex_enter(&spa->spa_txg_log_time_lock);
+		lasttime = dbrrd_tail_time(&spa->spa_txg_log_time);
+		if (lasttime > zfs_scrub_recent_time) {
+			txg_start = dbrrd_query(&spa->spa_txg_log_time,
+			    lasttime - zfs_scrub_recent_time, DBRRD_FLOOR);
+		}
+		mutex_exit(&spa->spa_txg_log_time_lock);
+
+		error = spa_scan_range(spa, scan_type, txg_start, 0);
 	} else {
 		uint64_t txg_start, txg_end;
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -568,7 +568,8 @@ tests = ['zpool_scrub_001_neg', 'zpool_scrub_002_pos', 'zpool_scrub_003_pos',
     'zpool_scrub_multiple_pools',
     'zpool_error_scrub_001_pos', 'zpool_error_scrub_002_pos',
     'zpool_error_scrub_003_pos', 'zpool_error_scrub_004_pos',
-    'zpool_scrub_date_range_001', 'zpool_scrub_date_range_002']
+    'zpool_scrub_date_range_001', 'zpool_scrub_date_range_002',
+    'zpool_scrub_recent_time_settings', 'zpool_scrub_recent_data']
 tags = ['functional', 'cli_root', 'zpool_scrub']
 
 [tests/functional/cli_root/zpool_set]

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -86,6 +86,7 @@ SCAN_LEGACY			scan_legacy			zfs_scan_legacy
 SCAN_SUSPEND_PROGRESS		scan_suspend_progress		zfs_scan_suspend_progress
 SCAN_VDEV_LIMIT			scan_vdev_limit			zfs_scan_vdev_limit
 SCRUB_AFTER_EXPAND		scrub_after_expand		zfs_scrub_after_expand
+SCRUB_AFTER_RESUME		scrub_after_resume		zfs_scrub_after_resume
 SCRUB_RECENT_TIME		scrub_recent_time		zfs_scrub_recent_time
 SCRUB_RECENT_TIME_HOURS		scrub_recent_time_hours		zfs_scrub_recent_time_hours
 SCRUB_RECENT_TIME_DAYS		scrub_recent_time_days		zfs_scrub_recent_time_days

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -86,6 +86,9 @@ SCAN_LEGACY			scan_legacy			zfs_scan_legacy
 SCAN_SUSPEND_PROGRESS		scan_suspend_progress		zfs_scan_suspend_progress
 SCAN_VDEV_LIMIT			scan_vdev_limit			zfs_scan_vdev_limit
 SCRUB_AFTER_EXPAND		scrub_after_expand		zfs_scrub_after_expand
+SCRUB_RECENT_TIME		scrub_recent_time		zfs_scrub_recent_time
+SCRUB_RECENT_TIME_HOURS		scrub_recent_time_hours		zfs_scrub_recent_time_hours
+SCRUB_RECENT_TIME_DAYS		scrub_recent_time_days		zfs_scrub_recent_time_days
 SEND_HOLES_WITHOUT_BIRTH_TIME	send_holes_without_birth_time	send_holes_without_birth_time
 SLOW_IO_EVENTS_PER_SECOND	slow_io_events_per_second	zfs_slow_io_events_per_second
 SPA_ASIZE_INFLATION		spa.asize_inflation		spa_asize_inflation

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1287,6 +1287,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_scrub/zpool_scrub_multiple_pools.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_offline_device.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_print_repairing.ksh \
+	functional/cli_root/zpool_scrub/zpool_scrub_recent_data.ksh \
+	functional/cli_root/zpool_scrub/zpool_scrub_recent_time_settings.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_txg_continue_from_last.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_date_range_001.ksh \
 	functional/cli_root/zpool_scrub/zpool_scrub_date_range_002.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_recent_data.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_recent_data.ksh
@@ -1,0 +1,92 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 Klara Inc.
+#
+# This software was developed by Mariusz Zaborski <oshogbo@FreeBSD.org>
+# under sponsorship from Wasabi Technology, Inc. and Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+
+#
+# DESCRIPTION:
+#	Verify that `zpool scrub -R` scrubs only recent data and
+#	does not report errors in older data.
+#
+# STRATEGY:
+#	 1. Adjust the scrub_recent_time to a small value to make the test quick
+#	    and concise.
+#	 2. Create the first file.
+#	 3. Export, wait, and re-import the pool to record entries in the TXG
+#	    database and to add some time margin between the files.
+#	 4. Create the second file.
+#	 5. Inject errors into the first file.
+#	 6. Run a scrub to detect the errors in the pool.
+#	 7. Verify that errors in the first file are detected and that
+#	    the second file is not corrupted.
+#	 8. Inject errors into the second file.
+#	 9. Clear errors and run `zpool scrub -R`.
+#	10. Confirm that only new errors corresponding to recent data
+#	    (the second file) are detected, and errors from the first
+#	    file are not found by the recent scrub.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must zinject -c all
+	rm -f $TESTDIR/*_file
+	log_must restore_tunable SCRUB_RECENT_TIME
+}
+
+log_onexit cleanup
+
+log_assert "Verify that 'zpool scrub -R' scrubs only recent data."
+
+log_must save_tunable SCRUB_RECENT_TIME
+log_must set_tunable64 SCRUB_RECENT_TIME 30
+
+log_must file_write -o create -f"$TESTDIR/0_file" \
+    -b 512 -c 2048 -dR
+log_must zpool export $TESTPOOL
+log_must sleep 60
+log_must zpool import $TESTPOOL
+log_must file_write -o create -f"$TESTDIR/1_file" \
+    -b 512 -c 2048 -dR
+
+log_must zinject -t data -e checksum -f 100 $TESTDIR/0_file
+log_must zpool scrub $TESTPOOL
+log_must eval "zpool status -v $TESTPOOL | grep '0_file'"
+log_mustnot eval "zpool status -v $TESTPOOL | grep '1_file'"
+
+log_must zinject -t data -e checksum -f 100 $TESTDIR/1_file
+log_must zpool clear $TESTPOOL
+log_must zpool scrub -R $TESTPOOL
+log_mustnot eval "zpool status -v $TESTPOOL | grep '0_file'"
+log_must eval "zpool status -v $TESTPOOL | grep '1_file'"
+
+log_pass "Verified that 'zpool scrub -R' scrubs only recent data."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_recent_data.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_recent_data.ksh
@@ -80,12 +80,14 @@ log_must file_write -o create -f"$TESTDIR/1_file" \
 
 log_must zinject -t data -e checksum -f 100 $TESTDIR/0_file
 log_must zpool scrub $TESTPOOL
+log_must wait_scrubbed $TESTPOOL
 log_must eval "zpool status -v $TESTPOOL | grep '0_file'"
 log_mustnot eval "zpool status -v $TESTPOOL | grep '1_file'"
 
 log_must zinject -t data -e checksum -f 100 $TESTDIR/1_file
 log_must zpool clear $TESTPOOL
 log_must zpool scrub -R $TESTPOOL
+log_must wait_scrubbed $TESTPOOL
 log_mustnot eval "zpool status -v $TESTPOOL | grep '0_file'"
 log_must eval "zpool status -v $TESTPOOL | grep '1_file'"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_recent_time_settings.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_recent_time_settings.ksh
@@ -1,0 +1,147 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025 Klara Inc.
+#
+# This software was developed by Mariusz Zaborski <oshogbo@FreeBSD.org>
+# under sponsorship from Wasabi Technology, Inc. and Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+
+#
+# DESCRIPTION:
+#	Verify that scrub_recent_time is correctly calculated.
+#
+# STRATEGY:
+#	1. Set scrub_recent_time and check if the scrub_recent_time_hours are
+#	   scrub_recent_time_day are set correctly.
+#	2. Set scrub_recent_time_hours and check if the scrub_recent_time are
+#	   scrub_recent_time_day are set correctly.
+#	3. Set scrub_recent_time_day and check if the scrub_recent_time are
+#	   scrub_recent_time_hours are set correctly.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must restore_tunable SCRUB_RECENT_TIME
+}
+
+function check_scrub_recent_time
+{
+	recent_time="${1}"
+	recent_time_hours="${2}"
+	recent_time_days="${3}"
+
+	[[ "${recent_time}" == "$(get_tunable SCRUB_RECENT_TIME)" ]] || \
+		log_fail "scrub_recent_time has wrong value"
+	[[ "${recent_time_hours}" == "$(get_tunable SCRUB_RECENT_TIME_HOURS)" ]] || \
+		log_fail "scrub_recent_time_hours has wrong value"
+	[[ "${recent_time_days}" == "$(get_tunable SCRUB_RECENT_TIME_DAYS)" ]] || \
+		log_fail "scrub_recent_time_days has wrong value"
+}
+
+log_onexit cleanup
+
+log_assert "Verify "\
+    "scrub_recent_time/scrub_recent_time_hours/scrub_recent_time_days is "\
+    "calculated correctly."
+
+log_must save_tunable SCRUB_RECENT_TIME
+
+log_must set_tunable64 SCRUB_RECENT_TIME 1
+check_scrub_recent_time "1" "0" "0"
+
+log_must set_tunable64 SCRUB_RECENT_TIME "30"
+check_scrub_recent_time "30" "0" "0"
+
+log_must set_tunable64 SCRUB_RECENT_TIME "59"
+check_scrub_recent_time "59" "0" "0"
+
+log_must set_tunable64 SCRUB_RECENT_TIME "60"
+check_scrub_recent_time "60" "0" "0"
+
+log_must set_tunable64 SCRUB_RECENT_TIME "3600"
+check_scrub_recent_time "3600" "1" "0"
+
+log_must set_tunable64 SCRUB_RECENT_TIME "86400"
+check_scrub_recent_time "86400" "24" "1"
+
+log_must set_tunable64 SCRUB_RECENT_TIME "172800"
+check_scrub_recent_time "172800" "48" "2"
+
+log_must set_tunable64 SCRUB_RECENT_TIME "100000"
+check_scrub_recent_time "100000" "27" "1"
+
+log_must set_tunable64 SCRUB_RECENT_TIME "200000"
+check_scrub_recent_time "200000" "55" "2"
+
+log_must set_tunable64 SCRUB_RECENT_TIME "86399"
+check_scrub_recent_time "86399" "23" "0"
+
+log_must set_tunable64 SCRUB_RECENT_TIME "604799"
+check_scrub_recent_time "604799" "167" "6"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_HOURS "1"
+check_scrub_recent_time "3600" "1" "0"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_HOURS "12"
+check_scrub_recent_time "43200" "12" "0"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_HOURS "23"
+check_scrub_recent_time "82800" "23" "0"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_HOURS "24"
+check_scrub_recent_time "86400" "24" "1"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_HOURS "25"
+check_scrub_recent_time "90000" "25" "1"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_HOURS "48"
+check_scrub_recent_time "172800" "48" "2"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_HOURS "100"
+check_scrub_recent_time "360000" "100" "4"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_DAYS "1"
+check_scrub_recent_time "86400" "24" "1"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_DAYS "2"
+check_scrub_recent_time "172800" "48" "2"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_DAYS "7"
+check_scrub_recent_time "604800" "168" "7"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_DAYS "30"
+check_scrub_recent_time "2592000" "720" "30"
+
+log_must set_tunable64 SCRUB_RECENT_TIME_DAYS "365"
+check_scrub_recent_time "31536000" "8760" "365"
+
+log_pass "Verified "\
+    "scrub_recent_time/scrub_recent_time_hours/scrub_recent_time_days is "\
+    "calculated correctly."


### PR DESCRIPTION
### Motivation and Context

When a disk goes offline and is later brought back online with `zpool clear`, the user may also want to trigger a scrub of the recently written data to ensure there is no corruption.

For user convenience, we provide a "recent" scrub option in `zpool scrub`.

### Description

We use `scn_max_txg` and `scn_min_txg`, which are already part of the scrub mechanism, to implement this feature.

Since we (developers) don’t want to expose a configuration that specifies "the number of TXGs" (as discussed in [#16301](https://github.com/openzfs/zfs/pull/16301)
), we instead use a time-based definition. Users can set the time using one of three units (seconds, hours, or days) for convenience. A TXG database is used to map these time ranges to valid TXG numbers.

Using time instead of TXG introduces an interesting problem: if the pool has been offline for days or weeks, and the user runs `zpool clear -s`, it may do nothing, since no recent data has been written. To handle this case, we decided to take the last known TXG from the database and use that as the starting point for scrubbing.

### How Has This Been Tested?
New tests have been added to the this feature.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
