### PR TITLE
 CI: Do not set scheduler in qemu-1-setup.sh

### DIFF
--- a/.github/workflows/scripts/qemu-1-setup.sh
+++ b/.github/workflows/scripts/qemu-1-setup.sh
@@ -149,8 +149,3 @@ echo 1 | sudo tee /sys/module/zfs/parameters/zvol_use_blk_mq
 sudo zpool create -f -o ashift=12 zpool $DISKS -O relatime=off \
   -O atime=off -O xattr=sa -O compression=lz4 -O sync=disabled \
   -O redundant_metadata=none -O mountpoint=/mnt/tests
-
-# no need for some scheduler
-for i in /sys/block/s*/queue/scheduler; do
-  echo "none" | sudo tee $i
-done


### PR DESCRIPTION




### Motivation and Context
Fix qemu-1-setup CI failures

### Description
We've seen some qemu-1-setup failures while trying to change the runner's block device scheduler value to 'none':


```
We have a single 150GB block device
Setting up swapspace version 1, size = 16 GiB (17179865088 bytes)
no label, UUID=7a790bfe-79e5-4e38-b208-9c63fe523294
tee: '/sys/block/s*/queue/scheduler': No such file or directory
```
Luckily, we don't need to set the scheduler anymore on modern kernels: https://github.com/openzfs/zfs/issues/9778#issuecomment-569347505

This commit just removes the code that sets the scheduler.

### How Has This Been Tested?
qemu-1-setup passed on local CI

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
