### PR TITLE
freebsd: Fix TIMESPEC_OVERFLOW for PowerPC

### DIFF
--- a/include/os/freebsd/spl/sys/time.h
+++ b/include/os/freebsd/spl/sys/time.h
@@ -51,7 +51,7 @@ extern int hz;
 
 typedef longlong_t	hrtime_t;
 
-#if defined(__i386__) || defined(__powerpc__)
+#ifdef __i386__
 #define	TIMESPEC_OVERFLOW(ts)						\
 	((ts)->tv_sec < INT32_MIN || (ts)->tv_sec > INT32_MAX)
 #else


### PR DESCRIPTION
Once upon a time, 32-bit PowerPC did indeed have a 32-bit time_t, but
FreeBSD 12.0 switched to a 64-bit time_t for PowerPC as an ABI break,
which predates the addition of FreeBSD support to OpenZFS. Moreover,
64-bit PowerPC has existed since FreeBSD 9.0, where __powerpc__ is also
defined (alongside __powerpc64__ to disambiguate), which has always had
a 64-bit time_t. This code has therefore always been wrong for all
PowerPC variants. Fix this by limiting the 32-bit case to just i386,
which is the only architecture in FreeBSD to have a 32-bit time_t and
not have broken ABI, due to its special legacy compatibility status.

Fixes: 9f0a21e6411a ("Add FreeBSD support to OpenZFS")
Closes: #18217
Signed-off-by: Jessica Clarke <jrtc27@jrtc27.com>
