### PR TITLE
Linux: expose zfs_arc_no_grow_shift as a module parameter

### DIFF
--- a/include/os/freebsd/zfs/sys/arc_os.h
+++ b/include/os/freebsd/zfs/sys/arc_os.h
@@ -29,6 +29,5 @@
 #define	_SYS_ARC_OS_H
 
 int param_set_arc_free_target(SYSCTL_HANDLER_ARGS);
-int param_set_arc_no_grow_shift(SYSCTL_HANDLER_ARGS);
 
 #endif

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -1103,7 +1103,7 @@ extern arc_sums_t arc_sums;
 extern hrtime_t arc_growtime;
 extern boolean_t arc_warm;
 extern uint_t arc_grow_retry;
-extern uint_t arc_no_grow_shift;
+extern uint_t zfs_arc_no_grow_shift;
 extern uint_t arc_shrink_shift;
 extern kmutex_t arc_prune_mtx;
 extern list_t arc_prune_list;
@@ -1134,6 +1134,7 @@ extern int param_set_arc_int(ZFS_MODULE_PARAM_ARGS);
 extern int param_set_arc_min(ZFS_MODULE_PARAM_ARGS);
 extern int param_set_arc_max(ZFS_MODULE_PARAM_ARGS);
 extern int param_set_l2arc_dwpd_limit(ZFS_MODULE_PARAM_ARGS);
+extern int param_set_arc_no_grow_shift(ZFS_MODULE_PARAM_ARGS);
 extern void l2arc_dwpd_bump_reset(void);
 
 /* used in zdb.c */

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -948,8 +948,6 @@ equivalent to the greater of the number of online CPUs and
 If less than
 .Sy arc_c No >> Sy zfs_arc_no_grow_shift
 free memory is available, the ARC is not allowed to grow.
-This parameter is
-.Fx Ns -specific .
 .
 .It Sy zfs_arc_overflow_shift Ns = Ns Sy 8 Pq int
 The ARC size is considered to be overflowing if it exceeds the current

--- a/module/os/freebsd/zfs/arc_os.c
+++ b/module/os/freebsd/zfs/arc_os.c
@@ -72,9 +72,6 @@ SYSINIT(arc_free_target_init, SI_SUB_KTHREAD_PAGE, SI_ORDER_ANY,
 ZFS_MODULE_PARAM_CALL(zfs_arc, zfs_arc_, free_target,
     param_set_arc_free_target, 0, CTLFLAG_RW,
 	"Desired number of free pages below which ARC triggers reclaim");
-ZFS_MODULE_PARAM_CALL(zfs_arc, zfs_arc_, no_grow_shift,
-    param_set_arc_no_grow_shift, 0, ZMOD_RW,
-	"log2(fraction of ARC which must be free to allow growing)");
 
 int64_t
 arc_available_memory(void)

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -256,7 +256,7 @@ param_set_arc_no_grow_shift(SYSCTL_HANDLER_ARGS)
 {
 	int err, val;
 
-	val = arc_no_grow_shift;
+	val = zfs_arc_no_grow_shift;
 	err = sysctl_handle_int(oidp, &val, 0, req);
 	if (err != 0 || req->newptr == NULL)
 		return (err);
@@ -264,7 +264,7 @@ param_set_arc_no_grow_shift(SYSCTL_HANDLER_ARGS)
 	if (val < 0 || val >= arc_shrink_shift)
 		return (EINVAL);
 
-	arc_no_grow_shift = val;
+	zfs_arc_no_grow_shift = val;
 
 	return (0);
 }

--- a/module/os/linux/zfs/arc_os.c
+++ b/module/os/linux/zfs/arc_os.c
@@ -411,6 +411,24 @@ param_set_arc_int(const char *buf, zfs_kernel_param_t *kp)
 }
 
 int
+param_set_arc_no_grow_shift(const char *buf, zfs_kernel_param_t *kp)
+{
+	unsigned long val;
+	int error;
+
+	error = kstrtoul(buf, 0, &val);
+	if (error)
+		return (SET_ERROR(error));
+
+	if (val >= arc_shrink_shift)
+		return (-SET_ERROR(EINVAL));
+
+	zfs_arc_no_grow_shift = val;
+
+	return (0);
+}
+
+int
 param_set_l2arc_dwpd_limit(const char *buf, zfs_kernel_param_t *kp)
 {
 	uint64_t old_val = l2arc_dwpd_limit;

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -398,14 +398,14 @@ uint_t zfs_arc_pc_percent = 0;
 
 /*
  * log2(fraction of ARC which must be free to allow growing).
- * I.e. If there is less than arc_c >> arc_no_grow_shift free memory,
+ * I.e. If there is less than arc_c >> zfs_arc_no_grow_shift free memory,
  * when reading a new block into the ARC, we will evict an equal-sized block
  * from the ARC.
  *
  * This must be less than arc_shrink_shift, so that when we shrink the ARC,
  * we will still not allow it to grow.
  */
-uint_t		arc_no_grow_shift = 5;
+uint_t		zfs_arc_no_grow_shift = 5;
 
 
 /*
@@ -4975,7 +4975,7 @@ arc_reap_cb_check(void *arg, zthr_t *zthr)
 		 */
 		arc_growtime = gethrtime() + SEC2NSEC(arc_grow_retry);
 		return (B_TRUE);
-	} else if (free_memory < arc_c >> arc_no_grow_shift) {
+	} else if (free_memory < arc_c >> zfs_arc_no_grow_shift) {
 		arc_no_grow = B_TRUE;
 	} else if (gethrtime() >= arc_growtime) {
 		arc_no_grow = B_FALSE;
@@ -7654,7 +7654,8 @@ arc_tuning_update(boolean_t verbose)
 	/* Valid range: 1 - N */
 	if (zfs_arc_shrink_shift) {
 		arc_shrink_shift = zfs_arc_shrink_shift;
-		arc_no_grow_shift = MIN(arc_no_grow_shift, arc_shrink_shift -1);
+		zfs_arc_no_grow_shift = MIN(zfs_arc_no_grow_shift,
+		    arc_shrink_shift - 1);
 	}
 
 	/* Valid range: 1 - N ms */
@@ -11700,6 +11701,10 @@ ZFS_MODULE_PARAM_CALL(zfs_arc, zfs_arc_, grow_retry, param_set_arc_int,
 
 ZFS_MODULE_PARAM_CALL(zfs_arc, zfs_arc_, shrink_shift, param_set_arc_int,
 	param_get_uint, ZMOD_RW, "log2(fraction of ARC to reclaim)");
+
+ZFS_MODULE_PARAM_CALL(zfs_arc, zfs_arc_, no_grow_shift,
+	param_set_arc_no_grow_shift, param_get_uint, ZMOD_RW,
+	"log2(fraction of ARC which must be free to allow growing)");
 
 #ifdef _KERNEL
 ZFS_MODULE_PARAM(zfs_arc, zfs_arc_, pc_percent, UINT, ZMOD_RW,


### PR DESCRIPTION
### Motivation

Follow-up to #18456 as suggested by @behlendorf 

### Description

Registers `zfs_arc_no_grow_shift` as a Linux module parameter copying the FreeBSD sysctl tunable.

### Testing performed

zfs.ko build module was tested against Linux 6.19.13.

### zfs.4

I will drop the FreeBSD parameter specificity when my previous commit will get merged.