### PR TITLE
README: add FreeBSD 14.4-RELEASE alongside 15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ Generally, if a distribution is following an LTS kernel, it should work well wit
 
 ## FreeBSD
 
-All FreeBSD releases receiving **security support** are supported by OpenZFS.
+All FreeBSD releases receiving [security support](https://www.freebsd.org/security/#sup) are supported by OpenZFS.
 
 **Supported FreeBSD releases**: **15.0**, **14.4**, **13.5**.


### PR DESCRIPTION
### Motivation and Context

Consistency with <https://www.freebsd.org/security/#sup>. 14.4 was announced yesterday: 

- https://github.com/freebsd/freebsd-doc/commit/baf4d6cc9cf6a4496e26c6218f0117562be4769e

### Description

Add 14.4.

### How Has This Been Tested?

Not applicable.

### Types of changes

- [X] Documentation (a change to man pages or other documentation)

### Checklist:

- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
