### PR TITLE
ZTS: add regression test for #17180

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -82,7 +82,8 @@ tests = ['block_cloning_clone_mmap_cached',
     'block_cloning_copyfilerange_fallback_same_txg',
     'block_cloning_replay', 'block_cloning_replay_encrypted',
     'block_cloning_lwb_buffer_overflow', 'block_cloning_clone_mmap_write',
-    'block_cloning_rlimit_fsize', 'block_cloning_large_offset']
+    'block_cloning_rlimit_fsize', 'block_cloning_large_offset',
+    'block_cloning_after_device_removal']
 tags = ['functional', 'block_cloning']
 
 [tests/functional/bootfs]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -491,6 +491,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/block_cloning/block_cloning_lwb_buffer_overflow.ksh \
 	functional/block_cloning/block_cloning_rlimit_fsize.ksh \
 	functional/block_cloning/block_cloning_large_offset.ksh \
+	functional/block_cloning/block_cloning_after_device_removal.ksh \
 	functional/bootfs/bootfs_001_pos.ksh \
 	functional/bootfs/bootfs_002_neg.ksh \
 	functional/bootfs/bootfs_003_pos.ksh \

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_after_device_removal.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_after_device_removal.ksh
@@ -1,0 +1,61 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+#
+# DESCRIPTION:
+#	Verify that when modifying and freeing cloned blocks after a top-level
+#	vdev removal, there is no panic. This is a regression test for #17180.
+#
+
+verify_runnable "global"
+
+export VDIR=$TEST_BASE_DIR/disk-bclone
+export VDEV="$VDIR/0 $VDIR/1"
+log_must rm -rf $VDIR
+log_must mkdir -p $VDIR
+log_must truncate -s $MINVDEVSIZE $VDEV
+
+claim="No panic when destroying dataset with cloned blocks after top-level vdev removal"
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -rf $TESTDIR $VDIR
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $VDEV
+log_must dd if=/dev/urandom of=/$TESTPOOL/file bs=16M count=2
+log_must zpool remove -w $TESTPOOL $VDIR/1
+log_must zfs create $TESTPOOL/$TESTFS
+log_must clonefile -f /$TESTPOOL/file /$TESTPOOL/$TESTFS/file
+log_must dd if=/dev/urandom of=/$TESTPOOL/file bs=16M count=2
+log_must zfs destroy -r $TESTPOOL/$TESTFS
+
+log_pass $claim


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
#17180 fixed an interesting bug that i believe i hit in one of my pools, but as far as i can tell, there was no test for it.

### Description
this patch adds a regression test for #17180, minimised from my attempts to reproduce the bug in a way that resembled the history of my pool.

### How Has This Been Tested?
tested using [quiz](https://github.com/robn/quiz), on linux 6.12.44 and zfs 2.3.1, with and without #17180 applied. without the patch, it kernel panics every time. with the patch, it passes every time. similarly on the latest zfs, it passes every time, but if the reverse patch is applied, it kernel panics every time.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
