### PR TITLE
Bypass snprintf() in quota checks if no quotas set

### DIFF
--- a/module/zfs/zfs_quota.c
+++ b/module/zfs/zfs_quota.c
@@ -433,13 +433,13 @@ zfs_id_overobjquota(zfsvfs_t *zfsvfs, uint64_t usedobj, uint64_t id)
 	} else {
 		return (B_FALSE);
 	}
+	if (quotaobj == 0 && default_quota == 0)
+		return (B_FALSE);
 	if (zfsvfs->z_replay)
 		return (B_FALSE);
 
 	(void) snprintf(buf, sizeof (buf), "%llx", (longlong_t)id);
 	if (quotaobj == 0) {
-		if (default_quota == 0)
-			return (B_FALSE);
 		quota = default_quota;
 	} else {
 		err = zap_lookup(zfsvfs->z_os, quotaobj, buf, 8, 1, &quota);
@@ -484,13 +484,13 @@ zfs_id_overblockquota(zfsvfs_t *zfsvfs, uint64_t usedobj, uint64_t id)
 	} else {
 		return (B_FALSE);
 	}
+	if (quotaobj == 0 && default_quota == 0)
+		return (B_FALSE);
 	if (zfsvfs->z_replay)
 		return (B_FALSE);
 
 	(void) snprintf(buf, sizeof (buf), "%llx", (longlong_t)id);
 	if (quotaobj == 0) {
-		if (default_quota == 0)
-			return (B_FALSE);
 		quota = default_quota;
 	} else {
 		err = zap_lookup(zfsvfs->z_os, quotaobj, buf, 8, 1, &quota);


### PR DESCRIPTION
This improves synthetic 1 byte write speed by ~2.5%.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
