### PR TITLE
libzfs: improve error message for zpool create with ENXIO

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -1632,6 +1632,11 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 				    errbuf));
 			}
 
+		case ENXIO:
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "one or more devices could not be opened"));
+			return (zfs_error(hdl, EZFS_BADDEV, errbuf));
+
 		default:
 			return (zpool_standard_error(hdl, errno, errbuf));
 		}


### PR DESCRIPTION
When zpool create fails because a vdev cannot be opened (ENXIO), the error falls through to zpool_standard_error() which reports the generic 'one or more devices is currently unavailable'. This is misleading when the real cause is a block size mismatch or other device open failure.

Add an explicit ENXIO case in zpool_create()'s error handling to provide a more descriptive message.

A companion kernel-side fix to return ZFS_ERR_ASHIFT_MISMATCH from spa_create() (matching the existing pattern in spa_vdev_add and spa_vdev_attach) is in progress as a separate PR.

Closes #11087