### PR TITLE
zfs_vnops_os.c: Move a vput() to after zfs_setattr_dir()

### DIFF
--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -2983,9 +2983,6 @@ out:
 		ASSERT0(err2);
 	}
 
-	if (attrzp)
-		vput(ZTOV(attrzp));
-
 	if (aclp)
 		zfs_acl_free(aclp);
 
@@ -2996,12 +2993,15 @@ out:
 
 	if (err) {
 		dmu_tx_abort(tx);
+		if (attrzp)
+			vput(ZTOV(attrzp));
 	} else {
 		err2 = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 		dmu_tx_commit(tx);
 		if (attrzp) {
 			if (err2 == 0 && handle_eadir)
 				err = zfs_setattr_dir(attrzp);
+			vput(ZTOV(attrzp));
 		}
 	}
 


### PR DESCRIPTION
Without this patch, the following crash can occur when a file system is configured with "xattr=dir".

VNASSERT failed: locked not true at /posix-acl/freebsd-rdma/sys/kern/vfs_subr.c:5786 (assert_vop_locked) 0xfffff8001cc29370: type VDIR state VSTATE_CONSTRUCTED op 0xffffffff82fb2158
    usecount 0, writecount 0, refcount 0 seqc users 0 mountedhere 0
    hold count flags ()
    flags ()
    lock type zfs: UNLOCKED
panic: zfs_dirent_lookup: vnode is not locked but should be cpuid = 3
time = 1770520763
KDB: stack backtrace:
db_trace_self_wrapper() at db_trace_self_wrapper+0x2b/frame 0xfffffe00914c8140 vpanic() at vpanic+0x136/frame 0xfffffe00914c8270
panic() at panic+0x43/frame 0xfffffe00914c82d0
assert_vop_locked() at assert_vop_locked+0x78/frame 0xfffffe00914c82f0 zfs_dirent_lookup() at zfs_dirent_lookup+0x41/frame 0xfffffe00914c8340 zfs_setattr_dir() at zfs_setattr_dir+0x123/frame 0xfffffe00914c84a0 zfs_setattr() at zfs_setattr+0x1389/frame 0xfffffe00914c89e0 zfs_freebsd_setattr() at zfs_freebsd_setattr+0x56b/frame 0xfffffe00914c8b80 VOP_SETATTR_APV() at VOP_SETATTR_APV+0x5d/frame 0xfffffe00914c8bb0 setfown() at setfown+0xb1/frame 0xfffffe00914c8cc0 kern_fchownat() at kern_fchownat+0x192/frame 0xfffffe00914c8de0

This patch fixes the problem by moving the vput() call for attrzp to after the zfs_setattr_dir() call that takes it as an argument.

This was tested on a FreeBSD system with/without the patch by running a little
program that does the following (the file system is configured xattr=dir and "foo"
has a named attribute associated with it.

fd = open("foo", O_RDONLY | O_NOFOLLOW | O_PATH, 0);
fchownat(fd, "", 1001, 1001, AT_EMPTY_PATH);

Without the patch the above syscalls cause the crash.
With the patch, the above syscalls perform correctly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
