### PR TITLE
Re-initialize objsets when feature@project_quota is enabled

### DIFF
--- a/include/sys/dmu_objset.h
+++ b/include/sys/dmu_objset.h
@@ -262,6 +262,7 @@ boolean_t dmu_objset_projectquota_enabled(objset_t *os);
 boolean_t dmu_objset_projectquota_present(objset_t *os);
 boolean_t dmu_objset_projectquota_upgradable(objset_t *os);
 void dmu_objset_id_quota_upgrade(objset_t *os);
+void dmu_objset_id_projectquota_upgrade(objset_t *os);
 int dmu_get_file_info(objset_t *os, dmu_object_type_t bonustype,
     const void *data, zfs_file_info_t *zfi);
 

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -2440,6 +2440,30 @@ dmu_objset_id_quota_upgrade(objset_t *os)
 	dmu_objset_upgrade(os, dmu_objset_id_quota_upgrade_cb);
 }
 
+static int
+dmu_objset_id_projectquota_upgrade_cb(objset_t *os)
+{
+	if (dmu_objset_projectquota_present(os))
+		return (0);
+	if (!dmu_objset_projectquota_enabled(os))
+		return (SET_ERROR(ENOTSUP));
+
+	dmu_objset_ds(os)->ds_feature_activation[
+	    SPA_FEATURE_PROJECT_QUOTA] = (void *)B_TRUE;
+
+	if (dmu_objset_projectquota_enabled(os))
+		os->os_flags |= OBJSET_FLAG_PROJECTQUOTA_COMPLETE;
+
+	txg_wait_synced(dmu_objset_pool(os), 0);
+	return (0);
+}
+
+void
+dmu_objset_id_projectquota_upgrade(objset_t *os)
+{
+	dmu_objset_upgrade(os, dmu_objset_id_projectquota_upgrade_cb);
+}
+
 boolean_t
 dmu_objset_userobjspace_upgradable(objset_t *os)
 {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When upgrading from an older version of ZFS which does not have project quotas to a version of OpenZFS which does, after a zpool upgrade, the feature remains enabled but not active and project operations fail with `ENOTSUP`, rendering it unusable until a given objset is re-opened.

This was observed with an upgrade from ZoL 0.7.1 to OpenZFS 2.3.

Fixes #17955

### Description
<!--- Describe your changes in detail -->

- On `dmu_objset_open_impl()`, if project quotas are present on the pool, a dnode is allocated to hold/refer to the projectused ZAP object and assigned to an in-memory objset field `os_projectused_dnode`.
- `os_projectused_dnode` is used to decide whether project quotas are enabled for a given objset.
- After a pool upgrade which enables project quotas, all open objsets still have `os_projectused_dnode == NULL`. For this reason `dmu_objset_projectquota_enabled()` will always be false, and actual upgrade will not happen until the objset is re-opened.

It seems like a similar issue has been happening with user quotas back in the day and the solution was to suspend and resume the affected file systems in order to re-initialize the affected object sets (see `zfs_prop_set_special()` → `zfs_ioc_userspace_upgrade()`). So analogously, we suspend+resume all the pool's affected file systems to re-initialize their associated object sets when `feature@project_quota` is set and `os_projectused_dnode` is `NULL`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).