### PR TITLE
CI: Add ARM builder

### DIFF
--- a/.github/workflows/scripts/qemu-3-deps-vm.sh
+++ b/.github/workflows/scripts/qemu-3-deps-vm.sh
@@ -3,8 +3,11 @@
 ######################################################################
 # 3) install dependencies for compiling and loading
 #
-# $1: OS name (like 'fedora41')
-# $2: (optional) Experimental Fedora kernel version, like "6.14" to
+# qemu-3-deps-vm.sh [--poweroff] OS_NAME [FEDORA_VERSION]
+#
+# --poweroff: Power off the VM after installing dependencies
+# OS_NAME: OS name (like 'fedora41')
+# FEDORA_VERSION: (optional) Experimental Fedora kernel version, like "6.14" to
 #     install instead of Fedora defaults.
 ######################################################################
 
@@ -153,6 +156,12 @@ function install_fedora_experimental_kernel {
   sudo dnf -y copr disable @kernel-vanilla/mainline
 }
 
+POWEROFF=""
+if [ "$1" == "--poweroff" ] ; then
+        POWEROFF=1
+        shift
+fi
+
 # Install dependencies
 case "$1" in
   almalinux8)
@@ -212,6 +221,11 @@ case "$1" in
     sudo apt-get install -yq linux-tools-common libtirpc-dev \
       linux-modules-extra-$(uname -r)
     sudo apt-get install -yq dh-sequence-dkms
+
+    # Need 'build-essential' explicitly for ARM builder
+    # https://github.com/actions/runner-images/issues/9946
+    sudo apt-get install -yq build-essential
+
     echo "##[endgroup]"
     echo "##[group]Delete Ubuntu OpenZFS modules"
     for i in $(find /lib/modules -name zfs -type d); do sudo rm -rvf $i; done
@@ -306,5 +320,7 @@ esac
 
 # reset cloud-init configuration and poweroff
 sudo cloud-init clean --logs
-sleep 2 && sudo poweroff &
+if [ "$POWEROFF" == "1" ] ; then
+        sleep 2 && sudo poweroff &
+fi
 exit 0

--- a/.github/workflows/scripts/qemu-4-build-vm.sh
+++ b/.github/workflows/scripts/qemu-4-build-vm.sh
@@ -350,7 +350,16 @@ fi
 # save some sysinfo
 uname -a > /var/tmp/uname.txt
 
-cd $HOME/zfs
+# Check if we're running this script from within a VM or on the runner itself.
+# Most of the time we will be running in a VM, but the ARM builder actually
+# runs this script on the runner.  If we happen to be running on the ARM
+# runner, we will start in the ZFS source directory.  If we're running on a VM
+# then we'll just start in our home directory, and will need to 'cd' into our
+# source directory.
+if [ ! -e META ] ; then
+  cd $HOME/zfs
+fi
+
 export PATH="$PATH:/sbin:/usr/sbin:/usr/local/sbin"
 
 extra=""

--- a/.github/workflows/zfs-arm.yml
+++ b/.github/workflows/zfs-arm.yml
@@ -1,0 +1,40 @@
+name: zfs-arm
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  zfs-arm:
+    name: ZFS ARM build
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Install dependencies
+      timeout-minutes: 20
+      run: |
+        sudo apt-get -y remove firefox || true
+        .github/workflows/scripts/qemu-3-deps-vm.sh ubuntu24
+
+        # We're running the VM scripts locally on the runner, so need to fix
+        # up hostnames to make it work.
+        for ((i=0; i<=3; i++)); do
+          echo "127.0.0.1 vm$i" | sudo tee -a /etc/hosts
+        done
+    - name: Build modules
+      timeout-minutes: 30
+      run: |
+        .github/workflows/scripts/qemu-4-build-vm.sh --enable-debug ubuntu24
+
+        # Quick sanity test since we're not running the full ZTS
+        sudo modprobe zfs
+        sudo dmesg | grep -i zfs
+        truncate -s 100M file
+        sudo zpool create tank ./file
+        zpool status
+
+        echo "Built ZFS successfully on ARM"

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -104,7 +104,7 @@ jobs:
 
     - name: Install dependencies
       timeout-minutes: 60
-      run: .github/workflows/scripts/qemu-3-deps.sh ${{ matrix.os }} ${{ github.event.inputs.fedora_kernel_ver }}
+      run: .github/workflows/scripts/qemu-3-deps.sh --poweroff ${{ matrix.os }} ${{ github.event.inputs.fedora_kernel_ver }}
 
     - name: Build modules
       timeout-minutes: 30


### PR DESCRIPTION
### Motivation and Context
Build ZFS on ARM64

### Description
Do a ZFS build inside of an ARM64 runner.  This only does a simple build, it does not run the test suite.  The build runs on the runner itself rather than in a VM, since nesting is not supported on Github ARM runners.  The run takes ~13min.

### How Has This Been Tested?
Runner built ZFS under ARM, loaded modules, and made a pool.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
