### PR TITLE
recv_begin_check: ensure no mounts before destroying destination

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -134,6 +134,8 @@ static int zfs_do_zone(int argc, char **argv);
 static int zfs_do_unzone(int argc, char **argv);
 #endif
 
+static int zfs_do_mountinfo(int argc, char **argv);
+
 static int zfs_do_help(int argc, char **argv);
 
 enum zfs_options {
@@ -200,6 +202,7 @@ typedef enum {
 	HELP_WAIT,
 	HELP_ZONE,
 	HELP_UNZONE,
+	HELP_MOUNTINFO,
 } zfs_help_t;
 
 typedef struct zfs_command {
@@ -279,6 +282,9 @@ static zfs_command_t command_table[] = {
 	{ "zone",	zfs_do_zone,		HELP_ZONE		},
 	{ "unzone",	zfs_do_unzone,		HELP_UNZONE		},
 #endif
+
+	{ NULL },
+	{ "mountinfo",	zfs_do_mountinfo,	HELP_MOUNTINFO		},
 };
 
 #define	NCOMMAND	(sizeof (command_table) / sizeof (command_table[0]))
@@ -451,6 +457,8 @@ get_usage(zfs_help_t idx)
 		return (gettext("\tzone <nsfile> <filesystem>\n"));
 	case HELP_UNZONE:
 		return (gettext("\tunzone <nsfile> <filesystem>\n"));
+	case HELP_MOUNTINFO:
+		return (gettext("\tmountinfo <filesystem>\n"));
 	default:
 		__builtin_unreachable();
 	}
@@ -9513,3 +9521,36 @@ zfs_do_unjail(int argc, char **argv)
 	return (zfs_do_jail_impl(argc, argv, B_FALSE));
 }
 #endif
+
+static int
+zfs_do_mountinfo(int argc, char **argv)
+{
+	zfs_handle_t *zhp;
+	int ret = 0;
+
+	if (argc < 2) {
+		(void) fprintf(stderr, gettext("missing argument(s)\n"));
+		usage(B_FALSE);
+	}
+
+	zhp = zfs_open(g_zfs, argv[1], ZFS_TYPE_FILESYSTEM);
+	if (zhp == NULL)
+		return (1);
+
+	printf("dataset: %s\n", zfs_get_name(zhp));
+
+	char *where = NULL;
+	if (zfs_is_mounted(zhp, &where)) {
+		printf("mounted: yes\n");
+		printf("mounted at: %s\n", where);
+		free(where);
+	}
+	else {
+		printf("mounted: no\n");
+	}
+
+	zfs_mount_info(zhp);
+
+	zfs_close(zhp);
+	return (ret);
+}

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -965,6 +965,7 @@ _LIBZFS_H int zfs_mount_at(zfs_handle_t *, const char *, int, const char *);
 _LIBZFS_H int zfs_unmount(zfs_handle_t *, const char *, int);
 _LIBZFS_H int zfs_unmountall(zfs_handle_t *, int);
 _LIBZFS_H int zfs_mount_delegation_check(void);
+_LIBZFS_H int zfs_mount_info(zfs_handle_t *);
 
 #if defined(__linux__) || defined(__APPLE__)
 _LIBZFS_H int zfs_parse_mount_options(const char *mntopts,

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -447,8 +447,10 @@ changelist_add_mounted(zfs_handle_t *zhp, void *data)
 		clp->cl_haszonedchild = B_TRUE;
 
 	if (avl_find(&clp->cl_tree, cn, &idx) == NULL) {
+		printf("changelist_add_mounted: adding %s\n", zfs_get_name(zhp));
 		avl_insert(&clp->cl_tree, cn, idx);
 	} else {
+		printf("changelist_add_mounted: already have %s, skipping\n", zfs_get_name(zhp));
 		free(cn);
 		zfs_close(zhp);
 	}

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1470,3 +1470,13 @@ out:
 
 	return (ret);
 }
+
+int
+zfs_mount_info(zfs_handle_t *zhp)
+{
+	prop_changelist_t *clp = changelist_gather(zhp, ZFS_PROP_MOUNTPOINT,
+            CL_GATHER_ITER_MOUNTED, 0);
+        changelist_free(clp);
+
+	return (0);
+}

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -520,6 +520,14 @@ recv_begin_check_existing_impl(dmu_recv_begin_arg_t *drba, dsl_dataset_t *ds,
 			return (SET_ERROR(EEXIST));
 
 		/*
+		 * If we're about to destroy a dataset, then there must not be
+		 * any long holds on it. For a filesystem, that likely means it
+		 * is still mounted somewhere.
+		 */
+		if (dsl_dataset_long_held(ds))
+			return (SET_ERROR(EBUSY));
+
+		/*
 		 * We don't support using zfs recv -F to blow away
 		 * encrypted filesystems. This would require the
 		 * dsl dir to point to the old encryption key and

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -520,14 +520,6 @@ recv_begin_check_existing_impl(dmu_recv_begin_arg_t *drba, dsl_dataset_t *ds,
 			return (SET_ERROR(EEXIST));
 
 		/*
-		 * If we're about to destroy a dataset, then there must not be
-		 * any long holds on it. For a filesystem, that likely means it
-		 * is still mounted somewhere.
-		 */
-		if (dsl_dataset_long_held(ds))
-			return (SET_ERROR(EBUSY));
-
-		/*
 		 * We don't support using zfs recv -F to blow away
 		 * encrypted filesystems. This would require the
 		 * dsl dir to point to the old encryption key and

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -292,7 +292,8 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_raw', 'zfs_receive_raw_incremental', 'zfs_receive_-e',
     'zfs_receive_raw_-d', 'zfs_receive_from_zstd', 'zfs_receive_new_props',
     'zfs_receive_-wR-encrypted-mix', 'zfs_receive_corrective',
-    'zfs_receive_compressed_corrective', 'zfs_receive_large_block_corrective']
+    'zfs_receive_compressed_corrective', 'zfs_receive_large_block_corrective',
+    'zfs_receive_bind_mount']
 tags = ['functional', 'cli_root', 'zfs_receive']
 
 [tests/functional/cli_root/zfs_rename]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -848,6 +848,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_receive/zfs_receive_corrective.ksh \
 	functional/cli_root/zfs_receive/zfs_receive_compressed_corrective.ksh \
 	functional/cli_root/zfs_receive/zfs_receive_large_block_corrective.ksh \
+	functional/cli_root/zfs_receive/zfs_receive_bind_mount.ksh \
 	functional/cli_root/zfs_rename/cleanup.ksh \
 	functional/cli_root/zfs_rename/setup.ksh \
 	functional/cli_root/zfs_rename/zfs_rename_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_bind_mount.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_bind_mount.ksh
@@ -1,0 +1,63 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+# Test that 'zfs recv -F' will not destroy/replace a dataset that still has
+# mounts.
+
+verify_runnable "both"
+
+if ! is_linux ; then
+	log_unsupported "bind mounts only available on Linux"
+fi
+
+CLAIM="'zfs recv -F' will not destroy a mounted dataset."
+
+mountpoint=$(mktemp -d)
+
+function cleanup
+{
+	unmount $mountpoint
+	rmdir $mountpoint
+	destroy_dataset $TESTPOOL/src@snap
+	destroy_dataset $TESTPOOL/src
+	destroy_dataset $TESTPOOL/dst
+}
+log_onexit cleanup
+
+log_assert $CLAIM
+
+log_must create_dataset $TESTPOOL/src
+log_must create_dataset $TESTPOOL/dst
+log_must create_snapshot $TESTPOOL/src snap
+
+log_must mount --bind $(get_prop mountpoint $TESTPOOL/dst) $mountpoint
+
+log_mustnot eval "zfs send $TESTPOOL/src@snap | zfs recv -F $TESTPOOL/dst"
+
+log_assert $CLAIM


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

A customer reports that after using `zfs recv -F` on a filesystem with no snapshots (that is, "rollback" to zero) that also has additional (bind) mounts, all mounts become invalid - attempts to access them yield `EIO`.

### Description

This is trivially reproducable:

```
$ zpool create tank raidz1 quizm0 quizm1 quizm2 quizm3
$ zfs create tank/src
$ zfs create tank/dst
$ zfs snap tank/src@snap

$ mkdir -p /mnt/bind
$ mount --bind /tank/dst /mnt/bind

$ zfs send tank/src@snap | zfs recv -F tank/dst

$ stat /tank/dst
stat: cannot statx '/tank/dst': Input/output error
$ stat /mnt/bind
stat: cannot statx '/mnt/bind': Input/output error
```

I don't understand all of this; the dance between kernel and userspace around mounts is still fairly opaque to me.

As I understand it though, if there's no previous snapshot, `zfs recv -F` will receive the stream into a brand new dataset and destroy the old one. By whatever means, the new dataset is wired up to the mount point, and things continue as planned.

If there are multiple mountpoints, then the original can't be destroyed, because there are outstanding long holds. I'm not entirely sure what happens next, but I'm assuming that means the process of "disconnecting" the dataset from the mount (the `zfsvfs_t`?) gets aborted part-way through. This appears to leave an "empty" `zfsvfs_t` associated with the mount inode, such that `zfs_verify_zp()` fails and returns `EIO`.

For now I'm doing the simplest thing I can think of to protect the system: checking for outstanding long holds in `recv_begin_checks()` for the rollback-destroy case, and abort with `EBUSY` if there are any. I don't love that this means `zfs recv -F` will succeed or fail depending on some combination of number of mountpoints and presence of snapshots, but this seems better than leaving the system in an inconsistent state.

A true fix probably requires understanding that a dataset can have multiple mountpoints. That's possibly not even so farfetched - if you squint, they're just another kind of share, and we already have to handle those.

### How Has This Been Tested?

Full ZTS run completed on Linux 6.19.0. New test added.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).