### PR TITLE
zpool: fix special vdev -v -o conflict

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -6745,10 +6745,12 @@ typedef struct list_cbdata {
 
 
 /*
- * Given a list of columns to display, output appropriate headers for each one.
+ * Given a list of columns to display, print an appropriate line. If
+ * `vdev_name` is not NULL, we print `vdev_name` followed by a line of dashes.
+ * If `vdev_name` is NULL, we print a line of the headers.
  */
 static void
-print_header(list_cbdata_t *cb)
+print_line(list_cbdata_t *cb, const char *vdev_name)
 {
 	zprop_list_t *pl = cb->cb_proplist;
 	char headerbuf[ZPOOL_MAXPROPLEN];
@@ -6756,6 +6758,8 @@ print_header(list_cbdata_t *cb)
 	boolean_t first = B_TRUE;
 	boolean_t right_justify;
 	size_t width = 0;
+
+	boolean_t print_header = (vdev_name == NULL);
 
 	for (; pl != NULL; pl = pl->pl_next) {
 		width = pl->pl_width;
@@ -6769,20 +6773,36 @@ print_header(list_cbdata_t *cb)
 
 		if (!first)
 			(void) fputs("  ", stdout);
-		else
-			first = B_FALSE;
 
-		right_justify = B_FALSE;
-		if (pl->pl_prop != ZPROP_USERPROP) {
-			header = zpool_prop_column_name(pl->pl_prop);
-			right_justify = zpool_prop_align_right(pl->pl_prop);
-		} else {
-			int i;
+		if (print_header) {
+			right_justify = B_FALSE;
+			if (pl->pl_prop != ZPROP_USERPROP) {
+				header = zpool_prop_column_name(pl->pl_prop);
+				right_justify = zpool_prop_align_right(
+				    pl->pl_prop);
+			} else {
+				int i;
 
-			for (i = 0; pl->pl_user_prop[i] != '\0'; i++)
-				headerbuf[i] = toupper(pl->pl_user_prop[i]);
-			headerbuf[i] = '\0';
-			header = headerbuf;
+				for (i = 0; pl->pl_user_prop[i] != '\0'; i++)
+					headerbuf[i] = toupper(
+					    pl->pl_user_prop[i]);
+				headerbuf[i] = '\0';
+				header = headerbuf;
+			}
+
+		}
+		/*
+		 * If `print_header` is false, we want to print a line of
+		 * dashes.
+		 */
+		else {
+			if (first) {
+				header = vdev_name;
+				right_justify = B_FALSE;
+			} else {
+				header = "-";
+				right_justify = B_TRUE;
+			}
 		}
 
 		if (pl->pl_next == NULL && !right_justify)
@@ -6791,6 +6811,9 @@ print_header(list_cbdata_t *cb)
 			(void) printf("%*s", (int)width, header);
 		else
 			(void) printf("%-*s", (int)width, header);
+
+		if (first)
+			first = B_FALSE;
 	}
 
 	(void) fputc('\n', stdout);
@@ -6994,8 +7017,6 @@ collect_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 	uint64_t islog = B_FALSE;
 	nvlist_t *props, *ent, *ch, *obj, *l2c, *sp;
 	props = ent = ch = obj = sp = l2c = NULL;
-	const char *dashes = "%-*s      -      -      -        -         "
-	    "-      -      -      -         -\n";
 
 	verify(nvlist_lookup_uint64_array(nv, ZPOOL_CONFIG_VDEV_STATS,
 	    (uint64_t **)&vs, &c) == 0);
@@ -7207,9 +7228,7 @@ collect_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 				continue;
 
 			if (!printed && !cb->cb_json) {
-				/* LINTED E_SEC_PRINTF_VAR_FMT */
-				(void) printf(dashes, cb->cb_namewidth,
-				    class_name[n]);
+				print_line(cb, class_name[n]);
 				printed = B_TRUE;
 			}
 			vname = zpool_vdev_name(g_zfs, zhp, child[c],
@@ -7230,8 +7249,7 @@ collect_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		if (cb->cb_json) {
 			l2c = fnvlist_alloc();
 		} else {
-			/* LINTED E_SEC_PRINTF_VAR_FMT */
-			(void) printf(dashes, cb->cb_namewidth, "cache");
+			print_line(cb, "cache");
 		}
 		for (c = 0; c < children; c++) {
 			vname = zpool_vdev_name(g_zfs, zhp, child[c],
@@ -7252,8 +7270,7 @@ collect_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		if (cb->cb_json) {
 			sp = fnvlist_alloc();
 		} else {
-			/* LINTED E_SEC_PRINTF_VAR_FMT */
-			(void) printf(dashes, cb->cb_namewidth, "spare");
+			print_line(cb, "spare");
 		}
 		for (c = 0; c < children; c++) {
 			vname = zpool_vdev_name(g_zfs, zhp, child[c],
@@ -7496,7 +7513,7 @@ zpool_do_list(int argc, char **argv)
 
 		if (!cb.cb_scripted && (first || cb.cb_verbose) &&
 		    !cb.cb_json) {
-			print_header(&cb);
+			print_line(&cb, NULL);
 			first = B_FALSE;
 		}
 		ret = pool_list_iter(list, B_TRUE, list_callback, &cb);


### PR DESCRIPTION
Right now, running `zpool list` with -v and -o passed does not work properly for special vdevs. This commit fixes that problem.

See the discussion on #17839.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
Manually in command line:
~~~bash
(v-o-special) ~/zfs$ sudo ./zpool create mypool /tmp/vdev0 spare /tmp/vdev1 log /tmp/vdev2 cache /tmp/vdev3
(v-o-special) ~/zfs$ sudo ./zpool list -v -o name,checkpoint,frag mypool
NAME          CKPOINT   FRAG
mypool              -     2%
  /tmp/vdev0        -     2%
logs                -      -
  /tmp/vdev2        -     0%
cache               -      -
  /tmp/vdev3        -     0%
spare               -      -
  /tmp/vdev1        -      -
~~~

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
