### PR TITLE
vdevprops.7: fix slow_io_t default value in documentation

### DIFF
--- a/cmd/zed/agents/zfs_diagnosis.c
+++ b/cmd/zed/agents/zfs_diagnosis.c
@@ -48,8 +48,6 @@
 #define	DEFAULT_CHECKSUM_T	600	/* seconds */
 #define	DEFAULT_IO_N		10	/* events */
 #define	DEFAULT_IO_T		600	/* seconds */
-#define	DEFAULT_SLOW_IO_N	10	/* events */
-#define	DEFAULT_SLOW_IO_T	30	/* seconds */
 
 #define	CASE_GC_TIMEOUT_SECS	43200	/* 12 hours */
 

--- a/man/man7/vdevprops.7
+++ b/man/man7/vdevprops.7
@@ -142,7 +142,17 @@ If the property is only set on the top-level vdev, this value will be used.
 The value of these properties do not persist across vdev replacement.
 For this reason, it is advisable to set the property on the top-level vdev -
 not on the leaf vdev itself.
+The
+.Sy slow_io_n
+and
+.Sy slow_io_t
+properties must be manually set to enable slow I/O diagnosis;
+there are no built-in defaults.
 The default values for
+.Sy checksum_n , checksum_t , io_n ,
+and
+.Sy io_t
+on
 .Sy OpenZFS on Linux
 are 10 errors in 600 seconds.
 For


### PR DESCRIPTION
## Summary
- The man page stated that the default threshold for all events is 10 errors in 600 seconds
- However, `slow_io_t` defaults to 30 seconds, not 600 (see `DEFAULT_SLOW_IO_T` in `cmd/zed/agents/zfs_diagnosis.c`)
- Correct the documentation to distinguish slow I/O defaults from checksum/I/O defaults

Closes #18305

## Testing
- [x] CI checkstyle passes

Signed-off-by: Christos Longros <chris.longros@gmail.com>