### PR TITLE
Fix aarch64 build failure by removing earlyclobber

### DIFF
--- a/module/zfs/vdev_raidz_math_aarch64_neon_common.h
+++ b/module/zfs/vdev_raidz_math_aarch64_neon_common.h
@@ -102,14 +102,14 @@
 
 #define	WVR(X) [w##X] "=w" (w##X)
 
-#define	UVR0_(REG, ...) [w##REG] "+&w" (w##REG)
-#define	UVR1_(_1, REG, ...) [w##REG] "+&w" (w##REG)
-#define	UVR2_(_1, _2, REG, ...) [w##REG] "+&w" (w##REG)
-#define	UVR3_(_1, _2, _3, REG, ...) [w##REG] "+&w" (w##REG)
-#define	UVR4_(_1, _2, _3, _4, REG, ...) [w##REG] "+&w" (w##REG)
-#define	UVR5_(_1, _2, _3, _4, _5, REG, ...) [w##REG] "+&w" (w##REG)
-#define	UVR6_(_1, _2, _3, _4, _5, _6, REG, ...) [w##REG] "+&w" (w##REG)
-#define	UVR7_(_1, _2, _3, _4, _5, _6, _7, REG, ...) [w##REG] "+&w" (w##REG)
+#define	UVR0_(REG, ...) [w##REG] "+w" (w##REG)
+#define	UVR1_(_1, REG, ...) [w##REG] "+w" (w##REG)
+#define	UVR2_(_1, _2, REG, ...) [w##REG] "+w" (w##REG)
+#define	UVR3_(_1, _2, _3, REG, ...) [w##REG] "+w" (w##REG)
+#define	UVR4_(_1, _2, _3, _4, REG, ...) [w##REG] "+w" (w##REG)
+#define	UVR5_(_1, _2, _3, _4, _5, REG, ...) [w##REG] "+w" (w##REG)
+#define	UVR6_(_1, _2, _3, _4, _5, _6, REG, ...) [w##REG] "+w" (w##REG)
+#define	UVR7_(_1, _2, _3, _4, _5, _6, _7, REG, ...) [w##REG] "+w" (w##REG)
 
 #define	UVR0(r...) UVR0_(r)
 #define	UVR1(r...) UVR1_(r)
@@ -120,7 +120,7 @@
 #define	UVR6(r...) UVR6_(r, 36, 35, 34, 33, 32, 31)
 #define	UVR7(r...) UVR7_(r, 36, 35, 34, 33, 32, 31, 30)
 
-#define	UVR(X) [w##X] "+&w" (w##X)
+#define	UVR(X) [w##X] "+w" (w##X)
 
 #define	R_01(REG1, REG2, ...) REG1, REG2
 #define	_R_23(_0, _1, REG2, REG3, ...) REG2, REG3


### PR DESCRIPTION
### Motivation and Context

Issue #18525.  I thought I'd let Copilot take a crack at this issue, the attached patch is the result.  The analysis and patch look reasonable to me based on my reading of the [gcc early clobber documentation](https://gcc.gnu.org/onlinedocs/gcc/Modifiers.html), but I'm not an expert in this area.  @rdolbeau since you authored the original code here can you review this.
### Descriptioncompile test it.

The UVR macros used "+&w" (read-write + earlyclobber) as the constraint for NEON register operands that are declared as explicit hard-register variables via:

```
register unsigned char wN asm("vN") __attribute__((vector_size(16)));
```

The + modifier implicitly makes the operand also an input (reading the register before the asm runs). The & (earlyclobber) modifier says "this output may be written before all inputs are consumed." Having an earlyclobber output on the same hard-register that is simultaneously an input is a contradiction — GCC 16 now strictly diagnoses this.

The fix removes the & from "+&w", yielding "+w". The earlyclobber was both incorrect (contradicts the implicit input) and unnecessary (the physical registers are already hard-bound, so the compiler has no freedom to assign conflicting registers anyway).

### How Has This Been Tested?

This has received no testing.  The CI will only verify it compiles.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)