### PR TITLE
statx requires <sys/stat.h> include file

### DIFF
--- a/tests/zfs-tests/cmd/statx.c
+++ b/tests/zfs-tests/cmd/statx.c
@@ -64,7 +64,7 @@ statx(int, const char *, int, unsigned int, void *)
 static inline int
 _statx(int fd, const char *path, int flags, unsigned int mask, void *stx)
 {
-	if (statx)
+	if (&statx != NULL)
 		return (statx(fd, path, flags, mask, stx));
 	else
 		return (syscall(__NR_statx, fd, path, flags, mask, stx));


### PR DESCRIPTION
For usage of statx() function you need to include <sys/stat.h>.

When compiling the testsuite with uClibc-ng >= 1.0.57 you get following gcc error:

tests/zfs-tests/cmd/statx.c:58:1: error: conflicting types for 'statx'; have 'int(int,  const char *, int,  unsigned int,  void *)'
   58 | statx(int, const char *, int, unsigned int, void *)
      | ^~~~~
In file included from /home/wbx/buildroot/br2-zfs/TestZfsUclibc/host/aarch64-buildroot-linux-uclibc/sysroot/usr/include/sys/stat.h:381,
                 from ./lib/libspl/include/os/linux/sys/stat.h:30,
                 from /home/wbx/buildroot/br2-zfs/TestZfsUclibc/host/aarch64-buildroot-linux-uclibc/sysroot/usr/include/fcntl.h:37,
                 from tests/zfs-tests/cmd/statx.c:29:
/home/wbx/buildroot/br2-zfs/TestZfsUclibc/host/aarch64-buildroot-linux-uclibc/sysroot/usr/include/bits/statx.h:98:5: note: previous declaration of 'statx' with type 'int(int,  const char * restrict,  int,  unsigned int,  struct statx * restrict)'
   98 | int statx (int __dirfd, const char *__restrict __path, int __flags,
      |     ^~~~~

The reason is that uClibc-ng before 1.0.56 did not expose statx(). With uClibc-ng 1.0.57 there is a mismatch when <fcntl.h> is included, because uClibc-ng has a transient dependency on <sys/stat.h>. Glibc does not include <sys/stat.h>, but <bits/stat.h> in fcntl.h so the error does not happen here, but not the real statx() from glibc is used in this case.

To make both C libraries happy, only define statx() locally, when no statx is recognized via configure and include the correct header.

The test failure was found by the Buildroot project:
https://gitlab.com/jolivain/buildroot/-/jobs/13308829775#L237
See here this thread for the discussion:
https://lists.buildroot.org/pipermail/buildroot/2026-March/797844.html