### PR TITLE
man: describe zfs-rewrite method and properties

### DIFF
--- a/man/man8/zfs-rewrite.8
+++ b/man/man8/zfs-rewrite.8
@@ -20,8 +20,9 @@
 .\" CDDL HEADER END
 .\"
 .\" Copyright (c) 2025 iXsystems, Inc.
+.\" Copyright (c) 2025, Klara, Inc.
 .\"
-.Dd July 23, 2025
+.Dd November 5, 2025
 .Dt ZFS-REWRITE 8
 .Os
 .
@@ -39,9 +40,10 @@
 .Sh DESCRIPTION
 Rewrite blocks of specified
 .Ar file
-as is without modification at a new location and possibly with new
-properties, such as checksum, compression, dedup, copies, etc,
+as is without modification at a new location and possibly with new properties,
 as if they were atomically read and written back.
+.No See Sx NOTES .
+for more information about property changes that may be applied during rewrite.
 .Bl -tag -width "-r"
 .It Fl P
 Perform physical rewrite, preserving logical birth time of blocks.
@@ -64,6 +66,20 @@ Print names of all successfully rewritten files.
 Don't cross file system mount points when recursing.
 .El
 .Sh NOTES
+Rewrite works by replacing an existing block with a new block of the same
+logical size.
+Changed dataset properties that operate on the data or metadata without
+changing the logical size will be applied.
+These include
+.Sy checksum ,
+.Sy compression ,
+.Sy dedup
+and
+.Sy copies .
+Changes to properties that affect the size of a logical block, like
+.Sy recordsize ,
+will have no effect.
+.Pp
 Rewrite of cloned blocks and blocks that are part of any snapshots,
 same as some property changes may increase pool space usage.
 Holes that were never written or were previously zero-compressed are


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

We've heard anecdotes that suggest some confusion/surprise/disappointment that a changed `recordsize` is not applied during rewrite. Until such time as we actually can do that, we can at least explicitly mention it at something that doesn't work.

### Description

Another paragraph in the `NOTES` part of `zfs-rewrite(8)`, describing vaguely what rewrite _is_, and from there, specific property changes that are and aren't applied.

### How Has This Been Tested?

Manpage change, so just `mancheck`.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
