### PR TITLE
ZTS: re-enable send_raw_ashift on FreeBSD

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -179,7 +179,6 @@ if sys.platform.startswith('freebsd'):
         'cp_files/cp_files_002_pos': ['SKIP', na_reason],
         'link_count/link_count_001': ['SKIP', na_reason],
         'mmap/mmap_sync_001_pos': ['SKIP', na_reason],
-        'rsend/send_raw_ashift': ['SKIP', 14961],
     })
 elif sys.platform.startswith('linux'):
     known.update({

--- a/tests/zfs-tests/tests/functional/rsend/send_raw_ashift.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_raw_ashift.ksh
@@ -38,9 +38,6 @@ verify_runnable "both"
 
 log_assert "Verify raw sending to pools with greater ashift succeeds"
 
-if is_freebsd; then
-	log_unsupported "Runs too long on FreeBSD 14 (Issue #14961)"
-fi
 
 function cleanup
 {


### PR DESCRIPTION
### Motivation and Context

The `send_raw_ashift` test was skipped on FreeBSD since 2023 (#14961) because it exceeded the 10-minute CI timeout on FreeBSD 14. Whatever caused the slowdown has since been resolved.

### Description

Remove the FreeBSD skip from `send_raw_ashift.ksh` and the corresponding known-skip entry in `zts-report.py`.

### Test Results

CI runs on the fork confirm the test completes quickly on all FreeBSD versions:

| FreeBSD Version | Duration |
|----------------|----------|
| 14.3-RELEASE | 10 seconds |
| 15.0-STABLE | 11 seconds |
| 16.0-CURRENT | 14 seconds |

Full CI run: https://github.com/chrislongros/zfs/actions/runs/23401625332

All 15 jobs passed (3 FreeBSD + 12 Linux).

### How Has This Been Tested?

- [x] Full CI suite on fork (all FreeBSD + Linux variants pass)
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).