### PR TITLE
`linux/super`: reimplement in-kernel mount options parser for `fc_context`

### DIFF
--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, 2018 by Delphix. All rights reserved.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #ifndef	_SYS_FS_ZFS_VFSOPS_H
@@ -244,6 +245,9 @@ extern int zfsvfs_create(const char *name, boolean_t readony, zfsvfs_t **zfvp);
 extern int zfsvfs_create_impl(zfsvfs_t **zfvp, zfsvfs_t *zfsvfs, objset_t *os);
 extern void zfsvfs_free(zfsvfs_t *zfsvfs);
 extern int zfs_check_global_label(const char *dsname, const char *hexsl);
+
+extern vfs_t *zfsvfs_vfs_alloc(void);
+extern void zfsvfs_vfs_free(vfs_t *vfsp);
 
 extern boolean_t zfs_is_readonly(zfsvfs_t *zfsvfs);
 extern int zfs_domount(struct super_block *sb, zfs_mnt_t *zm, int silent);

--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
@@ -74,11 +74,6 @@ typedef struct vfs {
 	kmutex_t	vfs_mntpt_lock;
 } vfs_t;
 
-typedef struct zfs_mnt {
-	const char	*mnt_osname;	/* Objset name */
-	vfs_t		*mnt_opts;	/* Parsed options */
-} zfs_mnt_t;
-
 struct zfsvfs {
 	vfs_t		*z_vfs;		/* generic fs struct */
 	struct super_block *z_sb;	/* generic super_block */
@@ -250,10 +245,11 @@ extern vfs_t *zfsvfs_vfs_alloc(void);
 extern void zfsvfs_vfs_free(vfs_t *vfsp);
 
 extern boolean_t zfs_is_readonly(zfsvfs_t *zfsvfs);
-extern int zfs_domount(struct super_block *sb, zfs_mnt_t *zm, int silent);
+extern int zfs_domount(struct super_block *sb, const char *osname,
+    vfs_t *mntopts, int silent);
 extern void zfs_preumount(struct super_block *sb);
 extern int zfs_umount(struct super_block *sb);
-extern int zfs_remount(struct super_block *sb, int *flags, zfs_mnt_t *zm);
+extern int zfs_remount(struct super_block *sb, vfs_t *mntopts, int flags);
 extern int zfs_statvfs(struct inode *ip, struct kstatfs *statp);
 extern int zfs_vget(struct super_block *sb, struct inode **ipp, fid_t *fidp);
 extern int zfs_prune(struct super_block *sb, unsigned long nr_to_scan,

--- a/include/os/linux/zfs/sys/zfs_vfsops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops_os.h
@@ -76,7 +76,7 @@ typedef struct vfs {
 
 typedef struct zfs_mnt {
 	const char	*mnt_osname;	/* Objset name */
-	char		*mnt_data;	/* Raw mount options */
+	vfs_t		*mnt_opts;	/* Parsed options */
 } zfs_mnt_t;
 
 struct zfsvfs {

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -110,7 +111,15 @@ static const match_table_t zpl_tokens = {
 	{ TOKEN_LAST,		NULL },
 };
 
-static void
+vfs_t *
+zfsvfs_vfs_alloc(void)
+{
+	vfs_t *vfsp = kmem_zalloc(sizeof (vfs_t), KM_SLEEP);
+	mutex_init(&vfsp->vfs_mntpt_lock, NULL, MUTEX_DEFAULT, NULL);
+	return (vfsp);
+}
+
+void
 zfsvfs_vfs_free(vfs_t *vfsp)
 {
 	if (vfsp != NULL) {
@@ -220,8 +229,7 @@ zfsvfs_parse_options(char *mntopts, vfs_t **vfsp)
 	vfs_t *tmp_vfsp;
 	int error;
 
-	tmp_vfsp = kmem_zalloc(sizeof (vfs_t), KM_SLEEP);
-	mutex_init(&tmp_vfsp->vfs_mntpt_lock, NULL, MUTEX_DEFAULT, NULL);
+	tmp_vfsp = zfsvfs_vfs_alloc();
 
 	if (mntopts != NULL) {
 		substring_t args[MAX_OPT_ARGS];

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1323,7 +1323,7 @@ zfs_domount(struct super_block *sb, zfs_mnt_t *zm, int silent)
 	uint64_t recordsize;
 	int error = 0;
 	zfsvfs_t *zfsvfs = NULL;
-	vfs_t *vfs = NULL;
+	vfs_t *vfs = zm->mnt_opts;
 	int canwrite;
 	int dataset_visible_zone;
 
@@ -1341,9 +1341,6 @@ zfs_domount(struct super_block *sb, zfs_mnt_t *zm, int silent)
 		return (SET_ERROR(EPERM));
 	}
 
-	/* XXX temp keep things working during params upgrade */
-	vfs = zfsvfs_vfs_alloc();
-
 	/*
 	 * If a non-writable filesystem is being mounted without the
 	 * read-only flag, pretend it was set, as done for snapshots.
@@ -1352,16 +1349,12 @@ zfs_domount(struct super_block *sb, zfs_mnt_t *zm, int silent)
 		vfs->vfs_readonly = B_TRUE;
 
 	error = zfsvfs_create(osname, vfs->vfs_readonly, &zfsvfs);
-	if (error) {
-		zfsvfs_vfs_free(vfs);
+	if (error)
 		goto out;
-	}
 
 	if ((error = dsl_prop_get_integer(osname, "recordsize",
-	    &recordsize, NULL))) {
-		zfsvfs_vfs_free(vfs);
+	    &recordsize, NULL)))
 		goto out;
-	}
 
 	vfs->vfs_data = zfsvfs;
 	zfsvfs->z_vfs = vfs;
@@ -1443,6 +1436,13 @@ zfs_domount(struct super_block *sb, zfs_mnt_t *zm, int silent)
 out:
 	if (error) {
 		if (zfsvfs != NULL) {
+			/*
+			 * We're returning error, so the caller still owns
+			 * the mount options vfs_t. Remove them from zfsvfs
+			 * so we don't try to free them.
+			 */
+			zfsvfs->z_vfs = NULL;
+
 			dmu_objset_disown(zfsvfs->z_os, B_TRUE, zfsvfs);
 			zfsvfs_free(zfsvfs);
 		}
@@ -1536,7 +1536,7 @@ int
 zfs_remount(struct super_block *sb, int *flags, zfs_mnt_t *zm)
 {
 	zfsvfs_t *zfsvfs = sb->s_fs_info;
-	vfs_t *vfsp;
+	vfs_t *vfsp = zm->mnt_opts;
 	boolean_t issnap = dmu_objset_is_snapshot(zfsvfs->z_os);
 
 	if ((issnap || !spa_writeable(dmu_objset_spa(zfsvfs->z_os))) &&
@@ -1544,9 +1544,6 @@ zfs_remount(struct super_block *sb, int *flags, zfs_mnt_t *zm)
 		*flags |= SB_RDONLY;
 		return (EROFS);
 	}
-
-	/* XXX temp keep things working during params upgrade */
-	vfsp = zfsvfs_vfs_alloc();
 
 	if (!zfs_is_readonly(zfsvfs) && (*flags & SB_RDONLY))
 		txg_wait_synced(dmu_objset_pool(zfsvfs->z_os), 0);

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1316,19 +1316,15 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 static atomic_long_t zfs_bdi_seq = ATOMIC_LONG_INIT(0);
 
 int
-zfs_domount(struct super_block *sb, zfs_mnt_t *zm, int silent)
+zfs_domount(struct super_block *sb, const char *osname,
+    vfs_t *vfs, int silent)
 {
-	const char *osname = zm->mnt_osname;
 	struct inode *root_inode = NULL;
 	uint64_t recordsize;
 	int error = 0;
 	zfsvfs_t *zfsvfs = NULL;
-	vfs_t *vfs = zm->mnt_opts;
 	int canwrite;
 	int dataset_visible_zone;
-
-	ASSERT(zm);
-	ASSERT(osname);
 
 	dataset_visible_zone = zone_dataset_visible(osname, &canwrite);
 
@@ -1533,19 +1529,16 @@ zfs_umount(struct super_block *sb)
 }
 
 int
-zfs_remount(struct super_block *sb, int *flags, zfs_mnt_t *zm)
+zfs_remount(struct super_block *sb, vfs_t *vfsp, int flags)
 {
 	zfsvfs_t *zfsvfs = sb->s_fs_info;
-	vfs_t *vfsp = zm->mnt_opts;
 	boolean_t issnap = dmu_objset_is_snapshot(zfsvfs->z_os);
 
 	if ((issnap || !spa_writeable(dmu_objset_spa(zfsvfs->z_os))) &&
-	    !(*flags & SB_RDONLY)) {
-		*flags |= SB_RDONLY;
+	    !(flags & SB_RDONLY))
 		return (EROFS);
-	}
 
-	if (!zfs_is_readonly(zfsvfs) && (*flags & SB_RDONLY))
+	if (!zfs_is_readonly(zfsvfs) && (flags & SB_RDONLY))
 		txg_wait_synced(dmu_objset_pool(zfsvfs->z_os), 0);
 
 	zfs_unregister_callbacks(zfsvfs);

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -65,52 +65,6 @@
 #include <linux/fs.h>
 #include "zfs_comutil.h"
 
-enum {
-	TOKEN_RO,
-	TOKEN_RW,
-	TOKEN_SETUID,
-	TOKEN_NOSETUID,
-	TOKEN_EXEC,
-	TOKEN_NOEXEC,
-	TOKEN_DEVICES,
-	TOKEN_NODEVICES,
-	TOKEN_DIRXATTR,
-	TOKEN_SAXATTR,
-	TOKEN_XATTR,
-	TOKEN_NOXATTR,
-	TOKEN_ATIME,
-	TOKEN_NOATIME,
-	TOKEN_RELATIME,
-	TOKEN_NORELATIME,
-	TOKEN_NBMAND,
-	TOKEN_NONBMAND,
-	TOKEN_MNTPOINT,
-	TOKEN_LAST,
-};
-
-static const match_table_t zpl_tokens = {
-	{ TOKEN_RO,		MNTOPT_RO },
-	{ TOKEN_RW,		MNTOPT_RW },
-	{ TOKEN_SETUID,		MNTOPT_SETUID },
-	{ TOKEN_NOSETUID,	MNTOPT_NOSETUID },
-	{ TOKEN_EXEC,		MNTOPT_EXEC },
-	{ TOKEN_NOEXEC,		MNTOPT_NOEXEC },
-	{ TOKEN_DEVICES,	MNTOPT_DEVICES },
-	{ TOKEN_NODEVICES,	MNTOPT_NODEVICES },
-	{ TOKEN_DIRXATTR,	MNTOPT_DIRXATTR },
-	{ TOKEN_SAXATTR,	MNTOPT_SAXATTR },
-	{ TOKEN_XATTR,		MNTOPT_XATTR },
-	{ TOKEN_NOXATTR,	MNTOPT_NOXATTR },
-	{ TOKEN_ATIME,		MNTOPT_ATIME },
-	{ TOKEN_NOATIME,	MNTOPT_NOATIME },
-	{ TOKEN_RELATIME,	MNTOPT_RELATIME },
-	{ TOKEN_NORELATIME,	MNTOPT_NORELATIME },
-	{ TOKEN_NBMAND,		MNTOPT_NBMAND },
-	{ TOKEN_NONBMAND,	MNTOPT_NONBMAND },
-	{ TOKEN_MNTPOINT,	MNTOPT_MNTPOINT "=%s" },
-	{ TOKEN_LAST,		NULL },
-};
-
 vfs_t *
 zfsvfs_vfs_alloc(void)
 {
@@ -128,138 +82,6 @@ zfsvfs_vfs_free(vfs_t *vfsp)
 		mutex_destroy(&vfsp->vfs_mntpt_lock);
 		kmem_free(vfsp, sizeof (vfs_t));
 	}
-}
-
-static int
-zfsvfs_parse_option(char *option, int token, substring_t *args, vfs_t *vfsp)
-{
-	switch (token) {
-	case TOKEN_RO:
-		vfsp->vfs_readonly = B_TRUE;
-		vfsp->vfs_do_readonly = B_TRUE;
-		break;
-	case TOKEN_RW:
-		vfsp->vfs_readonly = B_FALSE;
-		vfsp->vfs_do_readonly = B_TRUE;
-		break;
-	case TOKEN_SETUID:
-		vfsp->vfs_setuid = B_TRUE;
-		vfsp->vfs_do_setuid = B_TRUE;
-		break;
-	case TOKEN_NOSETUID:
-		vfsp->vfs_setuid = B_FALSE;
-		vfsp->vfs_do_setuid = B_TRUE;
-		break;
-	case TOKEN_EXEC:
-		vfsp->vfs_exec = B_TRUE;
-		vfsp->vfs_do_exec = B_TRUE;
-		break;
-	case TOKEN_NOEXEC:
-		vfsp->vfs_exec = B_FALSE;
-		vfsp->vfs_do_exec = B_TRUE;
-		break;
-	case TOKEN_DEVICES:
-		vfsp->vfs_devices = B_TRUE;
-		vfsp->vfs_do_devices = B_TRUE;
-		break;
-	case TOKEN_NODEVICES:
-		vfsp->vfs_devices = B_FALSE;
-		vfsp->vfs_do_devices = B_TRUE;
-		break;
-	case TOKEN_DIRXATTR:
-		vfsp->vfs_xattr = ZFS_XATTR_DIR;
-		vfsp->vfs_do_xattr = B_TRUE;
-		break;
-	case TOKEN_SAXATTR:
-		vfsp->vfs_xattr = ZFS_XATTR_SA;
-		vfsp->vfs_do_xattr = B_TRUE;
-		break;
-	case TOKEN_XATTR:
-		vfsp->vfs_xattr = ZFS_XATTR_SA;
-		vfsp->vfs_do_xattr = B_TRUE;
-		break;
-	case TOKEN_NOXATTR:
-		vfsp->vfs_xattr = ZFS_XATTR_OFF;
-		vfsp->vfs_do_xattr = B_TRUE;
-		break;
-	case TOKEN_ATIME:
-		vfsp->vfs_atime = B_TRUE;
-		vfsp->vfs_do_atime = B_TRUE;
-		break;
-	case TOKEN_NOATIME:
-		vfsp->vfs_atime = B_FALSE;
-		vfsp->vfs_do_atime = B_TRUE;
-		break;
-	case TOKEN_RELATIME:
-		vfsp->vfs_relatime = B_TRUE;
-		vfsp->vfs_do_relatime = B_TRUE;
-		break;
-	case TOKEN_NORELATIME:
-		vfsp->vfs_relatime = B_FALSE;
-		vfsp->vfs_do_relatime = B_TRUE;
-		break;
-	case TOKEN_NBMAND:
-		vfsp->vfs_nbmand = B_TRUE;
-		vfsp->vfs_do_nbmand = B_TRUE;
-		break;
-	case TOKEN_NONBMAND:
-		vfsp->vfs_nbmand = B_FALSE;
-		vfsp->vfs_do_nbmand = B_TRUE;
-		break;
-	case TOKEN_MNTPOINT:
-		if (vfsp->vfs_mntpoint != NULL)
-			kmem_strfree(vfsp->vfs_mntpoint);
-		vfsp->vfs_mntpoint = match_strdup(&args[0]);
-		if (vfsp->vfs_mntpoint == NULL)
-			return (SET_ERROR(ENOMEM));
-		break;
-	default:
-		break;
-	}
-
-	return (0);
-}
-
-/*
- * Parse the raw mntopts and return a vfs_t describing the options.
- */
-static int
-zfsvfs_parse_options(char *mntopts, vfs_t **vfsp)
-{
-	vfs_t *tmp_vfsp;
-	int error;
-
-	tmp_vfsp = zfsvfs_vfs_alloc();
-
-	if (mntopts != NULL) {
-		substring_t args[MAX_OPT_ARGS];
-		char *tmp_mntopts, *p, *t;
-		int token;
-
-		tmp_mntopts = t = kmem_strdup(mntopts);
-		if (tmp_mntopts == NULL)
-			return (SET_ERROR(ENOMEM));
-
-		while ((p = strsep(&t, ",")) != NULL) {
-			if (!*p)
-				continue;
-
-			args[0].to = args[0].from = NULL;
-			token = match_token(p, zpl_tokens, args);
-			error = zfsvfs_parse_option(p, token, args, tmp_vfsp);
-			if (error) {
-				kmem_strfree(tmp_mntopts);
-				zfsvfs_vfs_free(tmp_vfsp);
-				return (error);
-			}
-		}
-
-		kmem_strfree(tmp_mntopts);
-	}
-
-	*vfsp = tmp_vfsp;
-
-	return (0);
 }
 
 boolean_t
@@ -1519,9 +1341,8 @@ zfs_domount(struct super_block *sb, zfs_mnt_t *zm, int silent)
 		return (SET_ERROR(EPERM));
 	}
 
-	error = zfsvfs_parse_options(zm->mnt_data, &vfs);
-	if (error)
-		return (error);
+	/* XXX temp keep things working during params upgrade */
+	vfs = zfsvfs_vfs_alloc();
 
 	/*
 	 * If a non-writable filesystem is being mounted without the
@@ -1717,7 +1538,6 @@ zfs_remount(struct super_block *sb, int *flags, zfs_mnt_t *zm)
 	zfsvfs_t *zfsvfs = sb->s_fs_info;
 	vfs_t *vfsp;
 	boolean_t issnap = dmu_objset_is_snapshot(zfsvfs->z_os);
-	int error;
 
 	if ((issnap || !spa_writeable(dmu_objset_spa(zfsvfs->z_os))) &&
 	    !(*flags & SB_RDONLY)) {
@@ -1725,9 +1545,8 @@ zfs_remount(struct super_block *sb, int *flags, zfs_mnt_t *zm)
 		return (EROFS);
 	}
 
-	error = zfsvfs_parse_options(zm->mnt_data, &vfsp);
-	if (error)
-		return (error);
+	/* XXX temp keep things working during params upgrade */
+	vfsp = zfsvfs_vfs_alloc();
 
 	if (!zfs_is_readonly(zfsvfs) && (*flags & SB_RDONLY))
 		txg_wait_synced(dmu_objset_pool(zfsvfs->z_os), 0);
@@ -1740,7 +1559,7 @@ zfs_remount(struct super_block *sb, int *flags, zfs_mnt_t *zm)
 	if (!issnap)
 		(void) zfs_register_callbacks(vfsp);
 
-	return (error);
+	return (0);
 }
 
 int

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -448,7 +448,7 @@ zpl_get_tree(struct fs_context *fc)
 	if (sb->s_root == NULL) {
 		zfs_mnt_t zm = {
 		    .mnt_osname = fc->source,
-		    .mnt_data = NULL,
+		    .mnt_opts = fc->fs_private,
 		};
 
 		fstrans_cookie_t cookie = spl_fstrans_mark();
@@ -459,6 +459,12 @@ zpl_get_tree(struct fs_context *fc)
 			deactivate_locked_super(sb);
 			return (-err);
 		}
+
+		/*
+		 * zfsvfs has taken ownership of the mount options, so we
+		 * need to ensure we don't free them.
+		 */
+		fc->fs_private = NULL;
 
 		sb->s_flags |= SB_ACTIVE;
 	} else if (!issnap && ((fc->sb_flags ^ sb->s_flags) & SB_RDONLY)) {
@@ -481,7 +487,7 @@ zpl_get_tree(struct fs_context *fc)
 static int
 zpl_reconfigure(struct fs_context *fc)
 {
-	zfs_mnt_t zm = { .mnt_osname = NULL, .mnt_data = NULL };
+	zfs_mnt_t zm = { .mnt_osname = NULL, .mnt_opts = fc->fs_private };
 	fstrans_cookie_t cookie;
 	int error;
 
@@ -490,18 +496,80 @@ zpl_reconfigure(struct fs_context *fc)
 	spl_fstrans_unmark(cookie);
 	ASSERT3S(error, <=, 0);
 
+	if (error == 0) {
+		/*
+		 * zfsvfs has taken ownership of the mount options, so we
+		 * need to ensure we don't free them.
+		 */
+		fc->fs_private = NULL;
+	}
+
 	return (error);
+}
+
+static int
+zpl_dup_fc(struct fs_context *fc, struct fs_context *src_fc)
+{
+	vfs_t *src_vfs = src_fc->fs_private;
+	if (src_vfs == NULL)
+		return (0);
+
+	vfs_t *vfs = zfsvfs_vfs_alloc();
+	if (vfs == NULL)
+		return (-SET_ERROR(ENOMEM));
+
+	/*
+	 * This is annoying, but a straight memcpy() would require us to
+	 * reinitialise the lock.
+	 */
+	vfs->vfs_xattr = src_vfs->vfs_xattr;
+	vfs->vfs_readonly = src_vfs->vfs_readonly;
+	vfs->vfs_do_readonly = src_vfs->vfs_do_readonly;
+	vfs->vfs_setuid = src_vfs->vfs_setuid;
+	vfs->vfs_do_setuid = src_vfs->vfs_do_setuid;
+	vfs->vfs_exec = src_vfs->vfs_exec;
+	vfs->vfs_do_exec = src_vfs->vfs_do_exec;
+	vfs->vfs_devices = src_vfs->vfs_devices;
+	vfs->vfs_do_devices = src_vfs->vfs_do_devices;
+	vfs->vfs_do_xattr = src_vfs->vfs_do_xattr;
+	vfs->vfs_atime = src_vfs->vfs_atime;
+	vfs->vfs_do_atime = src_vfs->vfs_do_atime;
+	vfs->vfs_relatime = src_vfs->vfs_relatime;
+	vfs->vfs_do_relatime = src_vfs->vfs_do_relatime;
+	vfs->vfs_nbmand = src_vfs->vfs_nbmand;
+	vfs->vfs_do_nbmand = src_vfs->vfs_do_nbmand;
+
+	mutex_enter(&src_vfs->vfs_mntpt_lock);
+	if (src_vfs->vfs_mntpoint != NULL)
+		vfs->vfs_mntpoint = kmem_strdup(src_vfs->vfs_mntpoint);
+	mutex_exit(&src_vfs->vfs_mntpt_lock);
+
+	fc->fs_private = vfs;
+	return (0);
+}
+
+static void
+zpl_free_fc(struct fs_context *fc)
+{
+	zfsvfs_vfs_free(fc->fs_private);
 }
 
 const struct fs_context_operations zpl_fs_context_operations = {
 	.get_tree		= zpl_get_tree,
 	.reconfigure		= zpl_reconfigure,
+	.dup			= zpl_dup_fc,
+	.free			= zpl_free_fc,
 };
 
 static int
 zpl_init_fs_context(struct fs_context *fc)
 {
+	fc->fs_private = zfsvfs_vfs_alloc();
+	if (fc->fs_private == NULL)
+		return (-SET_ERROR(ENOMEM));
+
 	fc->ops = &zpl_fs_context_operations;
+
 	return (0);
 }
 

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -694,6 +694,128 @@ zpl_parse_param(struct fs_context *fc, struct fs_parameter *param)
 	return (0);
 }
 
+/*
+ * Before Linux 5.8, the kernel's individual parameter parsing had a list of
+ * "forbidden" options that would always be rejected early. These were options
+ * that should be specified by MS_* flags, to be set on the superblock
+ * directly. However, it was inconsistently applied (eg it had various "*atime"
+ * options but not "atime", and also caused problems when it was not in sync
+ * with the version of libmount in use. It was deemed needlessly restrictive
+ * and was dropped in torvalds/linux@9193ae87a8af.
+ *
+ * Unfortunately, some of the options on this list are used by OpenZFS, so
+ * we need to see them. These include the aforementioned "*atime", "dev",
+ * "exec" and "suid".
+ *
+ * There is no easy compile-time check available to detect this, so we use
+ * a simple version check that should make it available everywhere needed,
+ * most notably RHEL8's 4.18+extras, which has backported fs_context support
+ * but does not include the 5.8 commit.
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
+#define	HAVE_FORBIDDEN_SB_FLAGS	1
+#endif
+
+#ifdef HAVE_FORBIDDEN_SB_FLAGS
+/*
+ * The typical path for options parsing through mount(2) is:
+ *
+ *     ksys_mount
+ *     do_mount
+ *     generic_parse_monolithic
+ *     vfs_parse_fs_string
+ *     vfs_parse_fs_param
+ *     zpl_parse_param
+ *
+ * vfs_parse_fs_param() calls the internal vfs_parse_sb_flag(), which is
+ * where the "forbidden" flags are applied. If it makes it through there,
+ * it will later call fc->parse_param() ie zpl_parse_param(). We can't
+ * intercept this chain in the middle anywhere; the earliest thing we can
+ * override is generic_parse_monolithic(), substituting our own by setting
+ * fc->parse_monolithic and doing the parsing work ourselves.
+ *
+ * Fortunately, generic_parse_monolithic() is almost entirely splitting the
+ * incoming parameter string on comma and handing off to the rest of the
+ * pipeline. This is easily replaced (almost entirely by reviving a few bits
+ * of our old options parser).
+ *
+ * To keep the change as narrow as possible, we reuse zpl_param_spec and
+ * zpl_parse_param() as much as possible. Once we've parsed the option, we call
+ * fs_parse(zpl_param_spec) to find out if the option is actually one we
+ * explicitly care about. If it is, we call zpl_parse_param() directly,
+ * avoiding vfs_parse_fs_param() and so the risk of being rejected. If it is
+ * not one we explicitly care about, we call zpl_parse_param() as normal,
+ * letting the kernel reject it if it wishes. If it doesn't, it will end up
+ * back in zpl_parse_param() via fc->parse_param, and we can ignore or warn
+ * about it we normally would.
+ */
+static int
+zpl_parse_monolithic(struct fs_context *fc, void *data)
+{
+	char *mntopts = data;
+
+	if (mntopts == NULL)
+		return (0);
+
+	/*
+	 * Because we supply a .parse_monolithic callback, the kernel does
+	 * no consideration of the options blob at all. Because of this, we
+	 * have to give LSMs a first look at it. They will remove any options
+	 * of interest to them (eg the SELinux *context= options).
+	 */
+	int err = security_sb_eat_lsm_opts(mntopts, &fc->security);
+	if (err)
+		return (err);
+
+	char *key;
+	while ((key = strsep(&mntopts, ",")) != NULL) {
+		if (!*key)
+			continue;
+
+		struct fs_parameter param = {
+		    .key = key,
+		};
+
+		char *value = strchr(key, '=');
+		if (value != NULL) {
+			/* Key starts with '='. Kernel ignores, we will too. */
+			if (value == key)
+				continue;
+			*value++ = '\0';
+
+			/* key=value is a "string" type, set up for that */
+			param.string = value;
+			param.type = fs_value_is_string;
+			param.size = strlen(value);
+		} else {
+			/* unadorned key is a "flag" type */
+			param.type = fs_value_is_flag;
+		}
+
+		/* Check if this is one of our options. */
+		struct fs_parse_result result;
+		int opt = fs_parse(fc, zpl_param_spec, &param, &result);
+		if (opt >= 0) {
+			/*
+			 * We already know this one of our options, so a
+			 * failure here would be nonsensical.
+			 */
+			VERIFY0(zpl_parse_param(fc, &param));
+		} else {
+			/*
+			 * Not one of our option, send it through the kernel's
+			 * standard parameter handling.
+			 */
+			err = vfs_parse_fs_param(fc, &param);
+			if (err < 0)
+				return (err);
+		}
+	}
+
+	return (0);
+}
+#endif /* HAVE_FORBIDDEN_SB_FLAGS */
+
 static int
 zpl_get_tree(struct fs_context *fc)
 {
@@ -867,6 +989,9 @@ zpl_free_fc(struct fs_context *fc)
 }
 
 const struct fs_context_operations zpl_fs_context_operations = {
+#ifdef	HAVE_FORBIDDEN_SB_FLAGS
+	.parse_monolithic	= zpl_parse_monolithic,
+#endif
 	.parse_param		= zpl_parse_param,
 	.get_tree		= zpl_get_tree,
 	.reconfigure		= zpl_reconfigure,

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -37,6 +37,7 @@
 #include <linux/version.h>
 #include <linux/vfs_compat.h>
 #include <linux/fs_context.h>
+#include <linux/fs_parser.h>
 
 /*
  * What to do when the last reference to an inode is released. If 0, the kernel
@@ -390,6 +391,309 @@ zpl_prune_sb(uint64_t nr_to_scan, void *arg)
 #endif
 }
 
+/*
+ * Mount option parsing.
+ *
+ * The kernel receives a set of "stringy" mount options, typically a
+ * comma-separated list through mount(2) or fsconfig(2). These are split into a
+ * set of struct fs_parameter, and then vfs_parse_fs_param() is called for
+ * each. That function will handle (and consume) some options directly, and
+ * other subsystems (mainly security modules) are given the opportunity to
+ * consume them too. Any left over are passed to zpl_parse_param(). Our job is
+ * to use them to fill in the vfs_t we've attached previously to
+ * fc->fs_private, ready for the mount or remount call when it comes.
+ *
+ * Historically, mount options have been generated, removed, modified and
+ * otherwise complicated by multiple different actors over a long time: the
+ * kernel itself, the original mount(8) utility and later libmount,
+ * mount.zfs(8), libzfs and the ZFS tools that use it, and any program using
+ * the various mount APIs that have come and gone over the years. This is
+ * further complicated by cross-pollination between OpenSolaris/illumos, Linux
+ * and FreeBSD. Long story short: we could see all sorts of things, and we need
+ * to at least try not to break old userspace programs.
+ *
+ * At time of writing, this is my best understanding of all the options we
+ * might reasonably see, and where and how they're handled.
+ *
+ *
+ * These are common options for all filesystems that are processed by the
+ * kernel directly, without zpl_parse_param() being called. They're a bit of a
+ * mixed bag, but are ultimately all available to us via either sb->s_flags or
+ * fc->sb_flags:
+ *
+ *	dirsync:	set SB_DIRSYNC
+ *	lazytime:	set SB_LAZYTIME
+ *	mand:		set SB_MANDLOCK
+ *	ro:		set SB_RDONLY
+ *	sync:		set SB_SYNCHRONOUS
+ *
+ *	async:		clear SB_SYNCHRONOUS
+ *	nolazytime:	clear SB_LAZYTIME
+ *	nomand:		clear SB_MANDLOCK
+ *	rw:		clear SB_RDONLY
+ *
+ * Fortunately, almost all of these are handled directly by the kernel. 'mand'
+ * and 'nomand' are swallowed by the kernel ('mand' emits a warning in the
+ * kernel log), but it and the corresponding dataset property have been a no-op
+ * in OpenZFS for years, so there's nothing for us to do there.
+ *
+ * The only tricky one is SB_RDONLY ('ro'/'rw'), which can be both a mount and
+ * a superblock option. While we won't receive the "stringy" options, the
+ * kernel will set it for us in fc->sb_flags, and we've always had special
+ * handling for it at mount and remount time (eg handling snapshot mounts), so
+ * it's not a problem to do nothing here because we will sort it out later.
+ *
+ *
+ * These are options that we may receive as "stringy" options but also as mount
+ * flags.
+ *
+ *	exec:		clear MS_NOEXEC
+ *	noexec:		set MS_NOEXEC
+ *	suid:		clear MS_NOSUID
+ *	nosuid:		set MS_NOSUID
+ *	dev:		clear MS_NODEV
+ *	nodev:		set MS_NODEV
+ *	atime:		clear MS_NOATIME
+ *	noatime:	set MS_NOATIME
+ *	relatime:	set MS_RELATIME
+ *	norelatime:	clear MS_RELATIME
+ *
+ * In testing, it appears that recent libmount will convert them, but our own
+ * mount code (libzfs_mount) may not. We will be called for the stringy
+ * versions, but not for the flags. The flags will later be available on
+ * vfsmount->mnt_flags, not set on the vfs_t. This tends not to matter in
+ * practice, as almost all mounts come through libzfs (via zfs-mount(8) or
+ * mount.zfs(8)) and so as strings, and when they do come through flags, they
+ * will still be reported correctly via mountinfo and by zfs-get(8), which has
+ * special handling for "temporary" properties. Also, we never use these
+ * internally for any decisions; 'exec', 'suid' and 'dev' are handled in the
+ * kernel, and the kernel provides helpers for 'atime' and 'relatime'. The
+ * only place the difference is observable is through zfs_get_temporary_prop(),
+ * which is only used by the zfs.get_prop() Lua call.
+ *
+ * This is fixable by getting at vfsmount->mnt_flags, but this is not readily
+ * available until after the mount operation is completed, and with some
+ * effort. This is all very low impact, so it's left for future improvement.
+ *
+ *
+ * These are true OpenZFS-specific mount options. They give the equivalent
+ * of temporarily setting the pool properties as follows:
+ *
+ *	strictatime	atime=on, relatime=off
+ *
+ *	xattr:		xattr=sa
+ *	saxattr:	xattr=sa
+ *	dirxattr:	xattr=dir
+ *	noxattr:	xattr=off
+ *
+ *
+ * mntpoint= provides the canonical mount point for a snapshot mount. This
+ * is an assist for the snapshot automounter call out to userspace, to
+ * understand where the snapshot is mounted even when triggered from an
+ * alternate mount namespace (eg inside a chroot).
+ *
+ *	mntpoint=	vfs->vfs_mntpoint=...
+ *
+ *
+ * These are used for coordination inside libzfs, and should not make it
+ * to the kernel, but it does not strip them, so we handle them and ignore
+ * them.
+ *
+ *	defaults
+ *	zfsutil
+ *	remount
+ *
+ *
+ * These are specific to SELinux. When that security module is running, it
+ * will consume them, but if not, they will be passed through to us. libzfs
+ * adds them unconditionally, so we will always see them when SELinux is not
+ * running, and ignore them.
+ *
+ *	fscontext
+ *	defcontext
+ *	rootcontext
+ *	context
+ *
+ *
+ * When preparing a remount, libmount will read /proc/self/mountinfo and add
+ * any unrecognised flags it finds there to the options. So, we have to accept
+ * anything that __zpl_show_options() can produce.
+ *
+ *	posixacl
+ *	noacl
+ *	casesensitive
+ *	caseinsensitive
+ *	casemixed
+ *
+ *
+ * mount(8) has a notion of "sloppy" options. According to the documentation,
+ * when the -s switch is provided, unrecognised mount options will be ignored.
+ * Only the Linux NFS and SMB filesystems support it, and traditionally
+ * OpenZFS has too. however, it appears massively underspecified and
+ * inconsistent. Depending on the interplay between mount(8), the mount helper
+ * (eg mount.zfs(8)) and libmount, -s may cause unknown options to be filtered
+ * in userspace, _or_ an additional option 'sloppy' to be passed to the kernel
+ * either before or after the "unknown" option, _or_ nothing at all happens
+ * and the unknown option to be passed through to the kernel as-is. The
+ * kernel NFS and SMB filesystems both expect to see an explicit option
+ * 'sloppy' and use this to either ignore or reject unknown options, but as
+ * described, it's very easy for that option to not appear, or appear too late.
+ *
+ * OpenZFS has a test for this in the test suite, and it's documented in
+ * mount.zfs(8), so to support it we accept 'sloppy' and ignore it, and all
+ * other unknown options produce a notice in the kernel log, and are also
+ * ignored. This allows the "feature" to continue to work, while avoiding
+ * the additional housekeeping for the 'sloppy' option.
+ *
+ *	sloppy
+ *
+ *
+ * Finally, all filesystems get automatic handling for the 'source' option,
+ * that is, the "name" of the filesystem (the first column of df(1)'s output).
+ * However, this only happens if the handler does not otherwise handle
+ * the 'source' option. Since we handle _all_ options because of 'sloppy', we
+ * deal with this explicitly by calling into the kernel's helper for this,
+ * vfs_parse_fs_param_source(), which sets up fc->source.
+ *
+ *	source
+ *
+ *
+ * Thank you for reading this far. I hope you find what you are looking for,
+ * in this life or the next.
+ *
+ *   -- robn, 2026-03-26
+ */
+
+enum {
+	Opt_exec, Opt_suid, Opt_dev,
+	Opt_atime, Opt_relatime, Opt_strictatime,
+	Opt_saxattr, Opt_dirxattr, Opt_noxattr,
+	Opt_mntpoint,
+
+	Opt_ignore, Opt_warn,
+};
+
+static const struct fs_parameter_spec zpl_param_spec[] = {
+	fsparam_flag_no("exec",		Opt_exec),
+	fsparam_flag_no("suid",		Opt_suid),
+	fsparam_flag_no("dev",		Opt_dev),
+
+	fsparam_flag_no("atime",	Opt_atime),
+	fsparam_flag_no("relatime",	Opt_relatime),
+	fsparam_flag("strictatime",	Opt_strictatime),
+
+	fsparam_flag("xattr",		Opt_saxattr),
+	fsparam_flag("saxattr",		Opt_saxattr),
+	fsparam_flag("dirxattr",	Opt_dirxattr),
+	fsparam_flag("noxattr",		Opt_noxattr),
+
+	fsparam_string("mntpoint",	Opt_mntpoint),
+
+	fsparam_flag("defaults",	Opt_ignore),
+	fsparam_flag("zfsutil",		Opt_ignore),
+	fsparam_flag("remount",		Opt_ignore),
+
+	fsparam_string("fscontext",	Opt_ignore),
+	fsparam_string("defcontext",	Opt_ignore),
+	fsparam_string("rootcontext",	Opt_ignore),
+	fsparam_string("context",	Opt_ignore),
+
+	fsparam_flag("posixacl",	Opt_ignore),
+	fsparam_flag("noacl",		Opt_ignore),
+	fsparam_flag("casesensitive",	Opt_ignore),
+	fsparam_flag("caseinsensitive",	Opt_ignore),
+	fsparam_flag("casemixed",	Opt_ignore),
+
+	fsparam_flag("sloppy",		Opt_ignore),
+
+	{}
+};
+
+static int
+zpl_parse_param(struct fs_context *fc, struct fs_parameter *param)
+{
+	vfs_t *vfs = fc->fs_private;
+
+	/* Handle 'source' explicitly so we don't trip on it as an unknown. */
+	int opt = vfs_parse_fs_param_source(fc, param);
+	if (opt != -ENOPARAM)
+		return (opt);
+
+	struct fs_parse_result result;
+	opt = fs_parse(fc, zpl_param_spec, param, &result);
+	if (opt == -ENOPARAM) {
+		/*
+		 * Convert unknowns to warnings, to work around the whole
+		 * "sloppy option" mess.
+		 */
+		opt = Opt_warn;
+	}
+	if (opt < 0)
+		return (opt);
+
+	switch (opt) {
+	case Opt_exec:
+		vfs->vfs_exec = !result.negated;
+		vfs->vfs_do_exec = B_TRUE;
+		break;
+	case Opt_suid:
+		vfs->vfs_setuid = !result.negated;
+		vfs->vfs_do_setuid = B_TRUE;
+		break;
+	case Opt_dev:
+		vfs->vfs_devices = !result.negated;
+		vfs->vfs_do_devices = B_TRUE;
+		break;
+
+	case Opt_atime:
+		vfs->vfs_atime = !result.negated;
+		vfs->vfs_do_atime = B_TRUE;
+		break;
+	case Opt_relatime:
+		vfs->vfs_relatime = !result.negated;
+		vfs->vfs_do_relatime = B_TRUE;
+		break;
+	case Opt_strictatime:
+		vfs->vfs_atime = B_TRUE;
+		vfs->vfs_do_atime = B_TRUE;
+		vfs->vfs_relatime = B_FALSE;
+		vfs->vfs_do_relatime = B_TRUE;
+		break;
+
+	case Opt_saxattr:
+		vfs->vfs_xattr = ZFS_XATTR_SA;
+		vfs->vfs_do_xattr = B_TRUE;
+		break;
+	case Opt_dirxattr:
+		vfs->vfs_xattr = ZFS_XATTR_DIR;
+		vfs->vfs_do_xattr = B_TRUE;
+		break;
+	case Opt_noxattr:
+		vfs->vfs_xattr = ZFS_XATTR_OFF;
+		vfs->vfs_do_xattr = B_TRUE;
+		break;
+
+	case Opt_mntpoint:
+		if (vfs->vfs_mntpoint != NULL)
+			kmem_strfree(vfs->vfs_mntpoint);
+		vfs->vfs_mntpoint = kmem_strdup(param->string);
+		break;
+
+	case Opt_ignore:
+		break;
+
+	case Opt_warn:
+		cmn_err(CE_NOTE,
+		    "ZFS: ignoring unknown mount option: %s", param->key);
+		break;
+
+	default:
+		return (-SET_ERROR(EINVAL));
+	}
+
+	return (0);
+}
+
 static int
 zpl_get_tree(struct fs_context *fc)
 {
@@ -446,9 +750,17 @@ zpl_get_tree(struct fs_context *fc)
 	}
 
 	if (sb->s_root == NULL) {
+		vfs_t *vfs = fc->fs_private;
+
+		/* Apply readonly flag as mount option */
+		if (fc->sb_flags & SB_RDONLY) {
+			vfs->vfs_readonly = B_TRUE;
+			vfs->vfs_do_readonly = B_TRUE;
+		}
+
 		zfs_mnt_t zm = {
 		    .mnt_osname = fc->source,
-		    .mnt_opts = fc->fs_private,
+		    .mnt_opts = vfs,
 		};
 
 		fstrans_cookie_t cookie = spl_fstrans_mark();
@@ -555,6 +867,7 @@ zpl_free_fc(struct fs_context *fc)
 }
 
 const struct fs_context_operations zpl_fs_context_operations = {
+	.parse_param		= zpl_parse_param,
 	.get_tree		= zpl_get_tree,
 	.reconfigure		= zpl_reconfigure,
 	.dup			= zpl_dup_fc,

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -880,13 +880,9 @@ zpl_get_tree(struct fs_context *fc)
 			vfs->vfs_do_readonly = B_TRUE;
 		}
 
-		zfs_mnt_t zm = {
-		    .mnt_osname = fc->source,
-		    .mnt_opts = vfs,
-		};
-
 		fstrans_cookie_t cookie = spl_fstrans_mark();
-		err = zfs_domount(sb, &zm, fc->sb_flags & SB_SILENT ? 1 : 0);
+		err = zfs_domount(sb, fc->source, vfs,
+		    fc->sb_flags & SB_SILENT ? 1 : 0);
 		spl_fstrans_unmark(cookie);
 
 		if (err) {
@@ -921,12 +917,11 @@ zpl_get_tree(struct fs_context *fc)
 static int
 zpl_reconfigure(struct fs_context *fc)
 {
-	zfs_mnt_t zm = { .mnt_osname = NULL, .mnt_opts = fc->fs_private };
 	fstrans_cookie_t cookie;
 	int error;
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_remount(fc->root->d_sb, &fc->sb_flags, &zm);
+	error = -zfs_remount(fc->root->d_sb, fc->fs_private, fc->sb_flags);
 	spl_fstrans_unmark(cookie);
 	ASSERT3S(error, <=, 0);
 

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -391,30 +391,6 @@ zpl_prune_sb(uint64_t nr_to_scan, void *arg)
 }
 
 static int
-zpl_parse_monolithic(struct fs_context *fc, void *data)
-{
-	if (data == NULL)
-		return (0);
-
-	/*
-	 * Because we supply a .parse_monolithic callback, the kernel does
-	 * no consideration of the options blob at all. Because of this, we
-	 * have to give LSMs a first look at it. They will remove any options
-	 * of interest to them (eg the SELinux *context= options).
-	 */
-	int err = security_sb_eat_lsm_opts((char *)data, &fc->security);
-	if (err)
-		return (err);
-
-	/*
-	 * Whatever is left we stash on in the fs_context so we can pass it
-	 * down to zfs_domount() or zfs_remount() later.
-	 */
-	fc->fs_private = data;
-	return (0);
-}
-
-static int
 zpl_get_tree(struct fs_context *fc)
 {
 	struct super_block *sb;
@@ -472,7 +448,7 @@ zpl_get_tree(struct fs_context *fc)
 	if (sb->s_root == NULL) {
 		zfs_mnt_t zm = {
 		    .mnt_osname = fc->source,
-		    .mnt_data = fc->fs_private,
+		    .mnt_data = NULL,
 		};
 
 		fstrans_cookie_t cookie = spl_fstrans_mark();
@@ -505,7 +481,7 @@ zpl_get_tree(struct fs_context *fc)
 static int
 zpl_reconfigure(struct fs_context *fc)
 {
-	zfs_mnt_t zm = { .mnt_osname = NULL, .mnt_data = fc->fs_private };
+	zfs_mnt_t zm = { .mnt_osname = NULL, .mnt_data = NULL };
 	fstrans_cookie_t cookie;
 	int error;
 
@@ -518,7 +494,6 @@ zpl_reconfigure(struct fs_context *fc)
 }
 
 const struct fs_context_operations zpl_fs_context_operations = {
-	.parse_monolithic	= zpl_parse_monolithic,
 	.get_tree		= zpl_get_tree,
 	.reconfigure		= zpl_reconfigure,
 };


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

This PR removes the old mount options parser in favour of a new simpler one that uses the standard kernel facilities. It also moves mount options setup onto `fs_context`, where the kernel expects it, and before the mount/remount operation proper.

This ultimately results in much less code, and a much easier to understand process: `fs_context` is constructed for mount or remount as a kind of “intent”, and the options are configured as part of this. Once complete, the entire thing is handed to mount/remount to “instantiate”.

Along the way, all possible mount options have been identified and documented, even ones that shouldn’t be there but are because of historical bugs in deployed systems, that we must still support.

This is foundational work for other mount-related branches I have in progress:

- making snapshot automounting not call out to userspace tools to effect the change, but rather, using the in-kernel APIs. Setting up the intent fully before the mount makes that work far more tractable, as does not having to stringify a complete set of mount options to send out to userspace, only to parse them again on the way back
- vastly simplifying the work required by the userspace tools with respect to mounts. Right now there is ad-hoc option manipulation all through the code, which makes it very difficult to make any change, and it also has to then consider what the kernel will do as well. If we keep the kernel as the source of truth, then all userspace has to do is say what it wants, not how to get there, and a lot of nonsense can be removed
- moving userspace to use libmount directly, which already knows most of the Linux quirks
- removing entirely or vastly simplifying the `mount.zfs` helper tool; there’s likely no reason that it even has to exist, because the kernel will alway understand everything it needs to.

The last one is key - it also means that other programs using syscalls like `mount(2)` or `fsconfig(2)` can pretty much work as expected, without needing the ZFS userspace tools.

That additional work is context for quirks you may see. For example, `vfs->vfs_mntpt` and its lock is only there to support the weird way we do snapshot automounts; with those moved in-kernel, that can go away. There’s also stuff left over to support other things, like temporary properties. These can and should be fixed up, but is out of scope for this PR.

Regardless of above, I think this PR stands on its own at least as a nice cleanup.

### Description

To aid review, I’ve put this together as a series of commits that removes the old parser first, then prepares for the new, adds it, and cleans up. Since the whole deal with mounts is complex and was new to me not so long ago, I’ll start here with a light explainer which I also hope will help with review, or at the very least, let you see the ways I may have misunderstood things! After that, a bit more of what we’re doing and why, and then the commit detail.

#### Background: mount requests and `vfs_t`

Ultimately, all of this PR is about how and when `vfs_t` is set up.

`vfs_t` ([once known as `zfs_mntopts_t`](https://github.com/openzfs/zfs/commit/1c2555ef926521671eaca918f0aaaa97dbef02af)) tracks the ZFS-related options set on a given mountpoint. This is done, in part, to have a place to coordinate mount-specific dataset properties (such as `xattr` , `readonly`, etc), so that changing a property (`zfs-set`) will change the mount, and changing the mount (`mount -o`) will change the properties.

Before this PR, `vfs_t` is been allocated and populated in `zfs_domount()` and `zfs_remount()`, and then attached to the completed `zfsvfs_t` or discarded if the operation fails. This is more-or-less a requirement of how the legacy mount API in the kernel worked - the `mount()` syscall passes in an opaque blob for options (effectively the raw bytes of the `-o` switch to `mount(8)`), so the filesystem mount callback has to do everything on the spot.

Kernel 5.2 introduced the “new” mount API. This separated the “setup” for the mount/remount operation and the operation itself into two parts, connected by `struct fs_context`. This is a version of the [[builder pattern](https://en.wikipedia.org/wiki/Builder_pattern)](https://en.wikipedia.org/wiki/Builder_pattern): create and modify a configuration object describing the thing you want, and when its done, apply it. One of the features of the new API is to allow standard mount options to be parsed and applied one at a time. Rather than every filesystem receiving a blob and having to handle it on its own, it can instead provide a `.parse_param` callback, which instructs the kernel to do that and pass the options to the callback one-at-a-time. A helper facility lets the filesystem provide a description of the valid options, which the kernel can then validate and convert into simple structs, so the filesystem side can do almost no string parsing. The result is much smaller, simpler code for the filesystem, and very little potential for parsing bugs.

For backward-compatibility, a `.parse_monolithic` callback is available, which does it the old way - the just hands the whole lot to the filesystem to take care of. This is what we’ve been using since 5.2, first through the kernel’s own backcompat shims and, since 0f608aa6ca, our own shims. Our shim is set up understanding that the old API was a one-shot call to process the options and do the mount, so `zpl_parse_monolithic()` does nothing except stash the raw options blob in `fs_context.fs_private`, to be retrieved by `zpl_get_tree()`/`zpl_reconfigure()` (the “new” API entry points for the old `mount` and `remount` ops) and passed on to `zfs_domount()` and `zfs_remount()`.

#### What we’re changing

So that’s where we are before this PR. This PR is making two changes:

- separating the options parsing from the actual mount operation. That is, instead of parsing the options into `vfs_t` inside `zfs_domount()`/`zfs_remount()`, we do it before those are called, and present a fully-formed `vfs_t` to them to use.
- changing from using `.parse_monolithic` to `.parse_param`; that is, accepting fully parsed options from the kernel to apply, rather than pulling apart the raw options blob ourselves.

These changes don’t have to be done together. We don’t _have_ to switch to the kernel’s parser, we could wire our old one up to `.parse_monolithic` and set up `vfs_t` that way. Or, we could go the other way, and at least partially switch to using the kernel’s parser from inside `zfs_domount()`/`zfs_remount()`. However, its attractive to do them both at the same time.

The kernel’s parser is set up assuming it will call `.parse_param`. We could use the option matching parts only if we kept some of our own parsing code (eg comma-splitting) but string processing code in the kernel is both very boring and very important not to get wrong. It’s much nicer for us to use the same system that everyone else does. But, using that system means moving the options processing before the mount/remount call.

The other benefit to switching to the kernel parser is that it allows the kernel and other subsystem to using the kernel parser is that there are some options that are common to all filesystems and entirely implemented in the VFS, and there are some options that require special handling because they touch more than just the mount. Without that, we have to take care of informing the kernel of these things, if we even know about them.

(Fun fact: as I was writing this I had a strange sinking feeling. I went and looked and sure enough; the shim I added in 0f608aa6ca missed something: it doesn’t give security modules a first look at the options, which will break SELinux. Fix PR is in #18376 and makes exactly my point).

This cleanup alone would probably make it worth doing, but the real win in the future is going to come from having the options fully set up on the context, because that enables us to create new mounts directly from inside the kernel. Right now the snapshot automount facility (what you get when you `cd /mypool/mydataset/.zfs/snapshot/mysnapshot`) works by spinning up a userspace process from inside the kernel and executing `mount(8)`. Long ago this was necessary as the only path into the mount system in the kernel was through the front door: the `mount(2)` syscall.

These days, we can actually do this entirely inside the kernel, by creating a `struct fs_context` with `fs_context_for_*()`, setting the options we want with `vfs_parse_fs_string()`, and then creating the mount with `fc_mount()`. There are other functions available that let us copy options from another (active) mount, apply defaults, etc. Without this, we have to build a complete comma-separated options strings and just force it in through `generic_parse_monolithic()`. I have it prototyped both ways, the monolithic version is complicated. We get a lot more control doing it the “right” way.

So basically, doing it the way the kernel expects is better for us and better for the kernel.

The other nice side effect of redoing the parser is that is a good opportunity to audit the existing options we use and we see from userspace, and write everything down. The biggest part of this entire PR is a massive comment that tries to describe everything I know about. This knowledge is obviously good to have written down, but is also info I needed for the userspace mount work I’m doing in elsewhere.

And yes, its more reading for you. Thank you :bow:

#### Commit summary

The commits are laid out in a slightly odd order, because I wanted it to keep compiling at each step (though not running), as well as have a logical order for review. But mostly, its “remove the old”, then “add the new”.

##### `linux/vfsops: add vfs_t allocator, make public`

`vfs_t` was only ever allocated and freed inside `zfs_vfsops.c`, but we’re about to start allocating in `zpl_super.c` and freeing in both (`zpl_super` for failed contexts, `zfs_vfsops` during filesystem unmount). Just adding an allocator function for symmetry and exposing it to keep things tidy.

##### `linux/vfsops: remove old options parser`

Just ripping it all out. It’s not a lot of code really. The main quirk in this commit is replacing the calls to `zfsvfs_parse_options()` with `zfsvfs_vfs_alloc()`, just to keep the build running.

##### `linux/super: remove zpl_parse_monolithic`

Removing the function, its hook points, and the use of `mnt_data` for the raw options blob. This commit is hardly worth it, but it keeps these changes out of the next diffs.

##### `linux/super: match vfs_t lifetime to fs_context`

This commit sets up the lifetime changes for `vfs_t`. The idea is that its is owned by the `fs_context`, and so allocated and freed (and duplicated!) along with it. While the `fs_context` has it, it lives in `fc->fs_private`.

At mount/remount time, its passed to the actual work function in `zfs_mnt_t.mnt_opts`, previously named `mnt_data`. If the op succeeds, that function has taking ownership of it by moving it to `zfsvfs_t.z_vfs`, and the caller clears `fs_private` to avoid freeing it in `zpl_free_fc()`. If the op fails, then it remains with the context and is freed there.

##### `linux/super: implement new mount params parser`

The main part. The parser itself very close in shape to the old one (there’s only so many ways you can set a bunch of flags). The main thing here is the ~200 lines of commentary describing everything I know about the possible options.

##### `linux/super: work around kernels that enforce "forbidden" mount options`

Before Linux 5.8 (torvalds/linux@9193ae87a8af), the kernel would outright reject a fixed set of string parameters, expecting them to be delivered as flags instead. This includes our old friend RHEL8. This commit works around that by also providing a `.parse_monolithic` handler that does the string split, inspects the params, and for any that we know we want, avoiding the kernel param parsing entirely. Another huge explainer comment lies with.

Note that this will only workaround those options when passed via `mount(2)`, and not `fsconfig(2)`, since the latter provides structured parameters directly, so there's nowhere for us to hook it. I doubt this will ever be a problem, given `fsconfig(2)` is barely used (it was only [fully documented late last year](https://www.phoronix.com/news/New-Mount-API-Man-Pages)).

##### `linux/vfsops: remove zfs_mnt_t, pass directly`

Finally, a cleanup of opportunity. The `zfs_domount()` and `zfs_remount()` params were weird to help with portability back in the ZoL days, but its no long necessary. So we just flatten it out - remove the wrapper `zfs_mnt_t` and directly send in the completed `vfs_t` and for mount, the dataset name.

### How Has This Been Tested?

Full ZTS run completed on 6.18.12. Compile checked on Alma 8.10 (4.18.mystery) and Ubuntu 22.04 (5.15.mystery).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).