### PR TITLE
CI: remove FreeBSD 13.5 (EOL April 30, 2026)

### DIFF
--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -88,14 +88,6 @@ case "$OS" in
     OSv="fedora-unknown"
     URL="https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
     ;;
-  freebsd13-5r)
-    FreeBSD="13.5-RELEASE"
-    OSNAME="FreeBSD $FreeBSD"
-    OSv="freebsd13.0"
-    URLxz="$FREEBSD_REL/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI.raw.xz"
-    KSRC="$FREEBSD_REL/../amd64/$FreeBSD/src.txz"
-    NIC="rtl8139"
-    ;;
   freebsd14-4r)
     FreeBSD="14.4-RELEASE"
     OSNAME="FreeBSD $FreeBSD"
@@ -109,14 +101,6 @@ case "$OS" in
     OSv="freebsd15.0"
     URLxz="$FREEBSD_REL/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI-ufs.raw.xz"
     KSRC="$FREEBSD_REL/../amd64/$FreeBSD/src.txz"
-    ;;
-  freebsd13-5s)
-    FreeBSD="13.5-STABLE"
-    OSNAME="FreeBSD $FreeBSD"
-    OSv="freebsd13.0"
-    URLxz="$FREEBSD_SNAP/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI.raw.xz"
-    KSRC="$FREEBSD_SNAP/../amd64/$FreeBSD/src.txz"
-    NIC="rtl8139"
     ;;
   freebsd14-4s)
     FreeBSD="14.4-STABLE"
@@ -168,7 +152,6 @@ echo "ENV=$ENV" >> $ENV
 # result path
 echo 'RESPATH="/var/tmp/test_results"' >> $ENV
 
-# FreeBSD 13 has problems with: e1000 and virtio
 echo "NIC=$NIC" >> $ENV
 
 # freebsd15 -> used in zfs-qemu.yml

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -55,7 +55,7 @@ jobs:
             os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora43", "fedora44", "ubuntu22", "ubuntu24"]'
             ;;
           freebsd)
-            os_selection='["freebsd13-5r", "freebsd14-4r", "freebsd13-5s", "freebsd14-4s", "freebsd15-1s", "freebsd16-0c"]'
+            os_selection='["freebsd14-4r", "freebsd14-4s", "freebsd15-1s", "freebsd16-0c"]'
             ;;
           *)
             # default list
@@ -102,8 +102,8 @@ jobs:
         # debian:  debian12, debian13, ubuntu22, ubuntu24
         # misc:    archlinux, tumbleweed
         # FreeBSD variants of november 2025:
-        # FreeBSD Release: freebsd13-5r, freebsd14-4r, freebsd15-0r
-        # FreeBSD Stable:  freebsd13-5s, freebsd14-4s, freebsd15-1s
+        # FreeBSD Release: freebsd14-4r, freebsd15-0r
+        # FreeBSD Stable:  freebsd14-4s, freebsd15-1s
         # FreeBSD Current: freebsd16-0c
         os: ${{ fromJson(needs.test-config.outputs.test_os) }}
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ Generally, if a distribution is following an LTS kernel, it should work well wit
 
 All FreeBSD releases receiving [security support](https://www.freebsd.org/security/#sup) are supported by OpenZFS.
 
-**Supported FreeBSD releases**: **15.0**, **14.4**, **13.5**.
+**Supported FreeBSD releases**: **15.0**, **14.4**.


### PR DESCRIPTION
### Motivation and Context

FreeBSD 13.5 and the `stable/13` branch reached End-of-Life on April 30, 2026. After EOL, no further security fixes will be published by the FreeBSD Security Team.

### Description

- `README.md`: drop **13.5** from the supported FreeBSD versions.
- `.github/workflows/zfs-qemu.yml`: remove `freebsd13-5r` and `freebsd13-5s` from the `freebsd` preset's `os_selection`.
- `.github/workflows/scripts/qemu-2-start.sh`: remove the `freebsd13-5r` and `freebsd13-5s`.

### How Has This Been Tested?

CI will test the changes.

### Types of changes
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **contributing** document.
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain ``Signed-off-by``.