### PR TITLE
ZTS: zpool_iostat_002_pos increase sleep time

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_002_pos.ksh
@@ -38,7 +38,7 @@
 #
 # STRATEGY:
 # 1. Set the interval to 1 and count to 4.
-# 2. Sleep for 4 seconds.
+# 2. Sleep for 5 seconds.
 # 3. Verify that the output has 4 records.
 # 4. Set interval to 0.5 and count to 1 to test floating point intervals.
 
@@ -61,11 +61,12 @@ if ! is_global_zone ; then
 	TESTPOOL=${TESTPOOL%%/*}
 fi
 
-zpool iostat $TESTPOOL 1 4 > $tmpfile 2>&1 &
-sleep 4
+log_must eval "zpool iostat $TESTPOOL 1 4 > $tmpfile 2>&1 &"
+log_must sleep 5
 stat_count=$(grep -c $TESTPOOL $tmpfile)
 
 if [[ $stat_count -ne 4 ]]; then
+	cat $tmpfile
 	log_fail "zpool iostat [pool_name] [interval] [count] failed"
 fi
 


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/24791992863/job/72689944214?pr=18436

```
Debuginfo of failed tests:
cli_user/zpool_iostat/zpool_iostat_002_pos (56 KiB)
  [2026-04-23T13:10:13.852022] Test: /usr/share/zfs/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_002_pos (run as zfs) [00:05] [FAIL]
  13:10:08.47 ASSERTION: zpool iostat [pool_name ...] [interval] [count]
  13:10:13.69 zpool iostat [pool_name] [interval] [count] failed
  ```
  
  ### Description

Allow an additional second for the test to complete before checking the results.  This may explain occasional test failures in the CI. Additionally, when the test fails dump the tmpfile for inspection.

### How Has This Been Tested?

Locally tested.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
