### PR TITLE
Fix 'zpool add' safety check corner cases

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -609,22 +609,28 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 				    ZPOOL_CONFIG_PATH, &path) == 0);
 
 				/*
-				 * If we have a raidz/mirror that combines disks
-				 * with files, report it as an error.
+				 * Skip active spares they should never cause
+				 * the pool to be evaluated as inconsistent.
 				 */
-				if (!dontreport && type != NULL &&
+				if (is_spare(NULL, path))
+					continue;
+
+				/*
+				 * If we have a raidz/mirror that combines disks
+				 * with files, only report it as an error when
+				 * fatal is set to ensure all the replication
+				 * checks aren't skipped in check_replication().
+				 */
+				if (fatal && !dontreport && type != NULL &&
 				    strcmp(type, childtype) != 0) {
 					if (ret != NULL)
 						free(ret);
 					ret = NULL;
-					if (fatal)
-						vdev_error(gettext(
-						    "mismatched replication "
-						    "level: %s contains both "
-						    "files and devices\n"),
-						    rep.zprl_type);
-					else
-						return (NULL);
+					vdev_error(gettext(
+					    "mismatched replication "
+					    "level: %s contains both "
+					    "files and devices\n"),
+					    rep.zprl_type);
 					dontreport = B_TRUE;
 				}
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -395,8 +395,9 @@ tags = ['functional', 'cli_root', 'zpool']
 [tests/functional/cli_root/zpool_add]
 tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
     'zpool_add_004_pos', 'zpool_add_006_pos', 'zpool_add_007_neg',
-    'zpool_add_008_neg', 'zpool_add_009_neg', 'zpool_add_010_pos',
-    'add-o_ashift', 'add_prop_ashift', 'zpool_add_dryrun_output']
+    'zpool_add_008_neg', 'zpool_add_009_neg', 'zpool_add_warn_create',
+    'zpool_add_warn_degraded', 'zpool_add_warn_removal', 'add-o_ashift',
+    'add_prop_ashift', 'zpool_add_dryrun_output']
 tags = ['functional', 'cli_root', 'zpool_add']
 
 [tests/functional/cli_root/zpool_attach]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1027,7 +1027,9 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_add/zpool_add_007_neg.ksh \
 	functional/cli_root/zpool_add/zpool_add_008_neg.ksh \
 	functional/cli_root/zpool_add/zpool_add_009_neg.ksh \
-	functional/cli_root/zpool_add/zpool_add_010_pos.ksh \
+	functional/cli_root/zpool_add/zpool_add_warn_create.ksh \
+	functional/cli_root/zpool_add/zpool_add_warn_degraded.ksh \
+	functional/cli_root/zpool_add/zpool_add_warn_removal.ksh \
 	functional/cli_root/zpool_add/zpool_add_dryrun_output.ksh \
 	functional/cli_root/zpool_attach/attach-o_ashift.ksh \
 	functional/cli_root/zpool_attach/cleanup.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.kshlib
@@ -27,6 +27,7 @@
 
 #
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+# Copyright 2025 by Lawrence Livermore National Security, LLC.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -88,4 +89,45 @@ function save_dump_dev
 			awk '{print $1}'`
 	fi
 	echo $dumpdev
+}
+
+function zpool_create_add_setup
+{
+	typeset -i i=0
+
+	while ((i < 10)); do
+		log_must truncate -s $MINVDEVSIZE $TEST_BASE_DIR/vdev$i
+
+		eval vdev$i=$TEST_BASE_DIR/vdev$i
+		((i += 1))
+	done
+
+	if is_linux; then
+	        vdev_lo="$(losetup -f "$vdev4" --show)"
+	elif is_freebsd; then
+	        vdev_lo=/dev/"$(mdconfig -a -t vnode -f "$vdev4")"
+	else
+	        vdev_lo="$(lofiadm -a "$vdev4")"
+	fi
+}
+
+function zpool_create_add_cleanup
+{
+	datasetexists $TESTPOOL1 && destroy_pool $TESTPOOL1
+
+	if [[ -e $vdev_lo ]]; then
+		if is_linux; then
+			log_must losetup -d "$vdev_lo"
+		elif is_freebsd; then
+			log_must mdconfig -d -u "$vdev_lo"
+		else
+			log_must lofiadm -d "$vdev_lo"
+		fi
+	fi
+
+	typeset -i i=0
+	while ((i < 10)); do
+		rm -f $TEST_BASE_DIR/vdev$i
+		((i += 1))
+	done
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_warn_create.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_warn_create.ksh
@@ -23,67 +23,51 @@
 
 #
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
-# Use is subject to license terms.
-#
-
-#
-# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+# Copyright 2012, 2016 by Delphix. All rights reserved.
+# Copyright 2025 by Lawrence Livermore National Security, LLC.
 #
 
 . $STF_SUITE/include/libtest.shlib
-. $STF_SUITE/tests/functional/cli_root/zpool_create/zpool_create.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_add/zpool_add.kshlib
 
 #
 # DESCRIPTION:
-#	Verify zpool add succeed when adding vdevs with matching redundancy.
+#	Verify zpool add succeeds when adding vdevs with matching redundancy
+#	and warns with differing redundancy for a healthy pool.
 #
 # STRATEGY:
 #	1. Create several files == $MINVDEVSIZE.
 #	2. Verify 'zpool add' succeeds with matching redundancy.
 #	3. Verify 'zpool add' warns with differing redundancy.
-#	4. Verify 'zpool add' warns with differing redundancy after removal.
 #
 
 verify_runnable "global"
 
-function cleanup
-{
-	datasetexists $TESTPOOL1 && destroy_pool $TESTPOOL1
+log_assert "Verify 'zpool add' warns for differing redundancy."
+log_onexit zpool_create_add_cleanup
 
-	typeset -i i=0
-	while ((i < 10)); do
-		rm -f $TEST_BASE_DIR/vdev$i
-		((i += 1))
-	done
-}
+zpool_create_add_setup
 
-
-log_assert "Verify 'zpool add' succeed with keywords combination."
-log_onexit cleanup
-
-# 1. Create several files == $MINVDEVSIZE.
 typeset -i i=0
-while ((i < 10)); do
-	log_must truncate -s $MINVDEVSIZE $TEST_BASE_DIR/vdev$i
-
-	eval vdev$i=$TEST_BASE_DIR/vdev$i
-	((i += 1))
-done
+typeset -i j=0
 
 set -A redundancy0_create_args \
 	"$vdev0"
 
 set -A redundancy1_create_args \
 	"mirror $vdev0 $vdev1" \
-	"raidz1 $vdev0 $vdev1"
+	"raidz1 $vdev0 $vdev1" \
+	"draid1:1s $vdev0 $vdev1 $vdev9"
 
 set -A redundancy2_create_args \
 	"mirror $vdev0 $vdev1 $vdev2" \
-	"raidz2 $vdev0 $vdev1 $vdev2"
+	"raidz2 $vdev0 $vdev1 $vdev2" \
+	"draid2:1s $vdev0 $vdev1 $vdev2 $vdev9"
 
 set -A redundancy3_create_args \
 	"mirror $vdev0 $vdev1 $vdev2 $vdev3" \
-	"raidz3 $vdev0 $vdev1 $vdev2 $vdev3"
+	"raidz3 $vdev0 $vdev1 $vdev2 $vdev3" \
+	"draid3:1s $vdev0 $vdev1 $vdev2 $vdev3 $vdev9"
 
 set -A redundancy0_add_args \
 	"$vdev5" \
@@ -93,21 +77,19 @@ set -A redundancy1_add_args \
 	"mirror $vdev5 $vdev6" \
 	"raidz1 $vdev5 $vdev6" \
 	"raidz1 $vdev5 $vdev6 mirror $vdev7 $vdev8" \
-	"mirror $vdev5 $vdev6 raidz1 $vdev7 $vdev8"
+	"mirror $vdev5 $vdev6 raidz1 $vdev7 $vdev8" \
+	"draid1 $vdev5 $vdev6 mirror $vdev7 $vdev8" \
+	"mirror $vdev5 $vdev6 draid1 $vdev7 $vdev8"
 
 set -A redundancy2_add_args \
 	"mirror $vdev5 $vdev6 $vdev7" \
-	"raidz2 $vdev5 $vdev6 $vdev7"
+	"raidz2 $vdev5 $vdev6 $vdev7" \
+	"draid2 $vdev5 $vdev6 $vdev7"
 
 set -A redundancy3_add_args \
 	"mirror $vdev5 $vdev6 $vdev7 $vdev8" \
-	"raidz3 $vdev5 $vdev6 $vdev7 $vdev8"
-
-set -A log_args "log" "$vdev4"
-set -A cache_args "cache" "$vdev4"
-set -A spare_args "spare" "$vdev4"
-
-typeset -i j=0
+	"raidz3 $vdev5 $vdev6 $vdev7 $vdev8" \
+	"draid3 $vdev5 $vdev6 $vdev7 $vdev8"
 
 function zpool_create_add
 {
@@ -148,30 +130,6 @@ function zpool_create_forced_add
 	done
 }
 
-function zpool_create_rm_add
-{
-	typeset -n create_args=$1
-	typeset -n add_args=$2
-	typeset -n rm_args=$3
-
-	i=0
-	while ((i < ${#create_args[@]})); do
-		j=0
-		while ((j < ${#add_args[@]})); do
-			log_must zpool create $TESTPOOL1 ${create_args[$i]}
-			log_must zpool add $TESTPOOL1 ${rm_args[0]} ${rm_args[1]}
-			log_must zpool add $TESTPOOL1 ${add_args[$j]}
-			log_must zpool remove $TESTPOOL1 ${rm_args[1]}
-			log_mustnot zpool add $TESTPOOL1 ${rm_args[1]}
-			log_must zpool add $TESTPOOL1 ${rm_args[0]} ${rm_args[1]}
-			log_must zpool destroy -f $TESTPOOL1
-
-			((j += 1))
-		done
-		((i += 1))
-	done
-}
-
 # 2. Verify 'zpool add' succeeds with matching redundancy.
 zpool_create_add redundancy0_create_args redundancy0_add_args
 zpool_create_add redundancy1_create_args redundancy1_add_args
@@ -195,17 +153,4 @@ zpool_create_forced_add redundancy3_create_args redundancy0_add_args
 zpool_create_forced_add redundancy3_create_args redundancy1_add_args
 zpool_create_forced_add redundancy3_create_args redundancy2_add_args
 
-# 4. Verify 'zpool add' warns with differing redundancy after removal.
-zpool_create_rm_add redundancy1_create_args redundancy1_add_args log_args
-zpool_create_rm_add redundancy2_create_args redundancy2_add_args log_args
-zpool_create_rm_add redundancy3_create_args redundancy3_add_args log_args
-
-zpool_create_rm_add redundancy1_create_args redundancy1_add_args cache_args
-zpool_create_rm_add redundancy2_create_args redundancy2_add_args cache_args
-zpool_create_rm_add redundancy3_create_args redundancy3_add_args cache_args
-
-zpool_create_rm_add redundancy1_create_args redundancy1_add_args spare_args
-zpool_create_rm_add redundancy2_create_args redundancy2_add_args spare_args
-zpool_create_rm_add redundancy3_create_args redundancy3_add_args spare_args
-
-log_pass "'zpool add' succeed with keywords combination."
+log_pass "Verify 'zpool add' warns for differing redundancy."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_warn_degraded.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_warn_degraded.ksh
@@ -1,0 +1,204 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Copyright 2012, 2016 by Delphix. All rights reserved.
+# Copyright 2025 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_add/zpool_add.kshlib
+
+#
+# DESCRIPTION:
+#	Verify zpool add succeeds when adding vdevs with matching redundancy
+#	and warns with differing redundancy for a degraded pool.
+#
+# STRATEGY:
+#	1. Create several files == $MINVDEVSIZE.
+#	2. Verify 'zpool add' succeeds with matching redundancy
+#	3. Verify 'zpool add' warns with differing redundancy when
+#	  a. Degraded pool with replaced mismatch vdev (file vs disk)
+#	  b. Degraded pool dRAID distributed spare active
+#	  c. Degraded pool hot spare active
+#
+
+verify_runnable "global"
+
+log_assert "Verify 'zpool add' warns for differing redundancy."
+log_onexit zpool_create_add_cleanup
+
+zpool_create_add_setup
+
+set -A redundancy1_create_args \
+	"mirror $vdev0 $vdev1" \
+	"raidz1 $vdev0 $vdev1" \
+	"draid1:1s $vdev0 $vdev1 $vdev9"
+
+set -A redundancy2_create_args \
+	"mirror $vdev0 $vdev1 $vdev2" \
+	"raidz2 $vdev0 $vdev1 $vdev2" \
+	"draid2:1s $vdev0 $vdev1 $vdev2 $vdev9"
+
+set -A redundancy3_create_args \
+	"mirror $vdev0 $vdev1 $vdev2 $vdev3" \
+	"raidz3 $vdev0 $vdev1 $vdev2 $vdev3" \
+	"draid3:1s $vdev0 $vdev1 $vdev2 $vdev3 $vdev9"
+
+set -A redundancy1_add_args \
+	"mirror $vdev5 $vdev6" \
+	"raidz1 $vdev5 $vdev6" \
+	"raidz1 $vdev5 $vdev6 mirror $vdev7 $vdev8" \
+	"mirror $vdev5 $vdev6 raidz1 $vdev7 $vdev8" \
+	"draid1 $vdev5 $vdev6 mirror $vdev7 $vdev8" \
+	"mirror $vdev5 $vdev6 draid1 $vdev7 $vdev8"
+
+set -A redundancy2_add_args \
+	"mirror $vdev5 $vdev6 $vdev7" \
+	"raidz2 $vdev5 $vdev6 $vdev7" \
+	"draid2 $vdev5 $vdev6 $vdev7"
+
+set -A redundancy3_add_args \
+	"mirror $vdev5 $vdev6 $vdev7 $vdev8" \
+	"raidz3 $vdev5 $vdev6 $vdev7 $vdev8" \
+	"draid3 $vdev5 $vdev6 $vdev7 $vdev8"
+
+set -A redundancy1_create_draid_args \
+	"draid1:1s $vdev0 $vdev1 $vdev2"
+
+set -A redundancy2_create_draid_args \
+	"draid2:1s $vdev0 $vdev1 $vdev2 $vdev3"
+
+set -A redundancy3_create_draid_args \
+	"draid3:1s $vdev0 $vdev1 $vdev2 $vdev3 $vdev9"
+
+set -A redundancy1_create_spare_args \
+	"mirror $vdev0 $vdev1 spare $vdev_lo" \
+	"raidz1 $vdev0 $vdev1 spare $vdev_lo" \
+	"draid1 $vdev0 $vdev1 spare $vdev_lo"
+
+set -A redundancy2_create_spare_args \
+	"mirror $vdev0 $vdev1 $vdev2 spare $vdev_lo" \
+	"raidz2 $vdev0 $vdev1 $vdev2 spare $vdev_lo" \
+	"draid2 $vdev0 $vdev1 $vdev2 spare $vdev_lo"
+
+set -A redundancy3_create_spare_args \
+	"mirror $vdev0 $vdev1 $vdev2 $vdev3 spare $vdev_lo" \
+	"raidz3 $vdev0 $vdev1 $vdev2 $vdev3 spare $vdev_lo" \
+	"draid3 $vdev0 $vdev1 $vdev2 $vdev3 spare $vdev_lo"
+
+set -A replace_args "$vdev1" "$vdev_lo"
+set -A draid1_args "$vdev1" "draid1-0-0"
+set -A draid2_args "$vdev1" "draid2-0-0"
+set -A draid3_args "$vdev1" "draid3-0-0"
+
+typeset -i i=0
+typeset -i j=0
+
+function zpool_create_degraded_add
+{
+	typeset -n create_args=$1
+	typeset -n add_args=$2
+	typeset -n rm_args=$3
+
+	i=0
+	while ((i < ${#create_args[@]})); do
+		j=0
+		while ((j < ${#add_args[@]})); do
+			log_must zpool create $TESTPOOL1 ${create_args[$i]}
+			log_must zpool offline -f $TESTPOOL1 ${rm_args[0]}
+			log_must zpool replace -w $TESTPOOL1 ${rm_args[0]} ${rm_args[1]}
+			log_must zpool add $TESTPOOL1 ${add_args[$j]}
+			log_must zpool destroy -f $TESTPOOL1
+			log_must zpool labelclear -f ${rm_args[0]}
+
+			((j += 1))
+		done
+		((i += 1))
+	done
+}
+
+function zpool_create_forced_degraded_add
+{
+	typeset -n create_args=$1
+	typeset -n add_args=$2
+	typeset -n rm_args=$3
+
+	i=0
+	while ((i < ${#create_args[@]})); do
+		j=0
+		while ((j < ${#add_args[@]})); do
+			log_must zpool create $TESTPOOL1 ${create_args[$i]}
+			log_must zpool offline -f $TESTPOOL1 ${rm_args[0]}
+			log_must zpool replace -w $TESTPOOL1 ${rm_args[0]} ${rm_args[1]}
+			log_mustnot zpool add $TESTPOOL1 ${add_args[$j]}
+			log_must zpool add --allow-replication-mismatch $TESTPOOL1 ${add_args[$j]}
+			log_must zpool destroy -f $TESTPOOL1
+			log_must zpool labelclear -f ${rm_args[0]}
+
+			((j += 1))
+		done
+		((i += 1))
+	done
+}
+
+# 2. Verify 'zpool add' succeeds with matching redundancy and a degraded pool.
+zpool_create_degraded_add redundancy1_create_args redundancy1_add_args replace_args
+zpool_create_degraded_add redundancy2_create_args redundancy2_add_args replace_args
+zpool_create_degraded_add redundancy3_create_args redundancy3_add_args replace_args
+
+# 3. Verify 'zpool add' warns with differing redundancy and a degraded pool.
+#
+# a. Degraded pool with replaced mismatch vdev (file vs disk)
+zpool_create_forced_degraded_add redundancy1_create_args redundancy2_add_args replace_args
+zpool_create_forced_degraded_add redundancy1_create_args redundancy3_add_args replace_args
+
+zpool_create_forced_degraded_add redundancy2_create_args redundancy1_add_args replace_args
+zpool_create_forced_degraded_add redundancy2_create_args redundancy3_add_args replace_args
+
+zpool_create_forced_degraded_add redundancy3_create_args redundancy1_add_args replace_args
+zpool_create_forced_degraded_add redundancy3_create_args redundancy2_add_args replace_args
+
+# b. Degraded pool dRAID distributed spare active
+
+zpool_create_forced_degraded_add redundancy1_create_draid_args redundancy2_add_args draid1_args
+zpool_create_forced_degraded_add redundancy1_create_draid_args redundancy3_add_args draid1_args
+
+zpool_create_forced_degraded_add redundancy2_create_draid_args redundancy1_add_args draid2_args
+zpool_create_forced_degraded_add redundancy2_create_draid_args redundancy3_add_args draid2_args
+
+zpool_create_forced_degraded_add redundancy3_create_draid_args redundancy1_add_args draid3_args
+zpool_create_forced_degraded_add redundancy3_create_draid_args redundancy2_add_args draid3_args
+
+# c. Degraded pool hot spare active
+zpool_create_forced_degraded_add redundancy1_create_spare_args redundancy2_add_args replace_args
+zpool_create_forced_degraded_add redundancy1_create_spare_args redundancy3_add_args replace_args
+
+zpool_create_forced_degraded_add redundancy2_create_spare_args redundancy1_add_args replace_args
+zpool_create_forced_degraded_add redundancy2_create_spare_args redundancy3_add_args replace_args
+
+zpool_create_forced_degraded_add redundancy3_create_spare_args redundancy1_add_args replace_args
+zpool_create_forced_degraded_add redundancy3_create_spare_args redundancy2_add_args replace_args
+
+log_pass "Verify 'zpool add' warns for differing redundancy."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_warn_removal.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_warn_removal.ksh
@@ -1,0 +1,126 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Copyright 2012, 2016 by Delphix. All rights reserved.
+# Copyright 2025 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_add/zpool_add.kshlib
+
+#
+# DESCRIPTION:
+#	Verify zpool add succeeds when adding vdevs with matching redundancy
+#	and warns with differing redundancy after removal.
+#
+# STRATEGY:
+#	1. Create several files == $MINVDEVSIZE.
+#	2. Verify 'zpool add' warns with differing redundancy after removal.
+#
+
+verify_runnable "global"
+
+log_assert "Verify 'zpool add' warns for differing redundancy."
+log_onexit zpool_create_add_cleanup
+
+zpool_create_add_setup
+
+typeset -i i=0
+typeset -i j=0
+
+set -A redundancy1_create_args \
+	"mirror $vdev0 $vdev1" \
+	"raidz1 $vdev0 $vdev1" \
+	"draid1:1s $vdev0 $vdev1 $vdev9"
+
+set -A redundancy2_create_args \
+	"mirror $vdev0 $vdev1 $vdev2" \
+	"raidz2 $vdev0 $vdev1 $vdev2" \
+	"draid2:1s $vdev0 $vdev1 $vdev2 $vdev9"
+
+set -A redundancy3_create_args \
+	"mirror $vdev0 $vdev1 $vdev2 $vdev3" \
+	"raidz3 $vdev0 $vdev1 $vdev2 $vdev3" \
+	"draid3:1s $vdev0 $vdev1 $vdev2 $vdev3 $vdev9"
+
+set -A redundancy1_add_args \
+	"mirror $vdev5 $vdev6" \
+	"raidz1 $vdev5 $vdev6" \
+	"raidz1 $vdev5 $vdev6 mirror $vdev7 $vdev8" \
+	"mirror $vdev5 $vdev6 raidz1 $vdev7 $vdev8" \
+	"draid1 $vdev5 $vdev6 mirror $vdev7 $vdev8" \
+	"mirror $vdev5 $vdev6 draid1 $vdev7 $vdev8"
+
+set -A redundancy2_add_args \
+	"mirror $vdev5 $vdev6 $vdev7" \
+	"raidz2 $vdev5 $vdev6 $vdev7" \
+	"draid2 $vdev5 $vdev6 $vdev7"
+
+set -A redundancy3_add_args \
+	"mirror $vdev5 $vdev6 $vdev7 $vdev8" \
+	"raidz3 $vdev5 $vdev6 $vdev7 $vdev8" \
+	"draid3 $vdev5 $vdev6 $vdev7 $vdev8"
+
+set -A log_args "log" "$vdev_lo"
+set -A cache_args "cache" "$vdev_lo"
+set -A spare_args "spare" "$vdev_lo"
+
+
+function zpool_create_rm_add
+{
+	typeset -n create_args=$1
+	typeset -n add_args=$2
+	typeset -n rm_args=$3
+
+	i=0
+	while ((i < ${#create_args[@]})); do
+		j=0
+		while ((j < ${#add_args[@]})); do
+			log_must zpool create $TESTPOOL1 ${create_args[$i]}
+			log_must zpool add $TESTPOOL1 ${rm_args[0]} ${rm_args[1]}
+			log_must zpool add $TESTPOOL1 ${add_args[$j]}
+			log_must zpool remove $TESTPOOL1 ${rm_args[1]}
+			log_mustnot zpool add $TESTPOOL1 ${rm_args[1]}
+			log_must zpool add $TESTPOOL1 ${rm_args[0]} ${rm_args[1]}
+			log_must zpool destroy -f $TESTPOOL1
+
+			((j += 1))
+		done
+		((i += 1))
+	done
+}
+
+# 2. Verify 'zpool add' warns with differing redundancy after removal.
+zpool_create_rm_add redundancy1_create_args redundancy1_add_args log_args
+zpool_create_rm_add redundancy2_create_args redundancy2_add_args log_args
+zpool_create_rm_add redundancy3_create_args redundancy3_add_args log_args
+
+zpool_create_rm_add redundancy1_create_args redundancy1_add_args cache_args
+zpool_create_rm_add redundancy2_create_args redundancy2_add_args cache_args
+zpool_create_rm_add redundancy3_create_args redundancy3_add_args cache_args
+
+zpool_create_rm_add redundancy1_create_args redundancy1_add_args spare_args
+zpool_create_rm_add redundancy2_create_args redundancy2_add_args spare_args
+zpool_create_rm_add redundancy3_create_args redundancy3_add_args spare_args


### PR DESCRIPTION
### Motivation and Context

Issue #17756.  `zpool add` needs to warn for all cases where adding a vdev would result in a change of overall pool redundancy.

### Description

Three cases were discovered where 'zpool add' would fail to warn when adding vdevs to a pool with a mismatched replication level.  These are:

  1. When a pool contains mixed file and disk vdevs.
  2. When a pool contains an active dRAID distributed spare
  3. When a pool contains an active hot spare

The lack of warnings are caused by get_replication() assessing the current pool configuration an inconsistent and disabling the mismatched replication check for the new pool configuration after 'zpool add'.  This change updates get_replication() to be slightly more tolerant in the non-fatal case.

The zpool_add_010_pos.ksh test case was split in to separate tests: zpool_add_warn_create.ksh, pool_add_warn_degraded.ksh, and zpool_add_warn_removal.  These test were extended to include coverage for dRAID pools and the three scenarios described above.

### How Has This Been Tested?

Added new test coverage for not only the cover cases which were missed but several other common scenarios.

```
       functional/cli_root/zpool_add/zpool_add_warn_create.ksh
       functional/cli_root/zpool_add/zpool_add_warn_degraded.ksh
       functional/cli_root/zpool_add/zpool_add_warn_removal.ksh
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
