### PR TITLE
DDT: Move logs searches out of the lock

### DIFF
--- a/include/sys/ddt.h
+++ b/include/sys/ddt.h
@@ -213,6 +213,7 @@ typedef enum {
 #define	DDE_FLAG_LOADED		(1 << 0)	/* entry ready for use */
 #define	DDE_FLAG_OVERQUOTA	(1 << 1)	/* entry unusable, no space */
 #define	DDE_FLAG_LOGGED		(1 << 2)	/* loaded from log */
+#define	DDE_FLAG_FROM_FLUSHING	(1 << 3)	/* loaded from flushing log */
 
 /*
  * Additional data to support entry update or repair. This is fixed size
@@ -280,13 +281,14 @@ typedef struct {
  */
 typedef struct {
 	kmutex_t	ddt_lock;	/* protects changes to all fields */
-
 	avl_tree_t	ddt_tree;	/* "live" (changed) entries this txg */
-	avl_tree_t	ddt_log_tree;	/* logged entries */
-
 	avl_tree_t	ddt_repair_tree;	/* entries being repaired */
 
-	ddt_log_t	ddt_log[2];		/* active/flushing logs */
+	/*
+	 * Log trees are stable during I/O, and only modified during sync
+	 * with exclusive access.
+	 */
+	ddt_log_t	ddt_log[2] ____cacheline_aligned; /* logged entries */
 	ddt_log_t	*ddt_log_active;	/* pointers into ddt_log */
 	ddt_log_t	*ddt_log_flushing;	/* swapped when flush starts */
 

--- a/include/sys/ddt_impl.h
+++ b/include/sys/ddt_impl.h
@@ -69,8 +69,8 @@ extern "C" {
  * the live tree.
  */
 typedef struct {
-	ddt_key_t	ddle_key;	/* ddt_log_tree key */
-	avl_node_t	ddle_node;	/* ddt_log_tree node */
+	ddt_key_t	ddle_key;	/* ddl_tree key */
+	avl_node_t	ddle_node;	/* ddl_tree node */
 
 	ddt_type_t	ddle_type;	/* storage type */
 	ddt_class_t	ddle_class;	/* storage class */
@@ -193,7 +193,7 @@ extern boolean_t ddt_log_take_first(ddt_t *ddt, ddt_log_t *ddl,
     ddt_lightweight_entry_t *ddlwe);
 
 extern boolean_t ddt_log_find_key(ddt_t *ddt, const ddt_key_t *ddk,
-    ddt_lightweight_entry_t *ddlwe);
+    ddt_lightweight_entry_t *ddlwe, boolean_t *from_flushing);
 extern boolean_t ddt_log_remove_key(ddt_t *ddt, ddt_log_t *ddl,
     const ddt_key_t *ddk);
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -4067,19 +4067,21 @@ piggyback:
 
 	/*
 	 * We need to write. We will create a new write with the copies
-	 * property adjusted to match the number of DVAs we need to need to
-	 * grow the DDT entry by to satisfy the request.
+	 * property adjusted to match the number of DVAs we need to grow
+	 * the DDT entry by to satisfy the request.
 	 */
-	zio_prop_t czp = *zp;
+	zio_prop_t czp;
 	if (have_dvas > 0 || parent_dvas > 0) {
+		czp = *zp;
 		czp.zp_copies = need_dvas;
 		czp.zp_gang_copies = 0;
+		zp = &czp;
 	} else {
-		ASSERT3U(czp.zp_copies, ==, need_dvas);
+		ASSERT3U(zp->zp_copies, ==, need_dvas);
 	}
 
 	zio_t *cio = zio_write(zio, spa, txg, bp, zio->io_orig_abd,
-	    zio->io_orig_size, zio->io_orig_size, &czp,
+	    zio->io_orig_size, zio->io_orig_size, zp,
 	    zio_ddt_child_write_ready, NULL,
 	    zio_ddt_child_write_done, dde, zio->io_priority,
 	    ZIO_DDT_CHILD_FLAGS(zio), &zio->io_bookmark);


### PR DESCRIPTION
Postponing entry removal from the DDT log in case of hit till later single-threaded sync stage allows to make `ddl_tree` stable during multi-threaded ZIO processing stage.  It allows to drop the DDT lock before the search instead of after, reducing the contention a lot.

Actually `ddt_log_update_entry()` was already handling the case of entry present in the active log without removal, so we only need to remove it from flushing log, if the entry happen to be there.

### How Has This Been Tested?
My tests with parallel 4KB block writes show throughput increase from 480MB/s (122K blocks/s) to 827MB/s (212K blocks/s), even though still limited by the global DDT lock contention.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
