### PR TITLE
man: Fix checking manpages without a full build

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -130,17 +130,18 @@ SUBSTFILES += $(nodist_man_MANS)
 
 MANFILES = $(dist_noinst_man_MANS) $(dist_man_MANS) $(nodist_man_MANS)
 
-PHONY += mancheck
-
 mancheck_verbose = $(mancheck_verbose_@AM_V@)
 mancheck_verbose_ = $(mancheck_verbose_@AM_DEFAULT_V@)
-mancheck_verbose_0 = @echo MANCHECK $(_MTGT);
+mancheck_verbose_0 = @echo MANCHECK $<;
 
-_MTGT = $(subst ^,/,$(subst mancheck-,,$@))
-mancheck-%:
-	$(mancheck_verbose)scripts/mancheck.sh $(_MTGT)
+MANCHECK_TARGETS = $(foreach manfile, $(MANFILES), $(addprefix mancheck-,$(manfile)))
 
-mancheck: $(foreach manfile, $(MANFILES), $(addprefix mancheck-,$(subst /,^,$(manfile))))
+PHONY += $(MANCHECK_TARGETS) mancheck
+
+$(MANCHECK_TARGETS): mancheck-%: %
+	$(mancheck_verbose)scripts/mancheck.sh $<
+
+mancheck: $(MANCHECK_TARGETS)
 
 CHECKS += mancheck
 


### PR DESCRIPTION
Some of the man pages (ex: `man/man8/zed.8`) are generated from `.in` files, and `zed.8.in` *was* a dependency of `zed.8`, but `zed.8` was not a dependency of `mancheck-...zed.8`. This usually worked anyways because a full build had already been run, now it works regardless.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context

I ran into this while working on a small manpage change.

### Description

In the Makefile, for each of the `mancheck-<manfilepath>` targets, add &lt;manfilepath> as a dependency.

### How Has This Been Tested?

```
$ make clean
$ make mancheck
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

"fixing buildscripts" seems like a separate category but I picked the closest.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
