### PR TITLE
sa: fix sa_add_projid lock ordering

### DIFF
--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -1605,8 +1605,8 @@ sa_add_projid(sa_handle_t *hdl, dmu_tx_t *tx, uint64_t projid)
 
 	bulk = kmem_zalloc(sizeof (sa_bulk_attr_t) * ZPL_END, KM_SLEEP);
 	attrs = kmem_zalloc(sizeof (sa_bulk_attr_t) * ZPL_END, KM_SLEEP);
-	mutex_enter(&hdl->sa_lock);
 	mutex_enter(&zp->z_lock);
+	mutex_enter(&hdl->sa_lock);
 
 	err = sa_lookup_locked(hdl, SA_ZPL_PROJID(zfsvfs), &projid,
 	    sizeof (uint64_t));
@@ -1750,8 +1750,8 @@ sa_add_projid(sa_handle_t *hdl, dmu_tx_t *tx, uint64_t projid)
 	zp->z_is_sa = B_TRUE;
 
 out:
-	mutex_exit(&zp->z_lock);
 	mutex_exit(&hdl->sa_lock);
+	mutex_exit(&zp->z_lock);
 	kmem_free(attrs, sizeof (sa_bulk_attr_t) * ZPL_END);
 	kmem_free(bulk, sizeof (sa_bulk_attr_t) * ZPL_END);
 	if (dxattr_obj)


### PR DESCRIPTION
### Motivation and Context

sa_add_projid() acquires hdl->sa_lock before zp->z_lock, but several
same-znode update paths acquire zp->z_lock and then call sa_update()
or sa_bulk_update().

On Linux this is not just a class-based lockdep artifact.
FS_IOC_FSSETXATTR reaches zfs_setattr() through zpl_ioctl_setxattr()
without outer inode serialization, so adding a projid to an
old-format inode can race with hard link, unlink, lazytime, or atime
update paths on the same znode and deadlock.

```
WARNING: possible circular locking dependency detected
------------------------------------------------------
syz.0.69/556 is trying to acquire lock:
ffff88800e1ab428 (&zp->z_lock){+.+.}-{4:4}, at: sa_add_projid+0x4cc/0x50c0 fs/zfs/zfs/sa.c:1609

but task is already holding lock:
ffff88800e588730 (&hdl->sa_lock){+.+.}-{4:4}, at: sa_add_projid+0x3f9/0x50c0 fs/zfs/zfs/sa.c:1608

which lock already depends on the new lock.


the existing dependency chain (in reverse order) is:

-> #1 (&hdl->sa_lock){+.+.}-{4:4}:
       __mutex_lock_common kernel/locking/mutex.c:598 [inline]
       __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
       mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
       sa_bulk_update+0x89/0x430 fs/zfs/zfs/sa.c:2154
       zfs_link_create+0x7f7/0x1c10 fs/zfs/os/linux/zfs/zfs_dir.c:875
       zfs_create+0xfbd/0x17b0 fs/zfs/os/linux/zfs/zfs_vnops_os.c:759
       zpl_create+0x29a/0x540 fs/zfs/os/linux/zfs/zpl_inode.c:196
       lookup_open.isra.0+0x10a1/0x1460 fs/namei.c:3796
       open_last_lookups fs/namei.c:3895 [inline]
       path_openat+0x11fe/0x2ce0 fs/namei.c:4131
       do_filp_open+0x1f6/0x430 fs/namei.c:4161
       do_sys_openat2+0x117/0x1c0 fs/open.c:1437
       do_sys_open fs/open.c:1452 [inline]
       __do_sys_openat fs/open.c:1468 [inline]
       __se_sys_openat fs/open.c:1463 [inline]
       __x64_sys_openat+0x15b/0x220 fs/open.c:1463
       x64_sys_call+0x161b/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:258
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

-> #0 (&zp->z_lock){+.+.}-{4:4}:
       check_prev_add kernel/locking/lockdep.c:3165 [inline]
       check_prevs_add kernel/locking/lockdep.c:3284 [inline]
       validate_chain kernel/locking/lockdep.c:3908 [inline]
       __lock_acquire+0x14ae/0x21e0 kernel/locking/lockdep.c:5237
       lock_acquire kernel/locking/lockdep.c:5868 [inline]
       lock_acquire+0x169/0x2f0 kernel/locking/lockdep.c:5825
       __mutex_lock_common kernel/locking/mutex.c:598 [inline]
       __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
       mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
       sa_add_projid+0x4cc/0x50c0 fs/zfs/zfs/sa.c:1609
       zfs_setattr+0x1452/0x7480 fs/zfs/os/linux/zfs/zfs_vnops_os.c:2419
       zpl_ioctl_setxattr.isra.0+0x40a/0x630 fs/zfs/os/linux/zfs/zpl_file.c:1039
       zpl_ioctl+0x5ac/0x6f0 fs/zfs/os/linux/zfs/zpl_file.c:1168
       vfs_ioctl fs/ioctl.c:51 [inline]
       __do_sys_ioctl fs/ioctl.c:597 [inline]
       __se_sys_ioctl fs/ioctl.c:583 [inline]
       __x64_sys_ioctl+0x197/0x1e0 fs/ioctl.c:583
       x64_sys_call+0x1144/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:17
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

other info that might help us debug this:

 Possible unsafe locking scenario:

       CPU0                    CPU1
       ----                    ----
  lock(&hdl->sa_lock);
                               lock(&zp->z_lock);
                               lock(&hdl->sa_lock);
  lock(&zp->z_lock);

 *** DEADLOCK ***

1 lock held by syz.0.69/556:
 #0: ffff88800e588730 (&hdl->sa_lock){+.+.}-{4:4}, at: sa_add_projid+0x3f9/0x50c0 fs/zfs/zfs/sa.c:1608

Call Trace:
 __dump_stack lib/dump_stack.c:94 [inline]
 dump_stack_lvl+0xbe/0x130 lib/dump_stack.c:120
 dump_stack+0x15/0x20 lib/dump_stack.c:129
 print_circular_bug+0x285/0x360 kernel/locking/lockdep.c:2043
 check_noncircular+0x14e/0x170 kernel/locking/lockdep.c:2175
 check_prev_add kernel/locking/lockdep.c:3165 [inline]
 check_prevs_add kernel/locking/lockdep.c:3284 [inline]
 validate_chain kernel/locking/lockdep.c:3908 [inline]
 __lock_acquire+0x14ae/0x21e0 kernel/locking/lockdep.c:5237
 lock_acquire kernel/locking/lockdep.c:5868 [inline]
 lock_acquire+0x169/0x2f0 kernel/locking/lockdep.c:5825
 __mutex_lock_common kernel/locking/mutex.c:598 [inline]
 __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
 mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
 sa_add_projid+0x4cc/0x50c0 fs/zfs/zfs/sa.c:1609
 zfs_setattr+0x1452/0x7480 fs/zfs/os/linux/zfs/zfs_vnops_os.c:2419
 zpl_ioctl_setxattr.isra.0+0x40a/0x630 fs/zfs/os/linux/zfs/zpl_file.c:1039
 zpl_ioctl+0x5ac/0x6f0 fs/zfs/os/linux/zfs/zpl_file.c:1168
 vfs_ioctl fs/ioctl.c:51 [inline]
 __do_sys_ioctl fs/ioctl.c:597 [inline]
 __se_sys_ioctl fs/ioctl.c:583 [inline]
 __x64_sys_ioctl+0x197/0x1e0 fs/ioctl.c:583
 x64_sys_call+0x1144/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:17
 do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
 do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
 entry_SYSCALL_64_after_hwframe+0x76/0x7e
 ...
```

### Description

Reorder sa_add_projid() to acquire zp->z_lock before hdl->sa_lock.
This matches the prevailing znode update ordering and removes the
ABBA window without changing the projid conversion logic.

### How Has This Been Tested?

Built the touched object successfully:

make -C /home/hzy/zfs -j4 module/zfs/sa.lo

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain Signed-off-by.