### PR TITLE
refcount tag fixups

### DIFF
--- a/module/zfs/ddt_log.c
+++ b/module/zfs/ddt_log.c
@@ -221,7 +221,7 @@ ddt_log_begin(ddt_t *ddt, size_t nentries, dmu_tx_t *tx, ddt_log_update_t *dlu)
 	uint64_t length = nblocks * dlu->dlu_dn->dn_datablksz;
 
 	VERIFY0(dmu_buf_hold_array_by_dnode(dlu->dlu_dn, offset, length,
-	    B_FALSE, FTAG, &dlu->dlu_ndbp, &dlu->dlu_dbp,
+	    B_FALSE, dlu, &dlu->dlu_ndbp, &dlu->dlu_dbp,
 	    DMU_READ_NO_PREFETCH | DMU_UNCACHEDIO));
 
 	dlu->dlu_tx = tx;
@@ -338,7 +338,7 @@ ddt_log_commit(ddt_t *ddt, ddt_log_update_t *dlu)
 	 */
 	dmu_buf_fill_done(dlu->dlu_dbp[dlu->dlu_block], dlu->dlu_tx, B_FALSE);
 
-	dmu_buf_rele_array(dlu->dlu_dbp, dlu->dlu_ndbp, FTAG);
+	dmu_buf_rele_array(dlu->dlu_dbp, dlu->dlu_ndbp, dlu);
 
 	ddt->ddt_log_active->ddl_length +=
 	    dlu->dlu_ndbp * (uint64_t)dlu->dlu_dn->dn_datablksz;

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -490,7 +490,7 @@ dsl_bookmark_create_sync_impl_snap(const char *bookmark, const char *snapshot,
 		} else {
 			dmu_buf_t *db;
 			VERIFY0(dmu_spill_hold_by_bonus(local_rl->rl_bonus,
-			    DB_RF_MUST_SUCCEED, FTAG, &db));
+			    DB_RF_MUST_SUCCEED, tag, &db));
 			dmu_buf_will_fill(db, tx, B_FALSE);
 			VERIFY0(dbuf_spill_set_blksz(db, P2ROUNDUP(bonuslen,
 			    SPA_MINBLOCKSIZE), tx));

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -320,18 +320,18 @@ zap_lookup_norm_by_dnode(dnode_t *dn, const char *name,
 static int
 zap_lookup_length_uint64_impl(zap_t *zap, const uint64_t *key,
     int key_numints, uint64_t integer_size, uint64_t num_integers, void *buf,
-    uint64_t *actual_num_integers)
+    uint64_t *actual_num_integers, const void *tag)
 {
 	zap_name_t *zn = zap_name_alloc_uint64(zap, key, key_numints);
 	if (zn == NULL) {
-		zap_unlockdir(zap, FTAG);
+		zap_unlockdir(zap, tag);
 		return (SET_ERROR(ENOTSUP));
 	}
 
 	int err = fzap_lookup(zn, integer_size, num_integers, buf,
 	    NULL, 0, NULL, actual_num_integers);
 	zap_name_free(zn);
-	zap_unlockdir(zap, FTAG);
+	zap_unlockdir(zap, tag);
 	return (err);
 }
 
@@ -346,7 +346,7 @@ zap_lookup_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 	if (err != 0)
 		return (err);
 	err = zap_lookup_length_uint64_impl(zap, key, key_numints,
-	    integer_size, num_integers, buf, NULL);
+	    integer_size, num_integers, buf, NULL, FTAG);
 	/* zap_lookup_length_uint64_impl() calls zap_unlockdir() */
 	return (err);
 }
@@ -362,7 +362,7 @@ zap_lookup_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
 	if (err != 0)
 		return (err);
 	err = zap_lookup_length_uint64_impl(zap, key, key_numints,
-	    integer_size, num_integers, buf, NULL);
+	    integer_size, num_integers, buf, NULL, FTAG);
 	/* zap_lookup_length_uint64_impl() calls zap_unlockdir() */
 	return (err);
 }
@@ -379,7 +379,7 @@ zap_lookup_length_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
 	if (err != 0)
 		return (err);
 	err = zap_lookup_length_uint64_impl(zap, key, key_numints,
-	    integer_size, num_integers, buf, actual_num_integers);
+	    integer_size, num_integers, buf, actual_num_integers, FTAG);
 	/* zap_lookup_length_uint64_impl() calls zap_unlockdir() */
 	return (err);
 }
@@ -423,17 +423,18 @@ zap_prefetch(objset_t *os, uint64_t zapobj, const char *name)
 /* zap_prefetch_uint64 */
 
 static int
-zap_prefetch_uint64_impl(zap_t *zap, const uint64_t *key, int key_numints)
+zap_prefetch_uint64_impl(zap_t *zap, const uint64_t *key, int key_numints,
+    const void *tag)
 {
 	zap_name_t *zn = zap_name_alloc_uint64(zap, key, key_numints);
 	if (zn == NULL) {
-		zap_unlockdir(zap, FTAG);
+		zap_unlockdir(zap, tag);
 		return (SET_ERROR(ENOTSUP));
 	}
 
 	fzap_prefetch(zn);
 	zap_name_free(zn);
-	zap_unlockdir(zap, FTAG);
+	zap_unlockdir(zap, tag);
 	return (0);
 }
 
@@ -447,7 +448,7 @@ zap_prefetch_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 	    zap_lockdir(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
-	err = zap_prefetch_uint64_impl(zap, key, key_numints);
+	err = zap_prefetch_uint64_impl(zap, key, key_numints, FTAG);
 	/* zap_prefetch_uint64_impl() calls zap_unlockdir() */
 	return (err);
 }
@@ -461,7 +462,7 @@ zap_prefetch_uint64_by_dnode(dnode_t *dn, const uint64_t *key, int key_numints)
 	    zap_lockdir_by_dnode(dn, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
-	err = zap_prefetch_uint64_impl(zap, key, key_numints);
+	err = zap_prefetch_uint64_impl(zap, key, key_numints, FTAG);
 	/* zap_prefetch_uint64_impl() calls zap_unlockdir() */
 	return (err);
 }


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

I did a ZTS run with refcount tracking enabled, to confirm some of my own changes. Some existing places where we'd got our tags wrong fell out. This fixes them.

### Description

Three unrelated places:

- `zap_lookup_length_uint64_impl()` and `zap_prefetch_uint64_impl()` used `FTAG` for `zap_unlockdir()` when `zap_lockdir()` was called by their caller, so a mismatch. Fixed by using the pattern elsewhere of passing the tag from the frontend caller to the `_impl()` function.

- `ddt_log_begin()` and `ddt_log_commit()` both used `FTAG` to hold and release a dbuf array, and so mismatched. Changed to use the caller-provided `ddt_log_update_t *` as the tag, which is always the same for this pair of calls.

- `dsl_bookmark_create_sync_impl_snap()` would correctly use the passed-in tag for `dsl_redaction_list_hold_obj()` and `dsl_redaction_list_rele()`, but could also make an internal change to the returned `redaction_list_t` that added a hold, and used `FTAG` for that. Changed to use the same tag.

(Incidentally, that last is quite tangled, and probably that "and add a spill block" function should be inside `dsl_redaction_list_hold_obj()` or some kind of "upgrade" function. But I'm not putting redaction lists on my main quest line for today!)

### How Has This Been Tested?

With `reference_tracking_enable=1` and `reference_history=10`, any dedup or block cloning test will trigger the `zap_unlockdir()` crash. `recv_dedup_encrypted_zvol` was a convenient test for `ddt_log_commit()`, though probably just about any dedup test would hit it. `redacted_many_clones` tripped the redaction list crash; needs something to grow the list into the spill block.

With these patches, full ZTS run done with tracking enabled, all successful except `rsend/send-c_zstream_recompress`, see #18535 for that fix.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
