### PR TITLE
Linux: remove minimum version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,42 @@ We have a [Code of Conduct](./CODE_OF_CONDUCT.md).
 OpenZFS is released under a CDDL license.
 For more details see the NOTICE, LICENSE and COPYRIGHT files; `UCRL-CODE-235197`
 
-# Supported Kernels
-  * The `META` file contains the officially recognized supported Linux kernel versions.
-  * Supported FreeBSD versions are any supported branches and releases starting from 13.0-RELEASE.
+# Supported Kernels and Distributions
+
+## Linux
+
+Given the wide variety of Linux environments, we prioritize development and testing on stable, supported kernels and distributions.
+
+### Kernel ([kernel.org](https://kernel.org))
+
+All **longterm** kernels from [kernel.org](https://kernel.org) are supported. **stable** kernels are usually supported in the next OpenZFS release.
+
+**Supported longterm kernels**: **6.18**, **6.12**, **6.6**, **6.1**, **5.15**, **5.10**.
+
+### Red Hat Enterprise Linux (RHEL)
+
+All RHEL (and compatible systems: AlmaLinux OS, Rocky Linux, etc) on the **full** or **maintenance** support tracks are supported.
+
+**Supported RHEL releases**: **8.10**, **9.7**, **10.1**.
+
+### Ubuntu
+
+All Ubuntu **LTS** releases are supported.
+
+**Supported Ubuntu releases**: **24.04 “Noble”**, **22.04 “Jammy”**.
+
+### Debian
+
+All Debian **stable** and **LTS** releases are supported.
+
+**Supported Debian releases**: **13 “Trixie”**, **12 “Bookworm”**, **11 “Bullseye”**.
+
+### Other Distributions
+
+Generally, if a distribution is following an LTS kernel, it should work well with OpenZFS.
+
+## FreeBSD
+
+All FreeBSD releases receiving **security support** are supported by OpenZFS.
+
+**Supported FreeBSD releases**: **15.0**, **14.3**, **13.5**.

--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -452,13 +452,6 @@ AC_DEFUN([ZFS_AC_KERNEL], [
 
 	AC_MSG_RESULT([$kernsrcver])
 
-	AX_COMPARE_VERSION([$kernsrcver], [ge], [$ZFS_META_KVER_MIN], [], [
-		AC_MSG_ERROR([
-	*** Cannot build against kernel version $kernsrcver.
-	*** The minimum supported kernel version is $ZFS_META_KVER_MIN.
-		])
-	])
-
 	AC_ARG_ENABLE([linux-experimental],
 		AS_HELP_STRING([--enable-linux-experimental],
 		[Allow building against some unsupported kernel versions]))
@@ -900,7 +893,7 @@ AC_DEFUN([ZFS_LINUX_TEST_ERROR], [
 	*** incompatible modifications.
 	***
 	*** ZFS Version: $ZFS_META_ALIAS
-	*** Compatible Kernels: $ZFS_META_KVER_MIN - $ZFS_META_KVER_MAX
+	*** Highest compatible kernel version: $ZFS_META_KVER_MAX
 	])
 ])
 
@@ -1071,7 +1064,7 @@ AC_DEFUN([ZFS_LINUX_REQUIRE_API], [
 		*** APIs.
 		***
 		*** ZFS Version: $ZFS_META_ALIAS
-		*** Compatible Kernels: $ZFS_META_KVER_MIN - $ZFS_META_KVER_MAX
+		*** Highest compatible kernel version: $ZFS_META_KVER_MAX
 		])
 	], [
 		AC_MSG_RESULT(no)


### PR DESCRIPTION
### Motivation and Context

I've been looking at moving the snapshot automount code on Linux from calling out to userspace helpers to directly using the "new" `fscontext` kernel mount API introduced in Linux 5.2. It's working nicely, won't be an issue. So I started looking at the backcompat requirements, for kernels older than that.

The thing is, while we declare a minimum version of 4.18, we only do that because that's the number that RHEL8 asserts. RHEL8 however has backported the `fscontext` API to the RHEL8 kernel, and our configure checks find it and use it just fine. So the minimum version there is not actually doing anything useful.

It's worse though. 4.18 was never a LTS kernel and now does not even compile due to compiler changes. And, every significant kernel or distribution still in support has a base kernel much further forward than that. If we only count releases that are "current" or "long-term" support (ie not an "extended maintenance" or similar), apart from RHEL8 the oldest kernel out there is the 5.10 series in Debian 11 LTS (which is EOL in August 2026).

I think those of us who hang around the kernel support parts of OpenZFS all have a good working understand of what's actually supported. Something like:

- kernel.org longterm series
- RHEL still under support from Red Hat
- Ubuntu LTS

Together I believe that covers basically all distributions of interest ("rolling" distros tend to track kernel.org, Debian always uses a kernel.org longterm series as a base, etc).

So, this PR seeks to lift the minimum requirement, preferring instead to rely on the configure checks - if they pass, then that's good enough.

### Description

Remove the minimum version check.

To make up for the loss of a nice easy version range we can communicate (even if it wasn't quite correct), I've tried to document specific common distros/releases that we do support in the README, but leave it open-ended enough to not put anyone off who might see it and not see their favourite thing there. It's a little bit of extra maintenance required, but shouldn't be onerous - once a year really, when we do a new major release. I volunteer to keep track of it.

I have not removed `Linux-Minimum:` or `ZFS_META_KVER_MIN` outright, because its still used in the dependency fields in `rpm/generic/zfs-dkms.spec.in` and I don't know what the impact is. Ideally they can just be removed, if not, perhaps it can be moved into that file.

### How Has This Been Tested?

Compile checked only.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
