### PR TITLE
CI: tolerate missing artifacts

### DIFF
--- a/.github/workflows/scripts/qemu-7-prepare.sh
+++ b/.github/workflows/scripts/qemu-7-prepare.sh
@@ -51,6 +51,11 @@ cd $RESPATH
 
 # prepare result files for summary
 for ((i=1; i<=VMs; i++)); do
+
+  # no results, VM either didn't start or was unreachable, create
+  # the missing directory which is expected by subsequent steps
+  test -d vm$i || mkdir -p vm$i
+
   file="vm$i/build-stderr.txt"
   test -s $file && mv -f $file build-stderr.txt
 
@@ -62,8 +67,6 @@ for ((i=1; i<=VMs; i++)); do
 
   file="vm$i/tests-exitcode.txt"
   if [ ! -s $file ]; then
-    # XXX - add some tests for kernel panic's here
-    # tail -n 80 vm$i/console.txt | grep XYZ
     echo 1 > $file
   fi
   rv=$(cat vm$i/tests-exitcode.txt)

--- a/.github/workflows/scripts/qemu-8-summary.sh
+++ b/.github/workflows/scripts/qemu-8-summary.sh
@@ -37,9 +37,11 @@ function showfile_tail() {
   echo "##[endgroup]"
 }
 
-# overview
-cat /tmp/summary.txt
-echo ""
+# overview if available
+if [ -f /tmp/summary.txt -a -s /tmp/summary.txt ]; then
+  cat /tmp/summary.txt
+  echo ""
+fi
 
 if [ -f /tmp/have_failed_tests -a -s /tmp/failed.txt ]; then
   echo "Debuginfo of failed tests:"


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/24534337466/job/71725531088?pr=18437

### Description

When a VM fails to launch or is unreachable the qemu-7-prepare.sh script will fail to collect the artifacts due to the missing vm* directories.  We want to collect as much diagnostic information as possible, if missing create the directory to allow the subsequent steps to proceed normally.  Additionally, we don't want to fail if the /tmp/summary file is missing.

### How Has This Been Tested?

This will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)