### PR TITLE
FreeBSD zio_crypt.c: initialize uio variables before access

### DIFF
--- a/module/os/freebsd/zfs/zio_crypt.c
+++ b/module/os/freebsd/zfs/zio_crypt.c
@@ -437,6 +437,7 @@ zio_crypt_key_wrap(crypto_key_t *cwkey, zio_crypt_key_t *key, uint8_t *iv,
 
 	ASSERT3U(crypt, <, ZIO_CRYPT_FUNCTIONS);
 
+	memset(&cuio_s, 0, sizeof (cuio_s));
 	zfs_uio_init(&cuio, &cuio_s);
 
 	keydata_len = zio_crypt_table[crypt].ci_keylen;
@@ -519,6 +520,7 @@ zio_crypt_key_unwrap(crypto_key_t *cwkey, uint64_t crypt, uint64_t version,
 	keydata_len = zio_crypt_table[crypt].ci_keylen;
 	rw_init(&key->zk_salt_lock, NULL, RW_DEFAULT, NULL);
 
+	memset(&cuio_s, 0, sizeof (cuio_s));
 	zfs_uio_init(&cuio, &cuio_s);
 
 	/*


### PR DESCRIPTION
In zio_crypt_key_wrap and zio_crypt_key_unwrap, the cuio_s variable was not initialized before the calls to zfs_uio_init, leading to uninitialized access to cuio_s.uio_offset.  Initialize it to avoid gcc warnings.

Similar issue as fixed in 2bf152021 ("Fix gcc uninitialized warning in FreeBSD zio_crypt.c")

Signed off by: Ryan Libby <rlibby@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolve gcc -Wuninitialized compiler warning resulting in build error in the FreeBSD gcc build:
https://ci.freebsd.org/job/FreeBSD-stable-15-amd64-gcc14_build/94/console
```
--- zio_crypt.o ---
In file included from /workspace/src/sys/contrib/openzfs/include/os/freebsd/spl/sys/sunddi.h:29,
                 from /workspace/src/sys/contrib/openzfs/include/sys/zfs_context.h:70,
                 from /workspace/src/sys/contrib/openzfs/include/sys/dmu.h:48,
                 from /workspace/src/sys/contrib/openzfs/include/sys/zio_crypt.h:24,
                 from /workspace/src/sys/contrib/openzfs/module/os/freebsd/zfs/zio_crypt.c:21:
In function 'zfs_uio_init',
    inlined from 'zio_crypt_key_wrap' at /workspace/src/sys/contrib/openzfs/module/os/freebsd/zfs/zio_crypt.c:440:2:
/workspace/src/sys/contrib/openzfs/include/os/freebsd/spl/sys/uio.h:103:45: error: 'cuio_s.uio_offset' is used uninitialized [-Werror=uninitialized]
  103 |                 zfs_uio_soffset(uio) = uio_s->uio_offset;
      |                                        ~~~~~^~~~~~~~~~~~
/workspace/src/sys/contrib/openzfs/module/os/freebsd/zfs/zio_crypt.c: In function 'zio_crypt_key_wrap':
/workspace/src/sys/contrib/openzfs/module/os/freebsd/zfs/zio_crypt.c:433:20: note: 'cuio_s' declared here
  433 |         struct uio cuio_s;
      |                    ^~~~~~
```

### Description
<!--- Describe your changes in detail -->

Zero-initialize variable before access to avoid compiler warning.

I have not been able to determine that there is any further consequence from the uninitialized data: it seems to me that uio_offset and uio_soffset are not actually used deeper in these code paths, but I am not positive about that.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

make with clang and gcc.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
