### PR TITLE
Fix history logging for `zpool create -t`

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -8151,10 +8151,16 @@ zfsdev_ioctl_common(uint_t vecnum, zfs_cmd_t *zc, int flag)
 	 * Can't use kmem_strdup() as we might truncate the string and
 	 * kmem_strfree() would then free with incorrect size.
 	 */
-	saved_poolname_len = strlen(zc->zc_name) + 1;
+	const char *spa_name = zc->zc_name;
+	const char *tname;
+	if (nvlist_lookup_string(innvl,
+	    zpool_prop_to_name(ZPOOL_PROP_TNAME), &tname) == 0) {
+		spa_name = tname;
+	}
+	saved_poolname_len = strlen(spa_name) + 1;
 	saved_poolname = kmem_alloc(saved_poolname_len, KM_SLEEP);
 
-	strlcpy(saved_poolname, zc->zc_name, saved_poolname_len);
+	strlcpy(saved_poolname, spa_name, saved_poolname_len);
 	saved_poolname[strcspn(saved_poolname, "/@#")] = '\0';
 
 	if (vec->zvec_func != NULL) {

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_tempname.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_tempname.ksh
@@ -60,6 +60,8 @@ for poolprop in "${poolprops[@]}"; do
 		log_must test "$(get_prop $propname $TEMPPOOL)" == "$propval"
 		IFS='=' read -r propname propval <<<"$poolprop"
 		log_must test "$(get_pool_prop $propname $TEMPPOOL)" == "$propval"
+		# 3. Verify the `zpool create` command is logged to the pool history
+		log_must eval "zpool history $TEMPPOOL | grep -q 'zpool create -t'"
 		# Cleanup
 		destroy_pool $TEMPPOOL
 	done


### PR DESCRIPTION
### Motivation and Context
`zpool create` is supposed to log the command to the new pool’s history, as a special record that never gets evicted from the ring buffer. but when you create a pool with `zpool create -t`, no such record is ever logged (#18102). that bug may be the cause of issues like #16408.

### Description
`zpool create -t` (83e9986f6eefdf0afc387f06407087bba3ead4e9) and `zpool import -t` (26b42f3f9d03f85cc7966dc2fe4dfe9216601b0e) are both designed to override the on-disk zpool property `name` with an in-core “temporary” name, but they work somewhat differently under the hood.

importing with a temporary name sets `spa->spa_import_flags |= ZFS_IMPORT_TEMP_NAME` in ZFS_IOC_POOL_IMPORT, which tells spa_write_cachefile() and spa_config_generate() to use the ZPOOL_CONFIG_POOL_NAME in `spa->spa_config` instead of `spa->spa_name`.

creating with a temporary name permanently(!) sets the internal zpool property `tname` (ZPOOL_PROP_TNAME) in the `zc->zc_nvlist_src` of ZFS_IOC_POOL_CREATE, which tells zfs_ioc_pool_create() (4ceb8dd6fdfdde3b6ac55cf52132858973fce9d0) and spa_create() to use that name instead of `zc->zc_name`, then sets `spa->spa_import_flags |= ZFS_IMPORT_TEMP_NAME` like an import.

but zfsdev_ioctl_common() fails to check for `tname` when saving the pool name to `zfs_allow_log_key`, so when we call ZFS_IOC_LOG_HISTORY, we call spa_open() on the wrong pool name and get ENOENT, so the logging silently fails.

this patch fixes #18102 by checking for `tname` in zfsdev_ioctl_common() like we do in zfs_ioc_pool_create().

### How Has This Been Tested?
tested using [quiz](https://github.com/robn/quiz), on linux 6.12.44:
```
$ ./quiz -k 6.12.44 -p zfs,ztest /usr/local/share/zfs/zfs-tests.sh -t tests/functional/cli_root/zpool_create/zpool_create_tempname.ksh
$ ./quiz -k 6.12.44 -p memdev,zfs /usr/local/zfs-18102-repro.sh
```

zfs-18102-repro.sh:
```
#!/bin/sh
set -euvx
zpool create -t test2 test /dev/quizm0
zpool history test2
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
