### PR TITLE
vdev_disk: avoid vd_lock lockdep cycle during reopen

### DIFF
--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -74,6 +74,9 @@ typedef void zfs_bdev_handle_t;
 typedef struct vdev_disk {
 	zfs_bdev_handle_t		*vd_bdh;
 	krwlock_t			vd_lock;
+	kmutex_t			vd_open_lock;
+	kcondvar_t			vd_open_cv;
+	boolean_t			vd_opening;
 } vdev_disk_t;
 
 /*
@@ -239,6 +242,21 @@ vdev_disk_error(zio_t *zio)
 }
 
 static void
+vdev_disk_handle_eio(zio_t *zio, struct block_device *bdev)
+{
+	vdev_t *v = zio->io_vd;
+
+	if (zio->io_error != EIO || bdev == NULL)
+		return;
+
+	if (!zfs_check_disk_status(bdev)) {
+		invalidate_bdev(bdev);
+		v->vdev_remove_wanted = B_TRUE;
+		spa_async_request(zio->io_spa, SPA_ASYNC_REMOVE);
+	}
+}
+
+static void
 vdev_disk_kobj_evt_post(vdev_t *v)
 {
 	vdev_disk_t *vd = v->vdev_tsd;
@@ -280,6 +298,36 @@ vdev_blkdev_put(zfs_bdev_handle_t *bdh, spa_mode_t smode, void *holder)
 #endif
 }
 
+static void
+vdev_disk_set_opening(vdev_disk_t *vd, boolean_t opening)
+{
+	mutex_enter(&vd->vd_open_lock);
+	vd->vd_opening = opening;
+	if (!opening)
+		cv_broadcast(&vd->vd_open_cv);
+	mutex_exit(&vd->vd_open_lock);
+}
+
+static boolean_t
+vdev_disk_wait_open_done(vdev_disk_t *vd)
+{
+	boolean_t waited = B_FALSE;
+
+	/*
+	 * Return B_TRUE when a reopen was observed and waited for, so the
+	 * caller can retry vd_bdh.  B_FALSE means vd_bdh was already NULL
+	 * without an active reopen, which is a terminal closed-device state.
+	 */
+	mutex_enter(&vd->vd_open_lock);
+	while (vd->vd_opening) {
+		waited = B_TRUE;
+		cv_wait(&vd->vd_open_cv, &vd->vd_open_lock);
+	}
+	mutex_exit(&vd->vd_open_lock);
+
+	return (waited);
+}
+
 static int
 vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
     uint64_t *logical_ashift, uint64_t *physical_ashift)
@@ -288,6 +336,7 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 	spa_mode_t smode = spa_mode(v->vdev_spa);
 	hrtime_t timeout = MSEC2NSEC(zfs_vdev_open_timeout_ms);
 	vdev_disk_t *vd;
+	boolean_t reopening;
 
 	/* Must have a pathname and it must be absolute. */
 	if (v->vdev_path == NULL || v->vdev_path[0] != '/') {
@@ -305,13 +354,16 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 	 * open retry timeout before reporting the device as unavailable.
 	 */
 	vd = v->vdev_tsd;
-	if (vd) {
+	reopening = (vd != NULL);
+	if (reopening) {
 		char disk_name[BDEVNAME_SIZE + 6] = "/dev/";
 		boolean_t reread_part = B_FALSE;
 
 		rw_enter(&vd->vd_lock, RW_WRITER);
+		vdev_disk_set_opening(vd, B_TRUE);
 		bdh = vd->vd_bdh;
 		vd->vd_bdh = NULL;
+		rw_exit(&vd->vd_lock);
 
 		if (bdh) {
 			struct block_device *bdev = BDH_BDEV(bdh);
@@ -356,7 +408,8 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 		vd = kmem_zalloc(sizeof (vdev_disk_t), KM_SLEEP);
 
 		rw_init(&vd->vd_lock, NULL, RW_DEFAULT, NULL);
-		rw_enter(&vd->vd_lock, RW_WRITER);
+		mutex_init(&vd->vd_open_lock, NULL, MUTEX_DEFAULT, NULL);
+		cv_init(&vd->vd_open_cv, NULL, CV_DEFAULT, NULL);
 	}
 
 	/*
@@ -414,17 +467,23 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 		vdev_dbgmsg(v, "open error=%d timeout=%llu/%llu", error,
 		    (u_longlong_t)(gethrtime() - start),
 		    (u_longlong_t)timeout);
+		rw_enter(&vd->vd_lock, RW_WRITER);
 		vd->vd_bdh = NULL;
 		v->vdev_tsd = vd;
 		rw_exit(&vd->vd_lock);
+		if (reopening)
+			vdev_disk_set_opening(vd, B_FALSE);
 		return (SET_ERROR(error));
 	} else {
+		rw_enter(&vd->vd_lock, RW_WRITER);
 		vd->vd_bdh = bdh;
 		v->vdev_tsd = vd;
 		rw_exit(&vd->vd_lock);
+		if (reopening)
+			vdev_disk_set_opening(vd, B_FALSE);
 	}
 
-	struct block_device *bdev = BDH_BDEV(vd->vd_bdh);
+	struct block_device *bdev = BDH_BDEV(bdh);
 
 	/*  Determine the physical block size */
 	int physical_block_size = bdev_physical_block_size(bdev);
@@ -487,6 +546,8 @@ vdev_disk_close(vdev_t *v)
 	v->vdev_tsd = NULL;
 
 	rw_exit(&vd->vd_lock);
+	cv_destroy(&vd->vd_open_cv);
+	mutex_destroy(&vd->vd_open_lock);
 	rw_destroy(&vd->vd_lock);
 	kmem_free(vd, sizeof (vdev_disk_t));
 }
@@ -679,6 +740,36 @@ typedef struct {
 	struct bio	*vbio_bio;	/* pointer to the current bio */
 	int		vbio_flags;	/* bio flags */
 } vbio_t;
+
+typedef struct {
+	struct block_device	*vdb_bdev;
+} vdev_disk_io_bdev_t;
+
+static inline void
+vdev_disk_io_set_bdev(zio_t *zio, struct block_device *bdev)
+{
+	vdev_disk_io_bdev_t *io_bdev;
+
+	ASSERT3P(zio->io_bio, ==, NULL);
+
+	io_bdev = kmem_zalloc(sizeof (*io_bdev), KM_SLEEP);
+	io_bdev->vdb_bdev = bdev;
+	zio->io_bio = io_bdev;
+}
+
+static inline struct block_device *
+vdev_disk_io_clear_bdev(zio_t *zio)
+{
+	vdev_disk_io_bdev_t *io_bdev = zio->io_bio;
+	struct block_device *bdev;
+
+	ASSERT3P(io_bdev, !=, NULL);
+
+	bdev = io_bdev->vdb_bdev;
+	zio->io_bio = NULL;
+	kmem_free(io_bdev, sizeof (*io_bdev));
+	return (bdev);
+}
 
 static vbio_t *
 vbio_alloc(zio_t *zio, struct block_device *bdev, int flags)
@@ -1006,6 +1097,7 @@ vdev_disk_io_flush(struct block_device *bdev, zio_t *zio)
 	if (unlikely(bio == NULL))
 		return (SET_ERROR(ENOMEM));
 
+	vdev_disk_io_set_bdev(zio, bdev);
 	bio->bi_end_io = vdev_disk_io_flush_completion;
 	bio->bi_private = zio;
 	bio_set_flush(bio);
@@ -1092,8 +1184,11 @@ vdev_disk_io_trim(zio_t *zio)
 	struct bio *bio;
 
 	zfs_bdev_handle_t *bdh = ((vdev_disk_t *)zio->io_vd->vdev_tsd)->vd_bdh;
+	struct block_device *bdev = BDH_BDEV(bdh);
 	sector_t sector = zio->io_offset >> 9;
 	sector_t nsects = zio->io_size >> 9;
+
+	vdev_disk_io_set_bdev(zio, bdev);
 
 	if (zio->io_trim_flags & ZIO_TRIM_SECURE)
 		error = vdev_bdev_issue_secure_erase(bdh, sector, nsects, &bio);
@@ -1134,22 +1229,27 @@ vdev_disk_io_start(zio_t *zio)
 	 * Nothing to be done here but return failure.
 	 */
 	if (vd == NULL) {
-		zio->io_error = ENXIO;
+		zio->io_error = SET_ERROR(ENXIO);
 		zio_interrupt(zio);
 		return;
 	}
 
-	rw_enter(&vd->vd_lock, RW_READER);
-
-	/*
-	 * If the vdev is closed, it's likely due to a failed reopen and is
-	 * in the UNAVAIL state.  Nothing to be done here but return failure.
-	 */
-	if (vd->vd_bdh == NULL) {
+	for (;;) {
+		rw_enter(&vd->vd_lock, RW_READER);
+		if (vd->vd_bdh != NULL)
+			break;
 		rw_exit(&vd->vd_lock);
-		zio->io_error = ENXIO;
-		zio_interrupt(zio);
-		return;
+
+		/*
+		 * A reopen temporarily clears vd_bdh while the block layer open
+		 * runs outside vd_lock to avoid exporting vd_lock ordering into
+		 * unrelated kernel locks.
+		 */
+		if (!vdev_disk_wait_open_done(vd)) {
+			zio->io_error = SET_ERROR(ENXIO);
+			zio_interrupt(zio);
+			return;
+		}
 	}
 
 	switch (zio->io_type) {
@@ -1224,26 +1324,34 @@ vdev_disk_io_start(zio_t *zio)
 static void
 vdev_disk_io_done(zio_t *zio)
 {
-	/* If this was a read or write, we need to clean up the vbio */
+	/* Clean up any backend state attached while issuing the IO. */
+	struct block_device *io_bdev = NULL;
 	if (zio->io_bio != NULL) {
-		vbio_t *vbio = zio->io_bio;
-		zio->io_bio = NULL;
+		if (zio->io_type == ZIO_TYPE_READ ||
+		    zio->io_type == ZIO_TYPE_WRITE) {
+			vbio_t *vbio = zio->io_bio;
+			zio->io_bio = NULL;
+			io_bdev = vbio->vbio_bdev;
 
-		/*
-		 * If we copied the ABD before issuing it, clean up and return
-		 * the copy to the ADB, with changes if appropriate.
-		 */
-		if (vbio->vbio_abd != NULL) {
-			if (zio->io_type == ZIO_TYPE_READ)
-				abd_copy(zio->io_abd, vbio->vbio_abd,
-				    zio->io_size);
+			/*
+			 * If we copied the ABD before issuing it, clean up and
+			 * return the copy to the ADB, with changes if
+			 * appropriate.
+			 */
+			if (vbio->vbio_abd != NULL) {
+				if (zio->io_type == ZIO_TYPE_READ)
+					abd_copy(zio->io_abd, vbio->vbio_abd,
+					    zio->io_size);
 
-			abd_free(vbio->vbio_abd);
-			vbio->vbio_abd = NULL;
+				abd_free(vbio->vbio_abd);
+				vbio->vbio_abd = NULL;
+			}
+
+			/* Final cleanup */
+			kmem_free(vbio, sizeof (vbio_t));
+		} else {
+			io_bdev = vdev_disk_io_clear_bdev(zio);
 		}
-
-		/* Final cleanup */
-		kmem_free(vbio, sizeof (vbio_t));
 	}
 
 	/*
@@ -1252,14 +1360,7 @@ vdev_disk_io_done(zio_t *zio)
 	 * removal of the device from the configuration.
 	 */
 	if (zio->io_error == EIO) {
-		vdev_t *v = zio->io_vd;
-		vdev_disk_t *vd = v->vdev_tsd;
-
-		if (!zfs_check_disk_status(BDH_BDEV(vd->vd_bdh))) {
-			invalidate_bdev(BDH_BDEV(vd->vd_bdh));
-			v->vdev_remove_wanted = B_TRUE;
-			spa_async_request(zio->io_spa, SPA_ASYNC_REMOVE);
-		}
+		vdev_disk_handle_eio(zio, io_bdev);
 	}
 }
 


### PR DESCRIPTION
### Motivation and Context

This fixes a Linux lockdep cycle in the vdev disk backend.

`vdev_disk_io_start()` can acquire `vd_lock` from the page-fault read
path while `filemap_fault()` holds `mapping.invalidate_lock`.
Meanwhile `vdev_disk_open()` held `vd_lock` across
`bdev_file_open_by_path()` / `bdev_open_by_path()`, which ties
`vd_lock` into the block-open locking chain and back into
`mmap_lock` / `mapping.invalidate_lock`.

That makes this a real lock ordering issue rather than a lockdep-only
false positive.

```
WARNING: possible circular locking dependency detected
------------------------------------------------------
syz.0.54/547 is trying to acquire lock:
ffff88800fccfb78 (&vd->vd_lock){++++}-{4:4}, at: vdev_disk_io_start+0x137/0x26c0 fs/zfs/os/linux/zfs/vdev_disk.c:1135

but task is already holding lock:
ffff8880183612a8 (mapping.invalidate_lock#3){.+.+}-{4:4}, at: filemap_invalidate_lock_shared include/linux/fs.h:1045 [inline]
ffff8880183612a8 (mapping.invalidate_lock#3){.+.+}-{4:4}, at: filemap_fault+0x49b/0x30c0 mm/filemap.c:3496

which lock already depends on the new lock.


the existing dependency chain (in reverse order) is:

-> #4 (mapping.invalidate_lock#3){.+.+}-{4:4}:
       down_read+0x9c/0x4a0 kernel/locking/rwsem.c:1537
       filemap_invalidate_lock_shared include/linux/fs.h:1045 [inline]
       filemap_fault+0x49b/0x30c0 mm/filemap.c:3496
       __do_fault+0x10a/0x6e0 mm/memory.c:5281
       do_read_fault mm/memory.c:5716 [inline]
       do_fault+0x9b8/0x13e0 mm/memory.c:5850
       do_pte_missing mm/memory.c:4362 [inline]
       handle_pte_fault mm/memory.c:6195 [inline]
       __handle_mm_fault+0x138c/0x22f0 mm/memory.c:6336
       handle_mm_fault+0x42f/0x820 mm/memory.c:6505
       do_user_addr_fault+0x347/0xc30 arch/x86/mm/fault.c:1387
       handle_page_fault arch/x86/mm/fault.c:1476 [inline]
       exc_page_fault+0x73/0x110 arch/x86/mm/fault.c:1532
       asm_exc_page_fault+0x27/0x30 arch/x86/include/asm/idtentry.h:569
       __get_user_4+0x14/0x20 arch/x86/lib/getuser.S:86
       do_vfs_ioctl+0x68c/0x1320 fs/ioctl.c:560
       __do_sys_ioctl fs/ioctl.c:595 [inline]
       __se_sys_ioctl fs/ioctl.c:583 [inline]
       __x64_sys_ioctl+0x108/0x1e0 fs/ioctl.c:583
       x64_sys_call+0x1144/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:17
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

-> #3 (&mm->mmap_lock){++++}-{4:4}:
       __might_fault+0xeb/0x140 mm/memory.c:7099
       _inline_copy_from_user include/linux/uaccess.h:162 [inline]
       _copy_from_user+0x2a/0xa0 lib/usercopy.c:18
       copy_from_user include/linux/uaccess.h:212 [inline]
       get_sg_io_hdr+0xde/0x940 drivers/scsi/scsi_ioctl.c:714
       scsi_ioctl_sg_io drivers/scsi/scsi_ioctl.c:857 [inline]
       scsi_ioctl+0x75b/0x16b0 drivers/scsi/scsi_ioctl.c:917
       sr_block_ioctl+0x1bd/0x210 drivers/scsi/sr.c:557
       blkdev_ioctl+0x22a/0x700 block/ioctl.c:705
       vfs_ioctl fs/ioctl.c:51 [inline]
       __do_sys_ioctl fs/ioctl.c:597 [inline]
       __se_sys_ioctl fs/ioctl.c:583 [inline]
       __x64_sys_ioctl+0x197/0x1e0 fs/ioctl.c:583
       x64_sys_call+0x1144/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:17
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

-> #2 (&cd->lock){+.+.}-{4:4}:
       __mutex_lock_common kernel/locking/mutex.c:598 [inline]
       __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
       mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
       sr_block_open+0xaf/0x170 drivers/scsi/sr.c:511
       blkdev_get_whole+0xa2/0x250 block/bdev.c:730
       bdev_open+0x262/0xcf0 block/bdev.c:957
       blkdev_open+0x330/0x4d0 block/fops.c:701
       do_dentry_open+0x883/0x11e0 fs/open.c:965
       vfs_open+0x83/0x3a0 fs/open.c:1097
       do_open fs/namei.c:3975 [inline]
       path_openat+0x1d32/0x2ce0 fs/namei.c:4134
       do_filp_open+0x1f6/0x430 fs/namei.c:4161
       do_sys_openat2+0x117/0x1c0 fs/open.c:1437
       do_sys_open fs/open.c:1452 [inline]
       __do_sys_openat fs/open.c:1468 [inline]
       __se_sys_openat fs/open.c:1463 [inline]
       __x64_sys_openat+0x15b/0x220 fs/open.c:1463
       x64_sys_call+0x161b/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:258
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

-> #1 (&disk->open_mutex){+.+.}-{4:4}:
       __mutex_lock_common kernel/locking/mutex.c:598 [inline]
       __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
       mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
       bdev_open+0x9a/0xcf0 block/bdev.c:945
       bdev_file_open_by_dev block/bdev.c:1059 [inline]
       bdev_file_open_by_dev+0x13a/0x1c0 block/bdev.c:1034
       bdev_file_open_by_path+0x104/0x300 block/bdev.c:1082
       vdev_blkdev_get_by_path fs/zfs/os/linux/zfs/vdev_disk.c:259 [inline]
       vdev_disk_open+0x6e5/0x1750 fs/zfs/os/linux/zfs/vdev_disk.c:393
       vdev_open+0x3d2/0x1a20 fs/zfs/zfs/vdev.c:2182
       vdev_open_child+0x51/0xe0 fs/zfs/zfs/vdev.c:1979
       taskq_thread+0x9e4/0x19c0 fs/zfs/os/linux/spl/spl-taskq.c:1110
       kthread+0x3f0/0x850 kernel/kthread.c:463
       ret_from_fork+0x50f/0x610 arch/x86/kernel/process.c:158
       ret_from_fork_asm+0x1a/0x30 arch/x86/entry/entry_64.S:245

-> #0 (&vd->vd_lock){++++}-{4:4}:
       check_prev_add kernel/locking/lockdep.c:3165 [inline]
       check_prevs_add kernel/locking/lockdep.c:3284 [inline]
       validate_chain kernel/locking/lockdep.c:3908 [inline]
       __lock_acquire+0x14ae/0x21e0 kernel/locking/lockdep.c:5237
       lock_acquire kernel/locking/lockdep.c:5868 [inline]
       lock_acquire+0x169/0x2f0 kernel/locking/lockdep.c:5825
       down_read+0x9c/0x4a0 kernel/locking/rwsem.c:1537
       vdev_disk_io_start+0x137/0x26c0 fs/zfs/os/linux/zfs/vdev_disk.c:1135
       zio_vdev_io_start+0x4c6/0xc40 fs/zfs/zfs/zio.c:4797
       __zio_execute fs/zfs/zfs/zio.c:2483 [inline]
       zio_nowait+0x297/0x5e0 fs/zfs/zfs/zio.c:2576
       vdev_mirror_io_start+0x27c/0xad0 fs/zfs/zfs/vdev_mirror.c:688
       zio_vdev_io_start+0x879/0xc40 fs/zfs/zfs/zio.c:4663
       __zio_execute fs/zfs/zfs/zio.c:2483 [inline]
       zio_nowait+0x297/0x5e0 fs/zfs/zfs/zio.c:2576
       arc_read+0x29a1/0x5a10 fs/zfs/zfs/arc.c:6433
       dbuf_read_impl.constprop.0+0x8a2/0x1d90 fs/zfs/zfs/dbuf.c:1660
       dbuf_read+0xbf3/0x1940 fs/zfs/zfs/dbuf.c:1854
       dmu_buf_hold_array_by_dnode+0x24b/0x1710 fs/zfs/zfs/dmu.c:581
       dmu_read_impl+0x230/0x570 fs/zfs/zfs/dmu.c:1205
       dmu_read+0xca/0x130 fs/zfs/zfs/dmu.c:1243
       zfs_fillpage+0x1ef/0x610 fs/zfs/os/linux/zfs/zfs_vnops_os.c:4136
       zfs_getpage+0x1fe/0x960 fs/zfs/os/linux/zfs/zfs_vnops_os.c:4214
       zpl_readpage_common fs/zfs/os/linux/zfs/zpl_file.c:407 [inline]
       zpl_read_folio+0xb4/0x140 fs/zfs/os/linux/zfs/zpl_file.c:419
       filemap_read_folio+0xb8/0x250 mm/filemap.c:2444
       filemap_fault+0x17f8/0x30c0 mm/filemap.c:3581
       __do_fault+0x10a/0x6e0 mm/memory.c:5281
       do_read_fault mm/memory.c:5716 [inline]
       do_fault+0x9b8/0x13e0 mm/memory.c:5850
       do_pte_missing mm/memory.c:4362 [inline]
       handle_pte_fault mm/memory.c:6195 [inline]
       __handle_mm_fault+0x138c/0x22f0 mm/memory.c:6336
       handle_mm_fault+0x42f/0x820 mm/memory.c:6505
       do_user_addr_fault+0x347/0xc30 arch/x86/mm/fault.c:1387
       handle_page_fault arch/x86/mm/fault.c:1476 [inline]
       exc_page_fault+0x73/0x110 arch/x86/mm/fault.c:1532
       asm_exc_page_fault+0x27/0x30 arch/x86/include/asm/idtentry.h:569
       __get_user_4+0x14/0x20 arch/x86/lib/getuser.S:86
       do_vfs_ioctl+0x68c/0x1320 fs/ioctl.c:560
       __do_sys_ioctl fs/ioctl.c:595 [inline]
       __se_sys_ioctl fs/ioctl.c:583 [inline]
       __x64_sys_ioctl+0x108/0x1e0 fs/ioctl.c:583
       x64_sys_call+0x1144/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:17
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

other info that might help us debug this:

Chain exists of:
  &vd->vd_lock --> &mm->mmap_lock --> mapping.invalidate_lock#3

 Possible unsafe locking scenario:

       CPU0                    CPU1
       ----                    ----
  rlock(mapping.invalidate_lock#3);
                               lock(&mm->mmap_lock);
                               lock(mapping.invalidate_lock#3);
  rlock(&vd->vd_lock);

 *** DEADLOCK ***

1 lock held by syz.0.54/547:
 #0: ffff8880183612a8 (mapping.invalidate_lock#3){.+.+}-{4:4}, at: filemap_invalidate_lock_shared include/linux/fs.h:1045 [inline]
 #0: ffff8880183612a8 (mapping.invalidate_lock#3){.+.+}-{4:4}, at: filemap_fault+0x49b/0x30c0 mm/filemap.c:3496

Call Trace:
 __dump_stack lib/dump_stack.c:94 [inline]
 dump_stack_lvl+0xbe/0x130 lib/dump_stack.c:120
 dump_stack+0x15/0x20 lib/dump_stack.c:129
 print_circular_bug+0x285/0x360 kernel/locking/lockdep.c:2043
 check_noncircular+0x14e/0x170 kernel/locking/lockdep.c:2175
 check_prev_add kernel/locking/lockdep.c:3165 [inline]
 check_prevs_add kernel/locking/lockdep.c:3284 [inline]
 validate_chain kernel/locking/lockdep.c:3908 [inline]
 __lock_acquire+0x14ae/0x21e0 kernel/locking/lockdep.c:5237
 lock_acquire kernel/locking/lockdep.c:5868 [inline]
 lock_acquire+0x169/0x2f0 kernel/locking/lockdep.c:5825
 down_read+0x9c/0x4a0 kernel/locking/rwsem.c:1537
 vdev_disk_io_start+0x137/0x26c0 fs/zfs/os/linux/zfs/vdev_disk.c:1135
 zio_vdev_io_start+0x4c6/0xc40 fs/zfs/zfs/zio.c:4797
 __zio_execute fs/zfs/zfs/zio.c:2483 [inline]
 zio_nowait+0x297/0x5e0 fs/zfs/zfs/zio.c:2576
 vdev_mirror_io_start+0x27c/0xad0 fs/zfs/zfs/vdev_mirror.c:688
 zio_vdev_io_start+0x879/0xc40 fs/zfs/zfs/zio.c:4663
 __zio_execute fs/zfs/zfs/zio.c:2483 [inline]
 zio_nowait+0x297/0x5e0 fs/zfs/zfs/zio.c:2576
 arc_read+0x29a1/0x5a10 fs/zfs/zfs/arc.c:6433
 dbuf_read_impl.constprop.0+0x8a2/0x1d90 fs/zfs/zfs/dbuf.c:1660
 dbuf_read+0xbf3/0x1940 fs/zfs/zfs/dbuf.c:1854
 dmu_buf_hold_array_by_dnode+0x24b/0x1710 fs/zfs/zfs/dmu.c:581
 dmu_read_impl+0x230/0x570 fs/zfs/zfs/dmu.c:1205
 dmu_read+0xca/0x130 fs/zfs/zfs/dmu.c:1243
 zfs_fillpage+0x1ef/0x610 fs/zfs/os/linux/zfs/zfs_vnops_os.c:4136
 zfs_getpage+0x1fe/0x960 fs/zfs/os/linux/zfs/zfs_vnops_os.c:4214
 zpl_readpage_common fs/zfs/os/linux/zfs/zpl_file.c:407 [inline]
 zpl_read_folio+0xb4/0x140 fs/zfs/os/linux/zfs/zpl_file.c:419
 filemap_read_folio+0xb8/0x250 mm/filemap.c:2444
 filemap_fault+0x17f8/0x30c0 mm/filemap.c:3581
 __do_fault+0x10a/0x6e0 mm/memory.c:5281
 do_read_fault mm/memory.c:5716 [inline]
 do_fault+0x9b8/0x13e0 mm/memory.c:5850
 do_pte_missing mm/memory.c:4362 [inline]
 handle_pte_fault mm/memory.c:6195 [inline]
 __handle_mm_fault+0x138c/0x22f0 mm/memory.c:6336
 handle_mm_fault+0x42f/0x820 mm/memory.c:6505
 do_user_addr_fault+0x347/0xc30 arch/x86/mm/fault.c:1387
 handle_page_fault arch/x86/mm/fault.c:1476 [inline]
 exc_page_fault+0x73/0x110 arch/x86/mm/fault.c:1532
 asm_exc_page_fault+0x27/0x30 arch/x86/include/asm/idtentry.h:569
```

### Description

This change narrows `vd_lock` so it only protects `vd_bdh` state
transitions and no longer covers the slow block-device open/release
operations.

A small reopen wait state was added so I/O waits for a transient
reopen window instead of observing a temporary `vd_bdh == NULL` and
failing immediately.

The patch also keeps EIO media revalidation tied to the
submission-time block device, so reopen does not race with media
checks.

### How Has This Been Tested?

Tested on Linux.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
