### PR TITLE
Fix `send:raw` permission for send `-w -I`

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -685,7 +685,7 @@ zfs_secpolicy_send(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 	dsl_dataset_t *ds;
 	const char *cp;
 	int error;
-	boolean_t rawok = (zc->zc_flags & 0x8);
+	boolean_t rawok = !!(zc->zc_flags & 0x8);
 
 	/*
 	 * Generate the current snapshot name from the given objsetid, then
@@ -708,7 +708,7 @@ zfs_secpolicy_send(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 
 	error = zfs_secpolicy_write_perms_ds(zc->zc_name, ds,
 	    ZFS_DELEG_PERM_SEND, cr);
-	if (error != 0 && rawok == B_TRUE) {
+	if (error != 0 && rawok) {
 		error = zfs_secpolicy_write_perms_ds(zc->zc_name, ds,
 		    ZFS_DELEG_PERM_SEND_RAW, cr);
 	}
@@ -727,7 +727,7 @@ zfs_secpolicy_send_new(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 	(void) innvl;
 	error = zfs_secpolicy_write_perms(zc->zc_name,
 	    ZFS_DELEG_PERM_SEND, cr);
-	if (error != 0 && rawok == B_TRUE) {
+	if (error != 0 && rawok) {
 		error = zfs_secpolicy_write_perms(zc->zc_name,
 		    ZFS_DELEG_PERM_SEND_RAW, cr);
 	}


### PR DESCRIPTION
### Motivation and Context
Fixes: https://github.com/openzfs/zfs/issues/18193
Introduced-by: https://github.com/openzfs/zfs/pull/17543

When performing an incremental raw send with intermediates (`-w -I`), `send:raw` introduced in 2.4.0 is not accepted. The code falls back to requiring send and denies the operation when only `send:raw` is delegated.

### Description
This change relaxes the comparison `rawok == B_TRUE` to a standard truthy check in `zfs_secpolicy_send/_new()` and updates `zfs_send_usertest.ksh` to also verify incremental raw send with intermediates behaviour. Also added missing comment markers in the test script.

### How Has This Been Tested?
1. Ran the test case `zfs_send_usertest.ksh` without the fix to confirm reproduction of the "Permission denied" error.
2. Applied the fix and confirmed the test passes.
3. Ran the full test suite.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
