### PR TITLE
Fix zfs partition size for disks of different sector size

### DIFF
--- a/lib/libzfs/os/linux/libzfs_pool_os.c
+++ b/lib/libzfs/os/linux/libzfs_pool_os.c
@@ -264,10 +264,25 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, const char *name)
 		return (zfs_error(hdl, EZFS_NOCAP, errbuf));
 	}
 
+	/*
+	 * The disks of the same capacity may have different sector sizes
+	 * (512 or 4K). So to have the same start_block and slice_size on
+	 * such a disks, divide NEW_START_BLOCK and EFI_MIN_RESV_SIZE by
+	 * (efi_lbasize / DEV_BSIZE) coefficient.
+	 */
+	uint64_t coeff = vtoc->efi_lbasize / DEV_BSIZE;
+
+	/* This probably should never be the case, but who knows. */
+	if (((NEW_START_BLOCK * DEV_BSIZE) % vtoc->efi_lbasize) ||
+	    ((EFI_MIN_RESV_SIZE * DEV_BSIZE) % vtoc->efi_lbasize))
+		coeff = 1;
+
 	slice_size = vtoc->efi_last_u_lba + 1;
-	slice_size -= EFI_MIN_RESV_SIZE;
+	slice_size -= (EFI_MIN_RESV_SIZE / coeff);
 	if (start_block == MAXOFFSET_T)
 		start_block = NEW_START_BLOCK;
+	if (start_block == NEW_START_BLOCK)
+		start_block /= coeff;
 	slice_size -= start_block;
 	slice_size = P2ALIGN_TYPED(slice_size, PARTITION_END_ALIGNMENT,
 	    uint64_t);
@@ -298,7 +313,7 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, const char *name)
 	zpool_label_name(vtoc->efi_parts[0].p_name, EFI_PART_NAME_LEN);
 
 	vtoc->efi_parts[8].p_start = slice_size + start_block;
-	vtoc->efi_parts[8].p_size = resv;
+	vtoc->efi_parts[8].p_size = resv / coeff;
 	vtoc->efi_parts[8].p_tag = V_RESERVED;
 
 	rval = efi_write(fd, vtoc);


### PR DESCRIPTION
Currently, during disks partitioning, the zfs partition will have different start offset and size depending on the disks sector size, even if the disks have the same capacity. This can lead to undesirable effects; for example, decreasing of draid vdev asize when replacing failed disks with 4K-sectors disks while the pool has disks with 512-bytes sectors, which, in turn, may end up with import failure when asize drops below min_asize level (see also #18380).

Solution: always create the same start and size zfs partition on the disks of the same capacity, regardless of their sector sizes.

Note: this patch makes zfs partition start and size as if the disks have 512-bytes sectors, that is the start will be smaller and the size will be bigger since the NEW_START_BLOCK and EFI_MIN_RESV_SIZE would always be counted in 512 units. So for the disks of the same capacity, zfs partition would always have the same bigger possible size, which makes this fix compatible with all the existing pools, regardless of their disks sector sizes.

### How Has This Been Tested?
1. Create a pool, for example with draid vdev and disks of 512-bytes sectors.
2. Replace some disk in the pool with the disk of the same capacity but having 4K-sectors.
3. Make sure that start offset and size of the new zfs partition in the new disk are the same as in the existing disks in the pool (you can use `parted` utility for this) and that the asize of draid vdev didn't decrease (`gdb -C | grep asize`).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).