### PR TITLE
cmd/ztest: avoid `PATH_MAX` stack allocation in `ztest_get_zdb_bin()`

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -7144,6 +7144,7 @@ static void
 ztest_get_zdb_bin(char *bin, int len)
 {
 	char *zdb_path;
+	char *resolved;
 	/*
 	 * Try to use $ZDB and in-tree zdb path. If not successful, just
 	 * let popen to search through PATH.
@@ -7157,7 +7158,11 @@ ztest_get_zdb_bin(char *bin, int len)
 		return;
 	}
 
-	VERIFY3P(realpath(getexecname(), bin), !=, NULL);
+	resolved = realpath(getexecname(), NULL);
+	VERIFY3P(resolved, !=, NULL);
+	strlcpy(bin, resolved, len);
+	free(resolved);
+
 	if (strstr(bin, ".libs/ztest")) {
 		strstr(bin, ".libs/ztest")[0] = '\0'; /* In-tree */
 		strcat(bin, "zdb");


### PR DESCRIPTION
Calling `realpath(path, buf)` can trigger fortified header wrappers that allocate a `PATH_MAX`-sized temporary buffer on the stack, exceeding the 4 KiB frame limit on some systems. Use the heap-allocating `realpath(path, NULL)` form instead.

---

### Motivation and Context

When building on Alpine Linux with fortified headers, the compiler emits a warning:

```
cmd/ztest.c: In function 'ztest_get_zdb_bin.constprop':
cmd/ztest.c:7168:1: warning: the frame size of 4256 bytes is larger than 4096 bytes [-Wframe-larger-than=]
 7168 | }
      | ^
```

This occurs because the fortified `realpath(path, buf)` wrapper allocates a `PATH_MAX`-sized temporary buffer on the stack (typically 4096 bytes), which when combined with the function's other local variables, exceeds the 4 KiB stack frame limit.

### Description

This change avoids the fortified wrapper path by using the heap-allocating `realpath(path, NULL)` form. The resolved path is copied into the caller-provided buffer and freed immediately.

This preserves the existing behavior while avoiding the large temporary stack allocation and keeping the stack frame size below the configured limit.

### How Has This Been Tested?

Built on Alpine Linux where the warning was originally observed. The warning no longer appears after this change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
