### PR TITLE
zilstat: add AUTHORS section to man page

### DIFF
--- a/man/man1/zilstat.1
+++ b/man/man1/zilstat.1
@@ -185,3 +185,7 @@ tree.
 .Sh SEE ALSO
 .Xr zarcstat 1 ,
 .Xr zpool-status 8
+.
+.Sh AUTHORS
+This manual page was written by
+.An Christos Longros Aq Mt chris.longros@gmail.com .


### PR DESCRIPTION
## Summary
- Add an AUTHORS section to the zilstat(1) man page crediting the original
  man page author.

## Testing
- [x] Verified the man page renders correctly with `man ./man/man1/zilstat.1`