### PR TITLE
ZTS: zpool_export_parallel_admin.sh busy export

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh
@@ -64,7 +64,7 @@ log_must zpool create -f $TESTPOOL1 mirror ${DEVICE_DIR}/disk0 ${DEVICE_DIR}/dis
 
 log_must zinject -P export -s 10 $TESTPOOL1
 
-log_must zpool export $TESTPOOL1 &
+log_must_busy zpool export $TESTPOOL1 &
 
 zpool set comment=hello $TESTPOOL1
 zpool reguid $TESTPOOL1 &


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/24734611095/job/72358686292?pr=18436

```
 Debuginfo of failed tests:
cli_root/zpool_export/zpool_export_parallel_admin (5 KiB)
  [2026-04-21T17:31:53.799845] Test: /usr/local/share/zfs/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_parallel_admin (run as root) [00:00] [FAIL]
  17:31:53.57 ASSERTION: admin commands cannot race a pool export
  17:31:53.58 SUCCESS: mkdir -p /var/tmp/dev_export-test
  17:31:53.59 SUCCESS: truncate -s 268435456 /var/tmp/dev_export-test/disk0 /var/tmp/dev_export-test/disk1
  17:31:53.65 SUCCESS: zpool create -f testpool1 mirror /var/tmp/dev_export-test/disk0 /var/tmp/dev_export-test/disk1
  17:31:53.66 Added handler 30 with the following properties:
  17:31:53.66   pool: testpool1
  17:31:53.66  time: 10 seconds
  17:31:53.66 SUCCESS: zinject -P export -s 10 testpool1
  17:31:53.68 cannot export 'testpool1': pool is busy
  17:31:53.68 ERROR: zpool export testpool1 exited 1
  ```

### Description

If the pool is active 'zpool export' will fail resulting in a test failure.  Swap log_must with log_must_busy so the export is retried when reported as busy before failing the test.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
