### PR TITLE
range_tree: use zfs_panic_recover() for partial-overlap remove

### DIFF
--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -531,7 +531,7 @@ zfs_range_tree_remove_impl(zfs_range_tree_t *rt, uint64_t start, uint64_t size,
 	}
 
 	if (!(rstart <= start && rend >= end)) {
-		panic("zfs: rt=%s: removing segment "
+		zfs_panic_recover("zfs: rt=%s: removing segment "
 		    "(offset=%llx size=%llx) not completely overlapped by "
 		    "existing one (offset=%llx size=%llx)",
 		    ZFS_RT_NAME(rt),


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
The change is primarily motivated by https://github.com/openzfs/zfs/issues/13483#issuecomment-3616176362

zfs_range_tree_remove_impl() used a bare panic() when a segment to be removed was not completely overlapped by an existing tree entry. Every other consistency check in range_tree.c uses zfs_panic_recover(), which respects the zfs_recover tunable and allows pools with on-disk corruption to be imported and recovered. This inconsistency made the partial-overlap case unrecoverable regardless of zfs_recover.

Relates-to https://github.com/openzfs/zfs/issues/13483

### Description
Replace the bare panic() in zfs_range_tree_remove_impl() with zfs_panic_recover() so that operators can set zfs_recover=1 to import a corrupted pool and reclaim data, consistent with all other range tree error paths.

The change is a one-line substitution in module/zfs/range_tree.c.

### How Has This Been Tested?
This is untested. I don't have a corrupt pool at hand, nor do I know how to produce one.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
