### PR TITLE
libzfs/mnttab: restore ability to enable/disable cache

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -9417,6 +9417,7 @@ main(int argc, char **argv)
 	/*
 	 * Run the appropriate command.
 	 */
+	libzfs_mnttab_cache(g_zfs, B_TRUE);
 	if (find_command_idx(cmdname, &i) == 0) {
 		current_command = &command_table[i];
 		ret = command_table[i].func(argc - 1, newargv + 1);

--- a/lib/libzfs/libzfs_impl.h
+++ b/lib/libzfs/libzfs_impl.h
@@ -66,6 +66,7 @@ struct libzfs_handle {
 	char *libfetch_load_error;
 	kmutex_t zh_mnttab_lock;
 	avl_tree_t zh_mnttab;
+	boolean_t zh_mnttab_cache_enabled;
 };
 
 struct zfs_handle {

--- a/lib/libzfs/libzfs_mnttab.c
+++ b/lib/libzfs/libzfs_mnttab.c
@@ -81,34 +81,13 @@ mnttab_compare(const void *arg1, const void *arg2)
 	return (TREE_ISIGN(rv));
 }
 
-void
-libzfs_mnttab_init(libzfs_handle_t *hdl)
+static void
+mnttab_drop(libzfs_handle_t *hdl)
 {
-	mutex_init(&hdl->zh_mnttab_lock, NULL, MUTEX_DEFAULT, NULL);
-	assert(avl_numnodes(&hdl->zh_mnttab) == 0);
-	avl_create(&hdl->zh_mnttab, mnttab_compare,
-	    sizeof (mnttab_node_t), offsetof(mnttab_node_t, mtn_node));
-}
-
-void
-libzfs_mnttab_fini(libzfs_handle_t *hdl)
-{
-	void *cookie = NULL;
 	mnttab_node_t *mtn;
-
-	while ((mtn = avl_destroy_nodes(&hdl->zh_mnttab, &cookie))
-	    != NULL)
+	void *cookie = NULL;
+	while ((mtn = avl_destroy_nodes(&hdl->zh_mnttab, &cookie)) != NULL)
 		mnttab_node_free(hdl, mtn);
-
-	avl_destroy(&hdl->zh_mnttab);
-	(void) mutex_destroy(&hdl->zh_mnttab_lock);
-}
-
-void
-libzfs_mnttab_cache(libzfs_handle_t *hdl, boolean_t enable)
-{
-	/* This is a no-op to preserve ABI backward compatibility. */
-	(void) hdl, (void) enable;
 }
 
 static int
@@ -145,6 +124,33 @@ mnttab_update(libzfs_handle_t *hdl)
 	return (0);
 }
 
+
+void
+libzfs_mnttab_init(libzfs_handle_t *hdl)
+{
+	mutex_init(&hdl->zh_mnttab_lock, NULL, MUTEX_DEFAULT, NULL);
+	assert(avl_numnodes(&hdl->zh_mnttab) == 0);
+	avl_create(&hdl->zh_mnttab, mnttab_compare,
+	    sizeof (mnttab_node_t), offsetof(mnttab_node_t, mtn_node));
+	hdl->zh_mnttab_cache_enabled = B_FALSE;
+}
+
+void
+libzfs_mnttab_fini(libzfs_handle_t *hdl)
+{
+	mnttab_drop(hdl);
+	avl_destroy(&hdl->zh_mnttab);
+	(void) mutex_destroy(&hdl->zh_mnttab_lock);
+}
+
+void
+libzfs_mnttab_cache(libzfs_handle_t *hdl, boolean_t enable)
+{
+	mutex_enter(&hdl->zh_mnttab_lock);
+	hdl->zh_mnttab_cache_enabled = enable;
+	mutex_exit(&hdl->zh_mnttab_lock);
+}
+
 int
 libzfs_mnttab_find(libzfs_handle_t *hdl, const char *fsname,
     struct mnttab *entry)
@@ -154,6 +160,9 @@ libzfs_mnttab_find(libzfs_handle_t *hdl, const char *fsname,
 	int ret = ENOENT;
 
 	mutex_enter(&hdl->zh_mnttab_lock);
+	if (!hdl->zh_mnttab_cache_enabled)
+		mnttab_drop(hdl);
+
 	if (avl_numnodes(&hdl->zh_mnttab) == 0) {
 		int error;
 
@@ -180,6 +189,11 @@ libzfs_mnttab_add(libzfs_handle_t *hdl, const char *special,
 	mnttab_node_t *mtn;
 
 	mutex_enter(&hdl->zh_mnttab_lock);
+	if (!hdl->zh_mnttab_cache_enabled) {
+		/* Don't bother; we're going to discard it anyway. */
+		mutex_exit(&hdl->zh_mnttab_lock);
+		return;
+	}
 
 	mtn = mnttab_node_alloc(hdl, special, mountp, mntopts);
 
@@ -202,6 +216,12 @@ libzfs_mnttab_remove(libzfs_handle_t *hdl, const char *fsname)
 	mnttab_node_t *ret;
 
 	mutex_enter(&hdl->zh_mnttab_lock);
+	if (!hdl->zh_mnttab_cache_enabled) {
+		/* Don't bother; we're going to discard it anyway. */
+		mutex_exit(&hdl->zh_mnttab_lock);
+		return;
+	}
+
 	find.mtn_mt.mnt_special = (char *)fsname;
 	if ((ret = avl_find(&hdl->zh_mnttab, (void *)&find, NULL)) != NULL) {
 		avl_remove(&hdl->zh_mnttab, ret);

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -1150,7 +1150,7 @@ tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_004_pos']
 tags = ['functional', 'zvol', 'zvol_swap']
 
 [tests/functional/libzfs]
-tests = ['many_fds', 'libzfs_input']
+tests = ['many_fds', 'libzfs_input', 'libzfs_mnttab_cache']
 tags = ['functional', 'libzfs']
 
 [tests/functional/log_spacemap]

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -466,7 +466,7 @@ tests = ['large_files_001_pos', 'large_files_002_pos']
 tags = ['functional', 'large_files']
 
 [tests/functional/libzfs]
-tests = ['many_fds', 'libzfs_input']
+tests = ['many_fds', 'libzfs_input', 'libzfs_mnttab_cache']
 tags = ['functional', 'libzfs']
 
 [tests/functional/limits]

--- a/tests/zfs-tests/cmd/.gitignore
+++ b/tests/zfs-tests/cmd/.gitignore
@@ -18,6 +18,7 @@
 /getversion
 /largest_file
 /libzfs_input_check
+/libzfs_mnttab_cache_check
 /manipulate_user_buffer
 /mkbusy
 /mkfile

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -66,6 +66,10 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/libzfs_input_check
 	libzfs_core.la \
 	libnvpair.la
 
+scripts_zfs_tests_bin_PROGRAMS += %D%/libzfs_mnttab_cache_check
+%C%_libzfs_mnttab_cache_check_LDADD = \
+	libzfs.la
+
 scripts_zfs_tests_bin_PROGRAMS += %D%/manipulate_user_buffer
 %C%_manipulate_user_buffer_LDADD = -lpthread
 

--- a/tests/zfs-tests/cmd/libzfs_mnttab_cache_check.c
+++ b/tests/zfs-tests/cmd/libzfs_mnttab_cache_check.c
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026 by Delphix. All rights reserved.
+ */
+
+/*
+ * libzfs_mnttab_cache_check.c
+ *
+ * Tests that libzfs_mnttab_cache(hdl, B_FALSE) does indeed disable the
+ * per-handle mnttab cache. It does this by adding a fake entry to it, then
+ * trying to read the status of a known-mounted dataset from it.
+ *
+ * As currently implemented, when enabled, libzfs_mnttab_find() assumes the
+ * cache is correct and up to date if it has any entries in it at all. So by
+ * putting something in it before searching, the initial load from /etc/mtab
+ * never happens, and the real mounted datasets are never seen.
+ *
+ * When disabled, the entire cache is discarded and reloaded on every lookup,
+ * so the fake entry will disappear and the real state will be found correctly.
+ * to date if it has any entries in it at all.
+ *
+ * Run (as a user that can read /etc/mtab):
+ *   ./libzfs_mnttab_cache_check <name-of-any-currently-mounted-zfs-dataset>
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/mnttab.h>
+#include <libzfs.h>
+
+int
+main(int argc, char *argv[])
+{
+	if (argc != 2) {
+		fprintf(stderr,
+		    "usage: %s <currently-mounted-zfs-dataset>\n", argv[0]);
+		return (2);
+	}
+	const char *real_ds = argv[1];
+
+	libzfs_handle_t *hdl = libzfs_init();
+	if (hdl == NULL) {
+		fprintf(stderr, "libzfs_init failed\n");
+		return (1);
+	}
+
+	/* Ask libzfs to disable the per-handle mnttab cache. */
+	libzfs_mnttab_cache(hdl, B_FALSE);
+
+	/*
+	 * Stand-in for what zfs_mount() does internally on every successful
+	 * mount: zfs_mount_at() calls libzfs_mnttab_add(hdl, ...) after
+	 * do_mount(). In a real consumer, this happens implicitly; we call it
+	 * directly here so the reproducer doesn't need root or a mountable
+	 * dataset.
+	 */
+	libzfs_mnttab_add(hdl, "fake/dataset", "/fake/mountpoint", "rw");
+
+	/*
+	 * Now query ZFS_PROP_MOUNTED on a real, currently-mounted dataset.
+	 * This is the standard libzfs API a consumer uses to check mount
+	 * state. Internally it calls libzfs_mnttab_find().
+	 */
+	zfs_handle_t *zhp = zfs_open(hdl, real_ds, ZFS_TYPE_FILESYSTEM);
+	if (zhp == NULL) {
+		fprintf(stderr, "zfs_open(%s) failed\n", real_ds);
+		libzfs_fini(hdl);
+		return (1);
+	}
+
+	uint64_t mounted = zfs_prop_get_int(zhp, ZFS_PROP_MOUNTED);
+	zfs_close(zhp);
+
+	int rc;
+	if (mounted) {
+		printf("OK: ZFS_PROP_MOUNTED reports %s as mounted\n", real_ds);
+		rc = 0;
+	} else {
+		printf("BUG: ZFS_PROP_MOUNTED reports %s as NOT mounted\n",
+		    real_ds);
+		printf("     but %s IS mounted (see /etc/mtab and "
+		    "`zfs get mounted`).\n", real_ds);
+		printf("     libzfs_mnttab_cache(hdl, B_FALSE) did not "
+		    "actually disable the cache.\n");
+		rc = 1;
+	}
+
+	libzfs_fini(hdl);
+	return (rc);
+}

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -202,6 +202,7 @@ export ZFSTEST_FILES_COMMON='badsend
     get_diff
     getversion
     largest_file
+    libzfs_mnttab_cache_check
     libzfs_input_check
     manipulate_user_buffer
     mkbusy

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1700,6 +1700,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/largest_pool/largest_pool_001_pos.ksh \
 	functional/libzfs/cleanup.ksh \
 	functional/libzfs/libzfs_input.ksh \
+	functional/libzfs/libzfs_mnttab_cache.ksh \
 	functional/libzfs/setup.ksh \
 	functional/limits/cleanup.ksh \
 	functional/limits/filesystem_count.ksh \

--- a/tests/zfs-tests/tests/functional/libzfs/libzfs_mnttab_cache.ksh
+++ b/tests/zfs-tests/tests/functional/libzfs/libzfs_mnttab_cache.ksh
@@ -1,0 +1,26 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+log_assert "libzfs mnttab cache works as expected"
+
+log_must libzfs_mnttab_cache_check $TESTPOOL/$TESTFS
+
+log_pass "libzfs mnttab cache works as expected"


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Turns out that removing the ability to _disable_ the mnttab cache broke at least one third-party libzfs consumers. Regardless of my own feelings on libzfs, now that we know about it it'd be quite rude to just ignore it.

Fortunately it's relatively straightforward to restore the previous behaviour without reverting the change. That's this PR!

Closes #18464.

### Description

Fortunately when you have a "cache", its not hard to "disable" it - just throw it away between uses. That's what this commit does - on each call to `libzfs_mnttab_find()`, empty the `zh_mnttab` AVL before proceeding.

To truly return to the old behaviour, the cache is now "off" by default. This requires that the `zfs` explicitly enable it again, so that line is returned.

### How Has This Been Tested?

`zfs_mount` and `zfs_unmount` tests pass. If the `zfs` command is changed to _not_ enable the cache, the `zfs_multi_mount` test fails. This is also the case if make the same change on 2.4.1, which is a nice suggestion that the observable behaviour is pretty close.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).