### PR TITLE
Fix long POSIX_FADV_DONTNEED for single block files

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -966,8 +966,14 @@ dmu_evict_range(objset_t *os, uint64_t object, uint64_t offset, uint64_t len)
 	 * access patterns are rare.
 	 */
 	rw_enter(&dn->dn_struct_rwlock, RW_READER);
-	uint64_t start = dbuf_whichblock(dn, 0, offset);
-	uint64_t end = dbuf_whichblock(dn, 0, offset + len);
+	uint64_t start, end;
+	if (dn->dn_datablkshift != 0) {
+		start = dbuf_whichblock(dn, 0, offset);
+		end = dbuf_whichblock(dn, 0, offset + len);
+	} else {
+		start = (offset >= dn->dn_datablksz);
+		end = (offset + len >= dn->dn_datablksz);
+	}
 	if (end > start)
 		dbuf_evict_range(dn, start, end - 1);
 	rw_exit(&dn->dn_struct_rwlock);

--- a/tests/zfs-tests/tests/functional/fadvise/fadvise_dontneed.ksh
+++ b/tests/zfs-tests/tests/functional/fadvise/fadvise_dontneed.ksh
@@ -32,11 +32,13 @@
 # 2. Record cache_count from dbufstats
 # 3. Call file_fadvise with POSIX_FADV_DONTNEED on the file
 # 4. Verify that cache_count decreased
+# 5. Sanity-check eviction for single-block files.
 #
 
 verify_runnable "global"
 
-FILE=$TESTDIR/$TESTFILE0
+FILE0=$TESTDIR/$TESTFILE0
+FILE1=$TESTDIR/$TESTFILE1
 BLKSZ=$(get_prop recordsize $TESTPOOL)
 
 function cleanup
@@ -48,16 +50,21 @@ log_assert "Ensure POSIX_FADV_DONTNEED evicts data from the dbuf cache"
 
 log_onexit cleanup
 
-log_must file_write -o create -f $FILE -b $BLKSZ -c 100
+log_must file_write -o create -f $FILE0 -b $BLKSZ -c 100
 sync_pool $TESTPOOL
 
 evicts1=$(kstat dbufstats.cache_count)
 
-log_must file_fadvise -f $FILE -a POSIX_FADV_DONTNEED
+log_must file_fadvise -f $FILE0 -a POSIX_FADV_DONTNEED
 
 evicts2=$(kstat dbufstats.cache_count)
 log_note "cache_count before=$evicts1 after=$evicts2"
 
 log_must [ $evicts1 -gt $evicts2 ]
+
+log_must file_write -o create -f $FILE1 -b 12000 -c 1
+sync_pool $TESTPOOL
+
+log_must file_fadvise -f $FILE1 -a POSIX_FADV_DONTNEED
 
 log_pass "POSIX_FADV_DONTNEED evicts data from the dbuf cache"


### PR DESCRIPTION
dbuf_whichblock() is not made to handle offsets beyond the block end for single-block objects.  Handle it in dmu_evict_range(), similar to dmu_prefetch_by_dnode().

Fixes #18399

### How Has This Been Tested?
Extension to the CI test reproduced the issue.  This patch fixed it for me.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
