### PR TITLE
zpool-list.8: clarify that only imported pools are listed

### DIFF
--- a/man/man8/zpool-list.8
+++ b/man/man8/zpool-list.8
@@ -48,7 +48,9 @@
 Lists the given pools along with a health status and space usage.
 If no
 .Ar pool Ns s
-are specified, all pools in the system are listed.
+are specified, all pools currently imported are listed.
+For listing pools available for import, see
+.Xr zpool-import 8 .
 When given an
 .Ar interval ,
 the information is printed every


### PR DESCRIPTION
## Summary
- The man page stated "all pools in the system are listed" which is misleading, as only imported pools are shown
- Clarify this and add a cross-reference to zpool-import(8)

Closes #13650

## Testing
- [x] `man -l man/man8/zpool-list.8` renders correctly
- [x] CI checkstyle passes

Signed-off-by: Christos Longros <chris.longros@gmail.com>