### PR TITLE
zpool-labelclear.8: Warn that it's destructive

### DIFF
--- a/man/man8/zpool-labelclear.8
+++ b/man/man8/zpool-labelclear.8
@@ -50,6 +50,15 @@ is a cache device, it also removes the L2ARC header
 The
 .Ar device
 must not be part of an active pool configuration.
+.Pp
+This overwrites pool metadata, making all data on the
+.Ar device
+inaccessible without specialized recovery tools.
+Unlike
+.Nm zpool Cm destroy ,
+this cannot be undone by ZFS tooling.
+Only use this when you don't care about the data on the
+.Ar device .
 .Bl -tag -width Ds
 .It Fl f
 Treat exported or foreign devices as inactive.

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -108,7 +108,9 @@ specified.
 Destroys the given pool, freeing up any devices for other use.
 .It Xr zpool-labelclear 8
 Removes ZFS label information from the specified
-.Ar device .
+.Ar device ,
+making all data inaccessible without specialized recovery tools.
+Cannot be undone with ZFS tooling.
 .El
 .
 .Ss Virtual Devices


### PR DESCRIPTION
### Motivation and Context

If I could go back in time, I would beg Sun engineers to pick a different name. For those of us who have not read the ZFS On-Disk Specification pdf, it is not at all obvious that clearing a "label" is such a bad thing.

But changing the name would be a breaking change, so at least for now we can update the documentation.

### Description

Add a warning in the manpages `zpool-labelclear.8` and `zpool.8`

### How Has This Been Tested?

`make mancheck-man^man8^zpool{,-labelclear}.8`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
