### PR TITLE
Abort uio copy early on fatal signal to prevent usercopy kernel panic

### DIFF
--- a/module/os/linux/zfs/zfs_uio.c
+++ b/module/os/linux/zfs/zfs_uio.c
@@ -52,6 +52,7 @@
 #include <sys/zfs_refcount.h>
 #include <sys/zfs_debug.h>
 #include <linux/kmap_compat.h>
+#include <linux/sched/signal.h>
 #include <linux/uaccess.h>
 #include <linux/pagemap.h>
 #include <linux/mman.h>
@@ -234,6 +235,18 @@ zfs_uiomove_iter(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio,
     boolean_t revert)
 {
 	size_t cnt = MIN(n, uio->uio_resid);
+
+	/*
+	 * If the current task has a fatal signal pending (e.g. OOM killer
+	 * sent SIGKILL), the process address space may be in the process
+	 * of being torn down. Attempting to copy data to or from the
+	 * user buffer in this state can trigger a kernel BUG in the
+	 * hardened usercopy checks (__check_object_size), since the
+	 * destination pages may no longer be valid. Bail out early to
+	 * prevent a kernel panic. See openzfs/zfs#15918.
+	 */
+	if (fatal_signal_pending(current))
+		return (EINTR);
 
 	if (rw == UIO_READ)
 		cnt = copy_to_iter(p, cnt, uio->uio_iter);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1423,6 +1423,17 @@ dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
 		bufoff = zfs_uio_offset(uio) - db->db_offset;
 		tocpy = MIN(db->db_size - bufoff, size);
 
+		/*
+		 * Abort if a signal (e.g. SIGKILL from OOM killer) is
+		 * pending.  Continuing to copy data when the process is
+		 * dying can trigger a kernel panic in the hardened
+		 * usercopy checks.  See openzfs/zfs#15918.
+		 */
+		if (issig()) {
+			err = SET_ERROR(EINTR);
+			break;
+		}
+
 		ASSERT(db->db_data != NULL);
 		err = zfs_uio_fault_move((char *)db->db_data + bufoff, tocpy,
 		    UIO_READ, uio);
@@ -1542,6 +1553,17 @@ top:
 		dmu_buf_t *db = dbp[i];
 
 		ASSERT(write_size > 0);
+
+		/*
+		 * Abort if a signal (e.g. SIGKILL from OOM killer) is
+		 * pending.  Continuing to copy data when the process is
+		 * dying can trigger a kernel panic in the hardened
+		 * usercopy checks.  See openzfs/zfs#15918.
+		 */
+		if (issig()) {
+			err = SET_ERROR(EINTR);
+			break;
+		}
 
 		offset_t off = zfs_uio_offset(uio);
 		bufoff = off - db->db_offset;

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -1012,6 +1012,10 @@ tests = ['scrub_mirror_001_pos', 'scrub_mirror_002_pos',
     'scrub_mirror_003_pos', 'scrub_mirror_004_pos']
 tags = ['functional', 'scrub_mirror']
 
+[tests/functional/sigkill]
+tests = ['sigkill_read_write']
+tags = ['functional', 'sigkill']
+
 [tests/functional/slog]
 tests = ['slog_001_pos', 'slog_002_pos', 'slog_003_pos', 'slog_004_pos',
     'slog_005_pos', 'slog_006_pos', 'slog_007_pos', 'slog_008_neg',

--- a/tests/zfs-tests/cmd/.gitignore
+++ b/tests/zfs-tests/cmd/.gitignore
@@ -39,6 +39,7 @@
 /rm_lnkcnt_zero_file
 /send_doall
 /statx
+/sigkill_iothread
 /stride_dd
 /threadsappend
 /user_ns_exec

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -97,6 +97,9 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/send_doall
 	libzfs.la \
 	libnvpair.la
 
+scripts_zfs_tests_bin_PROGRAMS += %D%/sigkill_iothread
+%C%_sigkill_iothread_LDADD = -lpthread
+
 scripts_zfs_tests_bin_PROGRAMS += %D%/stride_dd
 %C%_stride_dd_LDADD = -lrt
 

--- a/tests/zfs-tests/cmd/sigkill_iothread.c
+++ b/tests/zfs-tests/cmd/sigkill_iothread.c
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Multi-threaded I/O program for testing SIGKILL safety during ZFS I/O.
+ *
+ * Creates multiple threads that continuously read from or write to a file.
+ * Designed to be killed with SIGKILL while threads are actively performing
+ * I/O, to verify that the kernel does not panic in usercopy checks when
+ * the address space is torn down while ZFS I/O is in flight.
+ *
+ * See openzfs/zfs#15918.
+ *
+ * Usage: sigkill_iothread <file> <r|w|rw> [nthreads]
+ */
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <errno.h>
+#include <err.h>
+
+#define	IO_BUF_SIZE	(128 * 1024)	/* 128K */
+
+struct thread_arg {
+	const char *file;
+	int do_write;
+};
+
+static void *
+io_thread(void *arg)
+{
+	struct thread_arg *ta = arg;
+	char buf[IO_BUF_SIZE];
+	int flags, fd;
+
+	(void) memset(buf, 'A', sizeof (buf));
+
+	flags = ta->do_write ? (O_RDWR | O_CREAT) : O_RDONLY;
+	fd = open(ta->file, flags, 0666);
+	if (fd == -1)
+		err(1, "open(%s)", ta->file);
+
+	for (;;) {
+		if (lseek(fd, 0, SEEK_SET) == -1)
+			break;
+		if (ta->do_write)
+			(void) write(fd, buf, sizeof (buf));
+		else
+			(void) read(fd, buf, sizeof (buf));
+	}
+
+	(void) close(fd);
+	return (NULL);
+}
+
+int
+main(int argc, char **argv)
+{
+	int nthreads = 4;
+	int do_read = 0, do_write = 0;
+
+	if (argc < 3) {
+		(void) fprintf(stderr,
+		    "usage: %s <file> <r|w|rw> [nthreads]\n", argv[0]);
+		exit(1);
+	}
+
+	if (strcmp(argv[2], "r") == 0) {
+		do_read = 1;
+	} else if (strcmp(argv[2], "w") == 0) {
+		do_write = 1;
+	} else if (strcmp(argv[2], "rw") == 0) {
+		do_read = 1;
+		do_write = 1;
+	} else {
+		(void) fprintf(stderr, "mode must be 'r', 'w', or 'rw'\n");
+		exit(1);
+	}
+
+	if (argc >= 4)
+		nthreads = atoi(argv[3]);
+
+	if (nthreads < 1 || nthreads > 64) {
+		(void) fprintf(stderr,
+		    "nthreads must be between 1 and 64\n");
+		exit(1);
+	}
+
+	pthread_t *tids = calloc(nthreads, sizeof (pthread_t));
+	struct thread_arg *args = calloc(nthreads, sizeof (struct thread_arg));
+
+	if (tids == NULL || args == NULL)
+		err(1, "calloc");
+
+	for (int i = 0; i < nthreads; i++) {
+		args[i].file = argv[1];
+		if (do_read && do_write)
+			args[i].do_write = (i % 2);
+		else
+			args[i].do_write = do_write;
+
+		if (pthread_create(&tids[i], NULL, io_thread, &args[i]))
+			err(1, "pthread_create");
+	}
+
+	for (int i = 0; i < nthreads; i++)
+		(void) pthread_join(tids[i], NULL);
+
+	free(tids);
+	free(args);
+	return (0);
+}

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -222,6 +222,7 @@ export ZFSTEST_FILES_COMMON='badsend
     rename_dir
     rm_lnkcnt_zero_file
     send_doall
+    sigkill_iothread
     statx
     threadsappend
     user_ns_exec

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2105,6 +2105,9 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/scrub_mirror/scrub_mirror_003_pos.ksh \
 	functional/scrub_mirror/scrub_mirror_004_pos.ksh \
 	functional/scrub_mirror/setup.ksh \
+	functional/sigkill/cleanup.ksh \
+	functional/sigkill/setup.ksh \
+	functional/sigkill/sigkill_read_write.ksh \
 	functional/slog/cleanup.ksh \
 	functional/slog/setup.ksh \
 	functional/slog/slog_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/sigkill/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/sigkill/cleanup.ksh
@@ -1,0 +1,28 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/sigkill/setup.ksh
+++ b/tests/zfs-tests/tests/functional/sigkill/setup.ksh
@@ -1,0 +1,28 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+
+default_setup $DISK

--- a/tests/zfs-tests/tests/functional/sigkill/sigkill_read_write.ksh
+++ b/tests/zfs-tests/tests/functional/sigkill/sigkill_read_write.ksh
@@ -1,0 +1,105 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify that SIGKILL during multi-threaded ZFS read/write I/O does not
+# trigger a kernel panic in the hardened usercopy checks.
+#
+# When a process is OOM-killed (or otherwise receives SIGKILL) while
+# multiple threads are performing ZFS I/O via read(2)/write(2), the
+# address space teardown can race with in-flight copy_to_iter() /
+# copy_from_iter() calls, potentially triggering:
+#   kernel BUG at mm/usercopy.c:102
+#
+# This test exercises that scenario by running a multi-threaded I/O
+# helper and killing it with SIGKILL while I/O is in progress.
+#
+# STRATEGY:
+# 1. Create a test file with data on a ZFS filesystem.
+# 2. Launch a multi-threaded I/O process (reads, writes, and mixed).
+# 3. Kill it with SIGKILL after a brief delay.
+# 4. Repeat several iterations to maximize race window coverage.
+# 5. Verify the pool is still healthy.
+# 6. Check dmesg for kernel BUG messages.
+#
+# See openzfs/zfs#15918.
+#
+
+verify_runnable "global"
+
+TESTFILE="$TESTDIR/sigkill_test_file"
+
+function cleanup
+{
+	rm -f "$TESTFILE"
+}
+
+log_assert "SIGKILL during multi-threaded ZFS I/O does not cause kernel panic"
+log_onexit cleanup
+
+if ! is_mp; then
+	log_unsupported "This test requires a multi-processor system."
+fi
+
+# Create test file with data for read tests
+log_must dd if=/dev/urandom of="$TESTFILE" bs=1M count=32
+
+# Record dmesg marker so we only check new messages
+if is_linux; then
+	DMESG_LINES=$(dmesg | wc -l)
+fi
+
+# Run several iterations of multi-threaded I/O + SIGKILL for each mode:
+#   r  = multiple threads reading
+#   w  = multiple threads writing
+#   rw = mixed read and write threads
+for mode in "r" "w" "rw"; do
+	for i in $(seq 1 5); do
+		sigkill_iothread "$TESTFILE" $mode 4 &
+		PID=$!
+		log_note "Started sigkill_iothread (mode=$mode, pid=$PID," \
+		    "iteration=$i)"
+
+		# Let the threads run I/O briefly
+		sleep 0.5
+
+		# Kill with SIGKILL (simulating OOM killer behavior)
+		kill -9 $PID 2>/dev/null
+		wait $PID 2>/dev/null
+	done
+done
+
+# Verify pool is still healthy after all the kills
+log_must zpool status $TESTPOOL
+
+# Check dmesg for kernel BUG (Linux only)
+if is_linux; then
+	if dmesg | tail -n +$((DMESG_LINES + 1)) | grep -q "kernel BUG at"; then
+		log_fail "Kernel BUG detected in dmesg after SIGKILL during I/O"
+	fi
+fi
+
+log_pass "SIGKILL during multi-threaded ZFS I/O completed without kernel panic"


### PR DESCRIPTION
When a process is OOM-killed while ZFS is copying data to/from userspace (via copy_to_iter/copy_from_iter), the kernel's hardened usercopy checks can trigger a kernel BUG at mm/usercopy.c:102.

This happens because:
1. OOM killer sends SIGKILL to all threads in the process
2. The process address space starts being torn down
3. A surviving thread still in kernel executing ZFS read/write attempts to copy data via copy_to_iter()/copy_from_iter()
4. The kernel's __check_object_size() validation on the vmalloc buffer fails, triggering a fatal kernel panic

Fix this by:
- Adding fatal_signal_pending() check in zfs_uiomove_iter() before calling copy_to_iter()/copy_from_iter() to bail out early when the process is dying
- Adding issig() checks in dmu_read_uio_dnode() and dmu_write_uio_dnode() buffer copy loops to abort the operation when signals are pending, consistent with other DMU operations

Fixes: openzfs/zfs#15918