### PR TITLE
Linux 6.18 compat: META

### DIFF
--- a/META
+++ b/META
@@ -6,5 +6,5 @@ Release:       1
 Release-Tags:  relext
 License:       CDDL
 Author:        OpenZFS
-Linux-Maximum: 6.17
+Linux-Maximum: 6.18
 Linux-Minimum: 4.18


### PR DESCRIPTION
### Motivation and Context

Indicate support for the 6.18 kernel.

### Description

Update the META file to reflect compatibility with the 6.18 kernel.

### How Has This Been Tested?

We'll test this with the CI.

https://github.com/behlendorf/zfs/actions/runs/20086922623

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
