### PR TITLE
FreeBSD: Fix uninitialized variable error

### DIFF
--- a/lib/libspl/tunables.c
+++ b/lib/libspl/tunables.c
@@ -124,10 +124,12 @@ zfs_tunable_parse_int(const char *val, intmax_t *np,
 {
 	intmax_t n;
 	char *end;
+	int err;
+
 	errno = 0;
 	n = strtoimax(val, &end, 0);
-	if (errno != 0)
-		return (errno);
+	if ((err = errno) != 0)
+		return (err);
 	if (*end != '\0')
 		return (EINVAL);
 	if (n < min || n > max)
@@ -142,10 +144,12 @@ zfs_tunable_parse_uint(const char *val, uintmax_t *np,
 {
 	uintmax_t n;
 	char *end;
+	int err;
+
 	errno = 0;
 	n = strtoumax(val, &end, 0);
-	if (errno != 0)
-		return (errno);
+	if ((err = errno) != 0)
+		return (err);
 	if (*end != '\0')
 		return (EINVAL);
 	if (strchr(val, '-'))


### PR DESCRIPTION
On FreeBSD errno is defined as (* __error()), which means compiler can't say whether two consecutive reads will return the same. And without this knowledge the reported error is formally right.

Caching of the errno in local variable fixes the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
