### PR TITLE
Annotate arc_buf_is_shared as __maybe_unused

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1392,6 +1392,7 @@ arc_get_complevel(arc_buf_t *buf)
 	return (buf->b_hdr->b_complevel);
 }
 
+__maybe_unused
 static inline boolean_t
 arc_buf_is_shared(arc_buf_t *buf)
 {


### PR DESCRIPTION
Otherwise the compiler warns about it on production FreeBSD builds.

The routine proved resilient to attempts to ifdef on debug.

Sponsored by:	Rubicon Communications, LLC ("Netgate")