### PR TITLE
zarcstat: detect attached L2ARC device with no data

### DIFF
--- a/cmd/zarcstat.in
+++ b/cmd/zarcstat.in
@@ -565,10 +565,10 @@ def init():
 
     update_hdr_intr()
 
-    # check if L2ARC exists
+    # check if L2ARC exists; fall back to l2_size for older kernels that
+    # do not export l2_ndev
     snap_stats()
-    l2_size = cur.get("l2_size")
-    if l2_size:
+    if cur.get("l2_ndev") or cur.get("l2_size"):
         l2exist = True
 
     if desired_cols:

--- a/cmd/zarcsummary
+++ b/cmd/zarcsummary
@@ -856,7 +856,10 @@ def section_l2arc(kstats_dict):
     # The L2ARC statistics live in the same section as the normal ARC stuff
     arc_stats = isolate_section('arcstats', kstats_dict)
 
-    if arc_stats['l2_size'] == '0':
+    # Skip the section only when no cache device is attached. Fall back to
+    # l2_size for older kernels that do not export l2_ndev.
+    if arc_stats.get('l2_ndev', '0') == '0' and \
+            arc_stats['l2_size'] == '0':
         print('L2ARC not detected, skipping section\n')
         return
 

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -832,6 +832,8 @@ typedef struct arc_stats {
 	 * due to ARC_FLAG_UNCACHED being set.
 	 */
 	kstat_named_t arcstat_uncached_evictable_metadata;
+	/* Number of L2ARC devices currently attached across all pools. */
+	kstat_named_t arcstat_l2_ndev;
 	kstat_named_t arcstat_l2_hits;
 	kstat_named_t arcstat_l2_misses;
 	/*

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -586,6 +586,7 @@ arc_stats_t arc_stats = {
 	{ "uncached_metadata",		KSTAT_DATA_UINT64 },
 	{ "uncached_evictable_data",	KSTAT_DATA_UINT64 },
 	{ "uncached_evictable_metadata", KSTAT_DATA_UINT64 },
+	{ "l2_ndev",			KSTAT_DATA_UINT64 },
 	{ "l2_hits",			KSTAT_DATA_UINT64 },
 	{ "l2_misses",			KSTAT_DATA_UINT64 },
 	{ "l2_prefetch_asize",		KSTAT_DATA_UINT64 },
@@ -7440,6 +7441,7 @@ arc_kstat_update(kstat_t *ksp, int rw)
 	    aggsum_value(&arc_sums.arcstat_dnode_size);
 	as->arcstat_bonus_size.value.ui64 =
 	    wmsum_value(&arc_sums.arcstat_bonus_size);
+	as->arcstat_l2_ndev.value.ui64 = l2arc_ndev;
 	as->arcstat_l2_hits.value.ui64 =
 	    wmsum_value(&arc_sums.arcstat_l2_hits);
 	as->arcstat_l2_misses.value.ui64 =


### PR DESCRIPTION
### Motivation and Context
`zarcstat` detects L2ARC presence using the `l2_size` kstat, which is the amount of data currently in L2ARC, not whether a cache device is attached. When a cache device is attached but empty (freshly added, or all entries evicted), explicit `-f l2*` requests are wrongly rejected with `Incompatible field specified!`.

### Description
Detect attachment via the per-device feed kernel thread named `l2arc_<spa>_<vdev_id>`, which is created in `l2arc_add_vdev()` and removed on detach. Its presence in `/proc` mirrors device attachment in real time, independent of whether L2ARC currently holds data. The `l2_size > 0` fast path is kept to avoid the `/proc` scan whenever data is already present.

### How Has This Been Tested?
Reproduces only when a cache device is attached but empty (`l2_size = 0`):

```
$ truncate -s 1G /tmp/cache1
$ sudo zpool add tank cache /tmp/cache1
$ grep ^l2_size /proc/spl/kstat/zfs/arcstats
l2_size                         4    0
```

**Before:**

```
$ zarcstat -f l2size 1 1
Incompatible field specified! -- ['l2size']
No L2ARC Here
l2size
```

**After:**

```
$ zarcstat -f l2size 1 1
l2size
     0
```



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
