### PR TITLE
Fix build for Linux 6.18 with PowerPC/RISC-V kernels.

### DIFF
--- a/config/kernel-mm-page-flags.m4
+++ b/config/kernel-mm-page-flags.m4
@@ -17,9 +17,36 @@ AC_DEFUN([ZFS_AC_KERNEL_MM_PAGE_FLAG_ERROR], [
 	])
 ])
 
+dnl #
+dnl # Linux 6.18+ uses a struct typedef (memdesc_flags_t) instead of an
+dnl # 'unsigned long' for the 'flags' field in 'struct page'.
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_MM_PAGE_FLAGS_STRUCT], [
+	ZFS_LINUX_TEST_SRC([mm_page_flags_struct], [
+		#include <linux/mm.h>
+
+		static const struct page p __attribute__ ((unused)) = {
+			.flags = { .f = 0 }
+		};
+	],[])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_MM_PAGE_FLAGS_STRUCT], [
+	AC_MSG_CHECKING([whether 'flags' in 'struct page' is a struct])
+	ZFS_LINUX_TEST_RESULT([mm_page_flags_struct], [
+		AC_MSG_RESULT([yes])
+		AC_DEFINE(HAVE_MM_PAGE_FLAGS_STRUCT, 1,
+			['flags' in 'struct page' is a struct])
+	],[
+		AC_MSG_RESULT([no])
+	])
+])
+
 AC_DEFUN([ZFS_AC_KERNEL_SRC_MM_PAGE_FLAGS], [
 	ZFS_AC_KERNEL_SRC_MM_PAGE_FLAG_ERROR
+	ZFS_AC_KERNEL_SRC_MM_PAGE_FLAGS_STRUCT
 ])
 AC_DEFUN([ZFS_AC_KERNEL_MM_PAGE_FLAGS], [
 	ZFS_AC_KERNEL_MM_PAGE_FLAG_ERROR
+	ZFS_AC_KERNEL_MM_PAGE_FLAGS_STRUCT
 ])

--- a/include/os/linux/kernel/linux/dcache_compat.h
+++ b/include/os/linux/kernel/linux/dcache_compat.h
@@ -34,6 +34,17 @@
 
 #define	d_alias			d_u.d_alias
 
+#ifdef HAVE_MM_PAGE_FLAGS_STRUCT
+/*
+ * Starting from Linux 6.18, the 'flags' field in 'struct page' is defined
+ * to a struct ('memdesc_flags_t' typedef) instead of an unsigned long for
+ * improved typesafety.
+ */
+#define	page_flags flags.f
+#else
+#define	page_flags flags
+#endif
+
 /*
  * Starting from Linux 5.13, flush_dcache_page() becomes an inline function
  * and under some configurations, may indirectly referencing GPL-only
@@ -44,8 +55,8 @@
 #include <linux/simd_powerpc.h>
 #define	flush_dcache_page(page)	do {					\
 		if (!cpu_has_feature(CPU_FTR_COHERENT_ICACHE) &&	\
-		    test_bit(PG_dcache_clean, &(page)->flags))		\
-			clear_bit(PG_dcache_clean, &(page)->flags);	\
+		    test_bit(PG_dcache_clean, &(page)->page_flags))	\
+			clear_bit(PG_dcache_clean, &(page)->page_flags);\
 	} while (0)
 #endif
 /*
@@ -55,8 +66,8 @@
  */
 #if defined __riscv && defined HAVE_FLUSH_DCACHE_PAGE_GPL_ONLY
 #define	flush_dcache_page(page)	do {					\
-		if (test_bit(PG_dcache_clean, &(page)->flags))		\
-			clear_bit(PG_dcache_clean, &(page)->flags);	\
+		if (test_bit(PG_dcache_clean, &(page)->page_flags))	\
+			clear_bit(PG_dcache_clean, &(page)->page_flags);\
 	} while (0)
 #endif
 


### PR DESCRIPTION
The macro 'flush_dcache_page(...)' modified the page flags, but in Linux 6.18 the type of the page flags changed from 'unsigned long' to the struct type 'memdesc_flags_t' with a single member 'f' which is the page flags field.

### Motivation and Context
This fixes a failure when building the OpenZFS Linux kernel module against PowerPC and RISC-V kernel versions 6.18 and later. (I have only seen the failure when building for a PowerPC 64-bit kernel, but it's obvious that it also affects RISC-V builds.)

### Description
This patch adds an intermediate macro `page_flags` which resolves to `flags` on kernels < 6.18 and `flags.f` on kernels >= 6.18 and modifies the 'flush_dcache_page' macro to use `page_flags` instead of `flags`, resolving the build issue for PowerPC / RISC-V kernels.

### How Has This Been Tested?
This has been tested and deployed with a Debian 6.18 ppc64 kernel running on a PowerMac G5. The *zfs-dkms* package failed to build before the fix and successfully builds now.
A package with this patch has been deployed in the powerpc-linux-builds repository for the convenience of other ppc64 users:
https://sourceforge.net/projects/powerpc-linux-builds/files/debian-ppc64/zfs-linux/2.4.0-1catacombae1/

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions). (As far as I can tell.)
- [X] I have updated the documentation accordingly. (I have added some comments describing my changes, anything else needed?)
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
