### PR TITLE
Add new version of space-based weighting algorithm

### DIFF
--- a/include/os/freebsd/spl/sys/mod.h
+++ b/include/os/freebsd/spl/sys/mod.h
@@ -80,6 +80,9 @@
 #define	param_set_active_allocator_args(var) \
     CTLTYPE_STRING, NULL, 0, param_set_active_allocator, "A"
 
+#define	param_set_active_weightfunc_args(var) \
+    CTLTYPE_STRING, NULL, 0, param_set_active_weightfunc, "A"
+
 #define	param_set_deadman_synctime_args(var) \
     CTLTYPE_U64, NULL, 0, param_set_deadman_synctime, "QU"
 

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -44,8 +44,12 @@ typedef struct metaslab_ops {
 	uint64_t (*msop_alloc)(metaslab_t *, uint64_t, uint64_t, uint64_t *);
 } metaslab_ops_t;
 
-
 extern const metaslab_ops_t zfs_metaslab_ops;
+
+typedef struct metaslab_wfs {
+	const char *mswf_name;
+	uint64_t (*mswf_func)(metaslab_t *);
+} metaslab_wfs_t;
 
 int metaslab_init(metaslab_group_t *, uint64_t, uint64_t, uint64_t,
     metaslab_t **);
@@ -113,7 +117,7 @@ metaslab_trace_fini(zio_alloc_list_t *zal __maybe_unused) {}
 #endif
 
 metaslab_class_t *metaslab_class_create(spa_t *, const char *,
-    const metaslab_ops_t *, boolean_t);
+    const metaslab_ops_t *, const metaslab_wfs_t *, boolean_t);
 void metaslab_class_destroy(metaslab_class_t *);
 void metaslab_class_validate(metaslab_class_t *);
 void metaslab_class_balance(metaslab_class_t *mc, boolean_t onsync);

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -205,6 +205,7 @@ struct metaslab_class {
 	spa_t			*mc_spa;
 	const char		*mc_name;
 	const metaslab_ops_t	*mc_ops;
+	const metaslab_wfs_t	*mc_wfs;
 
 	/*
 	 * Track the number of metaslab groups that have been initialized

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -79,10 +79,13 @@ typedef enum trace_alloc_type {
 #define	METASLAB_WEIGHT_PRIMARY		(1ULL << 63)
 #define	METASLAB_WEIGHT_SECONDARY	(1ULL << 62)
 #define	METASLAB_WEIGHT_CLAIM		(1ULL << 61)
-#define	METASLAB_WEIGHT_TYPE		(1ULL << 60)
+#define	METASLAB_WEIGHT_MASK		((1ULL << 60) | 1ULL << 59)
 #define	METASLAB_ACTIVE_MASK		\
 	(METASLAB_WEIGHT_PRIMARY | METASLAB_WEIGHT_SECONDARY | \
 	METASLAB_WEIGHT_CLAIM)
+
+#define	METASLAB_WEIGHT_MAX_IDX	58
+#define	METASLAB_WEIGHT_MAX	((1ULL << (METASLAB_WEIGHT_MAX_IDX + 1)) - 1)
 
 /*
  * The metaslab weight is used to encode the amount of free space in a
@@ -105,18 +108,30 @@ typedef enum trace_alloc_type {
  *
  *      64      56      48      40      32      24      16      8       0
  *      +-------+-------+-------+-------+-------+-------+-------+-------+
- *      |PSC1|                  weighted-free space                     |
+ *      |PSC10|                   weighted-free space                   |
  *      +-------+-------+-------+-------+-------+-------+-------+-------+
  *
  *	PS - indicates primary and secondary activation
  *	C - indicates activation for claimed block zio
  *	space - the fragmentation-weighted space
  *
+ * Space-based weight v2:
+ *
+ *      64      56      48      40      32      24      16      8       0
+ *      +-------+-------+-------+-------+-------+-------+-------+-------+
+ *      |PSC11|                weighted-free space                | idx |
+ *      +-------+-------+-------+-------+-------+-------+-------+-------+
+ *
+ *	PS - indicates primary and secondary activation
+ *	C - indicates activation for claimed block zio
+ *	idx - index for the highest bucket in the histogram
+ *	space - the fragmentation-weighted space
+ *
  * Segment-based weight:
  *
  *      64      56      48      40      32      24      16      8       0
  *      +-------+-------+-------+-------+-------+-------+-------+-------+
- *      |PSC0| idx|            count of segments in region              |
+ *      |PSC00| idx|            count of segments in region             |
  *      +-------+-------+-------+-------+-------+-------+-------+-------+
  *
  *	PS - indicates primary and secondary activation
@@ -127,17 +142,22 @@ typedef enum trace_alloc_type {
 #define	WEIGHT_GET_ACTIVE(weight)		BF64_GET((weight), 61, 3)
 #define	WEIGHT_SET_ACTIVE(weight, x)		BF64_SET((weight), 61, 3, x)
 
+#define	WEIGHT_GET_TYPE(weight)			BF64_GET((weight), 59, 2)
+#define	WEIGHT_SET_TYPE(weight, x)		BF64_SET((weight), 59, 2, x)
 #define	WEIGHT_IS_SPACEBASED(weight)		\
-	((weight) == 0 || BF64_GET((weight), 60, 1))
-#define	WEIGHT_SET_SPACEBASED(weight)		BF64_SET((weight), 60, 1, 1)
+	((weight) == 0 || WEIGHT_GET_TYPE((weight)))
+#define	WEIGHT_SET_SPACEBASED(weight)		WEIGHT_SET_TYPE((weight), 2)
+#define	WEIGHT_IS_SPACEBASED_V2(weight)		\
+	((weight) == 0 || WEIGHT_GET_TYPE((weight)) == 3)
+#define	WEIGHT_SET_SPACEBASED_V2(weight)	WEIGHT_SET_TYPE((weight), 3)
 
 /*
  * These macros are only applicable to segment-based weighting.
  */
-#define	WEIGHT_GET_INDEX(weight)		BF64_GET((weight), 54, 6)
-#define	WEIGHT_SET_INDEX(weight, x)		BF64_SET((weight), 54, 6, x)
-#define	WEIGHT_GET_COUNT(weight)		BF64_GET((weight), 0, 54)
-#define	WEIGHT_SET_COUNT(weight, x)		BF64_SET((weight), 0, 54, x)
+#define	WEIGHT_GET_INDEX(weight)		BF64_GET((weight), 53, 6)
+#define	WEIGHT_SET_INDEX(weight, x)		BF64_SET((weight), 53, 6, x)
+#define	WEIGHT_GET_COUNT(weight)		BF64_GET((weight), 0, 53)
+#define	WEIGHT_SET_COUNT(weight, x)		BF64_SET((weight), 0, 53, x)
 
 /*
  * Per-allocator data structure.

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1130,6 +1130,8 @@ extern uint64_t spa_dirty_data(spa_t *spa);
 extern spa_autotrim_t spa_get_autotrim(spa_t *spa);
 extern int spa_get_allocator(spa_t *spa);
 extern void spa_set_allocator(spa_t *spa, const char *allocator);
+extern int spa_get_weightfunc(spa_t *spa);
+extern void spa_set_weightfunc(spa_t *spa, const char *weightfunc);
 
 /* Miscellaneous support routines */
 extern void spa_load_failed(spa_t *spa, const char *fmt, ...)
@@ -1294,6 +1296,7 @@ int param_set_deadman_synctime(ZFS_MODULE_PARAM_ARGS);
 int param_set_slop_shift(ZFS_MODULE_PARAM_ARGS);
 int param_set_deadman_failmode(ZFS_MODULE_PARAM_ARGS);
 int param_set_active_allocator(ZFS_MODULE_PARAM_ARGS);
+int param_set_active_weightfunc(ZFS_MODULE_PARAM_ARGS);
 
 #ifdef ZFS_DEBUG
 #define	dprintf_bp(bp, fmt, ...) do {				\

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -296,6 +296,7 @@ struct spa {
 	spa_allocs_use_t *spa_allocs_use;
 	int		spa_alloc_count;
 	int		spa_active_allocator;	/* selectable allocator */
+	int		spa_active_weightfunc;	/* selectable weight function */
 
 	/* per-allocator sync thread taskqs */
 	taskq_t		*spa_sync_tq;
@@ -534,7 +535,9 @@ extern void spa_set_deadman_synctime(hrtime_t ns);
 extern void spa_set_deadman_ziotime(hrtime_t ns);
 extern const char *spa_history_zone(void);
 extern const char *zfs_active_allocator;
+extern const char *zfs_active_weightfunc;
 extern int param_set_active_allocator_common(const char *val);
+extern int param_set_active_weightfunc_common(const char *val);
 
 #ifdef	__cplusplus
 }

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -352,14 +352,8 @@ Prevent log spacemaps from being destroyed during pool exports and destroys.
 .
 .It Sy zfs_metaslab_segment_weight_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Enable/disable segment-based metaslab selection.
-.
-.It Sy zfs_metaslab_space_weight_v2_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
-Enable/disable the new space-based metaslab selection.
-.Pp
-Note that this algorithm is only enabled if
-.Sy zfs_metaslab_segment_weight_enabled
-is set to false.
-It also requires space map histograms to be enabled.
+Note that this tunable has been deprecated in favor of
+.Sy zfs_active_weightfunc .
 .
 .It Sy zfs_metaslab_switch_threshold Ns = Ns Sy 2 Pq int
 When using segment-based metaslab selection, continue allocating

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -800,6 +800,25 @@ Valid values are
 and
 .Sy cursor .
 .
+.It Sy zfs_active_weightfunc Ns = Ns Sy auto Pq string
+Selects the metaslab weighting function to use.
+The weighting function can be one of auto, space, space_v2, and segment.
+This determines what weighting algorithm will be used to sort metaslabs for
+selection during the allocation process.
+The space_v2 and segment algorithms require the spacemap histogram feature to be
+enabled, and will fall back to the space algorithm if that feature is not
+enabled on the pool.
+.Pp
+The space algorithm combines the total free space in the metaslab with the
+fragmentation metric to balance toward metaslabs with more contiguous free
+space.
+The segment algorithm uses the spacemap histograms to calculate the weight from
+the largest free segment size, bucketed to powers of two, and the number of
+segments in that bucket.
+The space_v2 algorithm considers not only the largest free segment bucket, but
+the smaller ones as well, providing a higher weight to larger contiguous chunks.
+Auto provides the recommended algorithm (currently space_v2).
+.
 .It Sy zfs_arc_dnode_limit Ns = Ns Sy 0 Ns B Pq u64
 When the number of bytes consumed by dnodes in the ARC exceeds this number of
 bytes, try to unpin some of it in response to demand for non-metadata.

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -353,6 +353,14 @@ Prevent log spacemaps from being destroyed during pool exports and destroys.
 .It Sy zfs_metaslab_segment_weight_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Enable/disable segment-based metaslab selection.
 .
+.It Sy zfs_metaslab_space_weight_v2_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
+Enable/disable the new space-based metaslab selection.
+.Pp
+Note that this algorithm is only enabled if
+.Sy zfs_metaslab_segment_weight_enabled
+is set to false.
+It also requires space map histograms to be enabled.
+.
 .It Sy zfs_metaslab_switch_threshold Ns = Ns Sy 2 Pq int
 When using segment-based metaslab selection, continue allocating
 from the active metaslab until this option's

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -350,11 +350,6 @@ This applies primarily to
 .It Sy zfs_keep_log_spacemaps_at_export Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Prevent log spacemaps from being destroyed during pool exports and destroys.
 .
-.It Sy zfs_metaslab_segment_weight_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
-Enable/disable segment-based metaslab selection.
-Note that this tunable has been deprecated in favor of
-.Sy zfs_active_weightfunc .
-.
 .It Sy zfs_metaslab_switch_threshold Ns = Ns Sy 2 Pq int
 When using segment-based metaslab selection, continue allocating
 from the active metaslab until this option's

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -289,6 +289,24 @@ param_set_active_allocator(SYSCTL_HANDLER_ARGS)
 	return (param_set_active_allocator_common(buf));
 }
 
+int
+param_set_active_weightfunc(SYSCTL_HANDLER_ARGS)
+{
+	char buf[16];
+	int rc;
+
+	if (req->newptr == NULL)
+		strlcpy(buf, zfs_active_weightfunc, sizeof (buf));
+
+	rc = sysctl_handle_string(oidp, buf, sizeof (buf), req);
+	if (rc || req->newptr == NULL)
+		return (rc);
+	if (strcmp(buf, zfs_active_weightfunc) == 0)
+		return (0);
+
+	return (param_set_active_weightfunc_common(buf));
+}
+
 /* mmp.c */
 
 int

--- a/module/os/linux/zfs/spa_misc_os.c
+++ b/module/os/linux/zfs/spa_misc_os.c
@@ -118,6 +118,18 @@ param_set_active_allocator(const char *val, zfs_kernel_param_t *kp)
 	return (error);
 }
 
+int
+param_set_active_weightfunc(const char *val, zfs_kernel_param_t *kp)
+{
+	int error;
+
+	error = -param_set_active_weightfunc_common(val);
+	if (error == 0)
+		error = param_set_charp(val, kp);
+
+	return (error);
+}
+
 const char *
 spa_history_zone(void)
 {

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -3133,8 +3133,8 @@ spa_set_weightfunc(spa_t *spa, const char *weightfunc)
 {
 	int a = spa_find_weightfunc_byname(weightfunc);
 	if (a < 0) a = 0;
-	if (a != 1 && !spa_feature_is_enabled(spa,
-	    SPA_FEATURE_SPACEMAP_HISTOGRAM)) {
+	if (metaslab_weightfuncs[a].mswf_func != metaslab_space_weight &&
+	    !spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_HISTOGRAM)) {
 		zfs_dbgmsg("warning: weight function %s will not be used for "
 		    "pool %s since space map histograms are not enabled",
 		    weightfunc, spa_name(spa));
@@ -3269,13 +3269,13 @@ metaslab_space_weight_from_spacemap(metaslab_t *msp)
  * actually use the number of segments in each bucket to determine the
  * weight. The weight is calculated as follows:
  *
- * sum from i = 0 to 29 of N(i) * 2^{2i}, where N(i) is the number of free
+ * sum from i = 0 to 29 of N(i) * 2^{3/2i}, where N(i) is the number of free
  * segments of size 2^{i + shift}
  *
  * N(i) * 2^i is just the space used by the segments in a bucket divided
- * by the shift, and the additional factor of 2^i weights the larger
+ * by the shift, and the additional factor of 2^{i/2} weights the larger
  * segments more heavily. If there are any segments of size larger than
- * (28 + shift), we just max out the weight. That metaslab is free enough
+ * (37 + shift), we just max out the weight. That metaslab is free enough
  * for any purpose.
  */
 static uint64_t

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -3137,7 +3137,7 @@ metaslab_space_weight_from_range_tree(metaslab_t *msp)
 
 	for (int i = ZFS_RANGE_TREE_HISTOGRAM_SIZE - 1; i >= vd_shift;
 	    i--) {
-		uint8_t seg_shift = 2 * (i - (vd_shift - 3));
+		uint8_t seg_shift = ((3 * (i - vd_shift)) / 2) + 6;
 		uint64_t segments = msp->ms_allocatable->rt_histogram[i];
 		if (segments == 0)
 			continue;
@@ -3187,13 +3187,13 @@ metaslab_space_weight_from_spacemap(metaslab_t *msp)
 
 	uint64_t weight = 0;
 	for (int i = SPACE_MAP_HISTOGRAM_SIZE - 1; i >= 0; i--) {
-		uint8_t seg_shift = 2 * (i + sm->sm_shift - vd_shift + 3);
+		uint8_t seg_shift = (3 * (i + sm->sm_shift - vd_shift) / 2) + 6;
 		uint64_t segments =
 		    sm->sm_phys->smp_histogram[i] - deferspace_histogram[i];
 		if (segments == 0)
 			continue;
 		if (weight == 0)
-			weight = i + sm->sm_shift;
+                	weight = i + sm->sm_shift;
 		// Prevent overflow using log_2 math
 		if (seg_shift + highbit64(segments) > METASLAB_WEIGHT_MAX_IDX)
 			return (METASLAB_WEIGHT_MAX);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -254,21 +254,6 @@ static int metaslab_perf_bias = 1;
 static const boolean_t zfs_remap_blkptr_enable = B_TRUE;
 
 /*
- * Enable/disable segment-based metaslab selection.
- */
-static int zfs_metaslab_segment_weight_enabled = B_TRUE;
-
-/*
- * Enable/disable the new space-based metaslab selection algorithm.
- *
- * The new space-based algorithm attempts to take into account not only the
- * largest free segment, as the segment-based weight does, but other segments
- * that are almost as large. This can improve metaslab selection and reduce the
- * number of metaslab loads needed to satisfy a given set of allocations.
- */
-static int zfs_metaslab_space_weight_v2_enabled = B_TRUE;
-
-/*
  * When using segment-based metaslab selection, we will continue
  * allocating from the active metaslab until we have exhausted
  * zfs_metaslab_switch_threshold of its buckets.
@@ -440,7 +425,7 @@ metaslab_stat_fini(void)
  */
 metaslab_class_t *
 metaslab_class_create(spa_t *spa, const char *name,
-    const metaslab_ops_t *ops, boolean_t is_log)
+    const metaslab_ops_t *ops, const metaslab_wfs_t *wfs, boolean_t is_log)
 {
 	metaslab_class_t *mc;
 
@@ -450,6 +435,7 @@ metaslab_class_create(spa_t *spa, const char *name,
 	mc->mc_spa = spa;
 	mc->mc_name = name;
 	mc->mc_ops = ops;
+	mc->mc_wfs = wfs;
 	mc->mc_is_log = is_log;
 	mc->mc_alloc_io_size = SPA_OLD_MAXBLOCKSIZE;
 	mc->mc_alloc_max = UINT64_MAX;
@@ -3119,6 +3105,79 @@ metaslab_fini(metaslab_t *msp)
 	kmem_free(msp, sizeof (metaslab_t));
 }
 
+static uint64_t metaslab_space_weight(metaslab_t *msp);
+static uint64_t metaslab_segment_weight(metaslab_t *msp);
+static uint64_t metaslab_space_weight_v2(metaslab_t *msp);
+metaslab_wfs_t *metaslab_weightfunc(spa_t *spa);
+
+static metaslab_wfs_t metaslab_weightfuncs[] = {
+	{ "auto", metaslab_space_weight_v2 },
+	{ "space", metaslab_space_weight },
+	{ "space_v2", metaslab_space_weight_v2 },
+	{ "segment", metaslab_segment_weight },
+};
+
+static int
+spa_find_weightfunc_byname(const char *val)
+{
+	int a = ARRAY_SIZE(metaslab_weightfuncs) - 1;
+	for (; a >= 0; a--) {
+		if (strcmp(val, metaslab_weightfuncs[a].mswf_name) == 0)
+			return (a);
+	}
+	return (-1);
+}
+
+void
+spa_set_weightfunc(spa_t *spa, const char *weightfunc)
+{
+	int a = spa_find_weightfunc_byname(weightfunc);
+	if (a < 0) a = 0;
+	if (a != 1 && !spa_feature_is_enabled(spa,
+	    SPA_FEATURE_SPACEMAP_HISTOGRAM)) {
+		zfs_dbgmsg("warning: weight function %s will not be used for "
+		    "pool %s since space map histograms are not enabled",
+		    weightfunc, spa_name(spa));
+	}
+	spa->spa_active_weightfunc = a;
+	zfs_dbgmsg("spa weight function: %s",
+	    metaslab_weightfuncs[a].mswf_name);
+}
+
+int
+spa_get_weightfunc(spa_t *spa)
+{
+	return (spa->spa_active_weightfunc);
+}
+
+#if defined(_KERNEL)
+int
+param_set_active_weightfunc_common(const char *val)
+{
+	char *p;
+
+	if (val == NULL)
+		return (SET_ERROR(EINVAL));
+
+	if ((p = strchr(val, '\n')) != NULL)
+		*p = '\0';
+
+	int a = spa_find_weightfunc_byname(val);
+	if (a < 0)
+		return (SET_ERROR(EINVAL));
+
+	zfs_active_weightfunc = metaslab_weightfuncs[a].mswf_name;
+	return (0);
+}
+#endif
+
+metaslab_wfs_t *
+metaslab_weightfunc(spa_t *spa)
+{
+	int weightfunc = spa_get_weightfunc(spa);
+	return (&metaslab_weightfuncs[weightfunc]);
+}
+
 /*
  * Return the weight of the specified metaslab, according to the new space-based
  * weighting algorithm. The metaslab must be loaded. This function can
@@ -3193,7 +3252,7 @@ metaslab_space_weight_from_spacemap(metaslab_t *msp)
 		if (segments == 0)
 			continue;
 		if (weight == 0)
-                	weight = i + sm->sm_shift;
+			weight = i + sm->sm_shift;
 		// Prevent overflow using log_2 math
 		if (seg_shift + highbit64(segments) > METASLAB_WEIGHT_MAX_IDX)
 			return (METASLAB_WEIGHT_MAX);
@@ -3223,8 +3282,16 @@ static uint64_t
 metaslab_space_weight_v2(metaslab_t *msp)
 {
 	metaslab_group_t *mg = msp->ms_group;
+	spa_t *spa = mg->mg_vd->vdev_spa;
 	uint64_t weight = 0;
 	uint8_t shift = mg->mg_vd->vdev_ashift;
+
+	if (!spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_HISTOGRAM) ||
+	    (msp->ms_sm != NULL && msp->ms_sm->sm_dbuf->db_size !=
+	    sizeof (space_map_phys_t))) {
+		return (metaslab_space_weight(msp));
+	}
+
 	if (metaslab_allocated_space(msp) == 0) {
 		int idx = highbit64(msp->ms_size) - shift - 1 + 3;
 		weight = 1ULL << MIN(METASLAB_WEIGHT_MAX_IDX, 2 * idx);
@@ -3402,17 +3469,9 @@ metaslab_space_weight(metaslab_t *msp)
 {
 	metaslab_group_t *mg = msp->ms_group;
 	vdev_t *vd = mg->mg_vd;
-	spa_t *spa = vd->vdev_spa;
 	uint64_t weight, space;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
-
-	if (zfs_metaslab_space_weight_v2_enabled &&
-	    spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_HISTOGRAM) &&
-	    (msp->ms_sm == NULL || msp->ms_sm->sm_dbuf->db_size ==
-	    sizeof (space_map_phys_t))) {
-		return (metaslab_space_weight_v2(msp));
-	}
 
 	/*
 	 * The baseline weight is the metaslab's free space.
@@ -3569,10 +3628,17 @@ static uint64_t
 metaslab_segment_weight(metaslab_t *msp)
 {
 	metaslab_group_t *mg = msp->ms_group;
+	spa_t *spa = mg->mg_vd->vdev_spa;
 	uint64_t weight = 0;
 	uint8_t shift = mg->mg_vd->vdev_ashift;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
+
+	if (!spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_HISTOGRAM) ||
+	    (msp->ms_sm != NULL && msp->ms_sm->sm_dbuf->db_size !=
+	    sizeof (space_map_phys_t))) {
+		return (metaslab_space_weight(msp));
+	}
 
 	/*
 	 * The metaslab is completely free.
@@ -3678,8 +3744,6 @@ metaslab_should_allocate(metaslab_t *msp, uint64_t asize, boolean_t try_hard)
 static uint64_t
 metaslab_weight(metaslab_t *msp, boolean_t nodirty)
 {
-	vdev_t *vd = msp->ms_group->mg_vd;
-	spa_t *spa = vd->vdev_spa;
 	uint64_t weight;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
@@ -3703,17 +3767,7 @@ metaslab_weight(metaslab_t *msp, boolean_t nodirty)
 		    metaslab_largest_unflushed_free(msp));
 	}
 
-	/*
-	 * Segment-based weighting requires space map histogram support.
-	 */
-	if (zfs_metaslab_segment_weight_enabled &&
-	    spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_HISTOGRAM) &&
-	    (msp->ms_sm == NULL || msp->ms_sm->sm_dbuf->db_size ==
-	    sizeof (space_map_phys_t))) {
-		weight = metaslab_segment_weight(msp);
-	} else {
-		weight = metaslab_space_weight(msp);
-	}
+	weight = msp->ms_group->mg_class->mc_wfs->mswf_func(msp);
 	return (weight);
 }
 
@@ -6615,12 +6669,6 @@ ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, bias_enabled, INT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, perf_bias, INT, ZMOD_RW,
 	"Enable performance-based metaslab group biasing");
 
-ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, segment_weight_enabled, INT,
-	ZMOD_RW, "Enable segment-based metaslab selection");
-
-ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, space_weight_v2_enabled, INT,
-	ZMOD_RW, "Enable new space-based metaslab selection");
-
 ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, switch_threshold, INT, ZMOD_RW,
 	"Segment-based metaslab selection maximum buckets before switching");
 
@@ -6671,6 +6719,10 @@ ZFS_MODULE_PARAM_CALL(zfs, zfs_, active_allocator,
 ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, condense_pct, UINT, ZMOD_RW,
 	"Condense on-disk spacemap when it is more than this many percents "
 	"of in-memory counterpart");
+
+ZFS_MODULE_PARAM_CALL(zfs, zfs_, active_weightfunc,
+	param_set_active_weightfunc, param_get_charp, ZMOD_RW,
+	"SPA active weight function");
 
 #ifdef METASLAB_TRACE
 ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, trace_enabled, INT, ZMOD_RW,

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -259,6 +259,16 @@ static const boolean_t zfs_remap_blkptr_enable = B_TRUE;
 static int zfs_metaslab_segment_weight_enabled = B_TRUE;
 
 /*
+ * Enable/disable the new space-based metaslab selection algorithm.
+ *
+ * The new space-based algorithm attempts to take into account not only the
+ * largest free segment, as the segment-based weight does, but other segments
+ * that are almost as large. This can improve metaslab selection and reduce the
+ * number of metaslab loads needed to satisfy a given set of allocations.
+ */
+static int zfs_metaslab_space_weight_v2_enabled = B_TRUE;
+
+/*
  * When using segment-based metaslab selection, we will continue
  * allocating from the active metaslab until we have exhausted
  * zfs_metaslab_switch_threshold of its buckets.
@@ -2370,7 +2380,7 @@ metaslab_verify_weight_and_frag(metaslab_t *msp)
 
 	uint64_t weight = msp->ms_weight;
 	uint64_t was_active = msp->ms_weight & METASLAB_ACTIVE_MASK;
-	boolean_t space_based = WEIGHT_IS_SPACEBASED(msp->ms_weight);
+	uint8_t type = WEIGHT_GET_TYPE(msp->ms_weight);
 	uint64_t frag = msp->ms_fragmentation;
 	uint64_t max_segsize = msp->ms_max_size;
 
@@ -2398,8 +2408,7 @@ metaslab_verify_weight_and_frag(metaslab_t *msp)
 	 * If the weight type changed then there is no point in doing
 	 * verification. Revert fields to their original values.
 	 */
-	if ((space_based && !WEIGHT_IS_SPACEBASED(msp->ms_weight)) ||
-	    (!space_based && WEIGHT_IS_SPACEBASED(msp->ms_weight))) {
+	if (type != WEIGHT_GET_TYPE(msp->ms_weight)) {
 		msp->ms_fragmentation = frag;
 		msp->ms_weight = weight;
 		return;
@@ -2784,6 +2793,7 @@ metaslab_unload(metaslab_t *msp)
 		return;
 
 	zfs_range_tree_vacate(msp->ms_allocatable, NULL, NULL);
+
 	msp->ms_loaded = B_FALSE;
 	msp->ms_unload_time = gethrtime();
 
@@ -3110,6 +3120,152 @@ metaslab_fini(metaslab_t *msp)
 }
 
 /*
+ * Return the weight of the specified metaslab, according to the new space-based
+ * weighting algorithm. The metaslab must be loaded. This function can
+ * be called within a sync pass since it relies only on the metaslab's
+ * range tree which is always accurate when the metaslab is loaded.
+ */
+static uint64_t
+metaslab_space_weight_from_range_tree(metaslab_t *msp)
+{
+	uint64_t weight = 0;
+	uint8_t vd_shift = msp->ms_group->mg_vd->vdev_ashift;
+	ASSERT3U(vd_shift, >=, 3);
+
+	ASSERT(msp->ms_loaded);
+	ASSERT3U(vd_shift, >=, SPA_MINBLOCKSHIFT);
+
+	for (int i = ZFS_RANGE_TREE_HISTOGRAM_SIZE - 1; i >= vd_shift;
+	    i--) {
+		uint8_t seg_shift = 2 * (i - (vd_shift - 3));
+		uint64_t segments = msp->ms_allocatable->rt_histogram[i];
+		if (segments == 0)
+			continue;
+		if (weight == 0)
+			weight = i;
+		// Prevent overflow using log_2 math
+		if (seg_shift + highbit64(segments) > METASLAB_WEIGHT_MAX_IDX)
+			return (METASLAB_WEIGHT_MAX);
+		weight = MIN(METASLAB_WEIGHT_MAX,
+		    weight + (segments << seg_shift));
+	}
+	return (weight);
+}
+
+/*
+ * Calculate the new space-based weight based on the on-disk histogram.
+ * Should be applied only to unloaded metaslabs (i.e no incoming allocations)
+ * in-order to give results consistent with the on-disk state.
+ */
+static uint64_t
+metaslab_space_weight_from_spacemap(metaslab_t *msp)
+{
+	space_map_t *sm = msp->ms_sm;
+	ASSERT(!msp->ms_loaded);
+	ASSERT(sm != NULL);
+	ASSERT3U(space_map_object(sm), !=, 0);
+	ASSERT3U(sm->sm_dbuf->db_size, ==, sizeof (space_map_phys_t));
+	uint8_t vd_shift = msp->ms_group->mg_vd->vdev_ashift;
+	ASSERT3U(vd_shift, >=, 3);
+
+	/*
+	 * Create a joint histogram from all the segments that have made
+	 * it to the metaslab's space map histogram, that are not yet
+	 * available for allocation because they are still in the freeing
+	 * pipeline (e.g. freeing, freed, and defer trees). Then subtract
+	 * these segments from the space map's histogram to get a more
+	 * accurate weight.
+	 */
+	uint64_t deferspace_histogram[SPACE_MAP_HISTOGRAM_SIZE] = {0};
+	for (int i = 0; i < SPACE_MAP_HISTOGRAM_SIZE; i++)
+		deferspace_histogram[i] += msp->ms_synchist[i];
+	for (int t = 0; t < TXG_DEFER_SIZE; t++) {
+		for (int i = 0; i < SPACE_MAP_HISTOGRAM_SIZE; i++) {
+			deferspace_histogram[i] += msp->ms_deferhist[t][i];
+		}
+	}
+
+	uint64_t weight = 0;
+	for (int i = SPACE_MAP_HISTOGRAM_SIZE - 1; i >= 0; i--) {
+		uint8_t seg_shift = 2 * (i + sm->sm_shift - vd_shift + 3);
+		uint64_t segments =
+		    sm->sm_phys->smp_histogram[i] - deferspace_histogram[i];
+		if (segments == 0)
+			continue;
+		if (weight == 0)
+			weight = i + sm->sm_shift;
+		// Prevent overflow using log_2 math
+		if (seg_shift + highbit64(segments) > METASLAB_WEIGHT_MAX_IDX)
+			return (METASLAB_WEIGHT_MAX);
+		weight = MIN(METASLAB_WEIGHT_MAX,
+		    weight + (segments << seg_shift));
+	}
+	return (weight);
+}
+
+/*
+ * The space weight v2 algorithm uses information from the free space
+ * histograms to provide a more useful weighting of the free space in
+ * the metaslab. Rather than simply using the fragmentation metric, we
+ * actually use the number of segments in each bucket to determine the
+ * weight. The weight is calculated as follows:
+ *
+ * sum from i = 0 to 29 of N(i) * 2^{2i}, where N(i) is the number of free
+ * segments of size 2^{i + shift}
+ *
+ * N(i) * 2^i is just the space used by the segments in a bucket divided
+ * by the shift, and the additional factor of 2^i weights the larger
+ * segments more heavily. If there are any segments of size larger than
+ * (28 + shift), we just max out the weight. That metaslab is free enough
+ * for any purpose.
+ */
+static uint64_t
+metaslab_space_weight_v2(metaslab_t *msp)
+{
+	metaslab_group_t *mg = msp->ms_group;
+	uint64_t weight = 0;
+	uint8_t shift = mg->mg_vd->vdev_ashift;
+	if (metaslab_allocated_space(msp) == 0) {
+		int idx = highbit64(msp->ms_size) - shift - 1 + 3;
+		weight = 1ULL << MIN(METASLAB_WEIGHT_MAX_IDX, 2 * idx);
+		weight += highbit64(msp->ms_size) - 1;
+		WEIGHT_SET_SPACEBASED_V2(weight);
+		return (weight);
+	}
+
+	ASSERT3U(msp->ms_sm->sm_dbuf->db_size, ==, sizeof (space_map_phys_t));
+
+	/*
+	 * If the metaslab is fully allocated then just make the weight 0.
+	 */
+	if (metaslab_allocated_space(msp) == msp->ms_size) {
+		WEIGHT_SET_SPACEBASED_V2(weight);
+		return (weight);
+	}
+
+	/*
+	 * If the metaslab is already loaded, then use the range tree to
+	 * determine the weight. Otherwise, we rely on the space map information
+	 * to generate the weight.
+	 */
+	if (msp->ms_loaded)
+		weight = metaslab_space_weight_from_range_tree(msp);
+	else
+		weight = metaslab_space_weight_from_spacemap(msp);
+	ASSERT3U(weight, <=, METASLAB_WEIGHT_MAX);
+
+	/*
+	 * If the metaslab was active the last time we calculated its weight
+	 * then keep it active. We want to consume the entire region that
+	 * is associated with this weight.
+	 */
+	if (msp->ms_activation_weight != 0 && weight != 0)
+		WEIGHT_SET_ACTIVE(weight, WEIGHT_GET_ACTIVE(msp->ms_weight));
+	WEIGHT_SET_SPACEBASED_V2(weight);
+	return (weight);
+}
+
+/*
  * This table defines a segment size based fragmentation metric that will
  * allow each metaslab to derive its own fragmentation value. This is done
  * by calculating the space in each bucket of the spacemap histogram and
@@ -3246,9 +3402,17 @@ metaslab_space_weight(metaslab_t *msp)
 {
 	metaslab_group_t *mg = msp->ms_group;
 	vdev_t *vd = mg->mg_vd;
+	spa_t *spa = vd->vdev_spa;
 	uint64_t weight, space;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
+
+	if (zfs_metaslab_space_weight_v2_enabled &&
+	    spa_feature_is_enabled(spa, SPA_FEATURE_SPACEMAP_HISTOGRAM) &&
+	    (msp->ms_sm == NULL || msp->ms_sm->sm_dbuf->db_size ==
+	    sizeof (space_map_phys_t))) {
+		return (metaslab_space_weight_v2(msp));
+	}
 
 	/*
 	 * The baseline weight is the metaslab's free space.
@@ -3500,9 +3664,12 @@ metaslab_should_allocate(metaslab_t *msp, uint64_t asize, boolean_t try_hard)
 		 */
 		should_allocate = (asize <
 		    1ULL << (WEIGHT_GET_INDEX(msp->ms_weight) + 1));
+	} else if (WEIGHT_IS_SPACEBASED_V2(msp->ms_weight)) {
+		should_allocate = (asize <
+		    1ULL << ((msp->ms_weight & 0x3f) + 1));
 	} else {
 		should_allocate = (asize <=
-		    (msp->ms_weight & ~METASLAB_WEIGHT_TYPE));
+		    (msp->ms_weight & ~METASLAB_WEIGHT_MASK));
 	}
 
 	return (should_allocate);
@@ -3715,14 +3882,15 @@ metaslab_passivate_allocator(metaslab_group_t *mg, metaslab_t *msp,
 static void
 metaslab_passivate(metaslab_t *msp, uint64_t weight)
 {
-	uint64_t size __maybe_unused = weight & ~METASLAB_WEIGHT_TYPE;
+	uint64_t size __maybe_unused = weight & ~METASLAB_WEIGHT_MASK;
 
 	/*
 	 * If size < SPA_MINBLOCKSIZE, then we will not allocate from
 	 * this metaslab again.  In that case, it had better be empty,
 	 * or we would be leaving space on the table.
 	 */
-	ASSERT(!WEIGHT_IS_SPACEBASED(msp->ms_weight) ||
+	ASSERT(!(WEIGHT_IS_SPACEBASED(msp->ms_weight) &&
+	    !WEIGHT_IS_SPACEBASED_V2(msp->ms_weight)) ||
 	    size >= SPA_MINBLOCKSIZE ||
 	    zfs_range_tree_space(msp->ms_allocatable) == 0);
 	ASSERT0(weight & METASLAB_ACTIVE_MASK);
@@ -6449,6 +6617,9 @@ ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, perf_bias, INT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, segment_weight_enabled, INT,
 	ZMOD_RW, "Enable segment-based metaslab selection");
+
+ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, space_weight_v2_enabled, INT,
+	ZMOD_RW, "Enable new space-based metaslab selection");
 
 ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, switch_threshold, INT, ZMOD_RW,
 	"Segment-based metaslab selection maximum buckets before switching");

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1810,6 +1810,7 @@ spa_thread(void *arg)
 #endif
 
 extern metaslab_ops_t *metaslab_allocator(spa_t *spa);
+extern metaslab_wfs_t *metaslab_weightfunc(spa_t *spa);
 
 /*
  * Activate an uninitialized pool.
@@ -1817,7 +1818,8 @@ extern metaslab_ops_t *metaslab_allocator(spa_t *spa);
 static void
 spa_activate(spa_t *spa, spa_mode_t mode)
 {
-	metaslab_ops_t *msp = metaslab_allocator(spa);
+	metaslab_ops_t *mso = metaslab_allocator(spa);
+	metaslab_wfs_t *msw = metaslab_weightfunc(spa);
 	ASSERT(spa->spa_state == POOL_STATE_UNINITIALIZED);
 
 	spa->spa_state = POOL_STATE_ACTIVE;
@@ -1826,16 +1828,17 @@ spa_activate(spa_t *spa, spa_mode_t mode)
 	spa->spa_read_spacemaps = spa_mode_readable_spacemaps;
 
 	spa->spa_normal_class = metaslab_class_create(spa, "normal",
-	    msp, B_FALSE);
-	spa->spa_log_class = metaslab_class_create(spa, "log", msp, B_TRUE);
+	    mso, msw, B_FALSE);
+	spa->spa_log_class = metaslab_class_create(spa, "log", mso, msw,
+	    B_TRUE);
 	spa->spa_embedded_log_class = metaslab_class_create(spa,
-	    "embedded_log", msp, B_TRUE);
+	    "embedded_log", mso, msw, B_TRUE);
 	spa->spa_special_class = metaslab_class_create(spa, "special",
-	    msp, B_FALSE);
+	    mso, msw, B_FALSE);
 	spa->spa_special_embedded_log_class = metaslab_class_create(spa,
-	    "special_embedded_log", msp, B_TRUE);
+	    "special_embedded_log", mso, msw, B_TRUE);
 	spa->spa_dedup_class = metaslab_class_create(spa, "dedup",
-	    msp, B_FALSE);
+	    mso, msw, B_FALSE);
 
 	/* Try to create a covering process */
 	mutex_enter(&spa->spa_proc_lock);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -5600,6 +5600,8 @@ spa_ld_load_vdev_metadata(spa_t *spa)
 		}
 	}
 
+	spa_set_weightfunc(spa, zfs_active_weightfunc);
+
 	/*
 	 * Load the vdev metadata such as metaslabs, DTLs, spacemap object, etc.
 	 */

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7369,6 +7369,8 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	spa->spa_dedup_table_quota =
 	    zpool_prop_default_numeric(ZPOOL_PROP_DEDUP_TABLE_QUOTA);
 
+	spa_set_weightfunc(spa, zfs_active_weightfunc);
+
 	if (props != NULL) {
 		spa_configfile_set(spa, props, B_FALSE);
 		spa_sync_props(props, tx);

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -802,7 +802,6 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	spa->spa_deadman_ziotime = MSEC2NSEC(zfs_deadman_ziotime_ms);
 	spa_set_deadman_failmode(spa, zfs_deadman_failmode);
 	spa_set_allocator(spa, zfs_active_allocator);
-	spa_set_weightfunc(spa, zfs_active_weightfunc);
 
 	zfs_refcount_create(&spa->spa_refcount);
 	spa_config_lock_init(spa);

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -404,6 +404,12 @@ static int spa_cpus_per_allocator = 4;
  */
 const char *zfs_active_allocator = "dynamic";
 
+/*
+ * Spa active weight function.
+ * Valid values are zfs_active_weightfunc=<auto|space|space_v2|segment>.
+ */
+const char *zfs_active_weightfunc = "auto";
+
 void
 spa_load_failed(spa_t *spa, const char *fmt, ...)
 {
@@ -796,6 +802,7 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	spa->spa_deadman_ziotime = MSEC2NSEC(zfs_deadman_ziotime_ms);
 	spa_set_deadman_failmode(spa, zfs_deadman_failmode);
 	spa_set_allocator(spa, zfs_active_allocator);
+	spa_set_weightfunc(spa, zfs_active_weightfunc);
 
 	zfs_refcount_create(&spa->spa_refcount);
 	spa_config_lock_init(spa);

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -802,6 +802,7 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	spa->spa_deadman_ziotime = MSEC2NSEC(zfs_deadman_ziotime_ms);
 	spa_set_deadman_failmode(spa, zfs_deadman_failmode);
 	spa_set_allocator(spa, zfs_active_allocator);
+	spa_set_weightfunc(spa, zfs_active_weightfunc);
 
 	zfs_refcount_create(&spa->spa_refcount);
 	spa_config_lock_init(spa);

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -44,7 +44,7 @@ static int zfs_read_history_hits = B_FALSE;
 /*
  * Keeps stats on the last 100 txgs by default.
  */
-static uint_t zfs_txg_history = 100;
+static uint_t zfs_txg_history = 300;
 
 /*
  * Keeps stats on the last N MMP updates, disabled by default.

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -44,7 +44,7 @@ static int zfs_read_history_hits = B_FALSE;
 /*
  * Keeps stats on the last 100 txgs by default.
  */
-static uint_t zfs_txg_history = 300;
+static uint_t zfs_txg_history = 100;
 
 /*
  * Keeps stats on the last N MMP updates, disabled by default.

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -775,7 +775,8 @@ tags = ['functional', 'features', 'large_dnode']
 [tests/functional/gang_blocks]
 tests = ['gang_blocks_001_pos', 'gang_blocks_redundant',
     'gang_blocks_ddt_copies', 'gang_blocks_dyn_header_pos',
-    'gang_blocks_dyn_header_neg', 'gang_blocks_dyn_multi']
+    'gang_blocks_dyn_header_neg', 'gang_blocks_dyn_multi',
+    'metaslab_tuning_001_pos']
 tags = ['functional', 'gang_blocks']
 
 [tests/functional/grow]

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3481,6 +3481,17 @@ function set_tunable32
 	set_tunable_impl "$1" "$2" W
 }
 
+#
+# Set a global system tunable (string value)
+#
+# $1 tunable name (use a NAME defined in tunables.cfg)
+# $2 tunable values
+#
+function set_tunable_string
+{
+	set_tunable_impl "$1" "$2" S
+}
+
 function set_tunable_impl
 {
 	typeset name="$1"
@@ -3531,6 +3542,16 @@ function restore_tunable
 		[[ ! -e $TEST_BASE_DIR/tunable-$1 ]] && return 1
 		val="$(cat $TEST_BASE_DIR/tunable-"""$1""")"
 		set_tunable64 "$1" "$val"
+		rm $TEST_BASE_DIR/tunable-$1
+	fi
+}
+
+function restore_tunable_string
+{
+	if tunable_exists $1 ; then
+		[[ ! -e $TEST_BASE_DIR/tunable-$1 ]] && return 1
+		val="$(cat $TEST_BASE_DIR/tunable-"""$1""")"
+		set_tunable_string "$1" "$val"
 		rm $TEST_BASE_DIR/tunable-$1
 	fi
 }

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -16,7 +16,7 @@ UNAME=$(uname)
 
 # NAME				FreeBSD tunable			Linux tunable
 cat <<%%%% |
-ACTIVE_WEIGHTFUNC		zfs.active_weightfunc		zfs_active_weightfunc
+ACTIVE_WEIGHTFUNC		active_weightfunc		zfs_active_weightfunc
 ADMIN_SNAPSHOT			UNSUPPORTED			zfs_admin_snapshot
 ALLOW_REDACTED_DATASET_MOUNT	allow_redacted_dataset_mount	zfs_allow_redacted_dataset_mount
 ARC_MAX				arc.max				zfs_arc_max

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -16,6 +16,7 @@ UNAME=$(uname)
 
 # NAME				FreeBSD tunable			Linux tunable
 cat <<%%%% |
+ACTIVE_WEIGHTFUNC		zfs.active_weightfunc		zfs_active_weightfunc
 ADMIN_SNAPSHOT			UNSUPPORTED			zfs_admin_snapshot
 ALLOW_REDACTED_DATASET_MOUNT	allow_redacted_dataset_mount	zfs_allow_redacted_dataset_mount
 ARC_MAX				arc.max				zfs_arc_max

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1706,6 +1706,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/gang_blocks/gang_blocks_dyn_header_neg.ksh \
 	functional/gang_blocks/gang_blocks_dyn_header_pos.ksh \
 	functional/gang_blocks/gang_blocks_dyn_multi.ksh \
+	functional/gang_blocks/metaslab_tuning_001_pos.ksh \
 	functional/gang_blocks/setup.ksh \
 	functional/grow/grow_pool_001_pos.ksh \
 	functional/grow/grow_replicas_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/gang_blocks/metaslab_tuning_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/gang_blocks/metaslab_tuning_001_pos.ksh
@@ -1,0 +1,48 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026 by Klara Inc.
+#
+
+#
+# Description:
+# Verify that metaslab weight algorithm selection works correctly.
+#
+# Strategy:
+# 1. Set the zfs_active_weightfunc to auto.
+# 2. Create a pool.
+# 3. Repeat steps 1 and 2 with the other valid values.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+log_assert "Metaslab weight algorithm selection works correctly."
+
+function cleanup
+{
+	restore_tunable_string ACTIVE_WEIGHTFUNC
+	zpool destroy $TESTPOOL
+}
+log_onexit cleanup
+
+save_tunable ACTIVE_WEIGHTFUNC
+
+for value in "auto" "space" "space_v2" "segment"
+do
+	set_tunable_string ACTIVE_WEIGHTFUNC
+	log_must zpool create -f $TESTPOOL $DISKS
+	log_must zpool destroy $TESTPOOL
+done
+
+log_pass "Metaslab weight algorithm selection works correctly."

--- a/tests/zfs-tests/tests/functional/gang_blocks/metaslab_tuning_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/gang_blocks/metaslab_tuning_001_pos.ksh
@@ -32,7 +32,7 @@ log_assert "Metaslab weight algorithm selection works correctly."
 function cleanup
 {
 	restore_tunable_string ACTIVE_WEIGHTFUNC
-	zpool destroy $TESTPOOL
+	poolexists $TESTPOOL && zpool destroy $TESTPOOL
 }
 log_onexit cleanup
 
@@ -40,8 +40,9 @@ save_tunable ACTIVE_WEIGHTFUNC
 
 for value in "auto" "space" "space_v2" "segment"
 do
-	set_tunable_string ACTIVE_WEIGHTFUNC
+	log_must set_tunable_string ACTIVE_WEIGHTFUNC $value
 	log_must zpool create -f $TESTPOOL $DISKS
+	log_must fill_fs /$TESTPOOL 1 100 1048576 R
 	log_must zpool destroy $TESTPOOL
 done
 

--- a/tests/zfs-tests/tests/functional/gang_blocks/metaslab_tuning_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/gang_blocks/metaslab_tuning_001_pos.ksh
@@ -26,6 +26,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/kstat.shlib
 
 log_assert "Metaslab weight algorithm selection works correctly."
 
@@ -42,6 +43,7 @@ for value in "auto" "space" "space_v2" "segment"
 do
 	log_must set_tunable_string ACTIVE_WEIGHTFUNC $value
 	log_must zpool create -f $TESTPOOL $DISKS
+	log_must eval "kstat dbgmsg | grep -q \"spa weight function: $value\""
 	log_must fill_fs /$TESTPOOL 1 100 1048576 R
 	log_must zpool destroy $TESTPOOL
 done


### PR DESCRIPTION
Sponsored by: _[Wasabi Technology, Inc.; Klara, Inc.]_


### Motivation and Context
Currently, the segment-based weighting algorithm is used by default to selected metaslabs for allocations. This algorithm uses the size of the largest bucket of free segments to estimate whether an allocation can be satisfied. This works reasonably well for selecting metaslabs to load, since they should always be able to satisfy at least one allocation. However, there are times where the best metaslab to select is not the one with the most segments of the largest size; for example, if one metaslab has a single 64MiB segment, while another has 100 32MiB free segments, the latter will be able to satisfy many more allocations in practice, as long as the allocations are less than 32MiB. The space-based weighting algorithm will sometimes make this decision correctly, but it also has its own downsides (mostly not having any good idea whether a metaslab will be able to satisfy any allocations at all).

### Description
This patch introduces a new weighting algorithm that tries to combine the strengths of both current algorithms. It is primarily space-based, but instead of taking the total free space and apply the fragmentation to it, it weights each bucket of segments (larger segment-size buckets get a higher weighting, to convey that larger free segments are useful for both having more space and satisfying larger individual allocations). It also includes information about the bucket of the largest free segment, which allows us to make better decisions about whether the metaslab is suitable for a given allocation.

I don't love the way the weighting algorithm is currently selected; it may be time to implement something more like the control for the `metaslab_allocators` tunables. I did not include that in this version, but that could be changed if people feel it is important.

### How Has This Been Tested?
In addition to correctness testing by running the test suite with segment weighting disabled and v2 space weighting enabled, there are also extensive performance testing completed. The setup that was used for the test is a pool that is 90% full, with 60% fragmentation. This allows the testing to primarily focus on the ability of the algorithms to select metaslabs for loading. Testing used random writes with large sector sizes, to further stress the allocation code. The test ran for 20 minutes each time. There are a few key metrics that were considered: bandwidth (self-explanatory), gang blocks and multi-level ganging, and TXG sync times.

|Weighting Algorithm | TXG mean (ms) | TXG stddev (ms) | TXG time (99%ile) | Gang Blocks | Gang multiblocks | BW (MB/s)|
|---|---|---|---|---|---|---|
|Space  | 111250.5 | 9366.88 | 36404.9 | 138748 | 110295 | 162.8 |
|Segment  | 11624.4 | 10096.3 | 36914.4 | 147258 | 121747 | 163.3 |
|New | 11743.1 | 9799.49 | 37313.4 | 129805 | 104044 | 160.333 |

While the changes in most categories are small (~1% in average and 99th%ile TXG sync times and bandwidth, within the margin of error), the new algorithm does seem to offer a reduction in stddev of sync times over the segment-based algorithm, and a reduction in ganging compared to both existing algorithms. Only the ganging reduction is statistically significant (95% confidence, 10 runs each).


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).