### PR TITLE
fix status in partial scrub

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -8922,11 +8922,21 @@ print_scan_scrub_resilver_status(pool_scan_stat_t *ps)
 	/* Scan is in progress. Resilvers can't be paused. */
 	if (is_scrub) {
 		if (pause == 0) {
-			(void) printf(gettext("scrub in progress since %s"),
-			    ctime(&start));
+			if (ps->pss_partial) {
+				(void) printf(gettext("partial scrub in "
+				    "progress since %s"), ctime(&start));
+			} else {
+				(void) printf(gettext("scrub in progress "
+				    "since %s"), ctime(&start));
+			}
 		} else {
-			(void) printf(gettext("scrub paused since %s"),
-			    ctime(&pause));
+			if (ps->pss_partial) {
+				(void) printf(gettext("partial scrub paused "
+				    "since %s"), ctime(&pause));
+			} else {
+				(void) printf(gettext("scrub paused since %s"),
+				    ctime(&pause));
+			}
 			(void) printf(gettext("\tscrub started on %s"),
 			    ctime(&start));
 		}
@@ -8940,7 +8950,11 @@ print_scan_scrub_resilver_status(pool_scan_stat_t *ps)
 	issued = ps->pss_issued;
 	pass_issued = ps->pss_pass_issued;
 	total_s = ps->pss_to_examine;
-	total_i = ps->pss_to_examine - ps->pss_skipped;
+	if (ps->pss_partial) {
+		total_i = scanned;
+	} else {
+		total_i = ps->pss_to_examine - ps->pss_skipped;
+	}
 
 	/* we are only done with a block once we have issued the IO for it */
 	fraction_done = (double)issued / total_i;

--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -131,6 +131,7 @@ typedef struct dsl_scan {
 	uint64_t scn_done_txg;
 	uint64_t scn_sync_start_time;
 	uint64_t scn_issued_before_pass;
+	uint64_t scn_partial;
 
 	/* for freeing blocks */
 	boolean_t scn_is_bptree;

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1180,6 +1180,7 @@ typedef struct pool_scan_stat {
 	uint64_t	pss_pass_scrub_spent_paused;
 	uint64_t	pss_pass_issued; /* issued bytes per scan pass */
 	uint64_t	pss_issued;	/* total bytes checked by scanner */
+	uint64_t	pss_partial; /* whether it's a -C, -S, or -E scrub */
 
 	/* error scrub values stored on disk */
 	uint64_t	pss_error_scrub_func;	/* pool_scan_func_t */

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -883,6 +883,11 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 
 	scn->scn_phys.scn_func = setup_sync_arg->func;
 	scn->scn_phys.scn_state = DSS_SCANNING;
+	if (setup_sync_arg->txgstart == 0 && setup_sync_arg->txgend == 0) {
+		scn->scn_partial = 0;
+	} else {
+		scn->scn_partial = 1;
+	}
 	scn->scn_phys.scn_min_txg = setup_sync_arg->txgstart;
 	if (setup_sync_arg->txgend == 0) {
 		scn->scn_phys.scn_max_txg = tx->tx_txg;

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2811,6 +2811,7 @@ spa_scan_get_stats(spa_t *spa, pool_scan_stat_t *ps)
 	ps->pss_pass_issued = spa->spa_scan_pass_issued;
 	ps->pss_issued =
 	    scn->scn_issued_before_pass + spa->spa_scan_pass_issued;
+	ps->pss_partial = scn->scn_partial;
 
 	/* error scrub data stored on disk */
 	ps->pss_error_scrub_func = scn->errorscrub_phys.dep_func;


### PR DESCRIPTION
### Motivation and Context

When running partial scrubs, ie with -C, -S, or -E, zpool status reports the remaining time and data to be scanned/issued inaccurately. Modify the output so that to be issued data is equal to the already scanned data. This is still an approximation, but somewhat closer to the reality. Also report in zpool status that we are performing a partial scrub.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
