### PR TITLE
Avoid flushing unrelated NFS exports on snapshot unmount

### DIFF
--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -1138,15 +1138,28 @@ zfsctl_snapshot_unmount(const char *snapname, int flags)
 		cv_wait(&se->se_cv, &se->se_mtx);
 	mutex_exit(&se->se_mtx);
 
-	exportfs_flush();
-
 	if (flags & MNT_FORCE)
 		argv[4] = "-fn";
 	argv[5] = se->se_path;
 	dprintf("unmount; path=%s\n", se->se_path);
 	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
-	zfsctl_snapshot_rele(se);
 
+	/*
+	 * The kernel's NFS export cache can hold references to the
+	 * snapshot mountpoint and cause umount to fail.  ZFS cannot
+	 * invalidate individual entries because the relevant kernel
+	 * APIs are exported GPL-only, so we issue a global flush
+	 * instead.  To avoid impacting unrelated snapshots, the flush
+	 * runs only on umount failure.  Not perfect, but better than
+	 * flushing unconditionally.
+	 */
+	if (error) {
+		exportfs_flush();
+		error = call_usermodehelper(argv[0], argv, envp,
+		    UMH_WAIT_PROC);
+	}
+
+	zfsctl_snapshot_rele(se);
 
 	/*
 	 * The umount system utility will return 256 on error.  We must


### PR DESCRIPTION
### Motivation and Context
`zfsctl_snapshot_unmount()` calls `exportfs_flush()` before every umount attempt to drop NFS export cache references that pin the snapshot mountpoint. `exportfs -f` is global. It flushes every NFS export cache on the host, affecting unrelated exports and clients.

### Description
This is a best-effort improvement. There is no easy way from ZFS to flush only the cache entries for a specific snapshot, since the relevant sunrpc cache APIs are exported GPL-only, so the global flush remains the only available mechanism.

Defer the flush to the failure path: try `umount` first; on failure, run `exportfs_flush()` and retry once. Snapshots that are not NFS-pinned skip the flush entirely. NFS-pinned snapshots see the same flush rate as before, just after the failed attempt rather than before every attempt.

### How Has This Been Tested?
Verified that unmounting or destroying snapshots not part of an active NFS export no longer triggers `exportfs_flush()`. NFS-pinned snapshots still trigger the flush and unmount or destroy as before.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
