### PR TITLE
CI: Fix 99.99 META version

### DIFF
--- a/.github/workflows/scripts/qemu-3-deps.sh
+++ b/.github/workflows/scripts/qemu-3-deps.sh
@@ -2,9 +2,12 @@
 # 3) Wait for VM to boot from previous step and launch dependencies
 #    script on it.
 #
-# $1: OS name (like 'fedora41')
-# $2: (optional) Experimental kernel version to install on fedora,
-#     like "6.14".
+# qemu-3-deps.sh [--poweroff] OS_NAME [FEDORA_VERSION]
+#
+# --poweroff: Power off the VM after installing dependencies
+# OS_NAME: OS name (like 'fedora41')
+# FEDORA_VERSION: (optional) Experimental Fedora kernel version, like "6.14" to
+#     install instead of Fedora defaults.
 ######################################################################
 
 .github/workflows/scripts/qemu-wait-for-vm.sh vm0
@@ -15,8 +18,13 @@
 # we need to update the kernel version in zfs's META file to allow the
 # build to happen.  We update our local copy of META here, since we know
 # it will be rsync'd up in the next step.
-if [ -n "${2:-}" ] ; then
-  sed -i -E 's/Linux-Maximum: .+/Linux-Maximum: 99.99/g' META
+#
+# Look to see if the last argument looks like a kernel version.
+ver="${@: -1}"
+if [[ $ver =~ ^[0-9]+\.[0-9]+ ]] ; then
+  # We got a kernel version, update META to say we support it so we
+  # can test against it.
+  sed -i -E 's/Linux-Maximum: .+/Linux-Maximum: '$ver'/g' META
 fi
 
 scp .github/workflows/scripts/qemu-3-deps-vm.sh zfs@vm0:qemu-3-deps-vm.sh


### PR DESCRIPTION
### Motivation and Context
Fixes: #18526

### Description
We have an option in the `zfs-qemu-packages` workflow to test against a specific kernel version.  However, `qemu-3-deps.sh` was incorrectly hard coded to look at `$2` for the kernel version argument (which could come in `$2` or `$3` depending on if `--poweroff` was also passed).  This caused the CI to incorrectly edit META with a max supported kernel version of 99.99 when we didn't want that.

Fix this by looking at all the arguments for something that looks like a kernel version and set that as the kernel max in META.

### How Has This Been Tested?
Built packages and did not see 99.99 in META file.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
