### PR TITLE
DDT: Switch to using ZAP _by_dnode() interfaces

### DIFF
--- a/include/sys/ddt.h
+++ b/include/sys/ddt.h
@@ -324,6 +324,7 @@ typedef struct {
 
 	/* per-type/per-class entry store objects */
 	uint64_t	ddt_object[DDT_TYPES][DDT_CLASSES];
+	dnode_t		*ddt_object_dnode[DDT_TYPES][DDT_CLASSES];
 
 	/* object ids for stored, logged and per-type/per-class stats */
 	uint64_t	ddt_stat_object;

--- a/include/sys/ddt_impl.h
+++ b/include/sys/ddt_impl.h
@@ -163,21 +163,18 @@ typedef struct {
 	int (*ddt_op_create)(objset_t *os, uint64_t *object, dmu_tx_t *tx,
 	    boolean_t prehash);
 	int (*ddt_op_destroy)(objset_t *os, uint64_t object, dmu_tx_t *tx);
-	int (*ddt_op_lookup)(objset_t *os, uint64_t object,
-	    const ddt_key_t *ddk, void *phys, size_t psize);
-	int (*ddt_op_contains)(objset_t *os, uint64_t object,
-	    const ddt_key_t *ddk);
-	void (*ddt_op_prefetch)(objset_t *os, uint64_t object,
-	    const ddt_key_t *ddk);
-	void (*ddt_op_prefetch_all)(objset_t *os, uint64_t object);
-	int (*ddt_op_update)(objset_t *os, uint64_t object,
-	    const ddt_key_t *ddk, const void *phys, size_t psize,
+	int (*ddt_op_lookup)(dnode_t *dn, const ddt_key_t *ddk,
+	    void *phys, size_t psize);
+	int (*ddt_op_contains)(dnode_t *dn, const ddt_key_t *ddk);
+	void (*ddt_op_prefetch)(dnode_t *dn, const ddt_key_t *ddk);
+	void (*ddt_op_prefetch_all)(dnode_t *dn);
+	int (*ddt_op_update)(dnode_t *dn, const ddt_key_t *ddk,
+	    const void *phys, size_t psize, dmu_tx_t *tx);
+	int (*ddt_op_remove)(dnode_t *dn, const ddt_key_t *ddk,
 	    dmu_tx_t *tx);
-	int (*ddt_op_remove)(objset_t *os, uint64_t object,
-	    const ddt_key_t *ddk, dmu_tx_t *tx);
-	int (*ddt_op_walk)(objset_t *os, uint64_t object, uint64_t *walk,
-	    ddt_key_t *ddk, void *phys, size_t psize);
-	int (*ddt_op_count)(objset_t *os, uint64_t object, uint64_t *count);
+	int (*ddt_op_walk)(dnode_t *dn, uint64_t *walk, ddt_key_t *ddk,
+	    void *phys, size_t psize);
+	int (*ddt_op_count)(dnode_t *dn, uint64_t *count);
 } ddt_ops_t;
 
 extern const ddt_ops_t ddt_zap_ops;

--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -288,6 +288,8 @@ int zap_length(objset_t *ds, uint64_t zapobj, const char *name,
     uint64_t *integer_size, uint64_t *num_integers);
 int zap_length_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
     int key_numints, uint64_t *integer_size, uint64_t *num_integers);
+int zap_length_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
+    int key_numints, uint64_t *integer_size, uint64_t *num_integers);
 
 /*
  * Remove the specified attribute.
@@ -309,6 +311,7 @@ int zap_remove_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
  * object.
  */
 int zap_count(objset_t *ds, uint64_t zapobj, uint64_t *count);
+int zap_count_by_dnode(dnode_t *dn, uint64_t *count);
 
 /*
  * Returns (in name) the name of the entry whose (value & mask)


### PR DESCRIPTION
As was previously done for BRT, avoid holding/releasing DDT ZAP dnodes for every access.  Instead hold the dnodes during all their life time, never releasing.

While at this, add `_by_dnode()` interfaces for `zap_length_uint64()` and `zap_count()`, actively used by DDT code.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
