### PR TITLE
kmem: don't add __GFP_RECLAIMABLE for KM_VMEM allocations

### DIFF
--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -142,8 +142,6 @@ kv_alloc(spl_kmem_cache_t *skc, int size, int flags)
 	gfp_t lflags = kmem_flags_convert(flags | KM_VMEM);
 	void *ptr;
 
-	if (skc->skc_flags & KMC_RECLAIMABLE)
-		lflags |= __GFP_RECLAIMABLE;
 	ptr = spl_vmalloc(size, lflags);
 
 	/* Resulting allocated memory will be page aligned */
@@ -424,7 +422,7 @@ spl_emergency_alloc(spl_kmem_cache_t *skc, int flags, void **obj)
 	if (!empty)
 		return (-EEXIST);
 
-	if (skc->skc_flags & KMC_RECLAIMABLE)
+	if (skc->skc_flags & KMC_RECLAIMABLE && !(flags & KM_VMEM))
 		lflags |= __GFP_RECLAIMABLE;
 	ske = kmalloc(sizeof (*ske), lflags);
 	if (ske == NULL)


### PR DESCRIPTION
### Description

Possibly another GFP flag misuse, now warned about in 6.19.

```
20:35:38.27 2025-12-31T20:20:12,760105+11:00 Unexpected gfp: 0x10 (__GFP_RECLAIMABLE). Fixing up to gfp: 0x2c00 (GFP_NOIO|__GFP_NOWARN). Fix your code!
20:35:38.27 2025-12-31T20:20:12,760109+11:00 WARNING: mm/vmalloc.c:3939 at __vmalloc_noprof+0x69/0x80, CPU#3: spl_kmem_cache/55109
...
20:35:38.27 2025-12-31T20:20:12,760182+11:00 Call Trace:
20:35:38.27 2025-12-31T20:20:12,760185+11:00  <TASK>
20:35:38.27 2025-12-31T20:20:12,760189+11:00  kv_alloc+0x2a/0x70 [spl]
20:35:38.27 2025-12-31T20:20:12,760203+11:00  spl_slab_alloc+0x20/0x120 [spl]
20:35:38.27 2025-12-31T20:20:12,760210+11:00  __spl_cache_grow+0x2c/0xb0 [spl]
20:35:38.27 2025-12-31T20:20:12,760215+11:00  spl_cache_grow_work+0x1c/0x60 [spl]
20:35:38.27 2025-12-31T20:20:12,760221+11:00  taskq_thread+0x27d/0x5d0 [spl]
20:35:38.27 2025-12-31T20:20:12,760230+11:00  ? __pfx_default_wake_function+0x10/0x10
20:35:38.27 2025-12-31T20:20:12,760233+11:00  ? __pfx_spl_cache_grow_work+0x10/0x10 [spl]
20:35:38.27 2025-12-31T20:20:12,760240+11:00  ? __pfx_taskq_thread+0x10/0x10 [spl]
20:35:38.27 2025-12-31T20:20:12,760247+11:00  kthread+0xfc/0x240
20:35:38.27 2025-12-31T20:20:12,760250+11:00  ? __pfx_kthread+0x10/0x10
20:35:38.27 2025-12-31T20:20:12,760253+11:00  ret_from_fork+0x254/0x290
20:35:38.27 2025-12-31T20:20:12,760256+11:00  ? __pfx_kthread+0x10/0x10
20:35:38.27 2025-12-31T20:20:12,760258+11:00  ret_from_fork_asm+0x1a/0x30
20:35:38.27 2025-12-31T20:20:12,760261+11:00  </TASK>
```

On the surface its simple: vmalloc'd memory is (apparently) not movable/reclaimable, so `__GFP_RECLAIMABLE` is not a valid for it. This commit fixes that.

However, I'm concerned that means the shrinker will not call the kmem cache reclaim functions when necessary. I'm not sure either way. `include/linux/gfp_types.h` says:

```
 * %__GFP_RECLAIMABLE is used for slab allocations that specify
 * SLAB_RECLAIM_ACCOUNT and whose pages can be freed via shrinkers.
```

So I wonder if we should be backing kmem caches with memory from reclaimable slabs?

(Or I could just be making up words; I don't know the SPL kmem cache code very well. Though, I have wondered if  the kernel's kmem_caches are good-enough these days to just use them directly?)

### How Has This Been Tested?

ZTS run against 6.19-rc3 tripped the warning initially. A followup run with this patch passed and didn't warn. That may not be enough to definitely say that it's benign but its a start.

Haven't tested on older kernels; I'll see what CI shakes out first.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
