### PR TITLE
Added support for multiple homes in pam_zfs_key module

### DIFF
--- a/contrib/debian/openzfs-libpam-zfs.install
+++ b/contrib/debian/openzfs-libpam-zfs.install
@@ -1,2 +1,3 @@
 usr/lib/*/security/pam_zfs_key.so
+usr/share/man/man8/pam_zfs_key.8
 usr/share/pam-configs/zfs_key

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -111,6 +111,7 @@ endif
 
 if BUILD_LINUX
 dist_man_MANS += \
+	%D%/man8/pam_zfs_key.8 \
 	%D%/man8/zfs-unzone.8 \
 	%D%/man8/zfs-zone.8
 endif

--- a/man/man8/pam_zfs_key.8
+++ b/man/man8/pam_zfs_key.8
@@ -1,0 +1,221 @@
+.\" SPDX-License-Identifier: BSD-3-Clause
+.\"
+.\" Copyright (c) 2020, Felix Dörre
+.\" All rights reserved.
+.\"
+.Dd December 24, 2025
+.Dt PAM_ZFS_KEY 8
+.Os
+.
+.Sh NAME
+.Nm pam_zfs_key
+.Nd PAM module for ZFS encryption key management
+.Sh SYNOPSIS
+.Nm pam_zfs_key.so
+.Op Ar options
+.
+.Sh DESCRIPTION
+.Nm
+is a PAM module that automatically manages encryption keys for ZFS
+datasets during user authentication and session management.
+When a user logs in, the module uses their password to unlock their encrypted
+home directory.
+When the last session closes, the module unmounts the dataset and unloads
+the key.
+.Pp
+The module tracks active sessions using reference counting to support multiple
+simultaneous logins from the same user.
+.Ss Multiple Home Prefixes
+When configured with multiple home prefixes, the module attempts operations
+on all matching datasets.
+Operations that succeed are not rolled back if others fail.
+The module returns success only if all operations succeed.
+.Pp
+For example, with datasets 1, 2, 3 where dataset 2 fails:
+.Bl -bullet -compact
+.It
+Auth/session: datasets 1 and 3 are unlocked and mounted, dataset 2 is not.
+.It
+Password change: datasets 1 and 3 have the new password,
+dataset 2 retains the old.
+.El
+.Pp
+With
+.Sy required ,
+login fails even though datasets 1 and 3 succeeded.
+With
+.Sy optional ,
+login proceeds.
+For password changes, datasets 1 and 3 are updated while dataset 2
+retains the old password.
+With
+.Sy required ,
+the user sees an error.
+With
+.Sy optional ,
+the user sees success and may not notice the inconsistency.
+Either way, passwords are left out of sync.
+.Pp
+Errors are logged to syslog.
+Use
+.Xr zfs-change-key 8
+to resync passwords after partial failure.
+.
+.Sh OPTIONS
+.Bl -tag -width "mount_recursively"
+.It Sy homes Ns = Ns Ar path Ns Oo , Ns Ar path2 Ns ... Oc
+Comma-separated list of dataset prefixes where user home directories
+are located.
+The module constructs the full dataset path as
+.Ar prefix Ns / Ns Ar username .
+Default:
+.Sy zroot/home
+on
+.Fx ,
+.Sy rpool/home
+on Linux.
+.It Sy runstatedir Ns = Ns Ar path
+Directory for storing session reference counts.
+Default:
+.Pa /var/run/pam_zfs_key .
+.It Sy uid_min Ns = Ns Ar uid
+Minimum user ID for which the module will operate.
+Default: 1000.
+.It Sy uid_max Ns = Ns Ar uid
+Maximum user ID for which the module will operate.
+Default: MAXUID.
+.It Sy nounmount
+Do not unmount datasets or unload encryption keys when sessions close.
+Datasets remain mounted and keys remain loaded.
+.It Sy forceunmount
+Force unmount datasets even if busy
+.Pq Dv MS_FORCE .
+.It Sy recursive_homes
+Recursively search for encrypted datasets under the homes prefix.
+.It Sy mount_recursively
+Mount and unmount child datasets recursively.
+.It Sy prop_mountpoint
+Find the user's dataset by matching the dataset's
+.Sy mountpoint
+property to the user's home directory from
+.Pa /etc/passwd ,
+instead of constructing the dataset name as
+.Ar prefix Ns / Ns Ar username .
+.El
+.
+.Sh FILES
+.Bl -tag -width Pa
+.It Pa /var/run/pam_zfs_key/ Ns Ar uid
+Session reference count files tracking active logins per user.
+.El
+.
+.Sh EXAMPLES
+.Ss Example 1: Basic Configuration
+Add to
+.Pa /etc/pam.d/system-auth :
+.Bd -literal -offset indent
+auth     optional  pam_zfs_key.so
+password optional  pam_zfs_key.so
+session  optional  pam_zfs_key.so
+.Ed
+.Pp
+This configuration uses default settings.
+User home datasets are expected at
+.Sy zroot/home/ Ns Ar username
+on
+.Fx
+or
+.Sy rpool/home/ Ns Ar username
+on Linux.
+.
+.Ss Example 2: Custom Home Directory Prefix
+.Bd -literal -offset indent
+auth     optional  pam_zfs_key.so homes=tank/users
+password optional  pam_zfs_key.so homes=tank/users
+session  optional  pam_zfs_key.so homes=tank/users
+.Ed
+.Pp
+Looks for user datasets at
+.Sy tank/users/ Ns Ar username .
+.
+.Ss Example 3: Multiple Dataset Prefixes
+.Bd -literal -offset indent
+session  optional  pam_zfs_key.so homes=rpool/home,tank/users
+.Ed
+.Pp
+Searches for user datasets in both
+.Sy rpool/home
+and
+.Sy tank/users .
+.
+.Ss Example 4: Keep Datasets Mounted
+.Bd -literal -offset indent
+session  optional  pam_zfs_key.so nounmount
+.Ed
+.Pp
+Leaves datasets mounted and keys loaded when sessions close.
+Useful for systems with background processes accessing the home directory.
+.
+.Ss Example 5: Recursive Mounting
+.Bd -literal -offset indent
+session  optional  pam_zfs_key.so mount_recursively
+.Ed
+.Pp
+Mounts child datasets recursively, useful when user data is organized
+hierarchically like
+.Sy rpool/home/alice/documents
+and
+.Sy rpool/home/alice/photos .
+.
+.Ss Example 6: Creating an Encrypted Home Dataset
+.Bd -literal -offset indent
+# zfs create -o encryption=on \e
+    -o keyformat=passphrase \e
+    -o keylocation=prompt \e
+    -o canmount=on \e
+    -o mountpoint=/home/alice \e
+    rpool/home/alice
+.Ed
+.Pp
+The user's login password must match the dataset passphrase for automatic
+unlocking to work.
+The dataset must have a ZFS-managed mountpoint (not legacy) and
+.Sy canmount Ns = Ns Sy on
+for automatic mounting.
+.
+.Ss Example 7: Multiple Homes with Password Sync Check
+.Bd -literal -offset indent
+auth     optional  pam_zfs_key.so homes=rpool/home,tank/home
+password required  pam_zfs_key.so homes=rpool/home,tank/home
+session  optional  pam_zfs_key.so homes=rpool/home,tank/home
+.Ed
+.Pp
+Login proceeds even if some datasets are unavailable.
+Password changes fail if any dataset cannot be updated, ensuring
+the user is notified of sync issues.
+See
+.Sx Multiple Home Prefixes
+for failure behavior.
+.
+.Sh SEE ALSO
+.Xr pam 8 ,
+.Xr zfs-change-key 8 ,
+.Xr zfs-load-key 8 ,
+.Xr zfs-mount 8
+.
+.Sh NOTES
+.Bl -bullet -compact
+.It
+Only works with datasets using
+.Sy keyformat Ns = Ns Sy passphrase .
+.It
+Datasets must have
+.Sy keylocation Ns = Ns Sy prompt .
+.It
+Datasets with
+.Sy mountpoint Ns = Ns Sy legacy ,
+.Sy canmount Ns = Ns Sy off ,
+or
+.Sy canmount Ns = Ns Sy noauto
+will have keys loaded but not be automatically mounted.
+.El

--- a/man/man8/zfs-load-key.8
+++ b/man/man8/zfs-load-key.8
@@ -92,6 +92,9 @@ will ask for the key and mount the dataset
 see
 .Xr zfs-mount 8
 .Pc .
+For automated key management during user login,
+.Xr pam_zfs_key 8
+can load keys and mount encrypted home directories on systems with PAM support.
 Once the key is loaded the
 .Sy keystatus
 property will become
@@ -301,5 +304,6 @@ written.
 .
 .Sh SEE ALSO
 .Xr zfsprops 7 ,
+.Xr pam_zfs_key 8 ,
 .Xr zfs-create 8 ,
 .Xr zfs-set 8

--- a/man/man8/zfs-mount.8
+++ b/man/man8/zfs-mount.8
@@ -110,6 +110,9 @@ on each encryption root before mounting it.
 Note that if a filesystem has
 .Sy keylocation Ns = Ns Sy prompt ,
 this will cause the terminal to interactively block after asking for the key.
+On systems with PAM support,
+.Xr pam_zfs_key 8
+can automate this process during user login.
 .It Fl v
 Report mount progress.
 .It Fl f
@@ -138,3 +141,6 @@ The command can also be given a path to a ZFS file system mount point on the
 system.
 .El
 .El
+.
+.Sh SEE ALSO
+.Xr pam_zfs_key 8

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -805,6 +805,7 @@ don't wait.
 .Xr exportfs 8 ,
 .Xr mount 8 ,
 .Xr net 8 ,
+.Xr pam_zfs_key 8 ,
 .Xr selinux 8 ,
 .Xr zfs-allow 8 ,
 .Xr zfs-bookmark 8 ,

--- a/tests/zfs-tests/tests/functional/pam/pam_basic.ksh
+++ b/tests/zfs-tests/tests/functional/pam/pam_basic.ksh
@@ -51,4 +51,62 @@ references 0
 log_mustnot ismounted "$TESTPOOL/pam/${username}"
 keystatus unavailable
 
+
+
+log_mustnot ismounted "$TESTPOOL/pam/${username}"
+keystatus unavailable
+log_mustnot ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh unavailable
+
+genconfig "homes=$TESTPOOL/pam,$TESTPOOL/pam-multi-home runstatedir=${runstatedir}"
+echo "testpass" | pamtester ${pamservice} ${username} open_session
+references 1
+log_must ismounted "$TESTPOOL/pam/${username}"
+keystatus available
+log_must ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh available
+
+echo "testpass" | pamtester ${pamservice} ${username} open_session
+references 2
+log_must ismounted "$TESTPOOL/pam/${username}"
+keystatus available
+log_must ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh available
+
+log_must pamtester ${pamservice} ${username} close_session
+references 1
+log_must ismounted "$TESTPOOL/pam/${username}"
+keystatus available
+log_must ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh available
+
+log_must pamtester ${pamservice} ${username} close_session
+references 0
+log_mustnot ismounted "$TESTPOOL/pam/${username}"
+keystatus unavailable
+log_mustnot ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh unavailable
+
+# Test a 'homes' with many entries
+allhomes="$TESTPOOL/pam-multi-home1"
+for i in {2..$PAM_MULTI_HOME_COUNT} ; do
+       allhomes="$allhomes,$TESTPOOL/pam-multi-home$i"
+done
+
+genconfig "homes=$allhomes runstatedir=${runstatedir}"
+
+echo "testpass" | pamtester ${pamservice} ${username} open_session
+for i in {1..$PAM_MULTI_HOME_COUNT} ; do
+       references 1
+       log_must ismounted "$TESTPOOL/pam-multi-home$i/${username}"
+       keystatus_mh available $i
+done
+
+log_must pamtester ${pamservice} ${username} close_session
+for i in {1..$PAM_MULTI_HOME_COUNT} ; do
+       references 0
+       log_mustnot ismounted "$TESTPOOL/pam-multi-home$i/${username}"
+       keystatus_mh unavailable $i
+done
+
 log_pass "done."

--- a/tests/zfs-tests/tests/functional/pam/pam_change_unmounted.ksh
+++ b/tests/zfs-tests/tests/functional/pam/pam_change_unmounted.ksh
@@ -29,28 +29,39 @@ fi
 
 log_mustnot ismounted "$TESTPOOL/pam/${username}"
 keystatus unavailable
+log_mustnot ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh unavailable
 
-genconfig "homes=$TESTPOOL/pam runstatedir=${runstatedir}"
+genconfig "homes=$TESTPOOL/pam,$TESTPOOL/pam-multi-home runstatedir=${runstatedir}"
 
 printf "testpass\nsecondpass\nsecondpass\n" | pamtester -v ${pamservice} ${username} chauthtok
 
 log_mustnot ismounted "$TESTPOOL/pam/${username}"
 keystatus unavailable
+log_mustnot ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh unavailable
 
 echo "secondpass" | pamtester ${pamservice} ${username} open_session
 references 1
 log_must ismounted "$TESTPOOL/pam/${username}"
 keystatus available
+log_must ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh available
 
 printf "secondpass\ntestpass\ntestpass\n" | pamtester -v ${pamservice} ${username} chauthtok
 
 log_must ismounted "$TESTPOOL/pam/${username}"
 log_must ismounted "$TESTPOOL/pam/${username}"
 keystatus available
+log_must ismounted "$TESTPOOL/pam-multi-home/${username}"
+log_must ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh available
 
 log_must pamtester ${pamservice} ${username} close_session
 references 0
 log_mustnot ismounted "$TESTPOOL/pam/${username}"
 keystatus unavailable
+log_mustnot ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh unavailable
 
 log_pass "done."

--- a/tests/zfs-tests/tests/functional/pam/pam_nounmount.ksh
+++ b/tests/zfs-tests/tests/functional/pam/pam_nounmount.ksh
@@ -29,28 +29,40 @@ fi
 
 log_mustnot ismounted "$TESTPOOL/pam/${username}"
 keystatus unavailable
+log_mustnot ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh unavailable
 
-genconfig "homes=$TESTPOOL/pam runstatedir=${runstatedir} nounmount"
+genconfig "homes=$TESTPOOL/pam,$TESTPOOL/pam-multi-home runstatedir=${runstatedir} nounmount"
 echo "testpass" | pamtester ${pamservice} ${username} open_session
 references 1
 log_must ismounted "$TESTPOOL/pam/${username}"
 keystatus available
+log_must ismounted "$TESTPOOL/pam-multi-home/${username}"
+keystatus_mh available
 
 echo "testpass" | pamtester ${pamservice} ${username} open_session
 references 2
 keystatus available
 log_must ismounted "$TESTPOOL/pam/${username}"
+keystatus_mh available
+log_must ismounted "$TESTPOOL/pam-multi-home/${username}"
 
 log_must pamtester ${pamservice} ${username} close_session
 references 1
 keystatus available
 log_must ismounted "$TESTPOOL/pam/${username}"
+keystatus_mh available
+log_must ismounted "$TESTPOOL/pam-multi-home/${username}"
 
 log_must pamtester ${pamservice} ${username} close_session
 references 0
 keystatus available
+keystatus_mh available
 log_must ismounted "$TESTPOOL/pam/${username}"
+log_must ismounted "$TESTPOOL/pam-multi-home/${username}"
 log_must zfs unmount "$TESTPOOL/pam/${username}"
+log_must zfs unmount "$TESTPOOL/pam-multi-home/${username}"
 log_must zfs unload-key "$TESTPOOL/pam/${username}"
+log_must zfs unload-key "$TESTPOOL/pam-multi-home/${username}"
 
 log_pass "done."

--- a/tests/zfs-tests/tests/functional/pam/setup.ksh
+++ b/tests/zfs-tests/tests/functional/pam/setup.ksh
@@ -30,6 +30,7 @@ DISK=${DISKS%% *}
 create_pool $TESTPOOL "$DISK"
 
 log_must zfs create -o mountpoint="$TESTDIR" "$TESTPOOL/pam"
+log_must zfs create -o mountpoint="$TESTDIR-multi-home" "$TESTPOOL/pam-multi-home"
 log_must add_group pamtestgroup
 log_must add_user pamtestgroup ${username}
 log_must mkdir -p "$runstatedir"
@@ -37,5 +38,15 @@ log_must mkdir -p "$runstatedir"
 echo "testpass" | zfs create -o encryption=aes-256-gcm -o keyformat=passphrase -o keylocation=prompt "$TESTPOOL/pam/${username}"
 log_must zfs unmount "$TESTPOOL/pam/${username}"
 log_must zfs unload-key "$TESTPOOL/pam/${username}"
+echo "testpass" | zfs create -o encryption=aes-256-gcm -o keyformat=passphrase -o keylocation=prompt "$TESTPOOL/pam-multi-home/${username}"
+log_must zfs unmount "$TESTPOOL/pam-multi-home/${username}"
+log_must zfs unload-key "$TESTPOOL/pam-multi-home/${username}"
+
+for i in {1..$PAM_MULTI_HOME_COUNT} ; do
+       log_must zfs create -o mountpoint="$TESTDIR-multi-home$i" "$TESTPOOL/pam-multi-home$i"
+       echo "testpass" | zfs create -o encryption=aes-256-gcm -o keyformat=passphrase -o keylocation=prompt "$TESTPOOL/pam-multi-home$i/${username}"
+       log_must zfs unmount "$TESTPOOL/pam-multi-home$i/${username}"
+       log_must zfs unload-key "$TESTPOOL/pam-multi-home$i/${username}"
+done
 
 log_pass

--- a/tests/zfs-tests/tests/functional/pam/utilities.kshlib.in
+++ b/tests/zfs-tests/tests/functional/pam/utilities.kshlib.in
@@ -28,9 +28,15 @@ runstatedir="${TESTDIR}_run"
 pammodule="@pammoduledir@/pam_zfs_key.so"
 pamservice="pam_zfs_key_test"
 pamconfig="/etc/pam.d/${pamservice}"
+PAM_MULTI_HOME_COUNT=20
 
 function keystatus {
     log_must [ "$(get_prop keystatus "$TESTPOOL/pam/${username}")" = "$1" ]
+}
+
+function keystatus_mh {
+    typeset suffix="${2:-}"
+    log_must [ "$(get_prop keystatus "$TESTPOOL/pam-multi-home${suffix}/${username}")" = "$1" ]
 }
 
 function genconfig {


### PR DESCRIPTION
**Disclamer:** I don't normally code C, so this is a best-effort attempt. There can easily be something I have overlooked when it comes to memory handling. So I am open for feedback and help to improve the code 😁

This implemented support for having multiple datasets unlocked and mounted when a session is opened.
Example: `homes=rpool/home,tank/users`

Extra unit tests have been added

A man page document has been added `man 8 pam_zfs_key` (since none existed 😭). A few references to the new man page have also been added in other documents.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
I have 2 pools on my system, both containing user data, so I want to be able to easily decrypt and mount the user dataset on both pools on user login.
So I have made this patch for the pam_zfs_key module, which worked on my system. So I thought I wanted to share it.
I want to upstream this patch because there may be other people with this problem.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
This patch adds support for comma-separated homes= prefixes in pam_zfs_key and makes it so that pam_zfs_key can manage encrypted ZFS datasets across multiple pools. This patch is, as far as I can tell, fully backward compatible with existing PAM configs.

### How Has This Been Tested?
I created a VM setup for the development and testing. When I applied the patch on my workstation. For the final test.
I am running NixOS, so I simply applied the patch as an overlay and rebuilt my system.

```nix
nixpkgs.overlays = [
  ( final: prev:  let
      zfs-patch = prev.fetchpatch {
        url = "https://github.com/dvaerum/zfs/commit/7ae5eb5797a5309f943601453a871460b1caefe2.patch";
        hash = "sha256-QGoR3S2vWbaxoFTqnKjgdyKkI3juKTsfO98UU2rEfi4=";
      };
    in {
      zfs = prev.zfs.overrideAttrs (old: {
        patches = (old.patches or [ ]) ++ [ zfs-patch ];
      });
      zfs_2_4 = prev.zfs_2_4.overrideAttrs (old: {
        patches = (old.patches or [ ]) ++ [ zfs-patch ];
      });
      zfs_unstable = prev.zfs_unstable.overrideAttrs (old: {
        patches = (old.patches or [ ]) ++ [ zfs-patch ];
      });
    }
  )
];

```

I have expanded the existing unittests for the PAM module to also cover multi-homes config to make sure that this feature continues to work, if accepted. However, I may not have covered everything, but if you see missing test scenarios, I will try to add them 😁 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
