### PR TITLE
CI: Remove deprecated Fedora 42

### DIFF
--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -78,11 +78,6 @@ case "$OS" in
     OPTS[0]="--boot"
     OPTS[1]="uefi=on"
     ;;
-  fedora42)
-    OSNAME="Fedora 42"
-    OSv="fedora-unknown"
-    URL="https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2"
-    ;;
   fedora43)
     OSNAME="Fedora 43"
     OSv="fedora-unknown"

--- a/.github/workflows/scripts/qemu-4-build-vm.sh
+++ b/.github/workflows/scripts/qemu-4-build-vm.sh
@@ -337,7 +337,7 @@ fi
 #
 # rhel8.10
 # almalinux9.5
-# fedora42
+# fedora44
 source /etc/os-release
  if which hostnamectl &> /dev/null ; then
   # Fedora 42+ use hostnamectl

--- a/.github/workflows/zfs-qemu-packages.yml
+++ b/.github/workflows/zfs-qemu-packages.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['almalinux8', 'almalinux9', 'almalinux10', 'fedora42', 'fedora43', 'fedora44']
+        os: ['almalinux8', 'almalinux9', 'almalinux10', 'fedora43', 'fedora44']
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -14,7 +14,7 @@ on:
         type: string
         required: false
         default: ""
-        description: "(optional) Only run on this specific OS (like 'fedora42' or 'alpine3-23')"
+        description: "(optional) Only run on this specific OS (like 'fedora44' or 'alpine3-23')"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -49,23 +49,23 @@ jobs:
             os_selection='[]'
             ;;
           quick)
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "debian12", "fedora42", "freebsd15-1s", "ubuntu24"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "debian12", "fedora44", "freebsd15-1s", "ubuntu24"]'
             ;;
           linux)
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora42", "fedora43", "fedora44", "ubuntu22", "ubuntu24"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora43", "fedora44", "ubuntu22", "ubuntu24"]'
             ;;
           freebsd)
             os_selection='["freebsd13-5r", "freebsd14-4r", "freebsd13-5s", "freebsd14-4s", "freebsd15-1s", "freebsd16-0c"]'
             ;;
           *)
             # default list
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora42", "fedora43", "fedora44", "freebsd14-4r", "freebsd15-1s", "freebsd16-0c", "ubuntu22", "ubuntu24"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora43", "fedora44", "freebsd14-4r", "freebsd15-1s", "freebsd16-0c", "ubuntu22", "ubuntu24"]'
             ;;
           esac
 
           # Repository-level override for OS selection.
           # Set vars.ZTS_OS_OVERRIDE in repo settings to restrict targets
-          # (e.g. '["debian13"]' or '["debian13", "fedora42"]').
+          # (e.g. '["debian13"]' or '["debian13", "fedora44"]').
           # Manual ZFS-CI-Type in commit messages bypasses the override.
           if [ -n "${{ vars.ZTS_OS_OVERRIDE }}" ] && [ "$ci_source" != "manual" ]; then
             override='${{ vars.ZTS_OS_OVERRIDE }}'


### PR DESCRIPTION
### Motivation and Context

Remove Fedora 42 from CI.

### Description

Fedora 42 was deprecated on May 13 2026.  Remove it from CI tests.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
