### PR TITLE
btree: Fix zdb crashes

### DIFF
--- a/module/zfs/btree.c
+++ b/module/zfs/btree.c
@@ -181,7 +181,10 @@ zfs_btree_init(void)
 void
 zfs_btree_fini(void)
 {
-	kmem_cache_destroy(zfs_btree_leaf_cache);
+	if (zfs_btree_leaf_cache != NULL) {
+		kmem_cache_destroy(zfs_btree_leaf_cache);
+		zfs_btree_leaf_cache = NULL;
+	}
 }
 
 static void *


### PR DESCRIPTION
### Motivation and Context
Fix `slog_replay_fs_002` and possibly other test failures

### Description
At least one codepath calls `zfs_btree_fini()` twice, leading to a zdb crash due to a double free.  This can cause `slog_replay_fs_002` and possibly other tests to fail.  This was most likely caused by d2f5cb3a5.  The fix is to add a check to allow multiple calls to `zfs_btree_fini()`.

### How Has This Been Tested?
Ran local CI and saw most runners pass

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
