### PR TITLE
ZTS: removal_with_export.ksh busy export

### DIFF
--- a/tests/zfs-tests/tests/functional/removal/removal_with_export.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_with_export.ksh
@@ -29,7 +29,7 @@ log_onexit default_cleanup_noexit
 function callback
 {
 	test_removal_with_operation_kill
-	log_must zpool export $TESTPOOL
+	log_must_busy zpool export $TESTPOOL
 
 	#
 	# We are concurrently starting dd processes that will


### PR DESCRIPTION
### Motivation and Context

Occasional CI failures:

https://github.com/openzfs/zfs/actions/runs/25400098995/job/74497099996?pr=18495

```
 [2026-05-05T21:48:11.260639] Test: /usr/local/share/zfs/zfs-tests/tests/functional/removal/removal_with_export (run as root) [00:14] [FAIL]
  21:47:57.01 NOTE: begin default_setup_noexit
  21:47:57.30 SUCCESS: zpool create -f testpool md0 md1 md2
  21:47:57.37 SUCCESS: zfs create testpool/testfs
  21:47:57.42 SUCCESS: zfs set mountpoint=/var/tmp/testdir testpool/testfs
  21:47:57.46 SUCCESS: zfs set compression=off testpool
  21:48:03.75 SUCCESS: mkfile 1g /var/tmp/testdir/testfile0
  21:48:08.05 NOTE: Starting writer for /var/tmp/testdir/testfile0
  21:48:08.05 vfs.zfs.vdev.removal_suspend_progress: 0 -> 1
  21:48:10.22 SUCCESS: zpool remove testpool md0
  21:48:10.40 SUCCESS: zpool sync testpool
  21:48:10.49 SUCCESS: is_pool_removing testpool
  21:48:10.51 ERROR: zpool export testpool exited 1
  21:48:10.53 /usr/local/share/zfs/zfs-tests/tests/functional/removal/removal_with_export.ksh[47]: test_removal_with_operation[132]: log_must[72]: log_pos[267]: attempt_during_removal[76]: log_must[72]: log_pos[267]: callback[31]: test_removal_with_operation_kill[148]: wait: 42517: Terminated
  21:48:10.53 cannot unmount '/var/tmp/testdir': pool or dataset is busy
```

### Description

If the pool is active 'zpool export' will fail resulting in a test failure.  Swap log_must with log_must_busy so the export is retried when reported as busy before failing the test.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)