### PR TITLE
draid: fix import failure after disks replacements

### DIFF
--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -1161,7 +1161,7 @@ vdev_draid_get_astart(vdev_t *vd, const uint64_t start)
 /*
  * Allocatable space for dRAID is (children - nspares) * sizeof(smallest child)
  * rounded down to the last full slice.  So each child must provide at least
- * 1 / (children - nspares) of its asize.
+ * 1 / (children - nspares) of its asize rounded up to VDEV_DRAID_ROWHEIGHT.
  */
 static uint64_t
 vdev_draid_min_asize(vdev_t *vd)
@@ -1171,7 +1171,9 @@ vdev_draid_min_asize(vdev_t *vd)
 	ASSERT3P(vd->vdev_ops, ==, &vdev_draid_ops);
 
 	return (VDEV_DRAID_REFLOW_RESERVE +
-	    (vd->vdev_min_asize + vdc->vdc_ndisks - 1) / (vdc->vdc_ndisks));
+	    ((vd->vdev_min_asize + vdc->vdc_ndisks - 1) / (vdc->vdc_ndisks) +
+	    VDEV_DRAID_ROWHEIGHT - 1) / VDEV_DRAID_ROWHEIGHT *
+	    VDEV_DRAID_ROWHEIGHT);
 }
 
 /*


### PR DESCRIPTION
Currently, it's possible that draid vdev asize would decrease after disks replacements when the disk size is a little less than all other disks in the pool. In such situations, import would fail on this check in vdev_open():

```c
        /*
         * Make sure the allocatable size hasn't shrunk too much.
         */
        if (asize < vd->vdev_min_asize) {
                vdev_set_state(vd, B_TRUE, VDEV_STATE_CANT_OPEN,
                    VDEV_AUX_BAD_LABEL);
                return (SET_ERROR(EINVAL));
        }
```

Solution: fix vdev_draid_min_asize() so that it would round up the required minimal disk capacity to the VDEV_DRAID_ROWHEIGHT. This would refuse replacements with the disks whose size is less than minimally required to avoid draid asize decrement.

Note: we also use VDEV_DRAID_ROWHEIGHT in vdev_draid_open() when calculating asize, and thats why we need to round up min_size at vdev_draid_min_asize() to avoid asize drops.

### How Has This Been Tested?
1. Create a pool with draid vdev. (For example, draid3:11d:106c:8s.)
2. Replace some disk with a little smaller one. (For example, 16000816775168  vs 16000890175488.)
3. Replacement fails with `device is too small` error.

Without patch, replacement would succeed, but the pool would refuse to import after export with `invalid vdev configuration` error.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
