### PR TITLE
Linux 7.0: ensure LSMs get to process mount options

### DIFF
--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -393,9 +393,22 @@ zpl_prune_sb(uint64_t nr_to_scan, void *arg)
 static int
 zpl_parse_monolithic(struct fs_context *fc, void *data)
 {
+	if (data == NULL)
+		return (0);
+
 	/*
-	 * We do options parsing in zfs_domount(); just stash the options blob
-	 * in the fs_context so we can pass it down later.
+	 * Because we supply a .parse_monolithic callback, the kernel does
+	 * no consideration of the options blob at all. Because of this, we
+	 * have to give LSMs a first look at it. They will remove any options
+	 * of interest to them (eg the SELinux *context= options).
+	 */
+	int err = security_sb_eat_lsm_opts((char *)data, &fc->security);
+	if (err)
+		return (err);
+
+	/*
+	 * Whatever is left we stash on in the fs_context so we can pass it
+	 * down to zfs_domount() or zfs_remount() later.
 	 */
 	fc->fs_private = data;
 	return (0);


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Normally, kernel gives any LSM registering a `sb_eat_lsm_opts` hook a first look at mount options coming in from a userspace mount request.  The LSM may process and/or remove any options. Whatever is left is passed to the filesystem.

This is how the dataset properties `context`, `fscontext`, `defcontext` and `rootcontext` are used to configure ZFS mounts for SELinux. libzfs will fetch those properties from the dataset, then add them to the mount options.

In 0f608aa6ca (#18216) we added our own mount shims to cover the loss of the kernel-provided ones. It turns out that if a filesystem provides a `.parse_monolithic`, it is expected to do _all_ mount option parameter processing - the kernel will not get involved at all. Because of that, LSMs are never given a chance to process mount options. The `context` properties are never seen by SELinux, nor are any other options targeting other LSMs.

@tonyhutter @behlendorf I've put "Linux 7.0" on this to assist with backport to 2.4.x; it will be needed with the 7.0 support there. Master branch will have had broken LSM support since #18339 for all kernels, but that's more a FYI than anything else.

@john-cabaj ping, since I know you're prepping for Ubuntu 26.04 on a 7.0-rc kernel at the moment.

### Description

Fix this by calling `security_sb_eat_lsm_opts()` in `zpl_parse_monolithic()`, before we stash the remaining options for `zfs_domount()`.

I've done a fresh read of the `fs_context` shims in 6.19, and I don't think there's anything like this that I've missed. The `.parse_monolithic` shim is functionality equivalent to what's here: offer the options to `security_sb_eat_lsm_opts()`, stash whatever is left.

### How Has This Been Tested?

`zfs_mount` and `zfs_unmount` tags run on 6.18.9. No other testing - I have never used an LSM in my life, and we don't have anything in the test suite using SELinux.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
