### PR TITLE
spl_kvmalloc: remove __GFP_COMP before calling vmalloc()

### DIFF
--- a/module/os/linux/spl/spl-kmem.c
+++ b/module/os/linux/spl/spl-kmem.c
@@ -188,6 +188,12 @@ spl_kvmalloc(size_t size, gfp_t lflags)
 		return (ptr);
 	}
 
+	/*
+	 * vmalloc fallback. KM_VMEM may not have been requested originally if
+	 * we've come through spl_kmem_alloc_impl(), so we need to remove
+	 * __GFP_COMP, which is not a valid flag for vmalloc.
+	 */
+	lflags &= ~__GFP_COMP;
 	return (spl_vmalloc(size, lflags));
 }
 


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Fixes: #18556

### Description

In cb1833023 we stopped using `__GFP_COMP` for `KM_VMEM` allocations, since its not a valid flag for `vmalloc()`. However, there's a fallback path for non-`KM_VMEM` allocations to use `vmalloc()`, and we need to remove __GFP_COMP there too to avoid a warning.

### How Has This Been Tested?

Full ZTS run completed on 7.0.8, no hits. However, I had not seen this before either, and its not entirely clear to me how to reproduce it without simulating certain kinds of kernel memory pressure.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).