### PR TITLE
Zstd: rework ZSTD_isError symbol renaming

### DIFF
--- a/module/zstd/include/zstd_compat_wrapper.h
+++ b/module/zstd/include/zstd_compat_wrapper.h
@@ -33,6 +33,8 @@
  * Copyright (c) 2020, Sebastian Gottschall
  */
 
+#define	_ZSTD_COMPAT_WRAPPER_H
+
 /*
  * This wrapper fixes a problem, in case the ZFS filesystem driver, is compiled
  * statically into the kernel.

--- a/module/zstd/lib/common/zstd_common.c
+++ b/module/zstd/lib/common/zstd_common.c
@@ -9,7 +9,9 @@
  * You may select, at your option, one of the above-listed licenses.
  */
 
-
+#ifdef _ZSTD_COMPAT_WRAPPER_H
+#undef ZSTD_isError   /* defined within zstd_internal.h */
+#endif
 
 /*-*************************************
 *  Dependencies
@@ -34,7 +36,9 @@ const char* ZSTD_versionString(void) { return ZSTD_VERSION_STRING; }
 /*! ZSTD_isError() :
  *  tells if a return value is an error code
  *  symbol is required for external callers */
-unsigned ZSTD_isError(size_t code) __asm__("zfs_ZSTD_isError");
+#ifdef _ZSTD_COMPAT_WRAPPER_H
+#define	ZSTD_isError zfs_ZSTD_isError
+#endif
 unsigned ZSTD_isError(size_t code) { return ERR_isError(code); }
 
 /*! ZSTD_getErrorName() :


### PR DESCRIPTION
### Motivation and Context

This fixes an issue whre the FreeBSD gcc build of openzfs is failing due to the forcible renaming of ZSTD_isError to zfs_ZSTD_isError via asm directive in zstd_common.c.  FreeBSD's build is not using the symbol renaming mechanism in zstd_compat_wrapper.h, so the rename in zstd_common.c results in an inconsistent name.

FreeBSD took the asm directive renaming in a2ac9cd606ce2428c23cc89cec6f0392424e82c9 in FreeBSD [8a62a2a5659d1839d8799b4274c04469d7f17c78](https://github.com/freebsd/freebsd-src/commit/8a62a2a5659d1839d8799b4274c04469d7f17c78) and the gcc build has not succeeded since (first CI run [here](https://ci.freebsd.org/job/FreeBSD-main-amd64-gcc14_build/3138/)).

The build error presents as
```
/usr/local/bin/x86_64-unknown-freebsd15.0-ld: /tmp/obj/workspace/src/amd64.amd64/tmp/usr/lib/libzpool.so: undefined reference to `ZSTD_isError'
```

### Description

The import of Zstd v1.5.7 in a2ac9cd606ce2428c23cc89cec6f0392424e82c9 added an unconditional renaming of ZSTD_isError to zfs_ZSTD_isError with an asm directive.  Instead, do it with a define that is conditioned on whether zstd_compat_wrapper.h is actually in use.  Also add a define to that header so that it can be detected.  This allows the build to work with and without using the compat wrapper.

### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Compile tests:
* Linux openzfs build with gcc
* FreeBSD openzfs build with clang and gcc
* This patch applied to FreeBSD current sys/contrib/openzfs with clang and gcc.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
