### PR TITLE
ZTS: redundancy_draid_spare1

### DIFF
--- a/tests/zfs-tests/tests/functional/redundancy/redundancy.kshlib
+++ b/tests/zfs-tests/tests/functional/redundancy/redundancy.kshlib
@@ -435,32 +435,38 @@ function verify_draid_pool
 
 	log_note "verify_draid_pool $pool $replace_mode"
 	log_must zpool scrub -w $pool
+	sync_pool $pool true
 
-	typeset -i cksum=$(cksum_pool $pool)
+	typeset status=$(zpool status -p $pool)
+	typeset -i cksum=$(echo "$status" | awk '
+	    !NF { isvdev = 0 }
+	    isvdev { errors += $NF }
+	    /CKSUM$/ { isvdev = 1 }
+	    END { print errors }')
 
 	if [[ "$replace_mode" = "healing" ]]; then
 		if [[ $cksum -gt 0 ]]; then
-			log_must zpool status -v $pool
+			log_note "$status"
 			log_fail "Unexpected CKSUM errors found for $pool ($cksum)"
 		fi
 
 		if ! check_pool_status $pool "scan" "repaired 0B"; then
-			log_must zpool status -v $pool
+			log_note "$status"
 			log_fail "Unexpected repair IO found for $pool ($cksum)"
 		fi
 	elif [[ "$replace_mode" = "sequential" ]]; then
 		if [[ $cksum -gt 0 ]]; then
-			log_must zpool status -v $pool
+			log_note "$status"
 			log_fail "Unexpected CKSUM errors found for $pool ($cksum)"
 		fi
 	elif [[ "$replace_mode" = "damaged" ]]; then
 		if [[ $cksum -lt 1 ]]; then
-			log_must zpool status -v $pool
+			log_note "$status"
 			log_fail "Expected CKSUM errors missing for $pool ($cksum)"
 		fi
 
 		if check_pool_status $pool "scan" "repaired 0B"; then
-			log_must zpool status -v $pool
+			log_note "$status"
 			log_fail "Expected repair IO missing for $pool ($cksum)"
 		fi
 	else
@@ -468,12 +474,12 @@ function verify_draid_pool
 	fi
 
 	if ! check_pool_status $pool "scan" "with 0 errors"; then
-		log_must zpool status -v $pool
+		log_note "$status"
 		log_fail "Unexpected repair errors found for $pool"
 	fi
 
 	if ! check_pool_status $pool "errors" "No known data errors"; then
-		log_must zpool status -v $pool
+		log_note "$status"
 		log_fail "Unexpected data errors found for $pool"
 	fi
 }


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/25447326578/job/74654957280?pr=18498

### Description

Preserve the 'zpool status' output used to calculate the number of checksum errors so it can be logged on failure.  Several instances have been observed in the CI where cksum was set to a non-zero value, yet a subsequent run of 'zpool status' on failure showed no checksum errors.

### How Has This Been Tested?

Manually tested the added debugging.  We'll need to get another instance of this in the CI with this change merged to determine which vdev logged checksum errors.  I've been unable to reproduce this locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)