### PR TITLE
Fix FreeBSD "panic: cache_vop_rename: lingering negative entry"

### DIFF
--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -3519,7 +3519,7 @@ zfs_do_rename_impl(vnode_t *sdvp, vnode_t **svpp, struct componentname *scnp,
 				    ZRENAMING, NULL));
 			}
 		}
-		if (error == 0) {
+		if (error == 0 && zfsvfs->z_use_namecache) {
 			cache_vop_rename(sdvp, *svpp, tdvp, *tvpp, scnp, tcnp);
 		}
 	}


### PR DESCRIPTION
A FreeBSD ZFS filesystem with properties  “utf8only=on” and "normalization=formD” consistently produces this panic when building the lang/perl-5.42.0 port.

A ZFS file system with “utf8only=off” and "normalization=none” works fine.

The cause of the panic seems to be incorrectly using the FreeBSD namecache when normalisation is present. This adds a predicate to prevent that.

This has been tested in a FreeBSD 16-CURRENT environment. Without this patch, building lang/perl-5.42.0 produced a consistent panic on when running llvm-strip. With the patch it works consistently without a panic.


- [X] Bug fix (non-breaking change which fixes an issue)
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
