### PR TITLE
Fix: draid autopkgtests fail on s390x architecture (Endianness Issue)

### DIFF
--- a/include/zfs_fletcher.h
+++ b/include/zfs_fletcher.h
@@ -60,6 +60,8 @@ _ZFS_FLETCHER_H int fletcher_2_incremental_native(void *, size_t, void *);
 _ZFS_FLETCHER_H int fletcher_2_incremental_byteswap(void *, size_t, void *);
 _ZFS_FLETCHER_H void fletcher_4_native_varsize(const void *, uint64_t,
     zio_cksum_t *);
+_ZFS_FLETCHER_H void fletcher_4_byteswap_varsize(const void *, uint64_t,
+    zio_cksum_t *);
 _ZFS_FLETCHER_H void fletcher_4_byteswap(const void *, uint64_t, const void *,
     zio_cksum_t *);
 _ZFS_FLETCHER_H int fletcher_4_incremental_native(void *, size_t, void *);

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -189,6 +189,7 @@
     <elf-symbol name='fletcher_2_incremental_native' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_2_native' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_4_byteswap' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='fletcher_4_byteswap_varsize' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_4_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_4_impl_set' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='fletcher_4_incremental_byteswap' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -1668,8 +1669,103 @@
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='lib/libspl/os/linux/mnttab.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='d315442e' size-in-bits='16' id='811205dc'>
+      <subrange length='1' type-id='7359adad' id='52f813b4'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='d3130597' size-in-bits='768' id='f63f23b9'>
+      <subrange length='12' type-id='7359adad' id='84827bdc'/>
+    </array-type-def>
+    <typedef-decl name='__u16' type-id='8efea9e5' id='d315442e'/>
+    <typedef-decl name='__s32' type-id='95e97e5e' id='3158a266'/>
+    <typedef-decl name='__u32' type-id='f0981eeb' id='3f1a6b60'/>
+    <typedef-decl name='__s64' type-id='1eb56b1e' id='49659421'/>
+    <typedef-decl name='__u64' type-id='3a47d82b' id='d3130597'/>
+    <class-decl name='statx_timestamp' size-in-bits='128' is-struct='yes' visibility='default' id='94101016'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='49659421' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_nsec' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__reserved' type-id='3158a266' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='statx' size-in-bits='2048' is-struct='yes' visibility='default' id='720b04c5'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='stx_mask' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='stx_blksize' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='stx_attributes' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stx_nlink' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='stx_uid' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='stx_gid' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='stx_mode' type-id='d315442e' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='240'>
+        <var-decl name='__spare0' type-id='811205dc' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='stx_ino' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='stx_size' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='stx_blocks' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='stx_attributes_mask' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='stx_atime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='stx_btime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='stx_ctime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='stx_mtime' type-id='94101016' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='stx_rdev_major' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='stx_rdev_minor' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='stx_dev_major' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='stx_dev_minor' type-id='3f1a6b60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='stx_mnt_id' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='__spare2' type-id='d3130597' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='__spare3' type-id='f63f23b9' visibility='default'/>
+      </data-member>
+    </class-decl>
     <pointer-type-def type-id='56fe4a37' size-in-bits='64' id='b6b61d2f'/>
     <qualified-type-def type-id='b6b61d2f' restrict='yes' id='3cad23cd'/>
+    <pointer-type-def type-id='720b04c5' size-in-bits='64' id='936b8e35'/>
+    <qualified-type-def type-id='936b8e35' restrict='yes' id='31d265b7'/>
     <function-decl name='getmntent_r' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='e75a27e9'/>
       <parameter type-id='3cad23cd'/>
@@ -1679,6 +1775,14 @@
     </function-decl>
     <function-decl name='feof' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='822cd80b'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='statx' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='9d26089a'/>
+      <parameter type-id='95e97e5e'/>
+      <parameter type-id='f0981eeb'/>
+      <parameter type-id='31d265b7'/>
       <return type-id='95e97e5e'/>
     </function-decl>
   </abi-instr>
@@ -3830,6 +3934,10 @@
       <parameter type-id='80f4b756'/>
       <return type-id='58603c44'/>
     </function-decl>
+    <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_user'>
+      <parameter type-id='80f4b756'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
     <function-decl name='nvlist_add_uint64' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='5ce45b60'/>
       <parameter type-id='80f4b756'/>
@@ -3853,9 +3961,6 @@
       <parameter type-id='80f4b756'/>
       <parameter type-id='7d3cd834'/>
       <return type-id='95e97e5e'/>
-    </function-decl>
-    <function-decl name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='5ce45b60'/>
     </function-decl>
     <function-decl name='__ctype_b_loc' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='c59e1ef0'/>
@@ -4529,10 +4634,6 @@
       <parameter type-id='c19b74c3'/>
       <return type-id='c19b74c3'/>
     </function-decl>
-    <function-decl name='zfs_prop_user' mangled-name='zfs_prop_user' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_user'>
-      <parameter type-id='80f4b756'/>
-      <return type-id='c19b74c3'/>
-    </function-decl>
     <function-decl name='zfs_prop_userquota' mangled-name='zfs_prop_userquota' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_prop_userquota'>
       <parameter type-id='80f4b756'/>
       <return type-id='c19b74c3'/>
@@ -4641,6 +4742,9 @@
       <parameter type-id='dace003f'/>
       <parameter type-id='7d3cd834'/>
       <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='fnvlist_alloc' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='5ce45b60'/>
     </function-decl>
     <function-decl name='fnvlist_free' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='5ce45b60'/>
@@ -4909,6 +5013,12 @@
       <parameter type-id='80f4b756' name='path'/>
       <return type-id='95e97e5e'/>
     </function-decl>
+    <function-decl name='zfs_create_ancestors_props' mangled-name='zfs_create_ancestors_props' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create_ancestors_props'>
+      <parameter type-id='b0382bb3' name='hdl'/>
+      <parameter type-id='80f4b756' name='path'/>
+      <parameter type-id='5ce45b60' name='props'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
     <function-decl name='zfs_create' mangled-name='zfs_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_create'>
       <parameter type-id='b0382bb3' name='hdl'/>
       <parameter type-id='80f4b756' name='path'/>
@@ -5153,6 +5263,19 @@
     </function-decl>
     <function-decl name='changelist_haszonedchild' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='0d41d328'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='zfs_is_namespace_prop' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='58603c44'/>
+      <return type-id='c19b74c3'/>
+    </function-decl>
+    <function-decl name='zfs_namespace_prop_flag' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='58603c44'/>
+      <return type-id='8f92235e'/>
+    </function-decl>
+    <function-decl name='zfs_mount_setattr' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='9200a744'/>
+      <parameter type-id='8f92235e'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zpool_name_valid' visibility='default' binding='global' size-in-bits='64'>
@@ -8337,6 +8460,7 @@
       <parameter type-id='b0382bb3'/>
       <parameter type-id='26a90f95'/>
       <parameter type-id='95e97e5e'/>
+      <parameter type-id='5ce45b60'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zfs_send_progress' mangled-name='zfs_send_progress' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zfs_send_progress'>
@@ -10328,6 +10452,12 @@
       <parameter type-id='eaa32e2f' name='buf'/>
       <parameter type-id='9c313c2d' name='size'/>
       <parameter type-id='eaa32e2f' name='ctx_template'/>
+      <parameter type-id='c24fc2ee' name='zcp'/>
+      <return type-id='48b5725f'/>
+    </function-decl>
+    <function-decl name='fletcher_4_byteswap_varsize' mangled-name='fletcher_4_byteswap_varsize' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='fletcher_4_byteswap_varsize'>
+      <parameter type-id='eaa32e2f' name='buf'/>
+      <parameter type-id='9c313c2d' name='size'/>
       <parameter type-id='c24fc2ee' name='zcp'/>
       <return type-id='48b5725f'/>
     </function-decl>

--- a/module/zcommon/zfs_fletcher.c
+++ b/module/zcommon/zfs_fletcher.c
@@ -499,6 +499,13 @@ fletcher_4_native_varsize(const void *buf, uint64_t size, zio_cksum_t *zcp)
 	fletcher_4_scalar_native((fletcher_4_ctx_t *)zcp, buf, size);
 }
 
+void
+fletcher_4_byteswap_varsize(const void *buf, uint64_t size, zio_cksum_t *zcp)
+{
+	ZIO_SET_CHECKSUM(zcp, 0, 0, 0, 0);
+	fletcher_4_scalar_byteswap((fletcher_4_ctx_t *)zcp, buf, size);
+}
+
 static inline void
 fletcher_4_byteswap_impl(const void *buf, uint64_t size, zio_cksum_t *zcp)
 {

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -505,7 +505,11 @@ verify_perms(uint8_t *perms, uint64_t children, uint64_t nperms,
 		int permssz = sizeof (uint8_t) * children * nperms;
 		zio_cksum_t cksum;
 
+#if defined(_ZFS_BIG_ENDIAN)
+		fletcher_4_byteswap_varsize(perms, permssz, &cksum);
+#else
 		fletcher_4_native_varsize(perms, permssz, &cksum);
+#endif
 
 		if (checksum != cksum.zc_word[0]) {
 			kmem_free(counts, countssz);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
Creating a draid1 pool was resulting in the following error:
```
cannot create 'pool-smoke-201219': invalid argument for this pool operation
```
This patch fixes this issue. Closes #16261

### Description
<!--- Describe your changes in detail -->
The ioctl call to create the pool was returning -1 with errno EINVAL. Inside the module code, inside vdev_draid.c, verify_perms is calling fletcher_4_native_varsize. This in turn calls fletcher_4_scalar_native. So, implemented a fletcher_4_byteswap_varsize which makes use of the fletcher_4_scalar_byteswap in Big endian machines.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
- Used `draid verify` to verify the generated draid maps
- Created a storage pool on s390x, exported it, imported it on a little endian machine, and verified the checksums of the files within the storage pool. Checked with 10 vdisks of 10 GB each and 10 files of 8 GB each

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
