### PR TITLE
ZTS: zpool_iostat_002_pos remove sleep

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_002_pos.ksh
@@ -38,9 +38,8 @@
 #
 # STRATEGY:
 # 1. Set the interval to 1 and count to 4.
-# 2. Sleep for 5 seconds.
-# 3. Verify that the output has 4 records.
-# 4. Set interval to 0.5 and count to 1 to test floating point intervals.
+# 2. Verify that the output has 4 records.
+# 3. Set interval to 0.5 and count to 1 to test floating point intervals.
 
 verify_runnable "both"
 
@@ -61,8 +60,7 @@ if ! is_global_zone ; then
 	TESTPOOL=${TESTPOOL%%/*}
 fi
 
-log_must eval "zpool iostat $TESTPOOL 1 4 > $tmpfile 2>&1 &"
-log_must sleep 5
+log_must eval "zpool iostat $TESTPOOL 1 4 > $tmpfile 2>&1"
 stat_count=$(grep -c $TESTPOOL $tmpfile)
 
 if [[ $stat_count -ne 4 ]]; then


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/25449069907/job/74665917121?pr=18496

### Description

In the CI environment commands may occasionally take longer than expected.  For zpool_iostat_002_pos this can cause a failure if fewer than the expected numbers of lines are logged in time.  To prevent this issue relax the time constraint and simply verify the command ran to completion and generated the correct number of lines.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)