### PR TITLE
FreeBSD: Improve dmesg kernel message prefix

### DIFF
--- a/module/os/freebsd/spl/spl_cmn_err.c
+++ b/module/os/freebsd/spl/spl_cmn_err.c
@@ -40,21 +40,21 @@ vcmn_err(int ce, const char *fmt, va_list adx)
 	prefix = NULL; /* silence unwitty compilers */
 	switch (ce) {
 	case CE_CONT:
-		prefix = "Solaris(cont): ";
+		prefix = "zfs(cont): ";
 		break;
 	case CE_NOTE:
-		prefix = "Solaris: NOTICE: ";
+		prefix = "zfs: NOTICE: ";
 		break;
 	case CE_WARN:
-		prefix = "Solaris: WARNING: ";
+		prefix = "zfs: WARNING: ";
 		break;
 	case CE_PANIC:
-		prefix = "Solaris(panic): ";
+		prefix = "zfs(panic): ";
 		break;
 	case CE_IGNORE:
 		break;
 	default:
-		panic("Solaris: unknown severity level");
+		panic("zfs: unknown severity level");
 	}
 	if (ce == CE_PANIC) {
 		vsnprintf(buf, sizeof (buf), fmt, adx);


### PR DESCRIPTION
Provide intuitive log search keywords and increased system consistency by renaming kernel message prefix from "`Solaris:`" to "`zfs:`", matching other drivers.

### Motivation and Context

Solaris is a different operating system, therefore this prefix is lore. On FreeBSD, drivers usually prefix messages with their names. This makes them easier to search for, decreasing operator onboarding time, and increasing system consistency.

### Description

Kernel messages formerly prefixed with `Solaris:` will now be prefixed with `zfs:` instead.

### How Has This Been Tested?

It hasn't. Of course I am using this on my FreeBSD 16.0 laptop, but I'm not hitting these messages. I can not imagine how this could break something reasonable. Note that `make check style` recommended in CONTRIBUTING outputs not found when run in the openzfs root directory.

### Types of changes
- [x] Quality assurance (non-breaking change which makes the information architecture more intuitive)
- [x] Documentation (a change to user facing messages)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated this documentation and see nothing else related.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I did not add [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes because no logic is changing.
- [ ] I did not run the ZFS Test Suite with this change applied because no logic is changing.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).