### PR TITLE
zhack: Fix importing large allocation profiles on small pools

### DIFF
--- a/cmd/zhack.c
+++ b/cmd/zhack.c
@@ -745,8 +745,11 @@ zhack_do_metaslab_leak(int argc, char **argv)
 			    &start, &size), ==, 2);
 
 			ASSERT(vd);
-			metaslab_t *cur =
-			    vd->vdev_ms[start >> vd->vdev_ms_shift];
+			size_t idx;
+			idx = start >> vd->vdev_ms_shift;
+			if (idx >= vd->vdev_ms_count)
+				continue;
+			metaslab_t *cur = vd->vdev_ms[idx];
 			if (prev != cur) {
 				if (prev) {
 					dmu_tx_commit(tx);


### PR DESCRIPTION
This patch fixes a segmentation fault in zhack metaslab leak which might be triggered by feeding zhack with a fragmentation profile that's exported from a pool larger than the target pool.

Fixes: 8f15d2e4d58525e583277ccfef83f2056be4f72e
Sponsored-by: Klara, Inc.
Sponsored-by: Wasabi Technology, Inc.

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context

Currently, if you export an allocation profile from pool A and you import that allocation profile into pool B, then zhack will segfault if pool A was larger than pool B. This patch fixes that.

### Description

The way this fix works is that the allocation profile's allocations targeting metaslabs, which are not present in the pool, are ignored.

### How Has This Been Tested?

I've tested this manually by importing the allocation profile of a larger pool into a smaller pool.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
