### PR TITLE
CI: Add Alpine Linux 3.23 runner to the pipeline

### DIFF
--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -43,6 +43,12 @@ case "$OS" in
     OSv="almalinux9"
     URL="https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/AlmaLinux-10-GenericCloud-latest.x86_64.qcow2"
     ;;
+  alpine3-23)
+    OSNAME="Alpine Linux 3.23.2"
+    # Alpine Linux v3.22 and v3.23 are unknown to osinfo as of 2025-12-26.
+    OSv="alpinelinux3.21"
+    URL="https://dl-cdn.alpinelinux.org/alpine/v3.23/releases/cloud/generic_alpine-3.23.2-x86_64-bios-cloudinit-r0.qcow2"
+    ;;
   archlinux)
     OSNAME="Archlinux"
     URL="https://geo.mirror.pkgbuild.com/images/latest/Arch-Linux-x86_64-cloudimg.qcow2"
@@ -216,13 +222,21 @@ if [ ${OS:0:7} != "freebsd" ]; then
 hostname: $OS
 
 users:
-- name: root
-  shell: $BASH
-- name: zfs
-  sudo: ALL=(ALL) NOPASSWD:ALL
-  shell: $BASH
-  ssh_authorized_keys:
-    - $PUBKEY
+  - name: root
+    shell: /bin/bash
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+  - name: zfs
+    shell: /bin/bash
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    ssh_authorized_keys:
+      - $PUBKEY
+    # Workaround for Alpine Linux.
+    lock_passwd: false
+    passwd: '*'
+
+packages:
+  - sudo
+  - bash
 
 growpart:
   mode: auto
@@ -304,4 +318,24 @@ else
   ssh root@vm0 'service sshd restart'
   scp ~/src.txz "root@vm0:/tmp/src.txz"
   ssh root@vm0 'tar -C / -zxf /tmp/src.txz'
+fi
+
+#
+# Config for Alpine Linux similar to FreeBSD.
+#
+if [ ${OS:0:6} == "alpine" ]; then
+  while pidof /usr/bin/qemu-system-x86_64 >/dev/null; do
+    ssh 2>/dev/null zfs@vm0 "uname -a" && break
+  done
+  # Enable community and testing repositories.
+  ssh zfs@vm0 "sudo rm -rf /etc/apk/repositories"
+  ssh zfs@vm0 "sudo setup-apkrepos -c1"
+  ssh zfs@vm0 "echo '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' | sudo tee -a /etc/apk/repositories"
+  # Upgrade to edge or latest-stable.
+  #ssh zfs@vm0 "sudo sed -i 's#/v[0-9]\+\.[0-9]\+/#/edge/#g' /etc/apk/repositories"
+  #ssh zfs@vm0 "sudo sed -i 's#/v[0-9]\+\.[0-9]\+/#/latest-stable/#g' /etc/apk/repositories"
+  # Update and upgrade after repository setup.
+  ssh zfs@vm0 "sudo apk update"
+  ssh zfs@vm0 "sudo apk add --upgrade apk-tools"
+  ssh zfs@vm0 "sudo apk upgrade --available"
 fi

--- a/.github/workflows/scripts/qemu-5-setup.sh
+++ b/.github/workflows/scripts/qemu-5-setup.sh
@@ -58,13 +58,21 @@ for ((i=1; i<=VMs; i++)); do
 fqdn: vm$i
 
 users:
-- name: root
-  shell: $BASH
-- name: zfs
-  sudo: ALL=(ALL) NOPASSWD:ALL
-  shell: $BASH
-  ssh_authorized_keys:
-    - $PUBKEY
+  - name: root
+    shell: /bin/bash
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+  - name: zfs
+    shell: /bin/bash
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    ssh_authorized_keys:
+      - $PUBKEY
+    # Workaround for Alpine Linux.
+    lock_passwd: false
+    passwd: '*'
+
+packages:
+  - sudo
+  - bash
 
 growpart:
   mode: auto

--- a/.github/workflows/scripts/qemu-6-tests.sh
+++ b/.github/workflows/scripts/qemu-6-tests.sh
@@ -95,10 +95,17 @@ case "$1" in
     ;;
 esac
 
-# enable io_uring on el9/el10
+# Distribution-specific settings.
 case "$1" in
   almalinux9|almalinux10|centos-stream*)
+    # Enable io_uring on Enterprise Linux 9 and 10.
     sudo sysctl kernel.io_uring_disabled=0 > /dev/null
+    ;;
+  alpine*)
+    # Ensure `/etc/zfs/zpool.cache` exists.
+    sudo mkdir -p /etc/zfs
+    sudo touch /etc/zfs/zpool.cache
+    sudo chmod 644 /etc/zfs/zpool.cache
     ;;
 esac
 

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -10,6 +10,11 @@ on:
         required: false
         default: ""
         description: "(optional) Experimental kernel version to install on Fedora (like '6.14' or '6.13.3-0.rc3')"
+      specific_os:
+        type: string
+        required: false
+        default: ""
+        description: "(optional) Only run on this specific OS (like 'fedora42' or 'alpine3-23')"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -58,6 +63,9 @@ jobs:
               # They specified a custom kernel version for Fedora.
               # Use only Fedora runners.
               os_json=$(echo ${os_selection} | jq -c '[.[] | select(startswith("fedora"))]')
+          elif ${{ github.event.inputs.specific_os != '' }}; then
+              # Use only the specified runner.
+              os_json=$(jq -cn --arg os "${{ github.event.inputs.specific_os }}" '[ $os ]')
           else
               # Normal case
               os_json=$(echo ${os_selection} | jq -c)

--- a/tests/zfs-tests/callbacks/zfs_dbgmsg.ksh
+++ b/tests/zfs-tests/callbacks/zfs_dbgmsg.ksh
@@ -26,7 +26,7 @@ echo "================================================================="
 sudo tail -n $lines /proc/spl/kstat/zfs/dbgmsg
 
 # reset dbgmsg
-sudo bash -c "echo > /proc/spl/kstat/zfs/dbgmsg"
+sudo sh -c "echo > /proc/spl/kstat/zfs/dbgmsg"
 
 echo "================================================================="
 echo " End of zfs_dbgmsg log"

--- a/tests/zfs-tests/callbacks/zfs_mmp.ksh
+++ b/tests/zfs-tests/callbacks/zfs_mmp.ksh
@@ -31,7 +31,7 @@ for f in /proc/spl/kstat/zfs/*/multihost; do
 	echo "================================================================="
 
 	sudo tail -n $lines $f
-	sudo bash -c "echo > $f"
+	sudo sh -c "echo > $f"
 done
 
 echo "================================================================="

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -559,7 +559,7 @@ function default_cleanup_noexit
 		# Here, we loop through the pools we're allowed to
 		# destroy, only destroying them if it's safe to do
 		# so.
-		while [ ! -z ${ALL_POOLS} ]
+		while [ -n "${ALL_POOLS}" ]
 		do
 			for pool in ${ALL_POOLS}
 			do

--- a/tests/zfs-tests/tests/functional/mount/mount_loopback.ksh
+++ b/tests/zfs-tests/tests/functional/mount/mount_loopback.ksh
@@ -79,7 +79,8 @@ function do_test
 	imgfile=$1
 	log_note "Running test on $imgfile"
 	log_must losetup -f $imgfile
-	DEV=$(losetup --associated $imgfile | grep -Eo '^/dev/loop[0-9]+')
+	# Alpine Linux loop devices appear as `/dev/loop/N` instead of `/dev/loopN`.
+	DEV=$(losetup --associated $imgfile | grep -Eo '^/dev/loop/?[0-9]+')
 	log_must mkfs.xfs $DEV
 	mkdir $TEST_BASE_DIR/mnt
 	log_must mount $DEV $TEST_BASE_DIR/mnt


### PR DESCRIPTION
Add an Alpine Linux 3.23 runner to the CI chain to run OpenZFS builds and tests against musl libc.

Currently, zfs_send_sparse is killed after ~10 minutes on Alpine, causing cascading EBUSY failures in the test suite. With zfs_send_sparse disabled, the ZFS test suite reaches a pass rate of 94.62%.

This commit introduces the required Alpine-specific setup and a small set of shell and cloud-init compatibility fixes that also apply to existing Linux runners.

The Alpine runner is not enabled by default and is not executed for new pull requests.

---

### Motivation and context

The CI chain currently does not cover musl-based Linux systems. Bugs on these systems are therefore often reported _after_ new releases. This pull request is meant to catch such issues earlier, before they hit downstream.

Disclaimer: I am co-maintaining the `sys-fs/zfs` package for Gentoo and, even though musl-based profiles are marked as experimental, I care about this use case.

Incidentally, work on this pull request already resulted in the following bug fix:
- https://github.com/openzfs/zfs/pull/18085

So, I assume the Alpine CI does what it is supposed to do. 😉

### Description

Parts of this commit are opinionated. I try to pick the simplest solution, keep the diff small, and avoid duplicating code where possible. If a maintainer prefers a different approach, I am very open to adjusting this.

The runner passes 94.62% of the ZFS test suite with `zfs_send_sparse` disabled. This is a solid starting point, but not sufficient for a green CI run. `zfs_send_sparse` currently times out and causes `EBUSY` failures that cascade through the test suite. There are also unresolved issues around `atime` and `hostid`.

While a fully green CI would be desirable prior to enabling the runner, this pull request deliberately limits its scope to adding Alpine support without enabling it for new pull requests. As such, the primary risk of merging lies in a small set of compatibility changes that affect existing runners.

94.62% is a good baseline to continue improving the runner and eventually enable it once it reliably passes the full ZFS test suite.

### What has been changed?

It is important to distinguish between changes that affect existing runners and those that are specific to the new Alpine runner. This commit does not touch `zfs-qemu.yml`. Therefore, the Alpine runner will not be executed when merging this pull request.

#### Changes affecting current runners

Some compatibility changes required for Alpine also affect the other runners in the CI chain. Most notably, the cloud-init configuration was adjusted. Aside from minor formatting changes, the relevant points are:

1. Replace `$BASH` with `/bin/bash`.
   - `$BASH` is not set on Alpine. Bash is located at `/bin/bash` on all Linux distributions in the CI chain.
2. Allow `root` to execute `sudo` without a password.
   - This appears to be the default on most distributions, but not on Alpine.
3. Add `lock_passwd: false` and `passwd: '*'`.
   - This is a pragmatic fix. The Alpine guide suggests installing `openssh-server-pam` and enabling PAM in `sshd_config`. Given that this runs in ephemeral CI VMs, this approach keeps the configuration simple and avoids per-distro branching.
4. Add `bash` and `sudo` packages.
   - These are not installed by default on Alpine, but are present on the other distributions.

The fourth point relies on `apt` for Debian-based systems, so `cloud-init status --wait` is needed to avoid hanging due to an `apt` lock. Adding this globally caused AlmaLinux 8 to hang, so it is limited to Debian and Ubuntu. Overall, waiting for cloud-init improves robustness.

In some scripts the Alpine runner initially complained about `bash` not being found, likely due to environment differences. These calls were changed to POSIX-compatible `sh`, as they are only used for output redirection with `sudo`.

Alpine mounts loop devices as `/dev/loop/X` instead of `/dev/loopX`, which required a small regular expression adjustment. Finally, a syntax fix in `libtest.shlib` prevents cleanup failures.

#### The new Alpine Linux runner

Alpine has a few peculiarities. One of them is `ksh` not being available in the repositories, so it is built from source, which takes a few minutes. Logging into the VMs also requires manually disabling cloud-init services during setup. The system is switched from `mdev` to `eudev`, and `/etc/zfs/zpool.cache` is created manually.

The remaining changes are what would be expected for a new Linux runner.

#### Possible future directions

This section lists ideas that could be explored in the future, but are likely out of scope for this pull request.

- An Alpine Edge runner to test against upcoming releases. A stub already exists.
- LLVM-based builds. LLVM-based user space builds work fine, but the Alpine kernel is built using GCC, so kernel modules cannot be built with LLVM.
- Full (kernel + user space) LLVM-based builds.

### How has this been tested?

Several test runs using GitHub Actions and the ZFS test suite. Alpine currently reaches a 94.62% pass rate.

All other distributions pass the CI pipeline after these changes.

---

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
