### PR TITLE
key lookup failure should always return EACCES

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1874,7 +1874,7 @@ arc_hdr_authenticate(arc_buf_hdr_t *hdr, spa_t *spa, uint64_t dsobj)
 
 	if (ret == 0)
 		arc_hdr_clear_flags(hdr, ARC_FLAG_NOAUTH);
-	else if (ret == ENOENT)
+	else if (ret == EACCES)
 		ret = 0;
 
 	if (free_abd)

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -2677,23 +2677,16 @@ int
 spa_crypt_get_salt(spa_t *spa, uint64_t dsobj, uint8_t *salt)
 {
 	int ret;
-	dsl_crypto_key_t *dck = NULL;
+	dsl_crypto_key_t *dck;
 
 	/* look up the key from the spa's keystore */
 	ret = spa_keystore_lookup_key(spa, dsobj, FTAG, &dck);
 	if (ret != 0)
-		goto error;
+		return (SET_ERROR(EACCES));
 
 	ret = zio_crypt_key_get_salt(&dck->dck_key, salt);
-	if (ret != 0)
-		goto error;
-
 	spa_keystore_dsl_key_rele(spa, dck, FTAG);
-	return (0);
 
-error:
-	if (dck != NULL)
-		spa_keystore_dsl_key_rele(spa, dck, FTAG);
 	return (ret);
 }
 
@@ -2708,9 +2701,7 @@ spa_do_crypt_objset_mac_abd(boolean_t generate, spa_t *spa, uint64_t dsobj,
     abd_t *abd, uint_t datalen, boolean_t byteswap)
 {
 	int ret;
-	dsl_crypto_key_t *dck = NULL;
-	void *buf = abd_borrow_buf_copy(abd, datalen);
-	objset_phys_t *osp = buf;
+	dsl_crypto_key_t *dck;
 	uint8_t portable_mac[ZIO_OBJSET_MAC_LEN];
 	uint8_t local_mac[ZIO_OBJSET_MAC_LEN];
 	const uint8_t zeroed_mac[ZIO_OBJSET_MAC_LEN] = {0};
@@ -2718,15 +2709,19 @@ spa_do_crypt_objset_mac_abd(boolean_t generate, spa_t *spa, uint64_t dsobj,
 	/* look up the key from the spa's keystore */
 	ret = spa_keystore_lookup_key(spa, dsobj, FTAG, &dck);
 	if (ret != 0)
-		goto error;
+		return (SET_ERROR(EACCES));
+
+	void *buf = abd_borrow_buf_copy(abd, datalen);
+	objset_phys_t *osp = buf;
 
 	/* calculate both HMACs */
 	ret = zio_crypt_do_objset_hmacs(&dck->dck_key, buf, datalen,
 	    byteswap, portable_mac, local_mac);
-	if (ret != 0)
-		goto error;
-
 	spa_keystore_dsl_key_rele(spa, dck, FTAG);
+	if (ret != 0) {
+		abd_return_buf(abd, buf, datalen);
+		return (ret);
+	}
 
 	/* if we are generating encode the HMACs in the objset_phys_t */
 	if (generate) {
@@ -2760,14 +2755,7 @@ spa_do_crypt_objset_mac_abd(boolean_t generate, spa_t *spa, uint64_t dsobj,
 	}
 
 	abd_return_buf(abd, buf, datalen);
-
 	return (0);
-
-error:
-	if (dck != NULL)
-		spa_keystore_dsl_key_rele(spa, dck, FTAG);
-	abd_return_buf(abd, buf, datalen);
-	return (ret);
 }
 
 int
@@ -2775,23 +2763,22 @@ spa_do_crypt_mac_abd(boolean_t generate, spa_t *spa, uint64_t dsobj, abd_t *abd,
     uint_t datalen, uint8_t *mac)
 {
 	int ret;
-	dsl_crypto_key_t *dck = NULL;
-	uint8_t *buf = abd_borrow_buf_copy(abd, datalen);
+	dsl_crypto_key_t *dck;
 	uint8_t digestbuf[ZIO_DATA_MAC_LEN];
 
 	/* look up the key from the spa's keystore */
 	ret = spa_keystore_lookup_key(spa, dsobj, FTAG, &dck);
 	if (ret != 0)
-		goto error;
+		return (SET_ERROR(EACCES));
 
+	uint8_t *buf = abd_borrow_buf_copy(abd, datalen);
 	/* perform the hmac */
 	ret = zio_crypt_do_hmac(&dck->dck_key, buf, datalen,
 	    digestbuf, ZIO_DATA_MAC_LEN);
-	if (ret != 0)
-		goto error;
-
-	abd_return_buf(abd, buf, datalen);
 	spa_keystore_dsl_key_rele(spa, dck, FTAG);
+	abd_return_buf(abd, buf, datalen);
+	if (ret != 0)
+		return (ret);
 
 	/*
 	 * Truncate and fill in mac buffer if we were asked to generate a MAC.
@@ -2806,12 +2793,6 @@ spa_do_crypt_mac_abd(boolean_t generate, spa_t *spa, uint64_t dsobj, abd_t *abd,
 		return (SET_ERROR(ECKSUM));
 
 	return (0);
-
-error:
-	if (dck != NULL)
-		spa_keystore_dsl_key_rele(spa, dck, FTAG);
-	abd_return_buf(abd, buf, datalen);
-	return (ret);
 }
 
 /*


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
When a key is unloaded and we try to access (read) the data - expected error code is `EACCES`. Right now this is not the case as some functions will return `EACCES` and some will return `ENOENT`.

`spa_do_crypt_abd()` already maps a missing key to `EACCES`. However `spa_do_crypt_mac_abd()` and `spa_do_crypt_objset_mac_abd()` return the raw `spa_keystore_lookup_key()` error (`ENOENT`), which is inconsistent.
We should consistently treat “no key” as a permission failure so I propose we standardize on `EACCES` for the unloaded-key case.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
Changed `spa_do_crypt_mac_abd()`/`spa_do_crypt_objset_mac_abd()` to return `EACCES` on `spa_keystore_lookup_key()` failure.

I think the only current consumer of `spa_do_crypt_mac_abd()`/`spa_do_crypt_objset_mac_abd()` that looks into if they returned `ENOENT` error code is `arc_hdr_authenticate()`. I've updated that function to instead expect a `EACCES`.


### How Has This Been Tested?
I've ran a subset of zfs-tests to confirm this patch resolves the issue that lead to this discovery (implementing a thorough scrub that not only verifies the checksum but also decrypts and decompresses data).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
