### PR TITLE
zfs-mount-generator improvements (remove udev-settle dependency) RFC

### DIFF
--- a/cmd/zed/zed.d/history_event-zfs-list-cacher.sh.in
+++ b/cmd/zed/zed.d/history_event-zfs-list-cacher.sh.in
@@ -6,6 +6,7 @@ set -ef
 
 FSLIST="@sysconfdir@/zfs/zfs-list.cache/${ZEVENT_POOL}"
 FSLIST_TMP="@runstatedir@/zfs-list.cache@${ZEVENT_POOL}"
+FSLIST_TMP2="@runstatedir@/zfs-list.cache@${ZEVENT_POOL}-2"
 
 # If the pool specific cache file is not writeable, abort
 [ -w "${FSLIST}" ] || exit 0
@@ -75,9 +76,14 @@ PROPS="name,mountpoint,canmount,atime,relatime,devices,exec\
 ,org.openzfs.systemd:nofail,org.openzfs.systemd:ignore"
 
 "${ZFS}" list -H -t filesystem -o "${PROPS}" -r "${ZEVENT_POOL}" > "${FSLIST_TMP}"
+"${ZPOOL}" status -P "${ZEVENT_POOL}" | sed -n '/^\t  *\//s/^\t *\([^ ]*\) .*/\1/p' > "${FSLIST_TMP2}"
 
 # Sort the output so that it is stable
 sort "${FSLIST_TMP}" -o "${FSLIST_TMP}"
+sort "${FSLIST_TMP2}" -o "${FSLIST_TMP2}"
+
+echo >> "${FSLIST_TMP}"
+cat "${FSLIST_TMP2}" >> "${FSLIST_TMP}"
 
 # Don't modify the file if it hasn't changed
 diff -q "${FSLIST_TMP}" "${FSLIST}" || cat "${FSLIST_TMP}" > "${FSLIST}"

--- a/contrib/debian/openzfs-zfsutils.install
+++ b/contrib/debian/openzfs-zfsutils.install
@@ -5,6 +5,7 @@ usr/lib/systemd/system-generators/
 usr/lib/systemd/system-preset/
 usr/lib/systemd/system/zfs-import-cache.service
 usr/lib/systemd/system/zfs-import-scan.service
+usr/lib/systemd/system/zfs-import@.service
 usr/lib/systemd/system/zfs-import.target
 usr/lib/systemd/system/zfs-load-key.service
 usr/lib/systemd/system/zfs-mount.service

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -49,6 +49,7 @@ dist_systemdpreset_DATA = \
 systemdunit_DATA = \
 	%D%/systemd/system/zfs-import-cache.service \
 	%D%/systemd/system/zfs-import-scan.service \
+	%D%/systemd/system/zfs-import@.service \
 	%D%/systemd/system/zfs-import.target \
 	%D%/systemd/system/zfs-mount.service \
 	%D%/systemd/system/zfs-mount@.service \

--- a/etc/systemd/system-generators/zfs-mount-generator.c
+++ b/etc/systemd/system-generators/zfs-mount-generator.c
@@ -40,7 +40,6 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <errno.h>
-#include <libzfs.h>
 
 /*
  * For debugging only.
@@ -72,7 +71,6 @@ static regex_t uri_regex;
 static const char *destdir = "/tmp";
 static int destdir_fd = -1;
 
-static void *known_pools = NULL; /* tsearch() of C strings */
 static void *noauto_files = NULL; /* tsearch() of C strings */
 
 
@@ -195,14 +193,20 @@ fopenat(int dirfd, const char *pathname, int flags,
 }
 
 static int
-line_worker(char *line, const char *cachefile)
+line_worker(char *line, const char *pool)
 {
 	int ret = 0;
 	void *tofree_all[8];
 	void **tofree = tofree_all;
 
+	/* Minimal pre-requisites to mount a ZFS dataset */
+	const char *bindsto = NULL;
+	char *wantedby = NULL;
+	char *requiredby = NULL;
+	bool noauto = false;
+	bool wantedby_append = true;
+
 	char *toktmp;
-	const char *toktmp2;
 	/* BEGIN CSTYLED */
 	const char *dataset                     = strtok_r(line, "\t", &toktmp);
 	      char *p_mountpoint                = strtok_r(NULL, "\t", &toktmp);
@@ -226,40 +230,19 @@ line_worker(char *line, const char *cachefile)
 	const char *p_systemd_ignore            = strtok_r(NULL, "\t", &toktmp) ?: "-";
 	/* END CSTYLED */
 
-	size_t pool_len = strlen(dataset);
-	if ((toktmp2 = strchr(dataset, '/')) != NULL)
-		pool_len = toktmp2 - dataset;
-	const char *pool = *(tofree++) = strndup(dataset, pool_len);
-
 	if (p_nbmand == NULL) {
 		fprintf(stderr, PROGNAME "[%d]: %s: not enough tokens!\n",
 		    getpid(), dataset);
 		goto err;
 	}
 
-	/* Minimal pre-requisites to mount a ZFS dataset */
-	const char *after = "zfs-import.target";
-	const char *wants = "zfs-import.target";
-	const char *bindsto = NULL;
-	char *wantedby = NULL;
-	char *requiredby = NULL;
-	bool noauto = false;
-	bool wantedby_append = true;
+	char *after = *(tofree++) = systemd_escape(pool, "zfs-import@", ".service");
+	if (after == NULL)
+		goto err_oom;
 
-	/*
-	 * zfs-import.target is not needed if the pool is already imported.
-	 * This avoids a dependency loop on root-on-ZFS systems:
-	 *   systemd-random-seed.service After (via RequiresMountsFor)
-	 *   var-lib.mount After
-	 *   zfs-import.target After
-	 *   zfs-import-{cache,scan}.service After
-	 *   cryptsetup.service After
-	 *   systemd-random-seed.service
-	 */
-	if (tfind(pool, &known_pools, STRCMP)) {
-		after = "";
-		wants = "";
-	}
+	char *wants = *(tofree++) = systemd_escape(pool, "zfs-import@", ".service");
+	if (wants == NULL)
+		goto err_oom;
 
 	if (strcmp(p_systemd_after, "-") == 0)
 		p_systemd_after = NULL;
@@ -328,7 +311,7 @@ line_worker(char *line, const char *cachefile)
 			    "DefaultDependencies=no\n"
 			    "Wants=%s\n"
 			    "After=%s\n",
-			    dataset, cachefile, wants, after);
+			    dataset, pool, wants, after);
 
 			if (need_network)
 				fprintf(keyloadunit_f,
@@ -387,11 +370,10 @@ line_worker(char *line, const char *cachefile)
 
 		/* Update dependencies for the mount file to want this */
 		bindsto = keyloadunit;
-		if (after[0] == '\0')
-			after = keyloadunit;
-		else if (asprintf(&toktmp, "%s %s", after, keyloadunit) != -1)
-			after = *(tofree++) = toktmp;
-		else {
+		if (asprintf(&toktmp, "%s %s", after, keyloadunit) != -1) {
+			free(after);
+			after = toktmp;
+		} else {
 			fprintf(stderr, PROGNAME "[%d]: %s: "
 			    "out of memory to generate after=\"%s %s\"!\n",
 			    getpid(), dataset, after, keyloadunit);
@@ -633,7 +615,7 @@ line_worker(char *line, const char *cachefile)
 	    "Documentation=man:zfs-mount-generator(8)\n"
 	    "\n"
 	    "Before=",
-	    cachefile);
+	    pool);
 
 	if (p_systemd_before)
 		fprintf(mountfile_f, "%s ", p_systemd_before);
@@ -748,29 +730,12 @@ end:
 	while (tofree-- != tofree_all)
 		free(*tofree);
 	return (ret);
+err_oom:
+	fprintf(stderr, PROGNAME "[%d]: %s: out of memory",
+	    getpid(), pool);
 err:
 	ret = 1;
 	goto end;
-}
-
-
-static int
-pool_enumerator(zpool_handle_t *pool, void *data __attribute__((unused)))
-{
-	int ret = 0;
-
-	/*
-	 * Pools are guaranteed-unique by the kernel,
-	 * no risk of leaking dupes here
-	 */
-	char *name = strdup(zpool_get_name(pool));
-	if (!name || !tsearch(name, &known_pools, STRCMP)) {
-		free(name);
-		ret = ENOMEM;
-	}
-
-	zpool_close(pool);
-	return (ret);
 }
 
 int
@@ -821,20 +786,6 @@ main(int argc, char **argv)
 			    PROGNAME "[%d]: couldn't open " FSLIST ": %s\n",
 			    getpid(), strerror(errno));
 		_exit(0);
-	}
-
-	{
-		libzfs_handle_t *libzfs = libzfs_init();
-		if (libzfs) {
-			if (zpool_iter(libzfs, pool_enumerator, NULL) != 0)
-				fprintf(stderr, PROGNAME "[%d]: "
-				    "error listing pools, ignoring\n",
-				    getpid());
-			libzfs_fini(libzfs);
-		} else
-			fprintf(stderr, PROGNAME "[%d]: "
-			    "couldn't start libzfs, ignoring\n",
-			    getpid());
 	}
 
 	{
@@ -895,8 +846,10 @@ main(int argc, char **argv)
 
 		const char *filename = FREE_STATICS ? "(elided)" : NULL;
 
+		// read in a block of lines.  an empty line indicates the end
+		// of the block of datasets
 		ssize_t read;
-		while ((read = getline(&line, &linelen, cachefile)) >= 0) {
+		while ((read = getline(&line, &linelen, cachefile)) >= 2) {
 			line[read - 1] = '\0'; /* newline */
 
 			char *canmount = line;
@@ -930,7 +883,105 @@ main(int argc, char **argv)
 			}
 		}
 
+		/* Generate the zfs-import .service drop-in */
+		char *dropdir = systemd_escape(cachent->d_name, "zfs-import@",
+		    ".service.d");
+		if (dropdir == NULL) {
+			goto dropin_err_oom;
+		}
+
+		(void) mkdirat(destdir_fd, dropdir, 0755);
+		int dropdir_fd = openat(destdir_fd, dropdir,
+		    O_PATH | O_DIRECTORY | O_CLOEXEC);
+		if (dropdir_fd < 0) {
+			fprintf(stderr, PROGNAME "[%d]: %s: "
+			    "couldn't open %s under %s: %s\n",
+			    getpid(), cachent->d_name, dropdir, destdir,
+			    strerror(errno));
+			free(dropdir);
+			continue;
+		}
+
+		int size_now = 0;
+		char **members = NULL;
+		int members_len = 0;
+
+		while ((read = getline(&line, &linelen, cachefile)) >= 2) {
+			line[read - 1] = '\0'; /* newline */
+
+			if (size_now < members_len + 1) {
+				if (size_now == 0) {
+					size_now = 32 * sizeof (char *);
+				} else {
+					size_now *= 2;
+				}
+				members = realloc(members, size_now);
+				if (members == NULL)
+					goto dropin_err_oom;
+			}
+
+			simplify_path(line);
+			members[members_len] = systemd_escape_path(
+			    line, "", ".device");
+			if (members[members_len++] == NULL) {
+				for (int i = 0; i < members_len; i++) {
+					free(members[i]);
+				}
+				goto dropin_err_oom;
+			}
+		}
+
+		if (members_len == 0) {
+			fprintf(stderr, PROGNAME "[%d]: %s:"
+			    "no zpool members found for zfs-import@",
+			    getpid(), cachent->d_name);
+			goto cleanup;
+		}
+
+		FILE *dropin_f = fopenat(dropdir_fd, "members.conf",
+		    O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, "w",
+		    0644);
+		if (!dropin_f) {
+			fprintf(stderr, PROGNAME "[%d]: %s: "
+			    "couldn't open members.conf under %s: %s\n",
+			    getpid(), cachent->d_name, dropdir,
+			    strerror(errno));
+			continue;
+		}
+
+		fprintf(dropin_f,
+		    OUTPUT_HEADER
+		    "[Unit]\n"
+		    "Wants=%s",
+		    members[0]);
+
+		for (int i = 1; i < members_len; i++) {
+			fprintf(dropin_f, " %s", members[i]);
+		}
+
+		fprintf(dropin_f, "\nAfter=%s", members[0]);
+		free(members[0]);
+
+		for (int i = 1; i < members_len; i++) {
+			fprintf(dropin_f, " %s", members[i]);
+			free(members[i]);
+		}
+		fprintf(dropin_f, "\n");
+		fclose(dropin_f);
+
+		// ignore additional blocks
+
+		cleanup:
+		free(members); // members may be NULL here
+		free(dropdir);
 		fclose(cachefile);
+		continue;
+
+		dropin_err_oom:
+		fprintf(stderr, PROGNAME "[%d]: %s:"
+		    "out of memory for zfs-import service\n",
+		    getpid(), cachent->d_name);
+		goto cleanup;
 	}
 	free(line);
 
@@ -999,7 +1050,6 @@ main(int argc, char **argv)
 	if (FREE_STATICS) {
 		closedir(fslist_dir);
 		tdestroy(noauto_files, free);
-		tdestroy(known_pools, free);
 		regfree(&uri_regex);
 	}
 	_exit(ret);

--- a/etc/systemd/system/zfs-import@.service.in
+++ b/etc/systemd/system/zfs-import@.service.in
@@ -1,0 +1,15 @@
+[Unit]
+Description=Import ZFS pool %i by zfs-list.cache
+Documentation=man:zfs-mount-generator(8)
+DefaultDependencies=no
+Before=zfs-import.target
+ConditionPathIsDirectory=/sys/module/zfs
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-@initconfdir@/zfs
+ExecStart=@bindir@/sh -c '@sbindir@/zpool list $0 || @sbindir@/zpool import -N $ZPOOL_IMPORT_OPTS $0' %i
+
+[Install]
+WantedBy=zfs-import.target

--- a/etc/systemd/system/zfs-mount@.service.in
+++ b/etc/systemd/system/zfs-mount@.service.in
@@ -2,8 +2,6 @@
 Description=Mount ZFS filesystem %I
 Documentation=man:zfs(8)
 DefaultDependencies=no
-After=systemd-udev-settle.service
-After=zfs-import.target
 After=zfs-mount.service
 After=systemd-remount-fs.service
 Before=local-fs.target

--- a/etc/systemd/system/zfs-volume-wait.service.in
+++ b/etc/systemd/system/zfs-volume-wait.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=Wait for ZFS Volume (zvol) links in /dev
 DefaultDependencies=no
-After=systemd-udev-settle.service
 After=zfs-import.target
 ConditionPathIsDirectory=/sys/module/zfs
 


### PR DESCRIPTION
### Motivation and Context

Previously, the zfs-mount-generator produced .mount units that depended on the zfs-import.target.  This meant that every filesystem required all pool imports be completed before beginning mounting.  Additionally, the `zfs-import*.service` units that actually performed the `zpool import` depended on the deprecated systemd-udev-settle.service.  This leads to warnings, and more fragile mount behavior.

See also #10891

### Description
Instead, make the zfs-mount-generator `.mount` units depend on a per-pool `zfs-import@.service` template.  Additionally, have zfs-mount-generator grant `zfs-import@.service` dependencies on the associated `.device`s required for the pool to actually import.

Additionally, remove udev settle dependencies in systemd units that depend on zfs-import targets.  Also, remove the zfs-import.target wait for `zfs-mount@.service`, since not all pools need to be imported to begin mounting filesystems.

### How Has This Been Tested?

I am running this, rebased onto 2.4.1.  I am looking for more widespread testing here.

I suspect that this may break some configurations.  We need to talk about this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
