### PR TITLE
Reduce dataset buffers re-dirtying

### DIFF
--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -161,7 +161,8 @@ dsl_dataset_block_born(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx)
 
 	ASSERT3U(BP_GET_BIRTH(bp), >,
 	    dsl_dataset_phys(ds)->ds_prev_snap_txg);
-	dmu_buf_will_dirty(ds->ds_dbuf, tx);
+	/* ds_dbuf is pre-dirtied in dsl_dataset_sync(). */
+	ASSERT(dmu_buf_is_dirty(ds->ds_dbuf, tx));
 	mutex_enter(&ds->ds_lock);
 	delta = parent_delta(ds, used);
 	dsl_dataset_phys(ds)->ds_referenced_bytes += used;
@@ -274,7 +275,8 @@ dsl_dataset_block_kill(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx,
 	ASSERT3P(tx->tx_pool, ==, ds->ds_dir->dd_pool);
 
 	ASSERT(!ds->ds_is_snapshot);
-	dmu_buf_will_dirty(ds->ds_dbuf, tx);
+	/* ds_dbuf is pre-dirtied in dsl_dataset_sync(). */
+	ASSERT(dmu_buf_is_dirty(ds->ds_dbuf, tx));
 
 	/*
 	 * Track block for livelist, but ignore embedded blocks because


### PR DESCRIPTION
For each block written or freed ZFS dirties `ds_dbuf` of the dataset. While `dbuf_dirty()` has a fast path for already dirty dbufs, it still require taking the lock and doing some things visible in profiler.

Investigation shown `ds_dbuf` dirtying by `dsl_dataset_block_born()` and some of `dsl_dataset_block_kill()` are just not needed, since by the time they are called in sync context the `ds_dbuf` is already dirtied by `dsl_dataset_sync()`.

Tests show this reducing large file deletion time by ~3% by saving CPU time of single-threaded part of the sync thread.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
