### PR TITLE
chksum: run 256K benchmark on demand, preserve chksum_stat_data

### DIFF
--- a/module/zfs/zfs_chksum.c
+++ b/module/zfs/zfs_chksum.c
@@ -155,11 +155,11 @@ chksum_run(chksum_stat_t *cs, abd_t *abd, void *ctx, int round,
 	switch (round) {
 	case 1: /* 1k */
 		size = 1<<10; loops = 128; break;
-	case 2: /* 2k */
+	case 2: /* 4k */
 		size = 1<<12; loops = 64; break;
-	case 3: /* 4k */
+	case 3: /* 16k */
 		size = 1<<14; loops = 32; break;
-	case 4: /* 16k */
+	case 4: /* 64k */
 		size = 1<<16; loops = 16; break;
 	case 5: /* 256k */
 		size = 1<<18; loops = 8; break;
@@ -212,6 +212,7 @@ chksum_benchit(chksum_stat_t *cs)
 	chksum_run(cs, abd, ctx, 2, &cs->bs4k);
 	chksum_run(cs, abd, ctx, 3, &cs->bs16k);
 	chksum_run(cs, abd, ctx, 4, &cs->bs64k);
+	chksum_run(cs, abd, ctx, 5, &cs->bs256k);
 	chksum_run(cs, abd, ctx, 6, &cs->bs1m);
 	abd_free(abd);
 
@@ -249,15 +250,16 @@ chksum_benchmark(void)
 	if (chksum_stat_limit == AT_DONE)
 		return;
 
-
 	/* count implementations */
-	chksum_stat_cnt = 1;  /* edonr */
-	chksum_stat_cnt += 1; /* skein */
-	chksum_stat_cnt += sha256->getcnt();
-	chksum_stat_cnt += sha512->getcnt();
-	chksum_stat_cnt += blake3->getcnt();
-	chksum_stat_data = kmem_zalloc(
-	    sizeof (chksum_stat_t) * chksum_stat_cnt, KM_SLEEP);
+	if (chksum_stat_limit == AT_STARTUP) {
+		chksum_stat_cnt = 1;  /* edonr */
+		chksum_stat_cnt += 1; /* skein */
+		chksum_stat_cnt += sha256->getcnt();
+		chksum_stat_cnt += sha512->getcnt();
+		chksum_stat_cnt += blake3->getcnt();
+		chksum_stat_data = kmem_zalloc(
+		    sizeof (chksum_stat_t) * chksum_stat_cnt, KM_SLEEP);
+	}
 
 	/* edonr - needs to be the first one here (slow CPU check) */
 	cs = &chksum_stat_data[cbid++];


### PR DESCRIPTION
### Motivation and Context
#17563 speeds up system boot by ensuring the 256K benchmark runs during boot, while others run on demand. However, for some reason, the 256K benchmark does not always run during boot. This patch forces the 256K benchmark to be run on demand as well, which should resolve #17945.

### Description
One of two things must be true: either the 256K benchmark is not being run when the system boots, or the results of that benchmark are not being taken into account. If you force the 256K benchmark to run on demand, the data is displayed correctly.

It may not quite fit the concept, but it seems to solve the problem. Probably @mcmilk has some more thoughts on the topic.

However, there is an objection to the current concept. If it is true that the 256K benchmark result obtained during boot should be provided on demand, then values should become inconsistent when the governor is changed.

```
# rmmod zfs spl; cpupower frequency-set -g performance; modprobe zfs && cat /proc/spl/kstat/zfs/chksum_bench
implementation               1k      4k     16k     64k    256k      1m      4m     16m
edonr-generic              1271    1546    1620    1574    1572    1607    1404    1553
skein-generic               537     597     612     607     564     611     595     602
sha256-generic              162     177     179     177     180     180     178     179
sha256-x64                  267     300     306     303     307     306     304     305
sha256-ssse3                326     368     378     383     383     382     381     378
sha512-generic              267     329     339     342     343     339     336     340
sha512-x64                  400     458     474     459     481     480     477     477
blake3-generic              347     379     382     379     377     366     315     357
blake3-sse2                 458    1298    1397    1414    1414    1374    1131    1231
blake3-sse41                459    1463    1590    1631    1612    1598    1544    1602
```

```
# rmmod zfs spl; cpupower frequency-set -g powersave; modprobe zfs && cat /proc/spl/kstat/zfs/chksum_bench
implementation               1k      4k     16k     64k    256k      1m      4m     16m
edonr-generic               274     339     363     315     360     354     356     349
skein-generic               119     122     130     115     104     134     135     133
sha256-generic               34      39      36      39      36      37      39      39
sha256-x64                   60      60      66      67      64      64      67      66
sha256-ssse3                 59      80      83      84      83      83      84      79
sha512-generic               59      63      70      73      71      73      55      57
sha512-x64                   57     100      99      99     104      90     102     103
blake3-generic               76      82      82      79      75      76      73      82
blake3-sse2                  93     280     308     311     310     306     308     308
blake3-sse41                106     321     360     372     373     365     366     362
```
Probably we do not want the 256K benchmark values from the upper table to end up in the lower one.

We could try even more aggressively.
```
# MAX=$(cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq)
# MIN=$(cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq)
# rmmod zfs spl; cpupower frequency-set -d "${MAX}" -u "${MAX}"; modprobe zfs && cat /proc/spl/kstat/zfs/chksum_bench
# rmmod zfs spl; cpupower frequency-set -d "${MIN}" -u "${MIN}"; modprobe zfs && cat /proc/spl/kstat/zfs/chksum_bench
```
However, this is an intuitive line of reasoning. It has not been tested yet because of the issue, which is probably more important.

### How Has This Been Tested?
The patch was tested on top of three current branches. If the 256K benchmark results were all zeros, they display correctly after applying the patch. However, it should be noted that the scenario where the 256K benchmark still runs during system boot and then runs again on demand was not tested. It could be that this PR does not solve the root cause of the problem. In any case, there is hope that this can be fixed without a major rewrite of the code.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
