### PR TITLE
zpool: accept --help, -h, -? after a subcommand

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -13878,6 +13878,15 @@ main(int argc, char **argv)
 	if (strcmp(cmdname, "help") == 0)
 		return (zpool_do_help(argc, argv));
 
+	/*
+	 * Special case '<subcommand> --help|-h|-?'
+	 */
+	if (argc >= 3 && (strcmp(argv[2], "--help") == 0 ||
+	    strcmp(argv[2], "-h") == 0 || strcmp(argv[2], "-?") == 0)) {
+		char *help_argv[] = { argv[0], (char *)"help", argv[1], NULL };
+		return (zpool_do_help(3, help_argv));
+	}
+
 	if ((g_zfs = libzfs_init()) == NULL) {
 		(void) fprintf(stderr, "%s\n", libzfs_error_init(errno));
 		return (1);


### PR DESCRIPTION
### Motivation and Context

`zpool <subcommand> --help` (and `-h`, `-?`) prints `invalid option '-'` followed by the subcommand's usage line, instead of showing help. Same bug for every subcommand. First reported as issue 1 in #17603.

### Description

Catch `--help`, `-h`, and `-?` after a subcommand and route to the existing `zpool help <subcommand>` handler, so the man page opens.

### How Has This Been Tested?

`zpool scrub|destroy --help|-h|-?` on:
- Arch Linux 6.19.10 — shows the `zpool-<subcommand>(8)` man page.
- FreeBSD 16.0-CURRENT — same.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain Signed-off-by.