### PR TITLE
CI: run full CI when a workflow YAML changes

### DIFF
--- a/.github/workflows/scripts/generate-ci-type.py
+++ b/.github/workflows/scripts/generate-ci-type.py
@@ -48,6 +48,7 @@ DOCS_ONLY_REGEX = list(map(re.compile, [
 Patterns of files that are considered to trigger full CI.
 """
 FULL_RUN_REGEX = list(map(re.compile, [
+    r'\.github/workflows/.*\.ya?ml',
     r'\.github/workflows/scripts/.*',
     r'cmd.*',
     r'configs/.*',


### PR DESCRIPTION
### Motivation and Context

generate-ci-type.py picks the CI tier for a PR. **FULL_RUN_REGEX** paths that trigger the full matrix covered .github/workflows/scripts/ but not the workflow YAML files. So a PR that only edited zfs-qemu.yml got "quick" CI and never ran its own matrix change.

### Description

Add the workflow YAML files to FULL_RUN_REGEX. `ya?ml` covers checkstyle.yaml as well as the .yml files. Editing a workflow file now triggers the full matrix, like the scripts/ directory already does.

### How Has This Been Tested?

Ran generate-ci-type.py on a workflow-YAML-only change: the CI matrix went from quick to full. Also confirmed on a test PR that the full matrix expands as expected.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
