### PR TITLE
[WIP] basic implementation of set prop[+|-]=value

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -648,26 +648,58 @@ usage(boolean_t requested)
 /*
  * Take a property=value argument string and add it to the given nvlist.
  * Modifies the argument inplace.
+ *
+ * Supports relative (incremental) syntax: property+=value or property-=value.
+ * In that case the value is stored with a leading '+' or '-' sentinel so that
+ * set_callback() can later resolve it against the dataset's current value.
  */
 static boolean_t
 parseprop(nvlist_t *props, char *propname)
 {
 	char *propval;
+	char op = '\0';
 
 	if ((propval = strchr(propname, '=')) == NULL) {
 		(void) fprintf(stderr, gettext("missing "
 		    "'=' for property=value argument\n"));
 		return (B_FALSE);
 	}
-	*propval = '\0';
+
+	/*
+	 * Detect += or -= immediately before the '='.
+	 * Back up the pointer and null-terminate the property name there.
+	 */
+	if (propval > propname &&
+	    (*(propval - 1) == '+' || *(propval - 1) == '-')) {
+		op = *(propval - 1);
+		*(propval - 1) = '\0';
+	} else {
+		*propval = '\0';
+	}
 	propval++;
+
 	if (nvlist_exists(props, propname)) {
 		(void) fprintf(stderr, gettext("property '%s' "
 		    "specified multiple times\n"), propname);
 		return (B_FALSE);
 	}
-	if (nvlist_add_string(props, propname, propval) != 0)
-		nomem();
+
+	if (op != '\0') {
+		/*
+		 * Store value with leading op char as a sentinel (e.g. "+100G"
+		 * or "-50G"). No existing ZFS value starts with '+' or '-', so
+		 * this is unambiguous and requires no extra struct fields.
+		 */
+		char *stored;
+		if (asprintf(&stored, "%c%s", op, propval) < 0)
+			nomem();
+		if (nvlist_add_string(props, propname, stored) != 0)
+			nomem();
+		free(stored);
+	} else {
+		if (nvlist_add_string(props, propname, propval) != 0)
+			nomem();
+	}
 	return (B_TRUE);
 }
 
@@ -4534,10 +4566,114 @@ out:
  * Sets the given properties for all datasets specified on the command line.
  */
 
+/*
+ * Scan props for any relative (+/-) values stored by parseprop(). For each,
+ * fetch the current value from zhp, compute the new absolute value, and
+ * replace the nvlist entry with a decimal string. Returns 0 on success, -1
+ * on error (message already printed to stderr).
+ */
+static int
+resolve_relative_props(zfs_handle_t *zhp, nvlist_t *props)
+{
+	nvpair_t *elem = NULL;
+
+	while ((elem = nvlist_next_nvpair(props, elem)) != NULL) {
+		const char *propname = nvpair_name(elem);
+		const char *valstr;
+
+		if (nvpair_value_string(elem, &valstr) != 0)
+			continue;
+
+		if (valstr[0] != '+' && valstr[0] != '-')
+			continue;
+
+		char op = valstr[0];
+		const char *deltastr = valstr + 1;
+
+		/* Must be a known property. */
+		zfs_prop_t prop = zfs_name_to_prop(propname);
+		if (prop == ZPROP_INVAL) {
+			(void) fprintf(stderr, gettext("cannot use '%c=' "
+			    "on property '%s': unknown property\n"),
+			    op, propname);
+			return (-1);
+		}
+
+		/* Must be a numeric property. */
+		if (zfs_prop_get_type(prop) != PROP_TYPE_NUMBER) {
+			(void) fprintf(stderr, gettext("cannot use '%c=' "
+			    "on property '%s': not a numeric property\n"),
+			    op, propname);
+			return (-1);
+		}
+
+		/* Must be writable (not readonly or one-time). */
+		zprop_attr_t attr = zfs_prop_get_table()[prop].pd_attr;
+		if (attr == PROP_READONLY || attr == PROP_ONETIME ||
+		    attr == PROP_ONETIME_DEFAULT) {
+			(void) fprintf(stderr, gettext("cannot use '%c=' "
+			    "on property '%s': read-only property\n"),
+			    op, propname);
+			return (-1);
+		}
+
+		/* Parse the delta value (e.g. "100G" -> bytes). */
+		uint64_t delta;
+		if (zfs_nicestrtonum(g_zfs, deltastr, &delta) != 0) {
+			(void) fprintf(stderr, gettext("invalid value for "
+			    "'%s%c=': '%s'\n"), propname, op, deltastr);
+			return (-1);
+		}
+
+		/* Fetch the current value from the dataset. */
+		uint64_t current = zfs_prop_get_int(zhp, prop);
+
+		/* Compute and range-check the new value. */
+		uint64_t newval;
+		if (op == '+') {
+			if (current > UINT64_MAX - delta) {
+				(void) fprintf(stderr, gettext("'%s+=%s': "
+				    "result overflows\n"), propname, deltastr);
+				return (-1);
+			}
+			newval = current + delta;
+		} else {
+			if (delta > current) {
+				(void) fprintf(stderr, gettext("'%s-=%s': "
+				    "result would be negative\n"),
+				    propname, deltastr);
+				return (-1);
+			}
+			newval = current - delta;
+			if (newval == 0) {
+				(void) fprintf(stderr, gettext("'%s-=%s': "
+				    "result is zero; use '%s=none' to "
+				    "disable\n"), propname, deltastr, propname);
+				return (-1);
+			}
+		}
+
+		/* Replace the nvlist entry with the resolved decimal string. */
+		char newvalstr[32];
+		(void) snprintf(newvalstr, sizeof (newvalstr), "%llu",
+		    (unsigned long long)newval);
+		if (nvlist_add_string(props, propname, newvalstr) != 0)
+			nomem();
+
+		/* Restart iteration: nvlist_add_string may have reordered. */
+		elem = NULL;
+	}
+	return (0);
+}
+
 static int
 set_callback(zfs_handle_t *zhp, void *data)
 {
 	zprop_set_cbdata_t *cb = data;
+
+	if (resolve_relative_props(zhp, cb->cb_proplist) != 0)
+		return (-1);
+
 	int ret = zfs_prop_set_list_flags(zhp, cb->cb_proplist, cb->cb_flags);
 
 	if (ret != 0 || libzfs_errno(g_zfs) != EZFS_SUCCESS) {

--- a/man/man8/zfs-set.8
+++ b/man/man8/zfs-set.8
@@ -44,6 +44,16 @@
 .Ar property Ns = Ns Ar value Oo Ar property Ns = Ns Ar value Oc Ns …
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns …
 .Nm zfs
+.Cm set
+.Op Fl u
+.Ar property Ns += Ns Ar value Oo Ar property Ns += Ns Ar value Oc Ns …
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns …
+.Nm zfs
+.Cm set
+.Op Fl u
+.Ar property Ns -= Ns Ar value Oo Ar property Ns -= Ns Ar value Oc Ns …
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns …
+.Nm zfs
 .Cm get
 .Op Fl r Ns | Ns Fl d Ar depth
 .Op Fl Hp
@@ -78,6 +88,29 @@ with a suffix of
 .Po for bytes, kilobytes, megabytes, gigabytes, terabytes, petabytes, exabytes,
 or zettabytes, respectively
 .Pc .
+.Pp
+Writable numeric properties also accept relative adjustments using the
+.Sy +=
+and
+.Sy -=
+operators.
+For example,
+.Dl # Nm zfs Cm set Sy quota Ns += Ns Ar 100G Ar pool/home/bob
+increases the current quota by 100\ GiB, and
+.Dl # Nm zfs Cm set Sy reservation Ns -= Ns Ar 50G Ar pool/home/bob
+decreases the current reservation by 50\ GiB.
+Relative operators are only valid for writable numeric properties
+.Po such as
+.Sy quota , refquota , reservation , refreservation , volsize ,
+.Sy filesystem_limit ,
+and
+.Sy snapshot_limit
+.Pc .
+A relative decrement that would reduce a property to zero is an error;
+use
+.Sy property Ns = Ns Sy none
+to disable quota or reservation properties.
+.Pp
 User properties can be set on snapshots.
 For more information, see the
 .Em User Properties

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -347,7 +347,8 @@ tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
     'user_property_004_pos', 'version_001_neg', 'zfs_set_001_neg',
     'zfs_set_002_neg', 'zfs_set_003_neg', 'property_alias_001_pos',
     'mountpoint_003_pos', 'ro_props_001_pos', 'zfs_set_keylocation',
-    'zfs_set_feature_activation', 'zfs_set_nomount']
+    'zfs_set_feature_activation', 'zfs_set_nomount',
+    'zfs_set_relative_pos', 'zfs_set_relative_neg']
 tags = ['functional', 'cli_root', 'zfs_set']
 
 [tests/functional/cli_root/zfs_share]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -944,6 +944,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_set/zfs_set_feature_activation.ksh \
 	functional/cli_root/zfs_set/zfs_set_keylocation.ksh \
 	functional/cli_root/zfs_set/zfs_set_nomount.ksh \
+	functional/cli_root/zfs_set/zfs_set_relative_neg.ksh \
+	functional/cli_root/zfs_set/zfs_set_relative_pos.ksh \
 	functional/cli_root/zfs_share/cleanup.ksh \
 	functional/cli_root/zfs_share/setup.ksh \
 	functional/cli_root/zfs_share/zfs_share_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_relative_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_relative_neg.ksh
@@ -1,0 +1,91 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025 by The OpenZFS Project. All rights reserved.
+#
+
+#
+# DESCRIPTION:
+# 'zfs set property+=value' and 'zfs set property-=value' should be rejected
+# for invalid inputs: non-numeric properties, read-only properties, underflow,
+# zero result, overflow, and bad numeric suffixes.
+#
+# STRATEGY:
+# 1. Attempt += on an index (non-numeric) property: must fail.
+# 2. Attempt += on a read-only property: must fail.
+# 3. Attempt -= that would result in exactly 0: must fail.
+# 4. Attempt -= that would underflow (result < 0): must fail.
+# 5. Attempt += with a malformed delta (bad suffix): must fail.
+# 6. Attempt += on an unknown property: must fail.
+# 7. Verify the property value is unchanged after each failed attempt.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "both"
+
+FS=$TESTPOOL/$TESTFS
+
+function cleanup
+{
+	log_must zfs set quota=none $FS
+}
+
+log_onexit cleanup
+
+log_assert "'zfs set prop+=val' is rejected for invalid inputs"
+
+# Establish a baseline quota for decrement tests
+log_must zfs set quota=100m $FS
+
+# --- non-numeric (index) property: checksum ---
+log_mustnot zfs set checksum+=1 $FS
+
+# --- read-only property: used ---
+log_mustnot zfs set used+=1 $FS
+
+# --- -= resulting in exactly zero ---
+# quota is 100m; subtracting 100m would make it 0, which is disallowed
+log_mustnot zfs set quota-=100m $FS
+typeset val
+val=$(get_prop quota $FS)
+[[ $val -eq $((100 * 1024 * 1024)) ]] || \
+	log_fail "quota changed after zero-result -=: got $val"
+
+# --- -= underflow (delta > current value) ---
+log_mustnot zfs set quota-=200m $FS
+val=$(get_prop quota $FS)
+[[ $val -eq $((100 * 1024 * 1024)) ]] || \
+	log_fail "quota changed after underflow -=: got $val"
+
+# --- malformed delta (bad suffix) ---
+log_mustnot zfs set quota+=100xyz $FS
+val=$(get_prop quota $FS)
+[[ $val -eq $((100 * 1024 * 1024)) ]] || \
+	log_fail "quota changed after bad suffix +=: got $val"
+
+# --- unknown property ---
+log_mustnot zfs set nosuchprop+=1 $FS
+
+log_pass "'zfs set prop+=val' is correctly rejected for invalid inputs"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_relative_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_relative_pos.ksh
@@ -1,0 +1,98 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025 by The OpenZFS Project. All rights reserved.
+#
+
+#
+# DESCRIPTION:
+# 'zfs set property+=value' and 'zfs set property-=value' (relative
+# increment/decrement) should succeed for writable numeric properties.
+#
+# STRATEGY:
+# 1. Set a numeric property (quota) to a known value.
+# 2. Use += to increment it and verify the new value.
+# 3. Use -= to decrement it and verify the new value.
+# 4. Use += when the property is unset (none/0) and verify it becomes the delta.
+# 5. Apply += to multiple datasets in one invocation and verify each.
+# 6. Verify reservation+= behaves correctly.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "both"
+
+FS=$TESTPOOL/$TESTFS
+
+function cleanup
+{
+	log_must zfs set quota=none $FS
+	log_must zfs set reservation=none $FS
+}
+
+log_onexit cleanup
+
+log_assert "'zfs set prop+=val' and 'zfs set prop-=val' work for numeric props"
+
+# --- quota += ---
+log_must zfs set quota=100m $FS
+log_must zfs set quota+=50m $FS
+typeset val
+val=$(get_prop quota $FS)
+# 150 MiB = 157286400 bytes
+[[ $val -eq $((150 * 1024 * 1024)) ]] || log_fail "quota+= expected 157286400, got $val"
+
+# --- quota -= ---
+log_must zfs set quota-=50m $FS
+val=$(get_prop quota $FS)
+# 100 MiB = 104857600 bytes
+[[ $val -eq $((100 * 1024 * 1024)) ]] || log_fail "quota-= expected 104857600, got $val"
+
+# --- += when quota is none (treated as 0) ---
+log_must zfs set quota=none $FS
+log_must zfs set quota+=200m $FS
+val=$(get_prop quota $FS)
+[[ $val -eq $((200 * 1024 * 1024)) ]] || log_fail "quota+= from none expected 209715200, got $val"
+
+# --- reservation+= ---
+log_must zfs set reservation=50m $FS
+log_must zfs set reservation+=10m $FS
+val=$(get_prop reservation $FS)
+[[ $val -eq $((60 * 1024 * 1024)) ]] || log_fail "reservation+= expected 62914560, got $val"
+log_must zfs set reservation=none $FS
+
+# --- multi-dataset: += applied to two filesystems ---
+typeset FS2=$TESTPOOL/${TESTFS}_rel2
+log_must zfs create $FS2
+log_must zfs set quota=100m $FS $FS2
+log_must zfs set quota+=20m $FS $FS2
+typeset v1 v2
+v1=$(get_prop quota $FS)
+v2=$(get_prop quota $FS2)
+[[ $v1 -eq $((120 * 1024 * 1024)) ]] || log_fail "multi-dataset: $FS quota wrong: $v1"
+[[ $v2 -eq $((120 * 1024 * 1024)) ]] || log_fail "multi-dataset: $FS2 quota wrong: $v2"
+log_must zfs set quota=none $FS $FS2
+log_must zfs destroy $FS2
+
+log_pass "'zfs set prop+=val' and 'zfs set prop-=val' succeed for numeric props"


### PR DESCRIPTION
Basic implementation of `zfs set prop+=value pool/dataset` as well as `-=`.

### Motivation and Context

Much of the time I need to increase/decrease quota/refquota/reservation while doing daily administration, and doing `+=`/`-=` seems much simpler than scripting around `zfs get` and `zfs set`.

Not sure if there’s an issue about this, although at first glance I didn’t find anything :))  


### Description

Basically the command line parser for set now looks to see if there a `+` or `-` sign and then decides what to do. if there’s no inc/dec sign, it will continue as before, otherwise it will try to get the value and change it. it also checks to see if the property is read-only or not.


### How Has This Been Tested?
Tested on FreeBSD 15.0-RELEASE, latest patch, pkg base, running UFS, with ZFS compiled from git, loaded and then running the bfs-test suite with the `-T zfs-set` flag.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied. (**ONLY THE TAG THAT I NEEDED THO!!!!**)
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

P.S. *some* parts of the C code was generate by an LLM (Claude… something 1M), which is the part that needs proper auditing and review. Tests are written by hand, the man pages are completely modified by the LLM however they work as expected and render fine :)) 