### PR TITLE
CI: Add Ubuntu 26.04 builder

### DIFF
--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -139,6 +139,11 @@ case "$OS" in
     OSv="ubuntu24.04"
     URL="$UBMIRROR/noble/current/noble-server-cloudimg-amd64.img"
     ;;
+  ubuntu26)
+    OSNAME="Ubuntu 26.04"
+    OSv="ubuntu24.04"
+    URL="$UBMIRROR/resolute/current/resolute-server-cloudimg-amd64.img"
+    ;;
   *)
     echo "Wrong value for OS variable!"
     exit 111

--- a/.github/workflows/scripts/qemu-3-deps-vm.sh
+++ b/.github/workflows/scripts/qemu-3-deps-vm.sh
@@ -215,7 +215,7 @@ case "$1" in
   tumbleweed)
     tumbleweed
     ;;
-  ubuntu*)
+  ubuntu22|ubuntu24)
     debian
     echo "##[group]Install Ubuntu specific"
     sudo apt-get install -yq linux-tools-common libtirpc-dev \
@@ -225,6 +225,27 @@ case "$1" in
     # Need 'build-essential' explicitly for ARM builder
     # https://github.com/actions/runner-images/issues/9946
     sudo apt-get install -yq build-essential
+
+    echo "##[endgroup]"
+    echo "##[group]Delete Ubuntu OpenZFS modules"
+    for i in $(find /lib/modules -name zfs -type d); do sudo rm -rvf $i; done
+    echo "##[endgroup]"
+    ;;
+  ubuntu26)
+    debian
+    echo "##[group]Install Ubuntu specific"
+    # Skip linux-modules-extra which is already installed
+    sudo apt-get install -yq linux-tools-common
+    sudo apt-get install -yq libtirpc-dev
+    sudo apt-get install -yq dh-sequence-dkms
+
+    # Need 'build-essential' explicitly for ARM builder
+    # https://github.com/actions/runner-images/issues/9946
+    sudo apt-get install -yq build-essential
+
+    # Replace sudo-rs with sudo for now because the Rust version
+    # does not support -E to preserve the entire environment
+    sudo update-alternatives --set sudo /usr/bin/sudo.ws
 
     echo "##[endgroup]"
     echo "##[group]Delete Ubuntu OpenZFS modules"
@@ -292,7 +313,7 @@ case "$1" in
     echo 'GRUB_SERIAL_COMMAND="serial --speed=115200"' \
       | sudo tee -a /etc/default/grub >/dev/null
     ;;
-  ubuntu24)
+  ubuntu24|ubuntu26)
     GRUB_CFG="/boot/grub/grub.cfg"
     GRUB_MKCONFIG="grub-mkconfig"
     echo 'GRUB_DISABLE_OS_PROBER="false"' \

--- a/.github/workflows/scripts/qemu-3-deps-vm.sh
+++ b/.github/workflows/scripts/qemu-3-deps-vm.sh
@@ -290,6 +290,9 @@ case "$1" in
     sudo -E systemctl enable nfs-kernel-server
     sudo -E systemctl enable smbd
 
+    # enable usershares (disabled by default on ubuntu 26.04)
+    sudo -E sed -i '/usershare max shares/s/^#//' /etc/samba/smb.conf
+
     # add systemd drop-in to allow the service to be enabled
     sudo -E mkdir -p /etc/systemd/system/qemu-guest-agent.service.d/
     sudo -E tee /etc/systemd/system/qemu-guest-agent.service.d/override.conf <<EOF

--- a/.github/workflows/scripts/qemu-3-deps-vm.sh
+++ b/.github/workflows/scripts/qemu-3-deps-vm.sh
@@ -288,8 +288,16 @@ case "$1" in
     ;;
   debian*|ubuntu*)
     sudo -E systemctl enable nfs-kernel-server
-    sudo -E systemctl enable qemu-guest-agent
     sudo -E systemctl enable smbd
+
+    # add systemd drop-in to allow the service to be enabled
+    sudo -E mkdir -p /etc/systemd/system/qemu-guest-agent.service.d/
+    sudo -E tee /etc/systemd/system/qemu-guest-agent.service.d/override.conf <<EOF
+[Install]
+WantedBy=multi-user.target
+EOF
+    sudo -E systemctl daemon-reload
+    sudo -E systemctl enable qemu-guest-agent
     ;;
   *)
     # All other linux distros

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -49,17 +49,17 @@ jobs:
             os_selection='[]'
             ;;
           quick)
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "debian12", "fedora44", "freebsd15-1s", "ubuntu24"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "debian12", "fedora44", "freebsd15-1s", "ubuntu26"]'
             ;;
           linux)
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora43", "fedora44", "ubuntu22", "ubuntu24"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora43", "fedora44", "ubuntu22", "ubuntu24", "ubuntu26"]'
             ;;
           freebsd)
             os_selection='["freebsd14-4r", "freebsd14-4s", "freebsd15-1s", "freebsd16-0c"]'
             ;;
           *)
             # default list
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora43", "fedora44", "freebsd14-4r", "freebsd15-1s", "freebsd16-0c", "ubuntu22", "ubuntu24"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora43", "fedora44", "freebsd14-4r", "freebsd15-1s", "freebsd16-0c", "ubuntu22", "ubuntu24", "ubuntu26"]'
             ;;
           esac
 
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         # rhl:     almalinux8, almalinux9, centos-streamX, fedora4x
-        # debian:  debian12, debian13, ubuntu22, ubuntu24
+        # debian:  debian12, debian13, ubuntu22, ubuntu24, ubuntu26
         # misc:    archlinux, tumbleweed
         # FreeBSD variants of november 2025:
         # FreeBSD Release: freebsd14-4r, freebsd15-0r

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ All RHEL (and compatible systems: AlmaLinux OS, Rocky Linux, etc) on the **full*
 
 All Ubuntu **LTS** releases are supported.
 
-**Supported Ubuntu releases**: **24.04 “Noble”**, **22.04 “Jammy”**.
+**Supported Ubuntu releases**: **26.04 “Resolute”**, **24.04 “Noble”**, **22.04 “Jammy”**.
 
 ### Debian
 

--- a/tests/zfs-tests/tests/functional/devices/devices_common.kshlib
+++ b/tests/zfs-tests/tests/functional/devices/devices_common.kshlib
@@ -54,9 +54,9 @@ function create_dev_file
 			# %t - major device type in hex
 			# %T - minor device type in hex
 			#
-			major=$(stat --dereference --format="%t" "$devstr")
-			minor=$(stat --dereference --format="%T" "$devstr")
-			log_must mknod $filename b "0x${major}" "0x${minor}"
+			major=$(printf '%d' 0x$(stat -L -c "%t" "$devstr"))
+			minor=$(printf '%d' 0x$(stat -L -c "%T" "$devstr"))
+			log_must mknod $filename b "${major}" "${minor}"
 			;;
 		*)
 			#
@@ -83,9 +83,9 @@ function create_dev_file
 			# %t - major device type in hex
 			# %T - minor device type in hex
 			#
-			major=$(stat --format="%t" /dev/null)
-			minor=$(stat --format="%T" /dev/null)
-			log_must mknod $filename c "0x${major}" "0x${minor}"
+			major=$(printf '%d' 0x$(stat -c "%t" /dev/null))
+			minor=$(printf '%d' 0x$(stat -c "%T" /dev/null))
+			log_must mknod $filename c "${major}" "${minor}"
 			;;
 		FreeBSD)
 			#

--- a/tests/zfs-tests/tests/functional/stat/statx_dioalign.ksh
+++ b/tests/zfs-tests/tests/functional/stat/statx_dioalign.ksh
@@ -89,7 +89,8 @@ typeset -i PAGE_SIZE=$(getconf PAGE_SIZE)
 # Set recordsize to 128K, and make a 64K file (so only one block) for the
 # sizing tests below.
 log_must zfs set recordsize=128K $TESTDS
-log_must dd if=/dev/urandom of=$TESTFILE bs=64k count=1
+log_must rm -f $TESTFILE
+log_must stride_dd -i /dev/urandom -o $TESTFILE -b 65536 -c 1
 log_must zpool sync
 
 # when DIO is disabled via tunable, statx will not return the dioalign result
@@ -141,7 +142,7 @@ done
 # Now we extend the file into its second block. This effectively locks in its
 # block size, which will always be returned regardless of recordsize changes.
 log_must zfs set recordsize=128K $TESTDS
-log_must dd if=/dev/urandom of=$TESTFILE bs=192K count=1
+log_must stride_dd -i /dev/urandom -o $TESTFILE -b 196608 -c 1
 log_must zpool sync
 
 # Confirm that no matter how we change the recordsize, the alignment remains at
@@ -167,14 +168,14 @@ log_must rm -f $TESTFILE
 log_must touch $TESTFILE
 log_must zpool sync
 assert_dioalign $TESTFILE $PAGE_SIZE 16384
-log_must dd if=/dev/urandom of=$TESTFILE bs=16384 count=16 oflag=direct
+log_must stride_dd -i /dev/urandom -o $TESTFILE -b 16384 -c 16 -D
 
 # same again, but writing with incorrect alignment, which should fail.
 log_must rm -f $TESTFILE
 log_must touch $TESTFILE
 log_must zpool sync
 assert_dioalign $TESTFILE $PAGE_SIZE 16384
-log_mustnot dd if=/dev/urandom of=$TESTFILE bs=1024 count=256 oflag=direct
+log_mustnot stride_dd -i /dev/urandom -o $TESTFILE -b 1024 -c 256 -D
 
 # same again, but without strict, which should succeed.
 log_must set_tunable32 DIO_STRICT 0
@@ -182,6 +183,6 @@ log_must rm -f $TESTFILE
 log_must touch $TESTFILE
 log_must zpool sync
 assert_dioalign $TESTFILE $PAGE_SIZE 16384
-log_must dd if=/dev/urandom of=$TESTFILE bs=1024 count=256 oflag=direct
+log_must stride_dd -i /dev/urandom -o $TESTFILE -b 1024 -c 256 -D
 
 log_pass $CLAIM


### PR DESCRIPTION
### Motivation and Context

Ubuntu 26.04 is the latest LTS release and should be included in our test matrix.

### Description

Adds three commits to get the Ubuntu 26.04 test environment in place.  The changes needed were minimal, but I did need to add `ubunut26` case to `qemu-3-deps-vm.sh`.  As of this release rust-coreutils replaces the traditional coreutils and while it's _almost_ a drop in replacement there are differences.

One such difference is that the rust version of `sudo` does not support the `-E` option to preserve the environment.  This is used by out test infrastructure and changing that would be significant.  Thankfully `update-alternatives` can be used to easily switch back to the default.  This works for now but may become a bigger issue depending on rust-coreutils adoption.

Another minor hiccup was the `mknod` command no longer accepts hex values for the major and minor numbers.  I've updated the test case to pass decimal values instead.

- CI: Add Ubuntu 26.04 builder
- CI: Fix qemu-guest-agent systemd enable
- ZTS: Pass dec instead of hex to mknod

### How Has This Been Tested?

This was tested by the CI in my fork and all tests are passing except two.  These failures need to be investigated to determine what's changed in the environment.

Lastly, there's a small CI change to fix an issue which prevented systemd from enabling the `qemu-guest-agent` on Debian and Ubunutu.  I happened to notice this while looking through the logs.

```
Tests with results other than PASS that are unexpected:
    FAIL cli_root/zfs_unshare/zfs_unshare_006_pos (expected PASS)
    FAIL stat/statx_dioalign (expected PASS)
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)