### PR TITLE
ZTS: use 'zpool trim -w' in zpool_trim_partial.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_partial.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_partial.ksh
@@ -73,7 +73,7 @@ log_must mkdir "$TESTDIR"
 log_must truncate -s $LARGESIZE "$LARGEFILE"
 log_must zpool create -O compression=off $TESTPOOL "$LARGEFILE"
 log_must mkfile $(( floor(LARGESIZE * 0.80) )) /$TESTPOOL/file
-sync_all_pools
+sync_pool $TESTPOOL
 
 new_size=$(du -k "$LARGEFILE" | awk '{print $1 * 1024}')
 log_must test $new_size -le $LARGESIZE
@@ -93,12 +93,8 @@ log_must test $new_size -gt $((4 * floor(LARGESIZE * 0.70) ))
 # Perform a partial trim, we expect it to skip most of the new metaslabs
 # which have never been used and therefore do not need be trimmed.
 log_must set_tunable64 TRIM_METASLAB_SKIP 1
-log_must zpool trim $TESTPOOL
-log_must set_tunable64 TRIM_METASLAB_SKIP 0
-
-while [[ "$(trim_progress $TESTPOOL $LARGEFILE)" -lt "100" ]]; do
-	sleep 0.5
-done
+log_must zpool trim -w $TESTPOOL
+sync_pool $TESTPOOL true
 
 new_size=$(du -k "$LARGEFILE" | awk '{print $1 * 1024}')
 log_must test $new_size -gt $LARGESIZE
@@ -106,11 +102,9 @@ log_must test $new_size -gt $LARGESIZE
 # Perform a full trim, all metaslabs will be trimmed the pool vdev
 # size will be reduced but not down to its original size due to the
 # space usage of the new metaslabs.
-log_must zpool trim $TESTPOOL
-
-while [[ "$(trim_progress $TESTPOOL $LARGEFILE)" -lt "100" ]]; do
-	sleep 0.5
-done
+log_must set_tunable64 TRIM_METASLAB_SKIP 0
+log_must zpool trim -w $TESTPOOL
+sync_pool $TESTPOOL true
 
 new_size=$(du -k "$LARGEFILE" | awk '{print $1 * 1024}')
 log_must test $new_size -le $(( 2 * LARGESIZE))


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/25333500137/job/74476150587

```
cli_root/zpool_trim/zpool_trim_partial (87 KiB)
  [2026-05-05T19:38:59.730516] Test: /usr/share/zfs/zfs-tests/tests/functional/cli_root/zpool_trim/zpool_trim_partial (run as root) [01:03] [FAIL]
  19:37:56.36 SUCCESS: set_tunable64 VDEV_MIN_MS_COUNT 64
  19:37:56.37 SUCCESS: set_tunable64 TRIM_EXTENT_BYTES_MIN 512
  19:37:56.37 SUCCESS: mkdir /var/tmp/testdir
  19:37:56.37 SUCCESS: truncate -s 1073741824 /var/tmp/testdir/largefile
  19:37:56.44 SUCCESS: zpool create -O compression=off testpool /var/tmp/testdir/largefile
  19:38:12.49 SUCCESS: mkfile 858993459 /testpool/file
  19:38:12.53 SUCCESS: zpool sync
  19:38:12.54 SUCCESS: test 864415744 -le 1073741824
  19:38:12.54 SUCCESS: test 864415744 -gt 751619276
  19:38:12.62 SUCCESS: zpool export testpool
  19:38:54.37 SUCCESS: dd if=/dev/urandom of=/var/tmp/testdir/largefile conv=notrunc seek=1024 bs=1048576 count=3072
  19:38:57.90 SUCCESS: zpool import -d /var/tmp/testdir testpool
  19:38:57.94 SUCCESS: zpool online -e testpool /var/tmp/testdir/largefile
  19:38:57.95 SUCCESS: test 4086120448 -gt 3006477104
  19:38:57.95 SUCCESS: set_tunable64 TRIM_METASLAB_SKIP 1
  19:38:57.97 SUCCESS: zpool trim testpool
  19:38:57.97 SUCCESS: set_tunable64 TRIM_METASLAB_SKIP 0
  19:38:59.03 SUCCESS: test 3843956736 -gt 1073741824
  19:38:59.04 cannot trim '/var/tmp/testdir/largefile': currently trimming
  19:38:59.04 ERROR: zpool trim testpool exited 255
```

### Description

Don't use trim_progress() which is racy to wait for the pool trim to complete.  Instead use the wait (-w) option which is intended for this.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)