### PR TITLE
Make sure we can still write data to txg when flushing RRD

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2167,6 +2167,9 @@ spa_sync_time_logger(spa_t *spa, uint64_t txg)
 	if (curtime < spa->spa_last_flush_txg_time + spa_flush_txg_time) {
 		return;
 	}
+	if (txg > spa_final_dirty_txg(spa)) {
+		return;
+	}
 	spa->spa_last_flush_txg_time = curtime;
 
 	tx = dmu_tx_create_assigned(spa_get_dsl(spa), txg);


### PR DESCRIPTION
### Motivation and Context

Fix #18112.

### Description

The final txgs are used only to clear out any remaining deferred frees, and we cannot write new data to them. Make sure we do not try to do so.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
