### PR TITLE
CI: Build custom branch from zfs-qemu-packages

### DIFF
--- a/.github/workflows/scripts/qemu-4-build-vm.sh
+++ b/.github/workflows/scripts/qemu-4-build-vm.sh
@@ -5,10 +5,12 @@
 #
 # Usage:
 #
-#       qemu-4-build-vm.sh OS [--enable-debug][--dkms][--patch-level NUM]
-#               [--poweroff][--release][--repo][--tarball]
+#       qemu-4-build-vm.sh OS [--custom-branch BRANCH][--enable-debug][--dkms]
+#               [--patch-level NUM][--poweroff][--release][--repo][--tarball]
 #
 # OS:           OS name like 'fedora41'
+# --custom-branch: When building packages, checkout this version of ZFS to
+#                  build, but use the current CI scripts to do it.
 # --enable-debug:  Build RPMs with '--enable-debug' (for testing)
 # --dkms:       Build DKMS RPMs as well
 # --patch-level NUM:    Use a custom patch level number for packages.
@@ -27,8 +29,27 @@ POWEROFF=""
 RELEASE=""
 REPO=""
 TARBALL=""
+CUSTOM_BRANCH=""
+PREV_BRANCH=""
+
+cleanup() {
+  if [ -n "$PREV_BRANCH" ] ; then
+    git checkout $PREV_BRANCH
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case $1 in
+    --custom-branch)
+      CUSTOM_BRANCH="$2"
+      # If the user specifies a custom tag/branch to build, and the build
+      # fails, we want to make sure our workflow scripts are restored to the
+      # current (more modern) versions so the subsequent CI steps use those.
+      shift
+      shift
+      PREV_BRANCH=$(git branch --show-current)
+      trap 'cleanup' ERR
+      ;;
     --enable-debug)
       ENABLE_DEBUG=1
       shift
@@ -367,6 +388,11 @@ if [ -n "$ENABLE_DEBUG" ] ; then
   extra="--enable-debug"
 fi
 
+if [ -n "$CUSTOM_BRANCH" ] ; then
+  git fetch --unshallow
+  git checkout $CUSTOM_BRANCH
+fi
+
 # build
 case "$OS" in
   freebsd*)
@@ -393,6 +419,8 @@ case "$OS" in
     ;;
 esac
 
+git checkout $PREV_BRANCH
+PREV_BRANCH=""
 
 # building the zfs module was ok
 echo 0 > /var/tmp/build-exitcode.txt

--- a/.github/workflows/zfs-qemu-packages.yml
+++ b/.github/workflows/zfs-qemu-packages.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: ""
         description: "(optional) repo URL (blank: use http://download.zfsonlinux.org)"
+      custom_branch:
+        type: string
+        required: false
+        default: ""
+        description: "(optional) custom tag/branch to build using current CI (like 'zfs-2.2.9')"
       lookup:
         type: boolean
         required: false
@@ -94,9 +99,16 @@ jobs:
                 if [ -n "${{ github.event.inputs.patch_level }}" ] ; then
                         EXTRA="--patch-level ${{ github.event.inputs.patch_level }}"
                 fi
+                if [ -n "${{ github.event.inputs.custom_branch }}" ] ; then
+                        EXTRA+=" --custom-branch ${{ github.event.inputs.custom_branch }}"
+                fi
 
                 .github/workflows/scripts/qemu-4-build.sh $EXTRA \
                         --repo --release --dkms --tarball ${{ matrix.os }}
+
+                if [ -n "${{ github.event.inputs.custom_branch }}" ] ; then
+                        echo "Built packages for ${{ github.event.inputs.custom_branch }}"
+                fi
         fi
 
     - name: Prepare artifacts


### PR DESCRIPTION
### Motivation and Context
Build RPMs for older branchs using the current CI environment 

### Description
The `zfs-qemu-packages` workflow allows us to easily build RPMs for the current branch.  However, there can be cases where we want to use the current CI environment to build older releases.  This can happen when the VM or runner environment changes, and the older CI doesn't have the updates needed to run with it anymore.

This commit adds in a text box to specify a specific branch/tag to build using the current CI environment.

### How Has This Been Tested?
Built zfs-2.2.9 packages that wouldn't build using the older zfs-2.2.9 CI files.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
