### PR TITLE
Fix 'kernel BUG at mm/usercopy.c'

### DIFF
--- a/module/os/linux/zfs/zfs_uio.c
+++ b/module/os/linux/zfs/zfs_uio.c
@@ -234,6 +234,8 @@ zfs_uiomove_iter(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio,
     boolean_t revert)
 {
 	size_t cnt = MIN(n, uio->uio_resid);
+	size_t oldcnt = cnt;
+	int error = 0;
 
 	if (rw == UIO_READ)
 		cnt = copy_to_iter(p, cnt, uio->uio_iter);
@@ -249,16 +251,21 @@ zfs_uiomove_iter(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio,
 		return (EFAULT);
 
 	/*
-	 * Revert advancing the uio_iter.  This is set by zfs_uiocopy()
-	 * to avoid consuming the uio and its iov_iter structure.
+	 * When revert is set this is a zfs_uiocopy() which should not
+	 * consume the uio and its iov_iter structure.  Otherwise, it's
+	 * a zfs_uiomove() which is expected to update the uio.  Partial
+	 * copies are allowed for both copy and move but EFAULT should
+	 * be returned for zfs_uiomove().
 	 */
 	if (revert)
 		iov_iter_revert(uio->uio_iter, cnt);
+	else if (cnt != oldcnt)
+		error = EFAULT;
 
 	uio->uio_resid -= cnt;
 	uio->uio_loffset += cnt;
 
-	return (0);
+	return (error);
 }
 
 int


### PR DESCRIPTION
### Motivation and Context
Fixes: #15918

### Description
Fix a bug where a cgroup-OOM-killed process can cause a panic:
```
usercopy: Kernel memory exposure attempt detected from vmalloc (offset 1007584, size 217120)!
kernel BUG at mm/usercopy.c:102!
```
### How Has This Been Tested?
Could not trigger panic using reproducer from https://github.com/openzfs/zfs/issues/15918#issuecomment-4178677841

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
