### PR TITLE
zfs: suppress reclaim lockdep in zfs_inactive

### DIFF
--- a/include/os/linux/spl/sys/rwlock.h
+++ b/include/os/linux/spl/sys/rwlock.h
@@ -75,20 +75,35 @@ spl_rw_set_type(krwlock_t *rwp, krw_type_t type)
 {
 	rwp->rw_type = type;
 }
+
+static inline void
+spl_rw_lockdep_off(void)
+{
+	lockdep_off();
+}
+
+static inline void
+spl_rw_lockdep_on(void)
+{
+	lockdep_on();
+}
+
 static inline void
 spl_rw_lockdep_off_maybe(krwlock_t *rwp)		\
 {							\
 	if (rwp && rwp->rw_type == RW_NOLOCKDEP)	\
-		lockdep_off();				\
+		spl_rw_lockdep_off();			\
 }
 static inline void
 spl_rw_lockdep_on_maybe(krwlock_t *rwp)			\
 {							\
 	if (rwp && rwp->rw_type == RW_NOLOCKDEP)	\
-		lockdep_on();				\
+		spl_rw_lockdep_on();			\
 }
 #else  /* CONFIG_LOCKDEP */
 #define	spl_rw_set_type(rwp, type)
+#define	spl_rw_lockdep_off()
+#define	spl_rw_lockdep_on()
 #define	spl_rw_lockdep_off_maybe(rwp)
 #define	spl_rw_lockdep_on_maybe(rwp)
 #endif /* CONFIG_LOCKDEP */
@@ -117,6 +132,56 @@ RW_READ_HELD(krwlock_t *rwp)
  * will be correctly located in the users code which is important
  * for the built in kernel lock analysis tools
  */
+#define	spl_rw_tryenter_impl(rwp, rw) /* CSTYLED */		\
+({									\
+	int _rc_ = 0;							\
+									\
+	switch (rw) {							\
+	case RW_READER:							\
+		_rc_ = down_read_trylock(SEM(rwp));			\
+		break;							\
+	case RW_WRITER:							\
+		if ((_rc_ = down_write_trylock(SEM(rwp))))		\
+			spl_rw_set_owner(rwp);				\
+		break;							\
+	default:							\
+		VERIFY(0);						\
+	}				\
+	_rc_;								\
+})
+
+#define	spl_rw_enter_impl(rwp, rw) /* CSTYLED */		\
+({									\
+	switch (rw) {							\
+	case RW_READER:							\
+		down_read(SEM(rwp));			\
+		break;							\
+	case RW_WRITER:							\
+		down_write(SEM(rwp));			\
+		spl_rw_set_owner(rwp);			\
+		break;							\
+	default:							\
+		VERIFY(0);						\
+	}				\
+})
+
+#define	spl_rw_exit_impl(rwp) /* CSTYLED */			\
+({									\
+	if (RW_WRITE_HELD(rwp)) {					\
+		spl_rw_clear_owner(rwp);				\
+		up_write(SEM(rwp));					\
+	} else {				\
+		ASSERT(RW_READ_HELD(rwp));				\
+		up_read(SEM(rwp));					\
+	}				\
+})
+
+#define	spl_rw_downgrade_impl(rwp) /* CSTYLED */		\
+({									\
+	spl_rw_clear_owner(rwp);					\
+	downgrade_write(SEM(rwp));					\
+})
+
 #define	rw_init(rwp, name, type, arg) /* CSTYLED */			\
 ({									\
 	static struct lock_class_key __key;				\
@@ -138,62 +203,62 @@ RW_READ_HELD(krwlock_t *rwp)
  */
 #define	rw_tryupgrade(rwp)	RW_WRITE_HELD(rwp)
 
-#define	rw_tryenter(rwp, rw) /* CSTYLED */				\
+#define	rw_tryenter(rwp, rw) /* CSTYLED */			\
 ({									\
-	int _rc_ = 0;							\
-									\
 	spl_rw_lockdep_off_maybe(rwp);					\
-	switch (rw) {							\
-	case RW_READER:							\
-		_rc_ = down_read_trylock(SEM(rwp));			\
-		break;							\
-	case RW_WRITER:							\
-		if ((_rc_ = down_write_trylock(SEM(rwp))))		\
-			spl_rw_set_owner(rwp);				\
-		break;							\
-	default:							\
-		VERIFY(0);						\
-	}								\
+	int _rc_ = spl_rw_tryenter_impl(rwp, rw);			\
 	spl_rw_lockdep_on_maybe(rwp);					\
 	_rc_;								\
 })
 
-#define	rw_enter(rwp, rw) /* CSTYLED */					\
+#define	rw_tryenter_nolockdep(rwp, rw) /* CSTYLED */		\
+({									\
+	spl_rw_lockdep_off();						\
+	int _rc_ = spl_rw_tryenter_impl(rwp, rw);			\
+	spl_rw_lockdep_on();						\
+	_rc_;								\
+})
+
+#define	rw_enter(rwp, rw) /* CSTYLED */				\
 ({									\
 	spl_rw_lockdep_off_maybe(rwp);					\
-	switch (rw) {							\
-	case RW_READER:							\
-		down_read(SEM(rwp));					\
-		break;							\
-	case RW_WRITER:							\
-		down_write(SEM(rwp));					\
-		spl_rw_set_owner(rwp);					\
-		break;							\
-	default:							\
-		VERIFY(0);						\
-	}								\
+	spl_rw_enter_impl(rwp, rw);					\
 	spl_rw_lockdep_on_maybe(rwp);					\
 })
 
-#define	rw_exit(rwp) /* CSTYLED */					\
+#define	rw_enter_nolockdep(rwp, rw) /* CSTYLED */		\
+({									\
+	spl_rw_lockdep_off();						\
+	spl_rw_enter_impl(rwp, rw);					\
+	spl_rw_lockdep_on();						\
+})
+
+#define	rw_exit(rwp) /* CSTYLED */				\
 ({									\
 	spl_rw_lockdep_off_maybe(rwp);					\
-	if (RW_WRITE_HELD(rwp)) {					\
-		spl_rw_clear_owner(rwp);				\
-		up_write(SEM(rwp));					\
-	} else {							\
-		ASSERT(RW_READ_HELD(rwp));				\
-		up_read(SEM(rwp));					\
-	}								\
+	spl_rw_exit_impl(rwp);						\
 	spl_rw_lockdep_on_maybe(rwp);					\
 })
 
-#define	rw_downgrade(rwp) /* CSTYLED */					\
+#define	rw_exit_nolockdep(rwp) /* CSTYLED */			\
+({									\
+	spl_rw_lockdep_off();						\
+	spl_rw_exit_impl(rwp);						\
+	spl_rw_lockdep_on();						\
+})
+
+#define	rw_downgrade(rwp) /* CSTYLED */			\
 ({									\
 	spl_rw_lockdep_off_maybe(rwp);					\
-	spl_rw_clear_owner(rwp);					\
-	downgrade_write(SEM(rwp));					\
+	spl_rw_downgrade_impl(rwp);					\
 	spl_rw_lockdep_on_maybe(rwp);					\
+})
+
+#define	rw_downgrade_nolockdep(rwp) /* CSTYLED */		\
+({									\
+	spl_rw_lockdep_off();						\
+	spl_rw_downgrade_impl(rwp);					\
+	spl_rw_lockdep_on();						\
 })
 
 #endif /* _SPL_RWLOCK_H */

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -4078,18 +4078,32 @@ zfs_inactive(struct inode *ip)
 {
 	znode_t	*zp = ITOZ(ip);
 	zfsvfs_t *zfsvfs = ITOZSB(ip);
+	krwlock_t *zti_lock = &zfsvfs->z_teardown_inactive_lock;
 	uint64_t atime[2];
 	int error;
 	int need_unlock = 0;
+	boolean_t no_lockdep = B_FALSE;
 
 	/* Only read lock if we haven't already write locked, e.g. rollback */
-	if (!RW_WRITE_HELD(&zfsvfs->z_teardown_inactive_lock)) {
+	if (!RW_WRITE_HELD(zti_lock)) {
 		need_unlock = 1;
-		rw_enter(&zfsvfs->z_teardown_inactive_lock, RW_READER);
+		/*
+		 * kswapd reaches evict_inode() with fs_reclaim held.  Suppress
+		 * lockdep only for this reclaim-thread acquire/release pair.
+		 */
+		no_lockdep = current_is_reclaim_thread();
+		if (no_lockdep)
+			rw_enter_nolockdep(zti_lock, RW_READER);
+		else
+			rw_enter(zti_lock, RW_READER);
 	}
 	if (zp->z_sa_hdl == NULL) {
-		if (need_unlock)
-			rw_exit(&zfsvfs->z_teardown_inactive_lock);
+		if (need_unlock) {
+			if (no_lockdep)
+				rw_exit_nolockdep(zti_lock);
+			else
+				rw_exit(zti_lock);
+		}
 		return;
 	}
 
@@ -4115,8 +4129,12 @@ zfs_inactive(struct inode *ip)
 	}
 
 	zfs_zinactive(zp);
-	if (need_unlock)
-		rw_exit(&zfsvfs->z_teardown_inactive_lock);
+	if (need_unlock) {
+		if (no_lockdep)
+			rw_exit_nolockdep(zti_lock);
+		else
+			rw_exit(zti_lock);
+	}
 }
 
 /*


### PR DESCRIPTION
### Motivation and Context

A possible circular locking dependency involving kswapd was reported
in the zfs_inactive/zfs_zinactive path. The warning occurs when reclaim
context reaches the synchronous unlinked-deletion path.

```
WARNING: possible circular locking dependency detected
------------------------------------------------------
kswapd0/55 is trying to acquire lock:
ffff88801d089f18 (&zfsvfs->z_teardown_inactive_lock){.+.+}-{4:4}, at: zfs_inactive+0x194/0x1300 fs/zfs/os/linux/zfs/zfs_vnops_os.c:4084

but task is already holding lock:
ffffffff87abcaa0 (fs_reclaim){+.+.}-{0:0}, at: balance_pgdat+0xc06/0x18b0 mm/vmscan.c:7137

which lock already depends on the new lock.

the existing dependency chain (in reverse order) is:

-> #3 (fs_reclaim){+.+.}-{0:0}:
       __fs_reclaim_acquire mm/page_alloc.c:4264 [inline]
       fs_reclaim_acquire+0xe6/0x120 mm/page_alloc.c:4278
       might_alloc include/linux/sched/mm.h:318 [inline]
       slab_pre_alloc_hook mm/slub.c:4929 [inline]
       slab_alloc_node mm/slub.c:5264 [inline]
       __do_kmalloc_node mm/slub.c:5649 [inline]
       __kvmalloc_node_noprof+0xef/0xa20 mm/slub.c:7112
       spl_kvmalloc+0x102/0x140 fs/zfs/os/linux/spl/spl-kmem.c:146
       spl_kmem_alloc_impl fs/zfs/os/linux/spl/spl-kmem.c:260 [inline]
       spl_kmem_alloc+0x240/0x260 fs/zfs/os/linux/spl/spl-kmem.c:467
       rrn_add fs/zfs/zfs/rrwlock.c:107 [inline]
       rrw_enter_read_impl+0x2c8/0x970 fs/zfs/zfs/rrwlock.c:186
       rrw_enter_read fs/zfs/zfs/rrwlock.c:198 [inline]
       rrw_enter+0x57/0x70 fs/zfs/zfs/rrwlock.c:235
       dsl_pool_config_enter fs/zfs/zfs/dsl_pool.c:1431 [inline]
       dsl_pool_hold+0x105/0x130 fs/zfs/zfs/dsl_pool.c:1403
       dmu_objset_hold_flags+0xae/0x1b0 fs/zfs/zfs/dmu_objset.c:751
       dmu_objset_hold+0x2c/0x40 fs/zfs/zfs/dmu_objset.c:772
       zpl_mount_impl fs/zfs/os/linux/zfs/zpl_super.c:394 [inline]
       zpl_mount+0xb6/0x770 fs/zfs/os/linux/zfs/zpl_super.c:465
       legacy_get_tree+0x112/0x220 fs/fs_context.c:663
       vfs_get_tree+0x9a/0x370 fs/super.c:1758
       fc_mount fs/namespace.c:1199 [inline]
       do_new_mount_fc fs/namespace.c:3642 [inline]
       do_new_mount fs/namespace.c:3718 [inline]
       path_mount+0x5b8/0x1ea0 fs/namespace.c:4028
       do_mount fs/namespace.c:4041 [inline]
       __do_sys_mount fs/namespace.c:4229 [inline]
       __se_sys_mount fs/namespace.c:4206 [inline]
       __x64_sys_mount+0x282/0x320 fs/namespace.c:4206
       x64_sys_call+0x1a7d/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:166
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

-> #2 (&rrl->rr_lock){+.+.}-{4:4}:
       __mutex_lock_common kernel/locking/mutex.c:598 [inline]
       __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
       mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
       rrw_enter_read_impl+0x77/0x970 fs/zfs/zfs/rrwlock.c:166
       rrw_enter_read fs/zfs/zfs/rrwlock.c:198 [inline]
       rrw_enter+0x57/0x70 fs/zfs/zfs/rrwlock.c:235
       dmu_buf_lock_parent+0x22c/0x380 fs/zfs/zfs/dbuf.c:1350
       dbuf_read+0xb88/0x1940 fs/zfs/zfs/dbuf.c:1834
       dmu_buf_hold_by_dnode+0x8e/0xe0 fs/zfs/zfs/dmu.c:232
       mzap_create_impl+0xb5/0x470 fs/zfs/zfs/zap_micro.c:842
       zap_create_impl fs/zfs/zfs/zap_micro.c:879 [inline]
       zap_create_norm_dnsize fs/zfs/zfs/zap_micro.c:968 [inline]
       zap_create_dnsize+0xd1/0x120 fs/zfs/zfs/zap_micro.c:952
       zap_create_link_dnsize+0xae/0x1b0 fs/zfs/zfs/zap.c:1104
       zap_create_link+0x3d/0x60 fs/zfs/zfs/zap.c:1095
       sa_attr_register_sync+0x8f1/0xd30 fs/zfs/zfs/sa.c:1859
       sa_replace_all_by_template_locked fs/zfs/zfs/sa.c:1892 [inline]
       sa_replace_all_by_template+0x4cd/0x640 fs/zfs/zfs/sa.c:1903
       zfs_mknode+0x162f/0x3e20 fs/zfs/os/linux/zfs/zfs_znode_os.c:905
       zfs_create_fs+0xc46/0x11f0 fs/zfs/os/linux/zfs/zfs_znode_os.c:1952
       dsl_pool_create+0x3f8/0x840 fs/zfs/zfs/dsl_pool.c:556
       spa_create+0xd2e/0x1a00 fs/zfs/zfs/spa.c:7207
       zfs_ioc_pool_create+0x4fb/0x650 fs/zfs/zfs/zfs_ioctl.c:1522
       zfsdev_ioctl_common+0x128c/0x1600 fs/zfs/zfs/zfs_ioctl.c:8239
       zfsdev_ioctl+0x65/0x120 fs/zfs/os/linux/zfs/zfs_ioctl_os.c:145
       vfs_ioctl fs/ioctl.c:51 [inline]
       __do_sys_ioctl fs/ioctl.c:597 [inline]
       __se_sys_ioctl fs/ioctl.c:583 [inline]
       __x64_sys_ioctl+0x197/0x1e0 fs/ioctl.c:583
       x64_sys_call+0x1144/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:17
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

-> #1 (&hdl->sa_lock){+.+.}-{4:4}:
       __mutex_lock_common kernel/locking/mutex.c:598 [inline]
       __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
       mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
       sa_lookup+0xf8/0x560 fs/zfs/zfs/sa.c:1509
       zfs_rmnode+0x245/0x14a0 fs/zfs/os/linux/zfs/zfs_dir.c:710
       zfs_zinactive+0x612/0x7e0 fs/zfs/os/linux/zfs/zfs_znode_os.c:1354
       zfs_inactive+0x258/0x1300 fs/zfs/os/linux/zfs/zfs_vnops_os.c:4113
       zpl_evict_inode+0x7d/0xe0 fs/zfs/os/linux/zfs/zpl_super.c:144
       evict+0x38e/0x8f0 fs/inode.c:810
       iput_final fs/inode.c:1914 [inline]
       iput fs/inode.c:1966 [inline]
       iput+0x55b/0x8b0 fs/inode.c:1926
       do_unlinkat+0x4cb/0x680 fs/namei.c:4744
       __do_sys_unlinkat fs/namei.c:4778 [inline]
       __se_sys_unlinkat fs/namei.c:4771 [inline]
       __x64_sys_unlinkat+0xae/0x130 fs/namei.c:4771
       x64_sys_call+0x1066/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:264
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

-> #0 (&zfsvfs->z_teardown_inactive_lock){.+.+}-{4:4}:
       check_prev_add kernel/locking/lockdep.c:3165 [inline]
       check_prevs_add kernel/locking/lockdep.c:3284 [inline]
       validate_chain kernel/locking/lockdep.c:3908 [inline]
       __lock_acquire+0x14ae/0x21e0 kernel/locking/lockdep.c:5237
       lock_acquire kernel/locking/lockdep.c:5868 [inline]
       lock_acquire+0x169/0x2f0 kernel/locking/lockdep.c:5825
       down_read+0x9c/0x4a0 kernel/locking/rwsem.c:1537
       zfs_inactive+0x194/0x1300 fs/zfs/os/linux/zfs/zfs_vnops_os.c:4084
       zpl_evict_inode+0x7d/0xe0 fs/zfs/os/linux/zfs/zpl_super.c:144
       evict+0x38e/0x8f0 fs/inode.c:810
       dispose_list+0xe4/0x1d0 fs/inode.c:852
       prune_icache_sb+0xef/0x170 fs/inode.c:1000
       super_cache_scan+0x354/0x530 fs/super.c:224
       do_shrink_slab+0x37f/0xe00 mm/shrinker.c:437
       shrink_slab+0x173/0x1000 mm/shrinker.c:664
       shrink_one+0x44f/0x8a0 mm/vmscan.c:4955
       shrink_many mm/vmscan.c:5016 [inline]
       lru_gen_shrink_node mm/vmscan.c:5094 [inline]
       shrink_node+0x2428/0x3870 mm/vmscan.c:6081
       kswapd_shrink_node mm/vmscan.c:6941 [inline]
       balance_pgdat+0xb3d/0x18b0 mm/vmscan.c:7124
       kswapd+0x527/0xa20 mm/vmscan.c:7389
       kthread+0x3f0/0x850 kernel/kthread.c:463
       ret_from_fork+0x50f/0x610 arch/x86/kernel/process.c:158
       ret_from_fork_asm+0x1a/0x30 arch/x86/entry/entry_64.S:245

other info that might help us debug this:

Chain exists of:
  &zfsvfs->z_teardown_inactive_lock --> &rrl->rr_lock --> fs_reclaim

 Possible unsafe locking scenario:

       CPU0                    CPU1
       ----                    ----
  lock(fs_reclaim);
                               lock(&rrl->rr_lock);
                               lock(fs_reclaim);
  rlock(&zfsvfs->z_teardown_inactive_lock);

 *** DEADLOCK ***

2 locks held by kswapd0/55:
 #0: ffffffff87abcaa0 (fs_reclaim){+.+.}-{0:0}, at: balance_pgdat+0xc06/0x18b0 mm/vmscan.c:7137
 #1: ffff88800afbc0e0 (&type->s_umount_key#60){.+.+}-{4:4}, at: super_trylock_shared fs/super.c:562 [inline]
 #1: ffff88800afbc0e0 (&type->s_umount_key#60){.+.+}-{4:4}, at: super_cache_scan+0x8c/0x530 fs/super.c:197

Call Trace:
 __dump_stack lib/dump_stack.c:94 [inline]
 dump_stack_lvl+0xbe/0x130 lib/dump_stack.c:120
 dump_stack+0x15/0x20 lib/dump_stack.c:129
 print_circular_bug+0x285/0x360 kernel/locking/lockdep.c:2043
 check_noncircular+0x14e/0x170 kernel/locking/lockdep.c:2175
 check_prev_add kernel/locking/lockdep.c:3165 [inline]
 check_prevs_add kernel/locking/lockdep.c:3284 [inline]
 validate_chain kernel/locking/lockdep.c:3908 [inline]
 __lock_acquire+0x14ae/0x21e0 kernel/locking/lockdep.c:5237
 lock_acquire kernel/locking/lockdep.c:5868 [inline]
 lock_acquire+0x169/0x2f0 kernel/locking/lockdep.c:5825
 down_read+0x9c/0x4a0 kernel/locking/rwsem.c:1537
 zfs_inactive+0x194/0x1300 fs/zfs/os/linux/zfs/zfs_vnops_os.c:4084
 zpl_evict_inode+0x7d/0xe0 fs/zfs/os/linux/zfs/zpl_super.c:144
 evict+0x38e/0x8f0 fs/inode.c:810
 dispose_list+0xe4/0x1d0 fs/inode.c:852
 prune_icache_sb+0xef/0x170 fs/inode.c:1000
 super_cache_scan+0x354/0x530 fs/super.c:224
 do_shrink_slab+0x37f/0xe00 mm/shrinker.c:437
 shrink_slab+0x173/0x1000 mm/shrinker.c:664
 shrink_one+0x44f/0x8a0 mm/vmscan.c:4955
 shrink_many mm/vmscan.c:5016 [inline]
 lru_gen_shrink_node mm/vmscan.c:5094 [inline]
 shrink_node+0x2428/0x3870 mm/vmscan.c:6081
 kswapd_shrink_node mm/vmscan.c:6941 [inline]
 balance_pgdat+0xb3d/0x18b0 mm/vmscan.c:7124
 kswapd+0x527/0xa20 mm/vmscan.c:7389
 kthread+0x3f0/0x850 kernel/kthread.c:463
 ret_from_fork+0x50f/0x610 arch/x86/kernel/process.c:158
 ret_from_fork_asm+0x1a/0x30 arch/x86/entry/entry_64.S:245
```

### Description

This keeps the existing zfs_zinactive() and unlinked cleanup semantics.

For reclaim threads only, zfs_inactive() temporarily disables lockdep
around the acquire and release of z_teardown_inactive_lock.  The real
rwsem is still taken normally, so teardown serialization is unchanged.

The patch also removes the extra zfs_unlinked_drain_try() path and the
additional z_drain_cv/TASKQID_INITIAL drain state added by the previous
version.

### How Has This Been Tested?

Tested on Linux.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
