### PR TITLE
CI: Allow testing with a newer GCC on ARM builder

### DIFF
--- a/.github/workflows/zfs-arm.yml
+++ b/.github/workflows/zfs-arm.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      gcc_ver:
+        type: string
+        required: false
+        default: ""
+        description: "(optional) install specific GCC version, like '16'"
 
 jobs:
   zfs-arm:
@@ -18,6 +24,31 @@ jobs:
       timeout-minutes: 20
       run: |
         sudo apt-get -y remove firefox || true
+
+        # Do we want to test with a custom GCC version?
+        if [ "${{ github.event.inputs.gcc_ver }}" != "" ] ; then
+          ver="${{ github.event.inputs.gcc_ver }}"
+
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+
+          echo "GCCs available:"
+          awk '/Package: gcc-/{print $2}'  /var/lib/apt/lists/*ubuntu-toolchain-r*Packages
+
+          sudo apt-get -y install gcc g++ gcc-$ver g++-$ver
+
+          sudo update-alternatives --remove-all gcc || true 2>&1
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$ver 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$ver 100
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 100
+          sudo update-alternatives --set cc /usr/bin/gcc
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 100
+          sudo update-alternatives --set c++ /usr/bin/g++
+
+          sudo update-alternatives --set gcc "/usr/bin/gcc-$ver"
+          sudo update-alternatives --set g++ "/usr/bin/g++-$ver"
+        fi
+
         .github/workflows/scripts/qemu-3-deps-vm.sh ubuntu24
 
         # We're running the VM scripts locally on the runner, so need to fix
@@ -28,7 +59,12 @@ jobs:
     - name: Build modules
       timeout-minutes: 30
       run: |
-        .github/workflows/scripts/qemu-4-build-vm.sh --enable-debug ubuntu24
+        # Even though we may have installed a newer GCC, the kernel builds don't
+        # seem to honor it, and instead use the older GCC.  I assume this is
+        # to match up with whatever GCC version was used for the kernel.  Always
+        # specify KERNEL_CC to get around this.  This works when using the
+        # default GCC and with a custom GCC.
+        KERNEL_CC=/usr/bin/gcc .github/workflows/scripts/qemu-4-build-vm.sh --enable-debug ubuntu24
 
         # Quick sanity test since we're not running the full ZTS
         sudo modprobe zfs


### PR DESCRIPTION
### Motivation and Context
Allow testing with a newer GCC on the ARM builder.  https://github.com/openzfs/zfs/pull/18532 was the motivating factor.

### Description
Add a text box to specify a custom GCC version (like '16') to install when running the zfs-arm builder.  This allows you to test with a newer GCC than the Ubuntu default.

### How Has This Been Tested?
Used https://github.com/openzfs/zfs/pull/18532 as a guinea pig to verify building with GCC 13 did not induce the bug, but building with GCC 16 did.  This proved that specifying '16' in the GCC textbox really did install and use GCC 16 to build ZFS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
