### PR TITLE
Linux 6.19: handle --werror with CONFIG_OBJTOOL_WERROR=y

### DIFF
--- a/scripts/objtool-wrapper.in
+++ b/scripts/objtool-wrapper.in
@@ -22,10 +22,10 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-# Filter out objtools '--Werror' flag.
+# Filter out objtools '--Werror or --werror' flag.
 
 objtool="@abs_objtool_binary@"
-args=$(echo "$*" | sed s/--Werror//)
+args=$(echo "$*" | sed 's/--Werror\|--werror//')
 
 if [ -z "$objtool" ]; then
 	echo "$(basename "$0"): No objtool binary configured" 1>&2


### PR DESCRIPTION
### Motivation and Context
When building against a 6.19 kernel using the Ubuntu 26.04 development build with `CONFIG_OBJTOOL_WERROR=y`, the zfs-linux DKMS package fails to build due to the following errors:

```  
LD [M]  spl.o
spl.o: error: objtool: spl_kmem_cache_destroy+0x23d: spl_panic() missing __noreturn in .c/.h or NORETURN() in noreturns.h
spl.o: error: objtool: spl_kmem_cache_create+0x5f4: spl_panic() missing __noreturn in .c/.h or NORETURN() in noreturns.h
spl.o: error: objtool: kstat_seq_data_addr+0x77: spl_panic() missing __noreturn in .c/.h or NORETURN() in noreturns.h
spl.o: error: objtool: __kstat_delete+0x7b: spl_panic() missing __noreturn in .c/.h or NORETURN() in noreturns.h
spl.o: error: objtool: kstat_seq_show+0x137: spl_panic() missing __noreturn in .c/.h or NORETURN() in noreturns.h
spl.o: error: objtool: __kstat_create+0x2b0: spl_panic() missing __noreturn in .c/.h or NORETURN() in noreturns.h
spl.o: error: objtool: kstat_seq_start+0x365: spl_panic() missing __noreturn in .c/.h or NORETURN() in noreturns.h
spl.o: error: objtool: taskq_destroy+0x32f: spl_panic() missing __noreturn in .c/.h or NORETURN() in noreturns.h
spl.o: error: objtool: taskq_create_synced+0xcb: spl_panic() missing __noreturn in .c/.h or NORETURN() in noreturns
```

This is because the upstream Linux kernel introduced a change in 6.19-rc1 (56754f0f46f6: "objtool: Rename --Werror to --werror"), which doesn't match the changes in scripts/objtool-wrapper.in to ignore the compiler flag.

### Description
Simple change to modify scripts/objtool-wrapper.in to look for both "--Werror" and "--werror", rather than just the former.

### How Has This Been Tested?
This was tested in a QEMU environment using virtme-ng, after bisecting the Linux kernel changes down to the aforementioned commit. Using the changes in this PR, zfs-linux successfully built.

Tests were repeated on a LXD VM, whereupon some simple regression tests were also executed, notably the tests from here - https://git.launchpad.net/~canonical-kernel-team/+git/autotest-client-tests (see "ubuntu_zfs_*" tests).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
