### PR TITLE
Fix caching of DDT log and BRT

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -126,7 +126,7 @@ typedef enum dmu_object_byteswap {
 	(ot) < DMU_OT_NUMTYPES)
 
 #define	DMU_OT_IS_METADATA_CACHED(ot) (((ot) & DMU_OT_NEWTYPE) ? \
-	B_TRUE : dmu_ot[(ot)].ot_dbuf_metadata_cache)
+	((ot) & DMU_OT_METADATA) != 0 : dmu_ot[(ot)].ot_dbuf_metadata_cache)
 
 /*
  * MDB doesn't have dmu_ot; it defines these macros itself.

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -446,7 +446,10 @@ static boolean_t
 dbuf_include_in_metadata_cache(dmu_buf_impl_t *db)
 {
 	DB_DNODE_ENTER(db);
-	dmu_object_type_t type = DB_DNODE(db)->dn_type;
+	dnode_t *dn = DB_DNODE(db);
+	dmu_object_type_t type = dn->dn_storage_type;
+	if (type == DMU_OT_NONE)
+		type = dn->dn_type;
 	DB_DNODE_EXIT(db);
 
 	/* Check if this dbuf is one of the types we care about */

--- a/module/zfs/ddt_log.c
+++ b/module/zfs/ddt_log.c
@@ -222,7 +222,7 @@ ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx, ddt_log_update_t *dlu)
 
 	VERIFY0(dmu_buf_hold_array_by_dnode(dlu->dlu_dn, offset, length,
 	    B_FALSE, FTAG, &dlu->dlu_ndbp, &dlu->dlu_dbp,
-	    DMU_READ_NO_PREFETCH));
+	    DMU_READ_NO_PREFETCH | DMU_UNCACHEDIO));
 
 	dlu->dlu_tx = tx;
 	dlu->dlu_block = dlu->dlu_offset = 0;
@@ -298,7 +298,8 @@ ddt_log_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe, ddt_log_update_t *dlu)
 	 * we will fill it, and zero it out.
 	 */
 	if (dlu->dlu_offset == 0) {
-		dmu_buf_will_fill(db, dlu->dlu_tx, B_FALSE);
+		dmu_buf_will_fill_flags(db, dlu->dlu_tx, B_FALSE,
+		    DMU_UNCACHEDIO);
 		memset(db->db_data, 0, db->db_size);
 	}
 
@@ -597,7 +598,7 @@ ddt_log_load_one(ddt_t *ddt, uint_t n)
 		for (uint64_t offset = 0; offset < hdr.dlh_length;
 		    offset += dn->dn_datablksz) {
 			err = dmu_buf_hold_by_dnode(dn, offset, FTAG, &db,
-			    DMU_READ_PREFETCH);
+			    DMU_READ_PREFETCH | DMU_UNCACHEDIO);
 			if (err != 0) {
 				dnode_rele(dn, FTAG);
 				ddt_log_empty(ddt, ddl);


### PR DESCRIPTION
Both DDT log and BRT counters we read on pool import and then only append or overwrite in full blocks.  We don't need them in DMU or ARC caches.  Fortunately we have `DMU_UNCACHEDIO` for this now.

Even more we don't need DDT log and BRT in non-evictable metadata DMU caches, since it will likely never fit there, while block the cache from its original users.  Since `DMU_OT_IS_METADATA_CACHED()` has no way to differentiate the new metadata types, mark BRT with storage type of `DMU_OT_DDT_ZAP`.  As side effect it will also put it on dedup device, but that should actually be right.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
