### PR TITLE
zpool status: add -E flag for pool exclusion

### DIFF
--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -38,6 +38,7 @@
 .Nm zpool
 .Cm status
 .Op Fl DdegiLPpstvx
+.Op Fl E Ar pool1 Ns Oo , Ns Ar pool2 Ns ,… Oc
 .Op Fl c Ar script1 Ns Oo , Ns Ar script2 Ns ,… Oc
 .Oo Fl j|--json
 .Oo Ns Fl -json-flat-vdevs Oc
@@ -95,6 +96,22 @@ Direct I/O reads checksum verify errors can also occur if the contents of the
 buffer are being manipulated after the I/O has been issued and is in flight.
 In the case of Direct I/O read checksum verify errors, the I/O will be reissued
 through the ARC.
+.It Fl E Ar pool Ns Oo , Ns Ar pool Oc Ns ...
+Exclude specified pools from output.
+Multiple pool names can be specified separated by commas.
+.Pp
+Examples:
+.Bl -bullet -compact
+.It
+.Ql zpool status -E tank
+shows all pools except tank.
+.It
+.Ql zpool status -E tank,backup
+shows all pools except tank and backup.
+.It
+.Ql zpool status pool1 pool2 -E pool1
+shows only pool2 (pool1 is excluded).
+.El
 .It Fl e
 Only show unhealthy vdevs (not-ONLINE or with errors).
 .It Fl g


### PR DESCRIPTION
### Motivation and Context
Currently, `zpool status` lacks an option to exclude specific pools from output. Useful for hiding `test`/`backup`/`boot` pools when monitoring systems with many pools.

### Description
Adds `-E` flag to exclude specified pools from output. Takes comma-separated pool names and filters them out.
**Example:** `zpool status -E tank,backup` excludes `tank` and `backup`, showing all other pools.

### How Has This Been Tested?
Manually tested exclusion from all pools and specific pools, edge cases (trailing commas, duplicate flags, invalid arguments), and combination with other flags.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
