### PR TITLE
Add some more file layout output, triggered by -v

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2802,18 +2802,18 @@ print_file_layout_raidz(vdev_t *vd, blkptr_t *bp, uint64_t file_offset,
 	    vd->vdev_children, vdrz->vd_nparity);
 	raidz_row_t *rr = rm->rm_row[0];
 
-	/*
-	 * Account for out of order disks in raidz1.
-	 * For now just reverse them back and adjust for it later.
-	 */
-	if (rr->rr_firstdatacol == 1 && (zio.io_offset & (1ULL << 20))) {
-		uint64_t devidx = rr->rr_col[0].rc_devidx;
-		rr->rr_col[0].rc_devidx = rr->rr_col[1].rc_devidx;
-		rr->rr_col[1].rc_devidx = devidx;
-	}
-
 	if (!dump_opt['H']) {
 		int last_disk = vd->vdev_children - 1;
+		/*
+		 * Account for out of order disks in raidz1.
+		 * For now just reverse them back and adjust for it later.
+		 */
+		if (rr->rr_firstdatacol == 1 &&
+		    (zio.io_offset & (1ULL << 20))) {
+			uint64_t devidx = rr->rr_col[0].rc_devidx;
+			rr->rr_col[0].rc_devidx = rr->rr_col[1].rc_devidx;
+			rr->rr_col[1].rc_devidx = devidx;
+		}
 		int first_disk = rr->rr_col[0].rc_devidx;
 
 		(void) printf("%12llx", (u_longlong_t)file_offset);
@@ -2843,23 +2843,49 @@ print_file_layout_raidz(vdev_t *vd, blkptr_t *bp, uint64_t file_offset,
 		static uint64_t next_offset = 0;
 
 		if (next_offset != file_offset) {
-			(void) printf("skip hole\t-\t%llx\n",
-			    (u_longlong_t)((file_offset - next_offset) >>
-			    vd->vdev_ashift));
+			(void) printf("skip hole\t-\t\t%lld\n",
+			    (u_longlong_t)((file_offset - next_offset) / 512));
 		}
 		next_offset = file_offset + BP_GET_LSIZE(bp);
+		uint64_t tmp_offset = file_offset;
+
 
 		for (int c = 0; c < rr->rr_cols; c++) {
+			boolean_t pcol = c < rr->rr_firstdatacol;
 			raidz_col_t *rc = &rr->rr_col[c];
 			char *path = vd->vdev_child[rc->rc_devidx]->vdev_path;
-			// c < rr->rr_firstdatacol
+
 			if (rc->rc_size == 0)
 				continue;
-			(void) printf("%s\t%llu\t%d\n",
+			(void) printf("%s\t\t%llu\t%d",
 			    zfs_basename(path),
 			    (u_longlong_t)(rc->rc_offset +
 			    VDEV_LABEL_START_SIZE)/512,
 			    (int)rc->rc_size/512);
+			if (dump_opt['v']) {
+				char label = pcol ? 'P' : 'D';
+				int num;
+
+				if (c < 2) {
+					num = 0;
+				} else {
+					num = pcol ? c :
+					    (c - rr->rr_firstdatacol);
+				}
+				printf("\t%c%d", label, num);
+				if (dump_opt['v'] > 1) {
+					unsigned long long off;
+					if (pcol)
+						off = file_offset;
+					else
+						off = tmp_offset;
+					off = off / 512ULL;
+					printf("\t%llu", off);
+				}
+			}
+			if (!pcol)
+				tmp_offset += rc->rc_size;
+			printf("\n");
 		}
 	}
 }
@@ -2989,7 +3015,12 @@ dump_indirect_layout(dnode_t *dn)
 	 * Start layout with a header
 	 */
 	if (dump_opt['H']) {
-		(void) printf("DISK\t\tLBA\t\tCOUNT\n");
+		(void) printf("DISK\t\t\tLBA\tCOUNT");
+		if (dump_opt['v'])
+			(void) printf("\tTYPE");
+		if (dump_opt['v'] > 1)
+			(void) printf("\tOFFSET");
+		printf("\n");
 	} else {
 		char diskhdr[16];
 
@@ -10519,6 +10550,7 @@ retry_lookup:
 		}
 
 		if (dump_opt['f'] && os != NULL) {
+			dump_opt['v'] = verbose;
 			dump_file_data_layout(os);
 		} else if (dump_opt['B']) {
 			dump_backup(target, objset_id,

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -284,10 +284,15 @@ Decode and display block from an embedded block pointer specified by the
 arguments.
 .It Fl f , -file-layout
 Display the file layout of an object for the disks of a raidz vdev.
+Numeric values in the disply are hexadecimal.
 With
 .Fl H ,
 the output is in scripted mode for easy parsing, with all values
-being presented as 512 byte blocks.
+being presented as 512 byte blocks in decimal; with
+.Fl v ,
+the block type (parity or data) is displayed; with
+.Fl vv ,
+the offset into the file for each block is also printed.
 Only a single top-level raidz vdev is supported.
 .It Fl h , -history
 Display pool history similar to

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -172,9 +172,10 @@ tests = ['zdb_002_pos', 'zdb_003_pos', 'zdb_004_pos', 'zdb_005_pos',
     'zdb_006_pos', 'zdb_args_neg', 'zdb_args_pos',
     'zdb_block_size_histogram', 'zdb_checksum', 'zdb_decompress',
     'zdb_display_block', 'zdb_encrypted', 'zdb_encrypted_raw',
-    'zdb_label_checksum', 'zdb_object_range_neg', 'zdb_object_range_pos',
-    'zdb_objset_id', 'zdb_decompress_zstd', 'zdb_recover', 'zdb_recover_2',
-    'zdb_backup', 'zdb_tunables']
+    'zdb_file_layout_001', 'zdb_file_layout_002', 'zdb_file_layout_003',
+    'zdb_file_layout_neg', 'zdb_label_checksum', 'zdb_object_range_neg',
+    'zdb_object_range_pos', 'zdb_objset_id', 'zdb_decompress_zstd',
+    'zdb_recover', 'zdb_recover_2', 'zdb_backup', 'zdb_tunables']
 pre =
 post =
 tags = ['functional', 'cli_root', 'zdb']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -647,7 +647,10 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zdb/zdb_display_block.ksh \
 	functional/cli_root/zdb/zdb_encrypted.ksh \
 	functional/cli_root/zdb/zdb_encrypted_raw.ksh \
-	functional/cli_root/zdb/zdb_label_checksum.ksh \
+	functional/cli_root/zdb/zdb_file_layout_001.ksh \
+	functional/cli_root/zdb/zdb_file_layout_002.ksh \
+	functional/cli_root/zdb/zdb_file_layout_003.ksh \
+	functional/cli_root/zdb/zdb_file_layout_neg.ksh \
 	functional/cli_root/zdb/zdb_object_range_neg.ksh \
 	functional/cli_root/zdb/zdb_object_range_pos.ksh \
 	functional/cli_root/zdb/zdb_objset_id.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -647,6 +647,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zdb/zdb_display_block.ksh \
 	functional/cli_root/zdb/zdb_encrypted.ksh \
 	functional/cli_root/zdb/zdb_encrypted_raw.ksh \
+	functional/cli_root/zdb/zdb_label_checksum.ksh \
 	functional/cli_root/zdb/zdb_file_layout_001.ksh \
 	functional/cli_root/zdb/zdb_file_layout_002.ksh \
 	functional/cli_root/zdb/zdb_file_layout_003.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_001.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_001.ksh
@@ -1,0 +1,77 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 by Datto, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb -fHv <dataset> <objnum> will display block
+# layouts for the object.
+#
+# Strategery:
+# 1. Create a RAIDZ1 pool, set compression to none
+# 2. Create a file filled with random data
+# 3. Get the inode number of the file
+# 4. Run zdb -fHv <pool>/ <inum> & extract file
+# 5. Compare real file and extracted file.
+
+DATA=/$TESTPOOL1/random.bin
+BLOCKS=$(( $RANDOM % 16 ))
+COMPARE=/tmp/compare.$$
+
+function cleanup
+{
+        destroy_pool $TESTPOOL1
+        rm -f $TESTDIR/file?.bin $COMPARE
+}
+
+log_assert "Verify zdb -fHv displays correct offsets"
+log_onexit cleanup
+
+# 1. Create a RAIDZ1 pool
+log_must mkdir -p $TESTDIR
+for file in 1 2 3 4 5
+do
+    rm -f $TESTDIR/file${file}.bin
+    touch $TESTDIR/file${file}.bin
+    log_must truncate -s 128m $TESTDIR/file${file}.bin
+done
+
+log_must zpool create -O compression=off -O recordsize=16K $TESTPOOL1 raidz1 $TESTDIR/file[12345].bin
+zfs get compression,recordsize $TESTPOOL1
+# 2. Create a file with random data
+log_must rm -f $DATA
+log_must dd if=/dev/urandom of=${DATA} bs=16k count=${BLOCKS} > /dev/null 2>&1
+log_must zpool sync $TESTPOOL1
+
+# 3. Get the inode number of the file
+INUM=$(ls -li $DATA | cut -f1 -d ' ')
+
+# 4. Extract the contents of the file using dd
+rm -f $COMPARE
+log_must touch ${COMPARE}
+log_must zdb -fHv $TESTPOOL1/ ${INUM} |  grep 'D.$' |
+    while read file offset count rest
+    do
+	log_must sh -c "dd if=$TESTDIR/${file} bs=512 skip=${offset} count=${count} >> ${COMPARE}"
+    done
+
+# 5. Compare files
+log_must cmp  ${COMPARE} ${DATA}
+
+log_pass "'zdb -fHv' works as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_001.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_001.ksh
@@ -14,6 +14,7 @@
 
 #
 # Copyright (c) 2019 by Datto, Inc. All rights reserved.
+# Copyright (c) 2026, Klara Inc.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -36,8 +37,8 @@ COMPARE=/tmp/compare.$$
 
 function cleanup
 {
-        destroy_pool $TESTPOOL1
-        rm -f $TESTDIR/file?.bin $COMPARE
+    destroy_pool $TESTPOOL1
+    rm -f $TESTDIR/file?.bin $COMPARE
 }
 
 log_assert "Verify zdb -fHv displays correct offsets"

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_002.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_002.ksh
@@ -1,0 +1,77 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 by Datto, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb -fHv <dataset> <objnum> will display block
+# layouts for the object.
+#
+# Strategery:
+# 1. Create a RAIDZ2 pool, set compression to none
+# 2. Create a file filled with random data
+# 3. Get the inode number of the file
+# 4. Run zdb -fHv <pool>/ <inum> & extract file
+# 5. Compare real file and extracted file.
+
+DATA=/$TESTPOOL1/random.bin
+BLOCKS=$(( $RANDOM % 16 ))
+COMPARE=/tmp/compare.$$
+
+function cleanup
+{
+        destroy_pool $TESTPOOL1
+        rm -f $TESTDIR/file?.bin $COMPARE
+}
+
+log_assert "Verify zdb -fHv displays correct offsets"
+log_onexit cleanup
+
+# 1. Create a RAIDZ1 pool
+log_must mkdir -p $TESTDIR
+for file in 1 2 3 4 5 6
+do
+    rm -f $TESTDIR/file${file}.bin
+    touch $TESTDIR/file${file}.bin
+    log_must truncate -s 128m $TESTDIR/file${file}.bin
+done
+
+log_must zpool create -O compression=off -O recordsize=16K $TESTPOOL1 raidz2 $TESTDIR/file[123456].bin
+zfs get compression,recordsize $TESTPOOL1
+# 2. Create a file with random data
+log_must rm -f $DATA
+log_must dd if=/dev/urandom of=${DATA} bs=16k count=${BLOCKS} > /dev/null 2>&1
+log_must zpool sync $TESTPOOL1
+
+# 3. Get the inode number of the file
+INUM=$(ls -li $DATA | cut -f1 -d ' ')
+
+# 4. Extract the contents of the file using dd
+rm -f $COMPARE
+log_must touch ${COMPARE}
+log_must zdb -fHv $TESTPOOL1/ ${INUM} |  grep 'D.$' |
+    while read file offset count rest
+    do
+	log_must sh -c "dd if=$TESTDIR/${file} bs=512 skip=${offset} count=${count} >> ${COMPARE}"
+    done
+
+# 5. Compare files
+log_must cmp  ${COMPARE} ${DATA}
+
+log_pass "'zdb -fHv' works as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_002.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_002.ksh
@@ -14,6 +14,7 @@
 
 #
 # Copyright (c) 2019 by Datto, Inc. All rights reserved.
+# Copyright (c) 2026, Klara Inc.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -36,8 +37,8 @@ COMPARE=/tmp/compare.$$
 
 function cleanup
 {
-        destroy_pool $TESTPOOL1
-        rm -f $TESTDIR/file?.bin $COMPARE
+    destroy_pool $TESTPOOL1
+    rm -f $TESTDIR/file?.bin $COMPARE
 }
 
 log_assert "Verify zdb -fHv displays correct offsets"

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_003.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_003.ksh
@@ -1,0 +1,77 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 by Datto, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb -fHv <dataset> <objnum> will display block
+# layouts for the object.
+#
+# Strategery:
+# 1. Create a RAIDZ3 pool, set compression to none
+# 2. Create a file filled with random data
+# 3. Get the inode number of the file
+# 4. Run zdb -fHv <pool>/ <inum> & extract file
+# 5. Compare real file and extracted file.
+
+DATA=/$TESTPOOL1/random.bin
+BLOCKS=$(( $RANDOM % 16 ))
+COMPARE=/tmp/compare.$$
+
+function cleanup
+{
+        destroy_pool $TESTPOOL1
+        rm -f $TESTDIR/file?.bin $COMPARE
+}
+
+log_assert "Verify zdb -fHv displays correct offsets"
+log_onexit cleanup
+
+# 1. Create a RAIDZ1 pool
+log_must mkdir -p $TESTDIR
+for file in 1 2 3 4 5 6 7
+do
+    rm -f $TESTDIR/file${file}.bin
+    touch $TESTDIR/file${file}.bin
+    log_must truncate -s 128m $TESTDIR/file${file}.bin
+done
+
+log_must zpool create -O compression=off -O recordsize=16K $TESTPOOL1 raidz3 $TESTDIR/file[123456].bin
+zfs get compression,recordsize $TESTPOOL1
+# 2. Create a file with random data
+log_must rm -f $DATA
+log_must dd if=/dev/urandom of=${DATA} bs=16k count=${BLOCKS} > /dev/null 2>&1
+log_must zpool sync $TESTPOOL1
+
+# 3. Get the inode number of the file
+INUM=$(ls -li $DATA | cut -f1 -d ' ')
+
+# 4. Extract the contents of the file using dd
+rm -f $COMPARE
+log_must touch ${COMPARE}
+log_must zdb -fHv $TESTPOOL1/ ${INUM} |  grep 'D.$' |
+    while read file offset count rest
+    do
+	log_must sh -c "dd if=$TESTDIR/${file} bs=512 skip=${offset} count=${count} >> ${COMPARE}"
+    done
+
+# 5. Compare files
+log_must cmp  ${COMPARE} ${DATA}
+
+log_pass "'zdb -fHv' works as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_003.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_003.ksh
@@ -14,6 +14,7 @@
 
 #
 # Copyright (c) 2019 by Datto, Inc. All rights reserved.
+# Copyright (c) 2026, Klara Inc.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -36,8 +37,8 @@ COMPARE=/tmp/compare.$$
 
 function cleanup
 {
-        destroy_pool $TESTPOOL1
-        rm -f $TESTDIR/file?.bin $COMPARE
+    destroy_pool $TESTPOOL1
+    rm -f $TESTDIR/file?.bin $COMPARE
 }
 
 log_assert "Verify zdb -fHv displays correct offsets"

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_neg.ksh
@@ -1,0 +1,56 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 by Datto, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# Ensure zdb -f only works on raidz
+#
+# Strategery:
+# 1. Create a pool with one disk
+# 2. Create a file
+# 3. Get the inode number of the file
+# 4. Run zdb -f
+# 5. Confirm failure status
+
+function cleanup
+{
+        destroy_pool $TESTPOOL1
+	rm -f $TESTDIR/file1.bin
+}
+
+log_assert "Verify zdb -f fails on non-raidz pool"
+log_onexit cleanup
+
+# 1. Create a RAIDZ1 pool
+log_must mkdir -p $TESTDIR
+touch $TESTDIR/file1.bin
+log_must truncate -s 128m $TESTDIR/file1.bin
+log_must zpool create -f $TESTPOOL1 $TESTDIR/file1.bin
+
+# 2. Create a file
+log_must touch /$TESTPOOL1/file.txt
+
+# 3. Get the inode number of the file
+INUM=$(ls -li /$TESTDIR/file1.txt | cut -f1 -d ' ')
+
+# 4. Run zdb -f
+log_mustnot zdb -f $TESTDIR/ $INUM
+
+log_pass "'zdb -f' fails on non-raidz as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_neg.ksh
@@ -14,6 +14,7 @@
 
 #
 # Copyright (c) 2019 by Datto, Inc. All rights reserved.
+# Copyright (c) 2026, Klara Inc.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -31,8 +32,8 @@
 
 function cleanup
 {
-        destroy_pool $TESTPOOL1
-	rm -f $TESTDIR/file1.bin
+    destroy_pool $TESTPOOL1
+    rm -f $TESTDIR/file1.bin
 }
 
 log_assert "Verify zdb -f fails on non-raidz pool"


### PR DESCRIPTION
With one -v, the block type (parity or data) is printed (matching the ASCII-art version); with two -v, the offset into the file is also printed.

This also updates the man page, and adds some simple test scripts.

Sponsored-by: Klara, Inc.
Sponsored-by: Wasabi Technology, Inc.
Reviewed-by: sean.fagan@klarasystems.com

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adding the type (parity or data) allows for the output to be scripted; it also makes it clearer to humans looking at the output. The file offset column is similarly useful for humans.

### Description
<!--- Describe your changes in detail -->
This builds on the previous change to add the file-layout printout to zdb. It essentially duplicates the existing functionality in the -H path of the code.

### How Has This Been Tested?

Initially by manually copying data from the devices to recreate the test file, and later by adding that code to test scripts.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
