### PR TITLE
cmd/zfs: clone: accept `-u` to not mount newly created datasets

### DIFF
--- a/man/man8/zfs-clone.8
+++ b/man/man8/zfs-clone.8
@@ -40,7 +40,7 @@
 .Sh SYNOPSIS
 .Nm zfs
 .Cm clone
-.Op Fl p
+.Op Fl pu
 .Oo Fl o Ar property Ns = Ns Ar value Oc Ns …
 .Ar snapshot Ar filesystem Ns | Ns Ar volume
 .
@@ -64,6 +64,8 @@ Datasets created in this manner are automatically mounted according to the
 property inherited from their parent.
 If the target filesystem or volume already exists, the operation completes
 successfully.
+.It Fl u
+Do not mount the newly created file system.
 .El
 .
 .Sh EXAMPLES

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -196,7 +196,7 @@ tests = ['zfs_clone_001_neg', 'zfs_clone_002_pos', 'zfs_clone_003_pos',
     'zfs_clone_004_pos', 'zfs_clone_005_pos', 'zfs_clone_006_pos',
     'zfs_clone_007_pos', 'zfs_clone_008_neg', 'zfs_clone_009_neg',
     'zfs_clone_010_pos', 'zfs_clone_encrypted', 'zfs_clone_deeply_nested',
-    'zfs_clone_rm_nested']
+    'zfs_clone_rm_nested', 'zfs_clone_nomount']
 tags = ['functional', 'cli_root', 'zfs_clone']
 
 [tests/functional/cli_root/zfs_copies]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -677,6 +677,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_clone/zfs_clone_010_pos.ksh \
 	functional/cli_root/zfs_clone/zfs_clone_deeply_nested.ksh \
 	functional/cli_root/zfs_clone/zfs_clone_encrypted.ksh \
+	functional/cli_root/zfs_clone/zfs_clone_nomount.ksh \
 	functional/cli_root/zfs_clone/zfs_clone_rm_nested.ksh \
 	functional/cli_root/zfs_copies/cleanup.ksh \
 	functional/cli_root/zfs_copies/setup.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_nomount.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_nomount.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+# shellcheck disable=SC2066
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Ivan Shapovalov <intelfx@intelfx.name>
+#
+
+. "$STF_SUITE/include/libtest.shlib"
+
+#
+# DESCRIPTION:
+# 	`zfs clone -u` should leave the new file system unmounted.
+#
+# STRATEGY:
+#	1. Prepare snapshots
+#	2. Clone a snapshot using `-u` and make sure the clone is not mounted.
+#
+
+verify_runnable "both"
+
+function setup_all
+{
+	log_note "Creating snapshots..."
+
+	for snap in "$SNAPFS" ; do
+		if ! snapexists "$snap" ; then
+			log_must zfs snapshot "$snap"
+		fi
+	done
+
+	return 0
+}
+
+function cleanup_all
+{
+	datasetexists "$fs" && destroy_dataset "$fs"
+
+	for snap in "$SNAPFS" ; do
+		snapexists "$snap" && destroy_dataset "$snap" -Rf
+	done
+
+	return 0
+}
+
+log_onexit cleanup_all
+log_must setup_all
+
+log_assert "zfs clone -u should leave the new file system unmounted"
+
+typeset fs="$TESTPOOL/clonefs$$"
+
+log_must zfs clone -u "$SNAPFS" "$fs"
+log_mustnot ismounted "$fs"
+
+log_pass "zfs clone -u leaves the new file system unmounted"


### PR DESCRIPTION
### Motivation and Context

### Description

Add a `zfs clone -u` flag, bringing it in line with all other subcommands that may create datasets.

### How Has This Been Tested?

- compile-tested
- run-tested on x86_64 Linux
- ZTS tests added

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
