### PR TITLE
zfs.4: Fix documentation of zfs_arc_dnode_reduce_percent

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -4,6 +4,7 @@
 .\" Copyright (c) 2019, 2021 by Delphix. All rights reserved.
 .\" Copyright (c) 2019 Datto Inc.
 .\" Copyright (c) 2023, 2024, 2025, Klara, Inc.
+.\" Copyright (c) 2026, Mateusz Piotrowski <0mp@FreeBSD.org>
 .\"
 .\" The contents of this file are subject to the terms of the Common Development
 .\" and Distribution License (the "License").  You may not use this file except
@@ -18,7 +19,7 @@
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
 .\"
-.Dd September 15, 2025
+.Dd May 8, 2026
 .Dt ZFS 4
 .Os
 .
@@ -768,9 +769,15 @@ See also
 which serves a similar purpose but has a higher priority if nonzero.
 .
 .It Sy zfs_arc_dnode_reduce_percent Ns = Ns Sy 10 Ns % Pq u64
-Percentage of ARC dnodes to try to scan in response to demand for non-metadata
-when the number of bytes consumed by dnodes exceeds
-.Sy zfs_arc_dnode_limit .
+Percentage used to size dnode prune requests.
+The request size is the larger of two values:
+.Sy zfs_arc_dnode_reduce_percent
+applied to the dnode count above
+.Sy zfs_arc_dnode_limit ,
+or
+.Sy zfs_arc_dnode_reduce_percent
+applied to the total dnode count
+when non-evictable metadata exceeds 3/4 of the metadata target.
 .
 .It Sy zfs_arc_average_blocksize Ns = Ns Sy 8192 Ns B Po 8 KiB Pc Pq uint
 The ARC's buffer hash table is sized based on the assumption of an average


### PR DESCRIPTION

### Motivation and Context

The current description of `zfs_arc_dnode_reduce_percent` is confusing and unclear.

The way `zfs_arc_dnode_reduce_percent` is used in arc.c has changed over the year. `zfs_arc_dnode_reduce_percent` is no longer operating only on the dnodes above the dnode limit (which actually also wasn't documented).

Here's the relevant code:

```c
	/*
	 * Try to reduce pinned dnodes if more than 3/4 of wanted metadata
	 * target is not evictable or if they go over arc_dnode_limit.
	 */
	int64_t prune = 0;
	int64_t dn = aggsum_value(&arc_sums.arcstat_dnode_size);
	int64_t nem = zfs_refcount_count(&arc_mru->arcs_size[ARC_BUFC_METADATA])
	    + zfs_refcount_count(&arc_mfu->arcs_size[ARC_BUFC_METADATA])
	    - zfs_refcount_count(&arc_mru->arcs_esize[ARC_BUFC_METADATA])
	    - zfs_refcount_count(&arc_mfu->arcs_esize[ARC_BUFC_METADATA]);
	w = wt * (int64_t)(arc_meta >> 16) >> 16;
	if (nem > w * 3 / 4) {
		prune = dn / sizeof (dnode_t) *
		    zfs_arc_dnode_reduce_percent / 100;
		if (nem < w && w > 4)
			prune = arc_mf(prune, nem - w * 3 / 4, w / 4);
	}
	if (dn > arc_dnode_limit) {
		prune = MAX(prune, (dn - arc_dnode_limit) / sizeof (dnode_t) *
		    zfs_arc_dnode_reduce_percent / 100);
	}
	if (prune > 0)
		arc_prune_async(prune);
```

### Description

Give the reader enough information to understand the role of the parameter without exposing too many details about the implementation.


### How Has This Been Tested?

```
mandoc -Tlint
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
