### PR TITLE
man: document spl_schedule_hrtimeout_slack_us, longname, raidz_expanding

### DIFF
--- a/man/man4/spl.4
+++ b/man/man4/spl.4
@@ -130,6 +130,19 @@ When not enabled, the thread is halted to facilitate further debugging.
 .Pp
 Set to a non-zero value to enable.
 .
+.It Sy spl_schedule_hrtimeout_slack_us Ns = Ns Sy 0 Pq uint
+Slack value in microseconds passed to
+.Fn schedule_hrtimeout_range
+when a condition variable times out.
+A non-zero value lets the kernel coalesce the wakeup with other timers
+to reduce wakeup count, at the cost of some additional sleep duration.
+The maximum is
+.Sy 1000 ,
+as defined by
+.Sy MAX_HRTIMEOUT_SLACK_US .
+.Pp
+Linux-only.
+.
 .It Sy spl_taskq_kick Ns = Ns Sy 0 Pq uint
 Kick stuck taskq to spawn threads.
 When writing a non-zero value to it, it will scan all the taskqs.

--- a/man/man4/spl.4
+++ b/man/man4/spl.4
@@ -134,7 +134,7 @@ Set to a non-zero value to enable.
 Slack value in microseconds passed to
 .Fn schedule_hrtimeout_range
 when a condition variable times out.
-A non-zero value lets the kernel coalesce the wakeup with other timers
+A non-zero value enforces the kernel coalesce the wakeup with other timers
 to reduce wakeup count, at the cost of some additional sleep duration.
 The maximum is
 .Sy 1000 ,

--- a/man/man7/vdevprops.7
+++ b/man/man7/vdevprops.7
@@ -134,6 +134,12 @@ The number of I/O operations of each type performed by this vdev
 The cumulative size of all operations of each type performed by this vdev
 .It Sy removing
 If this device is currently being removed from the pool
+.It Sy raidz_expanding
+Set while a
+.Nm zpool Cm attach
+expansion is in progress on this RAID-Z vdev; cleared on completion.
+See
+.Xr zpool-attach 8 .
 .It Sy trim_support
 Indicates if a leaf device supports trim operations.
 .El

--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1360,6 +1360,21 @@ This was only supported by Linux prior to 5.15, and was buggy there,
 and is not supported by
 .Fx .
 On Solaris it's used for SMB clients.
+.It Sy longname Ns = Ns Sy on Ns | Ns Sy off
+Controls support for filenames longer than 255 bytes, up to 1023 bytes.
+The default is
+.Sy off .
+Setting this property to
+.Sy on
+activates the
+.Sy longname
+pool feature, which must be enabled
+.Po see
+.Xr zpool-features 7
+.Pc .
+Once a file with a long name is created, the feature becomes active and
+the pool can no longer be imported by an OpenZFS implementation that does
+not support it.
 .It Sy overlay Ns = Ns Sy on Ns | Ns Sy off
 Allow mounting on a busy directory or a directory which already contains
 files or directories.


### PR DESCRIPTION
### Motivation and Context
Three parameters/properties exist in source but are not described in their respective manpages.

### Description
Adds entries for:

| Entry | Page | Source |
|---|---|---|
| `spl_schedule_hrtimeout_slack_us` | `spl.4` | `module/os/linux/spl/spl-condvar.c` |
| `longname` | `zfsprops.7` | `module/zcommon/zfs_prop.c` |
| `raidz_expanding` | `vdevprops.7` | `module/zcommon/zpool_prop.c` |

### Types of changes
- [x] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [contributing](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md) document.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).