### PR TITLE
ZTS: Fix stale symlinks with zfs-helpers.sh

### DIFF
--- a/scripts/zfs-helpers.sh
+++ b/scripts/zfs-helpers.sh
@@ -122,6 +122,13 @@ install() {
 	src=$1
 	dst=$2
 
+	# We may have an old symlink pointing to different ZFS workspace.
+	# Remove the old symlink if it doesn't point to our workspace.
+	if [ -h "$dst" ] && [ "$(readlink -f """$dst""")" != "$src" ] ; then
+		echo "Removing old symlink: $dst -> $(readlink """$dst""")"
+		rm "$dst"
+	fi
+
 	if [ -h "$dst" ]; then
 		echo "Symlink exists: $dst"
 	elif [ -e "$dst" ]; then


### PR DESCRIPTION


### Motivation and Context
Let `zfs-helpers.sh` remove stale symlinks

### Description
`zfs-helpers.sh` is a utility script that sets up udev symlinks so you can run ZTS from a local ZFS git workspace.  However, it doesn't check that the existing udev symlinks point to the current workspace.  They may point to an old workspace that has been deleted.  This means the udev rules never get executed, which in turn causes the zvol tests to fail.

This commit removes old symlinks that do not point to the current ZFS workspace.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
