### PR TITLE
CI: Add more debugging to qemu-1-setup.sh

### DIFF
--- a/.github/workflows/scripts/qemu-1-setup.sh
+++ b/.github/workflows/scripts/qemu-1-setup.sh
@@ -63,7 +63,7 @@ sudo swapoff -a
 # configurations.  On one config you get two 75GB block devices, and on the
 # other you get a single 150GB block device. Here's what both look like:
 #
-# --- Two 75GB block devices ---
+# --- One 150GB block device ---
 # NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
 # sda       8:0    0  150G  0 disk
 # ├─sda1    8:1    0  149G  0 part /
@@ -77,7 +77,7 @@ sudo swapoff -a
 # lrwxrwxrwx 1 root root 11 Jan 29 18:07 azure_root-part15 -> ../../sda15
 # lrwxrwxrwx 1 root root 11 Jan 29 18:07 azure_root-part16 -> ../../sda16
 #
-# --- One 150GB block device ---
+# --- Two 75GB block devices ---
 # NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
 # sda       8:0    0   75G  0 disk
 # ├─sda1    8:1    0   74G  0 part /
@@ -139,13 +139,20 @@ fi
 sudo mkswap $SWAP
 sudo swapon $SWAP
 
+echo "Block devices:"
+lsblk
+
 # adjust zfs module parameter and create pool
-exec 1>/dev/null
 ARC_MIN=$((1024*1024*256))
 ARC_MAX=$((1024*1024*512))
-echo $ARC_MIN | sudo tee /sys/module/zfs/parameters/zfs_arc_min
-echo $ARC_MAX | sudo tee /sys/module/zfs/parameters/zfs_arc_max
-echo 1 | sudo tee /sys/module/zfs/parameters/zvol_use_blk_mq
+echo $ARC_MIN | sudo tee /sys/module/zfs/parameters/zfs_arc_min >/dev/null
+echo $ARC_MAX | sudo tee /sys/module/zfs/parameters/zfs_arc_max >/dev/null
+echo 1 | sudo tee /sys/module/zfs/parameters/zvol_use_blk_mq >/dev/null
 sudo zpool create -f -o ashift=12 zpool $DISKS -O relatime=off \
   -O atime=off -O xattr=sa -O compression=lz4 -O sync=disabled \
   -O redundant_metadata=none -O mountpoint=/mnt/tests
+echo "Status:"
+zpool status
+
+echo "Last dmesg:"
+sudo dmesg | tail -n 10


### PR DESCRIPTION

### Motivation and Context
Help debug qemu-1-setup.sh failures

### Description
- Remove line where we disable stdout at the end of qemu-1-setup.sh
- Fix erroneous comment switching the 2x75GB -> 1x150GB cases
- Add some more debug to the end of the script

### How Has This Been Tested?
Local CI test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
