### PR TITLE
Linux: avoid znode list lock inversion during resume

### DIFF
--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1690,6 +1690,24 @@ zfs_suspend_fs(zfsvfs_t *zfsvfs)
 }
 
 /*
+ * Return a referenced znode at or after zp.  The z_znodes_lock protects the
+ * list walk; the returned inode reference keeps the znode alive after the
+ * lock is dropped for zfs_rezget().
+ */
+static znode_t *
+zfs_resume_hold_next_znode(zfsvfs_t *zfsvfs, znode_t *zp)
+{
+	ASSERT(MUTEX_HELD(&zfsvfs->z_znodes_lock));
+
+	for (; zp != NULL; zp = list_next(&zfsvfs->z_all_znodes, zp)) {
+		if (igrab(ZTOI(zp)) != NULL)
+			return (zp);
+	}
+
+	return (NULL);
+}
+
+/*
  * Rebuild SA and release VOPs.  Note that ownership of the underlying dataset
  * is an invariant across any of the operations that can be performed while the
  * filesystem was suspended.  Whether it succeeded or failed, the preconditions
@@ -1732,13 +1750,23 @@ zfs_resume_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 	 * dbufs.  If a zfs_rezget() fails, then we unhash the inode
 	 * and mark it stale.  This prevents a collision if a new
 	 * inode/object is created which must use the same inode
-	 * number.  The stale inode will be be released when the
-	 * VFS prunes the dentry holding the remaining references
-	 * on the stale inode.
+	 * number.  The stale inode will be released when the VFS
+	 * prunes the dentry holding the remaining references on
+	 * the stale inode.
+	 *
+	 * zfs_rezget() takes the per-object znode hold lock.  Pin each znode
+	 * while holding z_znodes_lock, then drop the list lock before calling
+	 * zfs_rezget() to preserve the normal zh_lock -> z_znodes_lock order.
 	 */
 	mutex_enter(&zfsvfs->z_znodes_lock);
-	for (zp = list_head(&zfsvfs->z_all_znodes); zp;
-	    zp = list_next(&zfsvfs->z_all_znodes, zp)) {
+	zp = zfs_resume_hold_next_znode(zfsvfs,
+	    list_head(&zfsvfs->z_all_znodes));
+	while (zp != NULL) {
+		znode_t *next = zfs_resume_hold_next_znode(zfsvfs,
+		    list_next(&zfsvfs->z_all_znodes, zp));
+
+		mutex_exit(&zfsvfs->z_znodes_lock);
+
 		err2 = zfs_rezget(zp);
 		if (err2) {
 			zpl_d_drop_aliases(ZTOI(zp));
@@ -1747,9 +1775,14 @@ zfs_resume_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 
 		/* see comment in zfs_suspend_fs() */
 		if (zp->z_suspended) {
-			zfs_zrele_async(zp);
 			zp->z_suspended = B_FALSE;
+			zfs_zrele_async(zp);
 		}
+
+		zfs_zrele_async(zp);
+
+		mutex_enter(&zfsvfs->z_znodes_lock);
+		zp = next;
 	}
 	mutex_exit(&zfsvfs->z_znodes_lock);
 


### PR DESCRIPTION
### Motivation and Context

Lockdep reports a circular locking dependency during mounted filesystem
rollback.  The resume path holds `z_znodes_lock` while calling
`zfs_rezget()`, which takes the per-object znode hold lock.  The normal
zget/allocation path takes these locks in the opposite order.

```
WARNING: possible circular locking dependency detected   
------------------------------------------------------
syz.0.3/482 is trying to acquire lock:
ffff88800eda4088 (&zh->zh_lock){+.+.}-{4:4}, at: zfs_znode_hold_enter+0x51d/0x950 fs/zfs/os/linux/zfs/zfs_znode_os.c:291

but task is already holding lock:
ffff88801d43dfe0 (&zfsvfs->z_znodes_lock){+.+.}-{4:4}, at: zfs_resume_fs+0x4d6/0x1040 fs/zfs/os/linux/zfs/zfs_vfsops.c:1923

which lock already depends on the new lock.

the existing dependency chain (in reverse order) is:

-> #1 (&zfsvfs->z_znodes_lock){+.+.}-{4:4}:
       __mutex_lock_common kernel/locking/mutex.c:598 [inline]
       __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
       mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
       zfs_znode_alloc+0xf8a/0x1d30 fs/zfs/os/linux/zfs/zfs_znode_os.c:617
       zfs_zget+0x6b9/0x820 fs/zfs/os/linux/zfs/zfs_znode_os.c:1148
       zfs_root fs/zfs/os/linux/zfs/zfs_vfsops.c:1206 [inline]
       zfs_domount+0xc05/0x16d0 fs/zfs/os/linux/zfs/zfs_vfsops.c:1594
       zpl_fill_super fs/zfs/os/linux/zfs/zpl_super.c:364 [inline]
       zpl_mount_impl fs/zfs/os/linux/zfs/zpl_super.c:441 [inline]
       zpl_mount+0x586/0x770 fs/zfs/os/linux/zfs/zpl_super.c:465
       legacy_get_tree+0x112/0x220 fs/fs_context.c:663
       vfs_get_tree+0x9a/0x370 fs/super.c:1758
       fc_mount fs/namespace.c:1199 [inline]
       do_new_mount_fc fs/namespace.c:3642 [inline]
       do_new_mount fs/namespace.c:3718 [inline]
       path_mount+0x5b8/0x1ea0 fs/namespace.c:4028
       do_mount fs/namespace.c:4041 [inline]
       __do_sys_mount fs/namespace.c:4229 [inline]
       __se_sys_mount fs/namespace.c:4206 [inline]
       __x64_sys_mount+0x282/0x320 fs/namespace.c:4206
       x64_sys_call+0x1a7d/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:166
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

-> #0 (&zh->zh_lock){+.+.}-{4:4}:
       check_prev_add kernel/locking/lockdep.c:3165 [inline]
       check_prevs_add kernel/locking/lockdep.c:3284 [inline]
       validate_chain kernel/locking/lockdep.c:3908 [inline]
       __lock_acquire+0x14ae/0x21e0 kernel/locking/lockdep.c:5237
       lock_acquire kernel/locking/lockdep.c:5868 [inline]
       lock_acquire+0x169/0x2f0 kernel/locking/lockdep.c:5825
       __mutex_lock_common kernel/locking/mutex.c:598 [inline]
       __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
       mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
       zfs_znode_hold_enter+0x51d/0x950 fs/zfs/os/linux/zfs/zfs_znode_os.c:291
       zfs_rezget+0x332/0x1d90 fs/zfs/os/linux/zfs/zfs_znode_os.c:1188
       zfs_resume_fs+0x621/0x1040 fs/zfs/os/linux/zfs/zfs_vfsops.c:1926
       zfs_ioc_rollback+0x2f9/0x320 fs/zfs/zfs/zfs_ioctl.c:4745
       zfsdev_ioctl_common+0xc31/0x1600 fs/zfs/zfs/zfs_ioctl.c:8190
       zfsdev_ioctl+0x65/0x120 fs/zfs/os/linux/zfs/zfs_ioctl_os.c:145
       vfs_ioctl fs/ioctl.c:51 [inline]
       __do_sys_ioctl fs/ioctl.c:597 [inline]
       __se_sys_ioctl fs/ioctl.c:583 [inline]
       __x64_sys_ioctl+0x197/0x1e0 fs/ioctl.c:583
       x64_sys_call+0x1144/0x26a0 arch/x86/include/generated/asm/syscalls_64.h:17
       do_syscall_x64 arch/x86/entry/syscall_64.c:63 [inline]
       do_syscall_64+0x93/0xf80 arch/x86/entry/syscall_64.c:94
       entry_SYSCALL_64_after_hwframe+0x76/0x7e

other info that might help us debug this:

 Possible unsafe locking scenario:

       CPU0                    CPU1
       ----                    ----
  lock(&zfsvfs->z_znodes_lock);
                               lock(&zh->zh_lock);
                               lock(&zfsvfs->z_znodes_lock);
  lock(&zh->zh_lock);

 *** DEADLOCK ***

2 locks held by syz.0.3/482:
 #0: ffff88801d43df18 (&zfsvfs->z_teardown_inactive_lock){+.+.}-{4:4}, at: zfsvfs_teardown+0x219/0x12a0 fs/zfs/os/linux/zfs/zfs_vfsops.c:1401
 #1: ffff88801d43dfe0 (&zfsvfs->z_znodes_lock){+.+.}-{4:4}, at: zfs_resume_fs+0x4d6/0x1040 fs/zfs/os/linux/zfs/zfs_vfsops.c:1923

Call Trace:
 __dump_stack lib/dump_stack.c:94 [inline]
 dump_stack_lvl+0xbe/0x130 lib/dump_stack.c:120
 dump_stack+0x15/0x20 lib/dump_stack.c:129
 print_circular_bug+0x285/0x360 kernel/locking/lockdep.c:2043
 check_noncircular+0x14e/0x170 kernel/locking/lockdep.c:2175
 check_prev_add kernel/locking/lockdep.c:3165 [inline]
 check_prevs_add kernel/locking/lockdep.c:3284 [inline]
 validate_chain kernel/locking/lockdep.c:3908 [inline]
 __lock_acquire+0x14ae/0x21e0 kernel/locking/lockdep.c:5237
 lock_acquire kernel/locking/lockdep.c:5868 [inline]
 lock_acquire+0x169/0x2f0 kernel/locking/lockdep.c:5825
 __mutex_lock_common kernel/locking/mutex.c:598 [inline]
 __mutex_lock+0x1a6/0x1d80 kernel/locking/mutex.c:760
 mutex_lock_nested+0x1b/0x30 kernel/locking/mutex.c:812
 zfs_znode_hold_enter+0x51d/0x950 fs/zfs/os/linux/zfs/zfs_znode_os.c:291
 zfs_rezget+0x332/0x1d90 fs/zfs/os/linux/zfs/zfs_znode_os.c:1188
 zfs_resume_fs+0x621/0x1040 fs/zfs/os/linux/zfs/zfs_vfsops.c:1926
 zfs_ioc_rollback+0x2f9/0x320 fs/zfs/zfs/zfs_ioctl.c:4745
 zfsdev_ioctl_common+0xc31/0x1600 fs/zfs/zfs/zfs_ioctl.c:8190
 zfsdev_ioctl+0x65/0x120 fs/zfs/os/linux/zfs/zfs_ioctl_os.c:145
 vfs_ioctl fs/ioctl.c:51 [inline]
 __do_sys_ioctl fs/ioctl.c:597 [inline]
 __se_sys_ioctl fs/ioctl.c:583 [inline]
 __x64_sys_ioctl+0x197/0x1e0 fs/ioctl.c:583
 ...
```

### Description

Change `zfs_resume_fs()` so the znode list lock is only held while
selecting and pinning znodes with `igrab()`.  The code now drops
`z_znodes_lock` before calling `zfs_rezget()`, preserving the normal
`zh_lock -> z_znodes_lock` ordering.

The existing stale inode handling is preserved.  Suspended references and
temporary traversal references are released asynchronously.

### How Has This Been Tested?

Tested on Linux.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
