### PR TITLE
#18172: Detect and heal orphaned DTL entries on pool import

### DIFF
--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -86,6 +86,7 @@ extern void vdev_dtl_reassess(vdev_t *vd, uint64_t txg, uint64_t scrub_txg,
 extern boolean_t vdev_dtl_required(vdev_t *vd);
 extern boolean_t vdev_resilver_needed(vdev_t *vd,
     uint64_t *minp, uint64_t *maxp);
+extern int vdev_dtl_check_orphaned(vdev_t *vd, int *count);
 extern void vdev_destroy_unlink_zap(vdev_t *vd, uint64_t zapobj,
     dmu_tx_t *tx);
 extern uint64_t vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6252,6 +6252,35 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 		    update_config_cache);
 
 		/*
+		 * Heal any orphaned DTL entries on hole or missing vdevs.
+		 * These arise when the system crashes during a vdev detach
+		 * after the vdev tree is updated but before the DTL space
+		 * map object is freed. If left unresolved the dangling object
+		 * reference causes an assertion failure in vdev_dtl_load()
+		 * on debug builds and permanently leaks MOS space. Healing
+		 * is always safe: any vdev the config identifies as a hole
+		 * or missing has already been verified removable.
+		 */
+		spa_import_progress_set_notes(spa,
+		    "Checking for orphaned DTL entries");
+		{
+			int orphaned_count = 0;
+			error = vdev_dtl_check_orphaned(spa->spa_root_vdev,
+			    &orphaned_count);
+			if (error != 0) {
+				spa_load_failed(spa, "failed to heal orphaned "
+				    "DTL entries [error=%d]", error);
+				return (error);
+			}
+			if (orphaned_count > 0) {
+				cmn_err(CE_NOTE, "pool '%s': healed orphaned "
+				    "DTL entries on %d vdev(s) after crash "
+				    "during topology change",
+				    spa_name(spa), orphaned_count);
+			}
+		}
+
+		/*
 		 * Check if a rebuild was in progress and if so resume it.
 		 * Then check all DTLs to see if anything needs resilvering.
 		 * The resilver will be deferred if a rebuild was started.

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -56,6 +56,7 @@
 #include <sys/arc.h>
 #include <sys/zil.h>
 #include <sys/dsl_scan.h>
+#include <sys/dsl_synctask.h>
 #include <sys/vdev_raidz.h>
 #include <sys/abd.h>
 #include <sys/vdev_initialize.h>
@@ -3537,6 +3538,18 @@ vdev_dtl_load(vdev_t *vd)
 	int error = 0;
 
 	if (vd->vdev_ops->vdev_op_leaf && vd->vdev_dtl_object != 0) {
+		if (!vdev_is_concrete(vd)) {
+			/*
+			 * Non-concrete (hole or missing) vdev with an orphaned
+			 * DTL object reference. This can occur when the system
+			 * crashes during vdev detach after the vdev tree is
+			 * updated but before the DTL space map is freed. Preserve
+			 * vdev_dtl_object so the import path can detect and free
+			 * the orphaned MOS object; do not attempt to open or load
+			 * it here.
+			 */
+			return (0);
+		}
 		ASSERT(vdev_is_concrete(vd));
 
 		/*
@@ -3651,6 +3664,129 @@ vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx)
 	for (uint64_t i = 0; i < vd->vdev_children; i++) {
 		vdev_construct_zaps(vd->vdev_child[i], tx);
 	}
+}
+
+/*
+ * Sync-task argument for freeing an orphaned DTL space map object.
+ */
+typedef struct {
+	spa_t		*dtof_spa;
+	uint64_t	dtof_object;
+	uint64_t	dtof_vdev_id;
+	const char	*dtof_vdev_type;
+} dtl_orphan_free_t;
+
+static void
+vdev_dtl_orphan_free_sync(void *arg, dmu_tx_t *tx)
+{
+	dtl_orphan_free_t *dtof = arg;
+	spa_t *spa = dtof->dtof_spa;
+	objset_t *mos = spa->spa_meta_objset;
+
+	/*
+	 * Guard against double-free: if a previous import attempt freed this
+	 * object but crashed before writing the updated vdev config, the
+	 * object may already be gone.
+	 */
+	dmu_object_info_t doi;
+	if (dmu_object_info(mos, dtof->dtof_object, &doi) != 0) {
+		zfs_dbgmsg("pool %s: orphaned DTL object %llu on %s vdev "
+		    "id %llu already freed, skipping",
+		    spa_name(spa), (u_longlong_t)dtof->dtof_object,
+		    dtof->dtof_vdev_type, (u_longlong_t)dtof->dtof_vdev_id);
+		return;
+	}
+
+	space_map_free_obj(mos, dtof->dtof_object, tx);
+
+	spa_history_log_internal(spa, "heal orphaned dtl", tx,
+	    "freed orphaned DTL object %llu from %s vdev id %llu",
+	    (u_longlong_t)dtof->dtof_object,
+	    dtof->dtof_vdev_type,
+	    (u_longlong_t)dtof->dtof_vdev_id);
+}
+
+/*
+ * Walk the vdev tree and heal any orphaned DTL entries found on
+ * non-concrete (hole or missing) vdevs. These arise when the system
+ * crashes during a vdev detach after the vdev tree is updated but
+ * before the DTL space map object is freed. Without healing, the
+ * orphaned space map object leaks permanently and, in debug builds,
+ * causes an assertion failure in vdev_dtl_load() on the next import.
+ *
+ * Called from spa_load_impl() after the sync thread is running and the
+ * pool is writable. Sets *count to the number of vdevs healed and
+ * returns 0 on success or the first error encountered.
+ */
+int
+vdev_dtl_check_orphaned(vdev_t *vd, int *count)
+{
+	spa_t *spa = vd->vdev_spa;
+	int error = 0;
+	int local_count = 0;
+
+	for (int c = 0; c < vd->vdev_children; c++) {
+		int child_count = 0;
+		int child_error = vdev_dtl_check_orphaned(
+		    vd->vdev_child[c], &child_count);
+		local_count += child_count;
+		if (child_error != 0 && error == 0)
+			error = child_error;
+	}
+
+	if ((vd->vdev_ops == &vdev_hole_ops ||
+	    vd->vdev_ops == &vdev_missing_ops) &&
+	    vd->vdev_dtl_object != 0) {
+
+		local_count++;
+
+		zfs_dbgmsg("pool %s: orphaned DTL object %llu on %s vdev "
+		    "id %llu (guid %llu), healing",
+		    spa_name(spa),
+		    (u_longlong_t)vd->vdev_dtl_object,
+		    vd->vdev_ops->vdev_op_type,
+		    (u_longlong_t)vd->vdev_id,
+		    (u_longlong_t)vd->vdev_guid);
+
+		cmn_err(CE_NOTE, "pool '%s': healing orphaned DTL on "
+		    "%s vdev id=%llu (crash during detach)",
+		    spa_name(spa), vd->vdev_ops->vdev_op_type,
+		    (u_longlong_t)vd->vdev_id);
+
+		dtl_orphan_free_t dtof = {
+		    .dtof_spa = spa,
+		    .dtof_object = vd->vdev_dtl_object,
+		    .dtof_vdev_id = vd->vdev_id,
+		    .dtof_vdev_type = vd->vdev_ops->vdev_op_type,
+		};
+		int err = dsl_sync_task(spa_name(spa), NULL,
+		    vdev_dtl_orphan_free_sync, &dtof,
+		    1, ZFS_SPACE_CHECK_NONE);
+		if (err != 0) {
+			cmn_err(CE_WARN, "pool '%s': failed to free orphaned "
+			    "DTL object %llu on %s vdev id=%llu [error=%d]",
+			    spa_name(spa), (u_longlong_t)vd->vdev_dtl_object,
+			    vd->vdev_ops->vdev_op_type,
+			    (u_longlong_t)vd->vdev_id, err);
+			if (error == 0)
+				error = err;
+		}
+
+		/*
+		 * Clear the in-memory reference regardless of whether the
+		 * sync task succeeded. If it failed the object remains in
+		 * the MOS but the import can proceed safely; vdev_dtl_load()
+		 * will skip it on this and future imports until the object
+		 * is eventually freed.
+		 */
+		vd->vdev_dtl_object = 0;
+		vdev_config_dirty(vd->vdev_top);
+	}
+
+	if (count != NULL)
+		*count = local_count;
+
+	return (error);
 }
 
 static void
@@ -3808,6 +3944,82 @@ vdev_resilver_needed(vdev_t *vd, uint64_t *minp, uint64_t *maxp)
 		*maxp = thismax;
 	}
 	return (needed);
+}
+
+/*
+ * Check for orphaned DTL entries on non-concrete vdevs (holes, missing).
+ * These can occur when the system crashes during a vdev detach operation,
+ * leaving the vdev tree updated (device becomes a hole) but DTL entries
+ * still referencing the old device.
+ *
+ * If heal is B_TRUE, clear the orphaned entries and log the action.
+ * Returns 0 on success, or EINVAL if orphaned entries found and heal is B_FALSE.
+ * Sets *count to number of vdevs with orphaned DTL entries.
+ */
+int
+vdev_dtl_check_orphaned(vdev_t *vd, boolean_t heal, int *count)
+{
+	spa_t *spa = vd->vdev_spa;
+	int error = 0;
+	int local_count = 0;
+
+	/*
+	 * Recurse into children first
+	 */
+	for (int c = 0; c < vd->vdev_children; c++) {
+		int child_count = 0;
+		int child_error;
+
+		child_error = vdev_dtl_check_orphaned(vd->vdev_child[c],
+		    heal, &child_count);
+		local_count += child_count;
+
+		if (child_error != 0 && error == 0)
+			error = child_error;
+	}
+
+	/*
+	 * Check if this is a hole or missing vdev with DTL entries.
+	 * This indicates a crash during detach left orphaned state.
+	 */
+	if ((vd->vdev_ops == &vdev_hole_ops ||
+	    vd->vdev_ops == &vdev_missing_ops) &&
+	    vd->vdev_dtl_object != 0) {
+
+		local_count++;
+
+		zfs_dbgmsg("pool %s: orphaned DTL object %llu on %s vdev "
+		    "id %llu (guid %llu)",
+		    spa_name(spa),
+		    (u_longlong_t)vd->vdev_dtl_object,
+		    vd->vdev_ops->vdev_op_type,
+		    (u_longlong_t)vd->vdev_id,
+		    (u_longlong_t)vd->vdev_guid);
+
+		if (heal) {
+			cmn_err(CE_WARN, "pool '%s': clearing orphaned DTL "
+			    "entries on %s vdev (id=%llu), likely from "
+			    "crash during detach operation",
+			    spa_name(spa),
+			    vd->vdev_ops->vdev_op_type,
+			    (u_longlong_t)vd->vdev_id);
+
+			/*
+			 * Clear the DTL object reference. The actual space
+			 * map object will be leaked but is harmless and will
+			 * be reclaimed on next scrub/resilver completion.
+			 */
+			vd->vdev_dtl_object = 0;
+			vdev_config_dirty(vd->vdev_top);
+		} else {
+			error = SET_ERROR(EINVAL);
+		}
+	}
+
+	if (count != NULL)
+		*count = local_count;
+
+	return (error);
 }
 
 /*


### PR DESCRIPTION
Fixes https://github.com/openzfs/zfs/issues/18172

### Motivation and Context

During `zpool detach`, `vdev_label_init()` wipes the detaching device's
labels before the transaction that removes it from the vdev tree and frees
its DTL space map commits. If the system crashes in this window the last
committed pool config still records the device with a valid
`ZPOOL_CONFIG_DTL` key, but the device is now represented as
`vdev_missing_ops` or `vdev_hole_ops` on the next import (since its labels
are gone).

Both of these vdev types have `vdev_op_leaf = B_TRUE`, so `vdev_alloc()`
loads `vdev_dtl_object` from the config nvlist for them. This causes two
problems:

1. **Assert panic (debug builds):** `vdev_dtl_load()` hits
   `ASSERT(vdev_is_concrete(vd))` immediately, making the pool
   unimportable on any debug kernel.

2. **Permanent space leak (all builds):** the DTL space map object in the
   MOS is never freed. In release builds (assert compiled out) the space
   map is also opened and its entries loaded into the in-memory
   `DTL_MISSING` range tree for a non-concrete vdev — the state that keeps
   a resilver scan running against the now-gone device ("resilver in
   progress" with no valid target).

### Description

Two cooperating fixes:

**`vdev_dtl_load()` guard** — before the existing `ASSERT(vdev_is_concrete(vd))`,
return early when the vdev is not concrete. This prevents the panic,
prevents stale DTL data from being loaded into memory (eliminating the
stuck-resilver symptom), and preserves `vdev_dtl_object != 0` so the
healing pass can find and free the object.

**`vdev_dtl_check_orphaned()`** — called from `spa_load_impl()` after the
sync thread is running and the pool is writable (after
`spa_ld_check_for_config_update()`, before the resilver decision). Walks
the vdev tree and for each hole/missing vdev with a non-zero
`vdev_dtl_object`, dispatches a `dsl_sync_task` to call
`space_map_free_obj()` in a syncing context (correctly handling the
`SPACEMAP_HISTOGRAM` feature refcount). A `dmu_object_info()` guard makes
the free idempotent: if a prior import freed the object but crashed before
writing the updated config, the next import skips without error.

Healing is unconditional — no import flag or operator confirmation is
required. Any vdev the config identifies as hole/missing has already been
verified safe to remove, so healing is always correct (per behlendorf).

**Read-only import:** the heal is skipped when the pool is imported
read-only (the writable block in `spa_load_impl()` does not execute). The
`vdev_dtl_load()` guard still prevents the panic; the space map object
will be freed on the next writable import.

### How Has This Been Tested?

Manual testing: reproduced the assert by injecting a crash-like state
(zeroing vdev labels and re-importing with a config that still carries
`ZPOOL_CONFIG_DTL` for the affected vdev). Confirmed import succeeds after
the fix, `zpool history` shows the heal action, and the MOS object is
freed.

A ZTS test that automates the crash window simulation is not yet included.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).