### PR TITLE
ZTS: Fix zed_synchronous_zedlet

### DIFF
--- a/tests/zfs-tests/tests/functional/events/zed_synchronous_zedlet.ksh
+++ b/tests/zfs-tests/tests/functional/events/zed_synchronous_zedlet.ksh
@@ -111,14 +111,14 @@ log_must zed_start
 # Do a scrub - it should be instantaneous.
 log_must zpool scrub -w $TESTPOOL2
 
-# Start off a trim immediately after scrubiung.  The trim should be
-# instantaneous and generate a trimp_start event.  This will happen in parallel
+# Start off a trim immediately after scrubbing.  The trim should be
+# instantaneous and generate a trim_start event.  This will happen in parallel
 # with the slow 'scrub_finish-sync-slow.sh' zedlet still running.
 log_must zpool trim -w $TESTPOOL2
 
 # Wait for scrub_finish event to happen for sanity. This is the *event*, not
 # the completion of zedlets for the event.
-log_must file_wait_event $ZED_DEBUG_LOG 'sysevent\.fs\.zfs\.trim_finish' 10
+log_must file_wait_event $ZED_DEBUG_LOG 'sysevent\.fs\.zfs\.scrub_finish' 10
 
 # At a minimum, scrub_start-slow.sh + scrub_finish-sync-slow.sh will take a
 # total of 6 seconds to run, so wait 7 sec to be sure.


### PR DESCRIPTION
### Motivation and Context
Fix ZTS failure: #18192

### Description
Wait for `scrub_finish` event (as the comments in the code suggest) rather than `trim_finish` in `zed_synchronous_zedlet.ksh`.  This seems to workaround the ZTS failures in #18192.  Also, fix some typos.

### How Has This Been Tested?
Ran test across all runners 7 times in CI with no `zed_synchronous_zedlet` failures.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
