### PR TITLE
Linux 6.17 compat: Fix broken projectquota on 6.17

### DIFF
--- a/include/sys/zfs_project.h
+++ b/include/sys/zfs_project.h
@@ -35,18 +35,16 @@
 
 #include <sys/vfs.h>
 
-#ifdef FS_PROJINHERIT_FL
-#define	ZFS_PROJINHERIT_FL	FS_PROJINHERIT_FL
-#else
-#define	ZFS_PROJINHERIT_FL	0x20000000
-#endif
-
 #ifdef FS_IOC_FSGETXATTR
 typedef struct fsxattr zfsxattr_t;
 
 #define	ZFS_IOC_FSGETXATTR	FS_IOC_FSGETXATTR
 #define	ZFS_IOC_FSSETXATTR	FS_IOC_FSSETXATTR
 #else
+/* Non-Linux OS */
+#define	FS_PROJINHERIT_FL	0x20000000
+#define	FS_XFLAG_PROJINHERIT	FS_PROJINHERIT_FL
+
 struct zfsxattr {
 	uint32_t	fsx_xflags;	/* xflags field value (get/set) */
 	uint32_t	fsx_extsize;	/* extsize field value (get/set) */

--- a/lib/libspl/include/Makefile.am
+++ b/lib/libspl/include/Makefile.am
@@ -78,6 +78,7 @@ libspl_sys_HEADERS += \
 	%D%/os/linux/sys/param.h \
 	%D%/os/linux/sys/stat.h \
 	%D%/os/linux/sys/sysmacros.h \
+	%D%/os/linux/sys/vfs.h \
 	%D%/os/linux/sys/zfs_context_os.h
 
 libspl_ia32_HEADERS = \

--- a/lib/libspl/include/os/linux/sys/vfs.h
+++ b/lib/libspl/include/os/linux/sys/vfs.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/* Copyright 2025 by Lawrence Livermore National Security, LLC. */
+
+/* This is the Linux userspace version of include/os/linux/spl/sys/vfs.h */
+
+#ifndef	_LIBSPL_SYS_VFS_H
+#define	_LIBSPL_SYS_VFS_H
+
+#include <linux/fs.h>
+#include <sys/statfs.h>
+
+#endif

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -278,7 +278,7 @@ zfs_ioctl_getxattr(vnode_t *vp, zfsxattr_t *fsx)
 
 	memset(fsx, 0, sizeof (*fsx));
 	fsx->fsx_xflags = (zp->z_pflags & ZFS_PROJINHERIT) ?
-	    ZFS_PROJINHERIT_FL : 0;
+	    FS_PROJINHERIT_FL : 0;
 	fsx->fsx_projid = zp->z_projid;
 
 	return (0);
@@ -290,7 +290,7 @@ zfs_ioctl_setflags(vnode_t *vp, uint32_t ioctl_flags, xvattr_t *xva)
 	uint64_t zfs_flags = VTOZ(vp)->z_pflags;
 	xoptattr_t *xoap;
 
-	if (ioctl_flags & ~(ZFS_PROJINHERIT_FL))
+	if (ioctl_flags & ~(FS_PROJINHERIT_FL))
 		return (SET_ERROR(EOPNOTSUPP));
 
 	xva_init(xva);
@@ -304,7 +304,7 @@ zfs_ioctl_setflags(vnode_t *vp, uint32_t ioctl_flags, xvattr_t *xva)
 	}								\
 } while (0)
 
-	FLAG_CHANGE(ZFS_PROJINHERIT_FL, ZFS_PROJINHERIT, XAT_PROJINHERIT,
+	FLAG_CHANGE(FS_PROJINHERIT_FL, ZFS_PROJINHERIT, XAT_PROJINHERIT,
 	    xoap->xoa_projinherit);
 
 #undef	FLAG_CHANGE


### PR DESCRIPTION
### Motivation and Context
Get projectquota working against the 6.17 kernel: #17869

### Description
We need to specifically use the `FX_XFLAG_*` macros in `zpl_ioctl_*attr()` codepaths, and the `FS_*_FL` macros in the `zpl_ioctl_*flags()` codepaths. The earlier code just assumes the `FS_*_FL` macros for both codepaths. The 6.17 kernel add a bitmask check in `copy_fsxattr_from_user()` that exposed this descrepency via failing `projectquota` ZTS tests.

### How Has This Been Tested?
All projectquota tests now pass on 6.17 kernel.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
