### PR TITLE
zpool/zfs: accept --help and -? after a subcommand

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -9399,6 +9399,18 @@ main(int argc, char **argv)
 		return (1);
 	}
 
+	/*
+	 * Special case '<subcommand> --help|-?'
+	 */
+	if (argc >= 3 && (strcmp(argv[2], "--help") == 0 ||
+	    strcmp(argv[2], "-?") == 0)) {
+		int idx;
+		if (find_command_idx(cmdname, &idx) == 0) {
+			current_command = &command_table[idx];
+			usage(B_FALSE);
+		}
+	}
+
 	zfs_save_arguments(argc, argv, history_str, sizeof (history_str));
 
 	libzfs_print_on_error(g_zfs, B_TRUE);

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -13878,6 +13878,18 @@ main(int argc, char **argv)
 	if (strcmp(cmdname, "help") == 0)
 		return (zpool_do_help(argc, argv));
 
+	/*
+	 * Special case '<subcommand> --help|-?'
+	 */
+	if (argc >= 3 && (strcmp(argv[2], "--help") == 0 ||
+	    strcmp(argv[2], "-?") == 0)) {
+		int idx;
+		if (find_command_idx(cmdname, &idx) == 0) {
+			current_command = &command_table[idx];
+			usage(B_FALSE);
+		}
+	}
+
 	if ((g_zfs = libzfs_init()) == NULL) {
 		(void) fprintf(stderr, "%s\n", libzfs_error_init(errno));
 		return (1);


### PR DESCRIPTION
### Motivation and Context

`zpool <subcommand> --help` and  `-?` prints `invalid option '-'` followed by the subcommand's usage line, instead of showing help. Same bug for every subcommand. First reported as issue 1 in #17603.

### Description

Catch `--help` and `-?` after a subcommand, look it up in the command table, and print its short usage. Unknown subcommands fall through to the existing "unrecognized command" error.

### How Has This Been Tested?

`zpool scrub|checkpoint|create|status|attach|list --help|-?` on:
- Arch Linux 6.19.10 — prints the matching short usage and exits 0.
- FreeBSD 16.0-CURRENT — same.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain Signed-off-by.