### PR TITLE
AUTHORS: add Christos Longros

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -150,6 +150,7 @@ CONTRIBUTORS:
     Chris Siden <chris.siden@delphix.com>
     Chris Siebenmann <cks.github@cs.toronto.edu>
     Christer Ekholm <che@chrekh.se>
+    Christos Longros <chris.longros@gmail.com>
     Christian Kohlschütter <christian@kohlschutter.com>
     Christian Neukirchen <chneukirchen@gmail.com>
     Christian Schwarz <me@cschwarz.com>


### PR DESCRIPTION
Add myself to the AUTHORS file as a contributor.

Signed-off-by: Christos Longros <chris.longros@gmail.com>