### PR TITLE
fix: zfs-initramfs breakages after recent refactor

### DIFF
--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -514,9 +514,9 @@ destroy_fs()
 	_destroy_fs="${1}"
 
 	[ "${quiet}" != "y" ] && \
-	    zfs_log_begin_msg "Destroying '${destroy_fs}'"
+	    zfs_log_begin_msg "Destroying '${_destroy_fs}'"
 
-	ZFS_CMD="${ZFS} destroy ${destroy_fs}"
+	ZFS_CMD="${ZFS} destroy ${_destroy_fs}"
 	ZFS_STDERR="$(${ZFS_CMD} 2>&1)"
 	ZFS_ERROR="${?}"
 	if [ "${ZFS_ERROR}" != 0 ]

--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -674,11 +674,11 @@ setup_snapshot_booting()
 	then
 		# Snapshot does not exist (...@<null> ?)
 		# ask the user for a snapshot to use.
-		snap="$(ask_user_snap "${_boot_snap%%@*}")"
+		_boot_snap="$(ask_user_snap "${_boot_snap%%@*}")"
 	fi
 
-	# Separate the full snapshot ('${snap}') into it's filesystem and
-	# snapshot names. Would have been nice with a split() function..
+	# Separate the full snapshot ('${_boot_snap}') into its filesystem and
+	# snapshot names. Would have been nice with a split() function.
 	_rootfs="${_boot_snap%%@*}"
 	_snapname="${_boot_snap##*@}"
 	ZFS_BOOTFS="${_rootfs}_${_snapname}"
@@ -693,7 +693,7 @@ setup_snapshot_booting()
 			    -r -Sname "${ZFS_BOOTFS}")"
 			for fs in ${_filesystems}
 			do
-				destroy_fs "${_boot_snap}"
+				destroy_fs "${fs}"
 			done
 		fi
 	fi


### PR DESCRIPTION
### Motivation and Context

I was porting my zsys patches on my PPA and was running the resulting code changes by Claude for a review. Some changes were only in my patch, others were found to be in the upstream repository. Pushing those fixes here. I've also added the Co-authored-by tag (hopefully in compliance with policy). The problems were identified by Claude but I did the fixes by hand.

### Description

See individual commits. They fix some identifier mix-ups in 61ab032ae0391bce38aef1e43b5b930724ecdb55 and 33dd57e1b4997c0e78e42bf340b2eed5ea954f64.

This should also be a candidate for backporting to 2.4.x

### How Has This Been Tested?

Mostly by static analysis of the comments and context. I've rebooted my machine with the new initramfs and cursorily it seems to work. Arguably, that won't tell us what we already know -- that this only affects the rollback path.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
