### PR TITLE
CI: skip full CI runs on push events

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
+    if: github.event_name == 'pull_request' || github.repository != 'openzfs/zfs'
     runs-on: ubuntu-22.04
     permissions:
       actions: read

--- a/.github/workflows/smatch.yml
+++ b/.github/workflows/smatch.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   smatch:
+    if: github.event_name == 'pull_request' || github.repository != 'openzfs/zfs'
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout smatch

--- a/.github/workflows/zfs-arm.yml
+++ b/.github/workflows/zfs-arm.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   zfs-arm:
     name: ZFS ARM build
+    if: github.event_name == 'pull_request' || github.repository != 'openzfs/zfs'
     runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   test-config:
     name: Setup
+    if: github.event_name == 'pull_request' || github.repository != 'openzfs/zfs'
     runs-on: ubuntu-24.04
     outputs:
       test_os: ${{ steps.os.outputs.os }}
@@ -94,7 +95,10 @@ jobs:
   qemu-vm:
     name: qemu-x86
     needs: [ test-config ]
-    if: needs.test-config.outputs.ci_type != 'docs'
+    if: >-
+      (github.event_name == 'pull_request' ||
+      github.repository != 'openzfs/zfs') &&
+      needs.test-config.outputs.ci_type != 'docs'
     strategy:
       fail-fast: false
       matrix:
@@ -157,7 +161,10 @@ jobs:
       run: .github/workflows/scripts/qemu-8-summary.sh '${{ steps.artifact-upload.outputs.artifact-url }}'
 
   cleanup:
-    if: always()
+    if: >-
+      (github.event_name == 'pull_request' ||
+      github.repository != 'openzfs/zfs') &&
+      always()
     name: Cleanup
     runs-on: ubuntu-latest
     needs: [ qemu-vm ]


### PR DESCRIPTION
### Motivation and Context

Prioritize leaving CI resources available for PRs rather than retesting commits post-merge.

### Description

~Update the CI to only perform full CI runs on the master branch weekly instead of on every push.  Furthermore, restrict these scheduled runs to the canonical openzfs/zfs repository so they are not performed on forks.  The sole excecption is checkstyle which has been left enabled for push events.~

Full CI runs for proposed changes always occur in the PR where the review is done and patch approved.  Once merged the full CI is run again using the merged commit.  This is somewhat overkill.  In the interest of reducing the CI load only run the zloop and checkstyle workflows which are enough to verify the build on the master branch.  Push events to forks will continue to trigger a full CI run.

### How Has This Been Tested?

Lightly tested in my fork.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)