### PR TITLE
More consistent use of `TREE_*` macros in AVL comparators

### DIFF
--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -45,21 +45,10 @@ struct launched_process_node {
 static int
 _launched_process_node_compare(const void *x1, const void *x2)
 {
-	pid_t p1;
-	pid_t p2;
+	const struct launched_process_node *node1 = x1;
+	const struct launched_process_node *node2 = x2;
 
-	assert(x1 != NULL);
-	assert(x2 != NULL);
-
-	p1 = ((const struct launched_process_node *) x1)->pid;
-	p2 = ((const struct launched_process_node *) x2)->pid;
-
-	if (p1 < p2)
-		return (-1);
-	else if (p1 == p2)
-		return (0);
-	else
-		return (1);
+	return (TREE_CMP(node1->pid, node2->pid));
 }
 
 static pthread_t _reap_children_tid = (pthread_t)-1;

--- a/cmd/zed/zed_strings.c
+++ b/cmd/zed/zed_strings.c
@@ -42,26 +42,10 @@ typedef struct zed_strings_node zed_strings_node_t;
 static int
 _zed_strings_node_compare(const void *x1, const void *x2)
 {
-	const char *s1;
-	const char *s2;
-	int rv;
+	const zed_strings_node_t *n1 = x1;
+	const zed_strings_node_t *n2 = x2;
 
-	assert(x1 != NULL);
-	assert(x2 != NULL);
-
-	s1 = ((const zed_strings_node_t *) x1)->key;
-	assert(s1 != NULL);
-	s2 = ((const zed_strings_node_t *) x2)->key;
-	assert(s2 != NULL);
-	rv = strcmp(s1, s2);
-
-	if (rv < 0)
-		return (-1);
-
-	if (rv > 0)
-		return (1);
-
-	return (0);
+	return (TREE_ISIGN(strcmp(n1->key, n2->key)));
 }
 
 /*

--- a/cmd/zfs/zfs_iter.c
+++ b/cmd/zfs/zfs_iter.c
@@ -413,14 +413,12 @@ zfs_sort(const void *larg, const void *rarg)
 
 		if (lstr)
 			ret = TREE_ISIGN(strcmp(lstr, rstr));
-		else if (lnum < rnum)
-			ret = -1;
-		else if (lnum > rnum)
-			ret = 1;
+		else
+			ret = TREE_CMP(lnum, rnum);
 
 		if (ret != 0) {
 			if (psc->sc_reverse == B_TRUE)
-				ret = (ret < 0) ? 1 : -1;
+				ret = -ret;
 			return (ret);
 		}
 	}

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -2905,15 +2905,13 @@ us_compare(const void *larg, const void *rarg)
 		uint64_t rv64 = 0;
 		zfs_prop_t prop = sortcol->sc_prop;
 		const char *propname = NULL;
-		boolean_t reverse = sortcol->sc_reverse;
 
 		switch (prop) {
 		case ZFS_PROP_TYPE:
 			propname = "type";
 			(void) nvlist_lookup_uint32(lnvl, propname, &lv32);
 			(void) nvlist_lookup_uint32(rnvl, propname, &rv32);
-			if (rv32 != lv32)
-				rc = (rv32 < lv32) ? 1 : -1;
+			rc = TREE_CMP(lv32, rv32);
 			break;
 		case ZFS_PROP_NAME:
 			propname = "name";
@@ -2923,8 +2921,7 @@ compare_nums:
 				    &lv64);
 				(void) nvlist_lookup_uint64(rnvl, propname,
 				    &rv64);
-				if (rv64 != lv64)
-					rc = (rv64 < lv64) ? 1 : -1;
+				rc = TREE_CMP(lv64, rv64);
 			} else {
 				if ((nvlist_lookup_string(lnvl, propname,
 				    &lvstr) == ENOENT) ||
@@ -2932,7 +2929,7 @@ compare_nums:
 				    &rvstr) == ENOENT)) {
 					goto compare_nums;
 				}
-				rc = strcmp(lvstr, rvstr);
+				rc = TREE_ISIGN(strcmp(lvstr, rvstr));
 			}
 			break;
 		case ZFS_PROP_USED:
@@ -2945,8 +2942,7 @@ compare_nums:
 				propname = "quota";
 			(void) nvlist_lookup_uint64(lnvl, propname, &lv64);
 			(void) nvlist_lookup_uint64(rnvl, propname, &rv64);
-			if (rv64 != lv64)
-				rc = (rv64 < lv64) ? 1 : -1;
+			rc = TREE_CMP(lv64, rv64);
 			break;
 
 		default:
@@ -2954,10 +2950,9 @@ compare_nums:
 		}
 
 		if (rc != 0) {
-			if (rc < 0)
-				return (reverse ? 1 : -1);
-			else
-				return (reverse ? -1 : 1);
+			if (sortcol->sc_reverse)
+				return (-rc);
+			return (rc);
 		}
 	}
 
@@ -2967,9 +2962,8 @@ compare_nums:
 	 * translation where we can have duplicate type/name combinations).
 	 */
 	if (nvlist_lookup_boolean_value(lnvl, "smbentity", &lvb) == 0 &&
-	    nvlist_lookup_boolean_value(rnvl, "smbentity", &rvb) == 0 &&
-	    lvb != rvb)
-		return (lvb < rvb ? -1 : 1);
+	    nvlist_lookup_boolean_value(rnvl, "smbentity", &rvb) == 0)
+		return (TREE_CMP(lvb, rvb));
 
 	return (0);
 }
@@ -5497,11 +5491,11 @@ who_perm_compare(const void *larg, const void *rarg)
 	zfs_deleg_who_type_t rtype = r->who_perm.who_type;
 	int lweight = who_type2weight(ltype);
 	int rweight = who_type2weight(rtype);
-	int res = lweight - rweight;
+	int res = TREE_CMP(lweight, rweight);
 	if (res == 0)
-		res = strncmp(l->who_perm.who_name, r->who_perm.who_name,
-		    ZFS_MAX_DELEG_NAME-1);
-	return (TREE_ISIGN(res));
+		res = TREE_ISIGN(strncmp(l->who_perm.who_name,
+		    r->who_perm.who_name, ZFS_MAX_DELEG_NAME-1));
+	return (res);
 }
 
 static int

--- a/lib/libzdb/libzdb.c
+++ b/lib/libzdb/libzdb.c
@@ -68,35 +68,23 @@ livelist_compare(const void *larg, const void *rarg)
 {
 	const blkptr_t *l = larg;
 	const blkptr_t *r = rarg;
+	int cmp = 0;
 
 	/* Sort them according to dva[0] */
-	uint64_t l_dva0_vdev, r_dva0_vdev;
-	l_dva0_vdev = DVA_GET_VDEV(&l->blk_dva[0]);
-	r_dva0_vdev = DVA_GET_VDEV(&r->blk_dva[0]);
-	if (l_dva0_vdev < r_dva0_vdev)
-		return (-1);
-	else if (l_dva0_vdev > r_dva0_vdev)
-		return (+1);
+	cmp = TREE_CMP(DVA_GET_VDEV(&l->blk_dva[0]),
+	    DVA_GET_VDEV(&r->blk_dva[0]));
+	if (cmp != 0)
+		return (cmp);
 
 	/* if vdevs are equal, sort by offsets. */
-	uint64_t l_dva0_offset;
-	uint64_t r_dva0_offset;
-	l_dva0_offset = DVA_GET_OFFSET(&l->blk_dva[0]);
-	r_dva0_offset = DVA_GET_OFFSET(&r->blk_dva[0]);
-	if (l_dva0_offset < r_dva0_offset) {
-		return (-1);
-	} else if (l_dva0_offset > r_dva0_offset) {
-		return (+1);
-	}
+	cmp = TREE_CMP(DVA_GET_OFFSET(&l->blk_dva[0]),
+	    DVA_GET_OFFSET(&r->blk_dva[0]));
+	if (cmp != 0)
+		return (cmp);
 
 	/*
 	 * Since we're storing blkptrs without cancelling FREE/ALLOC pairs,
 	 * it's possible the offsets are equal. In that case, sort by txg
 	 */
-	if (BP_GET_BIRTH(l) < BP_GET_BIRTH(r)) {
-		return (-1);
-	} else if (BP_GET_BIRTH(l) > BP_GET_BIRTH(r)) {
-		return (+1);
-	}
-	return (0);
+	return (TREE_CMP(BP_GET_BIRTH(l), BP_GET_BIRTH(r)));
 }

--- a/module/icp/core/kcf_mech_tabs.c
+++ b/module/icp/core/kcf_mech_tabs.c
@@ -90,8 +90,8 @@ static int
 kcf_mech_hash_compar(const void *lhs, const void *rhs)
 {
 	const kcf_mech_entry_t *l = lhs, *r = rhs;
-	int cmp = strncmp(l->me_name, r->me_name, CRYPTO_MAX_MECH_NAME);
-	return ((0 < cmp) - (cmp < 0));
+	return (TREE_ISIGN(strncmp(l->me_name, r->me_name,
+	    CRYPTO_MAX_MECH_NAME)));
 }
 
 void

--- a/module/os/freebsd/spl/acl_common.c
+++ b/module/os/freebsd/spl/acl_common.c
@@ -1213,15 +1213,7 @@ static int
 acevals_compare(const void *va, const void *vb)
 {
 	const acevals_t *a = va, *b = vb;
-
-	if (a->key == b->key)
-		return (0);
-
-	if (a->key > b->key)
-		return (1);
-
-	else
-		return (-1);
+	return (TREE_CMP(a->key, b->key));
 }
 
 /*

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -251,16 +251,7 @@ snapentry_compare_by_name(const void *a, const void *b)
 {
 	const zfs_snapentry_t *se_a = a;
 	const zfs_snapentry_t *se_b = b;
-	int ret;
-
-	ret = strcmp(se_a->se_name, se_b->se_name);
-
-	if (ret < 0)
-		return (-1);
-	else if (ret > 0)
-		return (1);
-	else
-		return (0);
+	return (TREE_ISIGN(strcmp(se_a->se_name, se_b->se_name)));
 }
 
 /*
@@ -272,15 +263,10 @@ snapentry_compare_by_objsetid(const void *a, const void *b)
 	const zfs_snapentry_t *se_a = a;
 	const zfs_snapentry_t *se_b = b;
 
-	if (se_a->se_spa != se_b->se_spa)
-		return ((ulong_t)se_a->se_spa < (ulong_t)se_b->se_spa ? -1 : 1);
-
-	if (se_a->se_objsetid < se_b->se_objsetid)
-		return (-1);
-	else if (se_a->se_objsetid > se_b->se_objsetid)
-		return (1);
-	else
-		return (0);
+	int cmp = TREE_PCMP(se_a->se_spa, se_b->se_spa);
+	if (cmp != 0)
+		return (cmp);
+	return (TREE_CMP(se_a->se_objsetid, se_b->se_objsetid));
 }
 
 /*

--- a/module/zfs/dmu_redact.c
+++ b/module/zfs/dmu_redact.c
@@ -176,11 +176,7 @@ objnode_compare(const void *o1, const void *o2)
 {
 	const struct objnode *obj1 = o1;
 	const struct objnode *obj2 = o2;
-	if (obj1->obj < obj2->obj)
-		return (-1);
-	if (obj1->obj > obj2->obj)
-		return (1);
-	return (0);
+	return (TREE_CMP(obj1->obj, obj2->obj));
 }
 
 
@@ -425,11 +421,11 @@ redact_node_compare_start(const void *arg1, const void *arg2)
 	if (rr2->eos_marker)
 		return (-1);
 
-	int cmp = redact_range_compare(rr1->start_object, rr1->start_blkid,
-	    rr1->datablksz, rr2->start_object, rr2->start_blkid,
-	    rr2->datablksz);
+	int cmp = redact_range_compare(
+	    rr1->start_object, rr1->start_blkid, rr1->datablksz,
+	    rr2->start_object, rr2->start_blkid, rr2->datablksz);
 	if (cmp == 0)
-		cmp = (rn1->thread_num < rn2->thread_num ? -1 : 1);
+		cmp = TREE_CMP(rn1->thread_num, rn2->thread_num);
 	return (cmp);
 }
 
@@ -451,11 +447,11 @@ redact_node_compare_end(const void *arg1, const void *arg2)
 	if (srr2->eos_marker)
 		return (-1);
 
-	int cmp = redact_range_compare(srr1->end_object, srr1->end_blkid,
-	    srr1->datablksz, srr2->end_object, srr2->end_blkid,
-	    srr2->datablksz);
+	int cmp = redact_range_compare(
+	    srr1->end_object, srr1->end_blkid, srr1->datablksz,
+	    srr2->end_object, srr2->end_blkid, srr2->datablksz);
 	if (cmp == 0)
-		cmp = (rn1->thread_num < rn2->thread_num ? -1 : 1);
+		cmp = TREE_CMP(rn1->thread_num, rn2->thread_num);
 	return (cmp);
 }
 

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -837,8 +837,7 @@ dsl_bookmark_compare(const void *l, const void *r)
 	    (rdbn->dbn_phys.zbm_flags & ZBM_FLAG_HAS_FBN));
 	if (likely(cmp))
 		return (cmp);
-	cmp = strcmp(ldbn->dbn_name, rdbn->dbn_name);
-	return (TREE_ISIGN(cmp));
+	return (TREE_ISIGN(strcmp(ldbn->dbn_name, rdbn->dbn_name)));
 }
 
 /*

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -259,12 +259,7 @@ spa_crypto_key_compare(const void *a, const void *b)
 {
 	const dsl_crypto_key_t *dcka = a;
 	const dsl_crypto_key_t *dckb = b;
-
-	if (dcka->dck_obj < dckb->dck_obj)
-		return (-1);
-	if (dcka->dck_obj > dckb->dck_obj)
-		return (1);
-	return (0);
+	return (TREE_CMP(dcka->dck_obj, dckb->dck_obj));
 }
 
 /*
@@ -306,12 +301,7 @@ spa_key_mapping_compare(const void *a, const void *b)
 {
 	const dsl_key_mapping_t *kma = a;
 	const dsl_key_mapping_t *kmb = b;
-
-	if (kma->km_dsobj < kmb->km_dsobj)
-		return (-1);
-	if (kma->km_dsobj > kmb->km_dsobj)
-		return (1);
-	return (0);
+	return (TREE_CMP(kma->km_dsobj, kmb->km_dsobj));
 }
 
 static int
@@ -319,12 +309,7 @@ spa_wkey_compare(const void *a, const void *b)
 {
 	const dsl_wrapping_key_t *wka = a;
 	const dsl_wrapping_key_t *wkb = b;
-
-	if (wka->wk_ddobj < wkb->wk_ddobj)
-		return (-1);
-	if (wka->wk_ddobj > wkb->wk_ddobj)
-		return (1);
-	return (0);
+	return (TREE_CMP(wka->wk_ddobj, wkb->wk_ddobj));
 }
 
 void

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -1001,16 +1001,14 @@ livelist_compare(const void *larg, const void *rarg)
 	const blkptr_t *r = &((livelist_entry_t *)rarg)->le_bp;
 
 	/* Sort them according to dva[0] */
-	uint64_t l_dva0_vdev = DVA_GET_VDEV(&l->blk_dva[0]);
-	uint64_t r_dva0_vdev = DVA_GET_VDEV(&r->blk_dva[0]);
-
-	if (l_dva0_vdev != r_dva0_vdev)
-		return (TREE_CMP(l_dva0_vdev, r_dva0_vdev));
+	int cmp = TREE_CMP(DVA_GET_VDEV(&l->blk_dva[0]),
+	    DVA_GET_VDEV(&r->blk_dva[0]));
+	if (cmp != 0)
+		return (cmp);
 
 	/* if vdevs are equal, sort by offsets. */
-	uint64_t l_dva0_offset = DVA_GET_OFFSET(&l->blk_dva[0]);
-	uint64_t r_dva0_offset = DVA_GET_OFFSET(&r->blk_dva[0]);
-	return (TREE_CMP(l_dva0_offset, r_dva0_offset));
+	return (TREE_CMP(DVA_GET_OFFSET(&l->blk_dva[0]),
+	    DVA_GET_OFFSET(&r->blk_dva[0])));
 }
 
 struct livelist_iter_arg {

--- a/module/zfs/dsl_deleg.c
+++ b/module/zfs/dsl_deleg.c
@@ -395,11 +395,7 @@ perm_set_compare(const void *arg1, const void *arg2)
 {
 	const perm_set_t *node1 = (const perm_set_t *)arg1;
 	const perm_set_t *node2 = (const perm_set_t *)arg2;
-	int val;
-
-	val = strcmp(node1->p_setname, node2->p_setname);
-
-	return (TREE_ISIGN(val));
+	return (TREE_ISIGN(strcmp(node1->p_setname, node2->p_setname)));
 }
 
 /*

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -1473,12 +1473,7 @@ static int
 scan_ds_queue_compare(const void *a, const void *b)
 {
 	const scan_ds_t *sds_a = a, *sds_b = b;
-
-	if (sds_a->sds_dsobj < sds_b->sds_dsobj)
-		return (-1);
-	if (sds_a->sds_dsobj == sds_b->sds_dsobj)
-		return (0);
-	return (1);
+	return (TREE_CMP(sds_a->sds_dsobj, sds_b->sds_dsobj));
 }
 
 static void

--- a/module/zfs/refcount.c
+++ b/module/zfs/refcount.c
@@ -57,10 +57,12 @@ zfs_refcount_compare(const void *x1, const void *x2)
 	const reference_t *r1 = (const reference_t *)x1;
 	const reference_t *r2 = (const reference_t *)x2;
 
-	int cmp1 = TREE_CMP(r1->ref_holder, r2->ref_holder);
-	int cmp2 = TREE_CMP(r1->ref_number, r2->ref_number);
-	int cmp = cmp1 ? cmp1 : cmp2;
-	return ((cmp || r1->ref_search) ? cmp : TREE_PCMP(r1, r2));
+	int cmp = TREE_CMP(r1->ref_holder, r2->ref_holder);
+	if (cmp == 0)
+		cmp = TREE_CMP(r1->ref_number, r2->ref_number);
+	if (cmp | r1->ref_search)
+		return (cmp);
+	return (TREE_PCMP(r1, r2));
 }
 
 void

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2616,11 +2616,8 @@ spa_name_compare(const void *a1, const void *a2)
 {
 	const spa_t *s1 = a1;
 	const spa_t *s2 = a2;
-	int s;
 
-	s = strcmp(s1->spa_name, s2->spa_name);
-
-	return (TREE_ISIGN(s));
+	return (TREE_ISIGN(strcmp(s1->spa_name, s2->spa_name)));
 }
 
 void

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -226,10 +226,10 @@ vdev_queue_to_compare(const void *x1, const void *x2)
 	const zio_t *z1 = (const zio_t *)x1;
 	const zio_t *z2 = (const zio_t *)x2;
 
-	int tcmp = TREE_CMP(z1->io_timestamp >> VDQ_T_SHIFT,
+	int cmp = TREE_CMP(z1->io_timestamp >> VDQ_T_SHIFT,
 	    z2->io_timestamp >> VDQ_T_SHIFT);
-	int ocmp = TREE_CMP(z1->io_offset, z2->io_offset);
-	int cmp = tcmp ? tcmp : ocmp;
+	if (cmp == 0)
+		cmp = TREE_CMP(z1->io_offset, z2->io_offset);
 
 	if (likely(cmp | (z1->io_queue_state == ZIO_QS_NONE)))
 		return (cmp);

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -84,11 +84,8 @@ domain_compare(const void *arg1, const void *arg2)
 {
 	const fuid_domain_t *node1 = (const fuid_domain_t *)arg1;
 	const fuid_domain_t *node2 = (const fuid_domain_t *)arg2;
-	int val;
-
-	val = strcmp(node1->f_ksid->kd_name, node2->f_ksid->kd_name);
-
-	return (TREE_ISIGN(val));
+	return (TREE_ISIGN(strcmp(node1->f_ksid->kd_name,
+	    node2->f_ksid->kd_name)));
 }
 
 void

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -910,33 +910,26 @@ zio_bookmark_compare(const void *x1, const void *x2)
 {
 	const zio_t *z1 = x1;
 	const zio_t *z2 = x2;
+	const zbookmark_phys_t *zb1 = &z1->io_bookmark;
+	const zbookmark_phys_t *zb2 = &z2->io_bookmark;
 
-	if (z1->io_bookmark.zb_objset < z2->io_bookmark.zb_objset)
-		return (-1);
-	if (z1->io_bookmark.zb_objset > z2->io_bookmark.zb_objset)
-		return (1);
+	int cmp = TREE_CMP(zb1->zb_objset, zb2->zb_objset);
+	if (cmp != 0)
+		return (cmp);
 
-	if (z1->io_bookmark.zb_object < z2->io_bookmark.zb_object)
-		return (-1);
-	if (z1->io_bookmark.zb_object > z2->io_bookmark.zb_object)
-		return (1);
+	cmp = TREE_CMP(zb1->zb_object, zb2->zb_object);
+	if (cmp != 0)
+		return (cmp);
 
-	if (z1->io_bookmark.zb_level < z2->io_bookmark.zb_level)
-		return (-1);
-	if (z1->io_bookmark.zb_level > z2->io_bookmark.zb_level)
-		return (1);
+	cmp = TREE_CMP(zb1->zb_level, zb2->zb_level);
+	if (cmp != 0)
+		return (cmp);
 
-	if (z1->io_bookmark.zb_blkid < z2->io_bookmark.zb_blkid)
-		return (-1);
-	if (z1->io_bookmark.zb_blkid > z2->io_bookmark.zb_blkid)
-		return (1);
+	cmp = TREE_CMP(zb1->zb_blkid, zb2->zb_blkid);
+	if (cmp != 0)
+		return (cmp);
 
-	if (z1 < z2)
-		return (-1);
-	if (z1 > z2)
-		return (1);
-
-	return (0);
+	return (TREE_PCMP(z1, z2));
 }
 
 /*


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Just some drive-by code uplift.

### Description

Where is it appropriate and obvious, use `TREE_CMP()`, `TREE_ISIGN()` and `TREE_PCMP()` instead of direct comparisons. It can make the code a lot smaller, less error prone, and easier to read.

Commit should be fairly self-explanatory, however there are three functions that have at least caused me to raise an eyebrow:

- `vdev_queue_to_compare()` has a curious construction at the end, where it will always consider two IOs with the same timestamp and offset to be the same if the first one is not queued. At least, I think that is the intent. The same construction is present in `zfs_refcount_compare()`, but there it considered two references with same var and size to be the same during a search. the difference is, `vdev_queue_to_compare()` uses a bitwise OR `|`, while `zfs_refcount_compare()` uses a conditional OR `||`. I don't love this shorthand either way; I'd prefer it written out, but I think `||` is (marginally) more correct for the intent. I didn't want to just change anything, though, in case its load-bearing in ways I'm not seeing.

- `spa_error_entry_compare()` uses `memcmp()` to compare two bookmarks, which isn't _wrong_, I guess, but compare to `zio_bookmark_compare()` or the bottom half of `recent_events_compare()`, where we spell it out. Those read a lot better, I think.

- `zbookmark_compare()` is not directly an AVL comparator, but is wrapped by `scan_prefetch_queue_compare()`, `redact_node_compare_start()` and `redact_node_compare_end()`, which are. It has a set of comparisons near the end that are begging to be converted to `TREE_CMP()`, however note this subtlety:

```c
        /* Now that we have a canonical representation, do the comparison. */
        if (zb1obj != zb2obj)
                return (zb1obj < zb2obj ? -1 : 1);
        else if (zb1L0 != zb2L0)
                return (zb1L0 < zb2L0 ? -1 : 1);
        else if (zb1level != zb2level)
                return (zb1level > zb2level ? -1 : 1);
```

The `zbNlevel` comparison at the end actually has opposite direction to the other two. I can't obviously tell if this is intentional or not.

### How Has This Been Tested?

ZTS run completed on Linux.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
