### PR TITLE
dmu_direct: avoid UAF in dmu_write_direct_done()

### DIFF
--- a/module/zfs/dmu_direct.c
+++ b/module/zfs/dmu_direct.c
@@ -91,6 +91,7 @@ dmu_write_direct_done(zio_t *zio)
 	dmu_sync_arg_t *dsa = zio->io_private;
 	dbuf_dirty_record_t *dr = dsa->dsa_dr;
 	dmu_buf_impl_t *db = dr->dr_dbuf;
+	dmu_tx_t *tx = dsa->dsa_tx;
 
 	abd_free(zio->io_abd);
 
@@ -101,6 +102,11 @@ dmu_write_direct_done(zio_t *zio)
 	db->db_state = DB_UNCACHED;
 	mutex_exit(&db->db_mtx);
 
+	/*
+	 * dmu_sync_done() owns dsa and frees it after publishing the final
+	 * override state.  The direct-I/O error path still needs the original
+	 * open-context tx to roll the dirty record back with dbuf_undirty().
+	 */
 	dmu_sync_done(zio, NULL, zio->io_private);
 
 	if (zio->io_error != 0) {
@@ -120,7 +126,7 @@ dmu_write_direct_done(zio_t *zio)
 		 * calling dbuf_undirty().
 		 */
 		mutex_enter(&db->db_mtx);
-		VERIFY3B(dbuf_undirty(db, dsa->dsa_tx), ==, B_FALSE);
+		VERIFY3B(dbuf_undirty(db, tx), ==, B_FALSE);
 		mutex_exit(&db->db_mtx);
 	}
 


### PR DESCRIPTION
### Motivation and Context

The Direct I/O completion path reuses dmu_sync_done() to
publish the final override state for the dirty record.
That helper also frees the dmu_sync_arg_t completion
context. In the error path, dmu_write_direct_done() still
accessed dsa->dsa_tx afterwards while calling
dbuf_undirty(), which leads to a use-after-free.

```
BUG: KASAN: slab-use-after-free in dmu_write_direct_done+0xb54/0xb90 fs/zfs/zfs/dmu_direct.c:123
Read of size 8 at addr ffff88801122af18 by task syz.0.665/1549

CPU: 1 UID: 0 PID: 1549 Comm: syz.0.665 Tainted: G           OE       6.18.0-dirty #4 PREEMPT(voluntary) 
Tainted: [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
Hardware name: QEMU Ubuntu 24.04 PC v2 (i440FX + PIIX, arch_caps fix, 1996), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
Call Trace:
 __dump_stack lib/dump_stack.c:94 [inline]
 dump_stack_lvl+0xbe/0x130 lib/dump_stack.c:120
 print_address_description mm/kasan/report.c:378 [inline]
 print_report+0xd1/0x650 mm/kasan/report.c:482
 kasan_report+0xfb/0x140 mm/kasan/report.c:595
 __asan_report_load8_noabort+0x14/0x30 mm/kasan/report_generic.c:381
 dmu_write_direct_done+0xb54/0xb90 fs/zfs/zfs/dmu_direct.c:123
 zio_done+0x882/0x5980 fs/zfs/zfs/zio.c:5857
 __zio_execute fs/zfs/zfs/zio.c:2483 [inline]
 zio_nowait+0x297/0x5e0 fs/zfs/zfs/zio.c:2576
 dmu_write_direct+0x814/0xc40 fs/zfs/zfs/dmu_direct.c:204
 dmu_write_abd+0x2d5/0x380 fs/zfs/zfs/dmu_direct.c:233
 dmu_write_uio_direct+0xc8/0x150 fs/zfs/zfs/dmu_direct.c:388
 dmu_write_uio_dnode+0x696/0x850 fs/zfs/zfs/dmu.c:1513
 dmu_write_uio_dbuf fs/zfs/zfs/dmu.c:1614 [inline]
 dmu_write_uio_dbuf+0x91/0xa0 fs/zfs/zfs/dmu.c:1604
 zfs_write+0xdc4/0x2170 fs/zfs/zfs/zfs_vnops.c:906
 zpl_iter_write+0x33f/0x510 fs/zfs/os/linux/zfs/zpl_file.c:275
 new_sync_write fs/read_write.c:593 [inline]
 vfs_write+0x63b/0xf70 fs/read_write.c:686
 ksys_write+0x133/0x250 fs/read_write.c:738
 __do_sys_write fs/read_write.c:749 [inline]
 __se_sys_write fs/read_write.c:746 [inline]
 __x64_sys_write+0x77/0xc0 fs/read_write.c:746
 ...

Allocated by task 1549:
 kasan_save_stack+0x39/0x70 mm/kasan/common.c:56
 kasan_save_track+0x14/0x40 mm/kasan/common.c:77
 kasan_save_alloc_info+0x37/0x60 mm/kasan/generic.c:573
 poison_kmalloc_redzone mm/kasan/common.c:400 [inline]
 __kasan_kmalloc+0xc3/0xd0 mm/kasan/common.c:417
 kasan_kmalloc include/linux/kasan.h:262 [inline]
 __do_kmalloc_node mm/slub.c:5650 [inline]
 __kmalloc_node_noprof+0x298/0x910 mm/slub.c:5656
 kmalloc_node_noprof include/linux/slab.h:987 [inline]
 spl_kvmalloc+0xac/0x140 fs/zfs/os/linux/spl/spl-kmem.c:185
 spl_kmem_alloc_impl fs/zfs/os/linux/spl/spl-kmem.c:260 [inline]
 spl_kmem_zalloc+0x230/0x250 fs/zfs/os/linux/spl/spl-kmem.c:484
 dmu_write_direct+0x711/0xc40 fs/zfs/zfs/dmu_direct.c:192
 dmu_write_abd+0x2d5/0x380 fs/zfs/zfs/dmu_direct.c:233
 dmu_write_uio_direct+0xc8/0x150 fs/zfs/zfs/dmu_direct.c:388
 dmu_write_uio_dnode+0x696/0x850 fs/zfs/zfs/dmu.c:1513
 dmu_write_uio_dbuf fs/zfs/zfs/dmu.c:1614 [inline]
 dmu_write_uio_dbuf+0x91/0xa0 fs/zfs/zfs/dmu.c:1604
 zfs_write+0xdc4/0x2170 fs/zfs/zfs/zfs_vnops.c:906
 zpl_iter_write+0x33f/0x510 fs/zfs/os/linux/zfs/zpl_file.c:275
 new_sync_write fs/read_write.c:593 [inline]
 vfs_write+0x63b/0xf70 fs/read_write.c:686
 ksys_write+0x133/0x250 fs/read_write.c:738
 __do_sys_write fs/read_write.c:749 [inline]
 __se_sys_write fs/read_write.c:746 [inline]
 __x64_sys_write+0x77/0xc0 fs/read_write.c:746
 x64_sys_call+0x79/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:2
 do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
 do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
 entry_SYSCALL_64_after_hwframe+0x76/0x7e

Freed by task 1549:
 kasan_save_stack+0x39/0x70 mm/kasan/common.c:56
 kasan_save_track+0x14/0x40 mm/kasan/common.c:77
 __kasan_save_free_info+0x3b/0x60 mm/kasan/generic.c:587
 kasan_save_free_info mm/kasan/kasan.h:406 [inline]
 poison_slab_object mm/kasan/common.c:252 [inline]
 __kasan_slab_free+0x6f/0xa0 mm/kasan/common.c:284
 kasan_slab_free include/linux/kasan.h:234 [inline]
 slab_free_hook mm/slub.c:2543 [inline]
 slab_free mm/slub.c:6642 [inline]
 kfree+0x2bf/0x6b0 mm/slub.c:6849
 spl_kmem_free_impl fs/zfs/os/linux/spl/spl-kmem.c:292 [inline]
 spl_kmem_free+0x4b/0x60 fs/zfs/os/linux/spl/spl-kmem.c:497
 dmu_sync_done+0x699/0x1470 fs/zfs/zfs/dmu.c:1953
 dmu_write_direct_done+0x28d/0xb90 fs/zfs/zfs/dmu_direct.c:104
 zio_done+0x882/0x5980 fs/zfs/zfs/zio.c:5857
 __zio_execute fs/zfs/zfs/zio.c:2483 [inline]
 zio_nowait+0x297/0x5e0 fs/zfs/zfs/zio.c:2576
 dmu_write_direct+0x814/0xc40 fs/zfs/zfs/dmu_direct.c:204
 dmu_write_abd+0x2d5/0x380 fs/zfs/zfs/dmu_direct.c:233
 dmu_write_uio_direct+0xc8/0x150 fs/zfs/zfs/dmu_direct.c:388
 dmu_write_uio_dnode+0x696/0x850 fs/zfs/zfs/dmu.c:1513
 dmu_write_uio_dbuf fs/zfs/zfs/dmu.c:1614 [inline]
 dmu_write_uio_dbuf+0x91/0xa0 fs/zfs/zfs/dmu.c:1604
 zfs_write+0xdc4/0x2170 fs/zfs/zfs/zfs_vnops.c:906
 zpl_iter_write+0x33f/0x510 fs/zfs/os/linux/zfs/zpl_file.c:275
 new_sync_write fs/read_write.c:593 [inline]
 vfs_write+0x63b/0xf70 fs/read_write.c:686
 ksys_write+0x133/0x250 fs/read_write.c:738
 __do_sys_write fs/read_write.c:749 [inline]
 __se_sys_write fs/read_write.c:746 [inline]
 __x64_sys_write+0x77/0xc0 fs/read_write.c:746
 x64_sys_call+0x79/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:2
 do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
 do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
 entry_SYSCALL_64_after_hwframe+0x76/0x7e
 ```

### Description

This change saves dsa->dsa_tx in a local variable before
calling dmu_sync_done() and uses that saved transaction
pointer for the rollback path. The fix is intentionally
minimal and keeps the existing callback ownership and
Direct I/O write semantics unchanged.

### How Has This Been Tested?
Tested on Linux.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
