### PR TITLE
CI: skip qemu matrix for documentation-only pull requests

### DIFF
--- a/.github/workflows/scripts/generate-ci-type.py
+++ b/.github/workflows/scripts/generate-ci-type.py
@@ -6,6 +6,9 @@ Determine the CI type based on the change list and commit message.
 Output format: "<type> <source>" where source is "manual" (from
 ZFS-CI-Type commit tag) or "auto" (from file change heuristics).
 
+Prints "docs auto" if every changed file is documentation; the qemu
+matrix is skipped in that case.
+
 Prints "quick manual" if:
 - the *last* commit message contains 'ZFS-CI-Type: quick'
 or "quick auto" if (heuristics):
@@ -26,6 +29,19 @@ Note: not using pathlib.Path.match() because it does not support '**'
 FULL_RUN_IGNORE_REGEX = list(map(re.compile, [
     r'.*\.md',
     r'.*\.gitignore'
+]))
+
+"""
+Patterns of files that are documentation only.
+"""
+DOCS_ONLY_REGEX = list(map(re.compile, [
+    r'man/.*',
+    r'.*\.md',
+    r'AUTHORS',
+    r'COPYRIGHT',
+    r'LICENSE',
+    r'NOTICE',
+    r'\.gitignore',
 ]))
 
 """
@@ -115,6 +131,12 @@ if __name__ == '__main__':
                         'full', 'auto',
                         f'changed file "{f}" matches pattern "{r.pattern}"'
                         )
+
+    if changed_files and all(
+            any(r.match(f) for r in DOCS_ONLY_REGEX)
+            for f in changed_files):
+        output_type('docs', 'auto',
+                    'all changed files are documentation')
 
     # catch-all
     output_type('quick', 'auto',

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -45,6 +45,9 @@ jobs:
           fi
 
           case "$ci_type" in
+          docs)
+            os_selection='[]'
+            ;;
           quick)
             os_selection='["almalinux8", "almalinux9", "almalinux10", "debian12", "fedora42", "freebsd15-1s", "ubuntu24"]'
             ;;
@@ -91,6 +94,7 @@ jobs:
   qemu-vm:
     name: qemu-x86
     needs: [ test-config ]
+    if: needs.test-config.outputs.ci_type != 'docs'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Motivation and Context

Documentation-only PRs (man pages, README, AUTHORS, etc.) currently run the default 15-OS qemu matrix. Each `qemu-x86 (<os>)` job builds ZFS from source and runs ZTS.

### Description

Adds a `docs` ci_type. The `qemu-vm` job carries `if: needs.test-config.outputs.ci_type != 'docs'` and is skipped on that ci_type. Mixed and code PRs follow the existing rules; `ZFS-CI-Type: <type>` tags continue to override.

`checkstyle` (running `mancheck`) continues to validate manpage syntax.

### How Has This Been Tested?

`generate-ci-type.py` was tested against 12 scenarios covering each pattern category, mixed diffs, manual overrides etc.

End-to-end on my fork:
- docs-only diff (README.md edit): Setup `docs auto`, `qemu-vm` skipped, workflow conclusion `success`.
- code-only diff (`lib/libzfs/libzfs_diff.c` edit): Setup `full auto`, 15 `qemu-x86` matrix entries spawned.

### Types of changes
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).