### PR TITLE
build: use pax tar format for make dist

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_CONFIG_MACRO_DIR([config])
 AC_CANONICAL_TARGET
 AM_MAINTAINER_MODE
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
-AM_INIT_AUTOMAKE([subdir-objects foreign])
+AM_INIT_AUTOMAKE([subdir-objects foreign tar-pax])
 # Remove default macros from config.h:
 #   PACKAGE, PACKAGE_{BUGREPORT,NAME,STRING,TARNAME,VERSION}, STDC_HEADERS, VERSION
 AC_CONFIG_HEADERS([zfs_config.h], [


### PR DESCRIPTION
## Motivation
Automake's default `make dist` tar imposes path length limits. Several test paths in the tree exceed those once the
`zfs-X.Y.Z/` directory prefix is added, so they get truncated or dropped from the release tarball.

Users building from the released `.tar.gz` then hit `No rule to make target ...` (issue #17276).

## Description
Adding `tar-pax` to `AM_INIT_AUTOMAKE` switches `make dist` to POSIX
1003.1-2001 pax format, which has no length limit and is read by GNU
tar 1.14+ (2004) and libarchive/bsdtar.

## Testing performed
- [x] `./autogen.sh && ./configure --with-config=user && make dist`
  emits `tar --format=posix`
- [x] Resulting tarball contains all 8 currently-over-100-char paths
  intact (longest 122 chars)
- [x] Extracted tarball: `./configure && make -C tests/zfs-tests/tests all-am`
  succeeds

Closes #17276