### PR TITLE
ZTS: resilver_restart_001 improvements

### DIFF
--- a/tests/zfs-tests/tests/functional/replacement/resilver_restart_001.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/resilver_restart_001.ksh
@@ -46,6 +46,7 @@
 
 function cleanup
 {
+	log_must zpool events
 	log_must set_tunable32 RESILVER_MIN_TIME_MS $ORIG_RESILVER_MIN_TIME
 	log_must set_tunable32 SCAN_SUSPEND_PROGRESS \
 	    $ORIG_SCAN_SUSPEND_PROGRESS
@@ -53,11 +54,12 @@ function cleanup
 	    $ORIG_RESILVER_DEFER_PERCENT
 	log_must set_tunable32 ZEVENT_LEN_MAX $ORIG_ZFS_ZEVENT_LEN_MAX
 	log_must zinject -c all
+	log_must zpool events -c
 	destroy_pool $TESTPOOL1
 	rm -f ${VDEV_FILES[@]} $SPARE_VDEV_FILE
 }
 
-# count resilver events in zpool and number of deferred rsilvers on vdevs
+# count resilver events in zpool and number of deferred resilvers on vdevs
 function verify_restarts # <msg> <cnt> <defer>
 {
 	msg=$1
@@ -113,7 +115,7 @@ log_must set_tunable32 ZEVENT_LEN_MAX 512
 log_must truncate -s $VDEV_FILE_SIZE ${VDEV_FILES[@]} $SPARE_VDEV_FILE
 
 log_must zpool create -f -o feature@resilver_defer=disabled $TESTPOOL1 \
-    raidz ${VDEV_FILES[@]}
+    raidz2 ${VDEV_FILES[@]}
 
 # create 4 filesystems
 for fs in fs{0..3}
@@ -157,8 +159,8 @@ do
 	log_must set_tunable32 RESILVER_MIN_TIME_MS 20
 
 	# initiate a resilver and suspend the scan as soon as possible
-	log_must zpool replace $TESTPOOL1 $VDEV_REPLACE
 	log_must set_tunable32 SCAN_SUSPEND_PROGRESS 1
+	log_must zpool replace $TESTPOOL1 $VDEV_REPLACE
 
 	# there should only be 1 resilver start
 	verify_restarts '' "${RESTARTS[0]}" "${VDEVS[0]}"
@@ -166,9 +168,12 @@ do
 	# offline then online a vdev to introduce a new DTL range after current
 	# scan, which should restart (or defer) the resilver
 	log_must zpool offline $TESTPOOL1 ${VDEV_FILES[2]}
-	sync_pool $TESTPOOL1
+	log_must wait_vdev_state $TESTPOOL1 ${VDEV_FILES[2]} "OFFLINE"
+	sync_pool $TESTPOOL1 true
+
 	log_must zpool online $TESTPOOL1 ${VDEV_FILES[2]}
-	sync_pool $TESTPOOL1
+	log_must wait_vdev_state $TESTPOOL1 ${VDEV_FILES[2]} "ONLINE"
+	sync_pool $TESTPOOL1 true
 
 	# there should now be 2 resilver starts w/o defer, 1 with defer
 	verify_restarts ' after offline/online' "${RESTARTS[1]}" "${VDEVS[1]}"
@@ -190,8 +195,8 @@ do
 	log_must is_pool_resilvered $TESTPOOL1
 
 	# wait for a few txg's to see if a resilver happens
-	sync_pool $TESTPOOL1
-	sync_pool $TESTPOOL1
+	sync_pool $TESTPOOL1 true
+	sync_pool $TESTPOOL1 true
 
 	# there should now be 2 resilver starts
 	verify_restarts ' after resilver' "${RESTARTS[3]}" "${VDEVS[3]}"


### PR DESCRIPTION
### Motivation and Context

Resolve the occasional CI failures for this test.

https://github.com/openzfs/zfs/actions/runs/24217052638/job/70700070007?pr=18387

### Description

The resilver_restart_001 test case has not been entirely reliable when run under the CI.  Address several small issues which may be responsible.

- Configure the pool as raidz2 instead of raidz1 since the test offlines two devices.  This ensures the second device is marked as OFFLINE instead of DEGRADED.

- Start the zpool replace after setting SCAN_SUSPEND_PROGRESS to close any potential race where the replace finishs to quickly.

- Wait for the offlines/onlined vdevs to fully transition to the expected state during the test.

- Add the true flag to sync_pool to force a TXG sync to happen even if it might not otherwise be required.

- During cleanup dump the zpool events history to aid debugging if the updated test case is still unreliable in the CI.

### How Has This Been Tested?

Tested locally, but will be verified by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)