### PR TITLE
zfs: annotate nested dd_lock in reservation sync accounting

### DIFF
--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1541,7 +1541,10 @@ static void dsl_dir_diduse_transfer_space_impl(dsl_dir_t *dd, int64_t used,
 static void
 dsl_dir_lock_enter(dsl_dir_t *dd, boolean_t nested)
 {
-	/* lockdep needs an explicit subclass when a child dd_lock nests an ancestor */
+	/*
+	 * lockdep needs an explicit subclass when a child dd_lock
+	 * nests an ancestor.
+	 */
 	if (nested) {
 		mutex_enter_nested(&dd->dd_lock, NESTED_SINGLE);
 	} else {
@@ -1605,8 +1608,8 @@ dsl_dir_diduse_space_impl(dsl_dir_t *dd, dd_used_t type,
 }
 
 void
-dsl_dir_diduse_space(dsl_dir_t *dd, dd_used_t type,
-    int64_t used, int64_t compressed, int64_t uncompressed, dmu_tx_t *tx)
+dsl_dir_diduse_space(dsl_dir_t *dd, dd_used_t type, int64_t used,
+    int64_t compressed, int64_t uncompressed, dmu_tx_t *tx)
 {
 	dsl_dir_diduse_space_impl(dd, type, used, compressed, uncompressed,
 	    B_FALSE, tx);

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1534,9 +1534,25 @@ dsl_dir_willuse_space(dsl_dir_t *dd, int64_t space, dmu_tx_t *tx)
 }
 
 /* call from syncing context when we actually write/free space for this dd */
-void
-dsl_dir_diduse_space(dsl_dir_t *dd, dd_used_t type,
-    int64_t used, int64_t compressed, int64_t uncompressed, dmu_tx_t *tx)
+static void dsl_dir_diduse_transfer_space_impl(dsl_dir_t *dd, int64_t used,
+    int64_t compressed, int64_t uncompressed, int64_t tonew,
+    dd_used_t oldtype, dd_used_t newtype, boolean_t nested, dmu_tx_t *tx);
+
+static void
+dsl_dir_lock_enter(dsl_dir_t *dd, boolean_t nested)
+{
+	/* lockdep needs an explicit subclass when a child dd_lock nests an ancestor */
+	if (nested) {
+		mutex_enter_nested(&dd->dd_lock, NESTED_SINGLE);
+	} else {
+		mutex_enter(&dd->dd_lock);
+	}
+}
+
+static void
+dsl_dir_diduse_space_impl(dsl_dir_t *dd, dd_used_t type,
+    int64_t used, int64_t compressed, int64_t uncompressed,
+    boolean_t nested, dmu_tx_t *tx)
 {
 	int64_t accounted_delta;
 
@@ -1554,7 +1570,7 @@ dsl_dir_diduse_space(dsl_dir_t *dd, dd_used_t type,
 	 */
 	boolean_t needlock = !MUTEX_HELD(&dd->dd_lock);
 	if (needlock)
-		mutex_enter(&dd->dd_lock);
+		dsl_dir_lock_enter(dd, nested);
 	dsl_dir_phys_t *ddp = dsl_dir_phys(dd);
 	accounted_delta = parent_delta(dd, ddp->dd_used_bytes, used);
 	ASSERT(used >= 0 || ddp->dd_used_bytes >= -used);
@@ -1582,10 +1598,18 @@ dsl_dir_diduse_space(dsl_dir_t *dd, dd_used_t type,
 		mutex_exit(&dd->dd_lock);
 
 	if (dd->dd_parent != NULL) {
-		dsl_dir_diduse_transfer_space(dd->dd_parent,
+		dsl_dir_diduse_transfer_space_impl(dd->dd_parent,
 		    accounted_delta, compressed, uncompressed,
-		    used, DD_USED_CHILD_RSRV, DD_USED_CHILD, tx);
+		    used, DD_USED_CHILD_RSRV, DD_USED_CHILD, nested, tx);
 	}
+}
+
+void
+dsl_dir_diduse_space(dsl_dir_t *dd, dd_used_t type,
+    int64_t used, int64_t compressed, int64_t uncompressed, dmu_tx_t *tx)
+{
+	dsl_dir_diduse_space_impl(dd, type, used, compressed, uncompressed,
+	    B_FALSE, tx);
 }
 
 void
@@ -1612,10 +1636,10 @@ dsl_dir_transfer_space(dsl_dir_t *dd, int64_t delta,
 	mutex_exit(&dd->dd_lock);
 }
 
-void
-dsl_dir_diduse_transfer_space(dsl_dir_t *dd, int64_t used,
+static void
+dsl_dir_diduse_transfer_space_impl(dsl_dir_t *dd, int64_t used,
     int64_t compressed, int64_t uncompressed, int64_t tonew,
-    dd_used_t oldtype, dd_used_t newtype, dmu_tx_t *tx)
+	dd_used_t oldtype, dd_used_t newtype, boolean_t nested, dmu_tx_t *tx)
 {
 	int64_t accounted_delta;
 
@@ -1625,7 +1649,7 @@ dsl_dir_diduse_transfer_space(dsl_dir_t *dd, int64_t used,
 
 	dmu_buf_will_dirty(dd->dd_dbuf, tx);
 
-	mutex_enter(&dd->dd_lock);
+	dsl_dir_lock_enter(dd, nested);
 	dsl_dir_phys_t *ddp = dsl_dir_phys(dd);
 	accounted_delta = parent_delta(dd, ddp->dd_used_bytes, used);
 	ASSERT(used >= 0 || ddp->dd_used_bytes >= -used);
@@ -1656,10 +1680,19 @@ dsl_dir_diduse_transfer_space(dsl_dir_t *dd, int64_t used,
 	mutex_exit(&dd->dd_lock);
 
 	if (dd->dd_parent != NULL) {
-		dsl_dir_diduse_transfer_space(dd->dd_parent,
+		dsl_dir_diduse_transfer_space_impl(dd->dd_parent,
 		    accounted_delta, compressed, uncompressed,
-		    used, DD_USED_CHILD_RSRV, DD_USED_CHILD, tx);
+		    used, DD_USED_CHILD_RSRV, DD_USED_CHILD, nested, tx);
 	}
+}
+
+void
+dsl_dir_diduse_transfer_space(dsl_dir_t *dd, int64_t used,
+    int64_t compressed, int64_t uncompressed, int64_t tonew,
+    dd_used_t oldtype, dd_used_t newtype, dmu_tx_t *tx)
+{
+	dsl_dir_diduse_transfer_space_impl(dd, used, compressed,
+	    uncompressed, tonew, oldtype, newtype, B_FALSE, tx);
 }
 
 typedef struct dsl_dir_set_qr_arg {
@@ -1828,8 +1861,8 @@ dsl_dir_set_reservation_sync_impl(dsl_dir_t *dd, uint64_t value, dmu_tx_t *tx)
 
 	if (dd->dd_parent != NULL) {
 		/* Roll up this additional usage into our ancestors */
-		dsl_dir_diduse_space(dd->dd_parent, DD_USED_CHILD_RSRV,
-		    delta, 0, 0, tx);
+		dsl_dir_diduse_space_impl(dd->dd_parent, DD_USED_CHILD_RSRV,
+		    delta, 0, 0, B_TRUE, tx);
 	}
 	mutex_exit(&dd->dd_lock);
 }


### PR DESCRIPTION
### Motivation and Context

Linux lockdep reports a possible recursive `dd_lock` acquisition during
rollback/destroy paths that clear a dataset reservation.

This is a false positive.  `dsl_dir_set_reservation_sync_impl()` holds a
child `dd_lock` and then rolls the reservation delta into ancestor space
accounting.  That child-to-ancestor ordering is valid, but lockdep needs
an explicit nested subclass to distinguish it from true recursive locking.

```
WARNING: possible recursive locking detected
--------------------------------------------
txg_sync/456 is trying to acquire lock:
ffff8880135601f0 (&dd->dd_lock){+.+.}-{4:4}, at: dsl_dir_diduse_space+0xfc/0x6e0 fs/zfs/zfs/dsl_dir.c:1557

but task is already holding lock:
ffff88801e40e1f0 (&dd->dd_lock){+.+.}-{4:4}, at: dsl_dir_set_reservation_sync_impl+0xbc/0x530 fs/zfs/zfs/dsl_dir.c:1824

other info that might help us debug this:
 Possible unsafe locking scenario:

       CPU0
       ----
  lock(&dd->dd_lock);
  lock(&dd->dd_lock);

 *** DEADLOCK ***

 May be due to missing lock nesting notation

1 lock held by txg_sync/456:
 #0: ffff88801e40e1f0 (&dd->dd_lock){+.+.}-{4:4}, at: dsl_dir_set_reservation_sync_impl+0xbc/0x530 fs/zfs/zfs/dsl_dir.c:1824

Call Trace:
 __dump_stack lib/dump_stack.c:94 [inline]
 dump_stack_lvl+0xbe/0x130 lib/dump_stack.c:120
 dump_stack+0x15/0x20 lib/dump_stack.c:129
 print_deadlock_bug+0x23f/0x320 kernel/locking/lockdep.c:3041
 check_deadlock kernel/locking/lockdep.c:3093 [inline]
 validate_chain kernel/locking/lockdep.c:3895 [inline]
 __lock_acquire+0x1317/0x21e0 kernel/locking/lockdep.c:5237
 lock_acquire kernel/locking/lockdep.c:5868 [inline]
 lock_acquire+0x169/0x2f0 kernel/locking/lockdep.c:5825
 __mutex_lock_common kernel/locking/mutex.c:598 [inline]
 __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
 mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
 dsl_dir_diduse_space+0xfc/0x6e0 fs/zfs/zfs/dsl_dir.c:1557
 dsl_dir_set_reservation_sync_impl+0x21e/0x530 fs/zfs/zfs/dsl_dir.c:1831
 dsl_dir_destroy_sync fs/zfs/zfs/dsl_destroy.c:852 [inline]
 dsl_destroy_head_sync_impl+0x16d2/0x2e10 fs/zfs/zfs/dsl_destroy.c:1167
 dsl_dataset_rollback_sync+0x269/0x430 fs/zfs/zfs/dsl_dataset.c:3290
 dsl_sync_task_sync+0x24c/0x3f0 fs/zfs/zfs/dsl_synctask.c:256
 dsl_pool_sync+0xadc/0x14f0 fs/zfs/zfs/dsl_pool.c:853
 spa_sync_iterate_to_convergence fs/zfs/zfs/spa.c:10645 [inline]
 spa_sync+0x9bb/0x27a0 fs/zfs/zfs/spa.c:10896
 txg_sync_thread+0x659/0x1290 fs/zfs/zfs/txg.c:602
 thread_generic_wrapper+0x1c8/0x2a0 fs/zfs/os/linux/spl/spl-thread.c:63
 kthread+0x3f0/0x850 kernel/kthread.c:463
 ret_from_fork+0x50f/0x610 arch/x86/kernel/process.c:158
 ret_from_fork_asm+0x1a/0x30 arch/x86/entry/entry_64.S:245
```

### Description

Add local helpers in `dsl_dir.c` so the reservation-sync ancestor
accounting path acquires ancestor `dd_lock` instances with
`mutex_enter_nested(..., NESTED_SINGLE)`.

The change is limited to the internal rollup path:
- normal `dsl_dir_diduse_space()` callers are unchanged
- reservation sync now routes ancestor accounting through the nested path
- recursive propagation to higher ancestors keeps the same nested
  annotation while preserving the existing accounting semantics


### How Has This Been Tested?
Tested on linux.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
