### PR TITLE
`zpool iostat`: fix regressions in "all pools" mode after #17786

### DIFF
--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -103,6 +103,8 @@ add_pool(zpool_handle_t *zhp, zpool_list_t *zlp)
 		new->zn_last_refresh = zlp->zl_last_refresh;
 		uu_avl_insert(zlp->zl_avl, new, idx);
 	} else {
+		zpool_refresh_stats_from_handle(node->zn_handle, zhp);
+		node->zn_last_refresh = zlp->zl_last_refresh;
 		zpool_close(zhp);
 		free(new);
 		return (-1);

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -6677,6 +6677,7 @@ zpool_do_iostat(int argc, char **argv)
 			if (skip) {
 				(void) fflush(stdout);
 				(void) fsleep(interval);
+				last_npools = npools;
 				continue;
 			}
 

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -479,6 +479,8 @@ _LIBZFS_H zpool_status_t zpool_import_status(nvlist_t *, const char **,
 _LIBZFS_H nvlist_t *zpool_get_config(zpool_handle_t *, nvlist_t **);
 _LIBZFS_H nvlist_t *zpool_get_features(zpool_handle_t *);
 _LIBZFS_H int zpool_refresh_stats(zpool_handle_t *, boolean_t *);
+_LIBZFS_H void zpool_refresh_stats_from_handle(zpool_handle_t *,
+    zpool_handle_t *);
 _LIBZFS_H int zpool_get_errlog(zpool_handle_t *, nvlist_t **);
 _LIBZFS_H void zpool_add_propname(zpool_handle_t *, const char *);
 

--- a/lib/libuutil/libuutil.abi
+++ b/lib/libuutil/libuutil.abi
@@ -616,6 +616,7 @@
     <array-type-def dimensions='1' type-id='de572c22' size-in-bits='1472' id='6d3c2f42'>
       <subrange length='23' type-id='7359adad' id='fdd0f594'/>
     </array-type-def>
+    <type-decl name='long long int' size-in-bits='64' id='1eb56b1e'/>
     <array-type-def dimensions='1' type-id='3a47d82b' size-in-bits='256' id='a133ec23'>
       <subrange length='4' type-id='7359adad' id='16fe7105'/>
     </array-type-def>
@@ -1020,13 +1021,6 @@
     <array-type-def dimensions='1' type-id='03085adc' size-in-bits='192' id='083f8d58'>
       <subrange length='3' type-id='7359adad' id='56f209d2'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='d315442e' size-in-bits='16' id='811205dc'>
-      <subrange length='1' type-id='7359adad' id='52f813b4'/>
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='d3130597' size-in-bits='768' id='f63f23b9'>
-      <subrange length='12' type-id='7359adad' id='84827bdc'/>
-    </array-type-def>
-    <type-decl name='long long int' size-in-bits='64' id='1eb56b1e'/>
     <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -1059,93 +1053,6 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
         <var-decl name='mnt_minor' type-id='3502e3ff' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__u16' type-id='8efea9e5' id='d315442e'/>
-    <typedef-decl name='__s32' type-id='95e97e5e' id='3158a266'/>
-    <typedef-decl name='__u32' type-id='f0981eeb' id='3f1a6b60'/>
-    <typedef-decl name='__s64' type-id='1eb56b1e' id='49659421'/>
-    <typedef-decl name='__u64' type-id='3a47d82b' id='d3130597'/>
-    <class-decl name='statx_timestamp' size-in-bits='128' is-struct='yes' visibility='default' id='94101016'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='49659421' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__reserved' type-id='3158a266' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='statx' size-in-bits='2048' is-struct='yes' visibility='default' id='720b04c5'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='stx_mask' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='stx_blksize' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='stx_attributes' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='stx_nlink' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='stx_uid' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='stx_gid' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='stx_mode' type-id='d315442e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='240'>
-        <var-decl name='__spare0' type-id='811205dc' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='stx_ino' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='stx_size' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='stx_blocks' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='stx_attributes_mask' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='stx_atime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='stx_btime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='stx_ctime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='stx_mtime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='stx_rdev_major' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='stx_rdev_minor' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='stx_dev_major' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='stx_dev_minor' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='stx_mnt_id' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='__spare2' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='__spare3' type-id='f63f23b9' visibility='default'/>
       </data-member>
     </class-decl>
     <class-decl name='mntent' size-in-bits='320' is-struct='yes' visibility='default' id='56fe4a37'>
@@ -1237,8 +1144,6 @@
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
     <qualified-type-def type-id='62f7a03d' restrict='yes' id='f1cadedf'/>
-    <pointer-type-def type-id='720b04c5' size-in-bits='64' id='936b8e35'/>
-    <qualified-type-def type-id='936b8e35' restrict='yes' id='31d265b7'/>
     <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>
       <parameter type-id='3cad23cd'/>
@@ -1253,14 +1158,6 @@
     <function-decl name='strerror' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
       <return type-id='26a90f95'/>
-    </function-decl>
-    <function-decl name='statx' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='9d26089a'/>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='f0981eeb'/>
-      <parameter type-id='31d265b7'/>
-      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='__fprintf_chk' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -571,6 +571,7 @@
     <elf-symbol name='zpool_props_refresh' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_read_label' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_refresh_stats' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zpool_refresh_stats_from_handle' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_reguid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_reopen_one' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zpool_scan' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -641,7 +642,7 @@
     <elf-symbol name='sa_protocol_names' size='16' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='spa_feature_table' size='2632' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfeature_checks_disable' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
-    <elf-symbol name='zfs_deleg_perm_tab' size='528' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zfs_deleg_perm_tab' size='544' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_history_event_names' size='328' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_max_dataset_nesting' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zfs_userquota_prop_prefixes' size='96' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1458,103 +1459,8 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libspl/os/linux/getmntany.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='d315442e' size-in-bits='16' id='811205dc'>
-      <subrange length='1' type-id='7359adad' id='52f813b4'/>
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='d3130597' size-in-bits='768' id='f63f23b9'>
-      <subrange length='12' type-id='7359adad' id='84827bdc'/>
-    </array-type-def>
-    <typedef-decl name='__u16' type-id='8efea9e5' id='d315442e'/>
-    <typedef-decl name='__s32' type-id='95e97e5e' id='3158a266'/>
-    <typedef-decl name='__u32' type-id='f0981eeb' id='3f1a6b60'/>
-    <typedef-decl name='__s64' type-id='1eb56b1e' id='49659421'/>
-    <typedef-decl name='__u64' type-id='3a47d82b' id='d3130597'/>
-    <class-decl name='statx_timestamp' size-in-bits='128' is-struct='yes' visibility='default' id='94101016'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='49659421' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__reserved' type-id='3158a266' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='statx' size-in-bits='2048' is-struct='yes' visibility='default' id='720b04c5'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='stx_mask' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='stx_blksize' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='stx_attributes' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='stx_nlink' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='stx_uid' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='stx_gid' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='stx_mode' type-id='d315442e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='240'>
-        <var-decl name='__spare0' type-id='811205dc' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='stx_ino' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='stx_size' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='stx_blocks' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='stx_attributes_mask' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='stx_atime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='stx_btime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='stx_ctime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='stx_mtime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='stx_rdev_major' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='stx_rdev_minor' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='stx_dev_major' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='stx_dev_minor' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='stx_mnt_id' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='__spare2' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='__spare3' type-id='f63f23b9' visibility='default'/>
-      </data-member>
-    </class-decl>
     <pointer-type-def type-id='56fe4a37' size-in-bits='64' id='b6b61d2f'/>
     <qualified-type-def type-id='b6b61d2f' restrict='yes' id='3cad23cd'/>
-    <pointer-type-def type-id='720b04c5' size-in-bits='64' id='936b8e35'/>
-    <qualified-type-def type-id='936b8e35' restrict='yes' id='31d265b7'/>
     <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>
       <parameter type-id='3cad23cd'/>
@@ -1564,14 +1470,6 @@
     </function-decl>
     <function-decl name='feof' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='822cd80b'/>
-      <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='statx' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='9d26089a'/>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='f0981eeb'/>
-      <parameter type-id='31d265b7'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
@@ -3194,6 +3092,10 @@
       <parameter type-id='dace003f'/>
       <return type-id='80f4b756'/>
     </function-decl>
+    <function-decl name='fnvlist_dup' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='22cce67b'/>
+      <return type-id='5ce45b60'/>
+    </function-decl>
     <function-decl name='fnvpair_value_nvlist' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='3fa542f0'/>
       <return type-id='5ce45b60'/>
@@ -3237,6 +3139,11 @@
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='37e3bd22' name='missing'/>
       <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zpool_refresh_stats_from_handle' mangled-name='zpool_refresh_stats_from_handle' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_refresh_stats_from_handle'>
+      <parameter type-id='4c81de99' name='dzhp'/>
+      <parameter type-id='4c81de99' name='szhp'/>
+      <return type-id='48b5725f'/>
     </function-decl>
     <function-decl name='zpool_skip_pool' mangled-name='zpool_skip_pool' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_skip_pool'>
       <parameter type-id='80f4b756' name='poolname'/>
@@ -9398,10 +9305,6 @@
       <parameter type-id='5ce45b60'/>
       <return type-id='48b5725f'/>
     </function-decl>
-    <function-decl name='fnvlist_dup' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='22cce67b'/>
-      <return type-id='5ce45b60'/>
-    </function-decl>
     <function-decl name='spl_pagesize' mangled-name='spl_pagesize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='spl_pagesize'>
       <return type-id='b59d7dce'/>
     </function-decl>
@@ -9774,8 +9677,8 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='module/zcommon/zfs_deleg.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='fa1870fd' size-in-bits='4224' id='55e705e7'>
-      <subrange length='33' type-id='7359adad' id='6a5934df'/>
+    <array-type-def dimensions='1' type-id='fa1870fd' size-in-bits='4352' id='55f84f08'>
+      <subrange length='34' type-id='7359adad' id='6a6a7e00'/>
     </array-type-def>
     <array-type-def dimensions='1' type-id='fa1870fd' size-in-bits='infinite' id='7c00e69d'>
       <subrange length='infinite' id='031f2035'/>
@@ -9805,30 +9708,31 @@
       <enumerator name='ZFS_DELEG_NOTE_PROMOTE' value='5'/>
       <enumerator name='ZFS_DELEG_NOTE_RENAME' value='6'/>
       <enumerator name='ZFS_DELEG_NOTE_SEND' value='7'/>
-      <enumerator name='ZFS_DELEG_NOTE_RECEIVE' value='8'/>
-      <enumerator name='ZFS_DELEG_NOTE_ALLOW' value='9'/>
-      <enumerator name='ZFS_DELEG_NOTE_USERPROP' value='10'/>
-      <enumerator name='ZFS_DELEG_NOTE_MOUNT' value='11'/>
-      <enumerator name='ZFS_DELEG_NOTE_SHARE' value='12'/>
-      <enumerator name='ZFS_DELEG_NOTE_USERQUOTA' value='13'/>
-      <enumerator name='ZFS_DELEG_NOTE_GROUPQUOTA' value='14'/>
-      <enumerator name='ZFS_DELEG_NOTE_USERUSED' value='15'/>
-      <enumerator name='ZFS_DELEG_NOTE_GROUPUSED' value='16'/>
-      <enumerator name='ZFS_DELEG_NOTE_USEROBJQUOTA' value='17'/>
-      <enumerator name='ZFS_DELEG_NOTE_GROUPOBJQUOTA' value='18'/>
-      <enumerator name='ZFS_DELEG_NOTE_USEROBJUSED' value='19'/>
-      <enumerator name='ZFS_DELEG_NOTE_GROUPOBJUSED' value='20'/>
-      <enumerator name='ZFS_DELEG_NOTE_HOLD' value='21'/>
-      <enumerator name='ZFS_DELEG_NOTE_RELEASE' value='22'/>
-      <enumerator name='ZFS_DELEG_NOTE_DIFF' value='23'/>
-      <enumerator name='ZFS_DELEG_NOTE_BOOKMARK' value='24'/>
-      <enumerator name='ZFS_DELEG_NOTE_LOAD_KEY' value='25'/>
-      <enumerator name='ZFS_DELEG_NOTE_CHANGE_KEY' value='26'/>
-      <enumerator name='ZFS_DELEG_NOTE_PROJECTUSED' value='27'/>
-      <enumerator name='ZFS_DELEG_NOTE_PROJECTQUOTA' value='28'/>
-      <enumerator name='ZFS_DELEG_NOTE_PROJECTOBJUSED' value='29'/>
-      <enumerator name='ZFS_DELEG_NOTE_PROJECTOBJQUOTA' value='30'/>
-      <enumerator name='ZFS_DELEG_NOTE_NONE' value='31'/>
+      <enumerator name='ZFS_DELEG_NOTE_SEND_RAW' value='8'/>
+      <enumerator name='ZFS_DELEG_NOTE_RECEIVE' value='9'/>
+      <enumerator name='ZFS_DELEG_NOTE_ALLOW' value='10'/>
+      <enumerator name='ZFS_DELEG_NOTE_USERPROP' value='11'/>
+      <enumerator name='ZFS_DELEG_NOTE_MOUNT' value='12'/>
+      <enumerator name='ZFS_DELEG_NOTE_SHARE' value='13'/>
+      <enumerator name='ZFS_DELEG_NOTE_USERQUOTA' value='14'/>
+      <enumerator name='ZFS_DELEG_NOTE_GROUPQUOTA' value='15'/>
+      <enumerator name='ZFS_DELEG_NOTE_USERUSED' value='16'/>
+      <enumerator name='ZFS_DELEG_NOTE_GROUPUSED' value='17'/>
+      <enumerator name='ZFS_DELEG_NOTE_USEROBJQUOTA' value='18'/>
+      <enumerator name='ZFS_DELEG_NOTE_GROUPOBJQUOTA' value='19'/>
+      <enumerator name='ZFS_DELEG_NOTE_USEROBJUSED' value='20'/>
+      <enumerator name='ZFS_DELEG_NOTE_GROUPOBJUSED' value='21'/>
+      <enumerator name='ZFS_DELEG_NOTE_HOLD' value='22'/>
+      <enumerator name='ZFS_DELEG_NOTE_RELEASE' value='23'/>
+      <enumerator name='ZFS_DELEG_NOTE_DIFF' value='24'/>
+      <enumerator name='ZFS_DELEG_NOTE_BOOKMARK' value='25'/>
+      <enumerator name='ZFS_DELEG_NOTE_LOAD_KEY' value='26'/>
+      <enumerator name='ZFS_DELEG_NOTE_CHANGE_KEY' value='27'/>
+      <enumerator name='ZFS_DELEG_NOTE_PROJECTUSED' value='28'/>
+      <enumerator name='ZFS_DELEG_NOTE_PROJECTQUOTA' value='29'/>
+      <enumerator name='ZFS_DELEG_NOTE_PROJECTOBJUSED' value='30'/>
+      <enumerator name='ZFS_DELEG_NOTE_PROJECTOBJQUOTA' value='31'/>
+      <enumerator name='ZFS_DELEG_NOTE_NONE' value='32'/>
     </enum-decl>
     <typedef-decl name='zfs_deleg_note_t' type-id='729d4547' id='4613c173'/>
     <class-decl name='zfs_deleg_perm_tab' size-in-bits='128' is-struct='yes' visibility='default' id='5aa05c1f'>

--- a/lib/libzfs/libzfs_config.c
+++ b/lib/libzfs/libzfs_config.c
@@ -308,6 +308,23 @@ zpool_refresh_stats(zpool_handle_t *zhp, boolean_t *missing)
 }
 
 /*
+ * Copies the pool config and state from szhp to dzhp. szhp and dzhp must
+ * represent the same pool. Used by pool_list_refresh() to avoid another
+ * round-trip into the kernel to get stats already collected earlier in the
+ * function.
+ */
+void
+zpool_refresh_stats_from_handle(zpool_handle_t *dzhp, zpool_handle_t *szhp)
+{
+	VERIFY0(strcmp(dzhp->zpool_name, szhp->zpool_name));
+	nvlist_free(dzhp->zpool_old_config);
+	dzhp->zpool_old_config = dzhp->zpool_config;
+	dzhp->zpool_config = fnvlist_dup(szhp->zpool_config);
+	dzhp->zpool_config_size = szhp->zpool_config_size;
+	dzhp->zpool_state = szhp->zpool_state;
+}
+
+/*
  * The following environment variables are undocumented
  * and should be used for testing purposes only:
  *

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -617,6 +617,7 @@
     <array-type-def dimensions='1' type-id='de572c22' size-in-bits='1472' id='6d3c2f42'>
       <subrange length='23' type-id='7359adad' id='fdd0f594'/>
     </array-type-def>
+    <type-decl name='long long int' size-in-bits='64' id='1eb56b1e'/>
     <array-type-def dimensions='1' type-id='3a47d82b' size-in-bits='256' id='a133ec23'>
       <subrange length='4' type-id='7359adad' id='16fe7105'/>
     </array-type-def>
@@ -988,13 +989,6 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libspl/os/linux/getmntany.c' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='d315442e' size-in-bits='16' id='811205dc'>
-      <subrange length='1' type-id='7359adad' id='52f813b4'/>
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='d3130597' size-in-bits='768' id='f63f23b9'>
-      <subrange length='12' type-id='7359adad' id='84827bdc'/>
-    </array-type-def>
-    <type-decl name='long long int' size-in-bits='64' id='1eb56b1e'/>
     <class-decl name='mnttab' size-in-bits='256' is-struct='yes' visibility='default' id='1b055409'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='mnt_special' type-id='26a90f95' visibility='default'/>
@@ -1027,93 +1021,6 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
         <var-decl name='mnt_minor' type-id='3502e3ff' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__u16' type-id='8efea9e5' id='d315442e'/>
-    <typedef-decl name='__s32' type-id='95e97e5e' id='3158a266'/>
-    <typedef-decl name='__u32' type-id='f0981eeb' id='3f1a6b60'/>
-    <typedef-decl name='__s64' type-id='1eb56b1e' id='49659421'/>
-    <typedef-decl name='__u64' type-id='3a47d82b' id='d3130597'/>
-    <class-decl name='statx_timestamp' size-in-bits='128' is-struct='yes' visibility='default' id='94101016'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='49659421' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='__reserved' type-id='3158a266' visibility='default'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='statx' size-in-bits='2048' is-struct='yes' visibility='default' id='720b04c5'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='stx_mask' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='stx_blksize' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='stx_attributes' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='stx_nlink' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='stx_uid' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='stx_gid' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='stx_mode' type-id='d315442e' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='240'>
-        <var-decl name='__spare0' type-id='811205dc' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='stx_ino' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='stx_size' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='stx_blocks' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='stx_attributes_mask' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='stx_atime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='stx_btime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='stx_ctime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='stx_mtime' type-id='94101016' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='stx_rdev_major' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='stx_rdev_minor' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='stx_dev_major' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='stx_dev_minor' type-id='3f1a6b60' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='stx_mnt_id' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='__spare2' type-id='d3130597' visibility='default'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='__spare3' type-id='f63f23b9' visibility='default'/>
       </data-member>
     </class-decl>
     <class-decl name='mntent' size-in-bits='320' is-struct='yes' visibility='default' id='56fe4a37'>
@@ -1191,8 +1098,6 @@
     <pointer-type-def type-id='1b055409' size-in-bits='64' id='9d424d31'/>
     <pointer-type-def type-id='0bbec9cd' size-in-bits='64' id='62f7a03d'/>
     <qualified-type-def type-id='62f7a03d' restrict='yes' id='f1cadedf'/>
-    <pointer-type-def type-id='720b04c5' size-in-bits='64' id='936b8e35'/>
-    <qualified-type-def type-id='936b8e35' restrict='yes' id='31d265b7'/>
     <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>
       <parameter type-id='3cad23cd'/>
@@ -1207,14 +1112,6 @@
     <function-decl name='strerror' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='95e97e5e'/>
       <return type-id='26a90f95'/>
-    </function-decl>
-    <function-decl name='statx' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='9d26089a'/>
-      <parameter type-id='95e97e5e'/>
-      <parameter type-id='f0981eeb'/>
-      <parameter type-id='31d265b7'/>
-      <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='stat64' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='9d26089a'/>


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

After #17786, `zpool iostat 1` ("all pools" mode) was not updating pool stats after the first line, if present.

Reported by @gamanakis in [comment on f0a95e8](https://github.com/openzfs/zfs/commit/f0a95e897162ed97a651ebbc630284885f26b01e#commitcomment-166885960)

### Description

First commit is a very simple fix that ensures the count of pools last time around the loop is updated if we take the "skip row" path. This fixes the issue where `zpool iostat -y 1` would simply display the header repeatedly.

Second commit fixes the stats updating. I didn't notice that the `zpool_iter()` callback receives a new instance of the handle, not an existing one, so while it has the latest stats, the instance in the `pool_list` tree does not. To fix, we just don't bump the refresh timestamp for existing pools in `add_pool()`, which then causes the second part of `pool_iter_refresh()` to issue `zpool_refresh_stats()` again and get it up to date.

The third commit is a better but more invasive fix. `zpool_iter()` calls `zpool_refresh_stats()` -> `ZFS_IOC_POOL_STATS` once for each pool, and then our own refresh of the tree will call it again for each pool. This was a side-effect in #17786 that I wanted to avoid, because of the extra pressure on `spa_namespace_lock` in particular, and is why I introduced the refresh timestamp. To get back there, I add a function to libzfs, `zpool_refresh_stats_from_handle()`, that copies the pool config and stats from one handle into another. Then, in the `zpool_iter()` callback `add_pool()`, if we already have this pool, we just refresh our handle from the iterator handle before we destroy it.

This gets us back to only one call per pool per interval. The possible downside is that its an ABI break for libzfs (it's also a little bit jank). So this PR could ship without the top commit if we don't mind the extra overhead.

### How Has This Been Tested?

Just a lot of by-hand testing.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
