### PR TITLE
CI: Disable zfs-qemu jobs with missing CI images

### DIFF
--- a/.github/workflows/scripts/qemu-1-setup.sh
+++ b/.github/workflows/scripts/qemu-1-setup.sh
@@ -112,6 +112,9 @@ fi
 sudo modprobe loop
 sudo modprobe zfs
 
+lsblk
+df -h
+
 if [ -e /dev/disk/cloud/azure_resource-part1 ] ; then
   echo "We have two 75GB block devices"
   # partition the disk as needed

--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -8,6 +8,18 @@ set -eu
 
 # short name used in zfs-qemu.yml
 OS="$1"
+CHECK=0
+
+if [ "$#" -eq 2 ]; then
+  shift
+
+  if [ "$1" == "--check" ] ; then
+    CHECK=1
+  else
+    echo "Unknown option $1"
+    exit 1
+  fi
+fi
 
 # OS variant (virt-install --os-variant list)
 OSv=$OS
@@ -176,33 +188,37 @@ echo "VMs=\"$VMs\"" >> $ENV
 CPU=2
 echo "CPU=\"$CPU\"" >> $ENV
 
-sudo mkdir -p "/mnt/tests"
-sudo chown -R $(whoami) /mnt/tests
-
-DISK="/dev/zvol/zpool/openzfs"
-sudo zfs create -ps -b 64k -V 80g zpool/openzfs
-while true; do test -b $DISK && break; sleep 1; done
+# Check that the URL is valid by downloading the headers but
+# don't actually download the image.
+if [ $CHECK -eq 1 ]; then
+  cmds=("curl --fail --retry 3 --connect-timeout 5 --max-time 5 -ILSs -o")
+else
+  cmds=("axel -q -o" "curl --fail -LSs -o")
+fi
 
 # We first try to download with 'axel', which is faster than curl, but fallback
 # to curl if that doesn't work.  It is hoped that the curl fallback will get
 # around the occasional "ERROR 502: Bad Gateway" errors.
-IMG="/mnt/tests/cloud-image"
-for cmd in 'axel -q -o' 'curl --fail -LSs -o' ; do
-  if [ ! -z "$URLxz" ]; then
-    echo "Loading $URLxz with $cmd..."
-    time eval "$cmd $IMG $URLxz" || true
+IMG="/var/tmp/cloud-image"
+SRC="/var/tmp/src.txz"
 
-    if [ ! -s ~/src.txz ] ; then
-      echo "Loading $KSRC with $cmd..."
-      time eval "$cmd ~/src.txz $KSRC" || true
+for cmd in "${cmds[@]}" ; do
+  rm -f $IMG $SRC
+
+  if [ ! -z "$URLxz" ]; then
+    echo "$OS: $cmd $IMG $URLxz"
+    $cmd $IMG $URLxz || rm -f $IMG
+
+    if [ ! -s "$SRC" ] ; then
+      echo "$OS: $cmd $SRC $KSRC"
+      $cmd $SRC $KSRC || rm -f $SRC
     fi
   else
-    echo "Loading $URL with $cmd..."
-    time eval "$cmd $IMG $URL" || true
+    echo "$OS: $cmd $IMG $URL"
+    $cmd $IMG $URL || rm -f $IMG
   fi
 
   if [ -s "$IMG" ] ; then
-    # Successful download
     break
   fi
 done
@@ -224,11 +240,41 @@ if [ ! -z "$URLxz" ] && [ ! -s "$IMG" ] ; then
   URLxz=$(wget --accept "*.raw.xz" --spider -np --recursive  --no-verbose \
     $(dirname $(dirname $URLxz)) 2>&1  | awk '/200 OK/{print $(NF-2)}' | \
     sort -n | tail -n 1)
-  echo "Couldn't download FreeBSD raw.xz.  Trying fallback snapshot $URLxz"
-  curl --fail -LSs -o $IMG $URLxz
+
+  if [ -n "$URLxz" ] ; then
+    echo "$OS: Couldn't download FreeBSD raw.xz. Trying fallback snapshot $URLxz"
+    if [ $CHECK -eq 1 ] ; then
+      ${cmds[0]} $IMG $URLxz || rm -f $IMG
+    else
+      ${cmds[1]} $IMG $URLxz || rm -f $IMG
+    fi
+  else
+    echo "$OS: Couldn't download FreeBSD raw.xz. No fallback snapshot found"
+    rm -f "$IMG"
+  fi
 fi
 
-echo "Importing VM image to zvol..."
+if [ -s "$IMG" ] ; then
+  echo "$OS: Downloaded CI image successfully"
+else
+  echo "$OS: Download of CI image failed"
+  rm -f $IMG $SRC
+  exit 1
+fi
+
+if [ $CHECK -eq 1 ] ; then
+  rm -f $IMG $SRC
+  exit 0
+fi
+
+sudo mkdir -p "/mnt/tests"
+sudo chown -R $(whoami) /mnt/tests
+
+DISK="/dev/zvol/zpool/openzfs"
+sudo zfs create -ps -b 64k -V 80g zpool/openzfs
+while true; do test -b $DISK && break; sleep 1; done
+
+echo "$OS: Importing VM image to zvol..."
 if [ ! -z "$URLxz" ]; then
   xzcat -T0 $IMG | sudo dd of=$DISK bs=4M
 else
@@ -338,7 +384,7 @@ else
   scp ~/.ssh/id_ed25519.pub "root@vm0:~zfs/.ssh/authorized_keys"
   ssh root@vm0 'chown -R zfs ~zfs'
   ssh root@vm0 'service sshd restart'
-  scp ~/src.txz "root@vm0:/tmp/src.txz"
+  scp $SRC "root@vm0:/tmp/src.txz"
   ssh root@vm0 'tar -C / -zxf /tmp/src.txz'
 fi
 

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -26,15 +26,17 @@ jobs:
     if: github.event_name == 'pull_request' || github.repository != 'openzfs/zfs'
     runs-on: ubuntu-24.04
     outputs:
-      test_os: ${{ steps.os.outputs.os }}
+      matrix: ${{ steps.os.outputs.matrix }}
       ci_type: ${{ steps.os.outputs.ci_type }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Generate OS config and CI type
+        timeout-minutes: 10
         id: os
         run: |
+          matrix='{"include":[]}'
           ci_type="default"
           ci_source="auto"
 
@@ -89,8 +91,19 @@ jobs:
               os_json=$(echo ${os_selection} | jq -c)
           fi
 
-          echo "os=$os_json" | tee -a $GITHUB_OUTPUT
-          echo "ci_type=$ci_type" | tee -a $GITHUB_OUTPUT
+          # Generate the test matrix, skip jobs with missing CI images
+          while IFS= read -r os; do
+              if .github/workflows/scripts/qemu-2-start.sh "$os" --check; then
+                  matrix=$(jq -c \
+                    --arg os "$os" \
+                    '.include += [{"os": $os}]' <<< "$matrix")
+              else
+                  echo -e "\033[1;31mDisabling $os job, CI image unavailable\033[0m"
+              fi
+          done < <(jq -r '.[]' <<< "$os_json")
+
+          echo "matrix=$matrix" | tee -a "$GITHUB_OUTPUT"
+          echo "ci_type=$ci_type" | tee -a "$GITHUB_OUTPUT"
 
   qemu-vm:
     name: qemu-x86
@@ -101,15 +114,7 @@ jobs:
       needs.test-config.outputs.ci_type != 'docs'
     strategy:
       fail-fast: false
-      matrix:
-        # rhl:     almalinux8, almalinux9, centos-streamX, fedora4x
-        # debian:  debian12, debian13, ubuntu22, ubuntu24, ubuntu26
-        # misc:    archlinux, tumbleweed
-        # FreeBSD variants of november 2025:
-        # FreeBSD Release: freebsd14-4r, freebsd15-0r
-        # FreeBSD Stable:  freebsd14-4s, freebsd15-1s
-        # FreeBSD Current: freebsd16-0c
-        os: ${{ fromJson(needs.test-config.outputs.test_os) }}
+      matrix: ${{ fromJson(needs.test-config.outputs.matrix) }}
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
### Motivation and Context

Given the number of distributions which are being tested it's not uncommon for CI images to be unavailable for one or more of them.  This results is the CI always reporting a top level failure until the issue is resolved.  In the past we've manually removed problematic builders and then added them back, but this takes a fair bit of effort and time.  This change is intended to automatically handle at least the case when the CI images cannot be downloaded.  We may extend it in the future to handle other cases.

### Description

When generating the jobs matrix check if the required CI image for each job is available for download.  If it is, include it in the jobs matrix.  If it's not, omit it.  Performing this check early allows the CI to avoid wasting resources starting jobs which are guaranteed to fail.  It also should help keep the CI green since if the job is never started due to an infrastructure issue it won't be reported as a failure.

The qemu-2-start.sh script has been extended to support this by adding a --check option which only fetches the HTTP headers (-I). This allows for a quick availability check during setup, the full image is still only downloaded once during the "Start Build Machine" step.  Furthermore, the max download time to fetch the headers is limited 15 seconds to keep the setup time bounded even in the worst case.  Normally, the setup step only takes a few seconds to run even after this change.

### How Has This Been Tested?

See https://github.com/behlendorf/zfs/actions/runs/25258757686/ for an example test run.

Currently the FreeBSD 15 CI images are unavailable which provided for a convenient test case.  Notice the freebsd15-0s builder is was disabled for this PR.

https://github.com/openzfs/zfs/actions/runs/25259084796/job/74063247871?pr=18484

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)