### PR TITLE
ztest: fix broken random call

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -8143,7 +8143,7 @@ ztest_raidz_expand_run(ztest_shared_t *zs, spa_t *spa)
 	/* Setup a 1 MiB buffer of random data */
 	uint64_t bufsize = 1024 * 1024;
 	void *buffer = umem_alloc(bufsize, UMEM_NOFAIL);
-	random_get_pseudo_bytes((uint8_t *)&buffer, bufsize);
+	random_get_pseudo_bytes((uint8_t *)buffer, bufsize);
 
 	/*
 	 * Put some data in the pool and then attach a vdev to initiate


### PR DESCRIPTION
_[Sponsors: Klara, Inc., Wasabi Technology, Inc.]_

### Description

Bad copypasta in 4d451bae8a, leading to random stuff being blasted all over stack, destroying the program.

The `read()` call in `random_get_bytes_common()` random call would end up returning -1 when it tried to write past the end of the stack (errno was `EFAULT`, not that we were checking it). The assert on the return immediately showed the extent of the damage:

```
starting main threads...
ASSERT at lib/libspl/random.c:81:random_get_bytes_common()
VERIFY3S(bytes, >=, 0) failed (-1 >= 0x0)
  PID: 37375     COMM: 2^N^G<81><B5>^L^H^L<8D><F6>^B<F4>!Kܵ٪     <BE><9B>^\<D7>Qf<F0>^G<E2>_<D0>˼<94>^P<C1>X}^X^S<A5>^O<C1><BF>B<B6><E0><EB>w<9C><C3>:*^UJ<FA>^O<E8>X<F3>V=<FC><EA><EB>\<EC><E6><FE><84>^Zs^N\<E8>$<9D>^\m<B6><9C><AC>
^]A<AF>cS<9A>u<C0><D3>8젼~i<95>w<81><   ^T<F3>6<CE><E4><B3>v<A5>vxA^\^HK<BF><81><95>^N<DC>D<98>ƏhjQay<D6>֊<A7><F2>>%,f<CA><DB>y!<E7>/<A7>[G<AB>k<D5>M<B4>
ԾiqRz+e7<A7>q<D3><F4><F0>k<EF><BC>^B<B3><9E><C8><C0><AF>#<8E>6<84>t<E6>j^G<C9><C6><F7>A<D1>|^G<B4><B2><F8>g<84>B^D^M^_<8F><EC>H<85><FB>S<A3><8B><9A>S<EE>_ĳ<9F>^Q<EA>ߪb<A4><BE>ESC!k<B4><E8>x^SX<FB><E0><EA>3<EF><BE><C9><DF>:<95>F
<EB><B5>^^G3<FF><A5><E8>^GI
?Sb^W<BC><A3><D7>Y^\ՙ<B3><A5><B4><96>"<A5><B2><F6>Ha?^O˻^S<F4>aW<EA>'^W<BC>^R<E0>^Qk<B4><F5><B2><E8><AF>8L<8C>tVP_<DB><CA>O<AE>~^U<85>f,<87>^H<EC><FB>=z<8C>^M^D<9E><A5>{Z<A5><8F><BC>N<89><85>^E49"^Z<9D>+<B5>]_Ỗ<E1><AC>^TS$N^K<E8>
<CC><F8>^D^M#<98>/Bwq<E3><^\I<C3>
  TID: 37375     NAME: ztest
```

### How Has This Been Tested?

Fairly easily reproduced in a ztest run with `-X` (raidz expansion test). 

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).