### PR TITLE
CI: Test & fix Linux ZFS built-in build

### DIFF
--- a/.github/workflows/scripts/qemu-8-summary.sh
+++ b/.github/workflows/scripts/qemu-8-summary.sh
@@ -33,7 +33,7 @@ EOF
 
 function showfile_tail() {
   echo "##[group]$2 (final lines)"
-  tail -n 40 $1
+  tail -n 80 $1
   echo "##[endgroup]"
 }
 
@@ -64,6 +64,18 @@ for ((i=1; i<=VMs; i++)); do
     fi
     file="vm$i/lustre.txt"
     test -s "$file" && showfile_tail "$file" "$vm: Lustre build"
+  fi
+
+  if [ -f vm$i/builtin-exitcode.txt ] ; then
+    rv=$(< vm$i/builtin-exitcode.txt)
+    if [ $rv = 0 ]; then
+      vm="[92mvm$i[0m"
+    else
+      vm="[1;91mvm$i[0m"
+      touch /tmp/have_failed_tests
+    fi
+    file="vm$i/builtin.txt"
+    test -s "$file" && showfile_tail "$file" "$vm: Linux built-in build"
   fi
 
   rv=$(cat vm$i/tests-exitcode.txt)

--- a/copy-builtin
+++ b/copy-builtin
@@ -8,7 +8,9 @@ usage()
 	exit 1
 }
 
-[ "$#" -eq 1 ] || usage
+if ! [ -d "$1" ] ; then
+	usage
+fi
 KERNEL_DIR="$1"
 
 if ! [ -e 'zfs_config.h' ]
@@ -31,6 +33,7 @@ cat > "$KERNEL_DIR/fs/zfs/Kconfig" <<EOF
 config ZFS
 	tristate "ZFS filesystem support"
 	depends on EFI_PARTITION
+	depends on BLOCK
 	select ZLIB_INFLATE
 	select ZLIB_DEFLATE
 	help

--- a/module/zfs/dataset_kstats.c
+++ b/module/zfs/dataset_kstats.c
@@ -213,7 +213,7 @@ dataset_kstats_rename(dataset_kstats_t *dk, const char *name)
 	char *ds_name;
 
 	ds_name = KSTAT_NAMED_STR_PTR(&dkv->dkv_ds_name);
-	ASSERT3S(ds_name, !=, NULL);
+	ASSERT3P(ds_name, !=, NULL);
 	(void) strlcpy(ds_name, name,
 	    KSTAT_NAMED_STR_BUFLEN(&dkv->dkv_ds_name));
 }

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -1586,7 +1586,7 @@ ddt_configure(ddt_t *ddt, boolean_t new)
 		    DMU_POOL_DIRECTORY_OBJECT, name, sizeof (uint64_t), 1,
 		    &ddt->ddt_dir_object);
 		if (error == 0) {
-			ASSERT3U(spa->spa_meta_objset, ==, ddt->ddt_os);
+			ASSERT3P(spa->spa_meta_objset, ==, ddt->ddt_os);
 
 			error = zap_lookup(ddt->ddt_os, ddt->ddt_dir_object,
 			    DDT_DIR_VERSION, sizeof (uint64_t), 1,

--- a/module/zfs/ddt_log.c
+++ b/module/zfs/ddt_log.c
@@ -278,7 +278,7 @@ ddt_log_update_entry(ddt_t *ddt, ddt_log_t *ddl, ddt_lightweight_entry_t *ddlwe,
 void
 ddt_log_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe, ddt_log_update_t *dlu)
 {
-	ASSERT3U(dlu->dlu_dbp, !=, NULL);
+	ASSERT3P(dlu->dlu_dbp, !=, NULL);
 
 	ddt_log_update_entry(ddt, ddt->ddt_log_active, ddlwe, B_TRUE);
 
@@ -328,7 +328,7 @@ ddt_log_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe, ddt_log_update_t *dlu)
 void
 ddt_log_commit(ddt_t *ddt, ddt_log_update_t *dlu)
 {
-	ASSERT3U(dlu->dlu_dbp, !=, NULL);
+	ASSERT3P(dlu->dlu_dbp, !=, NULL);
 	ASSERT3U(dlu->dlu_block+1, ==, dlu->dlu_ndbp);
 	ASSERT3U(dlu->dlu_offset, >, 0);
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1285,7 +1285,7 @@ spa_vdev_enter(spa_t *spa)
 	mutex_enter(&spa->spa_vdev_top_lock);
 	spa_namespace_enter(FTAG);
 
-	ASSERT0(spa->spa_export_thread);
+	ASSERT0P(spa->spa_export_thread);
 
 	vdev_autotrim_stop_all(spa);
 
@@ -1304,7 +1304,7 @@ spa_vdev_detach_enter(spa_t *spa, uint64_t guid)
 	mutex_enter(&spa->spa_vdev_top_lock);
 	spa_namespace_enter(FTAG);
 
-	ASSERT0(spa->spa_export_thread);
+	ASSERT0P(spa->spa_export_thread);
 
 	vdev_autotrim_stop_all(spa);
 

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -122,7 +122,7 @@ zio_compress_data(enum zio_compress c, abd_t *src, abd_t **dst, size_t s_len,
 	uint8_t complevel;
 	zio_compress_info_t *ci = &zio_compress_table[c];
 
-	ASSERT3U(ci->ci_compress, !=, NULL);
+	ASSERT3P(ci->ci_compress, !=, NULL);
 	ASSERT3U(s_len, >, 0);
 
 	complevel = ci->ci_level;


### PR DESCRIPTION
### Motivation and Context
Fix Linux built-in build.  Test built-in build in CI.

### Description
ZFS can be built directly into the Linux kernel.  Add a test build of this to the CI to verify it works.  The test build is only enabled on Fedora runners (since they run the newest kernels) and is done in parallel with ZTS.  The test build is done on vm2, since it typically finishes ~15min before vm1 and thus has time to spare.

In addition:

- Update `copy-builtin` to check that $1 is a directory
- Fix some VERIFYs that were causing the built-in build to fail

### How Has This Been Tested?
Saw that both successful and failed built-in builds produced the correct output in CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
