### PR TITLE
ci: update FreeBSD CI images from 14.3 to 14.4

### DIFF
--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -96,8 +96,8 @@ case "$OS" in
     KSRC="$FREEBSD_REL/../amd64/$FreeBSD/src.txz"
     NIC="rtl8139"
     ;;
-  freebsd14-3r)
-    FreeBSD="14.3-RELEASE"
+  freebsd14-4r)
+    FreeBSD="14.4-RELEASE"
     OSNAME="FreeBSD $FreeBSD"
     OSv="freebsd14.0"
     URLxz="$FREEBSD_REL/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI.raw.xz"
@@ -111,8 +111,8 @@ case "$OS" in
     KSRC="$FREEBSD_SNAP/../amd64/$FreeBSD/src.txz"
     NIC="rtl8139"
     ;;
-  freebsd14-3s)
-    FreeBSD="14.3-STABLE"
+  freebsd14-4s)
+    FreeBSD="14.4-STABLE"
     OSNAME="FreeBSD $FreeBSD"
     OSv="freebsd14.0"
     URLxz="$FREEBSD_SNAP/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI-ufs.raw.xz"

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -52,11 +52,11 @@ jobs:
             os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora42", "fedora43", "ubuntu22", "ubuntu24"]'
             ;;
           freebsd)
-            os_selection='["freebsd13-5r", "freebsd14-3r", "freebsd13-5s", "freebsd14-3s", "freebsd15-0s", "freebsd16-0c"]'
+            os_selection='["freebsd13-5r", "freebsd14-4r", "freebsd13-5s", "freebsd14-4s", "freebsd15-0s", "freebsd16-0c"]'
             ;;
           *)
             # default list
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora42", "fedora43", "freebsd14-3r", "freebsd15-0s", "freebsd16-0c", "ubuntu22", "ubuntu24"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora42", "fedora43", "freebsd14-4r", "freebsd15-0s", "freebsd16-0c", "ubuntu22", "ubuntu24"]'
             ;;
           esac
 
@@ -98,8 +98,8 @@ jobs:
         # debian:  debian12, debian13, ubuntu22, ubuntu24
         # misc:    archlinux, tumbleweed
         # FreeBSD variants of november 2025:
-        # FreeBSD Release: freebsd13-5r, freebsd14-3r, freebsd15-0r
-        # FreeBSD Stable:  freebsd13-5s, freebsd14-3s, freebsd15-0s
+        # FreeBSD Release: freebsd13-5r, freebsd14-4r, freebsd15-0r
+        # FreeBSD Stable:  freebsd13-5s, freebsd14-4s, freebsd15-0s
         # FreeBSD Current: freebsd16-0c
         os: ${{ fromJson(needs.test-config.outputs.test_os) }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Update the FreeBSD CI images from 14.3 to 14.4 in the QEMU test
script. FreeBSD 14.4-RELEASE CI images are available.

Signed-off-by: Christos Longros <chris.longros@gmail.com>