### PR TITLE
libzfs: scrub: only include start and end nv pairs if needed for scrub

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2868,8 +2868,11 @@ zpool_scan_range(zpool_handle_t *zhp, pool_scan_func_t func,
 	nvlist_t *args = fnvlist_alloc();
 	fnvlist_add_uint64(args, "scan_type", (uint64_t)func);
 	fnvlist_add_uint64(args, "scan_command", (uint64_t)cmd);
-	fnvlist_add_uint64(args, "scan_date_start", (uint64_t)date_start);
-	fnvlist_add_uint64(args, "scan_date_end", (uint64_t)date_end);
+	if (date_start != 0 || date_end != 0) {
+		fnvlist_add_uint64(args, "scan_date_start",
+		    (uint64_t)date_start);
+		fnvlist_add_uint64(args, "scan_date_end", (uint64_t)date_end);
+	}
 
 	err = lzc_scrub(ZFS_IOC_POOL_SCRUB, zhp->zpool_name, args, NULL);
 	fnvlist_free(args);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This patch addresses running `zpool scrub <pool>` with ZFS 2.4 userspace while the loaded kernel module is still 2.3, failing with:
```
cannot scrub <pool>: the loaded zfs module does not support an option
for this operation. A reboot may be required to enable this option.
```

This should help users who are still stuck on an older kernel module, while their distribution ships newer ZFS userspace.

This was observed in the Proxmox community forum:
https://forum.proxmox.com/threads/.180467/

### Description
<!--- Describe your changes in detail -->

Checking for the source of the message via `strace` showed the scrub ioctl failing and setting errno to ZFS_ERR_IOC_ARG_UNAVAIL[0]. With that and the comments in `module/zfs/zfs_ioctl.c`[1] commit: 894edd084 seemed like a likely cause for the backward incompatibility.

The corresponding kernelspace code in `module/zfs/zfs_ioctl.c` defaults to a setting of 0 if either parameter is not set, so not providing the nvpairs in case both are 0 should not make a semantic difference.

[0] https://github.com/openzfs/zfs/blob/d35951b18d6e12afeb0d5b0539ff2467ab4bfbcf/include/sys/fs/zfs.h#L1762
[1] https://github.com/openzfs/zfs/blob/d35951b18d6e12afeb0d5b0539ff2467ab4bfbcf/module/zfs/zfs_ioctl.c#L7799
Fixes: 894edd084 ("Add TXG timestamp database")


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Tested by:
* loading zfs.ko in version 2.3.6
* running `zpool scrub testpool` with zpool from master (error occurs)
* running `zpool scrub testpool` with this patch applied (scrub is started)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
