### PR TITLE
Fix activating large_microzap on receive

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -998,6 +998,7 @@ tests = ['recv_dedup', 'recv_dedup_encrypted_zvol', 'rsend_001_pos',
     'send_spill_block', 'send_holds', 'send_hole_birth', 'send_mixed_raw',
     'send-wR_encrypted_zvol', 'send_partial_dataset', 'send_invalid',
     'send_large_blocks_incremental', 'send_large_blocks_initial',
+    'send_large_microzap_incremental', 'send_large_microzap_transitive',
     'send_doall', 'send_raw_spill_block', 'send_raw_ashift',
     'send_raw_large_blocks', 'send_leak_keymaps']
 tags = ['functional', 'rsend']

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -114,6 +114,7 @@ BCLONE_WAIT_DIRTY		bclone_wait_dirty		zfs_bclone_wait_dirty
 DIO_ENABLED			dio_enabled			zfs_dio_enabled
 DIO_STRICT			dio_strict			zfs_dio_strict
 XATTR_COMPAT			xattr_compat			zfs_xattr_compat
+ZAP_MICRO_MAX_SIZE		zap_micro_max_size		zap_micro_max_size
 ZEVENT_LEN_MAX			zevent.len_max			zfs_zevent_len_max
 ZEVENT_RETAIN_MAX		zevent.retain_max		zfs_zevent_retain_max
 ZIO_SLOW_IO_MS			zio.slow_io_ms			zio_slow_io_ms

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2063,6 +2063,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/rsend/send_invalid.ksh \
 	functional/rsend/send_large_blocks_incremental.ksh \
 	functional/rsend/send_large_blocks_initial.ksh \
+	functional/rsend/send_large_microzap_incremental.ksh \
+	functional/rsend/send_large_microzap_transitive.ksh \
 	functional/rsend/send_leak_keymaps.ksh \
 	functional/rsend/send-L_toggle.ksh \
 	functional/rsend/send_mixed_raw.ksh \

--- a/tests/zfs-tests/tests/functional/rsend/send_large_microzap_incremental.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_large_microzap_incremental.ksh
@@ -1,0 +1,91 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026 by Austin Wise. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/rsend/rsend.kshlib
+. $STF_SUITE/include/properties.shlib
+
+#
+# Description:
+#   Ensure that it is possible to receive an incremental send of a snapshot that has the large microzap
+#   feature active into a pool where the feature is already active.
+#	Regression test for https://github.com/openzfs/zfs/issues/18143
+#
+# Strategy:
+#   1. Activate the large microzap feature in the source dataset.
+#   2. Create a snapshot.
+#   3. Send the snapshot from the first pool to a second pool.
+#   4. Create a second snapshot.
+#   5. Send the second snapshot incrementally to the second pool.
+#
+
+verify_runnable "both"
+
+log_assert "Verify incremental receive handles inactive large_blocks feature correctly."
+
+function cleanup
+{
+	restore_tunable ZAP_MICRO_MAX_SIZE
+	cleanup_pool $POOL
+	cleanup_pool $POOL2
+}
+
+function assert_feature_state {
+	typeset pool=$1
+	typeset expected_state=$2
+
+	typeset actual_state=$(zpool get -H -o value feature@large_microzap $pool)
+	log_note "Zpool $pool feature@large_microzap=$actual_state"
+	if [[ "$actual_state" != "$expected_state" ]]; then
+		log_fail "pool $pool feature@large_microzap=$actual_state (expected '$expected_state')"
+	fi
+}
+
+typeset src=$POOL/src
+typeset second=$POOL2/second
+
+log_onexit cleanup
+
+# Allow micro ZAPs to grow beyond SPA_OLD_MAXBLOCKSIZE.
+set_tunable64 ZAP_MICRO_MAX_SIZE 1048576
+
+# Create a dataset with a large recordsize (1MB)
+log_must zfs create -o recordsize=1M $src
+typeset mntpnt=$(get_prop mountpoint $src)
+
+# Activate the large_microzap feature by creating a micro ZAP that is larger than SPA_OLD_MAXBLOCKSIZE (128k)
+# but smaller than MZAP_MAX_SIZE (1MB). Each micro ZAP entry is 64 bytes (MZAP_ENT_LEN),
+# so 4096 files is about 256k.
+log_must eval "seq 1 4096 | xargs -I REPLACE_ME touch $mntpnt/REPLACE_ME"
+log_must zpool sync $POOL
+
+# Assert initial state of pools
+assert_feature_state $POOL "active"
+assert_feature_state $POOL2 "enabled"
+
+# Create initial snapshot and send to second pool.
+log_must zfs snapshot $src@snap
+log_must eval "zfs send -p -L $src@snap | zfs receive $second"
+log_must zpool sync $POOL2
+assert_feature_state $POOL2 "active"
+
+# Create a second snapshot and send incrementally.
+# This ensures that the feature is not activated a second time, which would cause a panic.
+log_must zfs snapshot $src@snap2
+log_must eval "zfs send -L -i $src@snap $src@snap2 | zfs receive -F $second"
+
+log_pass "Feature activation propagated successfully."

--- a/tests/zfs-tests/tests/functional/rsend/send_large_microzap_transitive.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_large_microzap_transitive.ksh
@@ -1,0 +1,100 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026 by Austin Wise. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/rsend/rsend.kshlib
+. $STF_SUITE/include/properties.shlib
+
+#
+# Description:
+#   Ensures that sending a snapshot with the large microzap feature active propagates
+#   the feature activation to the receiving pool. Also checks that the received snapshot also
+#   correctly propagates the feature activation when sent to a third third pool.
+#	Regression test for https://github.com/openzfs/zfs/issues/18143
+#
+# Strategy:
+#   1. Enable the large microzap feature in the source dataset.
+#   2. Create a snapshot.
+#   3. Send the snapshot from the first pool to a second pool.
+#   4. Send the snapshot from the second pool to a third pool.
+#   5. Verify that all pools have the large microzap feature active.
+#
+
+verify_runnable "both"
+verify_disk_count "$DISKS" 3
+
+log_assert "Verify incremental receive handles inactive large_blocks feature correctly."
+
+function cleanup
+{
+	restore_tunable ZAP_MICRO_MAX_SIZE
+	cleanup_pool $POOL
+	cleanup_pool $POOL2
+	cleanup_pool $POOL3
+}
+
+function assert_feature_state {
+	typeset pool=$1
+	typeset expected_state=$2
+
+	typeset actual_state=$(zpool get -H -o value feature@large_microzap $pool)
+	log_note "Zpool $pool feature@large_microzap=$actual_state"
+	if [[ "$actual_state" != "$expected_state" ]]; then
+		log_fail "pool $pool feature@large_microzap=$actual_state (expected '$expected_state')"
+	fi
+}
+
+typeset src=$POOL/src
+typeset second=$POOL2/second
+typeset third=$POOL3/third
+
+log_onexit cleanup
+
+# Allow micro ZAPs to grow beyond SPA_OLD_MAXBLOCKSIZE.
+set_tunable64 ZAP_MICRO_MAX_SIZE 1048576
+
+# Ensure the third pool exists.
+datasetexists $POOL3 || log_must zpool create $POOL3 $DISK3
+
+# Create a dataset with a large recordsize (1MB)
+log_must zfs create -o recordsize=1M $src
+typeset mntpnt=$(get_prop mountpoint $src)
+
+# Activate the large_microzap feature by creating a micro ZAP that is larger than SPA_OLD_MAXBLOCKSIZE (128k)
+# but smaller than MZAP_MAX_SIZE (1MB). Each micro ZAP entry is 64 bytes (MZAP_ENT_LEN),
+# so 4096 files is about 256k.
+log_must eval "seq 1 4096 | xargs -I REPLACE_ME touch $mntpnt/REPLACE_ME"
+log_must zpool sync $POOL
+
+# Assert initial state of pools
+assert_feature_state $POOL "active"
+assert_feature_state $POOL2 "enabled"
+assert_feature_state $POOL3 "enabled"
+
+# Create initial snapshot and send to second pool.
+log_must zfs snapshot $src@snap
+log_must eval "zfs send -p -L $src@snap | zfs receive $second"
+log_must zpool sync $POOL2
+assert_feature_state $POOL2 "active"
+
+# Send to third pool from second. This ensures that the second pool correctly recorded that that
+# large_microzap feature was active when it received the first send stream.
+log_must eval "zfs send -p -L $second@snap | zfs receive $third"
+log_must zpool sync $POOL3
+assert_feature_state $POOL3 "active"
+
+log_pass "Feature activation propagated successfully."


### PR DESCRIPTION
### Motivation and Context

Fixes #18143. 

### Description

When receiving a stream with the large microzap feature flag, the feature activation was not correctly recorded in two different ways:

* The in-memory state of the feature activation is not captured.
* `dsl_dataset_activate_feature` may be called when the feature is already recorded as active, causing a panic.

This PR fixes both problems.

### How Has This Been Tested?

Two tests that fail on the `master` branch but pass with this PR.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
