### PR TITLE
deb.am: propagate build errors in native-deb targets

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -93,17 +93,17 @@ debian:
 	cp -r contrib/debian debian; chmod +x debian/rules;
 
 native-deb-utils: native-deb-local debian
-	while [ -f debian/deb-build.lock ]; do sleep 1; done; \
-	echo "native-deb-utils" > debian/deb-build.lock; \
-	cp contrib/debian/control debian/control; \
-	$(DPKGBUILD) -b -rfakeroot -us -uc; \
-	$(RM) -f debian/deb-build.lock
+	while [ -f debian/deb-build.lock ]; do sleep 1; done && \
+	echo "native-deb-utils" > debian/deb-build.lock && \
+	trap '$(RM) -f debian/deb-build.lock' EXIT && \
+	cp contrib/debian/control debian/control && \
+	$(DPKGBUILD) -b -rfakeroot -us -uc
 
 native-deb-kmod: native-deb-local debian
-	while [ -f debian/deb-build.lock ]; do sleep 1; done; \
-	echo "native-deb-kmod" > debian/deb-build.lock; \
-	sh scripts/make_gitrev.sh; \
-	fakeroot debian/rules override_dh_binary-modules; \
-	$(RM) -f debian/deb-build.lock
+	while [ -f debian/deb-build.lock ]; do sleep 1; done && \
+	echo "native-deb-kmod" > debian/deb-build.lock && \
+	trap '$(RM) -f debian/deb-build.lock' EXIT && \
+	sh scripts/make_gitrev.sh && \
+	fakeroot debian/rules override_dh_binary-modules
 
 native-deb: native-deb-utils native-deb-kmod


### PR DESCRIPTION
## Summary
- Replace `;` with `&&` in `native-deb-utils` and `native-deb-kmod` targets
  so that build failures propagate to `make`
- Use `trap ... EXIT` for lockfile cleanup so it runs on both success and failure

## Testing
Tested on Debian 12 (bookworm) VM, kernel 6.1.0-44-amd64:
- `make native-deb-utils` builds all `.deb` packages successfully
- Simulated `dpkg-buildpackage` failure: old code exits 0 (bug), new code exits non-zero (fixed)
- Lockfile cleaned up on both success and failure

Fixes #18206