### PR TITLE
ICP: AES-GCM assembly: remove unused Gmul functions

### DIFF
--- a/module/icp/asm-x86_64/modes/aesni-gcm-avx2-vaes.S
+++ b/module/icp/asm-x86_64/modes/aesni-gcm-avx2-vaes.S
@@ -159,42 +159,6 @@ ENDBR
 
 .cfi_endproc
 SET_SIZE(gcm_init_vpclmulqdq_avx2)
-ENTRY_ALIGN(gcm_gmult_vpclmulqdq_avx2, 32)
-.cfi_startproc
-
-ENDBR
-
-
-
-	vmovdqu	(%rdi),%xmm0
-	vmovdqu	.Lbswap_mask(%rip),%xmm1
-	vmovdqu	128-16(%rsi),%xmm2
-	vmovdqu	.Lgfpoly(%rip),%xmm3
-	vpshufb	%xmm1,%xmm0,%xmm0
-
-	vpclmulqdq	$0x00,%xmm2,%xmm0,%xmm4
-	vpclmulqdq	$0x01,%xmm2,%xmm0,%xmm5
-	vpclmulqdq	$0x10,%xmm2,%xmm0,%xmm6
-	vpxor	%xmm6,%xmm5,%xmm5
-	vpclmulqdq	$0x01,%xmm4,%xmm3,%xmm6
-	vpshufd	$0x4e,%xmm4,%xmm4
-	vpxor	%xmm4,%xmm5,%xmm5
-	vpxor	%xmm6,%xmm5,%xmm5
-	vpclmulqdq	$0x11,%xmm2,%xmm0,%xmm0
-	vpclmulqdq	$0x01,%xmm5,%xmm3,%xmm4
-	vpshufd	$0x4e,%xmm5,%xmm5
-	vpxor	%xmm5,%xmm0,%xmm0
-	vpxor	%xmm4,%xmm0,%xmm0
-
-
-	vpshufb	%xmm1,%xmm0,%xmm0
-	vmovdqu	%xmm0,(%rdi)
-
-
-	RET
-
-.cfi_endproc
-SET_SIZE(gcm_gmult_vpclmulqdq_avx2)
 ENTRY_ALIGN(gcm_ghash_vpclmulqdq_avx2, 32)
 .cfi_startproc
 

--- a/module/icp/asm-x86_64/modes/ghash-x86_64.S
+++ b/module/icp/asm-x86_64/modes/ghash-x86_64.S
@@ -103,63 +103,6 @@
 
 .text
 
-/* Windows userland links with OpenSSL */
-#if !defined (_WIN32) || defined (_KERNEL)
-ENTRY_ALIGN(gcm_gmult_clmul, 16)
-
-.cfi_startproc
-	ENDBR
-
-.L_gmult_clmul:
-	movdqu	(%rdi),%xmm0
-	movdqa	.Lbswap_mask(%rip),%xmm5
-	movdqu	(%rsi),%xmm2
-	movdqu	32(%rsi),%xmm4
-.byte	102,15,56,0,197
-	movdqa	%xmm0,%xmm1
-	pshufd	$78,%xmm0,%xmm3
-	pxor	%xmm0,%xmm3
-.byte	102,15,58,68,194,0
-.byte	102,15,58,68,202,17
-.byte	102,15,58,68,220,0
-	pxor	%xmm0,%xmm3
-	pxor	%xmm1,%xmm3
-
-	movdqa	%xmm3,%xmm4
-	psrldq	$8,%xmm3
-	pslldq	$8,%xmm4
-	pxor	%xmm3,%xmm1
-	pxor	%xmm4,%xmm0
-
-	movdqa	%xmm0,%xmm4
-	movdqa	%xmm0,%xmm3
-	psllq	$5,%xmm0
-	pxor	%xmm0,%xmm3
-	psllq	$1,%xmm0
-	pxor	%xmm3,%xmm0
-	psllq	$57,%xmm0
-	movdqa	%xmm0,%xmm3
-	pslldq	$8,%xmm0
-	psrldq	$8,%xmm3
-	pxor	%xmm4,%xmm0
-	pxor	%xmm3,%xmm1
-
-
-	movdqa	%xmm0,%xmm4
-	psrlq	$1,%xmm0
-	pxor	%xmm4,%xmm1
-	pxor	%xmm0,%xmm4
-	psrlq	$5,%xmm0
-	pxor	%xmm4,%xmm0
-	psrlq	$1,%xmm0
-	pxor	%xmm1,%xmm0
-.byte	102,15,56,0,197
-	movdqu	%xmm0,(%rdi)
-	RET
-.cfi_endproc
-SET_SIZE(gcm_gmult_clmul)
-#endif /* !_WIN32 || _KERNEL */
-
 ENTRY_ALIGN(gcm_init_htab_avx, 32)
 .cfi_startproc
 	ENDBR
@@ -272,13 +215,6 @@ ENTRY_ALIGN(gcm_init_htab_avx, 32)
 SET_SIZE(gcm_init_htab_avx)
 
 #if !defined (_WIN32) || defined (_KERNEL)
-ENTRY_ALIGN(gcm_gmult_avx, 32)
-.cfi_startproc
-	ENDBR
-	jmp	.L_gmult_clmul
-.cfi_endproc
-SET_SIZE(gcm_gmult_avx)
-
 ENTRY_ALIGN(gcm_ghash_avx, 32)
 .cfi_startproc
 	ENDBR

--- a/module/icp/include/modes/gcm_asm_rename_funcs.h
+++ b/module/icp/include/modes/gcm_asm_rename_funcs.h
@@ -33,7 +33,6 @@
 
 /* module/icp/asm-x86_64/modes/aesni-gcm-avx2-vaes.S */
 #define	gcm_init_vpclmulqdq_avx2	icp_gcm_init_vpclmulqdq_avx2
-#define	gcm_gmult_vpclmulqdq_avx2	icp_gcm_gmult_vpclmulqdq_avx2
 #define	gcm_ghash_vpclmulqdq_avx2	icp_gcm_ghash_vpclmulqdq_avx2
 #define	aes_gcm_enc_update_vaes_avx2	icp_aes_gcm_enc_update_vaes_avx2
 #define	aes_gcm_dec_update_vaes_avx2	icp_aes_gcm_dec_update_vaes_avx2


### PR DESCRIPTION
### Motivation and Context

In the AES-GCM assembly files we are defining Gmul functions we don't use anywhere. 

### Description

Just remove the dead code.

### How Has This Been Tested?

make && make cstyle

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
