### PR TITLE
linux/super: require `fs_context`, remove support for old mount API

### DIFF
--- a/config/kernel-fs-context.m4
+++ b/config/kernel-fs-context.m4
@@ -29,5 +29,8 @@ AC_DEFUN([ZFS_AC_KERNEL_FS_CONTEXT], [
 		AC_DEFINE(HAVE_FS_CONTEXT, 1, [fs_context exists])
         ],[
 		AC_MSG_RESULT(no)
+		AC_MSG_ERROR([
+	*** This kernel does not have `struct fs_context`. OpenZFS cannot be compiled.
+		])
         ])
 ])

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -36,9 +36,7 @@
 #include <linux/iversion.h>
 #include <linux/version.h>
 #include <linux/vfs_compat.h>
-#ifdef HAVE_FS_CONTEXT
 #include <linux/fs_context.h>
-#endif
 
 /*
  * What to do when the last reference to an inode is released. If 0, the kernel
@@ -508,7 +506,6 @@ zpl_prune_sb(uint64_t nr_to_scan, void *arg)
 #endif
 }
 
-#ifdef HAVE_FS_CONTEXT
 /*
  * Since kernel 5.2, the "new" fs_context-based mount API has been preferred
  * over the traditional file_system_type->mount() and
@@ -559,7 +556,6 @@ zpl_init_fs_context(struct fs_context *fc)
 	fc->ops = &zpl_fs_context_operations;
 	return (0);
 }
-#endif
 
 const struct super_operations zpl_super_operations = {
 	.alloc_inode		= zpl_inode_alloc,
@@ -574,9 +570,6 @@ const struct super_operations zpl_super_operations = {
 	.put_super		= zpl_put_super,
 	.sync_fs		= zpl_sync_fs,
 	.statfs			= zpl_statfs,
-#ifndef HAVE_FS_CONTEXT
-	.remount_fs		= zpl_remount_fs,
-#endif
 	.show_devname		= zpl_show_devname,
 	.show_options		= zpl_show_options,
 	.show_stats		= NULL,
@@ -619,11 +612,7 @@ struct file_system_type zpl_fs_type = {
 #else
 	.fs_flags		= FS_USERNS_MOUNT,
 #endif
-#ifdef HAVE_FS_CONTEXT
 	.init_fs_context	= zpl_init_fs_context,
-#else
-	.mount			= zpl_mount,
-#endif
 	.kill_sb		= zpl_kill_sb,
 };
 

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -370,79 +370,6 @@ zpl_test_super(struct super_block *s, void *data)
 	return (zfsvfs != NULL && os == zfsvfs->z_os);
 }
 
-static struct super_block *
-zpl_mount_impl(struct file_system_type *fs_type, int flags, zfs_mnt_t *zm)
-{
-	struct super_block *s;
-	objset_t *os;
-	boolean_t issnap = B_FALSE;
-	int err;
-
-	err = dmu_objset_hold(zm->mnt_osname, FTAG, &os);
-	if (err)
-		return (ERR_PTR(-err));
-
-	/*
-	 * The dsl pool lock must be released prior to calling sget().
-	 * It is possible sget() may block on the lock in grab_super()
-	 * while deactivate_super() holds that same lock and waits for
-	 * a txg sync.  If the dsl_pool lock is held over sget()
-	 * this can prevent the pool sync and cause a deadlock.
-	 */
-	dsl_dataset_long_hold(dmu_objset_ds(os), FTAG);
-	dsl_pool_rele(dmu_objset_pool(os), FTAG);
-
-	s = sget(fs_type, zpl_test_super, set_anon_super, flags, os);
-
-	/*
-	 * Recheck with the lock held to prevent mounting the wrong dataset
-	 * since z_os can be stale when the teardown lock is held.
-	 *
-	 * We can't do this in zpl_test_super in since it's under spinlock and
-	 * also s_umount lock is not held there so it would race with
-	 * zfs_umount and zfsvfs can be freed.
-	 */
-	if (!IS_ERR(s) && s->s_fs_info != NULL) {
-		zfsvfs_t *zfsvfs = s->s_fs_info;
-		if (zpl_enter(zfsvfs, FTAG) == 0) {
-			if (os != zfsvfs->z_os)
-				err = -SET_ERROR(EBUSY);
-			issnap = zfsvfs->z_issnap;
-			zpl_exit(zfsvfs, FTAG);
-		} else {
-			err = -SET_ERROR(EBUSY);
-		}
-	}
-	dsl_dataset_long_rele(dmu_objset_ds(os), FTAG);
-	dsl_dataset_rele(dmu_objset_ds(os), FTAG);
-
-	if (IS_ERR(s))
-		return (ERR_CAST(s));
-
-	if (err) {
-		deactivate_locked_super(s);
-		return (ERR_PTR(err));
-	}
-
-	if (s->s_root == NULL) {
-		err = zpl_fill_super(s, zm, flags & SB_SILENT ? 1 : 0);
-		if (err) {
-			deactivate_locked_super(s);
-			return (ERR_PTR(err));
-		}
-		s->s_flags |= SB_ACTIVE;
-	} else if (!issnap && ((flags ^ s->s_flags) & SB_RDONLY)) {
-		/*
-		 * Skip ro check for snap since snap is always ro regardless
-		 * ro flag is passed by mount or not.
-		 */
-		deactivate_locked_super(s);
-		return (ERR_PTR(-EBUSY));
-	}
-
-	return (s);
-}
-
 static void
 zpl_kill_sb(struct super_block *sb)
 {
@@ -492,11 +419,78 @@ zpl_parse_monolithic(struct fs_context *fc, void *data)
 static int
 zpl_get_tree(struct fs_context *fc)
 {
-	zfs_mnt_t zm = { .mnt_osname = fc->source, .mnt_data = fc->fs_private };
+	struct super_block *sb;
+	objset_t *os;
+	boolean_t issnap = B_FALSE;
+	int err;
 
-	struct super_block *sb = zpl_mount_impl(fc->fs_type, fc->sb_flags, &zm);
+	err = dmu_objset_hold(fc->source, FTAG, &os);
+	if (err)
+		return (-err);
+
+	/*
+	 * The dsl pool lock must be released prior to calling sget().
+	 * It is possible sget() may block on the lock in grab_super()
+	 * while deactivate_super() holds that same lock and waits for
+	 * a txg sync.  If the dsl_pool lock is held over sget()
+	 * this can prevent the pool sync and cause a deadlock.
+	 */
+	dsl_dataset_long_hold(dmu_objset_ds(os), FTAG);
+	dsl_pool_rele(dmu_objset_pool(os), FTAG);
+
+	sb = sget(fc->fs_type, zpl_test_super, set_anon_super,
+	    fc->sb_flags, os);
+
+	/*
+	 * Recheck with the lock held to prevent mounting the wrong dataset
+	 * since z_os can be stale when the teardown lock is held.
+	 *
+	 * We can't do this in zpl_test_super in since it's under spinlock and
+	 * also s_umount lock is not held there so it would race with
+	 * zfs_umount and zfsvfs can be freed.
+	 */
+	if (!IS_ERR(sb) && sb->s_fs_info != NULL) {
+		zfsvfs_t *zfsvfs = sb->s_fs_info;
+		if (zpl_enter(zfsvfs, FTAG) == 0) {
+			if (os != zfsvfs->z_os)
+				err = SET_ERROR(EBUSY);
+			issnap = zfsvfs->z_issnap;
+			zpl_exit(zfsvfs, FTAG);
+		} else {
+			err = SET_ERROR(EBUSY);
+		}
+	}
+	dsl_dataset_long_rele(dmu_objset_ds(os), FTAG);
+	dsl_dataset_rele(dmu_objset_ds(os), FTAG);
+
 	if (IS_ERR(sb))
 		return (PTR_ERR(sb));
+
+	if (err) {
+		deactivate_locked_super(sb);
+		return (-err);
+	}
+
+	if (sb->s_root == NULL) {
+		zfs_mnt_t zm = {
+		    .mnt_osname = fc->source,
+		    .mnt_data = fc->fs_private,
+		};
+		err = zpl_fill_super(sb, &zm,
+		    fc->sb_flags & SB_SILENT ? 1 : 0);
+		if (err) {
+			deactivate_locked_super(sb);
+			return (-err);
+		}
+		sb->s_flags |= SB_ACTIVE;
+	} else if (!issnap && ((fc->sb_flags ^ sb->s_flags) & SB_RDONLY)) {
+		/*
+		 * Skip ro check for snap since snap is always ro regardless
+		 * ro flag is passed by mount or not.
+		 */
+		deactivate_locked_super(sb);
+		return (-SET_ERROR(EBUSY));
+	}
 
 	struct dentry *root = dget(sb->s_root);
 	if (IS_ERR(root))

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -341,21 +341,6 @@ zpl_show_options(struct seq_file *seq, struct dentry *root)
 }
 
 static int
-zpl_fill_super(struct super_block *sb, void *data, int silent)
-{
-	zfs_mnt_t *zm = (zfs_mnt_t *)data;
-	fstrans_cookie_t cookie;
-	int error;
-
-	cookie = spl_fstrans_mark();
-	error = -zfs_domount(sb, zm, silent);
-	spl_fstrans_unmark(cookie);
-	ASSERT3S(error, <=, 0);
-
-	return (error);
-}
-
-static int
 zpl_test_super(struct super_block *s, void *data)
 {
 	zfsvfs_t *zfsvfs = s->s_fs_info;
@@ -476,12 +461,16 @@ zpl_get_tree(struct fs_context *fc)
 		    .mnt_osname = fc->source,
 		    .mnt_data = fc->fs_private,
 		};
-		err = zpl_fill_super(sb, &zm,
-		    fc->sb_flags & SB_SILENT ? 1 : 0);
+
+		fstrans_cookie_t cookie = spl_fstrans_mark();
+		err = zfs_domount(sb, &zm, fc->sb_flags & SB_SILENT ? 1 : 0);
+		spl_fstrans_unmark(cookie);
+
 		if (err) {
 			deactivate_locked_super(sb);
 			return (-err);
 		}
+
 		sb->s_flags |= SB_ACTIVE;
 	} else if (!issnap && ((fc->sb_flags ^ sb->s_flags) & SB_RDONLY)) {
 		/*

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -267,21 +267,6 @@ zpl_statfs(struct dentry *dentry, struct kstatfs *statp)
 }
 
 static int
-zpl_remount_fs(struct super_block *sb, int *flags, char *data)
-{
-	zfs_mnt_t zm = { .mnt_osname = NULL, .mnt_data = data };
-	fstrans_cookie_t cookie;
-	int error;
-
-	cookie = spl_fstrans_mark();
-	error = -zfs_remount(sb, flags, &zm);
-	spl_fstrans_unmark(cookie);
-	ASSERT3S(error, <=, 0);
-
-	return (error);
-}
-
-static int
 __zpl_show_devname(struct seq_file *seq, zfsvfs_t *zfsvfs)
 {
 	int error;
@@ -458,19 +443,6 @@ zpl_mount_impl(struct file_system_type *fs_type, int flags, zfs_mnt_t *zm)
 	return (s);
 }
 
-static struct dentry *
-zpl_mount(struct file_system_type *fs_type, int flags,
-    const char *osname, void *data)
-{
-	zfs_mnt_t zm = { .mnt_osname = osname, .mnt_data = data };
-
-	struct super_block *sb = zpl_mount_impl(fs_type, flags, &zm);
-	if (IS_ERR(sb))
-		return (ERR_CAST(sb));
-
-	return (dget(sb->s_root));
-}
-
 static void
 zpl_kill_sb(struct super_block *sb)
 {
@@ -506,15 +478,6 @@ zpl_prune_sb(uint64_t nr_to_scan, void *arg)
 #endif
 }
 
-/*
- * Since kernel 5.2, the "new" fs_context-based mount API has been preferred
- * over the traditional file_system_type->mount() and
- * super_operations->remount_fs() callbacks, which were deprectate. In 7.0,
- * those callbacks were removed.
- *
- * Currently, the old-style interface are the only ones we need, so this is
- * a simple compatibility shim to adapt the new API to the old-style calls.
- */
 static int
 zpl_parse_monolithic(struct fs_context *fc, void *data)
 {
@@ -529,8 +492,13 @@ zpl_parse_monolithic(struct fs_context *fc, void *data)
 static int
 zpl_get_tree(struct fs_context *fc)
 {
-	struct dentry *root =
-	    zpl_mount(fc->fs_type, fc->sb_flags, fc->source, fc->fs_private);
+	zfs_mnt_t zm = { .mnt_osname = fc->source, .mnt_data = fc->fs_private };
+
+	struct super_block *sb = zpl_mount_impl(fc->fs_type, fc->sb_flags, &zm);
+	if (IS_ERR(sb))
+		return (PTR_ERR(sb));
+
+	struct dentry *root = dget(sb->s_root);
 	if (IS_ERR(root))
 		return (PTR_ERR(root));
 
@@ -541,7 +509,16 @@ zpl_get_tree(struct fs_context *fc)
 static int
 zpl_reconfigure(struct fs_context *fc)
 {
-	return (zpl_remount_fs(fc->root->d_sb, &fc->sb_flags, fc->fs_private));
+	zfs_mnt_t zm = { .mnt_osname = NULL, .mnt_data = fc->fs_private };
+	fstrans_cookie_t cookie;
+	int error;
+
+	cookie = spl_fstrans_mark();
+	error = -zfs_remount(fc->root->d_sb, &fc->sb_flags, &zm);
+	spl_fstrans_unmark(cookie);
+	ASSERT3S(error, <=, 0);
+
+	return (error);
 }
 
 const struct fs_context_operations zpl_fs_context_operations = {


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Follow #18295, we now don't have to support anything that doesn't have the "new" mount API, so we can start to remove it.

This is the first part, just removing the old API interface and flattening out some of the code.

### Description

- error out if `ZFS_AC_KERNEL_FS_CONTEXT` fails
- remove the old mount/remount entry points gated by `HAVE_FS_CONTEXT`
- flatten the series of functions involved in mount and remount into `zpl_get_tree()` and `zpl_reconfigure()

Note that this PR doesn't go beyond `zpl_super.c`; `zfs_domount()` and `zfs_remount()` are both ripe for further cleanup but are exported, so need a little more though & study first.

### How Has This Been Tested?

Full ZTS run on 6.12.63 completed succesfully. Compile checked on 6.18.12, 5.10.24 and 4.18.0-553.109.1.el8_10.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
