### PR TITLE
pyzfs: update license tags/classifiers

### DIFF
--- a/contrib/pyzfs/setup.py.in
+++ b/contrib/pyzfs/setup.py.in
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #
 # Copyright 2015 ClusterHQ
 #
@@ -25,11 +26,10 @@ setup(
     author="ClusterHQ",
     author_email="support@clusterhq.com",
     url="http://pyzfs.readthedocs.org",
-    license="Apache License, Version 2.0",
+    license="Apache-2.0",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/scripts/spdxcheck.pl
+++ b/scripts/spdxcheck.pl
@@ -147,7 +147,6 @@ my $untagged_patterns = q(
 	contrib/bpftrace/zfs-trace.sh
 	contrib/pyzfs/docs/source/conf.py
 	contrib/pyzfs/libzfs_core/test/__init__.py
-	contrib/pyzfs/setup.py.in
 	contrib/zcp/autosnap.lua
 	scripts/commitcheck.sh
 	scripts/man-dates.sh


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

I got annoyed at this noise in the build:

```
/usr/lib/python3/dist-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```

### Description

The standard for package license metadata[1] is a SPDX identifier in the the `license` and that's all. So, updating that, remove the deprecated license classifier, and adding a tag at the top of the file for spdxcheck to find.

1. https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

### How Has This Been Tested?

Built, observed noise, changed it, built again, observed (relative) silence.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).