### PR TITLE
contrib/debian: add zilstat.1 manpage to installation list

### DIFF
--- a/contrib/debian/openzfs-zfsutils.install
+++ b/contrib/debian/openzfs-zfsutils.install
@@ -44,6 +44,7 @@ usr/share/zfs/compatibility.d/
 usr/share/bash-completion/completions
 usr/share/man/man1/zarcstat.1
 usr/share/man/man1/zhack.1
+usr/share/man/man1/zilstat.1
 usr/share/man/man1/zvol_wait.1
 usr/share/man/man5/
 usr/share/man/man8/fsck.zfs.8


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

CI fix following #18303, caused Debian packaging to fail.

### Description

Add `zilstat.1` to the `openzfs-zfsutils` installation lists.

### How Has This Been Tested?

Not at all, CI will tell.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).