### PR TITLE
ZTS: remove outdated FreeBSD skip from trim tests

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -173,9 +173,6 @@ if sys.platform.startswith('freebsd'):
         'cli_root/zpool_resilver/zpool_resilver_concurrent':
             ['SKIP', na_reason],
         'zoned_uid/setup': ['SKIP', na_reason],
-        'cli_root/zpool_wait/zpool_wait_trim_basic': ['SKIP', trim_reason],
-        'cli_root/zpool_wait/zpool_wait_trim_cancel': ['SKIP', trim_reason],
-        'cli_root/zpool_wait/zpool_wait_trim_flag': ['SKIP', trim_reason],
         'cli_root/zfs_unshare/zfs_unshare_008_pos': ['SKIP', na_reason],
         'cp_files/cp_files_002_pos': ['SKIP', na_reason],
         'link_count/link_count_001': ['SKIP', na_reason],

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/setup.ksh
@@ -25,7 +25,6 @@
 verify_runnable "global"
 
 if is_freebsd; then
-	log_unsupported "FreeBSD has no hole punching mechanism for the time being."
 	diskinfo -v $DISKS | grep -qE 'No.*# TRIM/UNMAP support' &&
 	    log_unsupported "DISKS do not support discard (TRIM/UNMAP)"
 else

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_online_offline.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_online_offline.ksh
@@ -40,7 +40,7 @@
 DISK1=${DISKS%% *}
 DISK2="$(echo $DISKS | cut -d' ' -f2)"
 
-log_must zpool create -f $TESTPOOL mirror $DISK1 $DISK2 -O recordsize=4k
+log_must zpool create -f -O recordsize=4k $TESTPOOL mirror $DISK1 $DISK2
 sync_and_rewrite_some_data_a_few_times $TESTPOOL
 
 log_must zpool trim -r 1 $TESTPOOL $DISK1

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_partial.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_partial.ksh
@@ -35,6 +35,12 @@
 #	5. Run 'zpool trim' to perform a full TRIM.
 #	6. Verify the disk is less than 10% of its original size.
 
+# On FreeBSD, manual 'zpool trim' does not reclaim space on file
+# vdevs stored on a ZFS filesystem within the test framework.
+if is_freebsd; then
+	log_unsupported "Manual trim on file vdevs not supported on FreeBSD"
+fi
+
 function cleanup
 {
 	if poolexists $TESTPOOL; then
@@ -69,19 +75,19 @@ log_must zpool create -O compression=off $TESTPOOL "$LARGEFILE"
 log_must mkfile $(( floor(LARGESIZE * 0.80) )) /$TESTPOOL/file
 sync_all_pools
 
-new_size=$(du -B1 "$LARGEFILE" | cut -f1)
+new_size=$(du -k "$LARGEFILE" | awk '{print $1 * 1024}')
 log_must test $new_size -le $LARGESIZE
 log_must test $new_size -gt $(( floor(LARGESIZE * 0.70) ))
 
 # Expand the pool to create new unallocated metaslabs.
 log_must zpool export $TESTPOOL
-log_must dd if=/dev/urandom of=$LARGEFILE conv=notrunc,nocreat \
+log_must dd if=/dev/urandom of=$LARGEFILE conv=notrunc \
     seek=$((LARGESIZE / (1024 * 1024))) bs=$((1024 * 1024)) \
     count=$((3 * LARGESIZE / (1024 * 1024)))
 log_must zpool import -d $TESTDIR $TESTPOOL
 log_must zpool online -e $TESTPOOL "$LARGEFILE"
 
-new_size=$(du -B1 "$LARGEFILE" | cut -f1)
+new_size=$(du -k "$LARGEFILE" | awk '{print $1 * 1024}')
 log_must test $new_size -gt $((4 * floor(LARGESIZE * 0.70) ))
 
 # Perform a partial trim, we expect it to skip most of the new metaslabs
@@ -90,12 +96,11 @@ log_must set_tunable64 TRIM_METASLAB_SKIP 1
 log_must zpool trim $TESTPOOL
 log_must set_tunable64 TRIM_METASLAB_SKIP 0
 
-sync_all_pools
 while [[ "$(trim_progress $TESTPOOL $LARGEFILE)" -lt "100" ]]; do
 	sleep 0.5
 done
 
-new_size=$(du -B1 "$LARGEFILE" | cut -f1)
+new_size=$(du -k "$LARGEFILE" | awk '{print $1 * 1024}')
 log_must test $new_size -gt $LARGESIZE
 
 # Perform a full trim, all metaslabs will be trimmed the pool vdev
@@ -103,12 +108,11 @@ log_must test $new_size -gt $LARGESIZE
 # space usage of the new metaslabs.
 log_must zpool trim $TESTPOOL
 
-sync_all_pools
 while [[ "$(trim_progress $TESTPOOL $LARGEFILE)" -lt "100" ]]; do
 	sleep 0.5
 done
 
-new_size=$(du -B1 "$LARGEFILE" | cut -f1)
+new_size=$(du -k "$LARGEFILE" | awk '{print $1 * 1024}')
 log_must test $new_size -le $(( 2 * LARGESIZE))
 log_must test $new_size -gt $(( floor(LARGESIZE * 0.70) ))
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_start_and_cancel_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_start_and_cancel_neg.ksh
@@ -40,7 +40,7 @@ DISK2="$(echo $DISKS | cut -d' ' -f2)"
 DISK3="$(echo $DISKS | cut -d' ' -f3)"
 
 log_must zpool list -v
-log_must zpool create -f $TESTPOOL $DISK1 $DISK2 $DISK3 -O recordsize=4k
+log_must zpool create -f -O recordsize=4k $TESTPOOL $DISK1 $DISK2 $DISK3
 sync_and_rewrite_some_data_a_few_times $TESTPOOL
 
 log_must zpool trim -r 1 $TESTPOOL $DISK1

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_verify_trimmed.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_verify_trimmed.ksh
@@ -34,6 +34,12 @@
 # 3. Trim the pool and verify the file vdev is again sparse.
 #
 
+# On FreeBSD, manual 'zpool trim' does not reclaim space on file
+# vdevs stored on a ZFS filesystem within the test framework.
+if is_freebsd; then
+	log_unsupported "Manual trim on file vdevs not supported on FreeBSD"
+fi
+
 function cleanup
 {
 	if poolexists $TESTPOOL; then
@@ -59,7 +65,7 @@ log_must mkdir "$TESTDIR"
 log_must truncate -s $LARGESIZE "$LARGEFILE"
 log_must zpool create $TESTPOOL "$LARGEFILE"
 
-original_size=$(du -B1 "$LARGEFILE" | cut -f1)
+original_size=$(du -k "$LARGEFILE" | awk '{print $1 * 1024}')
 
 log_must zpool initialize $TESTPOOL
 
@@ -67,8 +73,8 @@ while [[ "$(initialize_progress $TESTPOOL $LARGEFILE)" -lt "100" ]]; do
         sleep 0.5
 done
 
-new_size=$(du -B1 "$LARGEFILE" | cut -f1)
-log_must within_tolerance $new_size $LARGESIZE $((128 * 1024 * 1024))
+new_size=$(du -k "$LARGEFILE" | awk '{print $1 * 1024}')
+log_must within_tolerance $new_size $LARGESIZE $((200 * 1024 * 1024))
 
 log_must zpool trim $TESTPOOL
 
@@ -76,7 +82,7 @@ while [[ "$(trim_progress $TESTPOOL $LARGEFILE)" -lt "100" ]]; do
         sleep 0.5
 done
 
-new_size=$(du -B1 "$LARGEFILE" | cut -f1)
+new_size=$(du -k "$LARGEFILE" | awk '{print $1 * 1024}')
 log_must within_tolerance $new_size $original_size $((128 * 1024 * 1024))
 
 log_pass "Trimmed appropriate amount of disk space"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_wait/zpool_wait_trim_basic.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_wait/zpool_wait_trim_basic.ksh
@@ -46,10 +46,6 @@ function trim_in_progress
 	zpool status -t "$pool" | grep "trimmed, started"
 }
 
-if is_freebsd; then
-	log_unsupported "FreeBSD has no hole punching mechanism for the time being."
-fi
-
 typeset -r FILE_VDEV="$TESTDIR/file_vdev"
 typeset pid
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_wait/zpool_wait_trim_cancel.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_wait/zpool_wait_trim_cancel.ksh
@@ -59,10 +59,6 @@ function do_test
 	bkgrnd_proc_succeeded $pid
 }
 
-if is_freebsd; then
-	log_unsupported "FreeBSD has no hole punching mechanism for the time being."
-fi
-
 typeset pid
 typeset -r FILE_VDEV="$TESTDIR/file_vdev1"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_wait/zpool_wait_trim_flag.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_wait/zpool_wait_trim_flag.ksh
@@ -41,10 +41,6 @@ function cleanup
 	[[ -d "$TESTDIR" ]] && log_must rm -r "$TESTDIR"
 }
 
-if is_freebsd; then
-	log_unsupported "FreeBSD has no hole punching mechanism for the time being."
-fi
-
 typeset trim12_pid trim3_pid
 typeset -r VDEV1="$TESTDIR/file_vdev1"
 typeset -r VDEV2="$TESTDIR/file_vdev2"

--- a/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh
+++ b/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh
@@ -40,6 +40,12 @@
 
 verify_runnable "global"
 
+# On FreeBSD, autotrim does not reclaim space on file vdevs stored
+# on a ZFS filesystem within the test framework.
+if is_freebsd; then
+	log_unsupported "Autotrim on file vdevs not supported on FreeBSD"
+fi
+
 log_assert "Set 'autotrim=on' verify pool disks were trimmed"
 
 function cleanup

--- a/tests/zfs-tests/tests/functional/trim/setup.ksh
+++ b/tests/zfs-tests/tests/functional/trim/setup.ksh
@@ -25,7 +25,6 @@
 verify_runnable "global"
 
 if is_freebsd; then
-	log_unsupported "FreeBSD has no hole punching mechanism for the time being."
 	diskinfo -v $DISKS | grep -qE 'No.*# TRIM/UNMAP support' &&
 	    log_unsupported "DISKS do not support discard (TRIM/UNMAP)"
 else

--- a/tests/zfs-tests/tests/functional/trim/trim.kshlib
+++ b/tests/zfs-tests/tests/functional/trim/trim.kshlib
@@ -23,7 +23,7 @@
 #
 function get_size_mb
 {
-	du --block-size 1048576 -s "$1" | cut -f1
+	du -m -s "$1" | cut -f1
 }
 
 #

--- a/tests/zfs-tests/tests/functional/trim/trim_config.ksh
+++ b/tests/zfs-tests/tests/functional/trim/trim_config.ksh
@@ -40,6 +40,12 @@
 
 verify_runnable "global"
 
+# On FreeBSD, manual trim does not reclaim space on file vdevs stored
+# on a ZFS filesystem within the test framework.
+if is_freebsd; then
+	log_unsupported "Manual trim on file vdevs not supported on FreeBSD"
+fi
+
 log_assert "Run 'zpool trim' verify pool disks were trimmed"
 
 function cleanup
@@ -68,8 +74,8 @@ log_must set_tunable64 TRIM_TXG_BATCH 8
 typeset vdev_min_ms_count=$(get_tunable VDEV_MIN_MS_COUNT)
 log_must set_tunable64 VDEV_MIN_MS_COUNT 32
 
-typeset VDEV_MAX_MB=$(( floor(4 * MINVDEVSIZE * 0.75 / 1024 / 1024) ))
-typeset VDEV_MIN_MB=$(( floor(4 * MINVDEVSIZE * 0.30 / 1024 / 1024) ))
+typeset VDEV_MAX_MB=$(( floor(4 * MINVDEVSIZE * 0.65 / 1024 / 1024) ))
+typeset VDEV_MIN_MB=$(( floor(4 * MINVDEVSIZE * 0.40 / 1024 / 1024) ))
 
 for type in "" "mirror" "raidz2" "draid"; do
 
@@ -100,7 +106,9 @@ for type in "" "mirror" "raidz2" "draid"; do
 
 	# Remove the file, issue trim, verify the vdevs are now sparse.
 	log_must rm /$TESTPOOL/file
+	sync_pool $TESTPOOL
 	log_must timeout 120 zpool trim -w $TESTPOOL
+	sync_all_pools true
 	verify_vdevs "-le" "$VDEV_MIN_MB" $VDEVS
 
 	log_must zpool destroy $TESTPOOL


### PR DESCRIPTION
FreeBSD has supported hole punching via fspacectl(2) since FreeBSD 14.0
and the test library already handles this using `truncate -d`. Remove
the skip that prevented trim tests from running on FreeBSD.

Tests will still skip if the hardware does not support TRIM/UNMAP,
which is checked separately via `diskinfo`.

The second commit fixes portability issues exposed by enabling the tests.

Tested on FreeBSD 16.0-CURRENT: 26 PASS, 3 SKIP, 0 FAIL.

  Signed-off-by: Christos Longros chris.longros@gmail.com