### PR TITLE
RAIDZ: Remove some excessive logging

### DIFF
--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -2703,16 +2703,6 @@ vdev_raidz_io_start(zio_t *zio)
 				next_offset = synced_offset;
 			}
 		}
-		if (use_scratch) {
-			zfs_dbgmsg("zio=%px %s io_offset=%llu offset_synced="
-			    "%lld next_offset=%lld use_scratch=%u",
-			    zio,
-			    zio->io_type == ZIO_TYPE_WRITE ? "WRITE" : "READ",
-			    (long long)zio->io_offset,
-			    (long long)synced_offset,
-			    (long long)next_offset,
-			    use_scratch);
-		}
 
 		rm = vdev_raidz_map_alloc_expanded(zio,
 		    tvd->vdev_ashift, vdrz->vd_physical_width,
@@ -2851,8 +2841,6 @@ raidz_parity_verify(zio_t *zio, raidz_row_t *rr)
 			continue;
 
 		if (abd_cmp(orig[c], rc->rc_abd) != 0) {
-			zfs_dbgmsg("found error on col=%u devidx=%u off %llx",
-			    c, (int)rc->rc_devidx, (u_longlong_t)rc->rc_offset);
 			vdev_raidz_checksum_error(zio, rc, orig[c]);
 			rc->rc_error = SET_ERROR(ECKSUM);
 			ret++;
@@ -3174,10 +3162,6 @@ vdev_raidz_io_done_verified(zio_t *zio, raidz_row_t *rr)
 			 * See comment in vdev_raid_row_alloc().
 			 */
 			ASSERT0(zio->io_flags & ZIO_FLAG_DIO_READ);
-
-			zfs_dbgmsg("zio=%px repairing c=%u devidx=%u "
-			    "offset=%llx",
-			    zio, c, rc->rc_devidx, (long long)rc->rc_offset);
 
 			zio_nowait(zio_vdev_child_io(zio, NULL, cvd,
 			    rc->rc_offset, rc->rc_abd, rc->rc_size,


### PR DESCRIPTION
There were some per I/O logging into dbgmsg in RAIDZ code, that increased CPU load and wiped useful content out of dbgmsg, for example during routine disk replacement process.  I don't think we need it to be that verbose.

### How Has This Been Tested?
```
# zpool offline optane nvd5p1
# zpool replace optane nvd5p1 nvd4p1
```
, and observe `dbgmsg` no longer trashed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
