### PR TITLE
During CI, use `nproc` instead of `sysctl -n hw.ncpu`

### DIFF
--- a/.github/workflows/scripts/qemu-4-build-vm.sh
+++ b/.github/workflows/scripts/qemu-4-build-vm.sh
@@ -181,7 +181,7 @@ function freebsd() {
   echo "##[endgroup]"
 
   echo "##[group]Build"
-  run gmake -j$(sysctl -n hw.ncpu)
+  run gmake -j$(nproc)
   echo "##[endgroup]"
 
   echo "##[group]Install"


### PR DESCRIPTION
The latter may give the wrong result if cpusets are in use.

Sponsored by:	ConnectWise
Signed-off-by:	Alan Somers <asomers@gmail.com>

### Motivation and Context
Prevents using too many CPUs during CI, if the build system is using cpusets.

### Description
Prefer `nproc` over `sysctl -n hw.ncpu`

### How Has This Been Tested?
Tested in CI only.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
