### PR TITLE
Linux 6.19 compat: in-tree build: fix duplicate GCM assembly functions

### DIFF
--- a/module/icp/algs/modes/gcm.c
+++ b/module/icp/algs/modes/gcm.c
@@ -34,6 +34,7 @@
 #include <modes/gcm_impl.h>
 #ifdef CAN_USE_GCM_ASM
 #include <aes/aes_impl.h>
+#include <modes/gcm_asm_rename_funcs.h>
 #endif
 
 #define	GHASH(c, d, t, o) \

--- a/module/icp/asm-x86_64/modes/aesni-gcm-avx2-vaes.S
+++ b/module/icp/asm-x86_64/modes/aesni-gcm-avx2-vaes.S
@@ -7,6 +7,7 @@
 
 #define _ASM
 #include <sys/asm_linkage.h>
+#include <modes/gcm_asm_rename_funcs.h>
 
 /* Windows userland links with OpenSSL */
 #if !defined (_WIN32) || defined (_KERNEL)

--- a/module/icp/include/modes/gcm_asm_rename_funcs.h
+++ b/module/icp/include/modes/gcm_asm_rename_funcs.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2026 Attila Fülöp <attila@fueloep.org>
+ */
+
+/*
+ * Prepend `icp_` to each function name defined in gcm assembly files.
+ * This avoids potential symbol conflicts with linux libcrypto in case of
+ * in-tree compilation. To keep the diff noise low, we do this using macros.
+ *
+ * Currently only done for aesni-gcm-avx2-vaes.S since there is a real conflict.
+ */
+
+/* module/icp/asm-x86_64/modes/aesni-gcm-avx2-vaes.S */
+#define	gcm_init_vpclmulqdq_avx2	icp_gcm_init_vpclmulqdq_avx2
+#define	gcm_gmult_vpclmulqdq_avx2	icp_gcm_gmult_vpclmulqdq_avx2
+#define	gcm_ghash_vpclmulqdq_avx2	icp_gcm_ghash_vpclmulqdq_avx2
+#define	aes_gcm_enc_update_vaes_avx2	icp_aes_gcm_enc_update_vaes_avx2
+#define	aes_gcm_dec_update_vaes_avx2	icp_aes_gcm_dec_update_vaes_avx2


### PR DESCRIPTION
### Motivation and Context

Linux 6.19 added an AES-GCM VAES-AVX2 assembly implementation. It's basically a translation from the BoringSSL perlasm syntax to macro assembly. We're using the same source but the perlasm generated flat assembly which shares some global function names with the former. When  building in-tree this results in the linker failing due to the duplicate symbols.

Closes #18204

### Description

To avoid the error we prepend `icp_` via a macro to our function names.

### How Has This Been Tested?

Compiled and manually tested with `nm` that the rename worked as expected.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
