### PR TITLE
Adjust length in `dmu_evict_range()` to not go beyond file end

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -953,11 +953,29 @@ void
 dmu_evict_range(objset_t *os, uint64_t object, uint64_t offset, uint64_t len)
 {
 	dnode_t *dn;
+	uint64_t end_offset;
 
 	if (len == 0)
 		return;
 	if (dnode_hold(os, object, FTAG, &dn) != 0)
 		return;
+
+	/*
+	 * The passed `len` may be equal to "offset + ~OFF_MAX", at least on
+	 * FreeBSD:
+	 *   1. `kern_posix_fadvise()` uses an end offset of OFF_MAX if the
+	 *      length passed to posix_fadvise(2) is 0. This end offset is
+	 *      passed to `zfs_freebsd_advise()`.
+	 *   2. `zfs_freebsd_advise()` computes a length from `end - start`, so
+	 *      possibly `OFF_MAX - start`. This length is passed to
+	 *      `dmu_evict_range()`.
+	 *   3. The `len` can't be passed as is to `dbuf_whichblock()` because
+	 *      it has an assertion that it does not go beyond the end of the
+	 *      file.
+	 * Therefore here, we take the minimum between the given `len` and the
+	 * last offset of the file.
+	 */
+	end_offset = MIN(offset + len, dn->dn_datablksz - 1);
 
 	/*
 	 * Exclude the last block if the range end is not block-aligned:
@@ -967,7 +985,7 @@ dmu_evict_range(objset_t *os, uint64_t object, uint64_t offset, uint64_t len)
 	 */
 	rw_enter(&dn->dn_struct_rwlock, RW_READER);
 	uint64_t start = dbuf_whichblock(dn, 0, offset);
-	uint64_t end = dbuf_whichblock(dn, 0, offset + len);
+	uint64_t end = dbuf_whichblock(dn, 0, end_offset);
 	if (end > start)
 		dbuf_evict_range(dn, start, end - 1);
 	rw_exit(&dn->dn_struct_rwlock);


### PR DESCRIPTION
### Motivation and Context

I get a reproducible panic while working on a work-related project (https://github.com/rabbitmq/khepri) by running its testsuite on a freshly built FreeBSD -CURRENT kernel that has #18399.

### Description

At least on FreeBSD, `OFF_MAX` is used to indicate "up to the end of the file". When passed to `dmu_evict_range()` and then `dbuf_whichblock()`, it caused a panic when `dbuf_whichblock()` asserted that its argument was not beyond the end of the file.

So instead of passing `offset + len` to `dbuf_whichblock()`, compute the end offset so that it stays within the file boundaries.

### How Has This Been Tested?

This has been tested using the testsuite of Khepri, because the Ra library (a dependency) uses posix_fadvise(2) + `POSIX_FADV_DONTNEED` with an offset of 0 and a length of 0.

```
git https://github.com/rabbitmq/khepri.git
cd khepri
rebar ct
```

You will need to install Erlang and Rebar.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
