### PR TITLE
prevent range tree corruption race by updating dnode_sync()

### DIFF
--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -652,6 +652,19 @@ extern dnode_sums_t dnode_sums;
 
 #endif
 
+/*
+ * Assert that we are not modifying the range tree for the syncing TXG from
+ * a non-syncing thread. We verify that either the transaction group is
+ * strictly newer than the one currently syncing (meaning it's being modified
+ * in open context), OR the current thread is the sync thread itself. If this
+ * triggers, it indicates a race where dn_free_ranges is being modified while
+ * dnode_sync() may be iterating over it.
+ */
+#define	FREE_RANGE_VERIFY(tx, dn) \
+	ASSERT((tx)->tx_txg > spa_syncing_txg((dn)->dn_objset->os_spa) || \
+	    dmu_objset_pool((dn)->dn_objset)->dp_tx.tx_sync_thread == \
+	    curthread)
+
 #ifdef	__cplusplus
 }
 #endif

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2201,6 +2201,17 @@ dbuf_dirty_lightweight(dnode_t *dn, uint64_t blkid, dmu_tx_t *tx)
 
 	mutex_enter(&dn->dn_mtx);
 	int txgoff = tx->tx_txg & TXG_MASK;
+
+	/*
+	 * Assert that we are not modifying the range tree for the syncing
+	 * TXG from a non-syncing thread. We verify that the tx's
+	 * transaction group is strictly newer than the one currently
+	 * syncing (meaning we are in open context). If this triggers,
+	 * it indicates a race where syncing dn_free_range tree is
+	 * being modified while dnode_sync() may be iterating over it.
+	 */
+	ASSERT(tx->tx_txg > spa_syncing_txg(dn->dn_objset->os_spa));
+
 	if (dn->dn_free_ranges[txgoff] != NULL) {
 		zfs_range_tree_clear(dn->dn_free_ranges[txgoff], blkid, 1);
 	}
@@ -2388,6 +2399,7 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 	    db->db_blkid != DMU_SPILL_BLKID) {
 		mutex_enter(&dn->dn_mtx);
 		if (dn->dn_free_ranges[txgoff] != NULL) {
+			FREE_RANGE_VERIFY(tx, dn);
 			zfs_range_tree_clear(dn->dn_free_ranges[txgoff],
 			    db->db_blkid, 1);
 		}

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -2409,6 +2409,8 @@ done:
 	mutex_enter(&dn->dn_mtx);
 	{
 		int txgoff = tx->tx_txg & TXG_MASK;
+
+		FREE_RANGE_VERIFY(tx, dn);
 		if (dn->dn_free_ranges[txgoff] == NULL) {
 			dn->dn_free_ranges[txgoff] =
 			    zfs_range_tree_create_flags(

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -440,24 +440,6 @@ dnode_sync_free_range_impl(dnode_t *dn, uint64_t blkid, uint64_t nblks,
 	}
 }
 
-typedef struct dnode_sync_free_range_arg {
-	dnode_t *dsfra_dnode;
-	dmu_tx_t *dsfra_tx;
-	boolean_t dsfra_free_indirects;
-} dnode_sync_free_range_arg_t;
-
-static void
-dnode_sync_free_range(void *arg, uint64_t blkid, uint64_t nblks)
-{
-	dnode_sync_free_range_arg_t *dsfra = arg;
-	dnode_t *dn = dsfra->dsfra_dnode;
-
-	mutex_exit(&dn->dn_mtx);
-	dnode_sync_free_range_impl(dn, blkid, nblks,
-	    dsfra->dsfra_free_indirects, dsfra->dsfra_tx);
-	mutex_enter(&dn->dn_mtx);
-}
-
 /*
  * Try to kick all the dnode's dbufs out of the cache...
  */
@@ -635,6 +617,64 @@ dnode_sync_free(dnode_t *dn, dmu_tx_t *tx)
 }
 
 /*
+ * We cannot simply detach the range tree (set dn_free_ranges to NULL)
+ * before processing it because dnode_block_freed() relies on it to
+ * correctly identify blocks that have been freed in the current TXG
+ * (for dbuf_read() calls on holes). If we detached it early, a concurrent
+ * reader might see the block as valid on disk and return stale data
+ * instead of zeros.
+ *
+ * We also can't use zfs_range_tree_walk() nor zfs_range_tree_vacate()
+ * with a callback that drops dn_mtx (dnode_sync_free_range()). This is
+ * unsafe because another thread (spa_sync_deferred_frees() ->
+ * dnode_free_range()) could acquire dn_mtx and modify the tree while the
+ * walk or vacate was in progress. This leads to tree corruption or panic
+ * when we resume.
+ *
+ * To fix the race while maintaining visibility, we process the tree
+ * incrementally. We pick a segment, drop the lock to sync it, and
+ * re-acquire the lock to remove it. By always restarting from the head
+ * of the tree, we ensure we are never using an invalid iterator.
+ * We use zfs_range_tree_clear() instead of ..._remove() because the range
+ * might have already been removed while the lock was dropped (specifically
+ * in the dbuf_dirty path mentioned above). ..._clear() handles this
+ * gracefully, while ..._remove() would panic on a missing segment.
+ */
+static void
+dnode_sync_free_ranges(dnode_t *dn, dmu_tx_t *tx)
+{
+	int txgoff = tx->tx_txg & TXG_MASK;
+
+	mutex_enter(&dn->dn_mtx);
+	zfs_range_tree_t *rt = dn->dn_free_ranges[txgoff];
+	if (rt != NULL) {
+		boolean_t freeing_dnode = dn->dn_free_txg > 0 &&
+		    dn->dn_free_txg <= tx->tx_txg;
+		zfs_range_seg_t *rs;
+
+		if (freeing_dnode) {
+			ASSERT(zfs_range_tree_contains(rt, 0,
+			    dn->dn_maxblkid + 1));
+		}
+
+		while ((rs = zfs_range_tree_first(rt)) != NULL) {
+			uint64_t start = zfs_rs_get_start(rs, rt);
+			uint64_t size = zfs_rs_get_end(rs, rt) - start;
+
+			mutex_exit(&dn->dn_mtx);
+			dnode_sync_free_range_impl(dn, start, size,
+			    freeing_dnode, tx);
+			mutex_enter(&dn->dn_mtx);
+
+			zfs_range_tree_clear(rt, start, size);
+		}
+		zfs_range_tree_destroy(rt);
+		dn->dn_free_ranges[txgoff] = NULL;
+	}
+	mutex_exit(&dn->dn_mtx);
+}
+
+/*
  * Write out the dnode's dirty buffers.
  * Does not wait for zio completions.
  */
@@ -781,32 +821,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 	}
 
 	/* process all the "freed" ranges in the file */
-	if (dn->dn_free_ranges[txgoff] != NULL) {
-		dnode_sync_free_range_arg_t dsfra;
-		dsfra.dsfra_dnode = dn;
-		dsfra.dsfra_tx = tx;
-		dsfra.dsfra_free_indirects = freeing_dnode;
-		mutex_enter(&dn->dn_mtx);
-		if (freeing_dnode) {
-			ASSERT(zfs_range_tree_contains(
-			    dn->dn_free_ranges[txgoff], 0,
-			    dn->dn_maxblkid + 1));
-		}
-		/*
-		 * Because dnode_sync_free_range() must drop dn_mtx during its
-		 * processing, using it as a callback to zfs_range_tree_vacate()
-		 * is not safe. No other operations (besides destroy) are
-		 * allowed once zfs_range_tree_vacate() has begun, and dropping
-		 * dn_mtx would leave a window open for another thread to
-		 * observe that invalid (and unsafe) state.
-		 */
-		zfs_range_tree_walk(dn->dn_free_ranges[txgoff],
-		    dnode_sync_free_range, &dsfra);
-		zfs_range_tree_vacate(dn->dn_free_ranges[txgoff], NULL, NULL);
-		zfs_range_tree_destroy(dn->dn_free_ranges[txgoff]);
-		dn->dn_free_ranges[txgoff] = NULL;
-		mutex_exit(&dn->dn_mtx);
-	}
+	dnode_sync_free_ranges(dn, tx);
 
 	if (freeing_dnode) {
 		dn->dn_objset->os_freed_dnodes++;
@@ -828,7 +843,7 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 	}
 
 	/*
-	 * This must be done after dnode_sync_free_range()
+	 * This must be done after dnode_sync_free_ranges()
 	 * and dnode_increase_indirection(). See dnode_new_blkid()
 	 * for an explanation of the high bit being set.
 	 */


### PR DESCRIPTION
### Motivation and Context
We (at Connectwise) have been looking into a rare range-tree corruption that we've seen in our private cloud and has been reported here on github.
There is a (seemingly AI-generated) meta issue that captures some of the related context (PRs and reported issues) - https://github.com/openzfs/zfs/issues/18186
TLDR is that people have been ending up with panics and unimportable pools with duplicate-free or overlapping segments 
due to range tree corruption.
Sadly, we have not been able to reproduce this on demand, but we think we have found the root cause of it, and the patch in this PR is the proposed fix.

The root cause is a race that can be described as the following parallel execution scenario:
```
  Thread A (`txg_sync` thread):
   1. Enters dnode_sync for a dnode.
   2. Acquires dn->dn_mtx.
   3. Calls zfs_range_tree_walk on dn->dn_free_ranges.
   4. Inside walk, calls callback dnode_sync_free_range.
   5. Drops `dn->dn_mtx`.
   6. Begins processing a range (e.g., freeing blocks).

  Thread B (`zfs destroy` command):
   1. Running concurrently.
   2. Needs to add a range to the same dnode's free list (e.g., in dnode_free_range).
   3. Acquires dn->dn_mtx (SUCCESS, because Thread A dropped it!).
   4. Accesses dn->dn_free_ranges[txgoff]. It sees the pointer is valid (not NULL).
   5. Calls zfs_range_tree_add on that same tree.

  The Crash:
   * Thread B modifies the range tree while Thread A is in the middle of iterating over it.
   * zfs_range_tree_walk (Thread A) reads a pointer that Thread B just freed or moved.
   * Result: Use-after-free, infinite loop, or invalid memory access leading to panic.
   * Alternatively: Thread B adds a range that overlaps with one Thread A is currently freeing, leading to the "overlapping segment" panic later. 
```
This code in `dnode_sync()` last changed [here](https://github.com/openzfs/zfs/pull/10823/changes) when there was a similar panic, and it seems like that fix only moved it to happen earlier. This fix for  https://github.com/openzfs/zfs/issues/10708 was included in 2.0.x, so the timing lines up with the issue reports that say the range tree issue started in ~2.0.x

I should mention that I also investigated making `dnode_sync_free_range()` re-entrant. While this would be a "cleaner" architectural solution, eliminating the need to drop and reacquire the mutex, it requires more extensive locking changes. Specifically, the [alternative approach](https://github.com/alek-p/openzfs/commit/37a2007ccbaff90d24a7bbcdb2ec7e8a85f049dd) involves a bunch of modifications around `dn_mtx` and a couple of adjustments to `dn_struct_rwlock`. Although my limited initial testing didn't uncover regressions, this broader shift in the locking strategy introduces a level of risk that may exceed the benefits of the cleanup. I’ve opted for the current, more localized approach to ensure stability and minimize unanticipated side effects. However, I am happy to reconsider and upstream the re-entrant implementation if the community prefers that.

### Description
To avoid the above referenced race, we cannot simply detach the range tree (set dn_free_ranges to NULL) before processing it because `dnode_block_freed()` relies on it to correctly identify blocks that have been freed in the current TXG (for `dbuf_read()` calls on holes). If we detached it early, a concurrent reader might see the block as valid on disk and return stale data instead of zeros.

We also can't use `zfs_range_tree_walk()` nor `zfs_range_tree_vacate()` with a callback that drops dn_mtx (`dnode_sync_free_range()`). This is unsafe because another thread (`dnode_free_range()`) or even the same thread via recursion (`dnode_sync_free_range_impl() -> free_children() ->  dbuf_dirty()`) could acquire dn_mtx and modify the tree while the walk or vacate was in progress. This leads to tree corruption or panic when we resume.

To fix the race while maintaining visibility, we process the tree incrementally. We pick a segment, drop the lock to sync it, and re-acquire the lock to remove it. By always restarting from the head of the tree, we ensure we are never using an invalid iterator.
We use `zfs_range_tree_clear()` instead of `zfs_range_tree_remove()` because the range might have already been removed while the lock was dropped (specifically in the `dbuf_dirty()` path mentioned above). `zfs_range_tree_clear()` handles this gracefully, while `zfs_range_tree_remove()` would panic on a missing segment.

### How Has This Been Tested?
I've run local zfs-tests with positive results.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
