### PR TITLE
DDT: Add/use zap_lookup_length_uint64_by_dnode()

### DIFF
--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -226,6 +226,9 @@ int zap_lookup_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
     int key_numints, uint64_t integer_size, uint64_t num_integers, void *buf);
 int zap_lookup_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
     int key_numints, uint64_t integer_size, uint64_t num_integers, void *buf);
+int zap_lookup_length_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
+    int key_numints, uint64_t integer_size, uint64_t num_integers, void *buf,
+    uint64_t *actual_num_integers);
 int zap_contains(objset_t *ds, uint64_t zapobj, const char *name);
 int zap_prefetch(objset_t *os, uint64_t zapobj, const char *name);
 int zap_prefetch_object(objset_t *os, uint64_t zapobj);

--- a/include/sys/zap_impl.h
+++ b/include/sys/zap_impl.h
@@ -219,7 +219,8 @@ void fzap_byteswap(void *buf, size_t size);
 int fzap_count(zap_t *zap, uint64_t *count);
 int fzap_lookup(zap_name_t *zn,
     uint64_t integer_size, uint64_t num_integers, void *buf,
-    char *realname, int rn_len, boolean_t *normalization_conflictp);
+    char *realname, int rn_len, boolean_t *normalization_conflictp,
+    uint64_t *actual_num_integers);
 void fzap_prefetch(zap_name_t *zn);
 int fzap_add(zap_name_t *zn, uint64_t integer_size, uint64_t num_integers,
     const void *val, const void *tag, dmu_tx_t *tx);

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -878,7 +878,8 @@ fzap_check(zap_name_t *zn, uint64_t integer_size, uint64_t num_integers)
 int
 fzap_lookup(zap_name_t *zn,
     uint64_t integer_size, uint64_t num_integers, void *buf,
-    char *realname, int rn_len, boolean_t *ncp)
+    char *realname, int rn_len, boolean_t *ncp,
+    uint64_t *actual_num_integers)
 {
 	zap_leaf_t *l;
 	zap_entry_handle_t zeh;
@@ -898,6 +899,8 @@ fzap_lookup(zap_name_t *zn,
 		}
 
 		err = zap_entry_read(&zeh, integer_size, num_integers, buf);
+		if (err == 0 && actual_num_integers != NULL)
+			*actual_num_integers = zeh.zeh_num_integers;
 		(void) zap_entry_read_name(zn->zn_zap, &zeh, rn_len, realname);
 		if (ncp) {
 			*ncp = zap_entry_normalization_conflict(&zeh,


### PR DESCRIPTION
Unlike other ZAP consumers, due to compression DDT does not know precisely how big entry it is reading from ZAP, even though knows the upper limit.  Due to this it called `zap_length_uint64_by_dnode()` and `zap_lookup_uint64_by_dnode()`, each of which does full ZAP entry lookup.

Introduction of the combined ZAP method dramatically reduces the CPU overhead and locks contention at DBUF layer.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
