### PR TITLE
Improve misleading error messages for ZPOOL_STATUS_CORRUPT_POOL

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3456,7 +3456,7 @@ show_import(nvlist_t *config, boolean_t report_error)
 
 	case ZPOOL_STATUS_CORRUPT_POOL:
 		(void) printf_color(ANSI_YELLOW, gettext("The pool metadata is "
-		    "corrupted.\n"));
+		    "incomplete or corrupted.\n"));
 		break;
 
 	case ZPOOL_STATUS_VERSION_OLDER:
@@ -3703,6 +3703,12 @@ show_import(nvlist_t *config, boolean_t report_error)
 		case ZPOOL_STATUS_HOSTID_REQUIRED:
 			(void) printf(gettext("Set a unique system hostid with "
 			    "the zgenhostid(8) command.\n"));
+			break;
+		case ZPOOL_STATUS_CORRUPT_POOL:
+			(void) printf(gettext("The pool cannot be imported due "
+			    "to missing or damaged devices.  Ensure\n"
+			    "\t%sall devices are present and not in use by "
+			    "another subsystem.\n"), indent);
 			break;
 		default:
 			(void) printf(gettext("The pool cannot be imported due "
@@ -10616,7 +10622,8 @@ print_status_reason(zpool_handle_t *zhp, status_cbdata_t *cbp,
 
 	case ZPOOL_STATUS_CORRUPT_POOL:
 		(void) snprintf(status, ST_SIZE, gettext("The pool metadata is "
-		    "corrupted and the pool cannot be opened.\n"));
+		    "incomplete or corrupted and the pool cannot be "
+		    "opened.\n"));
 		zpool_explain_recover(zpool_get_handle(zhp),
 		    zpool_get_name(zhp), reason, zpool_get_config(zhp, NULL),
 		    action, AC_SIZE);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2053,7 +2053,9 @@ zpool_explain_recover(libzfs_handle_t *hdl, const char *name, int reason,
 
 no_info:
 	(void) strlcat(buf, dgettext(TEXT_DOMAIN,
-	    "Destroy and re-create the pool from\n\ta backup source.\n"), size);
+	    "Ensure all pool devices are present and accessible, then "
+	    "retry the import.\n\tIf the problem persists, destroy and "
+	    "re-create the pool from a backup source.\n"), size);
 }
 
 /*


### PR DESCRIPTION
## Motivation

When devices are missing or claimed by another subsystem (e.g. mdadm, LVM), `zpool import` reports "The pool metadata is corrupted" and suggests destroying the pool. This is misleading because the metadata is not necessarily corrupted -- it may simply be incomplete due to inaccessible devices.

This has been an open issue for 7+ years. The `ZPOOL_STATUS_CORRUPT_POOL` status is a catch-all for any failure where the root vdev gets `VDEV_AUX_CORRUPT_DATA`, which includes both genuine corruption and missing/inaccessible devices.

## Description

Update four user-facing messages to acknowledge that missing devices can trigger this status:

1. **Import status message** (`show_import`): "The pool metadata is corrupted" → "The pool metadata is **incomplete or corrupted**"
2. **Import action message** (`show_import`): Add dedicated `ZPOOL_STATUS_CORRUPT_POOL` case instead of falling through to default. New message suggests ensuring all devices are present and not in use by another subsystem.
3. **Status display message** (`print_status_reason`): Same "incomplete or corrupted" wording for `zpool status` output.
4. **Recovery fallback** (`zpool_explain_recover`): Instead of immediately suggesting "Destroy and re-create the pool", first suggest ensuring all devices are present and retrying the import.


Closes #8236