### PR TITLE
spa_sync_rewrite_vdev_config: update only special vdevs if present

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -252,6 +252,7 @@ CONTRIBUTORS:
     Felix Schmidt <felixschmidt20@aol.com>
     Feng Sun <loyou85@gmail.com>
     Finix Yan <yancw@info2soft.com>
+    Francesco Conti <Pesc0@users.noreply.github.com>
     Francesco Mazzoli <f@mazzo.li>
     Frederik Wessels <wessels147@gmail.com>
     Friedrich Weber <f.weber@proxmox.com>

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -10827,8 +10827,15 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
  *
  * If there are no dirty vdevs, we sync the uberblock to a few random
  * top-level vdevs that are known to be visible in the config cache
- * (see spa_vdev_add() for a complete description). If there *are* dirty
- * vdevs, sync the uberblock to all vdevs.
+ * (see spa_vdev_add() for a complete description). In the presence 
+ * of special vdevs, prefer to update only the vdevs affected by 
+ * the current txg, this allows to keep rotational drives asleep if
+ * not used. Special vdevs will always be updated: given the special
+ * vdev is probably an SSD, there's no expensive head-seek penalty 
+ * when writing uberblocks, and they are an integral part of the pool.
+ *
+ * If there *are* dirty vdevs, sync the config (and uberblock) 
+ * to all vdevs.
  */
 static void
 spa_sync_rewrite_vdev_config(spa_t *spa, dmu_tx_t *tx)
@@ -10850,6 +10857,7 @@ spa_sync_rewrite_vdev_config(spa_t *spa, dmu_tx_t *tx)
 			int svdcount = 0;
 			int children = rvd->vdev_children;
 			int c0 = random_in_range(children);
+			boolean_t has_special_class = spa_has_special(spa);
 
 			for (int c = 0; c < children; c++) {
 				vdev_t *vd =
@@ -10861,7 +10869,10 @@ spa_sync_rewrite_vdev_config(spa_t *spa, dmu_tx_t *tx)
 
 				if (vd->vdev_ms_array == 0 ||
 				    vd->vdev_islog ||
-				    !vdev_is_concrete(vd))
+				    !vdev_is_concrete(vd) ||
+				    (has_special_class && 
+					vd->vdev_alloc_bias != VDEV_BIAS_SPECIAL &&
+					!txg_list_member(&spa->spa_vdev_txg_list, vd, TXG_CLEAN(txg))))
 					continue;
 
 				svd[svdcount++] = vd;


### PR DESCRIPTION
### Motivation and Context
This change allows to write the uberblock preferentially only on special vdevs if any are present during transaction sync. This allows to keep rotational drives asleep if not used.
This is an attempt to implement what @amotin suggested [here](https://github.com/openzfs/zfs/discussions/18265).

### How Has This Been Tested?
This has been tested on a proxmox system and indeed the issue is fixed: the hdd stays asleep. Please keep in mind that I have no knowledge of the system and don't know what I'm doing, this may break other things that i don't know about. I've tried to keep the changes minimal to reduce potential problems.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).