### PR TITLE
DDT: Fix compressed entry buffer size

### DIFF
--- a/module/zfs/ddt_zap.c
+++ b/module/zfs/ddt_zap.c
@@ -57,7 +57,7 @@ ddt_zap_compress(const void *src, uchar_t *dst, size_t s_len, size_t d_len)
 	/* Call compress function directly to avoid hole detection. */
 	abd_t sabd, dabd;
 	abd_get_from_buf_struct(&sabd, (void *)src, s_len);
-	abd_get_from_buf_struct(&dabd, dst, d_len);
+	abd_get_from_buf_struct(&dabd, dst, d_len - 1);
 	c_len = ci->ci_compress(&sabd, &dabd, s_len, d_len - 1, ci->ci_level);
 	abd_free(&dabd);
 	abd_free(&sabd);
@@ -86,9 +86,10 @@ ddt_zap_decompress(uchar_t *src, void *dst, size_t s_len, size_t d_len)
 	}
 
 	abd_t sabd, dabd;
-	abd_get_from_buf_struct(&sabd, src, s_len);
+	size_t c_len = s_len - 1;
+	abd_get_from_buf_struct(&sabd, src, c_len);
 	abd_get_from_buf_struct(&dabd, dst, d_len);
-	VERIFY0(zio_decompress_data(cpfunc, &sabd, &dabd, s_len, d_len, NULL));
+	VERIFY0(zio_decompress_data(cpfunc, &sabd, &dabd, c_len, d_len, NULL));
 	abd_free(&dabd);
 	abd_free(&sabd);
 


### PR DESCRIPTION
The first byte of the entry after compression is used for algorithm and byte order flag.  We should decrement when calling compression/ decompression algorithm.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
