### PR TITLE
zinject: Introduce waiting on injection events

### DIFF
--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -165,6 +165,8 @@ _LIBZFS_CORE_H int lzc_scrub(zfs_ioc_t, const char *, nvlist_t *, nvlist_t **);
 _LIBZFS_CORE_H int lzc_ddt_prune(const char *, zpool_ddt_prune_unit_t,
     uint64_t);
 
+_LIBZFS_CORE_H int lzc_wait_inject(uint64_t *state, hrtime_t timeout);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1567,6 +1567,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_POOL_SCRUB,			/* 0x5a57 */
 	ZFS_IOC_POOL_PREFETCH,			/* 0x5a58 */
 	ZFS_IOC_DDT_PRUNE,			/* 0x5a59 */
+	ZFS_IOC_WAIT_INJECT,			/* 0x5a5a */
 
 	/*
 	 * Per-platform (Optional) - 8/128 numbers reserved.
@@ -1827,6 +1828,12 @@ typedef enum {
  */
 #define	DDT_PRUNE_UNIT		"ddt_prune_unit"
 #define	DDT_PRUNE_AMOUNT	"ddt_prune_amount"
+
+/*
+ * The following are names used when invoking ZFS_IOC_WAIT_INJECT.
+ */
+#define	WAIT_INJECT_STATE	"state"
+#define	WAIT_INJECT_TIMEOUT	"timeout"
 
 /*
  * Flags for ZFS_IOC_VDEV_SET_STATE

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -704,6 +704,7 @@ extern int zio_inject_fault(char *name, int flags, int *id,
     struct zinject_record *record);
 extern int zio_inject_list_next(int *id, char *name, size_t buflen,
     struct zinject_record *record);
+extern int zio_inject_wait(uint64_t *state, hrtime_t timeout);
 extern int zio_clear_fault(int id);
 extern void zio_handle_panic_injection(spa_t *spa, const char *tag,
     uint64_t type);

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -1994,3 +1994,29 @@ lzc_ddt_prune(const char *pool, zpool_ddt_prune_unit_t unit, uint64_t amount)
 
 	return (error);
 }
+
+/*
+ * Wait for injection events.
+ */
+int
+lzc_wait_inject(uint64_t *state, hrtime_t timeout)
+{
+	int error;
+
+	nvlist_t *result = NULL;
+	nvlist_t *args = fnvlist_alloc();
+
+	if (timeout != 0)
+		fnvlist_add_uint64(args, WAIT_INJECT_STATE, *state);
+	if (timeout > 0)
+		VERIFY0(nvlist_add_hrtime(args, WAIT_INJECT_TIMEOUT, timeout));
+
+	error = lzc_ioctl(ZFS_IOC_WAIT_INJECT, NULL, args, &result);
+	if (error == 0)
+		*state = fnvlist_lookup_uint64(result, WAIT_INJECT_STATE);
+
+	fnvlist_free(args);
+	fnvlist_free(result);
+
+	return (error);
+}

--- a/man/man8/zinject.8
+++ b/man/man8/zinject.8
@@ -61,6 +61,21 @@ Cancel injection records.
 .
 .It Xo
 .Nm zinject
+.Fl w Ar state Ns | Ns Sy 0
+.Op Fl W Ar delay
+.Xc
+Wait until an injection event occurs.
+The
+.Ar state
+parameter synchronizes with kernel state and
+should be set to 0 for first call which gets the current state value,
+then the value printed to stdout after each wait.
+.Fl W Ar delay
+sets an optional timeout in milliseconds.
+If omitted, waits forever.
+.
+.It Xo
+.Nm zinject
 .Fl d Ar vdev
 .Fl A Sy degrade Ns | Ns Sy fault
 .Ar pool


### PR DESCRIPTION
This is useful for reproducing races during the sync pipeline.

See https://github.com/openzfs/zfs/pull/16025#issuecomment-3288781916 for use in the repro case for `free_children` panic in #16025.

### Motivation and Context

Blocking in the kernel on injection events allows reliably hitting race windows created by `zinject`. 

### Description

Adds a new ioctl `ZFS_IOC_WAIT_INJECT` to wait for inject events, `libzfs` marshalling call, and a `zinject` command.

Callers must have admin privileges to use wait on injection events.

The kernel stores a state of the number of events so far, and callers pass in this state to block until another event occurs. This pattern allows the waiter to obtain the state before triggering the inject event to reliably wake exactly when the injection event has fired.

I'm open to feedback on the kernel code as well as the ioctl, API, and zinject command syntax.

### How Has This Been Tested?

ZTS and by running the repro case from 16025.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:

- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).