### PR TITLE
FreeBSD: Fix a potential null dereference in zfs_freebsd_fsync()

### DIFF
--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -5277,7 +5277,7 @@ zfs_freebsd_fsync(struct vop_fsync_args *ap)
 	 * Push any dirty mmap()'d data out to the DMU and ZIL, ready for
 	 * zil_commit() to be called in zfs_fsync().
 	 */
-	if (vm_object_mightbedirty(vp->v_object)) {
+	if (vp->v_object != NULL && vm_object_mightbedirty(vp->v_object)) {
 		zfs_vmobject_wlock(vp->v_object);
 		if (!vm_object_page_clean(vp->v_object, 0, 0, 0))
 			err = SET_ERROR(EIO);


### PR DESCRIPTION
A recent change to zfs_freebsd_fsync() makes it possible to dereference a NULL pointer when fsyncing a named pipe. This change fixes that.

### Motivation and Context
A vnode might not have an associated VM object, in which case `vp->v_object == NULL`, but zfs_freebsd_fsync() assumed that this pointer was always non-NULL.

### Description
We don't need to flush anything from the page cache if this is a named pipe, so it's ok to just make the flush conditional on `vp->v_object != NULL`.

### How Has This Been Tested?
Tested with a reproducer program.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
