### PR TITLE
CI: Add smatch static analysis workflow

### DIFF
--- a/.github/workflows/smatch.yml
+++ b/.github/workflows/smatch.yml
@@ -1,0 +1,52 @@
+name: smatch
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  smatch:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout smatch
+      uses: actions/checkout@v4
+      with:
+        repository: error27/smatch
+        ref: master
+        path: smatch
+    - name: Install smatch dependencies
+      run: |
+        sudo apt-get install -y llvm gcc make sqlite3 libsqlite3-dev libdbd-sqlite3-perl libssl-dev libtry-tiny-perl
+    - name: Make smatch
+      run: |
+        cd $GITHUB_WORKSPACE/smatch
+        make -j$(nproc)
+    - name: Checkout OpenZFS
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: zfs
+    - name: Install OpenZFS dependencies
+      run: |
+        cd $GITHUB_WORKSPACE/zfs
+        sudo apt-get purge -y snapd google-chrome-stable firefox
+        ONLY_DEPS=1 .github/workflows/scripts/qemu-3-deps-vm.sh ubuntu24
+    - name: Autogen.sh OpenZFS
+      run: |
+        cd $GITHUB_WORKSPACE/zfs
+        ./autogen.sh
+    - name: Configure OpenZFS
+      run: |
+        cd $GITHUB_WORKSPACE/zfs
+        ./configure --enable-debug
+    - name: Make OpenZFS
+      run: |
+        cd $GITHUB_WORKSPACE/zfs
+        make -j$(nproc) CHECK="$GITHUB_WORKSPACE/smatch/smatch" CC=$GITHUB_WORKSPACE/smatch/cgcc | tee $GITHUB_WORKSPACE/smatch.log
+    - name: Smatch results log
+      run: |
+        grep -E 'error:|warn:|warning:' $GITHUB_WORKSPACE/smatch.log


### PR DESCRIPTION
### Motivation and Context

As discussed in #17885 we want to enforce certain cstyle guidelines and catch bugs early in the development process.  Adding the smatch code checker to the CI can help with both of these things.  This PR automates running the analysis but it will take a concerted effort to resolve all the warnings.

### Description

Smatch is an actively maintained kernel-aware static analyzer for C with a low false positive rate.  Since the code checker can be run relatively quickly against the entire OpenZFS code base (15 min) it makes sense to add it as a GitHub Actions workflow.  Today smatch reports a significant numbers warnings so the workflow is configured to always pass as long as the analysis was run.  The results are available for reference. Long term it would ideal to resolve all of the errors/warnings at which point the workflow can be updated to fail when new problems are detected.

### How Has This Been Tested?

Lightly tested here, https://github.com/behlendorf/zfs/actions/runs/19380431337

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
