### PR TITLE
zpool-iostat.8: clarify first report shows per-second averages

### DIFF
--- a/man/man8/zpool-iostat.8
+++ b/man/man8/zpool-iostat.8
@@ -67,8 +67,8 @@ If
 is specified, the command exits after
 .Ar count
 reports are printed.
-The first report printed is always the statistics since boot regardless of
-whether
+The first report printed is always the average per-second
+statistics since boot regardless of whether
 .Ar interval
 and
 .Ar count


### PR DESCRIPTION
## Summary
- Clarify that the first report printed by `zpool iostat` shows average per-second values since boot, not cumulative totals.
Closes #14156

## Testing
- [x] `man -l man/man8/zpool-iostat.8` renders correctly
- [x] CI checkstyle passes

Signed-off-by: Christos Longros <chris.longros@gmail.com>