### PR TITLE
`sha2_test`: test correctness for all implementations

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2896,7 +2896,7 @@ function is_mp
 function get_cpu_freq
 {
 	if is_linux; then
-		lscpu | awk '/CPU MHz/ { print $3 }'
+		lscpu | awk '/CPU( max)? MHz/ { print $NF }'
 	elif is_freebsd; then
 		sysctl -n hw.clockrate
 	else


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

I was messing with a new SHA512 implementation and noticed that we were only testing correctness for the fastest, not all implementations. That seemed ungood!

### Description

In the correctness part of the test, loop over all the implementations and check them, just like for the performance part.

Some output formatting tidying as well.

Bonus! The `get_cpu_freq` test function didn't really work on any CPU with variable frequency, because the `lscpu` output is different. It barely matters, but if its there it might as well do something, so I fixed it to understand both.

### How Has This Been Tested?

`checksum` test tag passes, which is where `sha2_test` is run from. I wouldn't have expected anything else in there to change; it was just convenient.

Output before:

```
$ ./tests/zfs-tests/cmd/sha2_test 5100
Running algorithm correctness tests:
SHASHA256   Message: test_msg0	Result: OK
SHASHA256   Message: test_msg1	Result: OK
SHASHA512   Message: test_msg0	Result: OK
SHASHA512   Message: test_msg2	Result: OK
SHASHA512_256Message: test_msg0	Result: OK
SHASHA512_256Message: test_msg2	Result: OK
Running performance tests (hashing 1024 MiB of data):
shaSHA256-generic  3436584 us (16.32 CPB)
shaSHA256-x64      3767889 us (17.90 CPB)
shaSHA256-ssse3    3444738 us (16.36 CPB)
shaSHA256-avx      3337586 us (15.85 CPB)
shaSHA256-avx2     3000874 us (14.25 CPB)
shaSHA256-shani     488592 us (2.32 CPB)
shaSHA512-generic  2425088 us (11.52 CPB)
shaSHA512-x64      2357300 us (11.20 CPB)
shaSHA512-avx      2179802 us (10.35 CPB)
shaSHA512-avx2     1869155 us (8.88 CPB)
```

Output after:

```
$ ./tests/zfs-tests/cmd/sha2_test 5100
Running algorithm correctness tests:
SHA256      generic   Message: test_msg0	Result: OK
SHA256      generic   Message: test_msg1	Result: OK
SHA256      x64       Message: test_msg0	Result: OK
SHA256      x64       Message: test_msg1	Result: OK
SHA256      ssse3     Message: test_msg0	Result: OK
SHA256      ssse3     Message: test_msg1	Result: OK
SHA256      avx       Message: test_msg0	Result: OK
SHA256      avx       Message: test_msg1	Result: OK
SHA256      avx2      Message: test_msg0	Result: OK
SHA256      avx2      Message: test_msg1	Result: OK
SHA256      shani     Message: test_msg0	Result: OK
SHA256      shani     Message: test_msg1	Result: OK
SHA512      generic   Message: test_msg0	Result: OK
SHA512      generic   Message: test_msg2	Result: OK
SHA512_256  generic   Message: test_msg0	Result: OK
SHA512_256  generic   Message: test_msg2	Result: OK
SHA512      x64       Message: test_msg0	Result: OK
SHA512      x64       Message: test_msg2	Result: OK
SHA512_256  x64       Message: test_msg0	Result: OK
SHA512_256  x64       Message: test_msg2	Result: OK
SHA512      avx       Message: test_msg0	Result: OK
SHA512      avx       Message: test_msg2	Result: OK
SHA512_256  avx       Message: test_msg0	Result: OK
SHA512_256  avx       Message: test_msg2	Result: OK
SHA512      avx2      Message: test_msg0	Result: OK
SHA512      avx2      Message: test_msg2	Result: OK
SHA512_256  avx2      Message: test_msg0	Result: OK
SHA512_256  avx2      Message: test_msg2	Result: OK

Running performance tests (hashing 1024 MiB of data):
SHA256-generic   003329334 us (15.81 CPB)
SHA256-x64       003733473 us (17.73 CPB)
SHA256-ssse3     002897979 us (13.76 CPB)
SHA256-avx       003373538 us (16.02 CPB)
SHA256-avx2      001860464 us (8.84 CPB)
SHA256-shani     000479456 us (2.28 CPB)
SHA512-generic   002437374 us (11.58 CPB)
SHA512-x64       001950795 us (9.27 CPB)
SHA512-avx       002102129 us (9.98 CPB)
SHA512-avx2      001861294 us (8.84 CPB)
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
