### PR TITLE
ZTS: zpool_expand_005_pos: correct variable name in expandsize check

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_005_pos.ksh
@@ -82,7 +82,7 @@ log_must zpool reopen $TESTPOOL1
 
 typeset expandsize=$(get_pool_prop expandsize $TESTPOOL1)
 log_note "pool expandsize: $expandsize"
-if [[ "$zpool_expandsize" = "-" ]]; then
+if [[ "$expandsize" = "-" ]]; then
 	log_fail "pool $TESTPOOL1 did not detect any " \
 	    "expandsize after reopen"
 fi


### PR DESCRIPTION
### Motivation and Context

The post-reopen check in `zpool_expand_005_pos.ksh` references `$zpool_expandsize`, which is never set in this file. The variable assigned two lines above is `$expandsize`. The condition therefore always evaluates false and the targeted `log_fail` is unreachable.

When `zpool reopen` fails to detect an expansion, the failure is only surfaced by the later post-`online -e` size check, with the misleading message *"did not expand after vdev expansion and zpool online -e"* instead of the intended *"did not detect any expandsize after reopen"*.

### Description

Rename `$zpool_expandsize` to `$expandsize` so the check matches the variable assigned before.

### How Has This Been Tested?

Verified on Arch Linux. Running the test produces the right output for each case.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:

- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain Signed-off-by.