### PR TITLE
CI/GCC: Add Fedora 44, fix compiler errors

### DIFF
--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -88,6 +88,11 @@ case "$OS" in
     OSv="fedora-unknown"
     URL="https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
     ;;
+  fedora44)
+    OSNAME="Fedora 44"
+    OSv="fedora-unknown"
+    URL="https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
+    ;;
   freebsd13-5r)
     FreeBSD="13.5-RELEASE"
     OSNAME="FreeBSD $FreeBSD"

--- a/.github/workflows/zfs-qemu-packages.yml
+++ b/.github/workflows/zfs-qemu-packages.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['almalinux8', 'almalinux9', 'almalinux10', 'fedora42', 'fedora43']
+        os: ['almalinux8', 'almalinux9', 'almalinux10', 'fedora42', 'fedora43', 'fedora44']
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -49,14 +49,14 @@ jobs:
             os_selection='["almalinux8", "almalinux9", "almalinux10", "debian12", "fedora42", "freebsd15-0s", "ubuntu24"]'
             ;;
           linux)
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora42", "fedora43", "ubuntu22", "ubuntu24"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora42", "fedora43", "fedora44", "ubuntu22", "ubuntu24"]'
             ;;
           freebsd)
             os_selection='["freebsd13-5r", "freebsd14-4r", "freebsd13-5s", "freebsd14-4s", "freebsd15-0s", "freebsd16-0c"]'
             ;;
           *)
             # default list
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora42", "fedora43", "freebsd14-4r", "freebsd15-0s", "freebsd16-0c", "ubuntu22", "ubuntu24"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora42", "fedora43", "fedora44", "freebsd14-4r", "freebsd15-0s", "freebsd16-0c", "ubuntu22", "ubuntu24"]'
             ;;
           esac
 

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -238,7 +238,7 @@ _zed_event_value_is_hex(const char *name)
 		NULL
 	};
 	const char **pp;
-	char *p;
+	const char *p;
 
 	if (!name)
 		return (0);

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6867,7 +6867,7 @@ holds_callback(zfs_handle_t *zhp, void *data)
 
 	if (cbp->cb_recursive) {
 		const char *snapname;
-		char *delim  = strchr(zname, '@');
+		const char *delim  = strchr(zname, '@');
 		if (delim == NULL)
 			return (0);
 

--- a/etc/systemd/system-generators/zfs-mount-generator.c
+++ b/etc/systemd/system-generators/zfs-mount-generator.c
@@ -202,6 +202,7 @@ line_worker(char *line, const char *cachefile)
 	void **tofree = tofree_all;
 
 	char *toktmp;
+	const char *toktmp2;
 	/* BEGIN CSTYLED */
 	const char *dataset                     = strtok_r(line, "\t", &toktmp);
 	      char *p_mountpoint                = strtok_r(NULL, "\t", &toktmp);
@@ -226,8 +227,8 @@ line_worker(char *line, const char *cachefile)
 	/* END CSTYLED */
 
 	size_t pool_len = strlen(dataset);
-	if ((toktmp = strchr(dataset, '/')) != NULL)
-		pool_len = toktmp - dataset;
+	if ((toktmp2 = strchr(dataset, '/')) != NULL)
+		pool_len = toktmp2 - dataset;
 	const char *pool = *(tofree++) = strndup(dataset, pool_len);
 
 	if (p_nbmand == NULL) {

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -708,7 +708,7 @@ zfs_open(libzfs_handle_t *hdl, const char *path, int types)
 {
 	zfs_handle_t *zhp;
 	char errbuf[ERRBUFLEN];
-	char *bookp;
+	const char *bookp;
 
 	(void) snprintf(errbuf, sizeof (errbuf),
 	    dgettext(TEXT_DOMAIN, "cannot open '%s'"), path);
@@ -2958,7 +2958,7 @@ userquota_propname_decode(const char *propname, boolean_t zoned,
     zfs_userquota_prop_t *typep, char *domain, int domainlen, uint64_t *ridp)
 {
 	zfs_userquota_prop_t type;
-	char *cp;
+	const char *cp;
 	boolean_t isuser;
 	boolean_t isgroup;
 	boolean_t isproject;
@@ -4314,12 +4314,13 @@ zfs_rename(zfs_handle_t *zhp, const char *target, renameflags_t flags)
 {
 	int ret = 0;
 	zfs_cmd_t zc = {"\0"};
-	char *delim;
 	prop_changelist_t *cl = NULL;
 	char parent[ZFS_MAX_DATASET_NAME_LEN];
 	char property[ZFS_MAXPROPLEN];
 	libzfs_handle_t *hdl = zhp->zfs_hdl;
 	char errbuf[ERRBUFLEN];
+	const char *delim;
+	char *delim2;
 
 	/* if we have the same exact name, just return success */
 	if (strcmp(zhp->zfs_name, target) == 0)
@@ -4344,11 +4345,11 @@ zfs_rename(zfs_handle_t *zhp, const char *target, renameflags_t flags)
 			 */
 			(void) strlcpy(parent, zhp->zfs_name,
 			    sizeof (parent));
-			delim = strchr(parent, '@');
+			delim2 = strchr(parent, '@');
 			if (strchr(target, '@') == NULL)
-				*(++delim) = '\0';
+				*(++delim2) = '\0';
 			else
-				*delim = '\0';
+				*delim2 = '\0';
 			(void) strlcat(parent, target, sizeof (parent));
 			target = parent;
 		} else {
@@ -4369,6 +4370,7 @@ zfs_rename(zfs_handle_t *zhp, const char *target, renameflags_t flags)
 		if (!zfs_validate_name(hdl, target, zhp->zfs_type, B_TRUE))
 			return (zfs_error(hdl, EZFS_INVALIDNAME, errbuf));
 	} else {
+
 		if (flags.recursive) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 			    "recursive rename must be a snapshot"));
@@ -4424,8 +4426,8 @@ zfs_rename(zfs_handle_t *zhp, const char *target, renameflags_t flags)
 	}
 	if (flags.recursive) {
 		char *parentname = zfs_strdup(zhp->zfs_hdl, zhp->zfs_name);
-		delim = strchr(parentname, '@');
-		*delim = '\0';
+		delim2 = strchr(parentname, '@');
+		*delim2 = '\0';
 		zfs_handle_t *zhrp = zfs_open(zhp->zfs_hdl, parentname,
 		    ZFS_TYPE_DATASET);
 		free(parentname);

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -550,8 +550,8 @@ get_snapshot_names(differ_info_t *di, const char *fromsnap,
     const char *tosnap)
 {
 	libzfs_handle_t *hdl = di->zhp->zfs_hdl;
-	char *atptrf = NULL;
-	char *atptrt = NULL;
+	const char *atptrf = NULL;
+	const char *atptrt = NULL;
 	int fdslen, fsnlen;
 	int tdslen, tsnlen;
 

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -640,7 +640,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 		prop = zpool_name_to_prop(propname);
 		if (prop == ZPOOL_PROP_INVAL && zpool_prop_feature(propname)) {
 			int err;
-			char *fname = strchr(propname, '@') + 1;
+			const char *fname = strchr(propname, '@') + 1;
 
 			err = zfeature_lookup_name(fname, NULL);
 			if (err != 0) {

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -2697,7 +2697,7 @@ zfs_send_one_cb_impl(zfs_handle_t *zhp, const char *from, int fd,
 		char bookname[ZFS_MAX_DATASET_NAME_LEN];
 		nvlist_t *redact_snaps;
 		zfs_handle_t *book_zhp;
-		char *at, *pound;
+		const char *at, *pound;
 		int dsnamelen;
 
 		pound = strchr(redactbook, '#');

--- a/lib/libzutil/os/linux/zutil_device_path_os.c
+++ b/lib/libzutil/os/linux/zutil_device_path_os.c
@@ -218,7 +218,8 @@ zfs_get_pci_slots_sys_path(const char *dev_name)
 	char *address2 = NULL;
 	char *path = NULL;
 	char buf[MAXPATHLEN];
-	char *tmp;
+	const char *tmp;
+	char *tmp2;
 
 	/* If they preface 'dev' with a path (like "/dev") then strip it off */
 	tmp = strrchr(dev_name, '/');
@@ -240,9 +241,9 @@ zfs_get_pci_slots_sys_path(const char *dev_name)
 	 * be "0000:01:00.0" while /sys/bus/pci/slots/0/address will be
 	 * "0000:01:00".  Just NULL terminate at the '.' so they match.
 	 */
-	tmp = strrchr(address1, '.');
-	if (tmp != NULL)
-		*tmp = '\0';
+	tmp2 = strrchr(address1, '.');
+	if (tmp2 != NULL)
+		*tmp2 = '\0';
 
 	dp = opendir("/sys/bus/pci/slots/");
 	if (dp == NULL) {
@@ -311,6 +312,7 @@ zfs_get_enclosure_sysfs_path(const char *dev_name)
 	DIR *dp = NULL;
 	struct dirent *ep;
 	char buf[MAXPATHLEN];
+	const char *tmp0;
 	char *tmp1 = NULL;
 	char *tmp2 = NULL;
 	char *tmp3 = NULL;
@@ -322,9 +324,9 @@ zfs_get_enclosure_sysfs_path(const char *dev_name)
 		return (NULL);
 
 	/* If they preface 'dev' with a path (like "/dev") then strip it off */
-	tmp1 = strrchr(dev_name, '/');
-	if (tmp1 != NULL)
-		dev_name = tmp1 + 1;    /* +1 since we want the chr after '/' */
+	tmp0 = strrchr(dev_name, '/');
+	if (tmp0 != NULL)
+		dev_name = tmp0 + 1;    /* +1 since we want the chr after '/' */
 
 	tmpsize = asprintf(&tmp1, "/sys/block/%s/device", dev_name);
 	if (tmpsize == -1 || tmp1 == NULL) {

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -1923,8 +1923,9 @@ nvlist_lookup_nvpair_ei_sep(nvlist_t *nvl, const char *name, const char sep,
 {
 	nvpair_t	*nvp;
 	const char	*np;
-	char		*sepp = NULL;
-	char		*idxp, *idxep;
+	const char	*sepp = NULL;
+	const char	*idxp;
+	char		*idxep;
 	nvlist_t	**nva;
 	long		idx = 0;
 	int		n;

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -3011,7 +3011,7 @@ dmu_objset_get_user(objset_t *os)
 int
 dmu_fsname(const char *snapname, char *buf)
 {
-	char *atp = strchr(snapname, '@');
+	const char *atp = strchr(snapname, '@');
 	if (atp == NULL)
 		return (SET_ERROR(EINVAL));
 	if (atp - snapname >= ZFS_MAX_DATASET_NAME_LEN)

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -39,10 +39,10 @@
 
 static int
 dsl_bookmark_hold_ds(dsl_pool_t *dp, const char *fullname,
-    dsl_dataset_t **dsp, const void *tag, char **shortnamep)
+    dsl_dataset_t **dsp, const void *tag, const char **shortnamep)
 {
 	char buf[ZFS_MAX_DATASET_NAME_LEN];
-	char *hashp;
+	const char *hashp;
 
 	if (strlen(fullname) >= ZFS_MAX_DATASET_NAME_LEN)
 		return (SET_ERROR(ENAMETOOLONG));
@@ -105,7 +105,7 @@ int
 dsl_bookmark_lookup(dsl_pool_t *dp, const char *fullname,
     dsl_dataset_t *later_ds, zfs_bookmark_phys_t *bmp)
 {
-	char *shortname;
+	const char *shortname;
 	dsl_dataset_t *ds;
 	int error;
 
@@ -219,7 +219,7 @@ dsl_bookmark_create_check_impl(dsl_pool_t *dp,
 
 	int error;
 	dsl_dataset_t *newbm_ds;
-	char *newbm_short;
+	const char *newbm_short;
 	zfs_bookmark_phys_t bmark_phys;
 
 	error = dsl_bookmark_hold_ds(dp, newbm, &newbm_ds, FTAG, &newbm_short);
@@ -329,7 +329,7 @@ dsl_bookmark_create_check(void *arg, dmu_tx_t *tx)
 }
 
 static dsl_bookmark_node_t *
-dsl_bookmark_node_alloc(char *shortname)
+dsl_bookmark_node_alloc(const char *shortname)
 {
 	dsl_bookmark_node_t *dbn = kmem_alloc(sizeof (*dbn), KM_SLEEP);
 	dbn->dbn_name = spa_strdup(shortname);
@@ -445,7 +445,7 @@ dsl_bookmark_create_sync_impl_snap(const char *bookmark, const char *snapshot,
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	objset_t *mos = dp->dp_meta_objset;
 	dsl_dataset_t *snapds, *bmark_fs;
-	char *shortname;
+	const char *shortname;
 	boolean_t bookmark_redacted;
 	uint64_t *dsredactsnaps;
 	uint64_t dsnumsnaps;
@@ -535,7 +535,7 @@ dsl_bookmark_create_sync_impl_book(
 {
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	dsl_dataset_t *bmark_fs_source, *bmark_fs_new;
-	char *source_shortname, *new_shortname;
+	const char *source_shortname, *new_shortname;
 	zfs_bookmark_phys_t source_phys;
 
 	VERIFY0(dsl_bookmark_hold_ds(dp, source_name, &bmark_fs_source, FTAG,
@@ -1105,7 +1105,7 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 		dsl_dataset_t *ds;
 		zfs_bookmark_phys_t bm;
 		int error;
-		char *shortname;
+		const char *shortname;
 
 		error = dsl_bookmark_hold_ds(dp, fullname, &ds,
 		    FTAG, &shortname);
@@ -1161,7 +1161,7 @@ dsl_bookmark_destroy_sync(void *arg, dmu_tx_t *tx)
 	for (nvpair_t *pair = nvlist_next_nvpair(dbda->dbda_success, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(dbda->dbda_success, pair)) {
 		dsl_dataset_t *ds;
-		char *shortname;
+		const char *shortname;
 		uint64_t zap_cnt;
 
 		VERIFY0(dsl_bookmark_hold_ds(dp, nvpair_name(pair),

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -417,7 +417,7 @@ dsl_dir_namelen(dsl_dir_t *dd)
 static int
 getcomponent(const char *path, char *component, const char **nextp)
 {
-	char *p;
+	const char *p;
 
 	if ((path == NULL) || (path[0] == '\0'))
 		return (SET_ERROR(ENOENT));

--- a/tests/zfs-tests/cmd/threadsappend.c
+++ b/tests/zfs-tests/cmd/threadsappend.c
@@ -87,7 +87,7 @@ usage(void)
 int
 main(int argc, char **argv)
 {
-	pthread_t tid;
+	pthread_t tid[2];
 	int	ret = 0;
 	long	ncpus = 0;
 	int	i;
@@ -120,7 +120,7 @@ main(int argc, char **argv)
 	}
 
 	for (i = 0; i < 2; i++) {
-		ret = pthread_create(&tid, NULL, go, (void *)&i);
+		ret = pthread_create(&tid[i], NULL, go, (void *)&i);
 		if (ret != 0) {
 			(void) fprintf(stderr,
 			    "zfs_threadsappend: thr_create(#%d) "
@@ -129,8 +129,8 @@ main(int argc, char **argv)
 		}
 	}
 
-	while (pthread_join(tid, NULL) == 0)
-		continue;
+	for (i = 0; i < 2; i++)
+		(void) pthread_join(tid[i], NULL);
 
 	return (0);
 }


### PR DESCRIPTION
### Motivation and Context
Support Fedora 44

### Description
- Add Fedora 44 to CI tests
- Fix build issues from the newer compiler. These are mostly 'char *' to 'const char *' conversions.
- Fix threadsappend.c test waiting for the same thread TID twice. This caused the test to hang on F44 (but strangely not other OSs?)

### How Has This Been Tested?
Fedora 44 passed local CI test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
