### PR TITLE
Support bin-sbin merge on Fedora

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -1,4 +1,9 @@
+# Since Fedora 42, Fedora has unified /bin and /sbin. For this to
+# work, we must not override _sbindir
+%if 0%{?fedora} >= 42
+%else
 %global _sbindir    /sbin
+%endif
 %global _libdir     /%{_lib}
 
 # Set the default udev directory based on distribution.
@@ -393,6 +398,7 @@ support for unlocking datasets on user login.
     --with-pammoduledir=%{_libdir}/security \
     --with-python=%{__python} \
     --with-pkgconfigdir=%{_pkgconfigdir} \
+    --with-mounthelperdir=%{_sbindir} \
     --disable-static \
     %{debug} \
     %{debuginfo} \


### PR DESCRIPTION
Starting with Fedora 42, Fedora has been working on merging /bin and /sbin directories. See
https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin

To support this, make sure we do not put files into */sbin directories on these distributions by respecting the distribution set value of %{_sbindir}.

In addition, explicitly set `mounthelperdir`, which affects the placement of `mount.zfs`, which does not respect %{_sbindir} by default. Making it point to %{_sbindir} will allow it to work correctly on Fedora, while keeping its previous directory of `/sbin` on all other distributions.

Note that files that used to reside in */sbin directories on Fedora will stay accessible under these paths, as the distribution maintains symlinks. No changes are needed to external scripts invoking these binaries.