### PR TITLE
zpool clear: remove undocumented rewind flags

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -8300,11 +8300,8 @@ zpool_do_clear(int argc, char **argv)
 		usage(B_FALSE);
 	}
 
-	if (nvlist_alloc(&policy, NV_UNIQUE_NAME, 0) != 0 ||
-	    nvlist_add_uint32(policy, ZPOOL_LOAD_REWIND_POLICY,
-	    ZPOOL_NO_REWIND) != 0) {
+	if (nvlist_alloc(&policy, NV_UNIQUE_NAME, 0) != 0)
 		return (1);
-	}
 
 	pool = argv[0];
 	device = argc == 2 ? argv[1] : NULL;

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4412,7 +4412,8 @@ zpool_clear(zpool_handle_t *zhp, const char *path, nvlist_t *rewindnvl)
 	zc.zc_cookie = policy.zlp_rewind;
 
 	zcmd_alloc_dst_nvlist(hdl, &zc, zhp->zpool_config_size * 2);
-	zcmd_write_src_nvlist(hdl, &zc, rewindnvl);
+	if (rewindnvl != NULL)
+		zcmd_write_src_nvlist(hdl, &zc, rewindnvl);
 
 	while ((error = zfs_ioctl(hdl, ZFS_IOC_CLEAR, &zc)) != 0 &&
 	    errno == ENOMEM)


### PR DESCRIPTION
## Summary
- Remove the `-F`, `-n`, and `-X` flags from `zpool clear`
- These flags were inherited from OpenSolaris but are not applicable in this context — unlike `zpool import`, the pool is already loaded so rewinding to an earlier TXG is not useful
- The rewind policy passed to `zpool_clear()` is now always `ZPOOL_NO_REWIND`

## Test plan
- [x] Built on FreeBSD 16.0-CURRENT (amd64)
- [x] Verified `-F`, `-n`, `-X` are rejected as invalid options
- [x] Verified usage output shows `clear [--power] <pool> [device]`

Closes #13825