### PR TITLE
ZTS: update upgrade_readonly_pool.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/upgrade/setup.ksh
+++ b/tests/zfs-tests/tests/functional/upgrade/setup.ksh
@@ -39,6 +39,6 @@
 verify_runnable "global"
 
 # create a pool without any features
-log_must mkfile 128m $TMPDEV
+log_must truncate -s $MINVDEVSIZE $TMPDEV
 
 log_pass


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Motivation and Context

Resolve CI failures like the following:

https://github.com/openzfs/zfs/actions/runs/17958066484/job/51074464832?pr=17780

```
  [2025-09-23T23:06:26.926614] Test: /usr/share/zfs/zfs-tests/tests/functional/upgrade/upgrade_readonly_pool (run as root) [00:00] [FAIL]
  23:06:26.60 ASSERTION: User accounting upgrade should not be executed on readonly pool
  23:06:26.65 SUCCESS: zpool create -d -m /var/tmp/testdir testpool /var/tmp/zpool_upgrade_test.dat
  23:06:26.65 SUCCESS: touch /var/tmp/testdir/file.bin
  23:06:26.67 SUCCESS: zpool set feature@userobj_accounting=enabled testpool
  23:06:26.68 SUCCESS: test enabled == enabled
  23:06:26.71 SUCCESS: zpool export testpool
  23:06:26.78 SUCCESS: zpool import -o readonly=on -N -d /var/tmp testpool
  23:06:26.79 filesystem '/testpool' cannot be mounted, unable to open the dataset
  23:06:26.79 ERROR: mount -t zfs -o zfsutil testpool /var/tmp/testdir exited 1
```

### Description

Modify the test case to use the `zfs mount` command instead of directly calling the mount command, create a dedictate dataset, and use the default mount point.  These changes are intended to preserve the intent of the original test case and resolve some spurious mount failures which have been observed by the CI.

### How Has This Been Tested?

I've been unable to locally reproduce the failure, but the updated test case works as intended.  We'll have to see if after this change we see see occasional failures in the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
