### PR TITLE
Persist z_seq across znode eviction

### DIFF
--- a/include/os/linux/zfs/sys/trace_acl.h
+++ b/include/os/linux/zfs/sys/trace_acl.h
@@ -54,7 +54,7 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __field(uint8_t,		z_atime_dirty)
 	    __field(uint8_t,		z_zn_prefetch)
 	    __field(uint_t,		z_blksz)
-	    __field(uint_t,		z_seq)
+	    __field(uint64_t,		z_seq)
 	    __field(uint64_t,		z_mapcnt)
 	    __field(uint64_t,		z_size)
 	    __field(uint64_t,		z_pflags)
@@ -111,7 +111,7 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __entry->mask_matched	= mask_matched;
 	),
 	TP_printk("zn { id %llu unlinked %u atime_dirty %u "
-	    "zn_prefetch %u blksz %u seq %u "
+	    "zn_prefetch %u blksz %u seq %llu "
 	    "mapcnt %llu size %llu pflags %llu "
 	    "sync_cnt %u "
 	    "mode 0x%x is_sa %d is_ctldir %d "

--- a/include/sys/zfs_sa.h
+++ b/include/sys/zfs_sa.h
@@ -76,6 +76,7 @@ typedef enum zpl_attr {
 	ZPL_DACL_ACES,
 	ZPL_DXATTR,
 	ZPL_PROJID,
+	ZPL_SEQ,
 	ZPL_END
 } zpl_attr_t;
 

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -112,6 +112,30 @@ extern "C" {
 #define	SA_ZPL_DXATTR(z)	z->z_attr_table[ZPL_DXATTR]
 #define	SA_ZPL_PAD(z)		z->z_attr_table[ZPL_PAD]
 #define	SA_ZPL_PROJID(z)	z->z_attr_table[ZPL_PROJID]
+#define	SA_ZPL_SEQ(z)		z->z_attr_table[ZPL_SEQ]
+
+/*
+ * may_grow for a dmu_tx_hold_sa() that may persist z_seq: the SA layout
+ * grows the first time SA_ZPL_SEQ is added, so grow until z_has_seq is
+ * set. z_has_seq is an in-core only marker (see znode_t) and is never
+ * persisted, so no global pflag bit is consumed.
+ */
+#define	ZFS_SEQ_MAY_GROW(zp)	\
+	((zp)->z_has_seq ? B_FALSE : B_TRUE)
+
+/*
+ * Persist zp->z_seq: mark z_has_seq and add SA_ZPL_SEQ to the caller's
+ * bulk. No-op for legacy (non-SA-native) znodes. Chunked writers add
+ * SA_ZPL_SEQ once before their loop and set z_has_seq per chunk instead.
+ */
+#define	ZFS_PERSIST_SEQ(zp, bulk, count) \
+{ \
+	if ((zp)->z_is_sa) { \
+		(zp)->z_has_seq = B_TRUE; \
+		SA_ADD_BULK_ATTR((bulk), (count), SA_ZPL_SEQ(ZTOZSB(zp)), \
+		    NULL, &(zp)->z_seq, 8); \
+	} \
+}
 
 /*
  * Is ID ephemeral?
@@ -195,8 +219,9 @@ typedef struct znode {
 	boolean_t	z_is_ctldir;	/* are we .zfs entry */
 	boolean_t	z_suspended;	/* extra ref from a suspend? */
 	boolean_t	z_xattr_dir_absent;	/* no xattr dir (cached) */
+	boolean_t	z_has_seq;	/* SA_ZPL_SEQ present (in-core only) */
 	uint_t		z_blksz;	/* block size in bytes */
-	uint_t		z_seq;		/* modification sequence number */
+	uint64_t	z_seq;		/* modification sequence number */
 	uint64_t	z_mapcnt;	/* number of pages mapped to file */
 	uint64_t	z_dnodesize;	/* dnode size */
 	uint64_t	z_size;		/* file size (cached) */

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -1317,6 +1317,7 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 
 	zfs_tstamp_update_setup(zp, STATE_CHANGED, NULL, ctime);
 	ZFS_PERSIST_SEQ(zp, bulk, count);
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	return (sa_bulk_update(zp->z_sa_hdl, bulk, count, tx));
 }
 

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -1170,7 +1170,7 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 	dmu_object_type_t	otype;
 	zfs_acl_locator_cb_t	locate = { 0 };
 	uint64_t		mode;
-	sa_bulk_attr_t		bulk[5];
+	sa_bulk_attr_t		bulk[6];
 	uint64_t		ctime[2];
 	int			count = 0;
 	zfs_acl_phys_t		acl_phys;
@@ -1316,6 +1316,7 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 		zp->z_pflags |= ZFS_ACL_TRIVIAL;
 
 	zfs_tstamp_update_setup(zp, STATE_CHANGED, NULL, ctime);
+	ZFS_PERSIST_SEQ(zp, bulk, count);
 	return (sa_bulk_update(zp->z_sa_hdl, bulk, count, tx));
 }
 

--- a/module/os/freebsd/zfs/zfs_dir.c
+++ b/module/os/freebsd/zfs/zfs_dir.c
@@ -649,6 +649,7 @@ zfs_link_create(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 		    ctime);
 		ZFS_PERSIST_SEQ(zp, bulk, count);
 	}
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 
@@ -667,6 +668,7 @@ zfs_link_create(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 	    &dzp->z_pflags, sizeof (dzp->z_pflags));
 	zfs_tstamp_update_setup(dzp, CONTENT_MODIFIED, mtime, ctime);
 	ZFS_PERSIST_SEQ(dzp, bulk, count);
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(dzp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 	return (0);
@@ -784,6 +786,7 @@ zfs_link_destroy(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 		}
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zfsvfs),
 		    NULL, &zp->z_links, sizeof (zp->z_links));
+		ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 		error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 		count = 0;
 		ASSERT0(error);
@@ -808,6 +811,7 @@ zfs_link_destroy(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 	    NULL, &dzp->z_pflags, sizeof (dzp->z_pflags));
 	zfs_tstamp_update_setup(dzp, CONTENT_MODIFIED, mtime, ctime);
 	ZFS_PERSIST_SEQ(dzp, bulk, count);
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(dzp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 

--- a/module/os/freebsd/zfs/zfs_dir.c
+++ b/module/os/freebsd/zfs/zfs_dir.c
@@ -394,9 +394,9 @@ zfs_purgedir(znode_t *dzp)
 		    (ZTOV(xzp)->v_type == VLNK));
 
 		tx = dmu_tx_create(zfsvfs->z_os);
-		dmu_tx_hold_sa(tx, dzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 		dmu_tx_hold_zap(tx, dzp->z_id, FALSE, zap->za_name);
-		dmu_tx_hold_sa(tx, xzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, xzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(xzp));
 		dmu_tx_hold_zap(tx, zfsvfs->z_unlinkedobj, FALSE, NULL);
 		/* Is this really needed ? */
 		zfs_sa_upgrade_txholds(tx, xzp);
@@ -584,7 +584,7 @@ zfs_link_create(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 	vnode_t *vp = ZTOV(zp);
 	uint64_t value;
 	int zp_is_dir = (vp->v_type == VDIR);
-	sa_bulk_attr_t bulk[5];
+	sa_bulk_attr_t bulk[6];
 	uint64_t mtime[2], ctime[2];
 	int count = 0;
 	int error;
@@ -647,6 +647,7 @@ zfs_link_create(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 		    ctime, sizeof (ctime));
 		zfs_tstamp_update_setup(zp, STATE_CHANGED, mtime,
 		    ctime);
+		ZFS_PERSIST_SEQ(zp, bulk, count);
 	}
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
@@ -665,6 +666,7 @@ zfs_link_create(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs), NULL,
 	    &dzp->z_pflags, sizeof (dzp->z_pflags));
 	zfs_tstamp_update_setup(dzp, CONTENT_MODIFIED, mtime, ctime);
+	ZFS_PERSIST_SEQ(dzp, bulk, count);
 	error = sa_bulk_update(dzp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 	return (0);
@@ -729,7 +731,7 @@ zfs_link_destroy(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 	vnode_t *vp = ZTOV(zp);
 	int zp_is_dir = (vp->v_type == VDIR);
 	boolean_t unlinked = B_FALSE;
-	sa_bulk_attr_t bulk[5];
+	sa_bulk_attr_t bulk[6];
 	uint64_t mtime[2], ctime[2];
 	int count = 0;
 	int error;
@@ -764,6 +766,13 @@ zfs_link_destroy(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 			zp->z_unlinked = B_TRUE;
 			zp->z_links = 0;
 			unlinked = B_TRUE;
+			/*
+			 * NFS observers see nlink=0; advance change_cookie.
+			 * POSIX permits skipping the ctime stamp at nlink=0,
+			 * and the znode is destined for reap so persistence
+			 * would be wasted.
+			 */
+			atomic_inc_64(&zp->z_seq);
 		} else {
 			SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs),
 			    NULL, &ctime, sizeof (ctime));
@@ -771,6 +780,7 @@ zfs_link_destroy(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 			    NULL, &zp->z_pflags, sizeof (zp->z_pflags));
 			zfs_tstamp_update_setup(zp, STATE_CHANGED, mtime,
 			    ctime);
+			ZFS_PERSIST_SEQ(zp, bulk, count);
 		}
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zfsvfs),
 		    NULL, &zp->z_links, sizeof (zp->z_links));
@@ -797,6 +807,7 @@ zfs_link_destroy(znode_t *dzp, const char *name, znode_t *zp, dmu_tx_t *tx,
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs),
 	    NULL, &dzp->z_pflags, sizeof (dzp->z_pflags));
 	zfs_tstamp_update_setup(dzp, CONTENT_MODIFIED, mtime, ctime);
+	ZFS_PERSIST_SEQ(dzp, bulk, count);
 	error = sa_bulk_update(dzp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -2321,7 +2321,7 @@ zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
 	boolean_t skipaclchk = (flags & ATTR_NOACLCHECK) ? B_TRUE : B_FALSE;
 	boolean_t	fuid_dirtied = B_FALSE;
 	boolean_t	handle_eadir = B_FALSE;
-	sa_bulk_attr_t	bulk[9], xattr_bulk[7];
+	sa_bulk_attr_t	bulk[9], xattr_bulk[6];
 	int		count = 0, xattr_count = 0;
 
 	if (mask == 0)
@@ -2985,6 +2985,7 @@ zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
 	}
 out:
 	if (err == 0 && attrzp) {
+		ASSERT3S(xattr_count, <=, ARRAY_SIZE(xattr_bulk));
 		err2 = sa_bulk_update(attrzp->z_sa_hdl, xattr_bulk,
 		    xattr_count, tx);
 		ASSERT0(err2);
@@ -3003,6 +3004,7 @@ out:
 		if (attrzp)
 			vput(ZTOV(attrzp));
 	} else {
+		ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 		err2 = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 		dmu_tx_commit(tx);
 		if (attrzp) {
@@ -4501,6 +4503,7 @@ zfs_putpages(struct vnode *vp, vm_page_t *ma, size_t len, int flags,
 		    &zp->z_pflags, 8);
 		zfs_tstamp_update_setup(zp, CONTENT_MODIFIED, mtime, ctime);
 		ZFS_PERSIST_SEQ(zp, bulk, count);
+		ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 		err = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 		ASSERT0(err);
 

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -1138,7 +1138,7 @@ zfs_create(znode_t *dzp, const char *name, vattr_t *vap, int excl, int mode,
 	if (fuid_dirtied)
 		zfs_fuid_txhold(zfsvfs, tx);
 	dmu_tx_hold_zap(tx, dzp->z_id, TRUE, name);
-	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 	if (!zfsvfs->z_use_sa &&
 	    acl_ids.z_aclp->z_acl_bytes > ZFS_ACE_SPACE) {
 		dmu_tx_hold_write(tx, DMU_NEW_OBJECT,
@@ -1269,7 +1269,8 @@ zfs_remove_(vnode_t *dvp, vnode_t *vp, const char *name, cred_t *cr)
 	 */
 	tx = dmu_tx_create(zfsvfs->z_os);
 	dmu_tx_hold_zap(tx, dzp->z_id, FALSE, name);
-	dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
+	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 	zfs_sa_upgrade_txholds(tx, zp);
 	zfs_sa_upgrade_txholds(tx, dzp);
 
@@ -1497,6 +1498,7 @@ zfs_mkdir(znode_t *dzp, const char *dirname, vattr_t *vap, znode_t **zpp,
 	tx = dmu_tx_create(zfsvfs->z_os);
 	dmu_tx_hold_zap(tx, dzp->z_id, TRUE, dirname);
 	dmu_tx_hold_zap(tx, DMU_NEW_OBJECT, FALSE, NULL);
+	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 	fuid_dirtied = zfsvfs->z_fuid_dirty;
 	if (fuid_dirtied)
 		zfs_fuid_txhold(zfsvfs, tx);
@@ -1605,7 +1607,8 @@ zfs_rmdir_(vnode_t *dvp, vnode_t *vp, const char *name, cred_t *cr)
 
 	tx = dmu_tx_create(zfsvfs->z_os);
 	dmu_tx_hold_zap(tx, dzp->z_id, FALSE, name);
-	dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
+	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 	dmu_tx_hold_zap(tx, zfsvfs->z_unlinkedobj, FALSE, NULL);
 	zfs_sa_upgrade_txholds(tx, zp);
 	zfs_sa_upgrade_txholds(tx, dzp);
@@ -2012,7 +2015,7 @@ zfs_getattr(vnode_t *vp, vattr_t *vap, int flags, cred_t *cr)
 		vap->va_rdev = NODEV;
 	vap->va_gen = zp->z_gen;
 	vap->va_flags = 0;	/* FreeBSD: Reset chflags(2) flags. */
-	vap->va_filerev = zp->z_seq;
+	vap->va_filerev = atomic_load_64(&zp->z_seq);
 
 	/*
 	 * Add in any requested optional attributes and the create time.
@@ -2318,7 +2321,7 @@ zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
 	boolean_t skipaclchk = (flags & ATTR_NOACLCHECK) ? B_TRUE : B_FALSE;
 	boolean_t	fuid_dirtied = B_FALSE;
 	boolean_t	handle_eadir = B_FALSE;
-	sa_bulk_attr_t	bulk[7], xattr_bulk[7];
+	sa_bulk_attr_t	bulk[9], xattr_bulk[7];
 	int		count = 0, xattr_count = 0;
 
 	if (mask == 0)
@@ -2758,14 +2761,15 @@ zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
 		if (((mask & AT_XVATTR) &&
 		    XVA_ISSET_REQ(xvap, XAT_AV_SCANSTAMP)) ||
 		    (projid != ZFS_INVALID_PROJID &&
-		    !(zp->z_pflags & ZFS_PROJID)))
+		    !(zp->z_pflags & ZFS_PROJID)) ||
+		    !zp->z_has_seq)
 			dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_TRUE);
 		else
 			dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
 	}
 
 	if (attrzp) {
-		dmu_tx_hold_sa(tx, attrzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, attrzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(attrzp));
 	}
 
 	fuid_dirtied = zfsvfs->z_fuid_dirty;
@@ -2908,16 +2912,19 @@ zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs), NULL,
 		    &ctime, sizeof (ctime));
 		zfs_tstamp_update_setup(zp, CONTENT_MODIFIED, mtime, ctime);
+		ZFS_PERSIST_SEQ(zp, bulk, count);
 	} else if (mask != 0) {
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs), NULL,
 		    &ctime, sizeof (ctime));
 		zfs_tstamp_update_setup(zp, STATE_CHANGED, mtime, ctime);
+		ZFS_PERSIST_SEQ(zp, bulk, count);
 		if (attrzp) {
 			SA_ADD_BULK_ATTR(xattr_bulk, xattr_count,
 			    SA_ZPL_CTIME(zfsvfs), NULL,
 			    &ctime, sizeof (ctime));
 			zfs_tstamp_update_setup(attrzp, STATE_CHANGED,
 			    mtime, ctime);
+			ZFS_PERSIST_SEQ(attrzp, xattr_bulk, xattr_count);
 		}
 	}
 
@@ -3464,16 +3471,16 @@ zfs_do_rename_impl(vnode_t *sdvp, vnode_t **svpp, struct componentname *scnp,
 	}
 
 	tx = dmu_tx_create(zfsvfs->z_os);
-	dmu_tx_hold_sa(tx, szp->z_sa_hdl, B_FALSE);
-	dmu_tx_hold_sa(tx, sdzp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, szp->z_sa_hdl, ZFS_SEQ_MAY_GROW(szp));
+	dmu_tx_hold_sa(tx, sdzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(sdzp));
 	dmu_tx_hold_zap(tx, sdzp->z_id, FALSE, snm);
 	dmu_tx_hold_zap(tx, tdzp->z_id, TRUE, tnm);
 	if (sdzp != tdzp) {
-		dmu_tx_hold_sa(tx, tdzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, tdzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(tdzp));
 		zfs_sa_upgrade_txholds(tx, tdzp);
 	}
 	if (tzp) {
-		dmu_tx_hold_sa(tx, tzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, tzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(tzp));
 		zfs_sa_upgrade_txholds(tx, tzp);
 	}
 
@@ -3672,7 +3679,7 @@ zfs_symlink(znode_t *dzp, const char *name, vattr_t *vap,
 	dmu_tx_hold_zap(tx, dzp->z_id, TRUE, name);
 	dmu_tx_hold_sa_create(tx, acl_ids.z_aclp->z_acl_bytes +
 	    ZFS_SA_BASE_ATTR_SIZE + len);
-	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 	if (!zfsvfs->z_use_sa && acl_ids.z_aclp->z_acl_bytes > ZFS_ACE_SPACE) {
 		dmu_tx_hold_write(tx, DMU_NEW_OBJECT, 0,
 		    acl_ids.z_aclp->z_acl_bytes);
@@ -3894,7 +3901,8 @@ zfs_link(znode_t *tdzp, znode_t *szp, const char *name, cred_t *cr,
 	}
 
 	tx = dmu_tx_create(zfsvfs->z_os);
-	dmu_tx_hold_sa(tx, szp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, szp->z_sa_hdl, ZFS_SEQ_MAY_GROW(szp));
+	dmu_tx_hold_sa(tx, tdzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(tdzp));
 	dmu_tx_hold_zap(tx, tdzp->z_id, TRUE, name);
 	zfs_sa_upgrade_txholds(tx, szp);
 	zfs_sa_upgrade_txholds(tx, tdzp);
@@ -4458,7 +4466,7 @@ zfs_putpages(struct vnode *vp, vm_page_t *ma, size_t len, int flags,
 	tx = dmu_tx_create(zfsvfs->z_os);
 	dmu_tx_hold_write(tx, zp->z_id, off, len);
 
-	dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
 	zfs_sa_upgrade_txholds(tx, zp);
 	err = dmu_tx_assign(tx, DMU_TX_WAIT);
 	if (err != 0) {
@@ -4482,7 +4490,7 @@ zfs_putpages(struct vnode *vp, vm_page_t *ma, size_t len, int flags,
 
 	if (err == 0) {
 		uint64_t mtime[2], ctime[2];
-		sa_bulk_attr_t bulk[3];
+		sa_bulk_attr_t bulk[4];
 		int count = 0;
 
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(zfsvfs), NULL,
@@ -4492,6 +4500,7 @@ zfs_putpages(struct vnode *vp, vm_page_t *ma, size_t len, int flags,
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs), NULL,
 		    &zp->z_pflags, 8);
 		zfs_tstamp_update_setup(zp, CONTENT_MODIFIED, mtime, ctime);
+		ZFS_PERSIST_SEQ(zp, bulk, count);
 		err = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 		ASSERT0(err);
 

--- a/module/os/freebsd/zfs/zfs_znode_os.c
+++ b/module/os/freebsd/zfs/zfs_znode_os.c
@@ -1736,6 +1736,7 @@ log:
 	    NULL, &zp->z_pflags, 8);
 	zfs_tstamp_update_setup(zp, CONTENT_MODIFIED, mtime, ctime);
 	ZFS_PERSIST_SEQ(zp, bulk, count);
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 

--- a/module/os/freebsd/zfs/zfs_znode_os.c
+++ b/module/os/freebsd/zfs/zfs_znode_os.c
@@ -151,6 +151,7 @@ zfs_znode_cache_constructor(void *buf, void *arg, int kmflags)
 	zp->z_xattr_cached = NULL;
 	zp->z_xattr_parent = 0;
 	zp->z_vnode = NULL;
+	zp->z_has_seq = B_FALSE;
 
 	return (0);
 }
@@ -491,6 +492,18 @@ zfs_znode_alloc(zfsvfs_t *zfsvfs, dmu_buf_t *db, int blksz,
 		zfs_znode_free_kmem(zp);
 		return (NULL);
 	}
+
+	/*
+	 * Restore z_seq from SA_ZPL_SEQ when present, marking the file migrated
+	 * via the in-core z_has_seq (never persisted). Absence keeps the
+	 * default z_seq; FreeBSD's va_filerev never folded ctime in, so no
+	 * seed is needed across the upgrade.
+	 */
+	if (zp->z_is_sa && sa_lookup(zp->z_sa_hdl, SA_ZPL_SEQ(zfsvfs),
+	    &zp->z_seq, sizeof (zp->z_seq)) == 0)
+		zp->z_has_seq = B_TRUE;
+	else
+		zp->z_has_seq = B_FALSE;
 
 	zp->z_projid = projid;
 	zp->z_mode = mode;
@@ -1190,6 +1203,17 @@ zfs_rezget(znode_t *zp)
 	}
 
 	zp->z_projid = projid;
+
+	/*
+	 * Reload z_has_seq and z_seq from disk so stale in-core state from
+	 * before rollback/recv does not survive. A stale TRUE marker would
+	 * make ZFS_SEQ_MAY_GROW() skip the grow reservation while SA_ZPL_SEQ
+	 * is gone on disk.
+	 */
+	zp->z_has_seq = (zp->z_is_sa &&
+	    sa_lookup(zp->z_sa_hdl, SA_ZPL_SEQ(zfsvfs),
+	    &zp->z_seq, sizeof (zp->z_seq)) == 0);
+
 	zp->z_mode = mode;
 
 	if (gen != zp->z_gen) {
@@ -1381,7 +1405,7 @@ zfs_tstamp_update_setup_ext(znode_t *zp, uint_t flag, uint64_t mtime[2],
 
 	if (have_tx) {	/* will sa_bulk_update happen really soon? */
 		zp->z_atime_dirty = 0;
-		zp->z_seq++;
+		atomic_inc_64(&zp->z_seq);
 	} else {
 		zp->z_atime_dirty = 1;
 	}
@@ -1671,7 +1695,7 @@ zfs_freesp(znode_t *zp, uint64_t off, uint64_t len, int flag, boolean_t log)
 	zilog_t *zilog = zfsvfs->z_log;
 	uint64_t mode;
 	uint64_t mtime[2], ctime[2];
-	sa_bulk_attr_t bulk[3];
+	sa_bulk_attr_t bulk[4];
 	int count = 0;
 	int error;
 
@@ -1698,7 +1722,7 @@ zfs_freesp(znode_t *zp, uint64_t off, uint64_t len, int flag, boolean_t log)
 		return (error);
 log:
 	tx = dmu_tx_create(zfsvfs->z_os);
-	dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
 	zfs_sa_upgrade_txholds(tx, zp);
 	error = dmu_tx_assign(tx, DMU_TX_WAIT);
 	if (error) {
@@ -1711,6 +1735,7 @@ log:
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs),
 	    NULL, &zp->z_pflags, 8);
 	zfs_tstamp_update_setup(zp, CONTENT_MODIFIED, mtime, ctime);
+	ZFS_PERSIST_SEQ(zp, bulk, count);
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -1359,7 +1359,7 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 	dmu_object_type_t	otype;
 	zfs_acl_locator_cb_t	locate = { 0 };
 	uint64_t		mode;
-	sa_bulk_attr_t		bulk[5];
+	sa_bulk_attr_t		bulk[6];
 	uint64_t		ctime[2];
 	int			count = 0;
 	zfs_acl_phys_t		acl_phys;
@@ -1501,6 +1501,7 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 		zp->z_pflags |= ZFS_ACL_TRIVIAL;
 
 	zfs_tstamp_update_setup(zp, STATE_CHANGED, NULL, ctime);
+	ZFS_PERSIST_SEQ(zp, bulk, count);
 	return (sa_bulk_update(zp->z_sa_hdl, bulk, count, tx));
 }
 

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -1502,6 +1502,7 @@ zfs_aclset_common(znode_t *zp, zfs_acl_t *aclp, cred_t *cr, dmu_tx_t *tx)
 
 	zfs_tstamp_update_setup(zp, STATE_CHANGED, NULL, ctime);
 	ZFS_PERSIST_SEQ(zp, bulk, count);
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	return (sa_bulk_update(zp->z_sa_hdl, bulk, count, tx));
 }
 

--- a/module/os/linux/zfs/zfs_dir.c
+++ b/module/os/linux/zfs/zfs_dir.c
@@ -873,6 +873,7 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 		    ctime);
 		ZFS_PERSIST_SEQ(zp, bulk, count);
 	}
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 
@@ -896,6 +897,7 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 	    &dzp->z_pflags, sizeof (dzp->z_pflags));
 	zfs_tstamp_update_setup(dzp, CONTENT_MODIFIED, mtime, ctime);
 	ZFS_PERSIST_SEQ(dzp, bulk, count);
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(dzp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 	mutex_exit(&dzp->z_lock);
@@ -995,6 +997,7 @@ zfs_drop_nlink_locked(znode_t *zp, dmu_tx_t *tx, boolean_t *unlinkedp)
 	links = ZTOI(zp)->i_nlink;
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zfsvfs),
 	    NULL, &links, sizeof (links));
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 
@@ -1093,6 +1096,7 @@ zfs_link_destroy(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag,
 	    NULL, &dzp->z_pflags, sizeof (dzp->z_pflags));
 	zfs_tstamp_update_setup(dzp, CONTENT_MODIFIED, mtime, ctime);
 	ZFS_PERSIST_SEQ(dzp, bulk, count);
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(dzp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 	mutex_exit(&dzp->z_lock);

--- a/module/os/linux/zfs/zfs_dir.c
+++ b/module/os/linux/zfs/zfs_dir.c
@@ -617,9 +617,9 @@ zfs_purgedir(znode_t *dzp)
 		    S_ISLNK(ZTOI(xzp)->i_mode));
 
 		tx = dmu_tx_create(zfsvfs->z_os);
-		dmu_tx_hold_sa(tx, dzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 		dmu_tx_hold_zap(tx, dzp->z_id, FALSE, zap->za_name);
-		dmu_tx_hold_sa(tx, xzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, xzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(xzp));
 		dmu_tx_hold_zap(tx, zfsvfs->z_unlinkedobj, FALSE, NULL);
 		/* Is this really needed ? */
 		zfs_sa_upgrade_txholds(tx, xzp);
@@ -809,7 +809,7 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 	zfsvfs_t *zfsvfs = ZTOZSB(zp);
 	uint64_t value;
 	int zp_is_dir = S_ISDIR(ZTOI(zp)->i_mode);
-	sa_bulk_attr_t bulk[5];
+	sa_bulk_attr_t bulk[6];
 	uint64_t mtime[2], ctime[2];
 	uint64_t links;
 	int count = 0;
@@ -871,6 +871,7 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 		    ctime, sizeof (ctime));
 		zfs_tstamp_update_setup(zp, STATE_CHANGED, mtime,
 		    ctime);
+		ZFS_PERSIST_SEQ(zp, bulk, count);
 	}
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
@@ -894,6 +895,7 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs), NULL,
 	    &dzp->z_pflags, sizeof (dzp->z_pflags));
 	zfs_tstamp_update_setup(dzp, CONTENT_MODIFIED, mtime, ctime);
+	ZFS_PERSIST_SEQ(dzp, bulk, count);
 	error = sa_bulk_update(dzp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 	mutex_exit(&dzp->z_lock);
@@ -955,7 +957,7 @@ zfs_drop_nlink_locked(znode_t *zp, dmu_tx_t *tx, boolean_t *unlinkedp)
 	zfsvfs_t	*zfsvfs = ZTOZSB(zp);
 	int		zp_is_dir = S_ISDIR(ZTOI(zp)->i_mode);
 	boolean_t	unlinked = B_FALSE;
-	sa_bulk_attr_t	bulk[3];
+	sa_bulk_attr_t	bulk[4];
 	uint64_t	mtime[2], ctime[2];
 	uint64_t	links;
 	int		count = 0;
@@ -975,6 +977,12 @@ zfs_drop_nlink_locked(znode_t *zp, dmu_tx_t *tx, boolean_t *unlinkedp)
 		zp->z_unlinked = B_TRUE;
 		clear_nlink(ZTOI(zp));
 		unlinked = B_TRUE;
+		/*
+		 * NFS observers must see nlink=0; advance change_cookie.
+		 * POSIX permits skipping the ctime stamp at nlink=0, and the
+		 * znode is destined for reap so persistence would be wasted.
+		 */
+		atomic_inc_64(&zp->z_seq);
 	} else {
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs),
 		    NULL, &ctime, sizeof (ctime));
@@ -982,6 +990,7 @@ zfs_drop_nlink_locked(znode_t *zp, dmu_tx_t *tx, boolean_t *unlinkedp)
 		    NULL, &zp->z_pflags, sizeof (zp->z_pflags));
 		zfs_tstamp_update_setup(zp, STATE_CHANGED, mtime,
 		    ctime);
+		ZFS_PERSIST_SEQ(zp, bulk, count);
 	}
 	links = ZTOI(zp)->i_nlink;
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zfsvfs),
@@ -1032,7 +1041,7 @@ zfs_link_destroy(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag,
 	zfsvfs_t *zfsvfs = ZTOZSB(dzp);
 	int zp_is_dir = S_ISDIR(ZTOI(zp)->i_mode);
 	boolean_t unlinked = B_FALSE;
-	sa_bulk_attr_t bulk[5];
+	sa_bulk_attr_t bulk[6];
 	uint64_t mtime[2], ctime[2];
 	uint64_t links;
 	int count = 0;
@@ -1083,6 +1092,7 @@ zfs_link_destroy(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag,
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs),
 	    NULL, &dzp->z_pflags, sizeof (dzp->z_pflags));
 	zfs_tstamp_update_setup(dzp, CONTENT_MODIFIED, mtime, ctime);
+	ZFS_PERSIST_SEQ(dzp, bulk, count);
 	error = sa_bulk_update(dzp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 	mutex_exit(&dzp->z_lock);

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -732,7 +732,7 @@ top:
 		if (fuid_dirtied)
 			zfs_fuid_txhold(zfsvfs, tx);
 		dmu_tx_hold_zap(tx, dzp->z_id, TRUE, name);
-		dmu_tx_hold_sa(tx, dzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 		if (!zfsvfs->z_use_sa &&
 		    acl_ids.z_aclp->z_acl_bytes > ZFS_ACE_SPACE) {
 			dmu_tx_hold_write(tx, DMU_NEW_OBJECT,
@@ -810,9 +810,7 @@ top:
 			goto out;
 		}
 
-		mutex_enter(&dzp->z_lock);
-		dzp->z_seq++;
-		mutex_exit(&dzp->z_lock);
+		atomic_inc_64(&dzp->z_seq);
 
 		/*
 		 * Truncate regular files if requested.
@@ -1063,7 +1061,8 @@ top:
 	obj = zp->z_id;
 	tx = dmu_tx_create(zfsvfs->z_os);
 	dmu_tx_hold_zap(tx, dzp->z_id, FALSE, name);
-	dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
+	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 	zfs_sa_upgrade_txholds(tx, zp);
 	zfs_sa_upgrade_txholds(tx, dzp);
 	if (may_delete_now) {
@@ -1080,7 +1079,7 @@ top:
 		error = zfs_zget(zfsvfs, xattr_obj, &xzp);
 		ASSERT0(error);
 		dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_TRUE);
-		dmu_tx_hold_sa(tx, xzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, xzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(xzp));
 	}
 
 	mutex_enter(&zp->z_lock);
@@ -1332,6 +1331,7 @@ top:
 	tx = dmu_tx_create(zfsvfs->z_os);
 	dmu_tx_hold_zap(tx, dzp->z_id, TRUE, dirname);
 	dmu_tx_hold_zap(tx, DMU_NEW_OBJECT, FALSE, NULL);
+	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 	fuid_dirtied = zfsvfs->z_fuid_dirty;
 	if (fuid_dirtied)
 		zfs_fuid_txhold(zfsvfs, tx);
@@ -1484,7 +1484,8 @@ top:
 
 	tx = dmu_tx_create(zfsvfs->z_os);
 	dmu_tx_hold_zap(tx, dzp->z_id, FALSE, name);
-	dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
+	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 	dmu_tx_hold_zap(tx, zfsvfs->z_unlinkedobj, FALSE, NULL);
 	zfs_sa_upgrade_txholds(tx, zp);
 	zfs_sa_upgrade_txholds(tx, dzp);
@@ -1947,7 +1948,7 @@ zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
 	boolean_t	fuid_dirtied = B_FALSE;
 	boolean_t	handle_eadir = B_FALSE;
 	sa_bulk_attr_t	*bulk, *xattr_bulk;
-	int		count = 0, xattr_count = 0, bulks = 8;
+	int		count = 0, xattr_count = 0, bulks = 9;
 
 	if (mask == 0)
 		return (0);
@@ -2376,7 +2377,8 @@ top:
 		if (((mask & ATTR_XVATTR) &&
 		    XVA_ISSET_REQ(xvap, XAT_AV_SCANSTAMP)) ||
 		    (projid != ZFS_INVALID_PROJID &&
-		    !(zp->z_pflags & ZFS_PROJID)))
+		    !(zp->z_pflags & ZFS_PROJID)) ||
+		    !zp->z_has_seq)
 			dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_TRUE);
 		else
 			dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
@@ -2589,15 +2591,12 @@ top:
 	if (mask != 0) {
 		zfs_log_setattr(zilog, tx, TX_SETATTR, zp, vap, mask, fuidp);
 		/*
-		 * Ensure that the z_seq is always incremented on setattr
-		 * operation. This is required for change accounting for
-		 * NFS clients.
-		 *
-		 * ATTR_MODE already increments via zfs_acl_chmod_setattr.
-		 * ATTR_SIZE already increments via zfs_freesp.
+		 * ATTR_MODE bumps via zfs_aclset_common -> tstamp_update_setup;
+		 * ATTR_SIZE goes through zfs_freesp(log=FALSE) which does not.
 		 */
-		if (!(mask & (ATTR_MODE | ATTR_SIZE)))
-			zp->z_seq++;
+		if (!(mask & ATTR_MODE))
+			atomic_inc_64(&zp->z_seq);
+		ZFS_PERSIST_SEQ(zp, bulk, count);
 	}
 
 	mutex_exit(&zp->z_lock);
@@ -3061,17 +3060,17 @@ top:
 	}
 
 	tx = dmu_tx_create(zfsvfs->z_os);
-	dmu_tx_hold_sa(tx, szp->z_sa_hdl, B_FALSE);
-	dmu_tx_hold_sa(tx, sdzp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, szp->z_sa_hdl, ZFS_SEQ_MAY_GROW(szp));
+	dmu_tx_hold_sa(tx, sdzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(sdzp));
 	dmu_tx_hold_zap(tx, sdzp->z_id,
 	    (rflags & RENAME_EXCHANGE) ? TRUE : FALSE, snm);
 	dmu_tx_hold_zap(tx, tdzp->z_id, TRUE, tnm);
 	if (sdzp != tdzp) {
-		dmu_tx_hold_sa(tx, tdzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, tdzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(tdzp));
 		zfs_sa_upgrade_txholds(tx, tdzp);
 	}
 	if (tzp) {
-		dmu_tx_hold_sa(tx, tzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, tzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(tzp));
 		zfs_sa_upgrade_txholds(tx, tzp);
 	}
 	if (rflags & RENAME_WHITEOUT) {
@@ -3079,7 +3078,7 @@ top:
 		    ZFS_SA_BASE_ATTR_SIZE);
 
 		dmu_tx_hold_zap(tx, sdzp->z_id, TRUE, snm);
-		dmu_tx_hold_sa(tx, sdzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, sdzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(sdzp));
 		if (!zfsvfs->z_use_sa &&
 		    acl_ids.z_aclp->z_acl_bytes > ZFS_ACE_SPACE) {
 			dmu_tx_hold_write(tx, DMU_NEW_OBJECT,
@@ -3380,7 +3379,7 @@ top:
 	dmu_tx_hold_zap(tx, dzp->z_id, TRUE, name);
 	dmu_tx_hold_sa_create(tx, acl_ids.z_aclp->z_acl_bytes +
 	    ZFS_SA_BASE_ATTR_SIZE + len);
-	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, dzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(dzp));
 	if (!zfsvfs->z_use_sa && acl_ids.z_aclp->z_acl_bytes > ZFS_ACE_SPACE) {
 		dmu_tx_hold_write(tx, DMU_NEW_OBJECT, 0,
 		    acl_ids.z_aclp->z_acl_bytes);
@@ -3632,7 +3631,8 @@ top:
 	}
 
 	tx = dmu_tx_create(zfsvfs->z_os);
-	dmu_tx_hold_sa(tx, szp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, szp->z_sa_hdl, ZFS_SEQ_MAY_GROW(szp));
+	dmu_tx_hold_sa(tx, tdzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(tdzp));
 	dmu_tx_hold_zap(tx, tdzp->z_id, TRUE, name);
 	if (is_tmpfile)
 		dmu_tx_hold_zap(tx, zfsvfs->z_unlinkedobj, FALSE, NULL);
@@ -3772,7 +3772,7 @@ zfs_putpage(struct inode *ip, struct page *pp, struct writeback_control *wbc,
 	int		err = 0;
 	uint64_t	mtime[2], ctime[2];
 	inode_timespec_t tmp_ts;
-	sa_bulk_attr_t	bulk[3];
+	sa_bulk_attr_t	bulk[4];
 	int		cnt = 0;
 	struct address_space *mapping;
 
@@ -3889,7 +3889,7 @@ zfs_putpage(struct inode *ip, struct page *pp, struct writeback_control *wbc,
 
 	tx = dmu_tx_create(zfsvfs->z_os);
 	dmu_tx_hold_write(tx, zp->z_id, pgoff, pglen);
-	dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
 	zfs_sa_upgrade_txholds(tx, zp);
 
 	err = dmu_tx_assign(tx, DMU_TX_WAIT);
@@ -3912,18 +3912,18 @@ zfs_putpage(struct inode *ip, struct page *pp, struct writeback_control *wbc,
 	    DMU_READ_PREFETCH);
 	kunmap(pp);
 
-	SA_ADD_BULK_ATTR(bulk, cnt, SA_ZPL_MTIME(zfsvfs), NULL, &mtime, 16);
-	SA_ADD_BULK_ATTR(bulk, cnt, SA_ZPL_CTIME(zfsvfs), NULL, &ctime, 16);
-	SA_ADD_BULK_ATTR(bulk, cnt, SA_ZPL_FLAGS(zfsvfs), NULL,
-	    &zp->z_pflags, 8);
-
 	/* Preserve the mtime and ctime provided by the inode */
 	tmp_ts = zpl_inode_get_mtime(ip);
 	ZFS_TIME_ENCODE(&tmp_ts, mtime);
 	tmp_ts = zpl_inode_get_ctime(ip);
 	ZFS_TIME_ENCODE(&tmp_ts, ctime);
 	zp->z_atime_dirty = B_FALSE;
-	zp->z_seq++;
+	atomic_inc_64(&zp->z_seq);
+	SA_ADD_BULK_ATTR(bulk, cnt, SA_ZPL_MTIME(zfsvfs), NULL, &mtime, 16);
+	SA_ADD_BULK_ATTR(bulk, cnt, SA_ZPL_CTIME(zfsvfs), NULL, &ctime, 16);
+	SA_ADD_BULK_ATTR(bulk, cnt, SA_ZPL_FLAGS(zfsvfs), NULL,
+	    &zp->z_pflags, 8);
+	ZFS_PERSIST_SEQ(zp, bulk, cnt);
 
 	err = sa_bulk_update(zp->z_sa_hdl, bulk, cnt, tx);
 
@@ -4010,7 +4010,7 @@ zfs_dirty_inode(struct inode *ip, int flags)
 	dmu_tx_t	*tx;
 	uint64_t	mode, atime[2], mtime[2], ctime[2];
 	inode_timespec_t tmp_ts;
-	sa_bulk_attr_t	bulk[4];
+	sa_bulk_attr_t	bulk[5];
 	int		error = 0;
 	int		cnt = 0;
 
@@ -4036,7 +4036,7 @@ zfs_dirty_inode(struct inode *ip, int flags)
 
 	tx = dmu_tx_create(zfsvfs->z_os);
 
-	dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
 	zfs_sa_upgrade_txholds(tx, zp);
 
 	error = dmu_tx_assign(tx, DMU_TX_WAIT);
@@ -4063,6 +4063,8 @@ zfs_dirty_inode(struct inode *ip, int flags)
 	mode = ip->i_mode;
 
 	zp->z_mode = mode;
+	/* persist z_seq; callers bump it before zfs_mark_inode_dirty */
+	ZFS_PERSIST_SEQ(zp, bulk, cnt);
 
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, cnt, tx);
 	mutex_exit(&zp->z_lock);

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -2610,6 +2610,7 @@ top:
 	}
 out:
 	if (err == 0 && xattr_count > 0) {
+		ASSERT3S(xattr_count, <=, bulks);
 		err2 = sa_bulk_update(attrzp->z_sa_hdl, xattr_bulk,
 		    xattr_count, tx);
 		ASSERT0(err2);
@@ -2630,6 +2631,7 @@ out:
 		if (err == ERESTART)
 			goto top;
 	} else {
+		ASSERT3S(count, <=, bulks);
 		if (count > 0)
 			err2 = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 		dmu_tx_commit(tx);
@@ -3925,6 +3927,7 @@ zfs_putpage(struct inode *ip, struct page *pp, struct writeback_control *wbc,
 	    &zp->z_pflags, 8);
 	ZFS_PERSIST_SEQ(zp, bulk, cnt);
 
+	ASSERT3S(cnt, <=, ARRAY_SIZE(bulk));
 	err = sa_bulk_update(zp->z_sa_hdl, bulk, cnt, tx);
 
 	/*
@@ -4066,6 +4069,7 @@ zfs_dirty_inode(struct inode *ip, int flags)
 	/* persist z_seq; callers bump it before zfs_mark_inode_dirty */
 	ZFS_PERSIST_SEQ(zp, bulk, cnt);
 
+	ASSERT3S(cnt, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, cnt, tx);
 	mutex_exit(&zp->z_lock);
 

--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -1824,6 +1824,7 @@ log:
 	    NULL, &zp->z_pflags, 8);
 	zfs_tstamp_update_setup(zp, CONTENT_MODIFIED, mtime, ctime);
 	ZFS_PERSIST_SEQ(zp, bulk, count);
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 

--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -127,6 +127,7 @@ zfs_znode_cache_constructor(void *buf, void *arg, int kmflags)
 	zp->z_acl_cached = NULL;
 	zp->z_xattr_cached = NULL;
 	zp->z_xattr_parent = 0;
+	zp->z_has_seq = B_FALSE;
 
 	return (0);
 }
@@ -543,7 +544,6 @@ zfs_znode_alloc(zfsvfs_t *zfsvfs, dmu_buf_t *db, int blksz,
 	zp->z_mapcnt = 0;
 	zp->z_id = db->db_object;
 	zp->z_blksz = blksz;
-	zp->z_seq = 0x7A4653;
 	zp->z_sync_cnt = 0;
 
 	zfs_znode_sa_init(zfsvfs, zp, db, obj_type, hdl);
@@ -572,6 +572,22 @@ zfs_znode_alloc(zfsvfs_t *zfsvfs, dmu_buf_t *db, int blksz,
 			sa_handle_destroy(zp->z_sa_hdl);
 		zp->z_sa_hdl = NULL;
 		goto error;
+	}
+
+	/*
+	 * Restore z_seq from SA_ZPL_SEQ. A successful lookup marks the file as
+	 * migrated via the in-core z_has_seq (never persisted, so no pflag bit
+	 * is consumed). Absence means the file predates persistence: seed z_seq
+	 * above any cookie the pre-persistence code could have presented
+	 * ((ctime << 32) | low) so it stays monotonic across the upgrade; the
+	 * first modify migrates the file.
+	 */
+	if (zp->z_is_sa && sa_lookup(zp->z_sa_hdl, SA_ZPL_SEQ(zfsvfs),
+	    &zp->z_seq, sizeof (zp->z_seq)) == 0) {
+		zp->z_has_seq = B_TRUE;
+	} else {
+		zp->z_has_seq = B_FALSE;
+		zp->z_seq = (ctime[0] + 1) << 32;
 	}
 
 	zp->z_projid = projid;
@@ -1263,6 +1279,17 @@ zfs_rezget(znode_t *zp)
 	}
 
 	zp->z_projid = projid;
+
+	/*
+	 * Reload z_has_seq and z_seq from disk so stale in-core state from
+	 * before rollback/recv does not survive. A stale TRUE marker would
+	 * make ZFS_SEQ_MAY_GROW() skip the grow reservation while SA_ZPL_SEQ
+	 * is gone on disk.
+	 */
+	zp->z_has_seq = (zp->z_is_sa &&
+	    sa_lookup(zp->z_sa_hdl, SA_ZPL_SEQ(zfsvfs),
+	    &zp->z_seq, sizeof (zp->z_seq)) == 0);
+
 	zp->z_mode = ZTOI(zp)->i_mode = mode;
 	zfs_uid_write(ZTOI(zp), z_uid);
 	zfs_gid_write(ZTOI(zp), z_gid);
@@ -1418,7 +1445,7 @@ zfs_tstamp_update_setup(znode_t *zp, uint_t flag, uint64_t mtime[2],
 
 	gethrestime(&now);
 
-	zp->z_seq++;
+	atomic_inc_64(&zp->z_seq);
 
 	if (flag & ATTR_MTIME) {
 		ZFS_TIME_ENCODE(&now, mtime);
@@ -1757,7 +1784,7 @@ zfs_freesp(znode_t *zp, uint64_t off, uint64_t len, int flag, boolean_t log)
 	zilog_t *zilog = zfsvfs->z_log;
 	uint64_t mode;
 	uint64_t mtime[2], ctime[2];
-	sa_bulk_attr_t bulk[3];
+	sa_bulk_attr_t bulk[4];
 	int count = 0;
 	int error;
 
@@ -1783,7 +1810,7 @@ zfs_freesp(znode_t *zp, uint64_t off, uint64_t len, int flag, boolean_t log)
 		goto out;
 log:
 	tx = dmu_tx_create(zfsvfs->z_os);
-	dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
 	zfs_sa_upgrade_txholds(tx, zp);
 	error = dmu_tx_assign(tx, DMU_TX_WAIT);
 	if (error) {
@@ -1796,6 +1823,7 @@ log:
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs),
 	    NULL, &zp->z_pflags, 8);
 	zfs_tstamp_update_setup(zp, CONTENT_MODIFIED, mtime, ctime);
+	ZFS_PERSIST_SEQ(zp, bulk, count);
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 	ASSERT0(error);
 

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -372,6 +372,31 @@ zpl_llseek(struct file *filp, loff_t offset, int whence)
  * helpful to move the ARC buffers to a scatter-gather lists
  * rather than a vmalloc'ed region.
  */
+/*
+ * Bump z_seq when a clean page first transitions to dirty via an mmap store.
+ * The default generic_file_vm_ops.page_mkwrite (filemap_page_mkwrite) updates
+ * mtime/ctime via file_update_time -> __mark_inode_dirty, but never tells the
+ * filesystem that the change cookie should advance. Without this hook NFSv4
+ * GETATTR between an mmap store and writeback returns a stale change_cookie
+ * alongside the newer mtime, violating monotonicity. zfs_dirty_inode persists
+ * the new value on the same dirty path.
+ */
+static vm_fault_t
+zpl_page_mkwrite(struct vm_fault *vmf)
+{
+	znode_t *zp = ITOZ(file_inode(vmf->vma->vm_file));
+
+	atomic_inc_64(&zp->z_seq);
+
+	return (filemap_page_mkwrite(vmf));
+}
+
+static const struct vm_operations_struct zpl_vm_ops = {
+	.fault		= filemap_fault,
+	.map_pages	= filemap_map_pages,
+	.page_mkwrite	= zpl_page_mkwrite,
+};
+
 static int
 zpl_mmap(struct file *filp, struct vm_area_struct *vma)
 {
@@ -391,6 +416,7 @@ zpl_mmap(struct file *filp, struct vm_area_struct *vma)
 	if (error)
 		return (error);
 
+	vma->vm_ops = &zpl_vm_ops;
 	return (error);
 }
 

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -767,7 +767,12 @@ zpl_fallocate_common(struct inode *ip, int mode, loff_t offset, loff_t len)
 			if (error)
 				goto out_unmark;
 
-			error = -zfs_freesp(zp, offset + len, 0, 0, FALSE);
+			/*
+			 * extend file: log=TRUE drives z_seq bump,
+			 * mtime/ctime advance, and TX_TRUNCATE ZIL
+			 * record; matches zfs_space().
+			 */
+			error = -zfs_freesp(zp, offset + len, 0, 0, TRUE);
 			zfs_exit(zfsvfs, FTAG);
 		}
 	}

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -517,16 +517,18 @@ zpl_getattr_impl(const struct path *path, struct kstat *stat, u32 request_mask,
 		 * ZFS uses a coarse timer to set them, which may cause
 		 * clients to fail to detect changes and invalidate cache.
 		 *
-		 * ZFS always increments znode z_seq number, but this is
-		 * uint_t and so we mask in ctime to upper bits.
+		 * z_seq is a per-file 64-bit counter bumped on every change
+		 * and persisted across znode eviction, so it is presented
+		 * directly as a monotonic change cookie. Files that predate
+		 * persistence are seeded from ctime on load so the cookie
+		 * never moves backward across the upgrade.
 		 *
 		 * STATX_ATTR_CHANGE_MONOTONIC is advertised
 		 * to prevent knfsd from generating the change cookie
 		 * based on ctime. C.f. nfsd4_change_attribute in
 		 * fs/nfsd/nfsfh.c.
 		 */
-		stat->change_cookie =
-		    ((u64)stat->ctime.tv_sec << 32) | zp->z_seq;
+		stat->change_cookie = atomic_load_64(&zp->z_seq);
 		stat->attributes |= STATX_ATTR_CHANGE_MONOTONIC;
 		stat->result_mask |= STATX_CHANGE_COOKIE;
 	}

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -523,6 +523,7 @@ zpl_xattr_set_dir(struct inode *ip, const char *name, const void *value,
 out:
 	if (error == 0) {
 		zpl_inode_set_ctime_to_ts(ip, current_time(ip));
+		atomic_inc_64(&ITOZ(ip)->z_seq);
 		zfs_mark_inode_dirty(ip);
 	}
 
@@ -1018,6 +1019,7 @@ zpl_set_acl_impl(struct inode *ip, struct posix_acl *acl, int type)
 					ip->i_mode = ITOZ(ip)->z_mode = mode;
 					zpl_inode_set_ctime_to_ts(ip,
 					    current_time(ip));
+					atomic_inc_64(&ITOZ(ip)->z_seq);
 					zfs_mark_inode_dirty(ip);
 				}
 
@@ -1158,6 +1160,7 @@ zpl_init_acl(struct inode *ip, struct inode *dir)
 		if (!acl) {
 			ITOZ(ip)->z_mode = (ip->i_mode &= ~current_umask());
 			zpl_inode_set_ctime_to_ts(ip, current_time(ip));
+			atomic_inc_64(&ITOZ(ip)->z_seq);
 			zfs_mark_inode_dirty(ip);
 			return (0);
 		}
@@ -1176,6 +1179,7 @@ zpl_init_acl(struct inode *ip, struct inode *dir)
 		error = __posix_acl_create(&acl, GFP_KERNEL, &mode);
 		if (error >= 0) {
 			ip->i_mode = ITOZ(ip)->z_mode = mode;
+			atomic_inc_64(&ITOZ(ip)->z_seq);
 			zfs_mark_inode_dirty(ip);
 			if (error > 0) {
 				error = zpl_set_acl_impl(ip, acl,

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -68,6 +68,7 @@ const sa_attr_reg_t zfs_attr_table[ZPL_END+1] = {
 	{"ZPL_DACL_ACES", 0, SA_ACL, 0},
 	{"ZPL_DXATTR", 0, SA_UINT8_ARRAY, 0},
 	{"ZPL_PROJID", sizeof (uint64_t), SA_UINT64_ARRAY, 0},
+	{"ZPL_SEQ", sizeof (uint64_t), SA_UINT64_ARRAY, 0},
 	{NULL, 0, 0, 0}
 };
 
@@ -270,7 +271,7 @@ zfs_sa_set_xattr(znode_t *zp, const char *name, const void *value, size_t vsize)
 		dmu_tx_abort(tx);
 	} else {
 		int count = 0;
-		sa_bulk_attr_t bulk[2];
+		sa_bulk_attr_t bulk[3];
 		uint64_t ctime[2];
 
 		if (logsaxattr)
@@ -282,6 +283,7 @@ zfs_sa_set_xattr(znode_t *zp, const char *name, const void *value, size_t vsize)
 		    NULL, obj, size);
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs),
 		    NULL, &ctime, 16);
+		ZFS_PERSIST_SEQ(zp, bulk, count);
 		VERIFY0(sa_bulk_update(zp->z_sa_hdl, bulk, count, tx));
 
 		dmu_tx_commit(tx);

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -284,6 +284,7 @@ zfs_sa_set_xattr(znode_t *zp, const char *name, const void *value, size_t vsize)
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs),
 		    NULL, &ctime, 16);
 		ZFS_PERSIST_SEQ(zp, bulk, count);
+		ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 		VERIFY0(sa_bulk_update(zp->z_sa_hdl, bulk, count, tx));
 
 		dmu_tx_commit(tx);

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -647,7 +647,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 	if ((error = zfs_enter_verify_zp(zfsvfs, zp, FTAG)) != 0)
 		return (error);
 
-	sa_bulk_attr_t bulk[4];
+	sa_bulk_attr_t bulk[5];
 	int count = 0;
 	uint64_t mtime[2], ctime[2];
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(zfsvfs), NULL, &mtime, 16);
@@ -656,6 +656,9 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 	    &zp->z_size, 8);
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs), NULL,
 	    &zp->z_pflags, 8);
+	if (zp->z_is_sa)
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SEQ(zfsvfs), NULL,
+		    &zp->z_seq, 8);
 
 	/*
 	 * Callers might not be able to detect properly that we are read-only,
@@ -870,7 +873,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 		 * Start a transaction.
 		 */
 		dmu_tx_t *tx = dmu_tx_create(zfsvfs->z_os);
-		dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
 		dmu_buf_impl_t *db = (dmu_buf_impl_t *)sa_get_db(zp->z_sa_hdl);
 		DB_DNODE_ENTER(db);
 		dmu_tx_hold_write_by_dnode(tx, DB_DNODE(db), woff, nbytes);
@@ -1010,6 +1013,8 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 		    &clear_setid_bits_txg, tx);
 
 		zfs_tstamp_update_setup(zp, CONTENT_MODIFIED, mtime, ctime);
+		if (zp->z_is_sa)
+			zp->z_has_seq = B_TRUE;
 
 		/*
 		 * Update the file size (zp_size) if it has changed;
@@ -1616,7 +1621,7 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	uint64_t	outsize, size;
 	int		error;
 	int		count = 0;
-	sa_bulk_attr_t	bulk[3];
+	sa_bulk_attr_t	bulk[5];
 	uint64_t	mtime[2], ctime[2];
 	uint64_t	uid, gid, projid;
 	blkptr_t	*bps;
@@ -1870,6 +1875,11 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	    &ctime, 16);
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SIZE(outzfsvfs), NULL,
 	    &outzp->z_size, 8);
+	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(outzfsvfs), NULL,
+	    &outzp->z_pflags, 8);
+	if (outzp->z_is_sa)
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SEQ(outzfsvfs), NULL,
+		    &outzp->z_seq, 8);
 
 	zilog = outzfsvfs->z_log;
 	maxblocks = zil_max_log_data(zilog, sizeof (lr_clone_range_t)) /
@@ -1933,7 +1943,7 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 		 * Start a transaction.
 		 */
 		tx = dmu_tx_create(outos);
-		dmu_tx_hold_sa(tx, outzp->z_sa_hdl, B_FALSE);
+		dmu_tx_hold_sa(tx, outzp->z_sa_hdl, ZFS_SEQ_MAY_GROW(outzp));
 		db = (dmu_buf_impl_t *)sa_get_db(outzp->z_sa_hdl);
 		DB_DNODE_ENTER(db);
 		dmu_tx_hold_clone_by_dnode(tx, DB_DNODE(db), outoff, size,
@@ -1988,6 +1998,8 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 		    &clear_setid_bits_txg, tx);
 
 		zfs_tstamp_update_setup(outzp, CONTENT_MODIFIED, mtime, ctime);
+		if (outzp->z_is_sa)
+			outzp->z_has_seq = B_TRUE;
 
 		/*
 		 * Update the file size (zp_size) if it has changed;
@@ -2068,7 +2080,7 @@ zfs_clone_range_replay(znode_t *zp, uint64_t off, uint64_t len, uint64_t blksz,
 	dmu_tx_t	*tx;
 	int		error;
 	int		count = 0;
-	sa_bulk_attr_t	bulk[3];
+	sa_bulk_attr_t	bulk[5];
 	uint64_t	mtime[2], ctime[2];
 
 	ASSERT3U(off, <, MAXOFFSET_T);
@@ -2091,17 +2103,12 @@ zfs_clone_range_replay(znode_t *zp, uint64_t off, uint64_t len, uint64_t blksz,
 		return (SET_ERROR(EINVAL));
 	}
 
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(zfsvfs), NULL, &mtime, 16);
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs), NULL, &ctime, 16);
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SIZE(zfsvfs), NULL,
-	    &zp->z_size, 8);
-
 	/*
 	 * Start a transaction.
 	 */
 	tx = dmu_tx_create(zfsvfs->z_os);
 
-	dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
+	dmu_tx_hold_sa(tx, zp->z_sa_hdl, ZFS_SEQ_MAY_GROW(zp));
 	db = (dmu_buf_impl_t *)sa_get_db(zp->z_sa_hdl);
 	DB_DNODE_ENTER(db);
 	dmu_tx_hold_clone_by_dnode(tx, DB_DNODE(db), off, len, blksz);
@@ -2119,7 +2126,14 @@ zfs_clone_range_replay(znode_t *zp, uint64_t off, uint64_t len, uint64_t blksz,
 
 	dmu_brt_clone(zfsvfs->z_os, zp->z_id, off, len, tx, bps, nbps);
 
+	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(zfsvfs), NULL, &mtime, 16);
+	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs), NULL, &ctime, 16);
+	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SIZE(zfsvfs), NULL,
+	    &zp->z_size, 8);
+	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs), NULL,
+	    &zp->z_pflags, 8);
 	zfs_tstamp_update_setup(zp, CONTENT_MODIFIED, mtime, ctime);
+	ZFS_PERSIST_SEQ(zp, bulk, count);
 
 	if (zp->z_size < off + len)
 		zp->z_size = off + len;

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1033,6 +1033,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 		if (zfsvfs->z_replay && zfsvfs->z_replay_eof != 0)
 			zp->z_size = zfsvfs->z_replay_eof;
 
+		ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 		error1 = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 		if (error1 != 0)
 			/* Avoid clobbering EFAULT. */
@@ -2010,6 +2011,7 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 			    outoff + size);
 		}
 
+		ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 		error = sa_bulk_update(outzp->z_sa_hdl, bulk, count, tx);
 
 		zfs_log_clone_range(zilog, tx, TX_CLONE_RANGE, outzp, outoff,
@@ -2138,6 +2140,7 @@ zfs_clone_range_replay(znode_t *zp, uint64_t off, uint64_t len, uint64_t blksz,
 	if (zp->z_size < off + len)
 		zp->z_size = off + len;
 
+	ASSERT3S(count, <=, ARRAY_SIZE(bulk));
 	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 
 	/*

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -111,7 +111,7 @@ tests = ['events_001_pos', 'events_002_pos', 'zed_rc_filter', 'zed_fd_spill',
 tags = ['functional', 'events']
 
 [tests/functional/fallocate:Linux]
-tests = ['fallocate_prealloc', 'fallocate_zero-range']
+tests = ['fallocate_extend_timestamps', 'fallocate_prealloc', 'fallocate_zero-range']
 tags = ['functional', 'fallocate']
 
 [tests/functional/fault:Linux]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1641,6 +1641,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/failmode/failmode_syncalways_continue.ksh \
 	functional/failmode/setup.ksh \
 	functional/fallocate/cleanup.ksh \
+	functional/fallocate/fallocate_extend_timestamps.ksh \
 	functional/fallocate/fallocate_prealloc.ksh \
 	functional/fallocate/fallocate_punch-hole.ksh \
 	functional/fallocate/fallocate_zero-range.ksh \

--- a/tests/zfs-tests/tests/functional/fallocate/fallocate_extend_timestamps.ksh
+++ b/tests/zfs-tests/tests/functional/fallocate/fallocate_extend_timestamps.ksh
@@ -1,0 +1,77 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026 by iXsystems, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+
+#
+# DESCRIPTION:
+# A fallocate(2) that extends a file past EOF must update mtime/ctime; a
+# FALLOC_FL_KEEP_SIZE preallocation must not change the size or timestamps.
+#
+# STRATEGY:
+# 1. Create a small file and record its mtime/ctime
+# 2. fallocate -l to a larger size (extend) and verify the size grew and both
+#    mtime and ctime advanced
+# 3. fallocate --keep-size to a larger length and verify the size and both
+#    timestamps are unchanged
+#
+
+verify_runnable "global"
+
+FILE=$TESTDIR/$TESTFILE0
+STARTSIZE=$((128 * 1024))
+
+function cleanup
+{
+	[[ -f $FILE ]] && rm -f $FILE
+}
+
+# extend past EOF: size must grow and mtime/ctime must advance
+function verify_extend # <newsize>
+{
+	typeset -i size="$1"
+
+	log_must mkfile $STARTSIZE $FILE
+	typeset -i tm="$(stat -c %Y $FILE)"
+	typeset -i tc="$(stat -c %Z $FILE)"
+	log_must sleep 1
+	log_must fallocate -l $size $FILE
+	verify_eq $size "$(stat_size $FILE)" "size"
+	verify_ne $tm "$(stat -c %Y $FILE)" "mtime"
+	verify_ne $tc "$(stat -c %Z $FILE)" "ctime"
+	log_must rm -f $FILE
+}
+
+log_assert "Ensure fallocate extend updates mtime/ctime and --keep-size does not"
+log_onexit cleanup
+
+verify_extend $((256 * 1024))
+verify_extend $((1024 * 1024))
+
+# --keep-size preallocation must not change size or timestamps
+log_must mkfile $STARTSIZE $FILE
+typeset -i tm="$(stat -c %Y $FILE)"
+typeset -i tc="$(stat -c %Z $FILE)"
+log_must sleep 1
+log_must fallocate --keep-size -l $((1024 * 1024)) $FILE
+verify_eq $STARTSIZE "$(stat_size $FILE)" "size"
+verify_eq $tm "$(stat -c %Y $FILE)" "mtime"
+verify_eq $tc "$(stat -c %Z $FILE)" "ctime"
+log_must rm -f $FILE
+
+log_pass "fallocate extend correctly updates timestamps"


### PR DESCRIPTION
### Motivation and Context
Commit 312bdab0f502 advertises `STATX_ATTR_CHANGE_MONOTONIC` to knfsd and builds the NFSv4 `change_cookie` from `(ctime.tv_sec << 32) | zp->z_seq`. `zp->z_seq` is reset to a magic constant in `zfs_znode_alloc()`, so any event that drops the znode from cache (memory pressure, remount, reboot) brings the file back with the same `ctime.tv_sec` upper bits but a smaller `z_seq` in the lower bits, regressing the cookie within the same second.

NFSv4 clients that trust the monotonicity contract treat this as metadata they cannot rely on. VMware ESXi over NFSv4.1 reliably reproduces it with _The file specified is not a virtual disk_, causing a VM stored on the affected ZFS dataset to fail to power on.

### Description
Persist `zp->z_seq` via a new SA attribute `SA_ZPL_SEQ` so it survives znode eviction. A new pflag bit `ZFS_HAS_SEQ` marks the file as carrying `SA_ZPL_SEQ` in its layout, mirroring the existing `ZPL_PROJID`/`ZFS_PROJID` pattern. The bit gates `may_grow` at SA tx-hold sites, choosing `B_TRUE` on the first add per file and `B_FALSE` thereafter, so steady-state operations pay no extra reservation.

A `ZFS_PERSIST_SEQ()` macro captures `z_seq` and sets the bit into the caller's bulk in one step, persisting both atomically alongside the file's other SA attributes. Every site that bumps `z_seq` uses it. `zfs_znode_alloc()` restores `z_seq` from `SA_ZPL_SEQ` when the bit is set.

No on-disk format change requiring a feature flag is needed. Older binaries preserve the new attribute and bit opaquely. The first modify by a patched binary lazily migrates each file.

### How Has This Been Tested?
- **Before:** ESXi VM fails to power on over NFSv4.1.
- **After:** VM powers on successfully. 
- CI Testing


### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).