### PR TITLE
Remove arc_bcopy_func() function

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -95,8 +95,7 @@ typedef void arc_prune_func_t(uint64_t bytes, void *priv);
 extern uint_t zfs_arc_average_blocksize;
 extern int l2arc_exclude_special;
 
-/* generic arc_done_func_t's which you can use */
-arc_read_done_func_t arc_bcopy_func;
+/* generic arc_done_func_t which can be used */
 arc_read_done_func_t arc_getbuf_func;
 
 /* generic arc_prune_func_t wrapper for callbacks */

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5572,20 +5572,6 @@ arc_buf_access(arc_buf_t *buf)
 	    !HDR_ISTYPE_METADATA(hdr), data, metadata, hits);
 }
 
-/* a generic arc_read_done_func_t which you can use */
-void
-arc_bcopy_func(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
-    arc_buf_t *buf, void *arg)
-{
-	(void) zio, (void) zb, (void) bp;
-
-	if (buf == NULL)
-		return;
-
-	memcpy(arg, buf->b_data, arc_buf_size(buf));
-	arc_buf_destroy(buf, arg);
-}
-
 /* a generic arc_read_done_func_t */
 void
 arc_getbuf_func(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,


### PR DESCRIPTION
### Motivation and Context

I happened to noticed while reviewing this area of the code that `arc_bcopy_func()` is unused.

### Description

While this function could be convenient it appears it's never been used.  In practice, callers end up using the `arc_getbuf_func()` instead.  Remove this unused function.

### How Has This Been Tested?

Locally compiled.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
