### PR TITLE
icp: emit .note.GNU-stack section for all ELF targets

### DIFF
--- a/module/icp/asm-x86_64/modes/aesni-gcm-avx2-vaes.S
+++ b/module/icp/asm-x86_64/modes/aesni-gcm-avx2-vaes.S
@@ -1316,7 +1316,7 @@ SET_SIZE(aes_gcm_dec_update_vaes_avx2)
 #endif /* !_WIN32 || _KERNEL */
 
 /* Mark the stack non-executable. */
-#if defined(__linux__) && defined(__ELF__)
+#ifdef __ELF__
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/module/icp/asm-x86_64/modes/aesni-gcm-x86_64.S
+++ b/module/icp/asm-x86_64/modes/aesni-gcm-x86_64.S
@@ -1275,7 +1275,7 @@ SECTION_STATIC
 #endif
 
 /* Mark the stack non-executable. */
-#if defined(__linux__) && defined(__ELF__)
+#ifdef __ELF__
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/module/icp/asm-x86_64/modes/ghash-x86_64.S
+++ b/module/icp/asm-x86_64/modes/ghash-x86_64.S
@@ -714,7 +714,7 @@ SET_OBJ(.Lrem_8bit)
 .balign	64
 
 /* Mark the stack non-executable. */
-#if defined(__linux__) && defined(__ELF__)
+#ifdef __ELF__
 .section .note.GNU-stack,"",%progbits
 #endif
 


### PR DESCRIPTION
### Description

On FreeBSD, linking the zfs kernel module with binutils ld 2.44 shows the following warning:

    ld: warning: aesni-gcm-avx2-vaes.o: missing .note.GNU-stack section implies executable stack
    ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker

Some of the `.S` files under `module/icp/asm-x86_64/modes` check whether to emit the `.note.GNU-stack` section using:

    #if defined(__linux__) && defined(__ELF__)

We could add `&& defined(__FreeBSD__)` to the test, but since all other `.S` files in the OpenZFS tree use:

    #ifdef __ELF__

it would seem more logical to use that instead. Any recent ELF platform should support these note sections by now.

### How Has This Been Tested?
* Built zfs kernel module for FreeBSD
* Observed warning about missing .note.GNU-stack section disappear
* Successfully loaded newly built zfs kernel module

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
