### PR TITLE
ZTS/alloc_class: move file_in_special_vdev to alloc_class.kshlib

### DIFF
--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class.kshlib
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class.kshlib
@@ -67,3 +67,41 @@ function display_status
 
 	return $ret
 }
+
+#
+# Verify the file identified by <inode> in <dataset> is written on a special
+# vdev.  Normal vdevs precede special vdevs in the pool layout, so a DVA whose
+# vdev id is below the number of normal disks is not on a special vdev.
+#
+# $1 dataset
+# $2 inode number
+#
+function file_in_special_vdev # <dataset> <inode>
+{
+	typeset dataset="$1"
+	typeset inum="$2"
+	typeset num_normal=$(echo $ZPOOL_DISKS | wc -w)
+	num_normal=${num_normal##* }
+
+	zdb -dddddd $dataset $inum | awk -v d=$num_normal '{
+# find DVAs from string "offset level dva" only for L0 (data) blocks
+if (match($0,"L0 [0-9]+")) {
+   dvas[0]=$3
+   dvas[1]=$4
+   dvas[2]=$5
+   for (i = 0; i < 3; ++i) {
+      if (match(dvas[i],"([^:]+):.*")) {
+         dva = substr(dvas[i], RSTART, RLENGTH);
+         # parse DVA from string "vdev:offset:asize"
+         if (split(dva,arr,":") != 3) {
+            print "Error parsing DVA: <" dva ">";
+            exit 1;
+         }
+         # verify vdev is "special"
+         if (arr[1] < d) {
+            exit 1;
+         }
+      }
+   }
+}}'
+}

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_012_pos.ksh
@@ -26,41 +26,6 @@
 verify_runnable "global"
 
 #
-# Verify the file identified by the input <inode> is written on a special vdev
-# According to the pool layout used in this test vdev_id 3 and 4 are special
-# XXX: move this function to libtest.shlib once we get "Vdev Properties"
-#
-function file_in_special_vdev # <dataset> <inode>
-{
-	typeset dataset="$1"
-	typeset inum="$2"
-	typeset num_normal=$(echo $ZPOOL_DISKS | wc -w)
-	num_normal=${num_normal##* }
-
-	zdb -dddddd $dataset $inum | awk -v d=$num_normal '{
-# find DVAs from string "offset level dva" only for L0 (data) blocks
-if (match($0,"L0 [0-9]+")) {
-   dvas[0]=$3
-   dvas[1]=$4
-   dvas[2]=$5
-   for (i = 0; i < 3; ++i) {
-      if (match(dvas[i],"([^:]+):.*")) {
-         dva = substr(dvas[i], RSTART, RLENGTH);
-         # parse DVA from string "vdev:offset:asize"
-         if (split(dva,arr,":") != 3) {
-            print "Error parsing DVA: <" dva ">";
-            exit 1;
-         }
-         # verify vdev is "special"
-         if (arr[1] < d) {
-            exit 1;
-         }
-      }
-   }
-}}'
-}
-
-#
 # Check that device removal works for special class vdevs
 #
 function check_removal


### PR DESCRIPTION
### Motivation and Context

`file_in_special_vdev` lived in `alloc_class_012_pos.ksh` with an XXX comment requesting it be moved to a shared library once vdev properties were available:

    XXX: move this function to libtest.shlib once we get "Vdev Properties"

The `alloc_bias` property specifically was added by amotin in d65015938 (2026-05-07).

### Description

Move the function into the shared library `alloc_class.kshlib`.

### How Has This Been Tested?

The function call resolves at its new location without any test-side change. `alloc_class_012_pos.ksh` passes unchanged on Arch Linux (kernel 6.19.10).

### Types of changes

- [x] Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain Signed-off-by.