### PR TITLE
Fix vdev_rebuild_range() tx commit

### DIFF
--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -616,7 +616,6 @@ vdev_rebuild_range(vdev_rebuild_t *vr, uint64_t start, uint64_t size)
 		return (SET_ERROR(EINTR));
 	}
 	mutex_exit(&vd->vdev_rebuild_lock);
-	dmu_tx_commit(tx);
 
 	vr->vr_scan_offset[txg & TXG_MASK] = start + size;
 	vr->vr_pass_bytes_issued += size;
@@ -626,6 +625,9 @@ vdev_rebuild_range(vdev_rebuild_t *vr, uint64_t start, uint64_t size)
 	    abd_alloc(psize, B_FALSE), psize, vdev_rebuild_cb, vr,
 	    ZIO_PRIORITY_REBUILD, ZIO_FLAG_RAW | ZIO_FLAG_CANFAIL |
 	    ZIO_FLAG_RESILVER, NULL));
+	/* vdev_rebuild_cb releases SCL_STATE_ALL */
+
+	dmu_tx_commit(tx);
 
 	return (0);
 }


### PR DESCRIPTION
### Motivation and Context

Fix ASSERT observed during a sequential resilver.

```
VERIFY0(pio->io_state[ZIO_WAIT_DONE]) failed (1)
PANIC at zio.c:774:zio_add_child_impl()
Showing stack for process 925188
Call trace:
 dump_backtrace+0xa4/0x150
 show_stack+0x24/0x50
 dump_stack_lvl+0xc8/0x138
 dump_stack+0x1c/0x38
 spl_dumpstack+0x30/0x58 [spl] 
 spl_panic+0xfc/0x120 [spl]
 zio_add_child_impl+0x210/0x380 [zfs]
 zio_create+0x308/0x648 [zfs]
 zio_read+0x8c/0xf0 [zfs]
 vdev_rebuild_range+0x4fc/0xb50 [zfs]
 vdev_rebuild_thread+0x514/0xed0 [zfs]
 thread_generic_wrapper+0x80/0xe8 [spl]
 kthread+0xf8/0x110
 ret_from_fork+0x10/0x20
```

### Description

The spa_sync thread waits on `->spa_txg_zio` and will set `ZIO_WAIT_DONE` before running the sync tasks.  The `dmu_tx_commit()` call must be done after we add the child zio to the `->spa_txg_zio` parent otherwise its possible the child is added after spa_sync has waited.

This change aligns the rebuild code with `vdev_initialize_write()` which operates in the same fashion but already does correctly call `dmx_tx_commit()` after `zio_write_phys()`.

### How Has This Been Tested?

@andriytk was able to reproduce this locally and is planning to verify the proposed fix.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
