### PR TITLE
libspl/mnttab: follow symlinks when resolving path via statx

### DIFF
--- a/lib/libspl/os/linux/mnttab.c
+++ b/lib/libspl/os/linux/mnttab.c
@@ -125,7 +125,14 @@ getextmntent(const char *path, struct mnttab *entry, struct stat64 *statbuf)
 	}
 
 #ifdef HAVE_STATX_MNT_ID
-	if (statx(AT_FDCWD, path, AT_STATX_SYNC_AS_STAT | AT_SYMLINK_NOFOLLOW,
+	/*
+	 * Use AT_STATX_SYNC_AS_STAT without AT_SYMLINK_NOFOLLOW so that
+	 * symlinks are followed, matching the behavior of stat64() above.
+	 * Without this, if path is a symlink crossing a mount boundary,
+	 * statx() returns the mnt_id of the symlink's location rather
+	 * than the symlink target's mount.
+	 */
+	if (statx(AT_FDCWD, path, AT_STATX_SYNC_AS_STAT,
 	    STATX_MNT_ID, &stx) == 0 && (stx.stx_mask & STATX_MNT_ID)) {
 		have_mnt_id = B_TRUE;
 		target_mnt_id = stx.stx_mnt_id;

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -254,6 +254,10 @@ tests = ['zfs_inherit_001_neg', 'zfs_inherit_002_neg', 'zfs_inherit_003_pos',
     'zfs_inherit_mountpoint']
 tags = ['functional', 'cli_root', 'zfs_inherit']
 
+[tests/functional/cli_root/zfs_list]
+tests = ['zfs_list_009_pos']
+tags = ['functional', 'cli_root', 'zfs_list']
+
 [tests/functional/cli_root/zfs_load-key]
 tests = ['zfs_load-key', 'zfs_load-key_all', 'zfs_load-key_file',
     'zfs_load-key_https', 'zfs_load-key_location', 'zfs_load-key_noop',

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -772,6 +772,9 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_jail/cleanup.ksh \
 	functional/cli_root/zfs_jail/setup.ksh \
 	functional/cli_root/zfs_jail/zfs_jail_001_pos.ksh \
+	functional/cli_root/zfs_list/cleanup.ksh \
+	functional/cli_root/zfs_list/setup.ksh \
+	functional/cli_root/zfs_list/zfs_list_009_pos.ksh \
 	functional/cli_root/zfs_load-key/cleanup.ksh \
 	functional/cli_root/zfs_load-key/setup.ksh \
 	functional/cli_root/zfs_load-key/zfs_load-key_all.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_list/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_list/cleanup.ksh
@@ -1,0 +1,30 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_list/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_list/setup.ksh
@@ -1,0 +1,32 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+default_setup $DISKS

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_list/zfs_list_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_list/zfs_list_009_pos.ksh
@@ -1,0 +1,69 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs list -Ho name <path>' follows symlinks when resolving the path to
+# a dataset name. A symlink that crosses a mount boundary must resolve to
+# the dataset owning the symlink's target, not the dataset containing the
+# symlink itself.
+#
+# STRATEGY:
+# 1. Create two child datasets: ds1 and ds2.
+# 2. Place a symlink inside ds1 that points into ds2.
+# 3. Verify that 'zfs list -Ho name <symlink>' returns ds2.
+#
+
+verify_runnable "global"
+
+DS1="$TESTPOOL/$TESTFS/ds1"
+DS2="$TESTPOOL/$TESTFS/ds2"
+LINK="$TESTDIR/ds1/link_to_ds2"
+
+function cleanup
+{
+	rm -f "$LINK"
+	datasetexists "$DS1" && log_must zfs destroy "$DS1"
+	datasetexists "$DS2" && log_must zfs destroy "$DS2"
+}
+
+log_onexit cleanup
+
+log_assert "'zfs list -Ho name' follows symlinks when resolving a path."
+
+log_must zfs create "$DS1"
+log_must zfs create "$DS2"
+log_must ln -s "$TESTDIR/ds2" "$LINK"
+
+result=$(zfs list -Ho name "$LINK")
+if [[ "$result" != "$DS2" ]]; then
+	log_fail "'zfs list -Ho name $LINK' returned '$result', expected '$DS2'"
+fi
+
+log_pass "'zfs list -Ho name' correctly follows a symlink crossing a mount boundary."


### PR DESCRIPTION
### Motivation and Context

`getextmntent()` in `lib/libspl/os/linux/mnttab.c` uses `statx(2)` with
`AT_SYMLINK_NOFOLLOW` to obtain the `mnt_id` of the caller-supplied path. When
that path is a symbolic link crossing a mount boundary, `AT_SYMLINK_NOFOLLOW`
prevents symlink resolution, causing `statx` to return the `mnt_id` of the
mount containing the symlink itself rather than the mount the symlink points
into. The subsequent search through `/proc/self/mounts` then matches the wrong
entry, so `zfs list -Ho name <symlink-path>` (and anything that calls
`zfs_path_to_zhandle()`) reports the wrong dataset.

The same function calls `stat64()` on the same path immediately beforehand, and
`stat64()` always follows symlinks — so the two calls were inconsistent when the
path was a symlink.

The bug was introduced by 523d9d6007 ("Validate mountpoint on path-based unmount
using statx") but was latent because the autoconf check in `config/user-statx.m4`
omitted `#define _GNU_SOURCE` when testing for `STATX_MNT_ID`, so
`HAVE_STATX_MNT_ID` was never defined and the `statx()` path was dead code.
It was exposed by 2b930f63f8 ("config: fix STATX_MNT_ID detection"), which
fixed the autoconf check and activated the broken path for the first time.

### Description

Remove `AT_SYMLINK_NOFOLLOW` from the `statx()` call on the caller-supplied
`path` in `getextmntent()`, so symlinks are followed — consistent with the
`stat64()` call on the same path in the same function.

The `AT_SYMLINK_NOFOLLOW` flag is retained in `getextmntent_impl()`, where
`statx()` is called on `mp->mnt_mountp` (a path read from `/proc/self/mounts`,
always a real directory).

A regression test is added in
`tests/functional/cli_user/zfs_list/zfs_list_009_pos.ksh`.

### How Has This Been Tested?

Verified with a minimal reproducer: created two ZFS datasets, placed a symlink
inside the first pointing into the second, and confirmed that
`zfs list -Ho name <symlink>` returns the dataset containing the symlink's
target rather than the dataset containing the symlink.

The regression test `zfs_list_009_pos` was also run via `zfs-tests.sh` on both
an unpatched build (FAIL) and with this fix applied (PASS).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).