### PR TITLE
initramfs-scripts: require canmount=on for non-bootfs

### DIFF
--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -336,7 +336,7 @@ mount_fs()
 
 	# Skip filesystems not set to canmount=on (i.e. off or noauto), except if set as bootfs.
 	# The bootfs should not have canmount=off (not be just a placehlder/inheritance provider),
-	# but we also ignore it for backwards compatibility just in case (top-level canmount=off
+	# but we also ignore 'off' for backwards compatibility just in case (top-level canmount=off
 	# boot pool).
 	if [ "$fs" != "${ZFS_BOOTFS}" ]
 	then


### PR DESCRIPTION
### Motivation and Context

The current initramfs script even auto-mounts "canmount=noauto" filesystems.

If there really are any cases that depend on disobeying `noauto` besides the current `bootfs=` exception, it's generally preferable to instead allow limited automounting cleanly (as in 17996) for these cases.

This is a "drive-by" filing of a very small, and sensible change, proposed in
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1110397 and https://github.com/openzfs/zfs/issues/17963

### Description
Skip mounting if `canmount != on` instead of only `canmount = off`  (i.e. also if `canmount = noauto`).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
not tested

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
