### PR TITLE
Add alloc_bias property for spare vdevs

### DIFF
--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -351,6 +351,54 @@ is_draid_fdomain_failure(fmd_hdl_t *hdl, libzfs_handle_t *zhdl,
 }
 
 /*
+ * Return B_TRUE if the vdev subtree rooted at 'vd' contains a vdev
+ * with 'target_guid' (including 'vd' itself).
+ */
+static boolean_t
+vdev_subtree_contains_guid(nvlist_t *vd, uint64_t target_guid)
+{
+	nvlist_t **children;
+	uint_t nchildren;
+	uint64_t guid;
+
+	if (nvlist_lookup_uint64(vd, ZPOOL_CONFIG_GUID, &guid) == 0 &&
+	    guid == target_guid)
+		return (B_TRUE);
+
+	if (nvlist_lookup_nvlist_array(vd, ZPOOL_CONFIG_CHILDREN,
+	    &children, &nchildren) != 0)
+		return (B_FALSE);
+
+	for (uint_t c = 0; c < nchildren; c++) {
+		if (vdev_subtree_contains_guid(children[c], target_guid))
+			return (B_TRUE);
+	}
+	return (B_FALSE);
+}
+
+/*
+ * Return the top-level vdev (direct child of nvroot) that contains the
+ * vdev with 'target_guid', or NULL if not found.
+ */
+static nvlist_t *
+find_top_vdev_by_guid(nvlist_t *nvroot, uint64_t target_guid)
+{
+	nvlist_t **top_children;
+	uint_t ntop;
+
+	if (nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
+	    &top_children, &ntop) != 0)
+		return (NULL);
+
+	for (uint_t t = 0; t < ntop; t++) {
+		if (vdev_subtree_contains_guid(top_children[t], target_guid))
+			return (top_children[t]);
+	}
+
+	return (NULL);
+}
+
+/*
  * Given a vdev, attempt to replace it with every known spare until one
  * succeeds or we run out of devices to try.
  * Return whether we were successful or not in replacing the device.
@@ -358,12 +406,14 @@ is_draid_fdomain_failure(fmd_hdl_t *hdl, libzfs_handle_t *zhdl,
 static boolean_t
 replace_with_spare(fmd_hdl_t *hdl, zpool_handle_t *zhp, nvlist_t *vdev)
 {
-	nvlist_t *config, *nvroot, *replacement;
+	nvlist_t *config, *nvroot, *replacement, *top_vdev;
 	nvlist_t **spares;
 	uint_t s, nspares;
 	char *dev_name;
 	zprop_source_t source;
 	int ashift;
+	uint64_t vdev_guid;
+	const char *target_bias = NULL;
 
 	config = zpool_get_config(zhp, NULL);
 	if (nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
@@ -378,6 +428,17 @@ replace_with_spare(fmd_hdl_t *hdl, zpool_handle_t *zhp, nvlist_t *vdev)
 		return (B_FALSE);
 
 	/*
+	 * Determine the alloc_bias of the failed vdev's top-level vdev
+	 * so we can select only a spare with a matching bias.
+	 */
+	if (nvlist_lookup_uint64(vdev, ZPOOL_CONFIG_GUID, &vdev_guid) == 0) {
+		top_vdev = find_top_vdev_by_guid(nvroot, vdev_guid);
+		if (top_vdev != NULL)
+			(void) nvlist_lookup_string(top_vdev,
+			    ZPOOL_CONFIG_ALLOCATION_BIAS, &target_bias);
+	}
+
+	/*
 	 * lookup "ashift" pool property, we may need it for the replacement
 	 */
 	ashift = zpool_get_prop_int(zhp, ZPOOL_PROP_ASHIFT, &source);
@@ -390,15 +451,24 @@ replace_with_spare(fmd_hdl_t *hdl, zpool_handle_t *zhp, nvlist_t *vdev)
 	dev_name = zpool_vdev_name(NULL, zhp, vdev, B_FALSE);
 
 	/*
-	 * Try to replace each spare, ending when we successfully
-	 * replace it.
+	 * Try to replace with a spare that has a matching alloc_bias,
+	 * ending when we successfully replace it.
 	 */
 	for (s = 0; s < nspares; s++) {
 		boolean_t rebuild = B_FALSE;
-		const char *spare_name, *type;
+		const char *spare_name, *type, *spare_bias = NULL;
 
 		if (nvlist_lookup_string(spares[s], ZPOOL_CONFIG_PATH,
 		    &spare_name) != 0)
+			continue;
+
+		/* Skip spares with a mismatched alloc_bias. */
+		(void) nvlist_lookup_string(spares[s],
+		    ZPOOL_CONFIG_ALLOCATION_BIAS, &spare_bias);
+		if (target_bias == NULL && spare_bias != NULL)
+			continue;
+		if (target_bias != NULL && (spare_bias == NULL ||
+		    strcmp(target_bias, spare_bias) != 0))
 			continue;
 
 		/* prefer sequential resilvering for distributed spares */

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1238,6 +1238,15 @@ fill_vdev_info(nvlist_t *list, zpool_handle_t *zhp, char *name,
 					    "normal");
 			}
 		}
+		if (!hole && !l2c) {
+			const char *ab = NULL;
+			(void) nvlist_lookup_string(nvdev,
+			    ZPOOL_CONFIG_ALLOCATION_BIAS, &ab);
+			if (ab == NULL && log)
+				ab = VDEV_TYPE_LOG;
+			if (ab != NULL)
+				fnvlist_add_string(list, "alloc_bias", ab);
+		}
 		if (nvlist_lookup_uint64_array(nvdev, ZPOOL_CONFIG_VDEV_STATS,
 		    (uint64_t **)&vs, &c) == 0) {
 			fnvlist_add_string(list, "state",
@@ -3114,6 +3123,13 @@ print_status_config(zpool_handle_t *zhp, status_cbdata_t *cb, const char *name,
 		(void) printf(gettext("  (removing)"));
 	} else if (VDEV_STAT_VALID(vs_noalloc, vsc) && vs->vs_noalloc != 0) {
 		(void) printf(gettext("  (non-allocating)"));
+	}
+
+	if (isspare) {
+		const char *bias = NULL;
+		if (nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &bias) == 0)
+			(void) printf(gettext("  (%s)"), bias);
 	}
 
 	/* The root vdev has the scrub/resilver stats */

--- a/man/man7/vdevprops.7
+++ b/man/man7/vdevprops.7
@@ -236,6 +236,12 @@ to be enabled.
 At least one top-level vdev must remain in the normal
 .Pq Sy none
 class.
+.Pp
+This property may also be set on spare vdevs; a biased spare will only
+activate for a failed vdev of the matching class.
+Unbiased spares
+.Pq Sy none
+are reserved for normal vdevs.
 .It Sy scheduler Ns = Ns Sy auto Ns | Ns Sy on Ns | Ns Sy off
 Controls how I/O requests are added to the vdev queue when reading or
 writing to this vdev.

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6644,34 +6644,31 @@ spa_add_spares(spa_t *spa, nvlist_t *config)
 		return;
 
 	nvroot = fnvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE);
-	VERIFY0(nvlist_lookup_nvlist_array(spa->spa_spares.sav_config,
-	    ZPOOL_CONFIG_SPARES, &spares, &nspares));
-	if (nspares != 0) {
-		fnvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_SPARES,
-		    (const nvlist_t * const *)spares, nspares);
-		VERIFY0(nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_SPARES,
-		    &spares, &nspares));
 
-		/*
-		 * Go through and find any spares which have since been
-		 * repurposed as an active spare.  If this is the case, update
-		 * their status appropriately.
-		 */
-		for (i = 0; i < nspares; i++) {
-			guid = fnvlist_lookup_uint64(spares[i],
-			    ZPOOL_CONFIG_GUID);
+	/*
+	 * Generate spare configs fresh from in-memory vdevs rather than
+	 * reading the cached sav_config.  This ensures that any property
+	 * changes made at runtime (e.g. alloc_bias) are reflected without
+	 * requiring a writer lock to update the cache.
+	 */
+	nspares = spa->spa_spares.sav_count;
+	spares = kmem_alloc(nspares * sizeof (void *), KM_SLEEP);
+	for (i = 0; i < nspares; i++) {
+		spares[i] = vdev_config_generate(spa,
+		    spa->spa_spares.sav_vdevs[i], B_TRUE, VDEV_CONFIG_SPARE);
+		guid = fnvlist_lookup_uint64(spares[i], ZPOOL_CONFIG_GUID);
+		if (spa_spare_exists(guid, &pool, NULL) && pool != 0ULL) {
 			VERIFY0(nvlist_lookup_uint64_array(spares[i],
 			    ZPOOL_CONFIG_VDEV_STATS, (uint64_t **)&vs, &vsc));
-			if (spa_spare_exists(guid, &pool, NULL) &&
-			    pool != 0ULL) {
-				vs->vs_state = VDEV_STATE_CANT_OPEN;
-				vs->vs_aux = VDEV_AUX_SPARED;
-			} else {
-				vs->vs_state =
-				    spa->spa_spares.sav_vdevs[i]->vdev_state;
-			}
+			vs->vs_state = VDEV_STATE_CANT_OPEN;
+			vs->vs_aux = VDEV_AUX_SPARED;
 		}
 	}
+	fnvlist_add_nvlist_array(nvroot, ZPOOL_CONFIG_SPARES,
+	    (const nvlist_t * const *)spares, nspares);
+	for (i = 0; i < nspares; i++)
+		nvlist_free(spares[i]);
+	kmem_free(spares, nspares * sizeof (void *));
 }
 
 /*
@@ -8333,10 +8330,22 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing,
 		return (spa_vdev_exit(spa, newrootvd, txg, error));
 
 	/*
-	 * log, dedup and special vdevs should not be replaced by spares.
+	 * A spare vdev is constructed fresh from the userland nvlist and does
+	 * not carry alloc_bias.  After vdev_create(), vdev_label_init() has
+	 * corrected newvd->vdev_guid to the real spare GUID; inherit the bias
+	 * from the registered spare now.
 	 */
-	if ((oldvd->vdev_top->vdev_alloc_bias != VDEV_BIAS_NONE ||
-	    oldvd->vdev_top->vdev_islog) && newvd->vdev_isspare) {
+	if (newvd->vdev_isspare) {
+		vdev_t *sv = spa_lookup_by_guid(spa, newvd->vdev_guid, B_TRUE);
+		if (sv != NULL)
+			newvd->vdev_alloc_bias = sv->vdev_alloc_bias;
+	}
+
+	/*
+	 * A spare can only replace a vdev with a matching alloc_bias.
+	 */
+	if (newvd->vdev_isspare &&
+	    newvd->vdev_alloc_bias != oldvd->vdev_top->vdev_alloc_bias) {
 		return (spa_vdev_exit(spa, newrootvd, txg, ENOTSUP));
 	}
 
@@ -10185,7 +10194,7 @@ spa_sync_nvlist(spa_t *spa, uint64_t obj, nvlist_t *nv, dmu_tx_t *tx)
 
 static void
 spa_sync_aux_dev(spa_t *spa, spa_aux_vdev_t *sav, dmu_tx_t *tx,
-    const char *config, const char *entry)
+    const char *config, const char *entry, vdev_config_flag_t vdev_flags)
 {
 	nvlist_t *nvroot;
 	nvlist_t **list;
@@ -10216,7 +10225,7 @@ spa_sync_aux_dev(spa_t *spa, spa_aux_vdev_t *sav, dmu_tx_t *tx,
 		list = kmem_alloc(sav->sav_count*sizeof (void *), KM_SLEEP);
 		for (i = 0; i < sav->sav_count; i++)
 			list[i] = vdev_config_generate(spa, sav->sav_vdevs[i],
-			    B_FALSE, VDEV_CONFIG_L2CACHE);
+			    B_FALSE, vdev_flags);
 		fnvlist_add_nvlist_array(nvroot, config,
 		    (const nvlist_t * const *)list, sav->sav_count);
 		for (i = 0; i < sav->sav_count; i++)
@@ -10733,9 +10742,10 @@ spa_sync_iterate_to_convergence(spa_t *spa, dmu_tx_t *tx)
 
 		spa_sync_config_object(spa, tx);
 		spa_sync_aux_dev(spa, &spa->spa_spares, tx,
-		    ZPOOL_CONFIG_SPARES, DMU_POOL_SPARES);
+		    ZPOOL_CONFIG_SPARES, DMU_POOL_SPARES, VDEV_CONFIG_SPARE);
 		spa_sync_aux_dev(spa, &spa->spa_l2cache, tx,
-		    ZPOOL_CONFIG_L2CACHE, DMU_POOL_L2CACHE);
+		    ZPOOL_CONFIG_L2CACHE, DMU_POOL_L2CACHE,
+		    VDEV_CONFIG_L2CACHE);
 		spa_errlog_sync(spa, txg);
 		dsl_pool_sync(dp, txg);
 

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -906,6 +906,12 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 		    !spa_feature_is_enabled(spa, SPA_FEATURE_DRAID)) {
 			return (SET_ERROR(ENOTSUP));
 		}
+	} else if (alloctype == VDEV_ALLOC_SPARE) {
+		const char *bias;
+
+		if (nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &bias) == 0)
+			alloc_bias = vdev_derive_alloc_bias(bias);
 	}
 
 	/*
@@ -924,9 +930,7 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 	vd = vdev_alloc_common(spa, id, guid, ops);
 	vd->vdev_tsd = tsd;
 	vd->vdev_islog = islog;
-
-	if (top_level && alloc_bias != VDEV_BIAS_NONE)
-		vd->vdev_alloc_bias = alloc_bias;
+	vd->vdev_alloc_bias = alloc_bias;
 
 	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &tmp) == 0)
 		vd->vdev_path = spa_strdup(tmp);
@@ -6053,7 +6057,7 @@ vdev_props_set_sync(void *arg, dmu_tx_t *tx)
 	objset_t *mos = spa->spa_meta_objset;
 	nvpair_t *elem = NULL;
 	uint64_t vdev_guid;
-	uint64_t objid;
+	uint64_t objid = 0;
 	nvlist_t *nvprops;
 
 	vdev_guid = fnvlist_lookup_uint64(nvp, ZPOOL_VDEV_PROPS_SET_VDEV);
@@ -6066,8 +6070,11 @@ vdev_props_set_sync(void *arg, dmu_tx_t *tx)
 
 	/*
 	 * Set vdev property values in the vdev props mos object.
+	 * Spare vdevs have no ZAP; their alloc_bias is persisted via
+	 * spa_sync_aux_dev() triggered by sav_sync below.
 	 */
-	if (vdev_prop_get_objid(vd, &objid) != 0)
+	boolean_t have_objid = (vdev_prop_get_objid(vd, &objid) == 0);
+	if (!have_objid && !vd->vdev_isspare)
 		panic("unexpected vdev type");
 
 	mutex_enter(&spa->spa_props_lock);
@@ -6099,13 +6106,23 @@ vdev_props_set_sync(void *arg, dmu_tx_t *tx)
 			break;
 		case VDEV_PROP_ALLOC_BIAS: {
 			intval = fnvpair_value_uint64(elem);
-			ASSERT3U(intval, !=, VDEV_BIAS_LOG);
+			/* LOG bias is only valid here for spare vdevs. */
+			ASSERT(intval != VDEV_BIAS_LOG || vd->vdev_isspare);
 			const char *bias_str =
+			    (intval == VDEV_BIAS_LOG) ?
+			    VDEV_ALLOC_BIAS_LOG :
 			    (intval == VDEV_BIAS_SPECIAL) ?
 			    VDEV_ALLOC_BIAS_SPECIAL :
 			    (intval == VDEV_BIAS_DEDUP) ?
 			    VDEV_ALLOC_BIAS_DEDUP : NULL;
-			if (bias_str == NULL) {
+			if (vd->vdev_isspare) {
+				/*
+				 * Spare vdevs have no vdev_top_zap.
+				 * Trigger spa_sync_aux_dev() to persist
+				 * the bias via the MOS spare list config.
+				 */
+				spa->spa_spares.sav_sync = B_TRUE;
+			} else if (bias_str == NULL) {
 				(void) zap_remove(mos, objid,
 				    VDEV_TOP_ZAP_ALLOCATION_BIAS, tx);
 			} else {
@@ -6170,10 +6187,14 @@ vdev_prop_set(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 
 	ASSERT(vd != NULL);
 
-	/* Check that vdev has a zap we can use */
+	/*
+	 * Check that vdev has a zap we can use, or is a spare vdev,
+	 * able to store alloc_bias without one.
+	 */
 	if (vd->vdev_root_zap == 0 &&
 	    vd->vdev_top_zap == 0 &&
-	    vd->vdev_leaf_zap == 0)
+	    vd->vdev_leaf_zap == 0 &&
+	    !vd->vdev_isspare)
 		return (SET_ERROR(EINVAL));
 
 	if (nvlist_lookup_uint64(innvl, ZPOOL_VDEV_PROPS_SET_VDEV,
@@ -6200,6 +6221,12 @@ vdev_prop_set(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 
 		if (prop != VDEV_PROP_USERPROP && vdev_prop_readonly(prop)) {
 			error = EROFS;
+			goto end;
+		}
+
+		/* Spare vdevs only support setting alloc_bias. */
+		if (vd->vdev_isspare && prop != VDEV_PROP_ALLOC_BIAS) {
+			error = ENOTSUP;
 			goto end;
 		}
 
@@ -6354,7 +6381,8 @@ vdev_prop_set(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 				error = EINVAL;
 				break;
 			}
-			if (vd != vd->vdev_top || vd->vdev_top_zap == 0) {
+			if (vd != vd->vdev_top ||
+			    (vd->vdev_top_zap == 0 && !vd->vdev_isspare)) {
 				error = ENOTSUP;
 				break;
 			}
@@ -6363,12 +6391,16 @@ vdev_prop_set(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 				error = ENOTSUP;
 				break;
 			}
+			/* Log bias only valid on spare vdevs. */
+			if (intval == VDEV_BIAS_LOG && !vd->vdev_isspare) {
+				error = ENOTSUP;
+				break;
+			}
 			/* special/dedup needs allocation_classes feature */
-			if (intval != VDEV_BIAS_NONE &&
-			    ((intval != VDEV_BIAS_SPECIAL &&
-			    intval != VDEV_BIAS_DEDUP) ||
+			if ((intval == VDEV_BIAS_SPECIAL ||
+			    intval == VDEV_BIAS_DEDUP) &&
 			    !spa_feature_is_enabled(spa,
-			    SPA_FEATURE_ALLOCATION_CLASSES))) {
+			    SPA_FEATURE_ALLOCATION_CLASSES)) {
 				error = ENOTSUP;
 				break;
 			}
@@ -6376,7 +6408,7 @@ vdev_prop_set(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 			 * Disallow converting the last normal vdev to
 			 * avoid pool suspension on failed allocations.
 			 */
-			if (intval != VDEV_BIAS_NONE &&
+			if (!vd->vdev_isspare && intval != VDEV_BIAS_NONE &&
 			    vd->vdev_alloc_bias == VDEV_BIAS_NONE) {
 				vdev_t *rvd = spa->spa_root_vdev;
 				int normal = 0;
@@ -6446,9 +6478,11 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 
 	nvlist_lookup_nvlist(innvl, ZPOOL_VDEV_PROPS_GET_PROPS, &nvprops);
 
-	if (vdev_prop_get_objid(vd, &objid) != 0)
+	objid = 0;
+	boolean_t have_get_objid = (vdev_prop_get_objid(vd, &objid) == 0);
+	if (!have_get_objid && !vd->vdev_isspare)
 		return (SET_ERROR(EINVAL));
-	ASSERT(objid != 0);
+	ASSERT(!have_get_objid || objid != 0);
 
 	mutex_enter(&spa->spa_props_lock);
 
@@ -6770,6 +6804,8 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 				    intval, src);
 				break;
 			case VDEV_PROP_FAILFAST:
+				if (!have_get_objid)
+					continue;
 				src = ZPROP_SRC_LOCAL;
 
 				err = zap_lookup(mos, objid, nvpair_name(elem),
@@ -6817,6 +6853,8 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 				break;
 
 			case VDEV_PROP_SLOW_IO_EVENTS:
+				if (!have_get_objid)
+					continue;
 				err = vdev_prop_get_bool(vd, prop, &boolval);
 				if (err && err != ENOENT)
 					break;
@@ -6830,9 +6868,13 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 				break;
 			case VDEV_PROP_ALLOC_BIAS:
 				if (vd == vd->vdev_top) {
+					zprop_source_t src =
+					    (vd->vdev_alloc_bias ==
+					    VDEV_BIAS_NONE) ?
+					    ZPROP_SRC_DEFAULT :
+					    ZPROP_SRC_LOCAL;
 					vdev_prop_add_list(outnvl, propname,
-					    NULL, vd->vdev_alloc_bias,
-					    ZPROP_SRC_NONE);
+					    NULL, vd->vdev_alloc_bias, src);
 				}
 				continue;
 			case VDEV_PROP_CHECKSUM_N:
@@ -6842,6 +6884,8 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 			case VDEV_PROP_SLOW_IO_N:
 			case VDEV_PROP_SLOW_IO_T:
 			case VDEV_PROP_SCHEDULER:
+				if (!have_get_objid)
+					continue;
 				err = vdev_prop_get_int(vd, prop, &intval);
 				if (err && err != ENOENT)
 					break;
@@ -6860,6 +6904,8 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 				/* FALLTHRU */
 			case VDEV_PROP_USERPROP:
 				/* User Properites */
+				if (!have_get_objid)
+					continue;
 				src = ZPROP_SRC_LOCAL;
 
 				err = zap_length(mos, objid, nvpair_name(elem),
@@ -6897,7 +6943,7 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 			if (err)
 				break;
 		}
-	} else {
+	} else if (have_get_objid) {
 		/*
 		 * Get all properties from the MOS vdev property object.
 		 */

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -451,6 +451,21 @@ top_vdev_actions_getprogress(vdev_t *vd, nvlist_t *nvl)
 	}
 }
 
+static const char *
+vdev_alloc_bias_str(vdev_alloc_bias_t bias)
+{
+	switch (bias) {
+	case VDEV_BIAS_LOG:
+		return (VDEV_ALLOC_BIAS_LOG);
+	case VDEV_BIAS_SPECIAL:
+		return (VDEV_ALLOC_BIAS_SPECIAL);
+	case VDEV_BIAS_DEDUP:
+		return (VDEV_ALLOC_BIAS_DEDUP);
+	default:
+		return (NULL);
+	}
+}
+
 /*
  * Generate the nvlist representing this vdev's config.
  */
@@ -530,25 +545,27 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 
 		/* zpool command expects alloc class data */
 		if (getstats && vd->vdev_alloc_bias != VDEV_BIAS_NONE) {
-			const char *bias = NULL;
-
-			switch (vd->vdev_alloc_bias) {
-			case VDEV_BIAS_LOG:
-				bias = VDEV_ALLOC_BIAS_LOG;
-				break;
-			case VDEV_BIAS_SPECIAL:
-				bias = VDEV_ALLOC_BIAS_SPECIAL;
-				break;
-			case VDEV_BIAS_DEDUP:
-				bias = VDEV_ALLOC_BIAS_DEDUP;
-				break;
-			default:
-				ASSERT3U(vd->vdev_alloc_bias, ==,
-				    VDEV_BIAS_NONE);
-			}
+			const char *bias =
+			    vdev_alloc_bias_str(vd->vdev_alloc_bias);
+			ASSERT(bias != NULL);
 			fnvlist_add_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
 			    bias);
 		}
+	}
+
+	/*
+	 * Include alloc_bias for spare vdevs when generating spare-list
+	 * config (aux-device context), not the main pool vdev tree.  Spare
+	 * vdevs inside a spare-N replacing group in the main tree must not
+	 * carry this key or the display code misidentifies them as
+	 * allocation-class group vdevs.
+	 */
+	if ((flags & VDEV_CONFIG_SPARE) &&
+	    vd->vdev_alloc_bias != VDEV_BIAS_NONE) {
+		const char *bias = vdev_alloc_bias_str(vd->vdev_alloc_bias);
+		if (bias != NULL)
+			fnvlist_add_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+			    bias);
 	}
 
 	if (vd->vdev_dtl_sm != NULL) {

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -38,7 +38,7 @@ tests = ['alloc_class_001_pos', 'alloc_class_002_neg', 'alloc_class_003_pos',
     'alloc_class_007_pos', 'alloc_class_008_pos', 'alloc_class_009_pos',
     'alloc_class_010_pos', 'alloc_class_011_neg', 'alloc_class_012_pos',
     'alloc_class_013_pos', 'alloc_class_014_pos', 'alloc_class_015_neg',
-    'alloc_class_016_pos']
+    'alloc_class_016_pos', 'alloc_class_017_pos', 'alloc_class_018_neg']
 tags = ['functional', 'alloc_class']
 
 [tests/functional/append]

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -118,7 +118,7 @@ tags = ['functional', 'fallocate']
 tests = ['auto_offline_001_pos', 'auto_online_001_pos', 'auto_online_002_pos',
     'auto_replace_001_pos', 'auto_replace_002_pos', 'auto_spare_001_pos',
     'auto_spare_002_pos', 'auto_spare_double', 'auto_spare_multiple',
-    'auto_spare_ashift', 'auto_spare_shared', 'decrypt_fault',
+    'auto_spare_ashift', 'auto_spare_bias', 'auto_spare_shared', 'decrypt_fault',
     'decompress_fault', 'fault_limits', 'scrub_after_resilver',
     'suspend_on_probe_errors', 'suspend_resume_single', 'suspend_draid_fgroups',
     'zpool_status_-s']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -439,6 +439,8 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/alloc_class/alloc_class_014_pos.ksh \
 	functional/alloc_class/alloc_class_015_neg.ksh \
 	functional/alloc_class/alloc_class_016_pos.ksh \
+	functional/alloc_class/alloc_class_017_pos.ksh \
+	functional/alloc_class/alloc_class_018_neg.ksh \
 	functional/alloc_class/cleanup.ksh \
 	functional/alloc_class/setup.ksh \
 	functional/append/file_append.ksh \
@@ -1620,6 +1622,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/fault/auto_spare_001_pos.ksh \
 	functional/fault/auto_spare_002_pos.ksh \
 	functional/fault/auto_spare_ashift.ksh \
+	functional/fault/auto_spare_bias.ksh \
 	functional/fault/auto_spare_double.ksh \
 	functional/fault/auto_spare_multiple.ksh \
 	functional/fault/auto_spare_shared.ksh \

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_015_neg.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_015_neg.ksh
@@ -26,7 +26,7 @@
 # STRATEGY:
 #	1. Create a pool with a normal mirror and a log vdev.
 #	2. Verify setting alloc_bias on a leaf vdev fails.
-#	3. Verify setting alloc_bias=log fails.
+#	3. Verify setting alloc_bias=log on a non-spare vdev fails.
 #	4. Verify setting alloc_bias to an unknown value fails.
 #	5. Verify setting alloc_bias on a log vdev fails.
 #	6. Verify setting alloc_bias=special fails when allocation_classes

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_017_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_017_pos.ksh
@@ -1,0 +1,80 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026, TrueNAS
+#
+
+. $STF_SUITE/tests/functional/alloc_class/alloc_class.kshlib
+
+#
+# DESCRIPTION:
+#	The alloc_bias property is readable and settable on spare vdevs,
+#	and persists across export/import.  A spare with a matching bias
+#	can replace a vdev of that allocation class.
+#
+# STRATEGY:
+#	1. Create a pool with a normal mirror, a single special vdev, and
+#	   two spares.
+#	2. Verify both spares default to alloc_bias=none.
+#	3. Set alloc_bias=special on one spare; verify and persist.
+#	4. Set alloc_bias=dedup; verify and persist.
+#	5. Set alloc_bias=log; verify and persist.
+#	6. Reset to alloc_bias=none; verify and persist.
+#	7. Set alloc_bias=special and replace the faulted special vdev;
+#	   verify the replacement succeeds.
+#
+
+verify_runnable "global"
+
+claim="alloc_bias is settable on spare vdevs and persists across export/import"
+
+log_assert $claim
+log_onexit cleanup
+
+log_must disk_setup
+
+# Pool: normal mirror + single special vdev + two spares.
+# CLASS_DISK2 will be the biased spare; CLASS_DISK3 the unbiased one.
+log_must zpool create -f $TESTPOOL \
+    mirror $ZPOOL_DISK0 $ZPOOL_DISK1 \
+    special $CLASS_DISK0 \
+    spare $CLASS_DISK2 $CLASS_DISK3
+
+# Both spares should default to none.
+for spare in $CLASS_DISK2 $CLASS_DISK3; do
+	BIAS=$(zpool get -H -o value alloc_bias $TESTPOOL $spare)
+	[[ "$BIAS" == "none" ]] ||
+	    log_fail "spare $spare: expected none, got $BIAS"
+done
+
+# Cycle through biases on CLASS_DISK2, checking persistence each time.
+for bias in special dedup log none; do
+	log_must zpool set alloc_bias=$bias $TESTPOOL $CLASS_DISK2
+	BIAS=$(zpool get -H -o value alloc_bias $TESTPOOL $CLASS_DISK2)
+	[[ "$BIAS" == "$bias" ]] ||
+	    log_fail "after set $bias: got $BIAS"
+
+	log_must zpool export $TESTPOOL
+	log_must zpool import -d $TEST_BASE_DIR $TESTPOOL
+	BIAS=$(zpool get -H -o value alloc_bias $TESTPOOL $CLASS_DISK2)
+	[[ "$BIAS" == "$bias" ]] ||
+	    log_fail "after reimport with $bias: got $BIAS"
+done
+
+# Set CLASS_DISK2 to special and verify it can replace the special vdev.
+log_must zpool set alloc_bias=special $TESTPOOL $CLASS_DISK2
+log_must zpool replace $TESTPOOL $CLASS_DISK0 $CLASS_DISK2
+
+log_must zpool destroy -f $TESTPOOL
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_018_neg.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_018_neg.ksh
@@ -1,0 +1,82 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026, TrueNAS
+#
+
+. $STF_SUITE/tests/functional/alloc_class/alloc_class.kshlib
+
+#
+# DESCRIPTION:
+#	A spare with a mismatched alloc_bias cannot replace a vdev of a
+#	different allocation class.
+#
+# STRATEGY:
+#	1. Create a pool with a normal mirror, a single special vdev, and
+#	   two spares: one unbiased, one set to alloc_bias=special.
+#	2. Verify an unbiased spare cannot replace the special vdev member.
+#	3. Verify a special-biased spare cannot replace a normal vdev member.
+#	4. Verify setting alloc_bias=log on a non-spare normal vdev fails.
+#	5. Verify setting alloc_bias=special on a spare fails when the
+#	   allocation_classes feature is disabled.
+#
+
+verify_runnable "global"
+
+claim="spare with mismatched alloc_bias is rejected as a replacement"
+
+log_assert $claim
+log_onexit cleanup
+
+log_must disk_setup
+
+# CLASS_DISK2: unbiased spare; CLASS_DISK3: special-biased spare.
+log_must zpool create -f $TESTPOOL \
+    mirror $ZPOOL_DISK0 $ZPOOL_DISK1 \
+    special $CLASS_DISK0 \
+    spare $CLASS_DISK2 $CLASS_DISK3
+log_must zpool set alloc_bias=special $TESTPOOL $CLASS_DISK3
+
+log_must zpool offline -f $TESTPOOL $CLASS_DISK0
+
+# Unbiased spare cannot replace a special vdev member.
+log_mustnot zpool replace $TESTPOOL $CLASS_DISK0 $CLASS_DISK2
+
+log_must zpool online $TESTPOOL $CLASS_DISK0
+log_must zpool clear $TESTPOOL
+
+log_must zpool offline -f $TESTPOOL $ZPOOL_DISK0
+
+# Special-biased spare cannot replace a normal vdev member.
+log_mustnot zpool replace $TESTPOOL $ZPOOL_DISK0 $CLASS_DISK3
+
+log_must zpool online $TESTPOOL $ZPOOL_DISK0
+log_must zpool clear $TESTPOOL
+
+log_must zpool destroy -f $TESTPOOL
+
+# Setting alloc_bias=log on a non-spare top-level vdev must fail.
+log_must zpool create $TESTPOOL mirror $ZPOOL_DISK0 $ZPOOL_DISK1
+NORMAL_VDEV=$(zpool list -v -H $TESTPOOL | awk '$1 ~ /^mirror/ {print $1; exit}')
+log_mustnot zpool set alloc_bias=log $TESTPOOL $NORMAL_VDEV
+log_must zpool destroy -f $TESTPOOL
+
+# Setting alloc_bias=special on a spare fails when feature is disabled.
+log_must zpool create -o feature@allocation_classes=disabled $TESTPOOL \
+    mirror $ZPOOL_DISK0 $ZPOOL_DISK1 spare $CLASS_DISK2
+log_mustnot zpool set alloc_bias=special $TESTPOOL $CLASS_DISK2
+log_mustnot zpool set alloc_bias=dedup $TESTPOOL $CLASS_DISK2
+log_must zpool destroy -f $TESTPOOL
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/fault/auto_spare_bias.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_spare_bias.ksh
@@ -1,0 +1,113 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026, TrueNAS
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/fault/fault.cfg
+
+#
+# DESCRIPTION:
+# ZED activates a spare whose alloc_bias matches the faulted vdev's
+# allocation class and does not activate a mismatched spare.
+#
+# STRATEGY:
+# 1. Create a pool with a normal mirror, a special mirror, an unbiased
+#    spare, and a special-biased spare.
+# 2. Fault a member of the special mirror; verify ZED activates the
+#    special-biased spare and leaves the unbiased spare available.
+# 3. Clear the fault; verify the special-biased spare returns to AVAIL.
+# 4. Fault a member of the normal mirror; verify ZED activates the
+#    unbiased spare and leaves the special-biased spare available.
+# 5. Clear the fault; verify the unbiased spare returns to AVAIL.
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zinject -c all
+	destroy_pool $TESTPOOL
+	rm -f $NORMAL_DEV1 $NORMAL_DEV2 $SPECIAL_DEV1 $SPECIAL_DEV2 \
+	    $SPARE_NORM $SPARE_SPEC
+}
+
+log_assert "ZED activates spares matching the faulted vdev's alloc_bias"
+log_onexit cleanup
+
+zed_events_drain
+
+NORMAL_DEV1="$TEST_BASE_DIR/normal-dev1"
+NORMAL_DEV2="$TEST_BASE_DIR/normal-dev2"
+SPECIAL_DEV1="$TEST_BASE_DIR/special-dev1"
+SPECIAL_DEV2="$TEST_BASE_DIR/special-dev2"
+SPARE_NORM="$TEST_BASE_DIR/spare-norm"
+SPARE_SPEC="$TEST_BASE_DIR/spare-spec"
+
+log_must truncate -s $MINVDEVSIZE \
+    $NORMAL_DEV1 $NORMAL_DEV2 $SPECIAL_DEV1 $SPECIAL_DEV2 \
+    $SPARE_NORM $SPARE_SPEC
+
+# 1. Create pool: normal mirror + special mirror + two spares.
+log_must zpool create -f $TESTPOOL \
+    mirror $NORMAL_DEV1 $NORMAL_DEV2 \
+    special mirror $SPECIAL_DEV1 $SPECIAL_DEV2 \
+    spare $SPARE_NORM $SPARE_SPEC
+log_must zpool set alloc_bias=special $TESTPOOL $SPARE_SPEC
+
+# Write data so the normal mirror has content for the scrub to read.
+log_must dd if=/dev/urandom of=/$TESTPOOL/testfile bs=1M count=16
+log_must sync_pool $TESTPOOL
+
+# 2. Fault a member of the special mirror.
+log_must zinject -d $SPECIAL_DEV1 -e io -T all -f 100 $TESTPOOL
+log_must zpool scrub $TESTPOOL
+
+log_note "Wait for ZED to activate special-biased spare"
+log_must wait_vdev_state $TESTPOOL $SPECIAL_DEV1 "FAULTED" 60
+log_must wait_vdev_state $TESTPOOL $SPARE_SPEC "ONLINE" 60
+log_must wait_hotspare_state $TESTPOOL $SPARE_SPEC "INUSE"
+
+# The unbiased spare must not have been activated.
+log_must wait_hotspare_state $TESTPOOL $SPARE_NORM "AVAIL"
+
+# 3. Clear the fault and verify the spare returns.
+log_must zinject -c all
+log_must zpool clear $TESTPOOL $SPECIAL_DEV1
+log_must wait_vdev_state $TESTPOOL $SPECIAL_DEV1 "ONLINE" 60
+log_must wait_hotspare_state $TESTPOOL $SPARE_SPEC "AVAIL"
+log_must check_state $TESTPOOL "" "ONLINE"
+
+# 4. Fault a member of the normal mirror.
+wait_scrubbed $TESTPOOL
+log_must zinject -d $NORMAL_DEV1 -e io -T all -f 100 $TESTPOOL
+log_must zpool scrub $TESTPOOL
+
+log_note "Wait for ZED to activate unbiased spare"
+log_must wait_vdev_state $TESTPOOL $NORMAL_DEV1 "FAULTED" 60
+log_must wait_vdev_state $TESTPOOL $SPARE_NORM "ONLINE" 60
+log_must wait_hotspare_state $TESTPOOL $SPARE_NORM "INUSE"
+
+# The special-biased spare must not have been activated.
+log_must wait_hotspare_state $TESTPOOL $SPARE_SPEC "AVAIL"
+
+# 5. Clear the fault and verify the spare returns.
+log_must zinject -c all
+log_must zpool clear $TESTPOOL $NORMAL_DEV1
+log_must wait_vdev_state $TESTPOOL $NORMAL_DEV1 "ONLINE" 60
+log_must wait_hotspare_state $TESTPOOL $SPARE_NORM "AVAIL"
+log_must check_state $TESTPOOL "" "ONLINE"
+
+log_pass "ZED spare activation respects alloc_bias"


### PR DESCRIPTION
This allows to specify for vdevs from which allocation class should each spare be used.  Before this spares were working only for normal vdevs, being explicitly rejected for others.

### How Has This Been Tested?
Manually tested the property operations.  CI shoudl also test that and `zed` changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
