### PR TITLE
zfs, zpool: ignore SIGPIPE in main()

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -8125,7 +8125,6 @@ zfs_do_diff(int argc, char **argv)
 	char *atp, *copy;
 	int err = 0;
 	int c;
-	struct sigaction sa;
 
 	while ((c = getopt(argc, argv, "FHth")) != -1) {
 		switch (c) {
@@ -8182,23 +8181,7 @@ zfs_do_diff(int argc, char **argv)
 	}
 	free(copy);
 
-	/*
-	 * Ignore SIGPIPE so that the library can give us
-	 * information on any failure
-	 */
-	if (sigemptyset(&sa.sa_mask) == -1) {
-		err = errno;
-		goto out;
-	}
-	sa.sa_flags = 0;
-	sa.sa_handler = SIG_IGN;
-	if (sigaction(SIGPIPE, &sa, NULL) == -1) {
-		err = errno;
-		goto out;
-	}
-
 	err = zfs_show_diffs(zhp, STDOUT_FILENO, fromsnap, tosnap, flags);
-out:
 	zfs_close(zhp);
 
 	return (err != 0);
@@ -9405,6 +9388,8 @@ main(int argc, char **argv)
 	}
 
 	zfs_save_arguments(argc, argv, history_str, sizeof (history_str));
+
+	(void) signal(SIGPIPE, SIG_IGN);
 
 	libzfs_print_on_error(g_zfs, B_TRUE);
 

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -48,6 +48,7 @@
 #include <libintl.h>
 #include <locale.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13867,6 +13868,8 @@ main(int argc, char **argv)
 	}
 
 	libzfs_print_on_error(g_zfs, B_TRUE);
+
+	(void) signal(SIGPIPE, SIG_IGN);
 
 	zfs_save_arguments(argc, argv, history_str, sizeof (history_str));
 


### PR DESCRIPTION
Move SIGPIPE ignore from `zfs_do_diff()` to `main()` and add it to
`zpool`, which had none.

Previously only `zfs diff` was protected from SIGPIPE. All other
subcommands would exit 141 when piped to `head`, `grep -q`, etc.
`zpool` had no SIGPIPE handling at all.

Signed-off-by: Christos Longros <chris.longros@gmail.com>