### PR TITLE
linux: verify stale znodes in legacy fallocate

### DIFF
--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -953,11 +953,12 @@ objs:
 int
 zfs_statvfs(struct inode *ip, struct kstatfs *statp)
 {
+	znode_t *zp = ITOZ(ip);
 	zfsvfs_t *zfsvfs = ITOZSB(ip);
 	uint64_t refdbytes, availbytes, usedobjs, availobjs;
 	int err = 0;
 
-	if ((err = zfs_enter(zfsvfs, FTAG)) != 0)
+	if ((err = zfs_enter_verify_zp(zfsvfs, zp, FTAG)) != 0)
 		return (err);
 
 	dmu_objset_space(zfsvfs->z_os,
@@ -1013,8 +1014,6 @@ zfs_statvfs(struct inode *ip, struct kstatfs *statp)
 
 	if (dmu_objset_projectquota_enabled(zfsvfs->z_os) &&
 	    dmu_objset_projectquota_present(zfsvfs->z_os)) {
-		znode_t *zp = ITOZ(ip);
-
 		if (zp->z_pflags & ZFS_PROJINHERIT && zp->z_projid &&
 		    zpl_is_valid_projid(zp->z_projid))
 			err = zfs_statfs_project(zfsvfs, zp, statp, bshift);

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -673,6 +673,8 @@ static long
 zpl_fallocate_common(struct inode *ip, int mode, loff_t offset, loff_t len)
 {
 	cred_t *cr = CRED();
+	znode_t *zp = ITOZ(ip);
+	zfsvfs_t *zfsvfs = ITOZSB(ip);
 	loff_t olen;
 	fstrans_cookie_t cookie;
 	int error = 0;
@@ -706,7 +708,7 @@ zpl_fallocate_common(struct inode *ip, int mode, loff_t offset, loff_t len)
 		bf.l_len = len;
 		bf.l_pid = 0;
 
-		error = -zfs_space(ITOZ(ip), F_FREESP, &bf, O_RDWR, offset, cr);
+		error = -zfs_space(zp, F_FREESP, &bf, O_RDWR, offset, cr);
 	} else if ((mode & ~FALLOC_FL_KEEP_SIZE) == 0) {
 		unsigned int percent = zfs_fallocate_reserve_percent;
 		struct kstatfs statfs;
@@ -721,7 +723,7 @@ zpl_fallocate_common(struct inode *ip, int mode, loff_t offset, loff_t len)
 		 * Use zfs_statvfs() instead of dmu_objset_space() since it
 		 * also checks project quota limits, which are relevant here.
 		 */
-		error = zfs_statvfs(ip, &statfs);
+		error = -zfs_statvfs(ip, &statfs);
 		if (error)
 			goto out_unmark;
 
@@ -734,8 +736,14 @@ zpl_fallocate_common(struct inode *ip, int mode, loff_t offset, loff_t len)
 			error = -ENOSPC;
 			goto out_unmark;
 		}
-		if (!(mode & FALLOC_FL_KEEP_SIZE) && offset + len > olen)
-			error = zfs_freesp(ITOZ(ip), offset + len, 0, 0, FALSE);
+		if (!(mode & FALLOC_FL_KEEP_SIZE) && offset + len > olen) {
+			error = zpl_enter_verify_zp(zfsvfs, zp, FTAG);
+			if (error)
+				goto out_unmark;
+
+			error = -zfs_freesp(zp, offset + len, 0, 0, FALSE);
+			zfs_exit(zfsvfs, FTAG);
+		}
 	}
 out_unmark:
 	spl_fstrans_unmark(cookie);


### PR DESCRIPTION
### Motivation and Context
The Linux legacy fallocate preallocation path can call zfs_freesp()
without first validating that the znode still has a live SA handle.
After a failed zfs_rezget() reload, a stale inode may remain alive in
the VFS with z_sa_hdl cleared, which turns a later fallocate call
into a NULL pointer dereference in sa_lookup().

```
Oops: general protection fault, probably for non-canonical address 0xdffffc0000000042: 0000 [#1] SMP KASAN NOPTI
KASAN: null-ptr-deref in range [0x0000000000000210-0x0000000000000217]
RIP: 0010:spl_mutex_lockdep_off_maybe include/zfs/os/linux/spl/sys/mutex.h:78 [inline]
RIP: 0010:sa_lookup+0xc7/0x560 fs/zfs/zfs/sa.c:1509
Call Trace:
 zfs_freesp+0x242/0xc00 fs/zfs/os/linux/zfs/zfs_znode_os.c:1761
 zpl_fallocate_common+0x530/0x5a0 fs/zfs/os/linux/zfs/zpl_file.c:735
 zpl_fallocate+0x4e/0x70 fs/zfs/os/linux/zfs/zpl_file.c:749
 vfs_fallocate+0x468/0xfd0 fs/open.c:342
 ksys_fallocate fs/open.c:366 [inline]
 __do_sys_fallocate fs/open.c:371 [inline]
 __se_sys_fallocate fs/open.c:369 [inline]
 __x64_sys_fallocate+0xcf/0x140 fs/open.c:369
 ...
```

### Description
This change adds an early stale-znode check in the legacy
preallocation branch of zpl_fallocate_common().

It also wraps the direct zfs_freesp() call in
zpl_enter_verify_zp()/zfs_exit(), matching the validation boundary
used by other Linux ZPL file operations.

The resulting failure mode is EIO for stale znodes instead of a
kernel crash.

### How Has This Been Tested?
Tested on Linux.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).