### PR TITLE
doc: note that resilver progress can exceed 100%

### DIFF
--- a/man/man8/zpool-resilver.8
+++ b/man/man8/zpool-resilver.8
@@ -48,6 +48,9 @@ resilver will be added to the new one.
 This requires the
 .Sy resilver_defer
 pool feature.
+.Pp
+Due to concurrent writes on a live system, it is possible for
+resilver to progress beyond 100% completion.
 .
 .Sh SEE ALSO
 .Xr zpool-iostat 8 ,

--- a/man/man8/zpool-scrub.8
+++ b/man/man8/zpool-scrub.8
@@ -28,7 +28,7 @@
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\" Copyright (c) 2025 Hewlett Packard Enterprise Development LP.
 .\"
-.Dd August 6, 2025
+.Dd March 16, 2026
 .Dt ZPOOL-SCRUB 8
 .Os
 .
@@ -87,7 +87,7 @@ If a resilver is in progress, ZFS does not allow a scrub to be started until the
 resilver completes.
 .Pp
 Note that, due to changes in pool data on a live system, it is possible for
-scrubs to progress slightly beyond 100% completion.
+scrubs and resilvers to progress beyond 100% completion.
 During this period, no completion time estimate will be provided.
 .
 .Sh OPTIONS

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -27,7 +27,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd May 20, 2025
+.Dd March 16, 2026
 .Dt ZPOOL-STATUS 8
 .Os
 .
@@ -63,6 +63,8 @@ If a scrub or resilver is in progress, this command reports the percentage done
 and the estimated time to completion.
 Both of these are only approximate, because the amount of data in the pool and
 the other workloads on the system can change.
+Due to concurrent writes on a live system, it is possible for both scrubs and
+resilvers to progress beyond 100% completion.
 .Bl -tag -width Ds
 .It Fl c Ar script1 Ns Oo , Ns Ar script2 Ns ,… Oc
 Run a script (or scripts) on each vdev and include the output as a new column


### PR DESCRIPTION
Document that both scrubs and resilvers can progress beyond 100% completion due to concurrent writes on a live system. Remove the "slightly" from the existing scrub note as progress can significantly exceed 100%.

Closes #17693