### PR TITLE
Fix: draid autopkgtests fail on s390x architecture (Endianness Issue)

### DIFF
--- a/include/zfs_fletcher.h
+++ b/include/zfs_fletcher.h
@@ -60,6 +60,8 @@ _ZFS_FLETCHER_H int fletcher_2_incremental_native(void *, size_t, void *);
 _ZFS_FLETCHER_H int fletcher_2_incremental_byteswap(void *, size_t, void *);
 _ZFS_FLETCHER_H void fletcher_4_native_varsize(const void *, uint64_t,
     zio_cksum_t *);
+_ZFS_FLETCHER_H void fletcher_4_byteswap_varsize(const void *, uint64_t,
+    zio_cksum_t *);
 _ZFS_FLETCHER_H void fletcher_4_byteswap(const void *, uint64_t, const void *,
     zio_cksum_t *);
 _ZFS_FLETCHER_H int fletcher_4_incremental_native(void *, size_t, void *);

--- a/module/zcommon/zfs_fletcher.c
+++ b/module/zcommon/zfs_fletcher.c
@@ -499,6 +499,13 @@ fletcher_4_native_varsize(const void *buf, uint64_t size, zio_cksum_t *zcp)
 	fletcher_4_scalar_native((fletcher_4_ctx_t *)zcp, buf, size);
 }
 
+void
+fletcher_4_byteswap_varsize(const void *buf, uint64_t size, zio_cksum_t *zcp)
+{
+	ZIO_SET_CHECKSUM(zcp, 0, 0, 0, 0);
+	fletcher_4_scalar_byteswap((fletcher_4_ctx_t *)zcp, buf, size);
+}
+
 static inline void
 fletcher_4_byteswap_impl(const void *buf, uint64_t size, zio_cksum_t *zcp)
 {

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -452,7 +452,11 @@ verify_perms(uint8_t *perms, uint64_t children, uint64_t nperms,
 		int permssz = sizeof (uint8_t) * children * nperms;
 		zio_cksum_t cksum;
 
+#if defined(_ZFS_BIG_ENDIAN)
+		fletcher_4_byteswap_varsize(perms, permssz, &cksum);
+#else
 		fletcher_4_native_varsize(perms, permssz, &cksum);
+#endif
 
 		if (checksum != cksum.zc_word[0]) {
 			kmem_free(counts, countssz);


### PR DESCRIPTION
The ioctl call to create the pool was returning -1 with errno EINVAL. Inside the module code, inside `vdev_draid.c`, `verify_perms` is calling `fletcher_4_native_varsize`. This in turn calls `fletcher_4_scalar_native`. So, implemented a `fletcher_4_byteswap_varsize` which makes use of the `fletcher_4_scalar_byteswap` in Big endian machines.