### PR TITLE
Fix off-by-one in PREVIOUSLY_REDACTED handler that drops last block

### DIFF
--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -1844,7 +1844,7 @@ send_reader_thread(void *arg)
 				continue;
 			}
 			uint64_t file_max =
-			    MIN(dn->dn_maxblkid, range->end_blkid);
+			    MIN(dn->dn_maxblkid + 1, range->end_blkid);
 			/*
 			 * The object exists, so we need to try to find the
 			 * blkptr for each block in the range we're processing.

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -906,7 +906,8 @@ tags = ['functional', 'quota']
 [tests/functional/redacted_send]
 tests = ['redacted_compressed', 'redacted_contents', 'redacted_deleted',
     'redacted_disabled_feature', 'redacted_embedded', 'redacted_holes',
-    'redacted_incrementals', 'redacted_largeblocks', 'redacted_many_clones',
+    'redacted_incrementals', 'redacted_largeblocks', 'redacted_max_blkid',
+    'redacted_many_clones',
     'redacted_mixed_recsize', 'redacted_mounts', 'redacted_negative',
     'redacted_origin', 'redacted_panic', 'redacted_props', 'redacted_resume',
     'redacted_size', 'redacted_volume']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1898,6 +1898,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/redacted_send/redacted_holes.ksh \
 	functional/redacted_send/redacted_incrementals.ksh \
 	functional/redacted_send/redacted_largeblocks.ksh \
+	functional/redacted_send/redacted_max_blkid.ksh \
 	functional/redacted_send/redacted_many_clones.ksh \
 	functional/redacted_send/redacted_mixed_recsize.ksh \
 	functional/redacted_send/redacted_mounts.ksh \

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_max_blkid.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_max_blkid.ksh
@@ -1,0 +1,118 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/redacted_send/redacted.kshlib
+
+#
+# Description:
+# Verify that an incremental send from a redaction bookmark correctly sends
+# the last block (dn_maxblkid) of a file through the PREVIOUSLY_REDACTED
+# path.
+#
+# Regression test for an off-by-one bug in the PREVIOUSLY_REDACTED handler
+# in send_reader_thread().  file_max was computed as:
+#
+#   MIN(dn->dn_maxblkid, range->end_blkid)
+#
+# dn_maxblkid is an inclusive maximum block ID while range->end_blkid is
+# exclusive (one past the last block).  Mixing these in MIN() caused the
+# loop condition "blkid < file_max" to skip block dn_maxblkid, silently
+# dropping the last block of any file whose last block was in the redaction
+# list.  The block remained as zeros on the receiver even though ZFS
+# reported the send and receive as successful.
+#
+# Strategy:
+# 1. Create a dataset with a 16-block file of random data and snapshot it.
+# 2. Create a clone (redact_clone) that overwrites only the last block
+#    (block 15, i.e., dn_maxblkid).
+# 3. Redact the base snapshot using redact_clone; block 15 enters the
+#    redaction list.
+# 4. Create a second clone (send_clone) of the base snapshot that does NOT
+#    modify block 15.  Because block 15 in send_clone has birth <=
+#    snap.creation_txg the TO traversal thread skips it; it must be sent
+#    via the PREVIOUSLY_REDACTED path.
+# 5. Redacted-send the base snapshot to the receiver (block 15 = zeros).
+# 6. Incrementally send send_clone from the redaction bookmark; block 15
+#    must be filled in by the PREVIOUSLY_REDACTED handler.
+# 7. Verify that block 15 on the receiver matches the original.
+#
+
+typeset ds_name="max_blkid"
+typeset sendfs="$POOL/$ds_name"
+typeset redact_clone="$POOL/${ds_name}_redact"
+typeset send_clone="$POOL/${ds_name}_send"
+typeset recvfs="$POOL2/$ds_name"
+typeset recv_clone="$POOL2/${ds_name}_send"
+typeset tmpdir="$(get_prop mountpoint $POOL)/tmp"
+typeset stream=$(mktemp $tmpdir/stream.XXXX)
+
+log_onexit redacted_cleanup $sendfs $recvfs $recv_clone
+
+# Create a dataset with a 16-block file.
+log_must zfs create $sendfs
+typeset mntpnt=$(get_prop mountpoint $sendfs)
+typeset bs=$(get_prop recsize $sendfs)
+log_must dd if=/dev/urandom of=$mntpnt/f1 bs=$bs count=16
+
+# Take the base snapshot.
+log_must zfs snapshot $sendfs@snap
+
+# Create redact_clone and overwrite ONLY the last block (block 15).
+# This is the block at index dn_maxblkid for a 16-block file.
+log_must zfs clone $sendfs@snap $redact_clone
+typeset redact_mnt=$(get_prop mountpoint $redact_clone)
+log_must dd if=/dev/urandom of=$redact_mnt/f1 bs=$bs count=1 seek=15 conv=notrunc
+log_must zfs snapshot $redact_clone@snap
+
+# Create the redaction bookmark; block 15 is now in the redaction list.
+log_must zfs redact $sendfs@snap book1 $redact_clone@snap
+
+# Create send_clone as an unmodified clone of the base snapshot.
+# Block 15 in send_clone is inherited (birth <= snap.creation_txg), so the
+# TO traversal thread does not include it.  The PREVIOUSLY_REDACTED path
+# must send it.
+log_must zfs clone $sendfs@snap $send_clone
+log_must zfs snapshot $send_clone@snap
+
+# Redacted send of the base snapshot; block 15 of f1 is omitted.
+log_must eval "zfs send --redact book1 $sendfs@snap >$stream"
+log_must eval "zfs recv $recvfs <$stream"
+
+# Incremental send of send_clone from the redaction bookmark.
+# Block 15 must be sent via the PREVIOUSLY_REDACTED path.
+log_must eval "zfs send -i $sendfs#book1 $send_clone@snap >$stream"
+log_must eval "zfs recv $recv_clone <$stream"
+
+# Verify that the received clone is identical to the source.
+# If the bug is present, block 15 is zeros on the receiver and this fails.
+typeset send_mnt=$(get_prop mountpoint $send_clone)
+typeset recv_mnt=$(get_prop mountpoint $recv_clone)
+log_must directory_diff $send_mnt $recv_mnt
+
+# Explicitly verify block 15 is not all zeros and matches the source.
+typeset src_block=$(mktemp $tmpdir/src_block.XXXX)
+typeset recv_block=$(mktemp $tmpdir/recv_block.XXXX)
+typeset zero_block=$(mktemp $tmpdir/zero_block.XXXX)
+log_must dd if=$mntpnt/f1 bs=$bs skip=15 count=1 of=$src_block 2>/dev/null
+log_must dd if=$recv_mnt/f1 bs=$bs skip=15 count=1 of=$recv_block 2>/dev/null
+log_must dd if=/dev/zero bs=$bs count=1 of=$zero_block 2>/dev/null
+
+cmp -s $recv_block $zero_block && log_fail "Block 15 is all zeros on receiver (off-by-one bug)"
+log_must cmp $src_block $recv_block
+
+log_pass "Incremental send from bookmark correctly sends the last block (dn_maxblkid)."


### PR DESCRIPTION
## Motivation and Context

In an incremental send from a redaction bookmark, blocks that were in
the FROM redaction list and exist in the TO dataset must be sent via
the `PREVIOUSLY_REDACTED` path in `send_reader_thread()`.  The loop
that iterates over those blocks computed its upper bound as:

```c
uint64_t file_max = MIN(dn->dn_maxblkid, range->end_blkid);
```

`dn->dn_maxblkid` is an **inclusive** maximum block ID (last valid
block index). `range->end_blkid` is an **exclusive** upper bound (one
past the last block in the range).  Mixing these two conventions in
`MIN()` causes `file_max` to equal `dn_maxblkid` whenever a
`PREVIOUSLY_REDACTED` range covers the end of the file.  The loop
condition `blkid < file_max` therefore never visits block
`dn_maxblkid` — silently dropping the last block of the file from the
send stream.

ZFS reports the send and receive as successful and raises no checksum
errors.  The receiver simply retains zeros for that block from the
earlier redacted base send.  The data loss is invisible to the caller.

Evidence that `dn_maxblkid` is inclusive is present in the same file:
- Line 804: `(dn_maxblkid + 1) * blksz` computes the first byte past
  end-of-file.
- Line 1837: asserts `range->end_blkid <= last_maxblkid + 1`.

## Description

Normalize `dn_maxblkid` to an exclusive bound before the `MIN()`:

```c
uint64_t file_max = MIN(dn->dn_maxblkid + 1, range->end_blkid);
```

## od Evidence

The following dumps were captured with a 16-block (128K recsize) file
where block 15 (`dn_maxblkid`) was in the redaction list.  The
incremental send from the redaction bookmark should have filled in
block 15 via the `PREVIOUSLY_REDACTED` path.

**Before fix — source has data, receiver has all zeros:**

```
=== od of block 15 on SOURCE ===
000000 b8 5b 53 f7 74 71 07 3b 3a 2b 04 82 e6 8a be c1  >.[S.tq.;:+......<
000010 68 20 2a b1 33 72 5b 5a 89 9a 0c 9b 38 9d 55 59  >h *.3r[Z....8.UY<
000020 7f f6 79 68 1b 86 0e 51 fb 0c a1 a3 f9 5f d5 66  >..yh...Q....._.f<
         ... (128K of random data) ...
01ffd0 22 93 a0 3f 35 fd 31 4f 0e c9 8c 1b 89 c9 d8 7e  >"..?5.1O.......~<
01ffe0 38 66 9a f1 58 58 6a a1 54 1e 71 db 5e df b7 64  >8f..XXj.T.q.^..d<
01fff0 0b a0 c8 d3 d7 cb ce 2e 74 b0 93 c9 31 ed 67 a7  >........t...1.g.<
020000

=== od of block 15 on RECEIVER ===
000000 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  >................<
*
020000
```

The `*` means every byte in the entire 128K block (offsets `000000`
through `020000`) is zero.  ZFS reported no error.

**After fix — source and receiver match byte-for-byte:**

```
=== od of block 15 on SOURCE ===
01fff0 48 e9 6b 2e e0 3a a2 ab f4 d0 94 55 c2 ac 88 0a  >H.k..:.....U....<
020000

=== od of block 15 on RECEIVER ===
01fff0 48 e9 6b 2e e0 3a a2 ab f4 d0 94 55 c2 ac 88 0a  >H.k..:.....U....<
020000
```

## How to Test

New test: `tests/zfs-tests/tests/functional/redacted_send/redacted_max_blkid.ksh`
Registered in: `tests/zfs-tests/tests/Makefile.am` and `tests/runfiles/common.run`

1. Create a 16-block file and take a base snapshot.
2. Create `redact_clone` that overwrites only block 15 (dn_maxblkid);
   use it to build a redaction bookmark.
3. Create `send_clone` as an unmodified clone — block 15 has birth ≤
   snap.creation_txg so the TO traversal thread skips it; it must be
   sent via the `PREVIOUSLY_REDACTED` path.
4. Redacted-send the base snapshot (block 15 = zeros at receiver).
5. Incrementally send `send_clone` from the redaction bookmark.
6. Verify with `directory_diff` and `cmp` that block 15 on the
   receiver matches the source and is not zeros.

The test FAILs on the unfixed kernel and PASSes on the fixed kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)