### PR TITLE
CI: Update checkstyle image to ubuntu-24.04

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   checkstyle:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -19,7 +19,7 @@ jobs:
       run: |
         # for x in lxd core20 snapd; do sudo snap remove $x; done
         sudo apt-get purge -y snapd google-chrome-stable firefox
-        ONLY_DEPS=1 .github/workflows/scripts/qemu-3-deps-vm.sh ubuntu22
+        ONLY_DEPS=1 .github/workflows/scripts/qemu-3-deps-vm.sh ubuntu24
         sudo apt-get install -y cppcheck devscripts mandoc pax-utils shellcheck
         sudo python -m pipx install --quiet flake8
         # confirm that the tools are installed


### PR DESCRIPTION
### Motivation and Context

Experiment with updating the checkstyle builder to pulling in newer packages.  This will likely result in some new `shellcheck`, `libabigail`, `mandoc`, or `flake8` warning which will need to be resolved before this can be merged.

### Description

With a new release cycle starting now is a good time to update the checkstyle builder to the latest Ubunutu 24.04 LTS.

### How Has This Been Tested?

We'll see what new things the CI warns about.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)