### PR TITLE
Rename several printf attributes declarations to __printf__

### DIFF
--- a/include/os/freebsd/spl/sys/cmn_err.h
+++ b/include/os/freebsd/spl/sys/cmn_err.h
@@ -52,28 +52,28 @@ extern "C" {
 #ifndef _ASM
 
 extern void cmn_err(int, const char *, ...)
-    __attribute__((format(printf, 2, 3)));
+    __attribute__((format(__printf__, 2, 3)));
 
 extern void vzcmn_err(zoneid_t, int, const char *, __va_list)
-    __attribute__((format(printf, 3, 0)));
+    __attribute__((format(__printf__, 3, 0)));
 
 extern void vcmn_err(int, const char *, __va_list)
-    __attribute__((format(printf, 2, 0)));
+    __attribute__((format(__printf__, 2, 0)));
 
 extern void zcmn_err(zoneid_t, int, const char *, ...)
-    __attribute__((format(printf, 3, 4)));
+    __attribute__((format(__printf__, 3, 4)));
 
 extern void vzprintf(zoneid_t, const char *, __va_list)
-    __attribute__((format(printf, 2, 0)));
+    __attribute__((format(__printf__, 2, 0)));
 
 extern void zprintf(zoneid_t, const char *, ...)
-    __attribute__((format(printf, 2, 3)));
+    __attribute__((format(__printf__, 2, 3)));
 
 extern void vuprintf(const char *, __va_list)
-    __attribute__((format(printf, 1, 0)));
+    __attribute__((format(__printf__, 1, 0)));
 
 extern void panic(const char *, ...)
-    __attribute__((format(printf, 1, 2), __noreturn__));
+    __attribute__((format(__printf__, 1, 2), __noreturn__));
 
 #define	cmn_err_once(ce, ...)				\
 do {							\

--- a/include/os/freebsd/spl/sys/kmem.h
+++ b/include/os/freebsd/spl/sys/kmem.h
@@ -55,9 +55,9 @@ MALLOC_DECLARE(M_SOLARIS);
 typedef struct vmem vmem_t;
 
 extern char	*kmem_asprintf(const char *, ...)
-    __attribute__((format(printf, 1, 2)));
+    __attribute__((format(__printf__, 1, 2)));
 extern char *kmem_vasprintf(const char *fmt, va_list ap)
-    __attribute__((format(printf, 1, 0)));
+    __attribute__((format(__printf__, 1, 0)));
 
 extern int kmem_scnprintf(char *restrict str, size_t size,
     const char *restrict fmt, ...);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1127,9 +1127,9 @@ extern void spa_set_allocator(spa_t *spa, const char *allocator);
 
 /* Miscellaneous support routines */
 extern void spa_load_failed(spa_t *spa, const char *fmt, ...)
-    __attribute__((format(printf, 2, 3)));
+    __attribute__((format(__printf__, 2, 3)));
 extern void spa_load_note(spa_t *spa, const char *fmt, ...)
-    __attribute__((format(printf, 2, 3)));
+    __attribute__((format(__printf__, 2, 3)));
 extern void spa_activate_mos_feature(spa_t *spa, const char *feature,
     dmu_tx_t *tx);
 extern void spa_deactivate_mos_feature(spa_t *spa, const char *feature);

--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -54,7 +54,7 @@ extern int zfs_nocacheflush;
 typedef boolean_t vdev_open_children_func_t(vdev_t *vd);
 
 extern void vdev_dbgmsg(vdev_t *vd, const char *fmt, ...)
-    __attribute__((format(printf, 2, 3)));
+    __attribute__((format(__printf__, 2, 3)));
 extern void vdev_dbgmsg_print_tree(vdev_t *, int);
 extern int vdev_open(vdev_t *);
 extern void vdev_open_children(vdev_t *);

--- a/include/sys/zfs_debug.h
+++ b/include/sys/zfs_debug.h
@@ -68,7 +68,7 @@ extern int zfs_dbgmsg_enable;
 extern void __set_error(const char *file, const char *func, int line, int err);
 extern void __zfs_dbgmsg(char *buf);
 extern void __dprintf(boolean_t dprint, const char *file, const char *func,
-    int line, const char *fmt, ...)  __attribute__((format(printf, 5, 6)));
+    int line, const char *fmt, ...)  __attribute__((format(__printf__, 5, 6)));
 
 /*
  * Some general principles for using zfs_dbgmsg():


### PR DESCRIPTION
### Motivation and Context
This fixes OpenZFS kernel builds on FreeBSD, with clang 21 or higher.

### Description
For kernel builds on FreeBSD, we redefine `__printf__` to `__freebsd_kprintf__`, to support FreeBSD kernel printf(9) extensions with clang.

In OpenZFS various printf related functions are declared with `__attribute__((format(printf, X, Y)))`, so these won't work with the above redefinition. With clang 21 and higher, this leads to errors similar to:

    sys/contrib/openzfs/module/zfs/spa_misc.c:414:38: error: passing 'printf' format string where 'freebsd_kprintf' format string is expected [-Werror,-Wformat]
      414 |         (void) vsnprintf(buf, sizeof (buf), fmt, adx);
          |                                             ^

Since attribute names can always be spelled with leading and trailing double underscores, rename these instances.

Note that in the FreeBSD base system we usually use `__printflike` from `<sys/cdefs.h>`, but that does not apply to OpenZFS.

### How Has This Been Tested?
This is a mechanical change that only spells the attributes differently, and has no effect on the generated code. It compiles without any issue, and has been committed to FreeBSD itself in https://github.com/freebsd/freebsd-src/commit/bcd9ea853b14c85a61eb9079c59e966eed336578.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
