### PR TITLE
taskq: deadman: log a message if a taskq has not made progress

### DIFF
--- a/config/kernel-timer.m4
+++ b/config/kernel-timer.m4
@@ -1,8 +1,19 @@
 dnl #
-dnl # 6.2: timer_delete_sync introduced, del_timer_sync deprecated and made
-dnl #      into a simple wrapper
+dnl # 6.2: timer_delete & timer_delete_sync introduced, del_timer &
+dnl        del_timer_sync deprecated and made into a simple wrapper
 dnl # 6.15: del_timer_sync removed
 dnl #
+dnl # We test for them separately as they appear to have not always been
+dnl # backported together
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_TIMER_DELETE], [
+	ZFS_LINUX_TEST_SRC([timer_delete], [
+		#include <linux/timer.h>
+	],[
+		struct timer_list *timer __attribute__((unused)) = NULL;
+		timer_delete(timer);
+	])
+])
 AC_DEFUN([ZFS_AC_KERNEL_SRC_TIMER_DELETE_SYNC], [
 	ZFS_LINUX_TEST_SRC([timer_delete_sync], [
 		#include <linux/timer.h>
@@ -12,6 +23,16 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_TIMER_DELETE_SYNC], [
 	])
 ])
 
+AC_DEFUN([ZFS_AC_KERNEL_TIMER_DELETE], [
+	AC_MSG_CHECKING([whether timer_delete() is available])
+	ZFS_LINUX_TEST_RESULT([timer_delete], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_TIMER_DELETE, 1,
+		    [timer_delete is available])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
 AC_DEFUN([ZFS_AC_KERNEL_TIMER_DELETE_SYNC], [
 	AC_MSG_CHECKING([whether timer_delete_sync() is available])
 	ZFS_LINUX_TEST_RESULT([timer_delete_sync], [
@@ -24,9 +45,11 @@ AC_DEFUN([ZFS_AC_KERNEL_TIMER_DELETE_SYNC], [
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_SRC_TIMER], [
+	ZFS_AC_KERNEL_SRC_TIMER_DELETE
 	ZFS_AC_KERNEL_SRC_TIMER_DELETE_SYNC
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_TIMER], [
+	ZFS_AC_KERNEL_TIMER_DELETE
 	ZFS_AC_KERNEL_TIMER_DELETE_SYNC
 ])

--- a/include/os/linux/spl/sys/taskq.h
+++ b/include/os/linux/spl/sys/taskq.h
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  */
 /*
- * Copyright (c) 2024, Klara Inc.
+ * Copyright (c) 2024, 2025, Klara, Inc.
  * Copyright (c) 2024, Syneto
  */
 
@@ -134,6 +134,8 @@ typedef struct taskq {
 	wait_queue_head_t	tq_work_waitq;	/* new work waitq */
 	wait_queue_head_t	tq_wait_waitq;	/* wait waitq */
 	tq_lock_role_t		tq_lock_class;	/* class when taking tq_lock */
+	struct timer_list	tq_deadman;	/* deadman timer */
+	unsigned long		tq_deadman_at;	/* time of last deadman trip */
 	/* list node for the cpu hotplug callback */
 	struct hlist_node	tq_hp_cb_node;
 	boolean_t		tq_hp_support;

--- a/man/man4/spl.4
+++ b/man/man4/spl.4
@@ -14,8 +14,9 @@
 .\" Portions Copyright [yyyy] [name of copyright owner]
 .\"
 .\" Copyright 2013 Turbo Fredriksson <turbo@bayour.com>. All rights reserved.
+.\" Copyright (c) 2025, Klara, Inc.
 .\"
-.Dd May 7, 2025
+.Dd November 12, 2025
 .Dt SPL 4
 .Os
 .
@@ -129,6 +130,14 @@ Cause a kernel panic on assertion failures.
 When not enabled, the thread is halted to facilitate further debugging.
 .Pp
 Set to a non-zero value to enable.
+.
+.It Sy spl_taskq_deadman_timeout Ns = Ns Sy 20 Pq uint
+Log a warning if a taskq has not made progress in N seconds.
+"Progress" here means a taskq thread has not picked up a new task in this
+time,
+or all threads have not completed in this time.
+This can be useful for deadlock debugging.
+Setting this value to 0 will disable this function.
 .
 .It Sy spl_taskq_kick Ns = Ns Sy 0 Pq uint
 Kick stuck taskq to spawn threads.


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Motivation and Context

It is very difficult to debug situations where all threads on a taskq go to sleep waiting for some condition that will not be satisfied until some task queued on that taskq performs some task. Its usually easy to see that the threads are waiting, but less easy to see that unscheduled tasks exist.

I have spent four days trying to find the source of a hang. A taskq thread was waiting on a condvar, but there were no other threads anywhere in the system holding some other lock preventing it from getting there. Eventually I found it - one of the tasks behind it on the taskq would have done the work and sent the signal, if it had ever been scheduled.

I've still got a bug to solve of course, but this has caught me out before and I would like to never see it again. There's a lot more we could do but for now I've just gone with a detect & report option: a deadman.

### Description

This adds a deadman timer to each taskq. The first time a taskq picks up a thread, it arms the timer to expire in `spl_taskq_deadman_timeout` seconds (default 20s). If another thread picks up a new task, the timer is rearmed. When the last active thread completes its task, the timer is disarmed.

All together, this means the deadman will fire if no new tasks have started or existing tasks have completed within the configured time. As long as the taskq is making progress, everything will be silent.

When it fires, it will log a notice to the kernel log:

```
[   28.715019] spl: taskq stuck for 20s: z_null_int.0 [1/1 threads active, 35 tasks queued]
```

If it clears by itself, that is, this was a genuinely long-running task, a second message will be logged:

```
[   38.819171] spl: taskq resumed after s105s: z_null_iss.0
```

`spl_taskq_deadman_timeout=0` will disable the facility entirely.

### How Has This Been Tested?

ZTS run completed on 6.12. Compile checked on 4.19, 5.4, 5.10, 5.15, 6.1, 6.6, 6.17.

In my own test run, `zpool_reopen_003_pos` actually made a little noise:

```
Nov 12 19:04:05 shop kernel: spl: taskq stuck for 20s: dsl_scan_iss.0 [1/1 threads active, 0 tasks queued]
Nov 12 19:04:21 shop kernel: spl: taskq resumed after 15s: dsl_scan_iss.0
```

To really try it out, I put `zfs_delay(10*h);` at the top of `zio_execute()`, set `spl_taskq_deadman_timeout=5`, then created a pool. Hilarity ensues:

```
[    8.715019] spl: taskq stuck for 5s: z_null_int.0 [1/1 threads active, 35 tasks queued]
[    8.715308] spl: taskq stuck for 5s: vdev_open.1 [12/12 threads active, 0 tasks queued]
[    8.715326] spl: taskq stuck for 5s: vdev_open.0 [1/1 threads active, 0 tasks queued]
[   13.579435] spl: taskq resumed after 4s: z_null_int.0
[   18.699045] spl: taskq stuck for 5s: z_null_iss.0 [1/1 threads active, 0 tasks queued]
[   18.699079] spl: taskq stuck for 5s: z_null_int.0 [1/1 threads active, 34 tasks queued]
[   23.819171] spl: taskq resumed after 5s: z_null_iss.0
[   23.819393] spl: taskq resumed after 5s: z_null_int.0
[   28.939009] spl: taskq stuck for 5s: z_null_iss.0 [1/1 threads active, 0 tasks queued]
[   28.939024] spl: taskq stuck for 5s: z_null_int.0 [1/1 threads active, 34 tasks queued]
```

And it helped my understand my bug a bit better too:

```
[   16.022768] NOTICE: dbuf_sync_leaf: timed out waiting for dbuf sync: dbuf ffff994d42c0b860 dr ffff994d51e59a70
[   16.145683] spl: taskq stuck for 5s: dp_sync_taskq.0 [1/1 threads active, 1 tasks queued]
```

So I feel pretty good about it as a cheap debug tool.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
