### PR TITLE
CI: Test 2.4.x in qemu-test-repo-vm.sh, quick mode

### DIFF
--- a/.github/workflows/scripts/qemu-test-repo-vm.sh
+++ b/.github/workflows/scripts/qemu-test-repo-vm.sh
@@ -4,7 +4,11 @@
 #
 # USAGE:
 #
-# 	./qemu-test-repo-vm [URL]
+# 	./qemu-test-repo-vm [--install] [URL]
+#
+# --lookup:	When testing a repo, only lookup the latest package versions,
+#		don't try to install them.  Installing all of them takes over
+#		an hour, so this is much quicker.
 #
 # URL:		URL to use instead of http://download.zfsonlinux.org
 #		If blank, use the default repo from zfs-release RPM.
@@ -14,6 +18,13 @@ set -e
 source /etc/os-release
 OS="$ID"
 VERSION="$VERSION_ID"
+
+
+LOOKUP=""
+if [ -n "$1" ] && [ "$1" == "--lookup" ] ; then
+	LOOKUP=1
+	shift
+fi
 
 ALTHOST=""
 if [ -n "$1" ] ; then
@@ -42,6 +53,15 @@ function test_install {
 		sudo sed -i "s;baseurl=http://download.zfsonlinux.org;baseurl=$host;g" /etc/yum.repos.d/zfs.repo
 	fi
 
+	baseurl=$(grep -A 5 "\[$repo\]" /etc/yum.repos.d/zfs.repo  | awk -F'=' '/baseurl=/{print $2; exit}')
+
+	# Just do a version lookup - don't try to install any RPMs
+	if [ "$LOOKUP" == "1" ] ; then
+		 package="$(dnf list $args zfs | tail -n 1 | awk '{print $2}')"
+		 echo "$repo ${package} $baseurl" >> $SUMMARY
+		 return
+	fi
+
 	if ! sudo dnf -y install $args zfs zfs-test ; then
 		echo "$repo ${package}...[FAILED] $baseurl" >> $SUMMARY
 		return
@@ -54,7 +74,6 @@ function test_install {
 	sudo zpool status
 
 	# Print out repo name, rpm installed (kmod or dkms), and repo URL
-	baseurl=$(grep -A 5 "\[$repo\]" /etc/yum.repos.d/zfs.repo  | awk -F'=' '/baseurl=/{print $2; exit}')
 	package=$(sudo rpm -qa | grep zfs | grep -E 'kmod|dkms')
 
 	echo "$repo $package $baseurl" >> $SUMMARY
@@ -75,7 +94,7 @@ almalinux*)
 	sudo rpm -qi zfs-release
 	for i in zfs zfs-kmod zfs-testing zfs-testing-kmod zfs-latest \
 		zfs-latest-kmod zfs-legacy zfs-legacy-kmod zfs-2.2 \
-		zfs-2.2-kmod zfs-2.3 zfs-2.3-kmod ; do
+		zfs-2.2-kmod zfs-2.3 zfs-2.3-kmod zfs-2.4 zfs-2.4-kmod; do
 		test_install $i $ALTHOST
 	done
 	;;
@@ -83,7 +102,7 @@ fedora*)
 	url='https://raw.githubusercontent.com/openzfs/openzfs-docs/refs/heads/master/docs/Getting%20Started/Fedora/index.rst'
 	name=$(curl -Ls $url | grep 'dnf install' | grep -Eo 'zfs-release-[0-9]+-[0-9]+')
 	sudo dnf -y install -y https://zfsonlinux.org/fedora/$name$(rpm --eval "%{dist}").noarch.rpm
-	for i in zfs zfs-latest zfs-legacy zfs-2.2 zfs-2.3 ; do
+	for i in zfs zfs-latest zfs-legacy zfs-2.2 zfs-2.3 zfs-2.4 ; do
 		test_install $i $ALTHOST
 	done
 	;;

--- a/.github/workflows/zfs-qemu-packages.yml
+++ b/.github/workflows/zfs-qemu-packages.yml
@@ -42,6 +42,12 @@ on:
         required: false
         default: ""
         description: "(optional) repo URL (blank: use http://download.zfsonlinux.org)"
+      lookup:
+        type: boolean
+        required: false
+        default: false
+        description: "(optional) do version lookup only on repo test"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -77,7 +83,12 @@ jobs:
                 .github/workflows/scripts/qemu-prepare-for-build.sh
 
                 mkdir -p /tmp/repo
-                ssh zfs@vm0 '$HOME/zfs/.github/workflows/scripts/qemu-test-repo-vm.sh' ${{ github.event.inputs.repo_url }}
+                EXTRA=""
+                if [ "${{ github.event.inputs.lookup }}" == 'true' ] ; then
+                        EXTRA="--lookup"
+                fi
+
+                ssh zfs@vm0 '$HOME/zfs/.github/workflows/scripts/qemu-test-repo-vm.sh' $EXTRA ${{ github.event.inputs.repo_url }}
         else
                 EXTRA=""
                 if [ -n "${{ github.event.inputs.patch_level }}" ] ; then


### PR DESCRIPTION
### Motivation and Context
Test 2.4.x repo in the `zfs-qemu-packages` workflow, add quick mode

### Description
The `qemu-test-repo-vm.sh`CI script tests installs ZFS from different repos.  Have it test from the new 2.4.x repos as well.

Also add a checkbox to run in "lookup mode".  This just does a quick lookup to see what version is installed in each repo.  It does not do a test install and module load.  It only takes 3min to run vs over an hour for the full version.

### How Has This Been Tested?
Tested manually

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
