### PR TITLE
CI: correct os-variant for FreeBSD 15.1-STABLE

### DIFF
--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -112,7 +112,7 @@ case "$OS" in
   freebsd15-1s)
     FreeBSD="15.1-STABLE"
     OSNAME="FreeBSD $FreeBSD"
-    OSv="freebsd14.0"
+    OSv="freebsd15.0"
     URLxz="$FREEBSD_SNAP/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI-ufs.raw.xz"
     KSRC="$FREEBSD_SNAP/../amd64/$FreeBSD/src.txz"
     ;;


### PR DESCRIPTION
### Motivation and Context

virt-install was given OSv=freebsd14.0 for the freebsd15-1s VM, but libosinfo has a freebsd15.0 entry.

### Description

Change `OSv` from `freebsd14.0` to `freebsd15.0` for the `freebsd15-1s` case branch in `qemu-2-start.sh`.

### How Has This Been Tested?

CI will tell ... 

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [x] I have read the contributing document.
- [x] All commit messages are properly formatted and contain Signed-off-by.