### PR TITLE
zap: internal locking uplift

### DIFF
--- a/include/sys/zap_impl.h
+++ b/include/sys/zap_impl.h
@@ -248,19 +248,19 @@ uint64_t zap_hash(zap_name_t *zn);
  * Return a zap_t for the given on-disk object, locked and ready for use.
  * The zap_t will be allocated and loaded from disk if its not already loaded.
  */
-int zap_lockdir(objset_t *os, uint64_t obj, dmu_tx_t *tx,
+int zap_lock(objset_t *os, uint64_t obj, dmu_tx_t *tx,
     krw_t lti, boolean_t fatreader, boolean_t adding, const void *tag,
     zap_t **zapp);
-int zap_lockdir_by_dnode(dnode_t *dn, dmu_tx_t *tx,
+int zap_lock_by_dnode(dnode_t *dn, dmu_tx_t *tx,
     krw_t lti, boolean_t fatreader, boolean_t adding, const void *tag,
     zap_t **zapp);
 
 /* Underlying implementation for above; do not use. */
-int zap_lockdir_impl(dnode_t *dn, dmu_buf_t *db, const void *tag, dmu_tx_t *tx,
+int zap_lock_impl(dnode_t *dn, dmu_buf_t *db, const void *tag, dmu_tx_t *tx,
     krw_t lti, boolean_t fatreader, boolean_t adding, zap_t **zapp);
 
 /* Unlock and release a zap_t. */
-void zap_unlockdir(zap_t *zap, const void *tag);
+void zap_unlock(zap_t *zap, const void *tag);
 
 /* zap_t release function for when associated dbuf is evicted. */
 void zap_evict_sync(void *dbu);

--- a/include/sys/zap_impl.h
+++ b/include/sys/zap_impl.h
@@ -258,6 +258,18 @@ int zap_lock_by_dnode(dnode_t *dn, dmu_tx_t *tx,
 /* Unlock and release a zap_t. */
 void zap_unlock(zap_t *zap, const void *tag);
 
+/*
+ * Try to upgrade a zap lock from READER to WRITER. If the upgrade is not
+ * possible without blocking, returns 0. If the upgrade happened, returns 1.
+ */
+int zap_lock_try_upgrade(zap_t *zap, dmu_tx_t *tx);
+
+/*
+ * Upgrade a zap lock from READER to WRITER. If it can't be upgraded
+ * immediately it will block.
+ */
+void zap_lock_upgrade(zap_t *zap, dmu_tx_t *tx);
+
 /* zap_t release function for when associated dbuf is evicted. */
 void zap_evict_sync(void *dbu);
 

--- a/include/sys/zap_impl.h
+++ b/include/sys/zap_impl.h
@@ -280,8 +280,7 @@ uint64_t zap_getflags(zap_t *zap);
 
 /* Microzap implementation. */
 zap_t *mzap_open(dmu_buf_t *db);
-int mzap_upgrade(zap_t **zapp, const void *tag, dmu_tx_t *tx,
-    zap_flags_t flags);
+int mzap_upgrade(zap_t **zapp, dmu_tx_t *tx, zap_flags_t flags);
 mzap_ent_t *mze_find(zap_name_t *zn, zfs_btree_index_t *idx);
 boolean_t mze_canfit_fzap_leaf(zap_name_t *zn, uint64_t hash);
 void mze_destroy(zap_t *zap);
@@ -300,19 +299,17 @@ int fzap_lookup(zap_name_t *zn,
     uint64_t *actual_num_integers);
 void fzap_prefetch(zap_name_t *zn);
 int fzap_add(zap_name_t *zn, uint64_t integer_size, uint64_t num_integers,
-    const void *val, const void *tag, dmu_tx_t *tx);
-int fzap_update(zap_name_t *zn,
-    int integer_size, uint64_t num_integers, const void *val,
-    const void *tag, dmu_tx_t *tx);
+    const void *val, dmu_tx_t *tx);
+int fzap_update(zap_name_t *zn, int integer_size, uint64_t num_integers,
+    const void *val, dmu_tx_t *tx);
 int fzap_length(zap_name_t *zn,
     uint64_t *integer_size, uint64_t *num_integers);
 int fzap_remove(zap_name_t *zn, dmu_tx_t *tx);
 int fzap_cursor_retrieve(zap_t *zap, zap_cursor_t *zc, zap_attribute_t *za);
 void fzap_get_stats(zap_t *zap, zap_stats_t *zs);
 void zap_put_leaf(struct zap_leaf *l);
-int fzap_add_cd(zap_name_t *zn,
-    uint64_t integer_size, uint64_t num_integers,
-    const void *val, uint32_t cd, const void *tag, dmu_tx_t *tx);
+int fzap_add_cd(zap_name_t *zn, uint64_t integer_size, uint64_t num_integers,
+    const void *val, uint32_t cd, dmu_tx_t *tx);
 void fzap_upgrade(zap_t *zap, dmu_tx_t *tx, zap_flags_t flags);
 
 #ifdef	__cplusplus

--- a/include/sys/zap_impl.h
+++ b/include/sys/zap_impl.h
@@ -255,10 +255,6 @@ int zap_lock_by_dnode(dnode_t *dn, dmu_tx_t *tx,
     krw_t lti, boolean_t fatreader, boolean_t adding, const void *tag,
     zap_t **zapp);
 
-/* Underlying implementation for above; do not use. */
-int zap_lock_impl(dnode_t *dn, dmu_buf_t *db, const void *tag, dmu_tx_t *tx,
-    krw_t lti, boolean_t fatreader, boolean_t adding, zap_t **zapp);
-
 /* Unlock and release a zap_t. */
 void zap_unlock(zap_t *zap, const void *tag);
 

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -500,14 +500,13 @@ zap_add_impl(zap_t *zap, const char *key,
 		return (SET_ERROR(ENOTSUP));
 	}
 	if (!zap->zap_ismicro) {
-		err = fzap_add(zn, integer_size, num_integers, val, tag, tx);
+		err = fzap_add(zn, integer_size, num_integers, val, tx);
 	} else if (integer_size != 8 || num_integers != 1 ||
 	    strlen(key) >= MZAP_NAME_LEN ||
 	    !mze_canfit_fzap_leaf(zn, zn->zn_hash)) {
-		err = mzap_upgrade(&zn->zn_zap, tag, tx, 0);
+		err = mzap_upgrade(&zn->zn_zap, tx, 0);
 		if (err == 0) {
-			err = fzap_add(zn, integer_size, num_integers, val,
-			    tag, tx);
+			err = fzap_add(zn, integer_size, num_integers, val, tx);
 		}
 	} else {
 		zfs_btree_index_t idx;
@@ -569,7 +568,7 @@ zap_add_uint64_impl(zap_t *zap, const uint64_t *key,
 		zap_unlock(zap, tag);
 		return (SET_ERROR(ENOTSUP));
 	}
-	err = fzap_add(zn, integer_size, num_integers, val, tag, tx);
+	err = fzap_add(zn, integer_size, num_integers, val, tx);
 	zap_name_free(zn);
 	zap_unlock(zap, tag);
 	return (err);
@@ -628,17 +627,16 @@ zap_update(objset_t *os, uint64_t zapobj, const char *name,
 		return (SET_ERROR(ENOTSUP));
 	}
 	if (!zap->zap_ismicro) {
-		err = fzap_update(zn, integer_size, num_integers, val,
-		    FTAG, tx);
+		err = fzap_update(zn, integer_size, num_integers, val, tx);
 	} else if (integer_size != 8 || num_integers != 1 ||
 	    strlen(name) >= MZAP_NAME_LEN) {
 		dprintf("upgrading obj %llu: intsz=%u numint=%llu name=%s\n",
 		    (u_longlong_t)zapobj, integer_size,
 		    (u_longlong_t)num_integers, name);
-		err = mzap_upgrade(&zn->zn_zap, FTAG, tx, 0);
+		err = mzap_upgrade(&zn->zn_zap, tx, 0);
 		if (err == 0) {
 			err = fzap_update(zn, integer_size, num_integers,
-			    val, FTAG, tx);
+			    val, tx);
 		}
 	} else {
 		zfs_btree_index_t idx;
@@ -669,7 +667,7 @@ zap_update_uint64_impl(zap_t *zap, const uint64_t *key, int key_numints,
 		zap_unlock(zap, tag);
 		return (SET_ERROR(ENOTSUP));
 	}
-	err = fzap_update(zn, integer_size, num_integers, val, tag, tx);
+	err = fzap_update(zn, integer_size, num_integers, val, tx);
 	zap_name_free(zn);
 	zap_unlock(zap, tag);
 	return (err);

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -501,7 +501,6 @@ zap_add_impl(zap_t *zap, const char *key,
 	}
 	if (!zap->zap_ismicro) {
 		err = fzap_add(zn, integer_size, num_integers, val, tag, tx);
-		zap = zn->zn_zap;	/* fzap_add() may change zap */
 	} else if (integer_size != 8 || num_integers != 1 ||
 	    strlen(key) >= MZAP_NAME_LEN ||
 	    !mze_canfit_fzap_leaf(zn, zn->zn_hash)) {
@@ -510,7 +509,6 @@ zap_add_impl(zap_t *zap, const char *key,
 			err = fzap_add(zn, integer_size, num_integers, val,
 			    tag, tx);
 		}
-		zap = zn->zn_zap;	/* fzap_add() may change zap */
 	} else {
 		zfs_btree_index_t idx;
 		if (mze_find(zn, &idx) != NULL) {
@@ -521,8 +519,7 @@ zap_add_impl(zap_t *zap, const char *key,
 	}
 	ASSERT(zap == zn->zn_zap);
 	zap_name_free(zn);
-	if (zap != NULL)	/* may be NULL if fzap_add() failed */
-		zap_unlock(zap, tag);
+	zap_unlock(zap, tag);
 	return (err);
 }
 
@@ -573,10 +570,8 @@ zap_add_uint64_impl(zap_t *zap, const uint64_t *key,
 		return (SET_ERROR(ENOTSUP));
 	}
 	err = fzap_add(zn, integer_size, num_integers, val, tag, tx);
-	zap = zn->zn_zap;	/* fzap_add() may change zap */
 	zap_name_free(zn);
-	if (zap != NULL)	/* may be NULL if fzap_add() failed */
-		zap_unlock(zap, tag);
+	zap_unlock(zap, tag);
 	return (err);
 }
 
@@ -635,7 +630,6 @@ zap_update(objset_t *os, uint64_t zapobj, const char *name,
 	if (!zap->zap_ismicro) {
 		err = fzap_update(zn, integer_size, num_integers, val,
 		    FTAG, tx);
-		zap = zn->zn_zap;	/* fzap_update() may change zap */
 	} else if (integer_size != 8 || num_integers != 1 ||
 	    strlen(name) >= MZAP_NAME_LEN) {
 		dprintf("upgrading obj %llu: intsz=%u numint=%llu name=%s\n",
@@ -646,7 +640,6 @@ zap_update(objset_t *os, uint64_t zapobj, const char *name,
 			err = fzap_update(zn, integer_size, num_integers,
 			    val, FTAG, tx);
 		}
-		zap = zn->zn_zap;	/* fzap_update() may change zap */
 	} else {
 		zfs_btree_index_t idx;
 		mzap_ent_t *mze = mze_find(zn, &idx);
@@ -658,8 +651,7 @@ zap_update(objset_t *os, uint64_t zapobj, const char *name,
 	}
 	ASSERT(zap == zn->zn_zap);
 	zap_name_free(zn);
-	if (zap != NULL)	/* may be NULL if fzap_upgrade() failed */
-		zap_unlock(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -678,10 +670,8 @@ zap_update_uint64_impl(zap_t *zap, const uint64_t *key, int key_numints,
 		return (SET_ERROR(ENOTSUP));
 	}
 	err = fzap_update(zn, integer_size, num_integers, val, tag, tx);
-	zap = zn->zn_zap;	/* fzap_update() may change zap */
 	zap_name_free(zn);
-	if (zap != NULL)	/* may be NULL if fzap_upgrade() failed */
-		zap_unlock(zap, tag);
+	zap_unlock(zap, tag);
 	return (err);
 }
 

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -288,12 +288,12 @@ zap_lookup_norm(objset_t *os, uint64_t zapobj, const char *name,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_lookup_impl(zap, name, integer_size,
 	    num_integers, buf, mt, realname, rn_len, ncp);
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -305,13 +305,13 @@ zap_lookup_norm_by_dnode(dnode_t *dn, const char *name,
 {
 	zap_t *zap;
 
-	int err = zap_lockdir_by_dnode(dn, NULL, RW_READER, TRUE, FALSE,
+	int err = zap_lock_by_dnode(dn, NULL, RW_READER, TRUE, FALSE,
 	    FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_lookup_impl(zap, name, integer_size,
 	    num_integers, buf, mt, realname, rn_len, ncp);
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -324,14 +324,14 @@ zap_lookup_length_uint64_impl(zap_t *zap, const uint64_t *key,
 {
 	zap_name_t *zn = zap_name_alloc_uint64(zap, key, key_numints);
 	if (zn == NULL) {
-		zap_unlockdir(zap, tag);
+		zap_unlock(zap, tag);
 		return (SET_ERROR(ENOTSUP));
 	}
 
 	int err = fzap_lookup(zn, integer_size, num_integers, buf,
 	    NULL, 0, NULL, actual_num_integers);
 	zap_name_free(zn);
-	zap_unlockdir(zap, tag);
+	zap_unlock(zap, tag);
 	return (err);
 }
 
@@ -342,12 +342,12 @@ zap_lookup_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_lookup_length_uint64_impl(zap, key, key_numints,
 	    integer_size, num_integers, buf, NULL, FTAG);
-	/* zap_lookup_length_uint64_impl() calls zap_unlockdir() */
+	/* zap_lookup_length_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -358,12 +358,12 @@ zap_lookup_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir_by_dnode(dn, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock_by_dnode(dn, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_lookup_length_uint64_impl(zap, key, key_numints,
 	    integer_size, num_integers, buf, NULL, FTAG);
-	/* zap_lookup_length_uint64_impl() calls zap_unlockdir() */
+	/* zap_lookup_length_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -375,12 +375,12 @@ zap_lookup_length_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir_by_dnode(dn, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock_by_dnode(dn, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_lookup_length_uint64_impl(zap, key, key_numints,
 	    integer_size, num_integers, buf, actual_num_integers, FTAG);
-	/* zap_lookup_length_uint64_impl() calls zap_unlockdir() */
+	/* zap_lookup_length_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -405,18 +405,18 @@ zap_prefetch(objset_t *os, uint64_t zapobj, const char *name)
 	int err;
 	zap_name_t *zn;
 
-	err = zap_lockdir(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	err = zap_lock(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err)
 		return (err);
 	zn = zap_name_alloc_str(zap, name, 0);
 	if (zn == NULL) {
-		zap_unlockdir(zap, FTAG);
+		zap_unlock(zap, FTAG);
 		return (SET_ERROR(ENOTSUP));
 	}
 
 	fzap_prefetch(zn);
 	zap_name_free(zn);
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -428,13 +428,13 @@ zap_prefetch_uint64_impl(zap_t *zap, const uint64_t *key, int key_numints,
 {
 	zap_name_t *zn = zap_name_alloc_uint64(zap, key, key_numints);
 	if (zn == NULL) {
-		zap_unlockdir(zap, tag);
+		zap_unlock(zap, tag);
 		return (SET_ERROR(ENOTSUP));
 	}
 
 	fzap_prefetch(zn);
 	zap_name_free(zn);
-	zap_unlockdir(zap, tag);
+	zap_unlock(zap, tag);
 	return (0);
 }
 
@@ -445,11 +445,11 @@ zap_prefetch_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_prefetch_uint64_impl(zap, key, key_numints, FTAG);
-	/* zap_prefetch_uint64_impl() calls zap_unlockdir() */
+	/* zap_prefetch_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -459,11 +459,11 @@ zap_prefetch_uint64_by_dnode(dnode_t *dn, const uint64_t *key, int key_numints)
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir_by_dnode(dn, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock_by_dnode(dn, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_prefetch_uint64_impl(zap, key, key_numints, FTAG);
-	/* zap_prefetch_uint64_impl() calls zap_unlockdir() */
+	/* zap_prefetch_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -496,7 +496,7 @@ zap_add_impl(zap_t *zap, const char *key,
 
 	zap_name_t *zn = zap_name_alloc_str(zap, key, 0);
 	if (zn == NULL) {
-		zap_unlockdir(zap, tag);
+		zap_unlock(zap, tag);
 		return (SET_ERROR(ENOTSUP));
 	}
 	if (!zap->zap_ismicro) {
@@ -522,7 +522,7 @@ zap_add_impl(zap_t *zap, const char *key,
 	ASSERT(zap == zn->zn_zap);
 	zap_name_free(zn);
 	if (zap != NULL)	/* may be NULL if fzap_add() failed */
-		zap_unlockdir(zap, tag);
+		zap_unlock(zap, tag);
 	return (err);
 }
 
@@ -534,11 +534,11 @@ zap_add(objset_t *os, uint64_t zapobj, const char *key,
 	zap_t *zap;
 	int err;
 
-	err = zap_lockdir(os, zapobj, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
+	err = zap_lock(os, zapobj, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_add_impl(zap, key, integer_size, num_integers, val, tx, FTAG);
-	/* zap_add_impl() calls zap_unlockdir() */
+	/* zap_add_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -550,11 +550,11 @@ zap_add_by_dnode(dnode_t *dn, const char *key,
 	zap_t *zap;
 	int err;
 
-	err = zap_lockdir_by_dnode(dn, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
+	err = zap_lock_by_dnode(dn, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_add_impl(zap, key, integer_size, num_integers, val, tx, FTAG);
-	/* zap_add_impl() calls zap_unlockdir() */
+	/* zap_add_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -569,14 +569,14 @@ zap_add_uint64_impl(zap_t *zap, const uint64_t *key,
 
 	zap_name_t *zn = zap_name_alloc_uint64(zap, key, key_numints);
 	if (zn == NULL) {
-		zap_unlockdir(zap, tag);
+		zap_unlock(zap, tag);
 		return (SET_ERROR(ENOTSUP));
 	}
 	err = fzap_add(zn, integer_size, num_integers, val, tag, tx);
 	zap = zn->zn_zap;	/* fzap_add() may change zap */
 	zap_name_free(zn);
 	if (zap != NULL)	/* may be NULL if fzap_add() failed */
-		zap_unlockdir(zap, tag);
+		zap_unlock(zap, tag);
 	return (err);
 }
 
@@ -588,12 +588,12 @@ zap_add_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir(os, zapobj, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
+	    zap_lock(os, zapobj, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_add_uint64_impl(zap, key, key_numints,
 	    integer_size, num_integers, val, tx, FTAG);
-	/* zap_add_uint64_impl() calls zap_unlockdir() */
+	/* zap_add_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -605,12 +605,12 @@ zap_add_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir_by_dnode(dn, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
+	    zap_lock_by_dnode(dn, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_add_uint64_impl(zap, key, key_numints,
 	    integer_size, num_integers, val, tx, FTAG);
-	/* zap_add_uint64_impl() calls zap_unlockdir() */
+	/* zap_add_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -624,12 +624,12 @@ zap_update(objset_t *os, uint64_t zapobj, const char *name,
 	const uint64_t *intval = val;
 
 	int err =
-	    zap_lockdir(os, zapobj, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
+	    zap_lock(os, zapobj, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	zap_name_t *zn = zap_name_alloc_str(zap, name, 0);
 	if (zn == NULL) {
-		zap_unlockdir(zap, FTAG);
+		zap_unlock(zap, FTAG);
 		return (SET_ERROR(ENOTSUP));
 	}
 	if (!zap->zap_ismicro) {
@@ -659,7 +659,7 @@ zap_update(objset_t *os, uint64_t zapobj, const char *name,
 	ASSERT(zap == zn->zn_zap);
 	zap_name_free(zn);
 	if (zap != NULL)	/* may be NULL if fzap_upgrade() failed */
-		zap_unlockdir(zap, FTAG);
+		zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -674,14 +674,14 @@ zap_update_uint64_impl(zap_t *zap, const uint64_t *key, int key_numints,
 
 	zap_name_t *zn = zap_name_alloc_uint64(zap, key, key_numints);
 	if (zn == NULL) {
-		zap_unlockdir(zap, tag);
+		zap_unlock(zap, tag);
 		return (SET_ERROR(ENOTSUP));
 	}
 	err = fzap_update(zn, integer_size, num_integers, val, tag, tx);
 	zap = zn->zn_zap;	/* fzap_update() may change zap */
 	zap_name_free(zn);
 	if (zap != NULL)	/* may be NULL if fzap_upgrade() failed */
-		zap_unlockdir(zap, tag);
+		zap_unlock(zap, tag);
 	return (err);
 }
 
@@ -693,12 +693,12 @@ zap_update_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir(os, zapobj, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
+	    zap_lock(os, zapobj, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_update_uint64_impl(zap, key, key_numints,
 	    integer_size, num_integers, val, tx, FTAG);
-	/* zap_update_uint64_impl() calls zap_unlockdir() */
+	/* zap_update_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -709,12 +709,12 @@ zap_update_uint64_by_dnode(dnode_t *dn, const uint64_t *key, int key_numints,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir_by_dnode(dn, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
+	    zap_lock_by_dnode(dn, tx, RW_WRITER, TRUE, TRUE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_update_uint64_impl(zap, key, key_numints,
 	    integer_size, num_integers, val, tx, FTAG);
-	/* zap_update_uint64_impl() calls zap_unlockdir() */
+	/* zap_update_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -727,12 +727,12 @@ zap_length(objset_t *os, uint64_t zapobj, const char *name,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	zap_name_t *zn = zap_name_alloc_str(zap, name, 0);
 	if (zn == NULL) {
-		zap_unlockdir(zap, FTAG);
+		zap_unlock(zap, FTAG);
 		return (SET_ERROR(ENOTSUP));
 	}
 	if (!zap->zap_ismicro) {
@@ -750,7 +750,7 @@ zap_length(objset_t *os, uint64_t zapobj, const char *name,
 		}
 	}
 	zap_name_free(zn);
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -763,17 +763,17 @@ zap_length_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	zap_name_t *zn = zap_name_alloc_uint64(zap, key, key_numints);
 	if (zn == NULL) {
-		zap_unlockdir(zap, FTAG);
+		zap_unlock(zap, FTAG);
 		return (SET_ERROR(ENOTSUP));
 	}
 	err = fzap_length(zn, integer_size, num_integers);
 	zap_name_free(zn);
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -783,18 +783,18 @@ zap_length_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
 {
 	zap_t *zap;
 
-	int err = zap_lockdir_by_dnode(dn, NULL, RW_READER, TRUE, FALSE,
+	int err = zap_lock_by_dnode(dn, NULL, RW_READER, TRUE, FALSE,
 	    FTAG, &zap);
 	if (err != 0)
 		return (err);
 	zap_name_t *zn = zap_name_alloc_uint64(zap, key, key_numints);
 	if (zn == NULL) {
-		zap_unlockdir(zap, FTAG);
+		zap_unlock(zap, FTAG);
 		return (SET_ERROR(ENOTSUP));
 	}
 	err = fzap_length(zn, integer_size, num_integers);
 	zap_name_free(zn);
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -838,11 +838,11 @@ zap_remove_by_dnode(dnode_t *dn, const char *name, dmu_tx_t *tx)
 	zap_t *zap;
 	int err;
 
-	err = zap_lockdir_by_dnode(dn, tx, RW_WRITER, TRUE, FALSE, FTAG, &zap);
+	err = zap_lock_by_dnode(dn, tx, RW_WRITER, TRUE, FALSE, FTAG, &zap);
 	if (err)
 		return (err);
 	err = zap_remove_impl(zap, name, 0, tx);
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -853,11 +853,11 @@ zap_remove_norm(objset_t *os, uint64_t zapobj, const char *name,
 	zap_t *zap;
 	int err;
 
-	err = zap_lockdir(os, zapobj, tx, RW_WRITER, TRUE, FALSE, FTAG, &zap);
+	err = zap_lock(os, zapobj, tx, RW_WRITER, TRUE, FALSE, FTAG, &zap);
 	if (err)
 		return (err);
 	err = zap_remove_impl(zap, name, mt, tx);
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -871,12 +871,12 @@ zap_remove_uint64_impl(zap_t *zap, const uint64_t *key, int key_numints,
 
 	zap_name_t *zn = zap_name_alloc_uint64(zap, key, key_numints);
 	if (zn == NULL) {
-		zap_unlockdir(zap, tag);
+		zap_unlock(zap, tag);
 		return (SET_ERROR(ENOTSUP));
 	}
 	err = fzap_remove(zn, tx);
 	zap_name_free(zn);
-	zap_unlockdir(zap, tag);
+	zap_unlock(zap, tag);
 	return (err);
 }
 
@@ -887,11 +887,11 @@ zap_remove_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir(os, zapobj, tx, RW_WRITER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock(os, zapobj, tx, RW_WRITER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_remove_uint64_impl(zap, key, key_numints, tx, FTAG);
-	/* zap_remove_uint64_impl() calls zap_unlockdir() */
+	/* zap_remove_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -902,11 +902,11 @@ zap_remove_uint64_by_dnode(dnode_t *dn, const uint64_t *key, int key_numints,
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir_by_dnode(dn, tx, RW_WRITER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock_by_dnode(dn, tx, RW_WRITER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	err = zap_remove_uint64_impl(zap, key, key_numints, tx, FTAG);
-	/* zap_remove_uint64_impl() calls zap_unlockdir() */
+	/* zap_remove_uint64_impl() calls zap_unlock() */
 	return (err);
 }
 
@@ -918,7 +918,7 @@ zap_count(objset_t *os, uint64_t zapobj, uint64_t *count)
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 	if (!zap->zap_ismicro) {
@@ -926,7 +926,7 @@ zap_count(objset_t *os, uint64_t zapobj, uint64_t *count)
 	} else {
 		*count = zap->zap_m.zap_num_entries;
 	}
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -935,7 +935,7 @@ zap_count_by_dnode(dnode_t *dn, uint64_t *count)
 {
 	zap_t *zap;
 
-	int err = zap_lockdir_by_dnode(dn, NULL, RW_READER, TRUE, FALSE,
+	int err = zap_lock_by_dnode(dn, NULL, RW_READER, TRUE, FALSE,
 	    FTAG, &zap);
 	if (err != 0)
 		return (err);
@@ -944,7 +944,7 @@ zap_count_by_dnode(dnode_t *dn, uint64_t *count)
 	} else {
 		*count = zap->zap_m.zap_num_entries;
 	}
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (err);
 }
 
@@ -1189,7 +1189,7 @@ zap_cursor_fini(zap_cursor_t *zc)
 {
 	if (zc->zc_zap) {
 		rw_enter(&zc->zc_zap->zap_rwlock, RW_READER);
-		zap_unlockdir(zc->zc_zap, NULL);
+		zap_unlock(zc->zc_zap, NULL);
 		zc->zc_zap = NULL;
 	}
 	if (zc->zc_leaf) {
@@ -1210,7 +1210,7 @@ zap_cursor_retrieve(zap_cursor_t *zc, zap_attribute_t *za)
 
 	if (zc->zc_zap == NULL) {
 		int hb;
-		err = zap_lockdir(zc->zc_objset, zc->zc_zapobj, NULL,
+		err = zap_lock(zc->zc_objset, zc->zc_zapobj, NULL,
 		    RW_READER, TRUE, FALSE, NULL, &zc->zc_zap);
 		if (err != 0)
 			return (err);
@@ -1305,7 +1305,7 @@ zap_get_stats(objset_t *os, uint64_t zapobj, zap_stats_t *zs)
 	zap_t *zap;
 
 	int err =
-	    zap_lockdir(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
+	    zap_lock(os, zapobj, NULL, RW_READER, TRUE, FALSE, FTAG, &zap);
 	if (err != 0)
 		return (err);
 
@@ -1318,7 +1318,7 @@ zap_get_stats(objset_t *os, uint64_t zapobj, zap_stats_t *zs)
 	} else {
 		fzap_get_stats(zap, zs);
 	}
-	zap_unlockdir(zap, FTAG);
+	zap_unlock(zap, FTAG);
 	return (0);
 }
 

--- a/module/zfs/zap_fat.c
+++ b/module/zfs/zap_fat.c
@@ -25,6 +25,7 @@
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2023 Alexander Stetsenko <alex.stetsenko@gmail.com>
  * Copyright (c) 2023, Klara Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 /*
@@ -155,18 +156,6 @@ fzap_upgrade(zap_t *zap, dmu_tx_t *tx, zap_flags_t flags)
 
 	kmem_free(l, sizeof (zap_leaf_t));
 	dmu_buf_rele(db, FTAG);
-}
-
-static int
-zap_tryupgradedir(zap_t *zap, dmu_tx_t *tx)
-{
-	if (RW_WRITE_HELD(&zap->zap_rwlock))
-		return (1);
-	if (rw_tryupgrade(&zap->zap_rwlock)) {
-		dmu_buf_will_dirty(zap->zap_dbuf, tx);
-		return (1);
-	}
-	return (0);
 }
 
 /*
@@ -711,6 +700,7 @@ static int
 zap_expand_leaf(zap_name_t *zn, zap_leaf_t *l,
     const void *tag, dmu_tx_t *tx, zap_leaf_t **lp)
 {
+	(void) tag;
 	zap_t *zap = zn->zn_zap;
 	uint64_t hash = zn->zn_hash;
 	int err;
@@ -722,21 +712,13 @@ zap_expand_leaf(zap_name_t *zn, zap_leaf_t *l,
 	ASSERT3U(ZAP_HASH_IDX(hash, old_prefix_len), ==,
 	    zap_leaf_phys(l)->l_hdr.lh_prefix);
 
-	if (zap_tryupgradedir(zap, tx) == 0 ||
+	if (zap_lock_try_upgrade(zap, tx) == 0 ||
 	    old_prefix_len == zap_f_phys(zap)->zap_ptrtbl.zt_shift) {
 		/* We failed to upgrade, or need to grow the pointer table */
-		objset_t *os = zap->zap_objset;
-		uint64_t object = zap->zap_object;
-
 		zap_put_leaf(l);
 		*lp = l = NULL;
-		zap_unlock(zap, tag);
-		err = zap_lock(os, object, tx, RW_WRITER,
-		    FALSE, FALSE, tag, &zn->zn_zap);
-		zap = zn->zn_zap;
-		if (err != 0)
-			return (err);
-		ASSERT(!zap->zap_ismicro);
+
+		zap_lock_upgrade(zap, tx);
 
 		while (old_prefix_len ==
 		    zap_f_phys(zap)->zap_ptrtbl.zt_shift) {
@@ -801,6 +783,7 @@ static void
 zap_put_leaf_maybe_grow_ptrtbl(zap_name_t *zn, zap_leaf_t *l,
     const void *tag, dmu_tx_t *tx)
 {
+	(void) tag;
 	zap_t *zap = zn->zn_zap;
 	int shift = zap_f_phys(zap)->zap_ptrtbl.zt_shift;
 	int leaffull = (zap_leaf_phys(l)->l_hdr.lh_prefix_len == shift &&
@@ -813,17 +796,7 @@ zap_put_leaf_maybe_grow_ptrtbl(zap_name_t *zn, zap_leaf_t *l,
 		 * We are in the middle of growing the pointer table, or
 		 * this leaf will soon make us grow it.
 		 */
-		if (zap_tryupgradedir(zap, tx) == 0) {
-			objset_t *os = zap->zap_objset;
-			uint64_t zapobj = zap->zap_object;
-
-			zap_unlock(zap, tag);
-			int err = zap_lock(os, zapobj, tx,
-			    RW_WRITER, FALSE, FALSE, tag, &zn->zn_zap);
-			zap = zn->zn_zap;
-			if (err != 0)
-				return;
-		}
+		zap_lock_upgrade(zap, tx);
 
 		/* could have finished growing while our locks were down */
 		if (zap_f_phys(zap)->zap_ptrtbl.zt_shift == shift)
@@ -946,7 +919,6 @@ retry:
 		zap_increment_num_entries(zap, 1, tx);
 	} else if (err == EAGAIN) {
 		err = zap_expand_leaf(zn, l, tag, tx, &l);
-		zap = zn->zn_zap;	/* zap_expand_leaf() may change zap */
 		if (err == 0)
 			goto retry;
 	}
@@ -1009,7 +981,6 @@ retry:
 
 	if (err == EAGAIN) {
 		err = zap_expand_leaf(zn, l, tag, tx, &l);
-		zap = zn->zn_zap;	/* zap_expand_leaf() may change zap */
 		if (err == 0)
 			goto retry;
 	}
@@ -1392,22 +1363,14 @@ zap_shrink(zap_name_t *zn, zap_leaf_t *l, dmu_tx_t *tx)
 		 * If there two empty sibling, we have work to do, so
 		 * we need to lock ZAP ptrtbl as WRITER.
 		 */
-		if (!writer && (writer = zap_tryupgradedir(zap, tx)) == 0) {
+		if (!writer && (writer = zap_lock_try_upgrade(zap, tx)) == 0) {
 			/* We failed to upgrade */
 			if (l != NULL) {
 				zap_put_leaf(l);
 				l = NULL;
 			}
 
-			/*
-			 * Usually, the right way to upgrade from a READER lock
-			 * to a WRITER lock is to call zap_unlock() and
-			 * zap_lock(), but we do not have a tag. Instead,
-			 * we do it in more sophisticated way.
-			 */
-			rw_exit(&zap->zap_rwlock);
-			rw_enter(&zap->zap_rwlock, RW_WRITER);
-			dmu_buf_will_dirty(zap->zap_dbuf, tx);
+			zap_lock_upgrade(zap, tx);
 
 			zt_shift = zap_f_phys(zap)->zap_ptrtbl.zt_shift;
 			writer = B_TRUE;

--- a/module/zfs/zap_fat.c
+++ b/module/zfs/zap_fat.c
@@ -697,10 +697,8 @@ zap_deref_leaf(zap_t *zap, uint64_t h, dmu_tx_t *tx, krw_t lt, zap_leaf_t **lp)
 }
 
 static int
-zap_expand_leaf(zap_name_t *zn, zap_leaf_t *l,
-    const void *tag, dmu_tx_t *tx, zap_leaf_t **lp)
+zap_expand_leaf(zap_name_t *zn, zap_leaf_t *l, dmu_tx_t *tx, zap_leaf_t **lp)
 {
-	(void) tag;
 	zap_t *zap = zn->zn_zap;
 	uint64_t hash = zn->zn_hash;
 	int err;
@@ -780,10 +778,8 @@ zap_expand_leaf(zap_name_t *zn, zap_leaf_t *l,
 }
 
 static void
-zap_put_leaf_maybe_grow_ptrtbl(zap_name_t *zn, zap_leaf_t *l,
-    const void *tag, dmu_tx_t *tx)
+zap_put_leaf_maybe_grow_ptrtbl(zap_name_t *zn, zap_leaf_t *l, dmu_tx_t *tx)
 {
-	(void) tag;
 	zap_t *zap = zn->zn_zap;
 	int shift = zap_f_phys(zap)->zap_ptrtbl.zt_shift;
 	int leaffull = (zap_leaf_phys(l)->l_hdr.lh_prefix_len == shift &&
@@ -887,9 +883,8 @@ fzap_lookup(zap_name_t *zn,
 }
 
 int
-fzap_add_cd(zap_name_t *zn,
-    uint64_t integer_size, uint64_t num_integers,
-    const void *val, uint32_t cd, const void *tag, dmu_tx_t *tx)
+fzap_add_cd(zap_name_t *zn, uint64_t integer_size, uint64_t num_integers,
+    const void *val, uint32_t cd, dmu_tx_t *tx)
 {
 	zap_leaf_t *l;
 	int err;
@@ -918,7 +913,7 @@ retry:
 	if (err == 0) {
 		zap_increment_num_entries(zap, 1, tx);
 	} else if (err == EAGAIN) {
-		err = zap_expand_leaf(zn, l, tag, tx, &l);
+		err = zap_expand_leaf(zn, l, tx, &l);
 		if (err == 0)
 			goto retry;
 	}
@@ -928,28 +923,26 @@ out:
 		if (err == ENOSPC)
 			zap_put_leaf(l);
 		else
-			zap_put_leaf_maybe_grow_ptrtbl(zn, l, tag, tx);
+			zap_put_leaf_maybe_grow_ptrtbl(zn, l, tx);
 	}
 	return (err);
 }
 
 int
-fzap_add(zap_name_t *zn,
-    uint64_t integer_size, uint64_t num_integers,
-    const void *val, const void *tag, dmu_tx_t *tx)
+fzap_add(zap_name_t *zn, uint64_t integer_size, uint64_t num_integers,
+    const void *val, dmu_tx_t *tx)
 {
 	int err = fzap_check(zn, integer_size, num_integers);
 	if (err != 0)
 		return (err);
 
 	return (fzap_add_cd(zn, integer_size, num_integers,
-	    val, ZAP_NEED_CD, tag, tx));
+	    val, ZAP_NEED_CD, tx));
 }
 
 int
-fzap_update(zap_name_t *zn,
-    int integer_size, uint64_t num_integers, const void *val,
-    const void *tag, dmu_tx_t *tx)
+fzap_update(zap_name_t *zn, int integer_size, uint64_t num_integers,
+    const void *val, dmu_tx_t *tx)
 {
 	zap_leaf_t *l;
 	int err;
@@ -980,7 +973,7 @@ retry:
 	}
 
 	if (err == EAGAIN) {
-		err = zap_expand_leaf(zn, l, tag, tx, &l);
+		err = zap_expand_leaf(zn, l, tx, &l);
 		if (err == 0)
 			goto retry;
 	}
@@ -989,7 +982,7 @@ retry:
 		if (err == ENOSPC)
 			zap_put_leaf(l);
 		else
-			zap_put_leaf_maybe_grow_ptrtbl(zn, l, tag, tx);
+			zap_put_leaf_maybe_grow_ptrtbl(zn, l, tx);
 	}
 	return (err);
 }

--- a/module/zfs/zap_fat.c
+++ b/module/zfs/zap_fat.c
@@ -730,8 +730,8 @@ zap_expand_leaf(zap_name_t *zn, zap_leaf_t *l,
 
 		zap_put_leaf(l);
 		*lp = l = NULL;
-		zap_unlockdir(zap, tag);
-		err = zap_lockdir(os, object, tx, RW_WRITER,
+		zap_unlock(zap, tag);
+		err = zap_lock(os, object, tx, RW_WRITER,
 		    FALSE, FALSE, tag, &zn->zn_zap);
 		zap = zn->zn_zap;
 		if (err != 0)
@@ -817,8 +817,8 @@ zap_put_leaf_maybe_grow_ptrtbl(zap_name_t *zn, zap_leaf_t *l,
 			objset_t *os = zap->zap_objset;
 			uint64_t zapobj = zap->zap_object;
 
-			zap_unlockdir(zap, tag);
-			int err = zap_lockdir(os, zapobj, tx,
+			zap_unlock(zap, tag);
+			int err = zap_lock(os, zapobj, tx,
 			    RW_WRITER, FALSE, FALSE, tag, &zn->zn_zap);
 			zap = zn->zn_zap;
 			if (err != 0)
@@ -1401,8 +1401,8 @@ zap_shrink(zap_name_t *zn, zap_leaf_t *l, dmu_tx_t *tx)
 
 			/*
 			 * Usually, the right way to upgrade from a READER lock
-			 * to a WRITER lock is to call zap_unlockdir() and
-			 * zap_lockdir(), but we do not have a tag. Instead,
+			 * to a WRITER lock is to call zap_unlock() and
+			 * zap_lock(), but we do not have a tag. Instead,
 			 * we do it in more sophisticated way.
 			 */
 			rw_exit(&zap->zap_rwlock);

--- a/module/zfs/zap_impl.c
+++ b/module/zfs/zap_impl.c
@@ -285,12 +285,8 @@ zap_hash(zap_name_t *zn)
 	return (h);
 }
 
-/*
- * This routine "consumes" the caller's hold on the dbuf, which must
- * have the specified tag.
- */
 static int
-zap_lock_impl(dnode_t *dn, dmu_buf_t *db, const void *tag, dmu_tx_t *tx,
+zap_lock_impl(dnode_t *dn, dmu_buf_t *db, dmu_tx_t *tx,
     krw_t lti, boolean_t fatreader, boolean_t adding, zap_t **zapp)
 {
 	ASSERT0(db->db_offset);
@@ -349,7 +345,7 @@ zap_lock_impl(dnode_t *dn, dmu_buf_t *db, const void *tag, dmu_tx_t *tx,
 			dprintf("upgrading obj %llu: num_entries=%u\n",
 			    (u_longlong_t)obj, zap->zap_m.zap_num_entries);
 			*zapp = zap;
-			int err = mzap_upgrade(zapp, tag, tx, 0);
+			int err = mzap_upgrade(zapp, tx, 0);
 			if (err != 0)
 				rw_exit(&zap->zap_rwlock);
 			return (err);
@@ -399,7 +395,7 @@ zap_lock_by_dnode(dnode_t *dn, dmu_tx_t *tx,
 	err = dmu_buf_hold_by_dnode(dn, 0, tag, &db, DMU_READ_NO_PREFETCH);
 	if (err != 0)
 		return (err);
-	err = zap_lock_impl(dn, db, tag, tx, lti, fatreader, adding, zapp);
+	err = zap_lock_impl(dn, db, tx, lti, fatreader, adding, zapp);
 	if (err != 0)
 		dmu_buf_rele(db, tag);
 	else

--- a/module/zfs/zap_impl.c
+++ b/module/zfs/zap_impl.c
@@ -413,22 +413,13 @@ zap_lock(objset_t *os, uint64_t obj, dmu_tx_t *tx,
     zap_t **zapp)
 {
 	dnode_t *dn;
-	dmu_buf_t *db;
 	int err;
 
 	err = dnode_hold(os, obj, tag, &dn);
 	if (err != 0)
 		return (err);
-	err = dmu_buf_hold_by_dnode(dn, 0, tag, &db, DMU_READ_NO_PREFETCH);
-	if (err != 0) {
-		dnode_rele(dn, tag);
-		return (err);
-	}
-	err = zap_lock_impl(dn, db, tag, tx, lti, fatreader, adding, zapp);
-	if (err != 0) {
-		dmu_buf_rele(db, tag);
-		dnode_rele(dn, tag);
-	}
+	err = zap_lock_by_dnode(dn, tx, lti, fatreader, adding, tag, zapp);
+	dnode_rele(dn, tag);
 	return (err);
 }
 

--- a/module/zfs/zap_impl.c
+++ b/module/zfs/zap_impl.c
@@ -290,7 +290,7 @@ zap_hash(zap_name_t *zn)
  * have the specified tag.
  */
 int
-zap_lockdir_impl(dnode_t *dn, dmu_buf_t *db, const void *tag, dmu_tx_t *tx,
+zap_lock_impl(dnode_t *dn, dmu_buf_t *db, const void *tag, dmu_tx_t *tx,
     krw_t lti, boolean_t fatreader, boolean_t adding, zap_t **zapp)
 {
 	ASSERT0(db->db_offset);
@@ -389,7 +389,7 @@ zap_lockdir_impl(dnode_t *dn, dmu_buf_t *db, const void *tag, dmu_tx_t *tx,
 }
 
 int
-zap_lockdir_by_dnode(dnode_t *dn, dmu_tx_t *tx,
+zap_lock_by_dnode(dnode_t *dn, dmu_tx_t *tx,
     krw_t lti, boolean_t fatreader, boolean_t adding, const void *tag,
     zap_t **zapp)
 {
@@ -399,7 +399,7 @@ zap_lockdir_by_dnode(dnode_t *dn, dmu_tx_t *tx,
 	err = dmu_buf_hold_by_dnode(dn, 0, tag, &db, DMU_READ_NO_PREFETCH);
 	if (err != 0)
 		return (err);
-	err = zap_lockdir_impl(dn, db, tag, tx, lti, fatreader, adding, zapp);
+	err = zap_lock_impl(dn, db, tag, tx, lti, fatreader, adding, zapp);
 	if (err != 0)
 		dmu_buf_rele(db, tag);
 	else
@@ -408,7 +408,7 @@ zap_lockdir_by_dnode(dnode_t *dn, dmu_tx_t *tx,
 }
 
 int
-zap_lockdir(objset_t *os, uint64_t obj, dmu_tx_t *tx,
+zap_lock(objset_t *os, uint64_t obj, dmu_tx_t *tx,
     krw_t lti, boolean_t fatreader, boolean_t adding, const void *tag,
     zap_t **zapp)
 {
@@ -424,7 +424,7 @@ zap_lockdir(objset_t *os, uint64_t obj, dmu_tx_t *tx,
 		dnode_rele(dn, tag);
 		return (err);
 	}
-	err = zap_lockdir_impl(dn, db, tag, tx, lti, fatreader, adding, zapp);
+	err = zap_lock_impl(dn, db, tag, tx, lti, fatreader, adding, zapp);
 	if (err != 0) {
 		dmu_buf_rele(db, tag);
 		dnode_rele(dn, tag);
@@ -433,7 +433,7 @@ zap_lockdir(objset_t *os, uint64_t obj, dmu_tx_t *tx,
 }
 
 void
-zap_unlockdir(zap_t *zap, const void *tag)
+zap_unlock(zap_t *zap, const void *tag)
 {
 	rw_exit(&zap->zap_rwlock);
 	dnode_rele(zap->zap_dnode, tag);

--- a/module/zfs/zap_impl.c
+++ b/module/zfs/zap_impl.c
@@ -431,6 +431,43 @@ zap_unlock(zap_t *zap, const void *tag)
 	dmu_buf_rele(zap->zap_dbuf, tag);
 }
 
+int
+zap_lock_try_upgrade(zap_t *zap, dmu_tx_t *tx)
+{
+	if (RW_WRITE_HELD(&zap->zap_rwlock))
+		/* Already have writer, nothing to do. */
+		return (1);
+
+	/* Try to upgrade the lock in-place. */
+	if (rw_tryupgrade(&zap->zap_rwlock)) {
+		/*
+		 * Got it, mark buffer dirty, since we only do that in
+		 * zap_lock_impl() for writer.
+		 */
+		dmu_buf_will_dirty(zap->zap_dbuf, tx);
+		return (1);
+	}
+
+	return (0);
+}
+
+void
+zap_lock_upgrade(zap_t *zap, dmu_tx_t *tx)
+{
+	if (zap_lock_try_upgrade(zap, tx))
+		return;
+
+	/*
+	 * It's safe to drop the lock here because we still have a hold on
+	 * zap_dbuf, which prevents the dbuf being evicted and the zap_t being
+	 * deallocated.
+	 */
+	rw_exit(&zap->zap_rwlock);
+
+	rw_enter(&zap->zap_rwlock, RW_WRITER);
+	dmu_buf_will_dirty(zap->zap_dbuf, tx);
+}
+
 void
 zap_evict_sync(void *dbu)
 {

--- a/module/zfs/zap_impl.c
+++ b/module/zfs/zap_impl.c
@@ -289,7 +289,7 @@ zap_hash(zap_name_t *zn)
  * This routine "consumes" the caller's hold on the dbuf, which must
  * have the specified tag.
  */
-int
+static int
 zap_lock_impl(dnode_t *dn, dmu_buf_t *db, const void *tag, dmu_tx_t *tx,
     krw_t lti, boolean_t fatreader, boolean_t adding, zap_t **zapp)
 {

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -255,9 +255,8 @@ mzap_open(dmu_buf_t *db)
 	}
 
 	/*
-	 * Make sure that zap_ismicro is set before we let others see
-	 * it, because zap_lockdir() checks zap_ismicro without the lock
-	 * held.
+	 * Make sure that zap_ismicro is set before we let others see it,
+	 * because zap_lock() checks zap_ismicro without the lock held.
 	 */
 	dmu_buf_init_user(&zap->zap_dbu, zap_evict_sync, NULL, &zap->zap_dbuf);
 	winner = dmu_buf_set_user(db, &zap->zap_dbu);
@@ -407,10 +406,10 @@ mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 		zap_t *zap;
 		/* Only fat zap supports flags; upgrade immediately. */
 		VERIFY(dnode_add_ref(dn, FTAG));
-		VERIFY0(zap_lockdir_impl(dn, db, FTAG, tx, RW_WRITER,
+		VERIFY0(zap_lock_impl(dn, db, FTAG, tx, RW_WRITER,
 		    B_FALSE, B_FALSE, &zap));
 		VERIFY0(mzap_upgrade(&zap, FTAG, tx, flags));
-		zap_unlockdir(zap, FTAG);
+		zap_unlock(zap, FTAG);
 	} else {
 		dmu_buf_rele(db, FTAG);
 	}

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -363,7 +363,6 @@ mzap_upgrade(zap_t **zapp, const void *tag, dmu_tx_t *tx, zap_flags_t flags)
 		/* If we fail here, we would end up losing entries */
 		VERIFY0(fzap_add_cd(zn, 8, 1, &mze->mze_value, mze->mze_cd,
 		    tag, tx));
-		zap = zn->zn_zap;	/* fzap_add_cd() may change zap */
 	}
 	zap_name_free(zn);
 	vmem_free(mzp, sz);

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -324,7 +324,7 @@ handle_winner:
 }
 
 int
-mzap_upgrade(zap_t **zapp, const void *tag, dmu_tx_t *tx, zap_flags_t flags)
+mzap_upgrade(zap_t **zapp, dmu_tx_t *tx, zap_flags_t flags)
 {
 	int err = 0;
 	zap_t *zap = *zapp;
@@ -362,7 +362,7 @@ mzap_upgrade(zap_t **zapp, const void *tag, dmu_tx_t *tx, zap_flags_t flags)
 		zap_name_init_str(zn, mze->mze_name, 0);
 		/* If we fail here, we would end up losing entries */
 		VERIFY0(fzap_add_cd(zn, 8, 1, &mze->mze_value, mze->mze_cd,
-		    tag, tx));
+		    tx));
 	}
 	zap_name_free(zn);
 	vmem_free(mzp, sz);
@@ -406,7 +406,7 @@ mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 		/* Only fat zap supports flags; upgrade immediately. */
 		VERIFY0(zap_lock_by_dnode(dn, tx,
 		    RW_WRITER, B_FALSE, B_FALSE, FTAG, &zap));
-		VERIFY0(mzap_upgrade(&zap, FTAG, tx, flags));
+		VERIFY0(mzap_upgrade(&zap, tx, flags));
 		zap_unlock(zap, FTAG);
 	}
 

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -405,14 +405,13 @@ mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 	if (flags != 0) {
 		zap_t *zap;
 		/* Only fat zap supports flags; upgrade immediately. */
-		VERIFY(dnode_add_ref(dn, FTAG));
-		VERIFY0(zap_lock_impl(dn, db, FTAG, tx, RW_WRITER,
-		    B_FALSE, B_FALSE, &zap));
+		VERIFY0(zap_lock_by_dnode(dn, tx,
+		    RW_WRITER, B_FALSE, B_FALSE, FTAG, &zap));
 		VERIFY0(mzap_upgrade(&zap, FTAG, tx, flags));
 		zap_unlock(zap, FTAG);
-	} else {
-		dmu_buf_rele(db, FTAG);
 	}
+
+	dmu_buf_rele(db, FTAG);
 }
 
 /*


### PR DESCRIPTION
### Motivation and Context

Further cleanup following #18516, working towards cleaner and more modular internals and laying the foundation for the unit tests.

### Description

See the commit messages. High-level, in order:

- rename `lockdir`/`unlockdir` to just `lock` and `unlock`
- make `zap_lock()` a simple wrapper around `zap_lock_by_dnode()` to reduce repetition and scope for errors (also foreshadowing the next PR)
- simplify `mzap_create_impl()` by using `zap_lock_by_dnode()`, and then de-exporting `zap_lock_impl()`
- simplify the "lock upgrade" dance when a fatzap header block update is required
- cleanup use of refcount tags made possible by previous commit

The "lock upgrade" one is the most involved, but I think my reasoning is sound.

### How Has This Been Tested?

Full ZTS pass on Linux with and without `reference_tracking_enable` set. Multiple ztest runs, no complaints.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
