### PR TITLE
Initialize vr_last_txg for rebuild

### DIFF
--- a/module/zfs/vdev_rebuild.c
+++ b/module/zfs/vdev_rebuild.c
@@ -825,6 +825,7 @@ vdev_rebuild_thread(void *arg)
 		uint64_t limit = (arc_c_max / 2) / MAX(rvd->vdev_children, 1);
 		vr->vr_bytes_inflight_max = MIN(limit, MAX(1ULL << 20,
 		    zfs_rebuild_vdev_limit * vd->vdev_children));
+		vr->vr_last_txg = 0;
 
 		/*
 		 * Removal of vdevs from the vdev tree may eliminate the need
@@ -916,7 +917,9 @@ vdev_rebuild_thread(void *arg)
 		 * to avoid any interfering allocations. Otherwise, we might
 		 * see checksum errors after scrub.
 		 */
-		txg_wait_synced(dp, vr->vr_last_txg);
+		if (vr->vr_last_txg != 0)
+			txg_wait_synced(dp, vr->vr_last_txg);
+
 		metaslab_enable(msp, B_FALSE, B_FALSE);
 		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 


### PR DESCRIPTION
### Motivation and Context

Minor optimization as a followup to #18473.

### Description

Only call txg_wait_synced() when rebuild IOs were issued for this metaslab.  This is a small optimization since in practice the first metaslab is very likely to have allocations and cause vr_last_txg to be initialized.  After this point when processing empty metaslabs txg_wait_synced() is called but with an already committed txg so it will not wait.  Still it's better not to call txg_wait_synced() at all when it's not needed.

### How Has This Been Tested?

Compiled, will be tested by the CI along with additional local testing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)