### PR TITLE
DDT: Switch to using wmsums for lookup stats

### DIFF
--- a/include/sys/ddt.h
+++ b/include/sys/ddt.h
@@ -33,6 +33,7 @@
 #include <sys/fs/zfs.h>
 #include <sys/zio.h>
 #include <sys/dmu.h>
+#include <sys/wmsum.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -295,6 +296,20 @@ typedef struct {
 	uint64_t	ddt_flush_force_txg;	/* flush hard before this txg */
 
 	kstat_t		*ddt_ksp;	/* kstats context */
+
+	/* wmsums for hot-path lookup counters */
+	wmsum_t		ddt_kstat_dds_lookup;
+	wmsum_t		ddt_kstat_dds_lookup_live_hit;
+	wmsum_t		ddt_kstat_dds_lookup_live_wait;
+	wmsum_t		ddt_kstat_dds_lookup_live_miss;
+	wmsum_t		ddt_kstat_dds_lookup_existing;
+	wmsum_t		ddt_kstat_dds_lookup_new;
+	wmsum_t		ddt_kstat_dds_lookup_log_hit;
+	wmsum_t		ddt_kstat_dds_lookup_log_active_hit;
+	wmsum_t		ddt_kstat_dds_lookup_log_flushing_hit;
+	wmsum_t		ddt_kstat_dds_lookup_log_miss;
+	wmsum_t		ddt_kstat_dds_lookup_stored_hit;
+	wmsum_t		ddt_kstat_dds_lookup_stored_miss;
 
 	enum zio_checksum ddt_checksum;	/* checksum algorithm in use */
 	spa_t		*ddt_spa;	/* pool this ddt is on */


### PR DESCRIPTION
`ddt_lookup()` is a very busy code under a highly congested global lock.  Anything we can save here is very important.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
