### PR TITLE
CI: Use Ubuntu mirrors instead of azure

### DIFF
--- a/.github/workflows/scripts/qemu-1-setup.sh
+++ b/.github/workflows/scripts/qemu-1-setup.sh
@@ -13,6 +13,20 @@ set -eu
 # handle on what the timeout value should be.
 (while [ 1 ] ; do sleep 30 && echo "[watchdog: $(ps -eo cmd --sort=-pcpu  | head -n 2 | tail -n 1)}')]"; done) &
 
+# The default 'azure.archive.ubuntu.com' mirrors can be really slow.
+# Prioritize the official Ubuntu mirrors.
+#
+# The normal apt-mirrors.txt will look like:
+#
+# http://azure.archive.ubuntu.com/ubuntu/       priority:1
+# https://archive.ubuntu.com/ubuntu/    priority:2
+# https://security.ubuntu.com/ubuntu/   priority:3
+#
+# Just delete the 'azure.archive.ubuntu.com' line.
+sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt
+echo "Using mirrors:"
+cat /etc/apt/apt-mirrors.txt
+
 # install needed packages
 export DEBIAN_FRONTEND="noninteractive"
 sudo apt-get -y update


### PR DESCRIPTION


### Motivation and Context
Speed up 'Setup QEMU' CI stage.

### Description
Use the official Ubuntu apt mirrors instead of azure.archive.ubuntu.com, since that mirror can be slow: https://github.com/actions/runner-images/issues/7048

This can help speed up the 'Setup QEMU' stage.
### How Has This Been Tested?
Tested on local runners

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
