### PR TITLE
Provide loff_t via <fcntl.h> on musl-based Linux systems

### DIFF
--- a/lib/libspl/include/sys/types.h
+++ b/lib/libspl/include/sys/types.h
@@ -54,4 +54,15 @@ typedef int		projid_t;
 typedef off_t loff_t;
 #endif
 
+/*
+ * On musl, loff_t is a macro within fcntl.h when _GNU_SOURCE is defined.
+ * If no macro is defined, a typedef fallback is provided.
+ */
+#if defined(__linux__) && !defined(__GLIBC__)
+#include <fcntl.h>
+#ifndef loff_t
+typedef off_t loff_t;
+#endif
+#endif
+
 #endif


### PR DESCRIPTION
Musl exposes `loff_t` only as a macro in `<fcntl.h>` when `_GNU_SOURCE` is defined. Including `<fcntl.h>` ensures the type is available, and a fallback typedef is provided when no macro is defined. This fixes build failures on musl systems.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context

Musl does not provide `loff_t` in the headers that libspl includes, which causes OpenZFS userland builds to fail on musl-based Linux systems. Musl only exposes `loff_t` as a macro in `<fcntl.h>` (usually when `_GNU_SOURCE` is defined), whereas glibc provides it as a typedef in `<sys/types.h>`.

On musl, `off_t` is always 64-bit and already serves as the large-file offset type, so falling back to `typedef off_t loff_t;` matches the role that `loff_t` has on glibc.

### Description

This change ensures that `loff_t` is available when building on non-glibc Linux:

- On glibc, nothing changes — it already defines `loff_t`.
- On Linux systems without glibc (e.g., musl):
  - `<fcntl.h>` is included to pick up any libc-provided `loff_t` macro.
  - If libc still doesn’t provide it, we fall back to `typedef off_t loff_t`.

The choice to import `<fcntl.h>` is more philosophical than practical: if libc provides a definition, we prefer to use it. In practice, one could simplify this and — similar to FreeBSD — always typedef `loff_t` on non-glibc Linux systems.

### How Has This Been Tested?

- Built on Gentoo ~arm64 with musl/LLVM/OpenRC.
- Built on Gentoo arm64 with glibc/GCC/systemd.
- Passed the full GitHub Actions CI pipeline.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
