### PR TITLE
libzfs: report permission error from umount helper

### DIFF
--- a/lib/libzfs/os/linux/libzfs_mount_os.c
+++ b/lib/libzfs/os/linux/libzfs_mount_os.c
@@ -406,7 +406,11 @@ do_unmount(zfs_handle_t *zhp, const char *mntpt, int flags)
 	argv[count] = (char *)mntpt;
 	rc = libzfs_run_process(argv[0], argv, STDOUT_VERBOSE|STDERR_VERBOSE);
 
-	return (rc ? EINVAL : 0);
+	if (rc == 0)
+		return (0);
+	if (rc > 0 && geteuid() != 0)
+		return (EPERM);
+	return (EINVAL);
 }
 
 #ifdef HAVE_MOUNT_SETATTR


### PR DESCRIPTION
### Motivation and Context

When `ZFS_MOUNT_HELPER` is set, unprivileged `zpool export` / `zfs unmount` prints `cannot unmount '/pool': unmount failed` instead of a permission-related message. `/bin/umount`'s exit status doesn't preserve errno, so `do_unmount()` returned a hardcoded `EINVAL`.

### Description

On a non-zero helper exit, return `EPERM` when `geteuid() != 0` instead of `EINVAL`. 

### Testing

Reproduced on Arch Linux 6.19.11 with `ZFS_MOUNT_HELPER=1` and a non-root caller:

- Before: `cannot unmount '/pool': unmount failed`
- After:  `cannot unmount '/pool': permission denied`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the OpenZFS code style requirements.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.

Closes #11740