### PR TITLE
ZTS: zhack_metaslab_leak.ksh busy export

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_metaslab_leak.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_metaslab_leak.ksh
@@ -31,7 +31,7 @@ verify_runnable "global"
 
 function cleanup
 {
-	zpool destroy $TESTPOOL
+	destroy_pool $TESTPOOL
 	rm $tmp
 }
 
@@ -58,7 +58,7 @@ log_must eval "zdb -m --allocated-map $TESTPOOL > $tmp"
 log_must zpool destroy $TESTPOOL
 
 log_must zpool create $TESTPOOL $DISKS
-log_must zpool export $TESTPOOL
+log_must_busy zpool export $TESTPOOL
 log_must eval "zhack metaslab leak $TESTPOOL < $tmp"
 log_must zpool import $TESTPOOL
 


### PR DESCRIPTION
### Motivation and Context

https://github.com/openzfs/zfs/actions/runs/25520004970/job/74912816645

```
 [2026-05-08T00:41:18.236946] Test: /usr/share/zfs/zfs-tests/tests/functional/cli_root/zhack/zhack_metaslab_leak (run as root) [00:04] [FAIL]
  00:41:13.49 ASSERTION: zhack metaslab leak leaks the right amount of space
  00:41:13.64 SUCCESS: zpool create testpool loop0 loop1 loop2
  00:41:13.74 SUCCESS: dd if=/dev/urandom of=/testpool/f1 bs=1M count=16
  00:41:13.79 SUCCESS: zpool sync testpool
  00:41:13.85 SUCCESS: dd if=/dev/urandom of=/testpool/f2 bs=1M count=16
  00:41:13.90 SUCCESS: zpool sync testpool
  00:41:13.96 SUCCESS: dd if=/dev/urandom of=/testpool/f3 bs=1M count=16
  00:41:14.01 SUCCESS: zpool sync testpool
  00:41:14.08 SUCCESS: dd if=/dev/urandom of=/testpool/f4 bs=1M count=16
  00:41:14.13 SUCCESS: zpool sync testpool
  00:41:14.18 SUCCESS: dd if=/dev/urandom of=/testpool/f5 bs=1M count=16
  00:41:14.24 SUCCESS: zpool sync testpool
  00:41:14.29 SUCCESS: dd if=/dev/urandom of=/testpool/f6 bs=1M count=16
  00:41:14.34 SUCCESS: zpool sync testpool
  00:41:14.40 SUCCESS: dd if=/dev/urandom of=/testpool/f7 bs=1M count=16
  00:41:14.45 SUCCESS: zpool sync testpool
  00:41:14.50 SUCCESS: dd if=/dev/urandom of=/testpool/f8 bs=1M count=16
  00:41:14.56 SUCCESS: zpool sync testpool
  00:41:14.62 SUCCESS: dd if=/dev/urandom of=/testpool/f9 bs=1M count=16
  00:41:14.67 SUCCESS: zpool sync testpool
  00:41:14.72 SUCCESS: dd if=/dev/urandom of=/testpool/f10 bs=1M count=16
  00:41:14.78 SUCCESS: zpool sync testpool
  00:41:14.83 SUCCESS: dd if=/dev/urandom of=/testpool/f11 bs=1M count=16
  00:41:14.89 SUCCESS: zpool sync testpool
  00:41:14.97 SUCCESS: dd if=/dev/urandom of=/testpool/f12 bs=1M count=16
  00:41:15.02 SUCCESS: zpool sync testpool
  00:41:15.09 SUCCESS: dd if=/dev/urandom of=/testpool/f13 bs=1M count=16
  00:41:15.58 SUCCESS: zpool sync testpool
  00:41:15.64 SUCCESS: dd if=/dev/urandom of=/testpool/f14 bs=1M count=16
  00:41:15.70 SUCCESS: zpool sync testpool
  00:41:15.77 SUCCESS: dd if=/dev/urandom of=/testpool/f15 bs=1M count=16
  00:41:15.85 SUCCESS: zpool sync testpool
  00:41:15.91 SUCCESS: dd if=/dev/urandom of=/testpool/f16 bs=1M count=16
  00:41:15.98 SUCCESS: zpool sync testpool
  00:41:15.99 SUCCESS: rm /testpool/f2
  00:41:15.99 SUCCESS: rm /testpool/f4
  00:41:16.00 SUCCESS: rm /testpool/f6
  00:41:16.00 SUCCESS: rm /testpool/f8
  00:41:16.01 SUCCESS: rm /testpool/f10
  00:41:16.02 SUCCESS: rm /testpool/f12
  00:41:16.03 SUCCESS: rm /testpool/f14
  00:41:16.03 SUCCESS: rm /testpool/f16
  00:41:16.04 SUCCESS: touch /testpool/g1
  00:41:16.08 SUCCESS: zpool sync testpool
  00:41:16.08 SUCCESS: touch /testpool/g2
  00:41:16.11 SUCCESS: zpool sync testpool
  00:41:16.11 SUCCESS: touch /testpool/g3
  00:41:16.14 SUCCESS: zpool sync testpool
  00:41:16.14 SUCCESS: touch /testpool/g4
  00:41:16.16 SUCCESS: zpool sync testpool
  00:41:16.17 SUCCESS: touch /testpool/g5
  00:41:16.20 SUCCESS: zpool sync testpool
  00:41:16.20 SUCCESS: touch /testpool/g6
  00:41:16.23 SUCCESS: zpool sync testpool
  00:41:16.24 SUCCESS: touch /testpool/g7
  00:41:16.26 SUCCESS: zpool sync testpool
  00:41:16.27 SUCCESS: touch /testpool/g8
  00:41:16.29 SUCCESS: zpool sync testpool
  00:41:16.29 SUCCESS: touch /testpool/g9
  00:41:16.31 SUCCESS: zpool sync testpool
  00:41:16.32 SUCCESS: touch /testpool/g10
  00:41:16.34 SUCCESS: zpool sync testpool
  00:41:16.35 SUCCESS: touch /testpool/g11
  00:41:16.37 SUCCESS: zpool sync testpool
  00:41:16.37 SUCCESS: touch /testpool/g12
  00:41:16.42 SUCCESS: zpool sync testpool
  00:41:16.42 SUCCESS: touch /testpool/g13
  00:41:16.44 SUCCESS: zpool sync testpool
  00:41:16.45 SUCCESS: touch /testpool/g14
  00:41:16.47 SUCCESS: zpool sync testpool
  00:41:16.48 SUCCESS: touch /testpool/g15
  00:41:16.50 SUCCESS: zpool sync testpool
  00:41:16.50 SUCCESS: touch /testpool/g16
  00:41:16.53 SUCCESS: zpool sync testpool
  00:41:17.65 SUCCESS: eval zdb -m --allocated-map testpool > /var/tmp/tmp.XguH5he2pG
  00:41:17.76 SUCCESS: zpool destroy testpool
  00:41:17.95 SUCCESS: zpool create testpool loop0 loop1 loop2
  00:41:18.03 ERROR: zpool export testpool exited 1
  00:41:18.03 cannot export 'testpool': pool is busy
```

### Description

If the pool is active 'zpool export' will fail resulting in a test failure.  Swap log_must with log_must_busy so the export is retried when reported as busy before failing the test.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)