### PR TITLE
Linux 7.0: also set setlease handler on directories

### DIFF
--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -1268,6 +1268,7 @@ const struct file_operations zpl_dir_file_operations = {
 	.read		= generic_read_dir,
 	.iterate_shared	= zpl_iterate,
 	.fsync		= zpl_fsync,
+	.setlease	= generic_setlease,
 	.unlocked_ioctl = zpl_ioctl,
 #ifdef CONFIG_COMPAT
 	.compat_ioctl   = zpl_compat_ioctl,


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

@satmandu reported problems accessing a NFS share on a 7.0 kernel, that worked with 6.19. I dug a bit, and here's the result.

### Description

It turns out the kernel can also take directory leases, most notably in the NFS server. Without a `setlease` handler on the directory file ops, attempts to open a directory over NFS can fail with `EINVAL`.

Adding a directory setlease handler was missed in 168023b603. This fixes that, allowing directories to be properly accessed over NFS.

Note that I haven't added anything to the `lease_setlease` test, because directory leases aren't exposed to userspace.

### How Has This Been Tested?

Just a local test. Before patch, on 7.0 on a NFS mount:

```
$ git pull
error: unable to open .git/objects/89: Invalid argument
error: unable to open .git/objects/b4: Invalid argument
error: unable to open .git/objects/72: Invalid argument
error: unable to open .git/objects/09: Invalid argument
error: unable to open .git/objects/af: Invalid argument
error: unable to open .git/objects/da: Invalid argument
error: unable to open .git/objects/7c: Invalid argument
error: unable to open object pack directory: .git/objects/pack: Invalid argument
Already up to date.
```

On 6.19, all fine. With patch, 7.0 also fine. Super!

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
