### PR TITLE
config: show progress output for kernel API checks

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -153,9 +153,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_SRC], [
 			;;
 	esac
 
-	AC_MSG_CHECKING([for available kernel interfaces])
-	ZFS_LINUX_TEST_COMPILE_ALL([kabi])
-	AC_MSG_RESULT([done])
+	ZFS_LINUX_TEST_COMPILE_ALL([kabi], [for available kernel interfaces])
 ])
 
 dnl #
@@ -754,6 +752,108 @@ AC_DEFUN([ZFS_LINUX_TEST_MODPOST], [
 ])
 
 dnl #
+dnl # Progress output for ZFS_LINUX_TEST_COMPILE_ALL
+dnl #
+dnl # From clean, we currently have ~250 kernel tests to compile. This can
+dnl # take anywhere from a few seconds to a few minutes while we wait for
+dnl # the module build invocation to complete (see ZFS_LINUX_COMPILE).
+dnl #
+dnl # To show some progress in the main set of tests, we start a background
+dnl # job to monitor the build progress and update the output.
+dnl #
+AC_DEFUN([_ZFS_LINUX_TEST_COMPILE_PROGRESS_START], [
+	dnl # normal "checking for..." output
+	AC_MSG_CHECKING([$2])
+
+	dnl # don't start the background job if configure was called with
+	dnl # --silent or --quiet, or if configure's output stream is not
+	dnl # attached to a terminal
+	AS_IF([test "x$silent" != "xyes" -a -t AS_MESSAGE_FD], [
+		dnl # save "checking" message for cleanup later
+		_zfs_linux_test_progress_text="$2"
+
+		dnl # new shell job in background
+		(
+			dnl # ZFS_LINUX_CONFTEST_MAKEFILE adds one line per
+			dnl # test to the top Makefile, so the line count
+			dnl # is our target
+			total=$(wc -l < $1/Makefile)
+			count=0
+
+			dnl # eject if our parent process has gone away. this
+			dnl # is protection against the parent being killed.
+			dnl # (we can't use trap because autoconf generates
+			dnl # that and doesn't provide an easy way to hook it).
+			while kill -0 $$ 2>/dev/null ; do
+
+				dnl # ZFS_LINUX_TEST_COMPILE_ALL has a short
+				dnl # second stage for modpost, where build.log
+				dnl # recreated. we make some effort to both
+				dnl # detect that and handle it, mostly by
+				dnl # making sure the counter never goes
+				dnl # backwards.
+				if test "$count" -lt "$total" ; then
+					dnl # if build.log went away, then
+					dnl # we never got to do a last count,
+					dnl # so we can assume they're all
+					dnl # finished and just bump the count
+					dnl # to the total
+					if ! test -f $1/build.log ; then
+						count=$total
+					else
+						dnl # look for compilation lines
+						dnl # (CC) for .o files that
+						dnl # are in a dir (so not
+						dnl # whole-of-build artifacts)
+						dnl # and only have a a single
+						dnl # period (so not .mod.o
+						dnl # link artifacts)
+						count_n=$(awk '/CC/ && /\/[[^\.]]+\.o$/ { c++ } END { print c }' $1/build.log 2>/dev/null)
+						if test "x$count_n" != "x" ; then
+							dnl # empty output
+							dnl # means awk failed,
+							dnl # likely build.log
+							dnl # went away. use
+							dnl # the current count
+							count=$count_n
+						fi
+					fi
+
+					dnl # re-output the entire message with
+					dnl # the new counts
+					printf '\rchecking %s... %d/%d' "$2" "$count" "$total" >&6
+				fi
+
+				dnl # yield before loop
+				sleep 0.5
+			done
+		) &
+
+		dnl # save the pid so we can kill it later
+		_zfs_linux_test_progress_pid=$!
+	])
+])
+
+AC_DEFUN([_ZFS_LINUX_TEST_COMPILE_PROGRESS_DONE], [
+	dnl # only do cleanup if we actually started the job
+	AS_IF([test "x$_zfs_linux_test_progress_pid" != "x"], [
+		dnl # kill it; no-op if it already died
+		kill $_zfs_linux_test_progress_pid 2>/dev/null
+		dnl # wait for it to really go away and clean it up
+		wait $_zfs_linux_test_progress_pid 2>/dev/null
+		dnl # reprint the original checking line. the control code
+		dnl # is ANSI "erase entire line"
+		printf '\r\033\1332Kchecking %s... ' "$_zfs_linux_test_progress_text" >&AS_MESSAGE_FD
+		dnl # cleanup for next run
+		_zfs_linux_test_progress_pid=
+		_zfs_linux_test_progress_text=
+	])
+
+	dnl # normal final output for screen and config.log
+	AC_MSG_RESULT([$1])
+])
+
+dnl #
 dnl # Perform the compilation of the test cases in two phases.
 dnl #
 dnl # Phase 1) attempt to build the object files for all of the tests
@@ -771,6 +871,10 @@ dnl # The maximum allowed parallelism can be controlled by setting the
 dnl # TEST_JOBS environment variable.  Otherwise, it default to $(nproc).
 dnl #
 AC_DEFUN([ZFS_LINUX_TEST_COMPILE_ALL], [
+	AS_IF([test "x$2" != "x"], [
+		_ZFS_LINUX_TEST_COMPILE_PROGRESS_START([build], [$2])
+	])
+
 	dnl # Phase 1 - Compilation only, final linking is skipped.
 	ZFS_LINUX_TEST_COMPILE([$1], [build])
 
@@ -817,6 +921,10 @@ AC_DEFUN([ZFS_LINUX_TEST_COMPILE_ALL], [
 				touch build/$name/$name.ko
 			])
 		done
+	])
+
+	AS_IF([test "x$2" != "x"], [
+		_ZFS_LINUX_TEST_COMPILE_PROGRESS_DONE([done])
 	])
 ])
 


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Someone asked emailed me and asked why configure was hanging at `checking for available kernel interfaces...`. Of course it wasn't, it was just they were building on some potato dev board. But it reminded me that I don't like it sitting there even on my nice computer that only takes a few seconds, and I was in a mood so I did something about it.

### Description

At the start of `ZFS_LINUX_TEST_COMPILE_ALL`, start a background job that watches `build.log` and updates a simple counter on screen as modules are built. In silent mode, or when not attached to a terminal, there's no background job, and it just does as it always has.

Here's a demo: https://asciinema.org/a/zf7wFvgp1q5ltvCf . Done on a RPi4, itself a potato, playback at 2x and its still glacial. So the numbers help to while away the hours...

### How Has This Been Tested?

Ran configure a lot with various options, with/without `--config-cache`, output redirected to file, output piped away, and so on. Nothing obviously weird happened! Sanity checked on FreeBSD, which doesn't run the Linux kernel checks, and sure enough, continues not to :sweat_smile:

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
