### PR TITLE
CI: enable FreeBSD 15.0-RELEASE in matrix

### DIFF
--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -98,7 +98,7 @@ case "$OS" in
   freebsd15-0r)
     FreeBSD="15.0-RELEASE"
     OSNAME="FreeBSD $FreeBSD"
-    OSv="freebsd15.0"
+    OSv="freebsd14.0"
     URLxz="$FREEBSD_REL/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI-ufs.raw.xz"
     KSRC="$FREEBSD_REL/../amd64/$FreeBSD/src.txz"
     ;;

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -55,11 +55,11 @@ jobs:
             os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora43", "fedora44", "ubuntu22", "ubuntu24", "ubuntu26"]'
             ;;
           freebsd)
-            os_selection='["freebsd14-4r", "freebsd14-4s", "freebsd15-1s", "freebsd16-0c"]'
+            os_selection='["freebsd14-4r", "freebsd14-4s", "freebsd15-0r", "freebsd15-1s", "freebsd16-0c"]'
             ;;
           *)
             # default list
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora43", "fedora44", "freebsd14-4r", "freebsd15-1s", "freebsd16-0c", "ubuntu22", "ubuntu24", "ubuntu26"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora43", "fedora44", "freebsd14-4r", "freebsd15-0r", "freebsd15-1s", "freebsd16-0c", "ubuntu22", "ubuntu24", "ubuntu26"]'
             ;;
           esac
 


### PR DESCRIPTION
### Motivation and Context

15.0-RELEASE is upstream-supported until September 30, 2026 but there is no `freebsd15-0r` preset reference.

### Description

Add `freebsd15-0r` to the `default` and `freebsd` presets in `zfs-qemu.yml`.

### How Has This Been Tested?

CI will tell ... 

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [x] I have read the contributing document.
- [x] All commit messages are properly formatted and contain Signed-off-by.