### PR TITLE
ZTS: fail test run if test runner crashes unexpectedly

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -797,6 +797,10 @@ msg "${TEST_RUNNER}" \
     2>&1; echo $? >"$REPORT_FILE"; } | tee "$RESULTS_FILE"
 read -r RUNRESULT <"$REPORT_FILE"
 
+if [[ "$RUNRESULT" -eq "255" ]] ; then
+    fail "$TEST_RUNNER failed, test aborted."
+fi 
+
 #
 # Analyze the results.
 #

--- a/tests/test-runner/bin/test-runner.py.in
+++ b/tests/test-runner/bin/test-runner.py.in
@@ -25,6 +25,7 @@ import sys
 import ctypes
 import re
 import configparser
+import traceback
 
 from datetime import datetime
 from optparse import OptionParser
@@ -1138,7 +1139,7 @@ def filter_tests(testrun, options):
     testrun.filter(failed)
 
 
-def fail(retstr, ret=1):
+def fail(retstr, ret=255):
     print('%s: %s' % (sys.argv[0], retstr))
     exit(ret)
 
@@ -1247,23 +1248,27 @@ def parse_args():
 def main():
     options = parse_args()
 
-    testrun = TestRun(options)
+    try:
+        testrun = TestRun(options)
 
-    if options.runfiles:
-        testrun.read(options)
-    else:
-        find_tests(testrun, options)
+        if options.runfiles:
+            testrun.read(options)
+        else:
+            find_tests(testrun, options)
 
-    if options.logfile:
-        filter_tests(testrun, options)
+        if options.logfile:
+            filter_tests(testrun, options)
 
-    if options.template:
-        testrun.write(options)
-        exit(0)
+        if options.template:
+            testrun.write(options)
+            exit(0)
 
-    testrun.complete_outputdirs()
-    testrun.run(options)
-    exit(testrun.summary())
+        testrun.complete_outputdirs()
+        testrun.run(options)
+        exit(testrun.summary())
+
+    except Exception:
+        fail("Uncaught exception in test runner:\n" + traceback.format_exc())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

I was looking at #17759 and noticed its tests had all passed but with unusually short run times. [Looking at the output](https://github.com/openzfs/zfs/actions/runs/18665848069/job/53216842059?pr=17759), it turns out there was a syntax error in the runfile, but the return code passed back to `zfs-tests.sh` was a "success" code, and so the whole run was deemed a success.

### Description

`zfs-tests.sh` executes `test-runner.py` to do the actual test work. Any exit code < 4 is interpreted as success, with the actual value describing the outcome of the tests inside.

If a Python program crashes in some way (eg an uncaught exception), the process exit code is 1.

Taken together, this means that `test-runner.py` can crash during setup, but return a "success" error code to `zfs-tests.sh`, which will report and exit 0. This in turn causes the CI runner to believe the test run completed successfully.

This commit addresses this by making `zfs-tests.sh` interpret an exit code of 255 as a failure in the runner itself. Then, in `test-runner.py`, the `fail()` function defaults to a 255 return, and the main function gets wrapped in a generic exception handler, which prints it and calls `fail()`.

All together, this should mean that any unexpected failure in the test runner itself will be propagated out of `zfs-tests.sh` for CI or any other calling program to deal with.

### How Has This Been Tested?

Manual testing, forcing success and failure within tests, and introducing errors into the runfile. Seems right.

To check the CI itself, I've pushed a second commit with a runfile error. If it does the right thing, I'll remove it and take this out of draft.
Update: this worked as expected, see [job output](https://github.com/openzfs/zfs/actions/runs/18670581110/job/53230487939?pr=17858).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
