### PR TITLE
zap_impl: use flex array field for `mzap_phys_t.mz_chunks[]`

### DIFF
--- a/include/sys/zap_impl.h
+++ b/include/sys/zap_impl.h
@@ -62,8 +62,9 @@ typedef struct mzap_phys {
 	uint64_t mz_salt;
 	uint64_t mz_normflags;
 	uint64_t mz_pad[5];
-	mzap_ent_phys_t mz_chunk[1];
+
 	/* actually variable size depending on block size */
+	mzap_ent_phys_t mz_chunk[];
 } mzap_phys_t;
 
 typedef struct mzap_ent {


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Silence UBSAN warnings.

Fixes: #18549

### Description

`mz_phys_t` is always a full-block allocation, with `mz_chunks[]` as an array over the rest of the block past the header.

Recent Linux compiled with `CONFIG_UBSAN` will complain about this:

    UBSAN: array-index-out-of-bounds in /home/robn/code/zfs-extra/module/zfs/zap.c:1236:28
    index 2 is out of range for type 'mzap_ent_phys_t [1]'

The fix is straightforward; simply convert this field to a flex member.

### How Has This Been Tested?

Tested on Linux 7.0.8 with/without `CONFIG_UBSAN` enabled. Before patch, warns on `CONFIG_UBSAN=y`. After, no more warnings.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).