### PR TITLE
Fix rare cksum errors after rebuild

### DIFF
--- a/include/sys/vdev_rebuild.h
+++ b/include/sys/vdev_rebuild.h
@@ -70,6 +70,7 @@ typedef struct vdev_rebuild {
 	zfs_range_tree_t	*vr_scan_tree;
 	kmutex_t	vr_io_lock;		/* inflight IO lock */
 	kcondvar_t	vr_io_cv;		/* inflight IO cv */
+	uint64_t	vr_last_txg;		/* last used txg */
 
 	/* In-core state and progress */
 	uint64_t	vr_scan_offset[TXG_SIZE];

--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -593,6 +593,7 @@ vdev_rebuild_range(vdev_rebuild_t *vr, uint64_t start, uint64_t size)
 	dmu_tx_t *tx = dmu_tx_create_dd(spa_get_dsl(spa)->dp_mos_dir);
 	VERIFY0(dmu_tx_assign(tx, DMU_TX_WAIT | DMU_TX_SUSPEND));
 	uint64_t txg = dmu_tx_get_txg(tx);
+	vr->vr_last_txg = txg;
 
 	spa_config_enter(spa, SCL_STATE_ALL, vd, RW_READER);
 	mutex_enter(&vd->vdev_rebuild_lock);
@@ -910,8 +911,14 @@ vdev_rebuild_thread(void *arg)
 		error = vdev_rebuild_ranges(vr);
 		zfs_range_tree_vacate(vr->vr_scan_tree, NULL, NULL);
 
-		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
+		/*
+		 * Allow rebuilt ranges to be sync-ed before enabling metaslab
+		 * to avoid any interfering allocations. Otherwise, we might
+		 * see checksum errors after scrub.
+		 */
+		txg_wait_synced(dp, vr->vr_last_txg);
 		metaslab_enable(msp, B_FALSE, B_FALSE);
+		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 
 		if (error != 0)
 			break;

--- a/tests/zfs-tests/tests/functional/redundancy/redundancy.kshlib
+++ b/tests/zfs-tests/tests/functional/redundancy/redundancy.kshlib
@@ -419,12 +419,7 @@ function recover_bad_missing_devs
 #    expected state after a healing resilver of a healthy pool.
 #
 # 2. sequential - The pool is fully intact.  There should never be a
-#    checksum error, but the occasional checksum error does occur in
-#    practice.  Until the root cause is identified and resolved, tolerate
-#    a checksum error when scrubbing after a sequential resilver.
-#
-#    https://github.com/openzfs/zfs/issues/18307
-#    https://github.com/openzfs/zfs/issues/18319
+#    checksum error.
 #
 # 3. damaged - The pool was intentionally silently damaged.  Checksum
 #    errors are expected to be reported as the damaged blocks are
@@ -454,7 +449,7 @@ function verify_draid_pool
 			log_fail "Unexpected repair IO found for $pool ($cksum)"
 		fi
 	elif [[ "$replace_mode" = "sequential" ]]; then
-		if [[ $cksum -gt 3 ]]; then
+		if [[ $cksum -gt 0 ]]; then
 			log_must zpool status -v $pool
 			log_fail "Unexpected CKSUM errors found for $pool ($cksum)"
 		fi


### PR DESCRIPTION
Currently, after rebuild (aka sequential resilver), checksum errors can be seen sometimes on the spare vdev or draid spare. On my laptop, it happens from 2 to 4 times of running `redundancy_draid_spare1` test in a loop for 100 times. It's a known issue for a long time, see #18307 and #18319.

It looks like there's a race in vdev_rebuild_thread() when the rebuild of space map ranges is finished and we re-enable allocations from the metaslab too soon: a new allocations may happen from that metaslab before txg with the rebuilt ranges is sync-ed, causing undesirable interference.

Solution: wait for the txg to be sync-ed before enabling metaslab.

### How Has This Been Tested?
`redundancy_draid_spare1` test has passed 1000 times in a loop, and `redundancy_draid_spare3` test has passed 300 times in a loop:
```
$ ./scripts/zfs-tests.sh -t redundancy_draid_spare1 -I 1000
...
Results Summary
PASS	 3000

Running Time:	05:22:13
Percent passed:	100.0%
$ ./scripts/zfs-tests.sh -t redundancy_draid_spare3 -I 300
...
Results Summary
PASS	 900

Running Time:	03:48:25
Percent passed:	100.0%
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Closes #18307 and #18319.