### PR TITLE
zstream: fix crashes when refcount tracking enabled

### DIFF
--- a/cmd/zstream/zstream.c
+++ b/cmd/zstream/zstream.c
@@ -29,6 +29,8 @@
 #include <libintl.h>
 #include <stddef.h>
 #include <libzfs.h>
+#include <signal.h>
+#include <sys/backtrace.h>
 #include "zstream.h"
 
 void
@@ -53,9 +55,43 @@ zstream_usage(void)
 	exit(1);
 }
 
+static void sig_handler(int signo)
+{
+	struct sigaction action;
+	libspl_backtrace(STDERR_FILENO);
+
+	/*
+	 * Restore default action and re-raise signal so SIGSEGV and
+	 * SIGABRT can trigger a core dump.
+	 */
+	action.sa_handler = SIG_DFL;
+	sigemptyset(&action.sa_mask);
+	action.sa_flags = 0;
+	(void) sigaction(signo, &action, NULL);
+	raise(signo);
+}
+
+
 int
 main(int argc, char *argv[])
 {
+	/*
+	 * Set up signal handlers, so if we crash due to bad data in the stream
+	 * we can get more info. Unlike ztest, we don't bail out if we can't
+	 * set up signal handlers, because zstream is very useful without them.
+	 */
+	struct sigaction action = { .sa_handler = sig_handler };
+	sigemptyset(&action.sa_mask);
+	action.sa_flags = 0;
+	if (sigaction(SIGSEGV, &action, NULL) < 0) {
+		(void) fprintf(stderr, "zstream: cannot catch SIGSEGV: %s\n",
+		    strerror(errno));
+	}
+	if (sigaction(SIGABRT, &action, NULL) < 0) {
+		(void) fprintf(stderr, "zstream: cannot catch SIGABRT: %s\n",
+		    strerror(errno));
+	}
+
 	char *basename = strrchr(argv[0], '/');
 	basename = basename ? (basename + 1) : argv[0];
 	if (argc >= 1 && strcmp(basename, "zstreamdump") == 0)

--- a/cmd/zstream/zstream_recompress.c
+++ b/cmd/zstream/zstream_recompress.c
@@ -99,6 +99,7 @@ zstream_do_recompress(int argc, char *argv[])
 		exit(1);
 	}
 
+	zfs_refcount_init();
 	abd_init();
 	fletcher_4_init();
 	zio_init();
@@ -353,6 +354,7 @@ zstream_do_recompress(int argc, char *argv[])
 	zio_fini();
 	zstd_fini();
 	abd_fini();
+	zfs_refcount_fini();
 
 	return (0);
 }


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

I've been running tests with refcount tracking enabled to smoke out any issues. It smoked some out! This is one.

### Description

zstream's `compress` and `decompress` paths both use ABDs. In a debug build with refcount tracking enabled, ABD will add refcounts. But, `zfs_refcount_init` has not been called, so the kmem cache it uses is not setup, and allocations crash.

Two commits here. One to set up the crash handling (just bringing over the signal handlers from `zdb`/`ztest`), the other add `zfs_refcount_init()`/`_fini()` before/after `abd_init()`/`_fini()`. It's kinda the simplest thing that might work.

### How Has This Been Tested?

Mostly by hand, though it was first noticed because `rsend/send-c_zstream_recompress` exercises this path, and would crash when compiled with refcounting enabled.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).