### PR TITLE
ZTS: mmp_on_uberblocks.ksh simplify

### DIFF
--- a/tests/zfs-tests/tests/functional/mmp/mmp_on_uberblocks.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_on_uberblocks.ksh
@@ -16,20 +16,17 @@
 #
 
 #
-# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+# Copyright (c) 2026 by Lawrence Livermore National Security, LLC.
 #
 
 # DESCRIPTION:
 #	Ensure that MMP updates uberblocks with MMP info at expected intervals. 
 #
 # STRATEGY:
-#	1. Set TXG_TIMEOUT to large value
-#	2. Create a zpool
-#	3. Clear multihost history
-#	4. Sleep, then collect count of uberblocks written
-#	5. If number of changes seen is less than min threshold, then fail
-#	6. If number of changes seen is more than max threshold, then fail
-#	7. Sequence number increments when no TXGs are syncing
+#	1. Create a zpool
+#	2. Clear multihost history
+#	3. Sleep for 10s, then collect count of uberblocks written
+#	4. Verify the mmp updates are within 20% of the expected target
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -38,51 +35,29 @@
 
 verify_runnable "both"
 
-UBER_CHANGES=0
 DURATION=10
-EXPECTED=$((($(echo $DISKS | wc -w) * $DURATION * 1000) / $MMP_INTERVAL_DEFAULT))
-FUDGE=$((EXPECTED * 20 / 100))
-MIN_UB_WRITES=$((EXPECTED - FUDGE))
-MAX_UB_WRITES=$((EXPECTED + FUDGE))
-MIN_SEQ_VALUES=8
+NDISKS=$(echo $DISKS | wc -w)
+MMP_INTERVAL=$(get_tunable MULTIHOST_INTERVAL)
+TARGET=$((($NDISKS * $DURATION * 1000) / $MMP_INTERVAL))
 
 function cleanup
 {
 	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
-	log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_DEFAULT
-	set_tunable64 TXG_TIMEOUT $TXG_TIMEOUT_DEFAULT
 	log_must mmp_clear_hostid
 }
 
 log_assert "Ensure MMP uberblocks update at the correct interval"
 log_onexit cleanup
 
-log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_DEFAULT
-log_must set_tunable64 TXG_TIMEOUT $TXG_TIMEOUT_LONG
 log_must mmp_set_hostid $HOSTID1
 
 log_must zpool create -f $TESTPOOL $DISKS
 log_must zpool set multihost=on $TESTPOOL
+
 clear_mmp_history
-UBER_CHANGES=$(count_mmp_writes $TESTPOOL $DURATION)
+MMP_WRITES=$(count_mmp_writes $TESTPOOL $DURATION)
 
-log_note "Uberblock changed $UBER_CHANGES times"
-
-if [ $UBER_CHANGES -lt $MIN_UB_WRITES ]; then
-	log_fail "Fewer uberblock writes occurred than expected ($EXPECTED)"
-fi
-
-if [ $UBER_CHANGES -gt $MAX_UB_WRITES ]; then
-	log_fail "More uberblock writes occurred than expected ($EXPECTED)"
-fi
-
-log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_MIN
-SEQ_BEFORE=$(zdb -luuuu ${DISK[0]} | awk '/mmp_seq/ {if ($NF>max) max=$NF}; END {print max}')
-sleep 5
-SEQ_AFTER=$(zdb  -luuuu ${DISK[0]} | awk '/mmp_seq/ {if ($NF>max) max=$NF}; END {print max}')
-if [ $((SEQ_AFTER - SEQ_BEFORE)) -lt $MIN_SEQ_VALUES ]; then
-	zdb -luuuu ${DISK[0]}
-	log_fail "ERROR: mmp_seq did not increase by $MIN_SEQ_VALUES; before $SEQ_BEFORE after $SEQ_AFTER"
-fi
+log_note "Uberblock changed $MMP_WRITES times"
+log_must within_percent $MMP_WRITES $TARGET 80
 
 log_pass "Ensure MMP uberblocks update at the correct interval passed"


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/24792352037/job/72552994804?pr=18398

Resolve a long standing flaw in the mmp_on_uberblocks.ksh test case which was causing CI failures.

### Description

The last portion of mmp_on_uberblocks.ksh was intended to verify that the sequence number was incremented.  However, it failed to account for the case where a txg sync would occur resulting in the sequence number being correctly reset.

Rather than add additional code to detect this that check has been removed.  The mmp update frequency is still verified via the kstat which is a more reliably mechanism to detect the writes.  There are several other mmp tests which verify the uberblock changes are reflected on disk so there's no significant loss of test coverage.

Finally, the test case has been simplified to use the within_percent function for readability.

### How Has This Been Tested?

Locally tested with 100 iterations of the updated test and will be further verified by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)