### PR TITLE
Linux 7.0 compat

### DIFF
--- a/config/kernel-acl.m4
+++ b/config/kernel-acl.m4
@@ -23,6 +23,35 @@ AC_DEFUN([ZFS_AC_KERNEL_POSIX_ACL_EQUIV_MODE_WANTS_UMODE_T], [
 ])
 
 dnl #
+dnl # 7.0 API change
+dnl # posix_acl_to_xattr() now allocates and returns the value.
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_POSIX_ACL_TO_XATTR_ALLOC], [
+	ZFS_LINUX_TEST_SRC([posix_acl_to_xattr_alloc], [
+		#include <linux/fs.h>
+		#include <linux/posix_acl_xattr.h>
+	], [
+		struct user_namespace *ns = NULL;
+		struct posix_acl *acl = NULL;
+		size_t size = 0;
+		gfp_t gfp = 0;
+		void *xattr = NULL;
+		xattr = posix_acl_to_xattr(ns, acl, &size, gfp);
+	])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_POSIX_ACL_TO_XATTR_ALLOC], [
+	AC_MSG_CHECKING([whether posix_acl_to_xattr() allocates its result]);
+	ZFS_LINUX_TEST_RESULT([posix_acl_to_xattr_alloc], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_POSIX_ACL_TO_XATTR_ALLOC, 1,
+		    [posix_acl_to_xattr() allocates its result])
+	], [
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
 dnl # 3.1 API change,
 dnl # Check if inode_operations contains the function get_acl
 dnl #
@@ -174,12 +203,14 @@ AC_DEFUN([ZFS_AC_KERNEL_INODE_OPERATIONS_SET_ACL], [
 
 AC_DEFUN([ZFS_AC_KERNEL_SRC_ACL], [
 	ZFS_AC_KERNEL_SRC_POSIX_ACL_EQUIV_MODE_WANTS_UMODE_T
+	ZFS_AC_KERNEL_SRC_POSIX_ACL_TO_XATTR_ALLOC
 	ZFS_AC_KERNEL_SRC_INODE_OPERATIONS_GET_ACL
 	ZFS_AC_KERNEL_SRC_INODE_OPERATIONS_SET_ACL
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_ACL], [
 	ZFS_AC_KERNEL_POSIX_ACL_EQUIV_MODE_WANTS_UMODE_T
+	ZFS_AC_KERNEL_POSIX_ACL_TO_XATTR_ALLOC
 	ZFS_AC_KERNEL_INODE_OPERATIONS_GET_ACL
 	ZFS_AC_KERNEL_INODE_OPERATIONS_SET_ACL
 ])

--- a/config/kernel-blk-queue.m4
+++ b/config/kernel-blk-queue.m4
@@ -227,6 +227,30 @@ AC_DEFUN([ZFS_AC_KERNEL_BLK_QUEUE_MAX_HW_SECTORS], [
 ])
 
 dnl #
+dnl # 7.0 API change
+dnl # blk_queue_rot() replaces blk_queue_nonrot() (inverted meaning)
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_SRC_BLK_QUEUE_ROT], [
+	ZFS_LINUX_TEST_SRC([blk_queue_rot], [
+		#include <linux/blkdev.h>
+	], [
+		struct request_queue *q __attribute__ ((unused)) = NULL;
+		(void) blk_queue_rot(q);
+	], [])
+])
+
+AC_DEFUN([ZFS_AC_KERNEL_BLK_QUEUE_ROT], [
+	AC_MSG_CHECKING([whether blk_queue_rot() is available])
+	ZFS_LINUX_TEST_RESULT([blk_queue_rot], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_BLK_QUEUE_ROT, 1,
+		    [blk_queue_rot() is available])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
 dnl # 2.6.34 API change
 dnl # blk_queue_max_segments() consolidates blk_queue_max_hw_segments()
 dnl # and blk_queue_max_phys_segments().
@@ -279,6 +303,7 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLK_QUEUE], [
 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_SECURE_ERASE
 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_MAX_HW_SECTORS
 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_MAX_SEGMENTS
+	ZFS_AC_KERNEL_SRC_BLK_QUEUE_ROT
 	ZFS_AC_KERNEL_SRC_BLK_MQ_RQ_HCTX
 ])
 
@@ -291,5 +316,6 @@ AC_DEFUN([ZFS_AC_KERNEL_BLK_QUEUE], [
 	ZFS_AC_KERNEL_BLK_QUEUE_SECURE_ERASE
 	ZFS_AC_KERNEL_BLK_QUEUE_MAX_HW_SECTORS
 	ZFS_AC_KERNEL_BLK_QUEUE_MAX_SEGMENTS
+	ZFS_AC_KERNEL_BLK_QUEUE_ROT
 	ZFS_AC_KERNEL_BLK_MQ_RQ_HCTX
 ])

--- a/config/kernel-fst-mount.m4
+++ b/config/kernel-fst-mount.m4
@@ -4,6 +4,10 @@ dnl # 2.6.38 API change
 dnl # The .get_sb callback has been replaced by a .mount callback
 dnl # in the file_system_type structure.
 dnl #
+dnl # 7.0 API change
+dnl # The .mount callback has been removed, requiring all mount work
+dnl # to be done through the "new" mount API introduced in 5.2.
+dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_FST_MOUNT], [
         ZFS_LINUX_TEST_SRC([file_system_type_mount], [
                 #include <linux/fs.h>
@@ -25,7 +29,8 @@ AC_DEFUN([ZFS_AC_KERNEL_FST_MOUNT], [
         AC_MSG_CHECKING([whether fst->mount() exists])
         ZFS_LINUX_TEST_RESULT([file_system_type_mount], [
                 AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_FST_MOUNT, 1, [fst->mount() exists])
         ],[
-		ZFS_LINUX_TEST_ERROR([fst->mount()])
+		AC_MSG_RESULT(no)
         ])
 ])

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -445,7 +445,11 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 	v->vdev_has_securetrim = bdev_secure_discard_supported(bdev);
 
 	/* Inform the ZIO pipeline that we are non-rotational */
+#ifdef HAVE_BLK_QUEUE_ROT
+	v->vdev_nonrot = !blk_queue_rot(bdev_get_queue(bdev));
+#else
 	v->vdev_nonrot = blk_queue_nonrot(bdev_get_queue(bdev));
+#endif
 
 	/* Physical volume size in bytes for the partition */
 	*psize = bdev_capacity(bdev);


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

> Don't throw the past away
> You might need it some rainy day
> Dreams can come true again
> When everything old is new again
> 
> – Everything Old Is New Again, Peter Allen, 1974.

7.0-rc1 should arrive next weekend, but because of the mount changes I've been poking at this for a couple of weeks already, and I thought I might as well post it for anyone interested.

Note #18215 also required to complete 7.0 support, but these are not dependent on each other and that one can be reviewed and merged seperately.

### Description

Three changes. See commits for the details, summary:

* `blk_queue_nonrot()` has been renamed `blk_queue_rot()` and had its meaning inverted. Very simple detect and `ifdef` selector.
* `posix_acl_to_xattr()` has a different signature and now allocates and returns the attribute vs fill in a caller-supplied buffer. Simple to detect, and relatively straightforward to hide inside the exist `zpl_acl_to_xattr()` shim.
* The "legacy" mount API has been removed, leaving only the "new" mount API (introduced in 5.2). I've added the smallest possible compat shim I could come up with.

Further changes may yet be required, however I was working against next- for the last couple of weeks and it has been stable there, so I'm not expecting too much change.

### How Has This Been Tested?

ZTS run succeeded on torvalds/linux@7449f86bafcd (`master` head as of a couple of days ago).

ZTS run also succeeded on 6.19.0.

Compile checked on 4.19, 5.4, 5.10, 5.15, 6.1, 6.9, 6.15, 6.18.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
