### PR TITLE
libzfs: report invalid permission name in zfs allow

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -5138,7 +5138,7 @@ zfs_set_fsacl(zfs_handle_t *zhp, boolean_t un, nvlist_t *nvl)
 			err = zfs_error(hdl, EZFS_BADVERSION, errbuf);
 			break;
 		case EINVAL:
-			err = zfs_error(hdl, EZFS_BADTYPE, errbuf);
+			err = zfs_error(hdl, EZFS_BADPERM, errbuf);
 			break;
 		case ENOENT:
 			err = zfs_error(hdl, EZFS_NOENT, errbuf);


### PR DESCRIPTION
### Motivation and Context

If you mistype a permission name in `zfs allow` the error you get is:

```
cannot set permissions on 'pool': operation not applicable to datasets of this type
```
### Description

Update the `EINVAL` handler in `zfs_set_fsacl()` to say "invalid permission" instead.

Before: `cannot set permissions on 'pool': operation not applicable to datasets of this type`
After: `cannot set permissions on 'pool': invalid permission`

### Testing

Tested on FreeBSD 16.0-CURRENT:
- `zfs allow -u root snapshop zroot` produces  "invalid permission" output.
- `zfs allow -u root snapshot zroot` works with no regression
- `zfs allow -u root snapshot,send,snapshop zroot` produces "invalid permission" output.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the OpenZFS code style requirements.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.

Closes #11903