### PR TITLE
Fix --enable-invariants on FreeBSD

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -19,8 +19,8 @@ check:
 	cppcheck cppcheck-Linux cppcheck-FreeBSD
 
 # For FreeBSD, use debug options from ./configure if not overridden.
-export WITH_DEBUG ?= @WITH_DEBUG@
-export WITH_INVARIANTS ?= @WITH_INVARIANTS@
+WITH_DEBUG ?= @WITH_DEBUG@
+WITH_INVARIANTS ?= @WITH_INVARIANTS@
 
 # Filter out options that FreeBSD make doesn't understand
 getflags = ( \
@@ -43,6 +43,7 @@ done; \
 echo $$fmakeflags \
 )
 FMAKEFLAGS = -C @abs_srcdir@ -f Makefile.bsd $(shell $(getflags))
+FMAKEFLAGS += WITH_DEBUG=$(WITH_DEBUG) WITH_INVARIANTS=$(WITH_INVARIANTS)
 
 ifneq (@abs_srcdir@,@abs_builddir@)
 FMAKEFLAGS += MAKEOBJDIR=@abs_builddir@


### PR DESCRIPTION
The make symbols were never getting forwarded to the correct make subprocess.  As far as I can tell, this has never worked.  Either that, or something has changed in the behavior of make.

### Motivation and Context
The `--enable-invariants` configure option had no effect on FreeBSD.  `ASSERT` statements in the kernel module were being ignored.

### Description
Pass the `WITH_DEBUG` and `WITH_INVARIANTS` variables to the make subprocess that builds the kernel.

### How Has This Been Tested?
1. Tested by examining the `cc` command line used to compile kernel sources
2. Tested by inserting a trivial `ASSERT(false)` into the kernel code, and verifying that it causes a panic at runtime.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
