### PR TITLE
config: fix `STATX_MNT_ID` detection

### DIFF
--- a/config/user-statx.m4
+++ b/config/user-statx.m4
@@ -15,6 +15,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_STATX], [
 			AC_MSG_CHECKING([for STATX_MNT_ID])
 			AC_COMPILE_IFELSE([
 				AC_LANG_PROGRAM([[
+					#define _GNU_SOURCE
 					#include <sys/stat.h>
 				]], [[
 					struct statx stx;


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

`statx(2)` requires `_GNU_SOURCE` to be defined in order for `sys/stat.h` to produce a definition for `struct statx` and the `STATX_*` defines. We get that at compile time because we pass `-D_GNU_SOURCE` through to everything, but in the configure check we aren't setting `_GNU_SOURCE`, so we don't find `STATX_MNT_ID`, and so don't set `HAVE_STATX_MNT_ID`.

(This was fine before ccf5a8a6fc, because `linux/stat.h` does not require `_GNU_SOURCE`).

### Description

Simple fix: in the check, define `_GNU_SOURCE` before including `sys/stat.h`.

### How Has This Been Tested?

Compile checked only. I'll be relying on CI to see if any important behaviour changes.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).