### PR TITLE
Fix `zdb --key` crash for unencrypted datasets, and teach tests to understand this better

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -30,6 +30,7 @@
 # Copyright (c) 2017, Open-E Inc. All rights reserved.
 # Copyright (c) 2021, The FreeBSD Foundation.
 # Copyright (c) 2025, Klara, Inc.
+# Copyright (c) 2026, TrueNAS.
 # Use is subject to license terms.
 #
 
@@ -3951,18 +3952,45 @@ function pop_coredump_pattern
 #
 function get_same_blocks # dataset1 file1 dataset2 file2 [key]
 {
-	typeset KEY=$5
-	if [ ${#KEY} -gt 0 ]; then
-		KEY="--key=$KEY"
+	typeset ds1=$1
+	typeset file1=$2
+	typeset ds2=$3
+	typeset file2=$4
+
+	typeset key=$5
+	typeset keyarg=
+	if [ ${#key} -gt 0 ]; then
+		keyarg="--key=$key"
 	fi
+
+	# this is usually called as $(get_same_blocks ...), and so expected
+	# to put its result on stdout, and usually the caller is not watching
+	# for failure. this makes things a little tricky to fail properly if
+	# zdb fails or crashes, as we end up returning an empty string, which
+	# is a valid return (no blocks the same)
+	#
+	# to get around this, we check zdb's return and echo a dummy value
+	# before returning failure. this will not match whatever the caller
+	# is checking for. if they do call it with log_must, then they get
+	# a failure as expected.
+
 	typeset zdbout1=$(mktemp)
 	typeset zdbout2=$(mktemp)
-	zdb $KEY -vvvvv $1 -O $2 | \
-	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout1
-	zdb $KEY -vvvvv $3 -O $4 | \
-	    awk '/ L0 / { print l++ " " $3 " " $7 }' > $zdbout2
-	echo $(sort -n $zdbout1 $zdbout2 | uniq -d | cut -f1 -d' ')
-	rm -f $zdbout1 $zdbout2
+	typeset awkout1=$(mktemp)
+	typeset awkout2=$(mktemp)
+
+	zdb $keyarg -vvvvv $ds1 -O $file1 > $zdbout1
+	[[ $? -ne 0 ]] && echo "zdb $ds1 failed" && return 1
+
+	zdb $keyarg -vvvvv $ds2 -O $file2 > $zdbout2
+	[[ $? -ne 0 ]] && echo "zdb $ds2 failed" && return 1
+
+	awk '/ L0 / { print l++ " " $3 " " $7 }' < $zdbout1 > $awkout1
+	awk '/ L0 / { print l++ " " $3 " " $7 }' < $zdbout2 > $awkout2
+
+	echo $(sort -n $awkout1 $awkout2 | uniq -d | cut -f1 -d' ')
+
+	rm -f $zdbout1 $zdbout2 $awkout1 $awkout2
 }
 
 . ${STF_SUITE}/include/kstat.shlib


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Today I happened to glance at some test output as it rolled by my screen, and I saw a zdb tripping an assertion. I didn't worry about at the time, I figured that I'd let the test run complete and look at the fail list and go find out what was up then. Except, nothing on the fail list!

Going back through the log, I found:

```
[2026-02-17T12:10:12.142904] Test: /usr/local/share/zfs/zfs-tests/tests/functional/block_cloning/block_cloning_cross_enc_dataset (run as root) [00:23] [PASS]
12:09:48.35 cannot open 'testpool/testfs': dataset does not exist
12:09:48.35 ASSERTION: Block cloning across encrypted datasets.
...
12:10:12.02 ASSERT at cmd/zdb/zdb.c:3406:zdb_load_key()
12:10:12.02 VERIFY0(zap_lookup(dd->dd_pool->dp_meta_objset, dd->dd_crypto_obj, DSL_CRYPTO_KEY_ROOT_DDOBJ, sizeof (uint64_t), 1, &rddobj)) failed (22)
12:10:12.02   PID: 835063    COMM: zdb
12:10:12.02   TID: 835063    NAME: zdb
12:10:12.02 Registers:
12:10:12.02   RAX: 0x0000000000000037  RDX: 0x0000000000000000  RCX: 0x0000000000000000
12:10:12.02   RBX: 0x0000000000000002  RSI: 0x0000000000000000  RDI: 0x00007fff82037cc0
12:10:12.02   RBP: 0x00007fff820384c0  RSP: 0x00007fff82037c10   R8: 0x0000000000000000
12:10:12.02    R9: 0x0000000000000000  R10: 0x00007fdf0309a668  R11: 0x00007fdf02e0a108
12:10:12.02   R12: 0x0000000000000000  R13: 0x00007fff82038090  R14: 0x00007fff82037cc0
12:10:12.02   R15: 0x0000562fcd2b4710  RIP: 0x00007fdf03d036e6
12:10:12.02 Call trace:
12:10:12.02   [0x00007fdf03d036e6] libspl_backtrace+0x36 (in /usr/local/lib/libzpool.so.7.0.0 +0x3036e6)
12:10:12.02   [0x00007fdf03d03605] libspl_assertf+0x135 (in /usr/local/lib/libzpool.so.7.0.0 +0x303605)
12:10:12.02   [0x0000562fcd2a0858] zdb_load_key+0x268 (in /usr/local/sbin/zdb +0x19858)
12:10:12.02   [0x0000562fcd2a097e] open_objset+0xae (in /usr/local/sbin/zdb +0x1997e)
12:10:12.02   [0x0000562fcd2a50fc] dump_path+0x2c (in /usr/local/sbin/zdb +0x1e0fc)
12:10:12.02   [0x0000562fcd292425] main+0xc25 (in /usr/local/sbin/zdb +0xb425)
12:10:12.02   [0x00007fdf03034ca8] __libc_start_call_main+0x78 (in /usr/lib/x86_64-linux-gnu/libc.so.6 +0x29ca8)
12:10:12.02   [0x00007fdf03034d65] __libc_start_main_alias_2+0x85 (in /usr/lib/x86_64-linux-gnu/libc.so.6 +0x29d65)
12:10:12.02   [0x0000562fcd293071] _start+0x21 (in /usr/local/sbin/zdb +0xc071)
12:10:12.02 Registers:
12:10:12.02   RAX: 0x0000000000000000  RDX: 0x00007fff82037e00  RCX: 0x00007fdf0309f95c
12:10:12.02   RBX: 0x0000000000000002  RSI: 0x00007fff82037f30  RDI: 0x00007fff82037530
12:10:12.02   RBP: 0x00007fff82037d30  RSP: 0x00007fff82037480   R8: 0x00007fdf04039288
12:10:12.02    R9: 0x00007fff820377f8  R10: 0xfcdbd2c44b4f9f00  R11: 0x00007fdf04039b20
12:10:12.02   R12: 0x0000000000000000  R13: 0x00007fff82037900  R14: 0x00007fff82037530
12:10:12.02   R15: 0x0000562fcd2b4710  RIP: 0x00007fdf03d036e6
12:10:12.02 Call trace:
12:10:12.02   [0x00007fdf03d036e6] libspl_backtrace+0x36 (in /usr/local/lib/libzpool.so.7.0.0 +0x3036e6)
12:10:12.02   [0x0000562fcd29ffe1] sig_handler+0x21 (in /usr/local/sbin/zdb +0x18fe1)
12:10:12.02   [0x00007fdf0304adf0] ??? (in /usr/lib/x86_64-linux-gnu/libc.so.6 +0x3fdf0)
12:10:12.02   [0x00007fdf0309f95c] __pthread_kill_implementation+0x10c (in /usr/lib/x86_64-linux-gnu/libc.so.6 +0x9495c)
12:10:12.02   [0x00007fdf0304acc2] __GI_raise+0x12 (in /usr/lib/x86_64-linux-gnu/libc.so.6 +0x3fcc2)
12:10:12.02   [0x00007fdf030334ac] __GI_abort+0x22 (in /usr/lib/x86_64-linux-gnu/libc.so.6 +0x284ac)
12:10:12.02   [0x00007fdf03a61082] libspl_assertf.cold+0x05 (in /usr/local/lib/libzpool.so.7.0.0 +0x61082)
12:10:12.02   [0x0000562fcd2a0858] zdb_load_key+0x268 (in /usr/local/sbin/zdb +0x19858)
12:10:12.02   [0x0000562fcd2a097e] open_objset+0xae (in /usr/local/sbin/zdb +0x1997e)
12:10:12.02   [0x0000562fcd2a50fc] dump_path+0x2c (in /usr/local/sbin/zdb +0x1e0fc)
12:10:12.02   [0x0000562fcd292425] main+0xc25 (in /usr/local/sbin/zdb +0xb425)
12:10:12.02   [0x00007fdf03034ca8] __libc_start_call_main+0x78 (in /usr/lib/x86_64-linux-gnu/libc.so.6 +0x29ca8)
12:10:12.02   [0x00007fdf03034d65] __libc_start_main_alias_2+0x85 (in /usr/lib/x86_64-linux-gnu/libc.so.6 +0x29d65)
12:10:12.02   [0x0000562fcd293071] _start+0x21 (in /usr/local/sbin/zdb +0xc071)
12:10:12.03 SUCCESS: [  =  ]
12:10:12.04 SUCCESS: zpool sync testpool
12:10:12.04 SUCCESS: sync_pool testpool
12:10:12.04 Block cloning across encrypted datasets.
```

That is, zdb crashed, but the test function `get_same_blocks()` didn't notice because it's only considering the output on stdout, and no output is valid for this test.

The PR fixes the test function, and then makes zdb a bit better-behaved in the event that a key can't be loaded, or the dataset isn't encrypted.

### Description

First commit upgrades `get_same_blocks()` to fail in a useful way if either of the `zdb` calls fail. See the comment for why this isn't as simple as a `log_must`.

Second commit update `zdb` to check that the target dataset is actually encrypted before trying to unlock it. I've opted for ignoring the `-K`/`--key` option if the dataset doesn't need it rather than exiting, partly because a single `zdb` can explore multiple datasets and it would be nice if that didn't need to care, but also because `get_same_blocks()` takes two datasets but only a single key, which would require either changing all the call sites or making it more complex again.

(of course, you still can't use `zdb` to explore multiple encrypted datasets with different encryption roots that have different keys, but I figure that's a pretty rare situation. If it comes up, we can allow multiple `--key` or something).

Third commit makes `zdb` handle failures to unlock the dataset or derive the key and return a bit more sensibly, rather than just crashing. No practical difference but its a lot less messy.

### How Has This Been Tested?

Mainly running the `block_cloning_cross_enc_dataset` test, which easily trips the issue. Once done, I ran the `zdb` test tag, and that seems fine. I'll let CI check the rest of it.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
