### PR TITLE
DDT: Make children writes inherit allocator

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3088,7 +3088,7 @@ zio_gang_issue(zio_t *zio)
 }
 
 static void
-zio_gang_inherit_allocator(zio_t *pio, zio_t *cio)
+zio_inherit_allocator(zio_t *pio, zio_t *cio)
 {
 	cio->io_allocator = pio->io_allocator;
 }
@@ -3223,7 +3223,7 @@ zio_write_gang_block(zio_t *pio, metaslab_class_t *mc)
 	    zio_write_gang_done, NULL, pio->io_priority,
 	    ZIO_GANG_CHILD_FLAGS(pio), &pio->io_bookmark);
 
-	zio_gang_inherit_allocator(pio, zio);
+	zio_inherit_allocator(pio, zio);
 	if (pio->io_flags & ZIO_FLAG_ALLOC_THROTTLED) {
 		boolean_t more;
 		VERIFY(metaslab_class_throttle_reserve(mc, zio->io_allocator,
@@ -3285,7 +3285,7 @@ zio_write_gang_block(zio_t *pio, metaslab_class_t *mc)
 		    (allocated ? ZIO_FLAG_PREALLOCATED : 0), &pio->io_bookmark);
 
 		resid -= psize;
-		zio_gang_inherit_allocator(zio, cio);
+		zio_inherit_allocator(zio, cio);
 		if (allocated) {
 			metaslab_trace_move(&cio_list, &cio->io_alloc_list);
 			metaslab_group_alloc_increment_all(spa,
@@ -4062,6 +4062,7 @@ zio_ddt_write(zio_t *zio)
 	    zio_ddt_child_write_ready, NULL,
 	    zio_ddt_child_write_done, dde, zio->io_priority,
 	    ZIO_DDT_CHILD_FLAGS(zio), &zio->io_bookmark);
+	zio_inherit_allocator(zio, cio);
 
 	zio_push_transform(cio, zio->io_abd, zio->io_size, 0, NULL);
 


### PR DESCRIPTION
Even though unlike gang children it is not so critical for dedup children to inherit parent's allocator, there is still no reason for them to have allocation policy different from normal writes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
