### PR TITLE
Backport #17675 to 2.3: linux: use sys/stat.h instead of linux/stat.h

### DIFF
--- a/config/user-statx.m4
+++ b/config/user-statx.m4
@@ -2,7 +2,7 @@ dnl #
 dnl # Check for statx() function and STATX_MNT_ID availability
 dnl #
 AC_DEFUN([ZFS_AC_CONFIG_USER_STATX], [
-	AC_CHECK_HEADERS([linux/stat.h],
+	AC_CHECK_HEADERS([sys/stat.h],
 		[have_stat_headers=yes],
 		[have_stat_headers=no])
 
@@ -14,7 +14,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_STATX], [
 			AC_MSG_CHECKING([for STATX_MNT_ID])
 			AC_COMPILE_IFELSE([
 				AC_LANG_PROGRAM([[
-					#include <linux/stat.h>
+					#include <sys/stat.h>
 				]], [[
 					struct statx stx;
 					int mask = STATX_MNT_ID;
@@ -29,6 +29,6 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_STATX], [
 			])
 		])
 	], [
-		AC_MSG_WARN([linux/stat.h not found; skipping statx support])
+		AC_MSG_WARN([sys/stat.h not found; skipping statx support])
 	])
 ])  dnl end AC_DEFUN

--- a/include/os/linux/spl/sys/stat.h
+++ b/include/os/linux/spl/sys/stat.h
@@ -25,6 +25,6 @@
 #ifndef _SPL_STAT_H
 #define	_SPL_STAT_H
 
-#include <linux/stat.h>
+#include <sys/stat.h>
 
 #endif /* SPL_STAT_H */

--- a/lib/libspl/include/os/linux/sys/stat.h
+++ b/lib/libspl/include/os/linux/sys/stat.h
@@ -33,7 +33,7 @@
 
 #ifdef HAVE_STATX
 #include <fcntl.h>
-#include <linux/stat.h>
+#include <sys/stat.h>
 #endif
 
 /*


### PR DESCRIPTION
glibc includes linux/stat.h for statx, but musl defines its own statx struct and associated constants, which does not include STATX_MNT_ID yet. Thus, including linux/stat.h directly should be avoided for maximum libc compatibility.

Tested on:
  - glibc: x86_64, i686, aarch64, armv7l, armv6l
  - musl: x86_64, aarch64, armv7l, armv6l

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Tested-By: Achill Gilgenast <achill@achill.org>

Closes #17675
(cherry picked from commit ccf5a8a6fcfdfbdaa2f0fdca5d787958224bf06d)

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
---

### Motivation and Context

This fixes building ZFS v2.3 against the musl C library. Original commit message above.

### Description

Changed to use `sys/stat.h` instead of `linux/stat.h`. This approach works correctly with both glibc and musl.

### How Has This Been Tested?

- Clean cherry pick from the `master` branch: ccf5a8a6fcfdfbdaa2f0fdca5d787958224bf06d.
- Patch is included in the Gentoo ebuild for ZFS.
  - Tested on `~arm64/llvm/musl/openrc`.
  - Tested on `arm64/gcc/glibc/systemd`.

I am co-maintaining the sys-fs/zfs package on Gentoo and thus test against musl and LLVM toolchains.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
