### PR TITLE
ZTS: snapshot_018_pos.ksh add extra margin

### DIFF
--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_018_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_018_pos.ksh
@@ -91,6 +91,7 @@ log_must eval "[[ $(stat_mtime $tfs_snapdir) == 0 ]]"
 
 # Create snapshots for filesystems and check snapshots_changed reports correct time
 curr_time=$(date '+%s')
+log_must sleep 1
 log_must zfs snapshot $snap_testpool
 snap_changed_testpool=$(zfs get -H -o value -p snapshots_changed $TESTPOOL)
 snap_changed_nsecs_testpool=$(zfs get -H -o value -p snapshots_changed_nsecs $TESTPOOL)
@@ -103,6 +104,7 @@ log_must eval "[[ $list_changed_nsecs_testpool == $snap_changed_nsecs_testpool ]
 log_must eval "[[ $(stat_mtime $tpool_snapdir) ==  $snap_changed_testpool ]]"
 
 curr_time=$(date '+%s')
+log_must sleep 1
 log_must zfs snapshot $snap_testfsv1
 snap_changed_testfs=$(zfs get -H -o value -p snapshots_changed $TESTPOOL/$TESTFS)
 snap_changed_nsecs_testfs=$(zfs get -H -o value -p snapshots_changed_nsecs $TESTPOOL/$TESTFS)
@@ -121,6 +123,7 @@ log_must eval "[[ $(zfs get -H -o value -p snapshots_changed_nsecs $TESTPOOL/$TE
 
 # Create snapshot while unmounted
 curr_time=$(date '+%s')
+log_must sleep 1
 log_must zfs snapshot $snap_testfsv2
 snap_changed_testfs=$(zfs get -H -o value -p snapshots_changed $TESTPOOL/$TESTFS)
 snap_changed_nsecs_testfs=$(zfs get -H -o value -p snapshots_changed_nsecs $TESTPOOL/$TESTFS)
@@ -144,6 +147,7 @@ log_must eval "[[ $(stat_mtime $tfs_snapdir) ==  $snap_changed_testfs ]]"
 
 # Destroy the snapshots and check snapshots_changed shows correct time
 curr_time=$(date '+%s')
+log_must sleep 1
 log_must zfs destroy $snap_testfsv1
 snap_changed_testfs=$(zfs get -H -o value -p snapshots_changed $TESTPOOL/$TESTFS)
 snap_changed_nsecs_testfs=$(zfs get -H -o value -p snapshots_changed_nsecs $TESTPOOL/$TESTFS)
@@ -152,6 +156,7 @@ log_must eval "[[ $((snap_changed_nsecs_testfs / 1000000000)) == $snap_changed_t
 log_must eval "[[ $(stat_mtime $tfs_snapdir) ==  $snap_changed_testfs ]]"
 
 curr_time=$(date '+%s')
+log_must sleep 1
 log_must zfs destroy $snap_testpool
 snap_changed_testpool=$(zfs get -H -o value -p snapshots_changed $TESTPOOL)
 snap_changed_nsecs_testpool=$(zfs get -H -o value -p snapshots_changed_nsecs $TESTPOOL)


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/24764467025/job/72455377060?pr=18445

```
...
  08:26:05.98 SUCCESS: zfs mount testpool/testfs
  08:26:05.99 SUCCESS: eval [[ 1776846365 == 1776846365 ]]
  08:26:05.99 SUCCESS: eval [[ 1776846365889999399 == 1776846365889999399 ]]
  08:26:06.00 SUCCESS: eval [[ 1776846365 ==  1776846365 ]]
  08:26:06.02 SUCCESS: zfs destroy testpool/testfs@v1
  08:26:06.03 ERROR: eval [[ 1776846365 -ge 1776846366 ]] exited 1
  ```

### Description

The date(1) command and snapshot timestamps use different clock sources which can result in a small discrepancy.  This can cause the test the incorrectly fail.  To avoid this, add a brief delay to the test case to allow for minor skew.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [q] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)