### PR TITLE
FreeBSD: unbreak compilation on i386

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -4674,7 +4674,7 @@ vdev_clear(spa_t *spa, vdev_t *vd)
 	vd->vdev_stat.vs_checksum_errors = 0;
 	vd->vdev_stat.vs_dio_verify_errors = 0;
 	vd->vdev_stat.vs_slow_ios = 0;
-	atomic_store_64(&vd->vdev_outlier_count, 0);
+	atomic_store_64((volatile uint64_t *)&vd->vdev_outlier_count, 0);
 	vd->vdev_read_sit_out_expire = 0;
 
 	for (int c = 0; c < vd->vdev_children; c++)

--- a/tests/zfs-tests/cmd/mmap_seek.c
+++ b/tests/zfs-tests/cmd/mmap_seek.c
@@ -55,7 +55,7 @@ seek_expect(int fd, off_t offset, int whence, off_t expect_offset)
 		return;
 
 	int err = errno;
-	fprintf(stderr, "lseek(fd, %ld, SEEK_%s) = %ld (expected %ld)",
+	fprintf(stderr, "lseek(fd, %jd, SEEK_%s) = %jd (expected %jd)",
 	    offset, (whence == SEEK_DATA ? "DATA" : "HOLE"),
 	    seek_offset, expect_offset);
 	if (err != 0)


### PR DESCRIPTION
### Motivation and Context
The compilation on FreeBSD i386 is broken.

### Description
Incorrect printf specifier in mmap_seek.c
Missing cast to atomic_add_64

### How Has This Been Tested?
Compilation on FreeBSD i386 and amd64

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).