### PR TITLE
abd: Fix stats asymmetry in case of Direct I/O

### DIFF
--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -280,7 +280,8 @@ static void
 abd_free_scatter(abd_t *abd)
 {
 	abd_free_chunks(abd);
-	abd_update_scatter_stats(abd, ABDSTAT_DECR);
+	if (!abd_is_from_pages(abd))
+		abd_update_scatter_stats(abd, ABDSTAT_DECR);
 }
 
 /*


### PR DESCRIPTION
`abd_alloc_from_pages()` does not call `abd_update_scatter_stats()`, since memory is not really allocated there.  But `abd_free_scatter()` called by `abd_free()` does.  It causes negative overflow of some ABD and possibly ARC counters.

### How Has This Been Tested?
Without the patch we observed `scatter_data_size` going negative during Direct I/O fio test on both FreeBSD and Linux.  With the patch at least on FreeBSD problem does not reproduce.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
